### PR TITLE
Fix Pi image SSH access and artifact selection/validation

### DIFF
--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -21,6 +21,16 @@ cd VibeSensor
 
 Output image: `infra/pi-image/pi-gen/out/vibesensor-rpi3a-plus-bookworm-lite.img`
 
+Default SSH credentials in generated images:
+- user: `pi`
+- password: `vibesensor`
+
+Override at build time if needed:
+
+```bash
+VS_FIRST_USER_NAME=pi VS_FIRST_USER_PASS='your-password' ./infra/pi-image/pi-gen/build.sh
+```
+
 ## What's Included
 
 The image contains:


### PR DESCRIPTION
## Summary
- force password SSH auth in generated Pi images and keep pubkey-only mode disabled
- add validation that first-user password hash matches the configured build password
- make artifact selection pick the newest output (not the oldest)
- make venv validation accept both `.venv/bin/python3` and `.venv/bin/python`
- document default SSH credentials and override env vars in the Pi image README

## Why
The previous flow produced images where SSH access could be unreliable and the wrapper could validate/copy the wrong artifact. This update makes SSH access deterministic for first boot and hardens build validation/output selection.

## Notes
Image artifacts were rebuilt and copied to `C:\temp` locally during verification.