### PR TITLE
Harden Pi image runtime deps and add ARM dependency smoke checks

### DIFF
--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -38,6 +38,7 @@ run_as_root apt-get install -y \
   python3 \
   python3-venv \
   python3-pip \
+  libopenblas0-pthread \
   network-manager \
   dnsmasq \
   rfkill \


### PR DESCRIPTION
## Summary
- add missing runtime package `libopenblas0-pthread` to Pi manual install script (`install_pi.sh`)
- add missing runtime packages `gpsd` and `gpsd-clients` to image build stage packages
- keep `libopenblas0-pthread` in image stage package list
- harden image validation in `build.sh`:
  - assert critical runtime packages are installed in rootfs
  - assert OpenBLAS runtime library exists
  - run ARM-chroot Python import smoke test for core modules
  - run ARM-chroot server startup smoke test and require successful startup
  - include `gpsd` binary validation in required binaries

## Why
Recent image boot verification found the web service could fail at runtime due to missing shared-library/package dependencies (`libopenblas.so.0`, and image parity gap for gpsd packages). This change makes runtime dependencies explicit and adds deterministic build-time checks so missing deps fail the build early.
