### PR TITLE
feat: move runtime persistence to sqlite only

### DIFF
--- a/apps/server/config.example.yaml
+++ b/apps/server/config.example.yaml
@@ -39,7 +39,6 @@ processing:
 logging:
   log_metrics: true
   metrics_log_path: data/metrics.jsonl
-  write_metrics_jsonl: false
   persist_history_db: true
   history_db_path: data/history.db
   metrics_log_hz: 4

--- a/apps/server/tests/test_analysis_settings_source_of_truth.py
+++ b/apps/server/tests/test_analysis_settings_source_of_truth.py
@@ -102,7 +102,10 @@ def _route(router, path: str, method: str = "GET"):
 
 @pytest.mark.asyncio
 async def test_analysis_settings_endpoint_updates_active_car_aspects(tmp_path: Path) -> None:
-    settings_store = SettingsStore(persist_path=tmp_path / "settings.json")
+    from vibesensor.history_db import HistoryDB
+
+    db = HistoryDB(tmp_path / "test.db")
+    settings_store = SettingsStore(db=db)
     analysis_settings = AnalysisSettingsStore()
     analysis_settings.update(settings_store.active_car_aspects())
     state = _State(settings_store=settings_store, analysis_settings=analysis_settings)

--- a/apps/server/tests/test_config.py
+++ b/apps/server/tests/test_config.py
@@ -39,10 +39,9 @@ def test_logging_flags_allow_db_only_mode(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     _write_config(
         config_path,
-        {"logging": {"write_metrics_jsonl": False, "persist_history_db": True}},
+        {"logging": {"persist_history_db": True}},
     )
     cfg = load_config(config_path)
-    assert cfg.logging.write_metrics_jsonl is False
     assert cfg.logging.persist_history_db is True
 
 

--- a/apps/server/tests/test_udp_control_tx.py
+++ b/apps/server/tests/test_udp_control_tx.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from vibesensor.history_db import HistoryDB
 from vibesensor.protocol import HelloMessage, parse_cmd
 from vibesensor.registry import ClientRegistry
 from vibesensor.udp_control_tx import UDPControlPlane
@@ -63,7 +64,7 @@ def test_send_identify_accepts_hex_and_mac_client_ids(
 
 def test_send_data_ack_sends_to_control_addr(tmp_path: Path) -> None:
     client_hex = "aabbccddeeff"
-    registry = ClientRegistry(tmp_path / "clients.json")
+    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
     registry.update_from_hello(
         HelloMessage(
             client_id=bytes.fromhex(client_hex),

--- a/apps/server/vibesensor/api.py
+++ b/apps/server/vibesensor/api.py
@@ -77,6 +77,10 @@ class LanguageRequest(BaseModel):
     language: str = Field(pattern="^(en|nl)$")
 
 
+class SpeedUnitRequest(BaseModel):
+    speedUnit: str = Field(pattern="^(kmh|mps)$")
+
+
 class CarUpsertRequest(BaseModel):
     name: str | None = None
     type: str | None = None
@@ -235,6 +239,18 @@ def create_router(state: RuntimeState) -> APIRouter:
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"language": language}
+
+    @router.get("/api/settings/speed-unit")
+    async def get_speed_unit() -> dict:
+        return {"speedUnit": state.settings_store.speed_unit}
+
+    @router.post("/api/settings/speed-unit")
+    async def set_speed_unit(req: SpeedUnitRequest) -> dict:
+        try:
+            unit = state.settings_store.set_speed_unit(req.speedUnit)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"speedUnit": unit}
 
     # -- legacy endpoints (adapters) -------------------------------------------
 

--- a/apps/server/vibesensor/config.py
+++ b/apps/server/vibesensor/config.py
@@ -47,10 +47,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "metrics_log_path": "data/metrics.jsonl",
         "metrics_log_hz": 4,
         "sensor_model": "ADXL345",
-        "write_metrics_jsonl": False,
         "persist_history_db": True,
-        "durable_jsonl_writes": False,
-        "durable_jsonl_fsync_every_records": 100,
     },
     "storage": {
         "clients_json_path": "data/clients.json",
@@ -139,10 +136,7 @@ class LoggingConfig:
     metrics_log_hz: int
     sensor_model: str
     history_db_path: Path
-    write_metrics_jsonl: bool
     persist_history_db: bool
-    durable_jsonl_writes: bool
-    durable_jsonl_fsync_every_records: int
 
 
 @dataclass(slots=True)
@@ -271,29 +265,10 @@ def load_config(config_path: Path | None = None) -> AppConfig:
                 ),
                 path,
             ),
-            write_metrics_jsonl=bool(
-                merged["logging"].get(
-                    "write_metrics_jsonl", DEFAULT_CONFIG["logging"]["write_metrics_jsonl"]
-                )
-            ),
             persist_history_db=bool(
                 merged["logging"].get(
                     "persist_history_db", DEFAULT_CONFIG["logging"]["persist_history_db"]
                 )
-            ),
-            durable_jsonl_writes=bool(
-                merged["logging"].get(
-                    "durable_jsonl_writes", DEFAULT_CONFIG["logging"]["durable_jsonl_writes"]
-                )
-            ),
-            durable_jsonl_fsync_every_records=max(
-                1,
-                int(
-                    merged["logging"].get(
-                        "durable_jsonl_fsync_every_records",
-                        DEFAULT_CONFIG["logging"]["durable_jsonl_fsync_every_records"],
-                    )
-                ),
             ),
         ),
         gps=GPSConfig(

--- a/apps/ui/src/api.ts
+++ b/apps/ui/src/api.ts
@@ -23,6 +23,10 @@ export {
   getSettingsSensors,
   updateSettingsSensor,
   deleteSettingsSensor,
+  getSettingsLanguage,
+  setSettingsLanguage,
+  getSettingsSpeedUnit,
+  setSettingsSpeedUnit,
 } from "./api/settings";
 export { getCarLibraryBrands, getCarLibraryTypes, getCarLibraryModels } from "./api/car_library";
 export {

--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -1,6 +1,30 @@
 import { apiJson } from "./http";
 import type { CarsPayload, SpeedSourcePayload } from "./types";
 
+export async function getSettingsLanguage(): Promise<{ language: string }> {
+  return apiJson("/api/settings/language");
+}
+
+export async function setSettingsLanguage(language: string): Promise<{ language: string }> {
+  return apiJson("/api/settings/language", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ language }),
+  });
+}
+
+export async function getSettingsSpeedUnit(): Promise<{ speedUnit: string }> {
+  return apiJson("/api/settings/speed-unit");
+}
+
+export async function setSettingsSpeedUnit(speedUnit: string): Promise<{ speedUnit: string }> {
+  return apiJson("/api/settings/speed-unit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ speedUnit }),
+  });
+}
+
 export async function getSpeedOverride(): Promise<{ speed_kmh: number | null }> {
   return apiJson("/api/speed-override");
 }

--- a/apps/ui/src/legacy/vehicle_config_feature.ts
+++ b/apps/ui/src/legacy/vehicle_config_feature.ts
@@ -12,22 +12,15 @@ import {
 } from "../api";
 
 export function createVehicleConfigFeature(ctx) {
-  const { state, els, t, settingsStorageKey, escapeHtml, fmt } = ctx;
+  const { state, els, t, escapeHtml, fmt } = ctx;
 
   function loadVehicleSettings() {
-    try {
-      const raw = window.localStorage.getItem(settingsStorageKey);
-      if (!raw) return;
-      const parsed = JSON.parse(raw);
-      if (typeof parsed !== "object" || !parsed) return;
-      for (const key of Object.keys(state.vehicleSettings)) {
-        if (typeof parsed[key] === "number") state.vehicleSettings[key] = parsed[key];
-      }
-    } catch (_err) {}
+    // Settings are loaded from server via loadAnalysisSettingsFromServer.
+    // This function is kept as a no-op for call-site compatibility.
   }
 
   function saveVehicleSettings() {
-    window.localStorage.setItem(settingsStorageKey, JSON.stringify(state.vehicleSettings));
+    // Vehicle settings are synced to server, no local persistence needed.
   }
 
   function syncSettingsInputs() {


### PR DESCRIPTION
## Summary
- migrate runtime persistence to SQLite-only storage for server settings, client names, and run history artifacts
- remove metrics JSONL persistence path and corresponding logging config toggles
- move UI language/speed unit persistence from localStorage to server-backed settings APIs
- rewire app startup to provide a shared HistoryDB to settings/client registry components
- update affected tests for new DB-backed constructors and metrics logger API

## Validation
- python3 -m pytest -x -m "not selenium" apps/server/tests/ --ignore=apps/server/tests/test_app_lifecycle.py
- ruff check apps/server/vibesensor apps/server/tests
- ruff format --check apps/server/vibesensor apps/server/tests
- cd apps/ui && npm run typecheck
- cd apps/ui && npm run build
- docker compose build --pull
- docker compose up -d
- python3 apps/simulator/sim_sender.py --count 5 --duration 10 --no-interactive
- python3 apps/simulator/ws_smoke.py --uri ws://127.0.0.1:8000/ws --min-clients 3 --timeout 35
- docker compose logs --tail 30

## Notes
- user requested Step D (hotspot self-heal persistence) be excluded from this migration
- UI screenshot checklist command currently fails in this environment because apps/ui/take-screenshot.mjs uses a hardcoded Chromium path under /root/.cache
