### PR TITLE
fix(pi-image): pass CONTINUE=1 so incremental builds actually work

### DIFF
--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -199,7 +199,10 @@ fi
 
 (
   cd "${PI_GEN_DIR}"
-  ./build-docker.sh
+  # CONTINUE=1 tells build-docker.sh to reuse the existing pigen_work container
+  # (volumes-from) rather than aborting. Safe for full builds too since we
+  # already removed the container above in that path.
+  CONTINUE=1 ./build-docker.sh
 )
 
 find "${PI_GEN_DIR}/deploy" -maxdepth 1 -type f \


### PR DESCRIPTION
## Summary

- Without `CONTINUE=1`, `build-docker.sh` exits 1 when `pigen_work` container already exists, causing `build.sh` (`set -e`) to silently fall through to a fresh full build every time
- With `CONTINUE=1`, build-docker.sh uses `--volumes-from pigen_work` so the SKIP files on stage0/1/2 take effect and only `stage-vibesensor` rebuilds (~5 min vs ~27 min)
- Safe for full builds too: the container is removed before this point in that code path, so `CONTINUE=1` is a no-op there

## Root cause

`build-docker.sh` lines 75-79:
```bash
if [ "${CONTAINER_EXISTS}" != "" ] && [ "${CONTINUE}" != "1" ]; then
    echo "Container already exists... Aborting."
    exit 1
fi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)