### PR TITLE
Add Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+Repository overview
+- VibeSensor: Python-based data-collection and analysis backend (located in `pi/`), a small web UI (`ui/`) built with Node, and device/firmware helpers under `esp/` and `hardware/`.
+- Key runtime artifacts: Docker Compose stack at `docker-compose.yml` and `pi/` Python package (`pi/pyproject.toml`). PDF report generation lives in `pi/vibesensor/report_pdf.py`.
+
+Common commands (exact as found in CI / repo files)
+- Install Python deps (dev):
+  - python -m pip install -e "./pi[dev]"
+- Run backend tests (fast):
+  - pytest -q -m "not selenium" pi/tests
+- Lint / format checks (as used in CI):
+  - ruff check pi/vibesensor pi/tests tools/simulator
+  - ruff format --check pi/vibesensor pi/tests tools/simulator
+- Web UI:
+  - cd ui && npm ci
+  - cd ui && npm run build
+  - cd ui && npm run typecheck
+- Docker (local dev / CI):
+  - docker compose build --pull
+  - docker compose up -d
+
+Repo conventions
+- Backend code: placed under `pi/vibesensor/`. Keep modules small and prefer explicit function signatures.
+- Tests live under `pi/tests/` and use pytest. Selenium-marked tests are slow/optional and excluded in CI with `-m "not selenium"`.
+- Strings that appear in generated reports are internationalised via `pi/vibesensor/report_i18n.py` and must be used with `tr(lang, KEY)`.
+
+Configuration and secrets
+- Config files: `pi/config.example.yaml`, `pi/config.dev.yaml`, and `pi/config.yaml` live in repo root `pi/`.
+- CI installs the dev package using `python -m pip install -e "./pi[dev]"`; follow that pattern for local dev.
+- Do NOT add secrets to the repo. Keep WiFi or device secrets out of `pi/config.yaml`; sample secrets live in `pi/wifi-secrets.example.env`.
+
+How to add a feature safely
+- Add code under `pi/vibesensor/` for backend changes; add small, focused tests in `pi/tests/` that are fast.
+- Update or add i18n keys in `pi/vibesensor/report_i18n.py` when changing report text.
+- For UI changes, modify `ui/` and update the `ui` build scripts; ensure `npm run build` succeeds.
+- If the change affects Docker, update `docker-compose.yml` or `pi/Dockerfile` and test locally with `docker compose up -d`.
+
+Guardrails for Copilot
+- Keep PRs small and self-contained. Add tests for behavior changes. Prefer backwards-compatible changes unless the task explicitly requests breaking changes.
+- Run the fast test suite (`pytest -q -m "not selenium" pi/tests`) locally before pushing changes.
+- Do not modify unrelated files or reformat the whole repo.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "pi/**"
+---
+Backend (python `pi/`)
+- Entry points: `pi/vibesensor/app.py` for runtime, `pi/vibesensor/report_pdf.py` for PDF generation, and `pi/vibesensor/api.py` for http endpoints.
+- Install: `python -m pip install -e "./pi[dev]"` (used by CI).
+- Tests: add unit tests under `pi/tests/` and prefer `-m "not selenium"` for fast runs.
+- i18n: Add/modify keys in `pi/vibesensor/report_i18n.py` when changing user-facing strings.
+- Styling/lint: `ruff` is used in CI; follow existing `ruff` conventions.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: "docs/**"
+---
+Docs
+- Keep `docs/` short and focused. Add design changes (e.g. report layout) to `docs/design_language.md`.
+- For any user-visible text changes, update `pi/vibesensor/report_i18n.py` and mention new keys in docs.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "ui/**"
+---
+Frontend (ui)
+- Commands: `cd ui && npm ci`, `cd ui && npm run build`, `cd ui && npm run typecheck`.
+- Keep frontend changes scoped and update `ui/nginx.conf` only if static paths change.
+- Prefer updating `ui/src/` components and running `npm run build` locally before pushing.

--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "docker-compose.yml,.github/workflows/**"
+---
+Infra / Docker / CI
+- Local dev: `docker compose build --pull` then `docker compose up -d`.
+- CI: `.github/workflows/ci.yml` shows steps used in CI (setup Python/Node, pip install -e "./pi[dev]", ruff, pytest, UI build).
+- Keep CI steps small; if adding new test dependencies, update `pi/pyproject.toml` so CI installs them via the editable install.
+- Avoid embedding secrets in workflow files; use repository secrets for tokens.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "pi/tests/**"
+---
+Tests
+- Fast tests: `pytest -q -m "not selenium" pi/tests` (used in CI).
+- Selenium UI tests are present but skipped in CI; mark them explicitly with the `selenium` marker.
+- New backend features should include focused unit tests under `pi/tests/` and avoid heavy integration tests in quick PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+Agent operating rules
+- How to explore the repo efficiently:
+  - Start at `pi/` for backend entry points and `ui/` for frontend. Follow imports from `pi/vibesensor/__init__.py` and `pi/vibesensor/app.py`.
+  - Use `pi/tests/` to see expected behaviour and fixtures; tests are the fastest way to understand runtime contracts.
+  - Search `.github/workflows/ci.yml` and `pi/pyproject.toml` for build, lint and test commands.
+
+- How to make changes:
+  - Make small commits with focused intent. Prefer a single logical change per commit.
+  - Do not perform large, sweeping refactors in a single PR.
+  - Update or add tests in `pi/tests/` covering new behaviour.
+
+- How to validate changes without running code:
+  - Use static checks: run `ruff` locally and inspect `pyproject.toml` for dependency changes.
+  - Read `pi/tests/` to confirm expected I/O and error cases; add/adjust assertions as necessary.
+
+- Misc rules:
+  - Never add secrets to the repository. Use `pi/wifi-secrets.example.env` as a template for device configuration.
+  - When altering report text, update `pi/vibesensor/report_i18n.py`.


### PR DESCRIPTION
Add repository-wide Copilot guidance, path-scoped instruction files under .github/instructions/, and AGENTS.md for agent operating rules.