### PR TITLE
Refine report insights and sensor-driven dashboard behavior

### DIFF
--- a/pi/tests/test_metrics_log_helpers.py
+++ b/pi/tests/test_metrics_log_helpers.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+
 from vibesensor.metrics_log import MetricsLogger
 
 # -- MetricsLogger._safe_metric ------------------------------------------------
@@ -100,3 +103,106 @@ def test_dominant_peak_skips_negative_amp() -> None:
     }
     hz, amp, axis = MetricsLogger._dominant_peak(metrics)
     assert hz is None
+
+
+@dataclass(slots=True)
+class _FakeRecord:
+    client_id: str
+    name: str
+    sample_rate_hz: int
+    latest_metrics: dict
+    frames_dropped: int = 0
+    queue_overflow_drops: int = 0
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self._records = {
+            "active": _FakeRecord(
+                client_id="active",
+                name="front-left wheel",
+                sample_rate_hz=800,
+                latest_metrics={
+                    "combined": {
+                        "vib_mag_rms": 0.09,
+                        "vib_mag_p2p": 0.20,
+                        "noise_floor_amp": 0.01,
+                        "peaks": [{"hz": 15.0, "amp": 0.12}],
+                    },
+                    "x": {"rms": 0.04, "p2p": 0.11, "peaks": [{"hz": 15.0, "amp": 0.12}]},
+                    "y": {"rms": 0.03, "p2p": 0.10, "peaks": [{"hz": 16.0, "amp": 0.08}]},
+                    "z": {"rms": 0.02, "p2p": 0.09, "peaks": [{"hz": 14.0, "amp": 0.07}]},
+                },
+            ),
+            "stale": _FakeRecord(
+                client_id="stale",
+                name="rear-right wheel",
+                sample_rate_hz=800,
+                latest_metrics={
+                    "combined": {
+                        "vib_mag_rms": 0.22,
+                        "vib_mag_p2p": 0.40,
+                        "noise_floor_amp": 0.02,
+                        "peaks": [{"hz": 28.0, "amp": 0.26}],
+                    },
+                    "x": {"rms": 0.10, "p2p": 0.22, "peaks": [{"hz": 28.0, "amp": 0.26}]},
+                    "y": {"rms": 0.09, "p2p": 0.18, "peaks": [{"hz": 29.0, "amp": 0.20}]},
+                    "z": {"rms": 0.08, "p2p": 0.17, "peaks": [{"hz": 27.0, "amp": 0.19}]},
+                },
+            ),
+        }
+
+    def active_client_ids(self) -> list[str]:
+        return ["active"]
+
+    def get(self, client_id: str) -> _FakeRecord | None:
+        return self._records.get(client_id)
+
+
+class _FakeGPSMonitor:
+    speed_mps = None
+    effective_speed_mps = None
+
+
+class _FakeProcessor:
+    def latest_sample_xyz(self, client_id: str):
+        return (0.01, 0.02, 0.03)
+
+    def latest_sample_rate_hz(self, client_id: str):
+        return 800
+
+
+class _FakeAnalysisSettings:
+    def snapshot(self) -> dict[str, float]:
+        return {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+            "final_drive_ratio": 3.08,
+            "current_gear_ratio": 0.64,
+        }
+
+
+def test_build_sample_records_uses_only_active_clients(tmp_path: Path) -> None:
+    logger = MetricsLogger(
+        enabled=False,
+        log_path=tmp_path / "metrics.jsonl",
+        metrics_log_hz=2,
+        registry=_FakeRegistry(),
+        gps_monitor=_FakeGPSMonitor(),
+        processor=_FakeProcessor(),
+        analysis_settings=_FakeAnalysisSettings(),
+        sensor_model="ADXL345",
+        default_sample_rate_hz=800,
+        fft_window_size_samples=1024,
+    )
+
+    rows = logger._build_sample_records(
+        run_id="run-1",
+        t_s=1.0,
+        timestamp_utc="2026-02-16T12:00:00+00:00",
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["client_id"] == "active"
+    assert rows[0]["client_name"] == "front-left wheel"

--- a/pi/vibesensor/metrics_log.py
+++ b/pi/vibesensor/metrics_log.py
@@ -292,7 +292,11 @@ class MetricsLogger:
             engine_rpm_estimated = wheel_hz * final_drive_ratio * gear_ratio * 60.0
 
         records: list[dict[str, object]] = []
-        for record in self.registry.iter_records():
+        active_client_ids = sorted(set(self.registry.active_client_ids()))
+        for client_id in active_client_ids:
+            record = self.registry.get(client_id)
+            if record is None:
+                continue
             metrics = record.latest_metrics
             if not metrics:
                 continue
@@ -373,7 +377,7 @@ class MetricsLogger:
                     "run_id": run_id,
                     "timestamp_utc": timestamp_utc,
                     "t_s": t_s,
-                    "client_id": record.client_id,
+                    "client_id": client_id,
                     "client_name": record.name,
                     "sample_rate_hz": int(sample_rate_hz) if sample_rate_hz else None,
                     "speed_kmh": speed_kmh,

--- a/pi/vibesensor/report_i18n.py
+++ b/pi/vibesensor/report_i18n.py
@@ -452,6 +452,9 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "CONFIDENCE_MEDIUM": {"en": "Medium", "nl": "Middel"},
     "CONFIDENCE_LOW": {"en": "Low", "nl": "Laag"},
     "CONFIDENCE_LABEL": {"en": "Confidence", "nl": "Score"},
+    "CERTAINTY": {"en": "Certainty", "nl": "Zekerheid"},
+    "SPEED": {"en": "Speed", "nl": "Snelheid"},
+    "FREQUENCY": {"en": "Frequency", "nl": "Frequentie"},
     "CONFIRM": {"en": "Confirm", "nl": "Bevestig"},
     "CHART_INTERPRETATION_SWEEP": {
         "en": "Charts show how vibration amplitude and frequency track with vehicle speed. A clear rising pattern confirms speed-dependent excitation.",

--- a/ui/index.html
+++ b/ui/index.html
@@ -59,7 +59,6 @@
             </div>
             <div id="legend" class="legend"></div>
             <div id="bandLegend" class="legend band-legend"></div>
-            <div id="strengthChart" class="strength-chart"></div>
           </div>
 
           <div class="dashboard-grid__side">
@@ -96,6 +95,10 @@
               </div>
               <div id="vibrationLog" class="log-box"></div>
             </div>
+          </div>
+
+          <div class="panel card dashboard-grid__strength">
+            <div id="strengthChart" class="strength-chart"></div>
           </div>
 
           <div class="panel card dashboard-grid__full">

--- a/ui/src/styles/app.css
+++ b/ui/src/styles/app.css
@@ -298,10 +298,11 @@ input:focus-visible,
   display: grid;
   gap: var(--space-4);
   grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr);
-  grid-template-areas: "spectrum side" "matrix matrix";
+  grid-template-areas: "spectrum side" "strength strength" "matrix matrix";
 }
 .dashboard-grid__main { grid-area: spectrum; }
 .dashboard-grid__side { grid-area: side; display: grid; gap: var(--space-4); }
+.dashboard-grid__strength { grid-area: strength; }
 .dashboard-grid__full { grid-area: matrix; }
 
 .spectrum-wrap { position: relative; min-height: 360px; }
@@ -568,7 +569,7 @@ label { font-size: 0.86rem; color: var(--pill-muted-text); }
 @media (max-width: 980px) {
   .dashboard-grid {
     grid-template-columns: 1fr;
-    grid-template-areas: "spectrum" "side" "matrix";
+    grid-template-areas: "spectrum" "side" "strength" "matrix";
   }
   .menu { width: 100%; overflow-x: auto; }
   .speed { min-width: 180px; }


### PR DESCRIPTION
## Summary
- Remove spectrogram rendering from PDF reports.
- Replace "Confirm/Falsify/ETA" with "Certainty/Speed/Frequency" in the report action table and add i18n labels.
- Restrict run sample record generation to active clients so stale/offline sensors are excluded.
- Ensure report sensor-location summaries include all sampled locations, not only those with strong amplitudes.
- Update logs preview heatmap to show only sensors that are actually present in a run.
- Stop advancing the strength-over-time chart when no fresh sensor frames arrive.
- Make the strength-over-time chart full width on the dashboard layout.
- Add/update tests for report text changes and active-client sample generation.

## Validation
- ........................                                                 [100%]
24 passed in 0.36s (24 passed)
- 
> vibesensor-ui@0.1.0 typecheck
> tsc --noEmit


> vibesensor-ui@0.1.0 build
> vite build

vite v6.4.1 building for production...
transforming...
✓ 15 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  12.50 kB │ gzip:  2.71 kB
dist/assets/index-BJZXrCqC.css   15.63 kB │ gzip:  4.25 kB
dist/assets/index-D_ErqpAh.js   125.54 kB │ gzip: 44.36 kB
✓ built in 388ms
