### PR TITLE
Add polished PDF mockup v4 for diagnostic worksheet

### DIFF
--- a/vibesensor_pdf_mockup_v4_polished_clean-1.pdf
+++ b/vibesensor_pdf_mockup_v4_polished_clean-1.pdf
@@ -1,0 +1,93 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260220172453+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260220172453+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2969
+>>
+stream
+Gau`V=a-W1(4Ol=W(3[3`mb2l5IR,-12"2YfLl"Z0*mgp@MT,DGB?T/r7lnXZs]qEcD5mB=<EmQ=*H;/7Nq]frc_BeoO3;'J&DU+[!5!+"Um!^MgedP!YM[sN"?tmLr=7+(rZn@:U@(93+4d;&s4:hGX,^ZTgkcsG;ISL59L`[8O=gq5n_1V/K@&"([18kAA6?h)<1bZN)IS](@W^bW1:gN$94[g.o'L8+IREo'7h9nmccLZ3Cr:PFh3U<F-,b,\r.6S3Cl&4cT]"2r@u4DWuN&j8cmf*Y(Y7)VWo610G>U\"#/]=EY>l(gPEWG7uJ#>JNu=#M2hkA,%COU^6JAtC?l(PqX*2(3_uBJ]']%sh8rCIFQ`d3eQ!qT*VrlNceH]gB^n/f]Ml*-$iDuE&MrRGOjB.:+Vd8&@2qcK2CrG[TAUOq*&1';5%oXZ$4QC3(&I1k4hCO`dfg%LF:f-F?A'IcK*mICG:'#(Rm'DcGh_g'K+mW@`oA1P0i<diLk2SF<%udOL"nsPE`j(\30#4*@=sN*(JKpc*+SICUTeF4>R6m0Q@V=WO/]r<P`pX6MEK)eY#Xm5`9;6/Tj%5Y?BEWR(4C#$j0YIK,[g`ADl<NGk=q[C?\pHX8t\cXTmSni4%$rgdS=+lGq%YFmT.0N?T(D,##Qf*@l>6Z,bdShn;57mV9KUK%j+#'b_J3iC!m>?[S>VEodDJLqB/c&VBr\'D2sTu6cm.1mdp*"+m6k4#I,TIk&gQ,2p^kpapo0NY24?KaWC%GY0^P>[]/"u.3%n4<6B$J<dAjR&*aAKG3G")$DCh,XR>\MlSC@E*,%c(XlCt1&J/B(qcRekQfT!g\I*Wb&JO+Jd3.I^3@'_=(`#aGJYU.p3NsAnLoW>MA<W?g`+Gmi6]JW]29J(8)dO5c<!ses$aSLRU5uGL6C(QIC+B&!jqle7(TKt"W1"jn"6AWV/"81'&8hDGV;8SBB>c3,6"ER"2/-rt]M+e8g8&"%S*DDOY+,?I/0JWHWsflI4>F,<Y,SHLflj=]Vh<IBg3*8ETl+(7Z8faDQqkbB,JeHEZs"Ji9*gJ.3)%\?H+?,VEmsUE)Hf4GlQ]G_8^B(h81(-R-(?O3X)<."kG);DgCj2KBWX_pLO&he2FY41jOFp.d'V1D0k=#+5(*,$ROHZ1i_oO<K34`u(X'0cft2Z1Odal:WiKSFT\Hj<>#aR"#A6uf^LVIi_V$^3ZF+MrUE[I*ZR+-$U<ZYZD=Bm01ooOXGXg5^M$hUX:SL9bo59P\2m'm6mG$es6=9l8$&6aCi1>Nd]<W:'AXNH1bdbP-NfB8'5H1?q,*WQm:u`!S)7;?Y@;ujrfT3+WAZ]:]Ej1AOHS"=P*d=IJ+BH*AW6o02bLPoADFI%,?1kJ9FRO2rf=U&ceh6@mf%]K<6gK'3hQs_+`tks$gX:/!1UucNcJTb@9k">6@l62^3."l,^:ds!'ZSq;2kc#`FGR94_0gT6bhCfbG>WNoXmo^.M)B.M^"u?:]jWM:hYXDYfF/Wfp%P-RUU3ChDf;XTEVWX&l"*unAj,adThqV'>A&5]b3)7EdW$0`*Q,A5^]u\;?r)Sr[e[3uQft]9J"fs"B'<[;11#XNS]M6*L=UM!DX-Yd/nAaK:]WO)afBt\]A<*T9:!pG<L\B'CN`jlbU_f7oiVE]E,$o?:1l@NeAJq!,LZg`mhm,29W8-`"bKPRFVU9)/O./PXLMNr09"cUk5V'd]U)c,X]/o4@HXAH@(WV"VD6R<9`NM9KLjNJVGG>r2?.gW/sM^GZq.5kp*g?f94]7LR58%#m`JFNc0iQl14<[/h#%.$3"2m@q]=nunZo'B:='qpdq@du6"IO;dE$.Y1hP5YA;3DIM!Elb$o)R@oHSW&6_fCl]>KLD:FPjOk/m-=1/^s\#oK9S6:1R^csR!r5s5f>%-0eXMmh=GCfQ5sb]'dWk"i8+:)@eke!N)OC$cBb*5'D?EqLbH]-=<3Xnp+FH;_!YIIq<>_>HEM:DftIGjh&_1VYn+[5TFYju8KoL$Z$V\N7Z3hi3ZAqVHb%mGheTD*i/;FiG5Q%KT',YScKSF.4;-Y-j'A^;W4p43WGCdI)sCA?GAVOb?RSqV+`oO$:ZM+l>>kH"#iT2obrA2h1.jp?-$6)tca3LW[3q@/p'SM]GJ&gK)2RY\C`>/ZRoc@Jn-*P9>Hci$>Oa>8<Rk0rB6N(TU)^h&6eA\kk$\pYYTlObilY</[]QGseCn22e..l&.M]FjZde.fP0/'"t:]cr56t$4IXS_b2_Y?]o^FK8^2'^XSH.cha49M2fT\Rm/JNKTWPP[P-8<`&J,G%5786Ga*ms3ORDjVd`)EWaI0t3qRMNCTD(n=d*IDmIt9mUq?(-!8Z#!:?tmjBXM#!9%&U0:=>#+X_%3B`r3eH40;PF/mIQ3C21rBPFO@R1t2ls-p9*O3^#!.Cq-a6[^+^=/_/TBpoE(KlK,oEDnEU6NKJk)3N-G_jK-GETm<9$Q+d3dDS.-km1%XfNDpQq>"UVf$Ij,rE,XKjqGuqBj/tP;SIrQ9e("V($\h2.9_q`[7m6\K>,HT,f47nYrWE1MT*5P_;!)0NiD;,UZ*,4Kr<A4]#!A-]dT$MH<1nU:N<]t)pYaE?GnR%*5b7OB^aF1)C8#hQ5+*(+NtHN7TZVO-i0-/%jiff[^8oVQ+9O.RnI\V/M9%rs*53R,6f"rDDP5TqQ_LY9mR>RFbqTVUZ+]rIYAO<lVF>sn=nbWrYKl'ipj=D+oU1/1%XFC`:f>R]&Pl.gXa\?4.$@qJ",5tJ*ms%253A-1LFU474,#J(nB#BlW_lgXrVMO0ma&h96f,"#b@R]G[A^-+bC[R5KOtEW:t7bn[$g2or<E:@gj<J!=*`Pm,bQ\tWee/ZJAG2:n92<b/!PQMebNnpl$]PppA.;Np:]h-5L_X4AYZ7c[)3M>6<#RGbS^"@bfu/\>*:8Jb_'O-"4<7W*<~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 4006
+>>
+stream
+Gau0F9mbYR%_g8mi6gqp(%FYef\<iKg@!F5;odX!EfnDJ8+hgQ.`k9<?bZS0JfJJgSAq$\m:9N(+96un#RtE,r8mAHb7.rg?aEgP39,Trh_D8h`NF]$hd.rkX-LdaK?mF'".uEQ>d<^Gd5pDfnZ49YaU26__A&G]27ra+!OCW:OCb:?Ke->,jp$(h'*K):?$ur7*uF<2'q$V;PcVr+<bQ@'Amqdd$:#iE5(Gd$=XJO=Al`l]-S&TN6'dA1;:Z_6%^J3)p\Fm`*+ZT^/\_4)n]-7Y>qL:DOWrh'\IC[H\AUT_j3$Kc5!Y=Ki$Q;6F,C6p($p5KnK8qqZI26r`/(qu[CN9oeSW(gf[%<]cX&Q\ICnm%B$%4@h6n9T-2V</0'h?/IbHCr*d:tqlegCgQP`B1^u))c<l)IIV`MsUQPPfaS/VoGUPp\t!?Lj3,A1TMK%?ZnT]+F2bC4^7'ta>2c^,glqD&lVH(!jn)6*u&GNVCoH!B+V9MCb#rkU"9haIQ\.@&r0OLiY.UE['O80]mbUlLg!`CM9GX>"$W"OouI>QdT#&V;Z&3WjX2,K\*^OXMbV^bTXr(kcms.Bk/8-tl1sJqtP-0N*"`@br#d:'T$-2*V^//6;nX>OI]8KV9WQj70XsUESDFJ%m$#h0*1qC<,1</0DL,D?om/koZr`H[q=LremP6=.#YGi@h7^[i_'n)@dslg0;!(<U>e3_'+)>Xp"*Kc1n4%+g>41H<@'J+7$tdS#cSeI!oJOEa2RWQ/uo8?=M<_DuXr;=YnNOdQf(2NtH?lbZNERW+?_EA[/J!LY[ug&e!KH_Z:;acFbQN3.V.JcUoW1[U'7/ROrB.#p#s\%XCGgLs1.#;8SQlZP,'aB3GT!%+:F7<29U>bGZq"lNPm&'@J3E08RbDO,/\!!_0c(,=WH2FL$5\07OJ<Or)J15`PpgF8U-Z'`="e/i$XqOBcfS<`54.aj<^pX!39nk*aJ*KERed:LpaTLYa=$:p:oKpc)ZCF^S@oSZ%&f$(T_R+C(md,U*['=[l*l6PnKNMB_$?=p?H04<d&pO;0HIFe)pV+HfJhcb5#bIL"\rJ/mL-;tOS<U;dUUj%>$N["Y<e8XpSNUkRq@qE?ko2MVs?i6t[n=2<mA1,Dph-acbS&G]T`V`&H+%%9Y:/+=0\aV`N'H1+0DX6=b@8Q9R?.W)&G#YBG<Qp;tFHU3fCVsB2Lc_M:Q7;ILNR=.^:oG1n/:?$,S?pS'!LJ=*^0e!Dg10gb?.gsW9.VYcCj>=T%04J8D-qVVa4;o9K,-#<NO>O;i)bqHJLu+q0R2(GIV"^u*Z\TA2dBl]3.dU`2'G3Cm&^)aOHY>40Ug25@O=!0>MPs'eOu0L`]&SY+$0Kbahi^Pca[O*]T-BOW;b?OFQ6RrZ)^PZOP,,,<H9j'U,0`^-bW]Za<cBUbONUdmO%BD:K"tuaZV:3Fm[IjU'Hm']gngbcqMeajZOnp*#8Dqub[mY;3!7`j,?7EI!<LG"7iJKC.M+Y''G8)$ne($\:9]d)jnX#3J,g[*'rgh)d`fGQ;l;YpGAe=:%GG1#P<MKU'/\+37-JnKlLqr+CN`W>-&k[0RY*2%7g!UeYj1SPE!ngM+WsT(^iP&i:'0Z28'ADBfRmj&+:>AjYY[#DOqGJs"C2=87AKtPM3s*XCEZc0%(&%1c_;Ch->Rl,\4@^90iKf*]0:ElY[@&M.jkn;ijNVde/dl@C=q8Klnb>M$4VInIH"Q]iHh-?F[UKAMa`hQ)m06FDP>9l;@Eu_GgF;'9F8j7,=eb9q?)=hY2SqPVGt*r8rAFbI"XdA-TP'.8^N8gedDbTO.]LK1/gb#qd/W:8BC^(,&KreWpU'L4LT+?hV/s.pMC+Nn1W!kE&+4LIn[)CSWu.N9Er`p"J()\Z$:KTT^R??$-:c"K8h@Wb%Hn.aa2#u(e8?FMiodW:!-ZXf*bao<Ra-%Rb@Ggk65bWhJuuHE,W>!l7U[GCsC"#]tZ?-o+edmpqBXr0.97!GI_GP--Wt6Y=fL4JDffs$0.T_jao>B-b.o)"[s]9]S(Q+7S1GN8`_PaH<r$EML#Ln1[@7%\DSZNPW7K^Y.7m[fTT5i0O2e[,;1UXoAt'2\d1jLmQQHMj]N'kfmU/")Du7L?I!d<:[[b7)iUtEEZ@rgd<&VrqhYl+6H7?K%sKWX1[5[<oh6]f_u]CqA(m"hB3Cbc4IU7nB(\a@ULaSrE4PM!3lLiafk#8'Ogt8.]'k\r%1c[,df6]Al@f/Pa:5%f3mMq5GH?,(WnF]C_Gi%EgA7LhlIiUW4#_?-rq>+^gD;g0KM'<YpH#%Uj+'*Sp]a#rd,bj+D[WdHK>Xl*"KEc2,d/DTWG@+]aXDuU_pc,C*4qAsEU#"s$M.LKR"V!D5LCcB6pVmb>-9(_/;\tlYu;1XVQCIfFp'H]CjfLs6f#/O%cbh.OM,i'C0C;t^8lFX'>mjK$6#Wuj#f.t%'r>?/frO__S7"TX88.T:]4+.qQJ]F(q#CoK"]01A<$!Qqhnb3CoZpfr>5KE^L<jbFkq.qp[rR]hRY)t[F[(2rO\cX[eFo/Yk<0B%F)=ECqu0FC@WDLDEZ![n^9JdC@L[de_\SnK;S8RJtuofRocZ^Xt*i2F`7j1<\pRAT,uNP=oNotk*rq$Whpf.B'T:nh_pN7k2<#FQX.8=fYU'h?0uf0HdAoBJ4klKdFU>OD7/f(':VT[_fF*LT?_ip7uMaq5G?MD<S)gXd3?nW_6-Ttf;gU/Fb]?*n!\.34uU=$5O1O73sHJ%)[Kb0V9=XC=r%Sb+cD[DieJ9^eul'/alt!R^8[7SE`q3T/\BhVR^U)O[bJZ:p2&Be>KS'r?U&pe@Dh?BeRakD2Srp;,D\sV^d;GXC+&MRN\j=IP7ZZG8.l&a7B*8p8[qF*Z5M4(5cec&8IA[P6A6Vg&`=pgHX"[$=+n4$,aU'QH0ApQK+5j%`/>A=hc<Nh=OfQNI+?'IJ#o>!X;e)e[q?pdin0*0Z!J74FQ)2V)Ho4K;f]c.nJ<2B5LVl\6DPliRaC)5aFHk96VMiIL&N$3n[8#jVUK`2!V_`HD4m9R7O5]cFc#eNSL`9H]3GH_WjK<se8Jbc=MNR=C_(UFJ:s8H7h4>!!t=4Dl%FX\GlcDPSC*H9^3a[6[d4a@>M"A1gSS>L;3`!=oL$mq5E^,@-24V\fGjgHRM(6[Y^bH=+,nu?.W=#cQU+Mnaus@[TrZmre+A(KgAYN'9NthPU:/#0[bL4To5dAe@W:/G,qSQd9hY-?DJWR=.9KF)KXUATE-d6h)Q+"r9>6kNi"*ilN4J5G2Of$VdXa/#RX`5)^Fum5*$o6/!G<*2h3iEScW,P(AP=eIG\#dfpo4pm:@NWAc6HU]EEEW[VrRl+$P,Lbj8jW9&&b&/,)UF046_<Ge*6<#UN999qEcY;GM?!M4f0n3nLoBu(?8UF-.')&M[><LQlmlX3&`LJ677T68"-4h$TIADANaF?s!aWY;DAqVqa+*75X8d=-7Gk6KMcFmU'V+ka,3Q*`emHuOCYY@k,4sh)2AjE/bMFVq0KY_]=N=Ph/?uHq]1opFo;=[['NaM?Rsg.O2]d!<]U0n'^MV_<-kB^R4<de89L4V-$a);(&AKjSm3lYaurg>bEGq"Nl_sIG9l4*//L>jIFH_r5k`oT[rln*qBS`=%A8S@5;j&FqT83MOd$)r=USpW-@a@4=6:/362;D/q.Xo+:)UPdI/b!b"HDK7B+,ue1Y%>@fk39b2kLl$O[GWs+OWjF;k*m8k8*53+LZ@aMbG7RX/#+c-3\E8Q`'KeA/7h.;]cY#3UM`#FT3E\m+pPHQH`m?7K*9&E`+eY4tW6lQV\Y;j/\r)0X$N9_7Vi*#?2^t*F8$3TDpjP_hB"WM,3@D4bh`H]$<$c0E1KD3_r`!2Z?fX5hIKe;"`lZl7j!=bZOuXC`@TE?Y95+qull`lSiWc4`)8G[W0'*Ap8d^FB-f`_m\=(46QidWo_.G@UTTnk:`jr_4MdT`W#q/HqhH~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000740 00000 n 
+0000000808 00000 n 
+0000001104 00000 n 
+0000001169 00000 n 
+0000004229 00000 n 
+trailer
+<<
+/ID 
+[<b350a57feb7736b46751037dfc7f1846><b350a57feb7736b46751037dfc7f1846>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 11
+>>
+startxref
+8327
+%%EOF


### PR DESCRIPTION
## Summary
Add a polished mockup PDF (v4) for the diagnostic worksheet report layout.

## Changes
- Added `vibesensor_pdf_mockup_v4_polished_clean-1.pdf` - high-fidelity visual mockup of the improved diagnostic worksheet layout

## Context
This mockup provides the visual design reference for the Canvas-based PDF report implementation on the `feat/diagnostic-worksheet-report` branch.