### PR TITLE
Enable port 80 for non-root service and keep safe runtime paths

### DIFF
--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -64,6 +64,14 @@ run_as_root systemd-tmpfiles --create /etc/tmpfiles.d/vibesensor-wifi.conf >/dev
 if [ ! -f /etc/vibesensor/config.yaml ]; then
   run_as_root cp "${PI_DIR}/config.example.yaml" /etc/vibesensor/config.yaml
 fi
+# Ensure first-boot config is writable for non-root service user and binds a non-privileged port.
+# Only rewrite known defaults so explicit custom values are preserved.
+run_as_root sed -i \
+  -e 's#state_file: data/hotspot-self-heal-state.json#state_file: /var/lib/vibesensor/hotspot-self-heal-state.json#' \
+  -e 's#metrics_log_path: data/metrics.jsonl#metrics_log_path: /var/log/vibesensor/metrics.jsonl#' \
+  -e 's#history_db_path: data/history.db#history_db_path: /var/lib/vibesensor/history.db#' \
+  -e 's#clients_json_path: data/clients.json#clients_json_path: /var/lib/vibesensor/clients.json#' \
+  /etc/vibesensor/config.yaml
 if [ ! -f /etc/vibesensor/wifi-secrets.env ]; then
   run_as_root cp "${PI_DIR}/wifi-secrets.example.env" /etc/vibesensor/wifi-secrets.env
 fi

--- a/apps/server/systemd/vibesensor.service
+++ b/apps/server/systemd/vibesensor.service
@@ -6,6 +6,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=__SERVICE_USER__
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 WorkingDirectory=__PI_DIR__
 ExecStartPre=/usr/bin/test -r /etc/vibesensor/config.yaml
 ExecStartPre=/usr/bin/test -w /var/log/vibesensor

--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -121,6 +121,15 @@ if [ ! -f "${ROOTFS_DIR}/etc/vibesensor/config.yaml" ]; then
     "${ROOTFS_DIR}/etc/vibesensor/config.yaml"
 fi
 
+# Ensure first-boot config paths are writable by the non-root service user and
+# default HTTP binds to a non-privileged port.
+sed -i \
+  -e 's#state_file: data/hotspot-self-heal-state.json#state_file: /var/lib/vibesensor/hotspot-self-heal-state.json#' \
+  -e 's#metrics_log_path: data/metrics.jsonl#metrics_log_path: /var/log/vibesensor/metrics.jsonl#' \
+  -e 's#history_db_path: data/history.db#history_db_path: /var/lib/vibesensor/history.db#' \
+  -e 's#clients_json_path: data/clients.json#clients_json_path: /var/lib/vibesensor/clients.json#' \
+  "${ROOTFS_DIR}/etc/vibesensor/config.yaml"
+
 if [ ! -f "${ROOTFS_DIR}/etc/vibesensor/wifi-secrets.env" ]; then
   install -m 0600 \
     "${ROOTFS_DIR}/opt/VibeSensor/apps/server/wifi-secrets.example.env" \


### PR DESCRIPTION
## Summary
- allow non-root `vibesensor.service` to bind privileged port 80 by adding:
  - `AmbientCapabilities=CAP_NET_BIND_SERVICE`
  - `CapabilityBoundingSet=CAP_NET_BIND_SERVICE`
- keep Pi runtime data path rewrites to writable locations under `/var/lib/vibesensor` and `/var/log/vibesensor`
- stop forcing config port rewrite from `80 -> 8000` in install/image scripts

## Why
The service was healthy except for Linux privilege constraints on binding port 80 as user `pi`. This patch enables port 80 binding correctly without running the service as root, while preserving safe writable runtime paths.
