### PR TITLE
Increase Ruff line-length lint threshold by 30%

### DIFF
--- a/pi/pyproject.toml
+++ b/pi/pyproject.toml
@@ -38,7 +38,7 @@ testpaths = ["tests"]
 markers = ["selenium: browser-based UI tests"]
 
 [tool.ruff]
-line-length = 100
+line-length = 130
 target-version = "py311"
 
 [tool.ruff.lint]


### PR DESCRIPTION
### Motivation
- Raise the allowed line length for Ruff-based linting in CI by 30% to accommodate longer lines without triggering line-length violations.

### Description
- Updated `pi/pyproject.toml` to change the Ruff `line-length` setting from `100` to `130`.

### Testing
- Confirmed the config change with `rg -n "^line-length =" pi/pyproject.toml` which shows `line-length = 130`; running `cd pi && python -m ruff check vibesensor tests ../tools/simulator` executed but reported a pre-existing unrelated import-order issue in `tools/simulator/sim_sender.py` (lint run otherwise completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69929a0407148323bd272e0d0df1ded1)