### PR TITLE
Stabilize live diagnostics tracking and align UI strength bands with backend

### DIFF
--- a/pi/tests/test_live_diagnostics_continuous.py
+++ b/pi/tests/test_live_diagnostics_continuous.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from vibesensor.diagnostics_shared import severity_from_peak
+from vibesensor.live_diagnostics import LiveDiagnosticsEngine
+from vibesensor.strength_bands import DECAY_TICKS, HYSTERESIS_DB, band_by_key
+
+
+def test_severity_holds_for_small_hysteresis_dip_then_decays() -> None:
+    state = None
+    out = None
+    for _ in range(3):
+        out = severity_from_peak(strength_db=23.0, band_rms=0.02, sensor_count=1, prior_state=state)
+        state = dict((out or {}).get("state") or {})
+    assert out is not None
+    assert out["key"] == "l3"
+
+    l3 = band_by_key("l3")
+    assert l3 is not None
+    slight_dip = float(l3["min_db"]) - (HYSTERESIS_DB / 2)
+    out = severity_from_peak(strength_db=slight_dip, band_rms=0.02, sensor_count=1, prior_state=state)
+    state = dict((out or {}).get("state") or state or {})
+    assert out is not None
+    assert out["key"] == "l3"
+
+    for _ in range(DECAY_TICKS):
+        out = severity_from_peak(strength_db=-120.0, band_rms=0.0, sensor_count=1, prior_state=state)
+        state = dict((out or {}).get("state") or state or {})
+    assert out is not None
+    assert out["key"] is None
+
+
+def test_live_matrix_seconds_accumulate_during_throttled_emission(monkeypatch) -> None:
+    current_s = {"value": 10.0}
+
+    def fake_monotonic() -> float:
+        return current_s["value"]
+
+    monkeypatch.setattr("vibesensor.live_diagnostics.monotonic", fake_monotonic)
+
+    engine = LiveDiagnosticsEngine()
+    settings = {}
+    speed_mps = 27.8
+    freq = [idx * 0.1 for idx in range(1, 1200)]
+    peak_idx = 320
+    base = [0.8 for _ in freq]
+    base[peak_idx] = 150.0
+    spectra = {"freq": freq, "clients": {"c1": {"freq": freq, "x": base, "y": base, "z": base}}}
+
+    snapshots = []
+    for _ in range(12):
+        snapshots.append(
+            engine.update(
+                speed_mps=speed_mps,
+                clients=[{"id": "c1", "name": "front"}],
+                spectra=spectra,
+                settings=settings,
+            )
+        )
+        current_s["value"] += 1.0
+
+    final = snapshots[-1]
+    max_seconds = max(
+        float(cell["seconds"])
+        for source_row in final["matrix"].values()
+        for cell in source_row.values()
+    )
+    assert max_seconds >= 8.0
+
+    emitted = sum(len(snapshot.get("events") or []) for snapshot in snapshots)
+    assert emitted < len(snapshots)

--- a/ui/index.html
+++ b/ui/index.html
@@ -233,6 +233,7 @@
       </section>
     </div>
     <div id="matrixTooltip" class="matrix-tooltip"></div>
+    <div id="strengthTooltip" class="matrix-tooltip strength-tooltip"></div>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -36,12 +36,13 @@ export const sourceColumns = [
   { key: "other", labelKey: "matrix.source.other" },
 ] as const;
 
-export const severityBands = [
-  { key: "l5", labelKey: "matrix.severity.l5", minDb: 34, maxDb: Number.POSITIVE_INFINITY, minAmp: 0.048 },
-  { key: "l4", labelKey: "matrix.severity.l4", minDb: 28, maxDb: 34, minAmp: 0.024 },
-  { key: "l3", labelKey: "matrix.severity.l3", minDb: 22, maxDb: 28, minAmp: 0.012 },
-  { key: "l2", labelKey: "matrix.severity.l2", minDb: 16, maxDb: 22, minAmp: 0.006 },
-  { key: "l1", labelKey: "matrix.severity.l1", minDb: 10, maxDb: 16, minAmp: 0.003 },
+// Deprecated fallback until server diagnostics are available.
+export const defaultStrengthBands = [
+  { key: "l1", min_db: 10, min_amp: 0.003 },
+  { key: "l2", min_db: 16, min_amp: 0.006 },
+  { key: "l3", min_db: 22, min_amp: 0.012 },
+  { key: "l4", min_db: 28, min_amp: 0.024 },
+  { key: "l5", min_db: 34, min_amp: 0.048 },
 ] as const;
 
 export const multiSyncWindowMs = 500;

--- a/ui/src/diagnostics.ts
+++ b/ui/src/diagnostics.ts
@@ -1,10 +1,45 @@
-import { severityBands, sourceColumns } from "./constants";
+import { defaultStrengthBands, sourceColumns } from "./constants";
 
-export function createEmptyMatrix(): Record<string, Record<string, { count: number; seconds: number; contributors: Record<string, number> }>> {
+export type StrengthBand = {
+  key: string;
+  min_db: number;
+  min_amp: number;
+  max_db?: number;
+  labelKey?: string;
+};
+
+export const SEVERITY_ORDER = ["l5", "l4", "l3", "l2", "l1"] as const;
+
+export function normalizeStrengthBands(input: unknown): StrengthBand[] {
+  const parsed = Array.isArray(input)
+    ? input
+        .map((band) => {
+          if (!band || typeof band !== "object") return null;
+          const key = String((band as any).key || "").toLowerCase();
+          const minDb = Number((band as any).min_db);
+          const minAmp = Number((band as any).min_amp);
+          if (!key || !Number.isFinite(minDb) || !Number.isFinite(minAmp)) return null;
+          return { key, min_db: minDb, min_amp: minAmp } as StrengthBand;
+        })
+        .filter((band): band is StrengthBand => band !== null)
+    : [];
+  const bands = parsed.length ? parsed : defaultStrengthBands;
+  const ascending = [...bands].sort((a, b) => a.min_db - b.min_db);
+  return ascending.map((band, idx) => ({
+    ...band,
+    max_db: idx + 1 < ascending.length ? ascending[idx + 1].min_db : Number.POSITIVE_INFINITY,
+    labelKey: `matrix.severity.${band.key}`,
+  }));
+}
+
+export function createEmptyMatrix(
+  strengthBands: StrengthBand[] = normalizeStrengthBands(defaultStrengthBands),
+): Record<string, Record<string, { count: number; seconds: number; contributors: Record<string, number> }>> {
   const matrix: Record<string, Record<string, { count: number; seconds: number; contributors: Record<string, number> }>> = {};
+  const ordered = [...strengthBands].sort((a, b) => b.min_db - a.min_db);
   for (const src of sourceColumns) {
     matrix[src.key] = {};
-    for (const band of severityBands) {
+    for (const band of ordered) {
       matrix[src.key][band.key] = { count: 0, seconds: 0, contributors: {} };
     }
   }
@@ -30,12 +65,14 @@ export function severityFromPeak(
   peakAmp: number,
   floorAmp: number,
   sensorCount: number,
+  strengthBands: StrengthBand[],
 ): { key: string; labelKey: string; db: number } | null {
   const db = relativeDbAboveFloor(peakAmp, floorAmp);
   const adjustedDb = sensorCount >= 2 ? db + 3 : db;
-  for (const band of severityBands) {
-    if (adjustedDb >= band.minDb && adjustedDb < band.maxDb && peakAmp >= band.minAmp) {
-      return { key: band.key, labelKey: band.labelKey, db: adjustedDb };
+  for (const band of [...strengthBands].sort((a, b) => b.min_db - a.min_db)) {
+    const maxDb = Number.isFinite(band.max_db) ? Number(band.max_db) : Number.POSITIVE_INFINITY;
+    if (adjustedDb >= band.min_db && adjustedDb < maxDb && peakAmp >= band.min_amp) {
+      return { key: band.key, labelKey: band.labelKey || `matrix.severity.${band.key}`, db: adjustedDb };
     }
   }
   return null;

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -507,3 +507,16 @@ label { font-size: 0.86rem; color: var(--pill-muted-text); }
     min-width: 0;
   }
 }
+
+.strength-chart {
+  position: relative;
+}
+
+.strength-tooltip {
+  display: none;
+  right: 20px;
+  left: auto;
+  top: auto;
+  bottom: 20px;
+  position: fixed;
+}


### PR DESCRIPTION
### Motivation
- Persistent vibrations were intermittently dropping to zero in the live UI because event dedupe logic removed active state between emitted events, undercounting seconds and creating a flickery “current” severity.
- The UI duplicated strength-band thresholds and severity math, which could drift from backend behavior and made maintenance harder.

### Description
- Live diagnostics: introduced continuous per-tracker level state (sensor and combined trackers) and separated it from throttled event emission so levels are updated every tick while event feed remains deduped/heartbeated; matrix seconds now accrue from continuous active levels and counts only on bucket-entry/up transitions. (pi/vibesensor/live_diagnostics.py)
- Multi-sensor grouping: build combined severity from fresh per-sensor continuous tracker states (freshness window + freq proximity) instead of relying on recent emitted events so combined severity remains active even when emission is throttled. (pi/vibesensor/live_diagnostics.py)
- UI unification: moved strength-band parsing and severity helpers into `ui/src/diagnostics.ts`, deprecated hard-coded fallback bands in `ui/src/constants.ts`, and switched rendering and detection code to consume server-provided `diagnostics.strength_bands` at runtime. (ui/src/diagnostics.ts, ui/src/constants.ts, ui/src/main.ts)
- Strength chart improvements: render dynamic shaded band regions and threshold lines from server bands, add small right-side L1..L5 labels, hover tooltip showing per-source strength at cursor, handle resize/visibility changes, and cap history to the last 60s to avoid unbounded growth. (ui/src/main.ts, ui/index.html, ui/src/styles/app.css)
- Tests: added fast pytest unit tests covering hysteresis/decay behavior and continuous matrix seconds accumulation during throttled emission. (pi/tests/test_live_diagnostics_continuous.py)
- Small code comments added to clarify separation between continuous level tracking and event emission throttling.

### Testing
- Ran `cd pi && ruff check .`; this command was executed as requested but reported repository-wide lint findings unrelated to the change set (pre-existing files), so lint failures are not caused by these changes. 
- Ran `cd pi && pytest -q`; result: 52 passed, 1 skipped. 
- Built the UI with `cd ui && npm run build`; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992bd2ace788323af7603f6da5b7cb1)