### PR TITLE
Fix Pi web-update flow and harden repo ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Execution loop (medium/large tasks)
 Setup
 - Python: `python -m pip install -e "./apps/server[dev]"`
 - UI: `cd apps/ui && npm ci`
+- Pi hotspot SSH (default image): host `10.4.0.1`, user `pi`, password `vibesensor`
 
 Validation
 - Lint: `make lint`

--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -60,6 +60,7 @@ run_as_root install -d -m 0755 /var/lib/vibesensor
 run_as_root install -d -m 0755 /var/log/vibesensor
 run_as_root install -d -m 0755 /var/log/wifi
 run_as_root chown "${SERVICE_USER}:${SERVICE_USER}" /var/lib/vibesensor /var/log/vibesensor
+run_as_root chown -R "${SERVICE_USER}:${SERVICE_USER}" "${PI_DIR}"
 run_as_root tee /etc/tmpfiles.d/vibesensor-wifi.conf >/dev/null <<'EOF'
 d /var/log/wifi 0755 root root -
 EOF

--- a/apps/server/systemd/vibesensor.service
+++ b/apps/server/systemd/vibesensor.service
@@ -11,6 +11,7 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
 WorkingDirectory=__PI_DIR__
 ExecStartPre=/usr/bin/test -r /etc/vibesensor/config.yaml
+ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ __PI_DIR__
 ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ /var/log/vibesensor /var/lib/vibesensor
 ExecStartPre=/usr/bin/test -w /var/log/vibesensor
 ExecStartPre=/usr/bin/test -w /var/lib/vibesensor

--- a/apps/server/tests/test_ai_smoke.py
+++ b/apps/server/tests/test_ai_smoke.py
@@ -41,3 +41,6 @@ def test_smoke_install_pi_installs_rebuild_toolchain() -> None:
     text = script.read_text(encoding="utf-8")
     assert "nodejs" in text, "Pi install script must install nodejs for on-device rebuilds"
     assert "npm" in text, "Pi install script must install npm for on-device rebuilds"
+    assert 'chown -R "${SERVICE_USER}:${SERVICE_USER}" "${PI_DIR}"' in text, (
+        "Pi install script must ensure repo ownership for update writes"
+    )


### PR DESCRIPTION
## Summary
- fix Pi web update Wi-Fi connection flow so passworded SSIDs connect reliably on older nmcli
- harden update flow to run git/build as service user and preserve repo writeability
- enforce repo ownership in install/service startup to prevent permission regressions
- add tests for secure SSID/password handling and install ownership guard
- document default Pi hotspot SSH credentials in AGENTS.md

## Validation
- make lint
- python3 -m pytest -q apps/server/tests/test_update_manager.py apps/server/tests/test_ai_smoke.py
- live validation on Pi at 10.4.0.1 with SSID=Pim (web update ended in state=success, assets_verified=true)
