### PR TITLE
docs: replace LoC limits with maintainability-first guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ Common commands (exact as found in CI / repo files)
   - docker compose up -d
 
 Repo conventions
-- Backend code: placed under `apps/server/vibesensor/`. Keep modules small and prefer explicit function signatures.
+- Backend code: placed under `apps/server/vibesensor/`. Keep files/modules short where practical, but avoid splitting that harms human maintainability; prefer explicit function signatures.
 - Tests live under `apps/server/tests/` and use pytest. Selenium-marked tests are slow/optional and excluded in CI with `-m "not selenium"`.
 - Strings that appear in generated reports are internationalised via `apps/server/data/report_i18n.json` and loaded by `apps/server/vibesensor/report_i18n.py`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Deterministic commands
 - Lint: `make lint`
 - Test: `make test`
 - Smoke: `make smoke`
-- LOC check: `make loc`
+- File-length advisory: `make loc`
 - Docs lint: `make docs-lint`
 
 Architecture map
@@ -44,4 +44,5 @@ Invariants
 - Canonical vibration severity metric is `vibration_strength_db`.
 - Strength bucket assignment must use `bucket_for_strength` logic.
 - Shared contracts under `libs/shared/contracts` are source of truth.
+- Keep files short where practical, as long as this does not reduce human maintainability.
 - Avoid reading or indexing build outputs/caches (`artifacts/`, `.cache/`, `node_modules/`, `dist/`) unless debugging packaging.


### PR DESCRIPTION
## Summary\n- remove LoC hard/soft enforcement from the file-length utility\n- rephrase guidance to keep files short where practical without harming maintainability\n- update AI operating guidance references to advisory wording\n\n## Notes\n-  is now advisory-only and always exits 0\n- no runtime product behavior changes\n\n## Validation\n- python3 tools/dev/loc_check.py\n- ruff check tools/dev/loc_check.py\n