### PR TITLE
chore: ignore pi wheel cache staging directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ firmware/esp/.pio/
 
 # Image build artifacts
 infra/pi-image/pi-gen/.cache/
+infra/pi-image/pi-gen/.pip-cache-stage/
 infra/pi-image/pi-gen/out/*
 !infra/pi-image/pi-gen/out/.gitkeep
 


### PR DESCRIPTION
## Summary
- add `infra/pi-image/pi-gen/.pip-cache-stage/` to `.gitignore`
- prevent temporary pi wheel cache staging artifacts from appearing as untracked files

## Validation
- verified only `.gitignore` changed
- verified untracked `infra/pi-image/pi-gen/.pip-cache-stage/` no longer appears after cleanup