### PR TITLE
fix(pi-image): chown var/log and var/lib vibesensor dirs to pi user

### DIFF
--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -88,7 +88,8 @@ cat >"${STAGE_STEP_DIR}/00-run.sh" <<'EOF'
 install -d "${ROOTFS_DIR}/opt"
 cp -a files/opt/VibeSensor "${ROOTFS_DIR}/opt/"
 
-install -d "${ROOTFS_DIR}/etc/vibesensor" "${ROOTFS_DIR}/var/lib/vibesensor" "${ROOTFS_DIR}/var/log/vibesensor"
+install -d "${ROOTFS_DIR}/etc/vibesensor"
+install -d -o 1000 -g 1000 "${ROOTFS_DIR}/var/lib/vibesensor" "${ROOTFS_DIR}/var/log/vibesensor"
 install -d "${ROOTFS_DIR}/var/log/wifi"
 install -d "${ROOTFS_DIR}/etc/systemd/system"
 install -d "${ROOTFS_DIR}/etc/NetworkManager/conf.d"


### PR DESCRIPTION
## Summary

- `vibesensor.service` has `ExecStartPre=/usr/bin/test -w /var/log/vibesensor` and `-w /var/lib/vibesensor`
- These dirs were created with `install -d` (root:root ownership), so the `pi` user service failed the writable check on every boot (restart counter was at 350+)
- Fix: pass `-o 1000 -g 1000` to `install -d` so the dirs are owned by `pi:pi` at image build time

## Root cause observed

```
ExecStartPre=/usr/bin/test -w /var/log/vibesensor  (code=exited, status=1/FAILURE)
vibesensor.service: Control process exited, code=exited, status=1/FAILURE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)