### PR TITLE
docs: overhaul README files and add missing ui/README

### DIFF
--- a/esp/README.md
+++ b/esp/README.md
@@ -1,7 +1,7 @@
-# ESP32 Firmware (ATOM ESP32-PICO)
+# ESP32 Firmware
 
-This PlatformIO project streams ADXL345 acceleration data to the Pi over UDP.
-Default PlatformIO environment targets `m5stack-atom` (ATOM ESP32-PICO).
+PlatformIO firmware for M5Stack ATOM Lite (ESP32-PICO) that reads an ADXL345
+accelerometer at 800 Hz and streams samples to the Pi server over UDP.
 
 ## Features
 
@@ -13,7 +13,22 @@ Default PlatformIO environment targets `m5stack-atom` (ATOM ESP32-PICO).
 - ADXL345 I2C driver at 800 Hz with error-checked initialisation
 - Synthetic waveform fallback when the sensor is absent or I2C fails
 
-## Error handling
+## Project Structure
+
+```
+esp/
+├── src/
+│   └── main.cpp              Firmware entry point
+├── lib/
+│   ├── adxl345/              I2C driver for ADXL345 accelerometer
+│   └── vibesensor_proto/     Protocol packet builder
+├── include/
+│   ├── vibesensor_network.local.example.h   Network override template
+│   └── vibesensor_network.local.h           Local overrides (gitignored)
+└── platformio.ini            PlatformIO build config
+```
+
+## Error Handling
 
 - **I2C init**: Every register write during `ADXL345::begin()` is validated;
   if any write fails the sensor is marked unavailable and the firmware falls
@@ -24,7 +39,7 @@ Default PlatformIO environment targets `m5stack-atom` (ATOM ESP32-PICO).
 - **Wi-Fi**: Automatic reconnect with configurable retry interval
   (`kWifiRetryIntervalMs`).
 
-## Build and flash
+## Build and Flash
 
 ```bash
 cd esp

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,28 @@
 # Examples
 
-This folder contains schema-v2 sample input for deterministic report generation.
+Sample run data in [schema v2](../docs/run_schema_v2.md) JSONL format for
+testing report generation without recording a live session.
 
-Generate a PDF report from the sample run:
+## Generate a PDF Report
 
 ```bash
 vibesensor-report examples/sample_complete_run.jsonl --output examples/sample_complete_run_report.pdf
 ```
 
-Optional summary JSON:
+With summary JSON:
 
 ```bash
 vibesensor-report examples/sample_complete_run.jsonl \
   --output examples/sample_complete_run_report.pdf \
   --summary-json examples/sample_complete_run_summary.json
 ```
+
+## Schema
+
+Each JSONL file contains:
+
+1. `run_metadata` record (first line) — sensor model, sample rate, FFT config
+2. `sample` records — time series with acceleration, speed, FFT peaks
+3. Optional `run_end` record
+
+See [docs/run_schema_v2.md](../docs/run_schema_v2.md) for the full field reference.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,33 +1,29 @@
-# Hardware Used
+# Hardware
 
-This prototype is built with the following hardware:
+Bill of materials for the VibeSensor prototype.
 
-1. Raspberry Pi 3 A+
-2. M5Stack ATOM Lite ESP32 IoT M5 Development Kit
-3. M5Stack 3-Axis Digital Accelerometer Unit (ADXL345)
-4. M5Stack Atomic Battery Base (200mAh)
+## Components
 
-## Role Of Each Part
+| # | Part | Role |
+|---|------|------|
+| 1 | Raspberry Pi 3 A+ | Wi-Fi AP, server, web UI host |
+| 2 | M5Stack ATOM Lite ESP32 | Sensor node — samples accelerometer, streams UDP |
+| 3 | M5Stack ADXL345 3-Axis Accelerometer Unit | Vibration measurement (3-axis, 800 Hz) |
+| 4 | M5Stack Atomic Battery Base (200 mAh) | Portable power for the ATOM Lite node |
 
-1. Raspberry Pi 3 A+:
-Hosts the local Wi-Fi AP, runs the VibeSensor server, and serves the web UI.
+Multiple sensor nodes (items 2-4) can connect to a single Pi simultaneously.
 
-2. M5Stack ATOM Lite ESP32:
-Runs the firmware that samples accelerometer data and streams UDP telemetry to the Pi.
+## Wiring
 
-3. M5Stack ADXL345 Unit:
-Provides 3-axis acceleration measurements for vibration analysis.
+The ESP32 connects to the ADXL345 via I2C over the ATOM Lite 4-pin Unit port:
 
-4. M5Stack Atomic Battery Base (200mAh):
-Portable power base for the ATOM Lite node.
+| Signal | GPIO |
+|--------|------|
+| SDA | GPIO26 |
+| SCL | GPIO32 |
+| ADDR | 0x53 |
+| Power/GND | Via 4-pin Unit cable |
 
-## ESP32 <-> ADXL345 4-Pin Unit Cable (Current Firmware Defaults)
+No soldering required — the M5Stack components connect with plug-in cables.
 
-The firmware is configured for I2C over the ATOM Lite Unit port:
-
-- `SDA -> GPIO26`
-- `SCL -> GPIO32`
-- `ADDR = 0x53`
-- `Power/GND via the 4-pin Unit cable`
-
-See `esp/README.md` for firmware and pin configuration details.
+See [esp/README.md](../esp/README.md) for firmware configuration.

--- a/image/pi-gen/README.md
+++ b/image/pi-gen/README.md
@@ -1,22 +1,51 @@
-# Prebuilt Image (Mode B, Raspberry Pi 3 A+)
+# Prebuilt Raspberry Pi Image
 
-Build machine commands:
+Builds a custom Raspberry Pi OS Lite (Bookworm) image with VibeSensor
+pre-installed. After flashing to an SD card and booting, the Pi is ready to use
+with no manual setup.
+
+## Prerequisites
+
+- Linux build machine (or WSL2)
+- Docker
+- git, rsync
+- ~20 minutes build time (depends on cache and network)
+
+## Build
 
 ```bash
 git clone https://github.com/Skamba/VibeSensor.git
 cd VibeSensor
-./image/pi-gen/build.sh   # outputs an .img in image/pi-gen/out/
+./image/pi-gen/build.sh
 ```
 
-`build.sh` uses `pi-gen` in Docker, adds VibeSensor into the image, installs the server, and enables:
+Output image: `image/pi-gen/out/vibesensor-rpi3a-plus-bookworm-lite.img`
 
-- `vibesensor.service`
-- `vibesensor-hotspot.service`
+## What's Included
 
-Output image artifacts are written to:
+The image contains:
 
-- `image/pi-gen/out/`
+- Raspberry Pi OS Lite (Bookworm, arm64)
+- VibeSensor Python server with all dependencies
+- Built web UI (served from `pi/public/`)
+- systemd services enabled at boot:
+  - `vibesensor.service` — FastAPI server
+  - `vibesensor-hotspot.service` — Wi-Fi AP setup via NetworkManager
+  - `vibesensor-hotspot-self-heal.timer` — periodic AP health check (every 2 min)
 
-The produced image name is `vibesensor-rpi3a-plus-bookworm-lite` and is intended for Raspberry Pi 3 A+.
+## Flash
 
-After flashing the produced image and first boot, no manual install steps are required.
+Use [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to write the
+`.img` file (or `.img.xz`/`.zip` artifact) to an SD card.
+
+Insert the card into a Raspberry Pi 3 A+ and power on. The hotspot and server
+start automatically on first boot.
+
+## How It Works
+
+`build.sh` uses [pi-gen](https://github.com/RPi-Distro/pi-gen) in Docker to
+produce the image. It adds a custom stage that:
+
+1. Copies the VibeSensor repository into `/opt/VibeSensor`
+2. Runs `pi/scripts/install_pi.sh` (deps, venv, systemd units)
+3. Enables the hotspot and self-heal services

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,35 +1,51 @@
 # Pi Server
 
-This package runs the local FastAPI + WebSocket server on Raspberry Pi and
-ingests UDP telemetry from ESP32 vibration nodes.
+FastAPI backend that ingests UDP accelerometer telemetry from ESP32 nodes,
+performs real-time FFT signal processing, pushes live diagnostics over WebSocket,
+and generates PDF diagnostic reports.
 
-## Files
+## Architecture
 
-- `config.yaml`: active configuration
-- `config.dev.yaml`: local development config (repo-relative paths)
-- `config.example.yaml`: template for deployments
-- `wifi-secrets.example.env`: template for uplink Wi-Fi + git update settings
-- `scripts/hotspot_nmcli.sh`: idempotent AP setup using NetworkManager shared mode
-- `scripts/install_pi.sh`: install deps, venv, and systemd unit
-- `scripts/run_dev.sh`: local dev run with built-in simulator
+```
+  ESP32 nodes ──► UDP 9000 ──► udp_data_rx.py ──► processing.py (FFT + metrics)
+                                                         │
+                  UDP 9001 ◄── udp_control_tx.py         ├──► ws_hub.py ──► Browser
+                                                         │
+                                                         ├──► metrics_log.py ──► JSONL + SQLite
+                                                         │
+                                                         └──► live_diagnostics.py (events)
+```
 
-## Uplink Update Before Hotspot
+Key modules in `vibesensor/`:
 
-The hotspot script can briefly join an existing Wi-Fi network, update this
-repo, then switch back to AP mode.
+| Module | Purpose |
+|--------|---------|
+| `app.py` | FastAPI application entry point and lifecycle |
+| `api.py` | HTTP + WebSocket endpoint definitions |
+| `protocol.py` | UDP wire protocol parser (HELLO, DATA, CMD, ACK) |
+| `processing.py` | FFT, waveform, RMS/P2P, peak detection, spike filtering |
+| `metrics_log.py` | Run recording to JSONL with auto-start/stop on silence |
+| `history_db.py` | SQLite storage for run metadata and analysis results |
+| `live_diagnostics.py` | Real-time vibration event detection and severity tracking |
+| `ws_hub.py` | WebSocket connection management and broadcast |
+| `udp_data_rx.py` | UDP data listener (port 9000) |
+| `udp_control_tx.py` | UDP control sender (port 9001, identify command) |
+| `report_pdf.py` | PDF report generation (A4 landscape, workshop handout format) |
+| `report_analysis.py` | Post-run analysis engine (findings, order matching) |
+| `report_i18n.py` | Internationalization strings (EN, NL) |
+| `config.py` | YAML configuration loader with defaults |
+| `registry.py` | Connected client registry |
+| `gps_speed.py` | GPSD client for speed input |
+| `hotspot_self_heal.py` | Wi-Fi AP health monitoring and auto-recovery |
+| `analysis_settings.py` | Vehicle parameter defaults and frequency band math |
+| `settings_store.py` | Persistent car profiles and sensor settings |
+| `car_library.py` | Vehicle database for car setup wizard |
+| `locations.py` | Canonical sensor location codes |
+| `constants.py` | Shared physical and analysis constants |
 
-1. Copy `wifi-secrets.example.env` to `/etc/vibesensor/wifi-secrets.env`.
-2. Set `WIFI_UPLINK_SSID` and `WIFI_UPLINK_PSK`.
-3. Keep permissions strict: `chmod 600 /etc/vibesensor/wifi-secrets.env`.
+## Setup
 
-Behavior in `scripts/hotspot_nmcli.sh`:
-
-- Scan for the uplink SSID for up to 10 seconds (configurable).
-- If found, connect and wait for git update commands to finish.
-- Disconnect uplink and create/start the hotspot.
-- If SSID is not found within timeout, skip uplink and start hotspot directly.
-
-## Local run
+### Local development
 
 ```bash
 cd pi
@@ -39,30 +55,179 @@ pip install -e ".[dev]"
 python -m vibesensor.app --config config.dev.yaml
 ```
 
-## Test progress visibility
+### Docker
 
-For longer test runs, use the progress helper to get live completion, pass/fail
-counts, execution rate, and ETA while tests run:
-
-```bash
-python3 tools/tests/pytest_progress.py -- -m "not selenium" pi/tests
-```
-
-## Local Docker run (server only)
-
-Run from repository root:
+From the repository root:
 
 ```bash
 docker compose up --build
 ```
 
-This runs only the FastAPI/UDP server path and skips AP/hotspot configuration.
+This runs the FastAPI/UDP server only — no AP/hotspot configuration.
 
-## API
+## Configuration
 
-- `GET /api/clients`
-- `GET /api/client-locations`
-- `POST /api/clients/{client_id}/location`
-- `POST /api/clients/{client_id}/rename`
-- `POST /api/clients/{client_id}/identify`
-- `WS /ws`
+Configuration is loaded from YAML. See `config.example.yaml` for all options.
+
+| Section | Key fields |
+|---------|------------|
+| `server` | `host`, `port` (default 0.0.0.0:8000) |
+| `udp` | `data_listen` (9000), `control_listen` (9001) |
+| `processing` | `sample_rate_hz`, `fft_n`, `spectrum_max_hz`, `ui_push_hz` |
+| `logging` | `log_metrics`, `metrics_log_path`, `sensor_model` |
+| `storage` | `clients_json_path` |
+| `gps` | `gps_enabled`, `gps_speed_only` |
+| `ap` | `ssid`, `psk`, `ip`, `channel`, `self_heal` |
+
+Development configs (`config.dev.yaml`, `config.docker.yaml`) override only
+paths — all other values use built-in defaults.
+
+## Files
+
+```
+pi/
+├── pyproject.toml           Package metadata and dependencies
+├── config.yaml              Active Pi configuration
+├── config.dev.yaml          Local dev overrides (repo-relative paths)
+├── config.docker.yaml       Docker overrides
+├── config.example.yaml      Deployment template (all options documented)
+├── wifi-secrets.example.env Template for uplink Wi-Fi credentials
+├── public/                  Built UI static assets (served by FastAPI)
+├── data/                    Runtime data (settings.json)
+├── scripts/
+│   ├── install_pi.sh        Install deps, venv, systemd units
+│   ├── hotspot_nmcli.sh     Idempotent AP setup via NetworkManager
+│   └── hotspot_self_heal.py Self-heal entry point (also in vibesensor/)
+├── systemd/
+│   ├── vibesensor.service
+│   ├── vibesensor-hotspot.service
+│   ├── vibesensor-hotspot-self-heal.service
+│   └── vibesensor-hotspot-self-heal.timer
+├── tests/                   pytest suite (391+ tests)
+└── vibesensor/              Application package
+```
+
+## Uplink Update Before Hotspot
+
+The hotspot script can briefly join an existing Wi-Fi network to pull updates
+before switching to AP mode.
+
+1. Copy `wifi-secrets.example.env` to `/etc/vibesensor/wifi-secrets.env`
+2. Set `WIFI_UPLINK_SSID` and `WIFI_UPLINK_PSK`
+3. Restrict permissions: `chmod 600 /etc/vibesensor/wifi-secrets.env`
+
+Behavior: scan for uplink SSID (up to 10 s) → connect and wait for update →
+disconnect → start hotspot. If SSID not found, start hotspot directly.
+
+## API Reference
+
+### Health
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/health` | Server health check |
+
+### Clients
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/clients` | List connected sensors |
+| GET | `/api/client-locations` | Available location codes |
+| POST | `/api/clients/{id}/rename` | Rename a sensor |
+| POST | `/api/clients/{id}/identify` | Trigger LED blink |
+| POST | `/api/clients/{id}/location` | Set sensor location |
+| DELETE | `/api/clients/{id}` | Remove a client |
+
+### Settings
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/settings` | Current settings |
+| GET | `/api/settings/cars` | List car profiles |
+| POST | `/api/settings/cars` | Create car profile |
+| PUT | `/api/settings/cars/{id}` | Update car profile |
+| DELETE | `/api/settings/cars/{id}` | Delete car profile |
+| POST | `/api/settings/cars/active` | Set active car |
+| GET | `/api/settings/speed-source` | Speed source config |
+| POST | `/api/settings/speed-source` | Update speed source |
+| GET | `/api/settings/sensors` | Sensor metadata |
+| POST | `/api/settings/sensors/{mac}` | Update sensor metadata |
+| DELETE | `/api/settings/sensors/{mac}` | Delete sensor metadata |
+
+### Analysis
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/analysis-settings` | Current analysis parameters |
+| POST | `/api/analysis-settings` | Update analysis parameters |
+| GET | `/api/speed-override` | Current speed override |
+| POST | `/api/speed-override` | Set manual speed |
+
+### History & Reports
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/history` | List recorded runs |
+| GET | `/api/history/{id}` | Run details |
+| GET | `/api/history/{id}/insights` | Analysis findings |
+| GET | `/api/history/{id}/report.pdf` | Download PDF report |
+| GET | `/api/history/{id}/export` | Download raw JSONL data |
+| DELETE | `/api/history/{id}` | Delete a run |
+
+### Recording
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/logging/status` | Recording state |
+| POST | `/api/logging/start` | Start recording |
+| POST | `/api/logging/stop` | Stop recording |
+
+### Car Library
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/car-library` | Full vehicle database |
+| GET | `/api/car-library/brands` | Available brands |
+| GET | `/api/car-library/types` | Body types for a brand |
+| GET | `/api/car-library/models` | Models for brand + type |
+
+### Debug
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/debug/spectrum/{id}` | Detailed FFT debug info |
+| GET | `/api/debug/raw-samples/{id}` | Raw time-domain samples |
+
+### WebSocket
+
+| Endpoint | Description |
+|----------|-------------|
+| `/ws` | Live spectrum, client list, diagnostics, speed |
+
+## Reports
+
+Generate a PDF from a saved run:
+
+```bash
+vibesensor-report path/to/metrics_run.jsonl
+```
+
+Optional summary JSON output:
+
+```bash
+vibesensor-report path/to/run.jsonl --output report.pdf --summary-json summary.json
+```
+
+## Testing
+
+```bash
+# Fast run (excludes browser tests)
+pytest -q -m "not selenium" pi/tests
+
+# With live progress and ETA
+python3 tools/tests/pytest_progress.py -- -m "not selenium" pi/tests
+```
+
+Test markers:
+- `selenium` — browser-based UI tests (require Selenium + Chrome)
+- `long_sim` — longer simulated-run tests (>20 s)

--- a/tools/simulator/README.md
+++ b/tools/simulator/README.md
@@ -1,6 +1,10 @@
 # Simulator
 
-`sim_sender.py` spawns multiple fake ESP32 clients that send:
+Spawns fake ESP32 sensor clients for testing VibeSensor without physical
+hardware. Useful for local development, CI smoke tests, and reproducing
+specific vibration scenarios.
+
+`sim_sender.py` sends:
 
 - HELLO packets every 2 seconds
 - DATA frames at 800 Hz sample rate (200 samples per UDP frame)
@@ -45,7 +49,9 @@ Useful options:
 - `--interactive` force CLI mode
 - `--no-interactive` disable CLI mode
 
-Deterministic mild single-wheel fault scenario:
+## Scenarios
+
+Deterministic fault scenarios for reproducible testing:
 
 ```bash
 python tools/simulator/sim_sender.py \

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,78 @@
+# Web UI
+
+Single-page TypeScript application that provides real-time vibration monitoring,
+sensor management, run history, and car configuration. Communicates with the Pi
+server over HTTP (REST) and WebSocket (live data).
+
+## Tech Stack
+
+- **TypeScript** — application logic
+- **Vite** — build tool and dev server
+- **uPlot** — high-performance spectrum charts
+- **Playwright** — visual regression testing
+- **CSS custom properties** — Material Design 3 inspired theming
+
+## Setup
+
+```bash
+cd ui
+npm ci
+npm run dev          # Dev server on http://localhost:5173
+npm run build        # Production build to dist/
+npm run typecheck    # Type check without emitting
+```
+
+The built output in `dist/` is copied to `pi/public/` for serving by FastAPI.
+Use `python tools/sync_ui_to_pi_public.py` from the repo root to build and sync
+in one step.
+
+## Source Modules
+
+| File | Purpose |
+|------|---------|
+| `main.ts` | Core application logic, DOM bindings, view management |
+| `api.ts` | REST API client with typed request/response interfaces |
+| `ws.ts` | WebSocket client with auto-reconnect and stale detection |
+| `i18n.ts` | Internationalization dictionary (English, Dutch) |
+| `spectrum.ts` | uPlot chart wrapper for interactive spectrum visualization |
+| `server_payload.ts` | TypeScript type definitions for server messages |
+| `diagnostics.ts` | Strength band normalization and vibration matrix helpers |
+| `vehicle_math.ts` | Tire diameter, order tolerance, and uncertainty calculations |
+| `format.ts` | Number, byte, and timestamp formatting utilities |
+| `constants.ts` | Sensor location codes and vibration source columns |
+| `theme.ts` | Chart color palette and order band fill colors |
+| `styles/app.css` | Full CSS with light/dark theme tokens |
+
+## Features
+
+- **Live view** — spectrum chart, stat cards, car heatmap, vibration log, recording controls
+- **History view** — recorded runs with insights, PDF download, JSONL export
+- **Settings view** — car profiles (tire/drivetrain wizard with car library), analysis parameters, speed source, sensor naming and location mapping
+- **Auto theme** — follows system light/dark preference
+- **Drive sizing** — larger touch targets on tablet viewports
+- **Demo mode** — deterministic UI state via `?demo=1` for testing
+
+## Visual Tests
+
+Playwright snapshot tests capture the UI across 4 viewports:
+
+| Viewport | Theme |
+|----------|-------|
+| Laptop (1280x800) | Light |
+| Laptop (1280x800) | Dark |
+| Tablet (768x1024) | Light |
+| Tablet (768x1024) | Dark |
+
+```bash
+npx playwright install chromium   # first time only
+npm run test:visual               # compare against baselines
+npm run test:visual:update        # regenerate after intentional changes
+```
+
+Baselines live in `tests/snapshots/`. Tests use demo mode for deterministic payloads.
+
+## Design Language
+
+The UI follows the design system documented in
+[docs/design_language.md](../docs/design_language.md) — purple accent, minimal
+flat aesthetic, token-driven styling.


### PR DESCRIPTION
## Summary

- **Root README** — rewritten with project overview, key features, system architecture ASCII diagram, complete repo layout tree (was missing ui/, hardware/, docs/, tools/, image/, examples/), and streamlined quick start
- **pi/README** — expanded from 69 → ~200 lines with architecture data-flow diagram, module reference table, full configuration guide, and complete API reference (40+ endpoints; was missing ~35 of them)
- **ui/README** — new file covering tech stack, setup, source module reference, visual test guide
- **esp, hardware, image/pi-gen, tools/simulator, examples READMEs** — polished with structure, wiring tables, prerequisites, cross-links, and context for first-time readers

## Test plan

- [x] Extended test suite: `python3 tools/tests/pytest_progress.py -- -m "not selenium" pi/tests` → 432 passed, 0 failures
- [x] Ruff lint: `ruff check pi/vibesensor pi/tests tools/simulator` → all checks passed
- [ ] Verify rendered markdown looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)