### PR TITLE
Fix top spectrum graph to include all connected sensors

### DIFF
--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -320,13 +320,6 @@ export function startUiApp(): void {
     const fallbackFreq: number[] = [];
     const entries: { id: string; label: string; color: string; values: number[] }[] = [];
     let targetFreq: number[] = [];
-    let latestFrameTotal: number | null = null;
-    for (const client of state.clients) {
-      if (!client?.connected) continue;
-      const framesTotal = Number(client.frames_total);
-      if (!Number.isFinite(framesTotal)) continue;
-      latestFrameTotal = latestFrameTotal === null ? framesTotal : Math.max(latestFrameTotal, framesTotal);
-    }
     const interpolateToTarget = (sourceFreq: number[], sourceVals: number[], desiredFreq: number[]): number[] => {
       if (!Array.isArray(sourceFreq) || !Array.isArray(sourceVals)) return [];
       if (!Array.isArray(desiredFreq) || !desiredFreq.length) return sourceVals.slice();
@@ -341,9 +334,7 @@ export function startUiApp(): void {
       return out;
     };
     for (const [i, client] of state.clients.entries()) {
-      const framesTotal = Number(client.frames_total);
-      if (!Number.isFinite(framesTotal)) continue;
-      if (latestFrameTotal !== null && framesTotal < latestFrameTotal) continue;
+      if (!client?.connected) continue;
       const s = state.spectra.clients?.[client.id];
       if (!s || !Array.isArray(s.combined)) continue;
       const clientFreq = Array.isArray(s.freq) && s.freq.length ? s.freq : fallbackFreq;


### PR DESCRIPTION
## Problem
The multi-sensor blended spectrum chart only showed one line (often the purple series) because rendering filtered out clients whose `frames_total` was behind the max.

## Fix
- Remove `latestFrameTotal` gating in `renderSpectrum()`.
- Keep only the `client.connected` check so every connected client with spectrum data is rendered.
- Preserve frequency interpolation so series stay aligned on the x-axis.

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`