### PR TITLE
Improve PDF report layout and diagnostics visuals

### DIFF
--- a/pi/pyproject.toml
+++ b/pi/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 dev = [
   "pytest>=8,<9",
   "pytest-asyncio>=0.23,<1",
+  "pypdf>=5,<6",
   "ruff>=0.6",
   "selenium>=4.20,<5",
   "websockets>=12,<16",

--- a/pi/vibesensor/report_analysis.py
+++ b/pi/vibesensor/report_analysis.py
@@ -1363,6 +1363,190 @@ def _most_likely_origin_summary(
     }
 
 
+def _aggregate_fft_spectrum(
+    samples: list[dict[str, Any]],
+    *,
+    freq_bin_hz: float = 2.0,
+) -> list[tuple[float, float]]:
+    if freq_bin_hz <= 0:
+        freq_bin_hz = 2.0
+    bins: dict[float, float] = {}
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        for hz, amp in _sample_top_peaks(sample):
+            if hz <= 0 or amp <= 0:
+                continue
+            bin_low = floor(hz / freq_bin_hz) * freq_bin_hz
+            bin_center = bin_low + (freq_bin_hz / 2.0)
+            current = bins.get(bin_center, 0.0)
+            if amp > current:
+                bins[bin_center] = amp
+    return sorted(bins.items(), key=lambda item: item[0])
+
+
+def _spectrogram_from_peaks(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    peak_rows: list[tuple[float, float, float]] = []
+    time_values: list[float] = []
+    speed_values: list[float] = []
+
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        t_s = _as_float(sample.get("t_s"))
+        speed = _as_float(sample.get("speed_kmh"))
+        peaks = _sample_top_peaks(sample)
+        if t_s is not None and t_s >= 0:
+            time_values.append(t_s)
+        if speed is not None and speed > 0:
+            speed_values.append(speed)
+        if not peaks:
+            continue
+        for hz, amp in peaks:
+            if hz <= 0 or amp <= 0:
+                continue
+            if t_s is not None and t_s >= 0:
+                peak_rows.append((t_s, hz, amp))
+            elif speed is not None and speed > 0:
+                peak_rows.append((speed, hz, amp))
+
+    use_time = bool(time_values)
+    if not use_time and not speed_values:
+        return {
+            "x_axis": "none",
+            "x_label_key": "TIME_S",
+            "x_bins": [],
+            "y_bins": [],
+            "cells": [],
+            "max_amp": 0.0,
+        }
+
+    x_axis = "time_s" if use_time else "speed_kmh"
+    x_values = time_values if use_time else speed_values
+    x_min = min(x_values)
+    x_max = max(x_values)
+    x_span = max(0.0, x_max - x_min)
+    if x_axis == "time_s":
+        x_bin_width = max(2.0, (x_span / 40.0) if x_span > 0 else 2.0)
+        x_label_key = "TIME_S"
+    else:
+        x_bin_width = max(5.0, (x_span / 30.0) if x_span > 0 else 5.0)
+        x_label_key = "SPEED_KM_H"
+
+    peak_freqs = [hz for _x, hz, _amp in peak_rows]
+    if not peak_freqs:
+        return {
+            "x_axis": x_axis,
+            "x_label_key": x_label_key,
+            "x_bins": [],
+            "y_bins": [],
+            "cells": [],
+            "max_amp": 0.0,
+        }
+
+    observed_max_hz = max(peak_freqs)
+    freq_cap_hz = min(200.0, max(40.0, observed_max_hz))
+    freq_bin_hz = max(2.0, freq_cap_hz / 45.0)
+
+    cell_by_bin: dict[tuple[float, float], float] = {}
+    for x_val, hz, amp in peak_rows:
+        if hz > freq_cap_hz:
+            continue
+        x_bin_low = floor((x_val - x_min) / x_bin_width) * x_bin_width + x_min
+        y_bin_low = floor(hz / freq_bin_hz) * freq_bin_hz
+        key = (x_bin_low, y_bin_low)
+        current = cell_by_bin.get(key, 0.0)
+        if amp > current:
+            cell_by_bin[key] = amp
+
+    x_bins = sorted({x for x, _y in cell_by_bin})
+    y_bins = sorted({y for _x, y in cell_by_bin})
+    if not x_bins or not y_bins:
+        return {
+            "x_axis": x_axis,
+            "x_label_key": x_label_key,
+            "x_bins": [],
+            "y_bins": [],
+            "cells": [],
+            "max_amp": 0.0,
+        }
+
+    x_index = {value: idx for idx, value in enumerate(x_bins)}
+    y_index = {value: idx for idx, value in enumerate(y_bins)}
+    cells = [[0.0 for _ in x_bins] for _ in y_bins]
+    max_amp = max(cell_by_bin.values()) if cell_by_bin else 0.0
+    for (x_key, y_key), amp in cell_by_bin.items():
+        yi = y_index[y_key]
+        xi = x_index[x_key]
+        cells[yi][xi] = amp
+
+    return {
+        "x_axis": x_axis,
+        "x_label_key": x_label_key,
+        "x_bin_width": x_bin_width,
+        "y_bin_width": freq_bin_hz,
+        "x_bins": [x + (x_bin_width / 2.0) for x in x_bins],
+        "y_bins": [y + (freq_bin_hz / 2.0) for y in y_bins],
+        "cells": cells,
+        "max_amp": max_amp,
+    }
+
+
+def _top_peaks_table_rows(
+    samples: list[dict[str, Any]],
+    *,
+    top_n: int = 12,
+    freq_bin_hz: float = 1.0,
+) -> list[dict[str, Any]]:
+    grouped: dict[float, dict[str, Any]] = {}
+    if freq_bin_hz <= 0:
+        freq_bin_hz = 1.0
+
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        speed = _as_float(sample.get("speed_kmh"))
+        for hz, amp in _sample_top_peaks(sample):
+            if hz <= 0 or amp <= 0:
+                continue
+            freq_key = round(hz / freq_bin_hz) * freq_bin_hz
+            bucket = grouped.setdefault(
+                freq_key,
+                {
+                    "frequency_hz": freq_key,
+                    "max_amp_g": 0.0,
+                    "speeds": [],
+                },
+            )
+            if amp > float(bucket["max_amp_g"]):
+                bucket["max_amp_g"] = amp
+            if speed is not None and speed > 0:
+                bucket["speeds"].append(speed)
+
+    ordered = sorted(
+        grouped.values(),
+        key=lambda item: float(item.get("max_amp_g") or 0.0),
+        reverse=True,
+    )[:top_n]
+
+    rows: list[dict[str, Any]] = []
+    for idx, item in enumerate(ordered, start=1):
+        speeds = [float(v) for v in item.get("speeds", []) if isinstance(v, (int, float))]
+        speed_band = "-"
+        if speeds:
+            speed_band = f"{min(speeds):.0f}-{max(speeds):.0f} km/h"
+        rows.append(
+            {
+                "rank": idx,
+                "frequency_hz": float(item.get("frequency_hz") or 0.0),
+                "order_label": "",
+                "max_amp_g": float(item.get("max_amp_g") or 0.0),
+                "typical_speed_band": speed_band,
+            }
+        )
+    return rows
+
+
 def _plot_data(summary: dict[str, Any]) -> dict[str, Any]:
     samples: list[dict[str, Any]] = summary.get("samples", [])
     raw_sample_rate_hz = _as_float(summary.get("raw_sample_rate_hz"))
@@ -1459,6 +1643,10 @@ def _plot_data(summary: dict[str, Any]) -> dict[str, Any]:
                 "p95": _percentile(vals, 0.95),
             }
 
+    fft_spectrum = _aggregate_fft_spectrum(samples)
+    peaks_spectrogram = _spectrogram_from_peaks(samples)
+    peaks_table = _top_peaks_table_rows(samples)
+
     return {
         "vib_magnitude": vib_mag_points,
         "dominant_freq": dominant_freq_points,
@@ -1466,6 +1654,9 @@ def _plot_data(summary: dict[str, Any]) -> dict[str, Any]:
         "matched_amp_vs_speed": matched_by_finding,
         "freq_vs_speed_by_finding": freq_vs_speed_by_finding,
         "steady_speed_distribution": steady_speed_distribution,
+        "fft_spectrum": fft_spectrum,
+        "peaks_spectrogram": peaks_spectrogram,
+        "peaks_table": peaks_table,
     }
 
 


### PR DESCRIPTION
## Summary
- redesign PDF report for dense A4 landscape workshop layout
- add FFT spectrum, spectrogram, and peaks table derived from top_peaks
- add footer generator marker with version and optional short GIT_SHA
- enforce ReportLab-only generation (remove fallback behavior)
- keep main-page confidence qualitative and retain numeric values in appendix

## Validation
- python3 -m pytest -q pi/tests/test_reports.py
- python3 -m pytest -q -m "not selenium" pi/tests
