### PR TITLE
Extend live vibration matrix window to 5 minutes

### DIFF
--- a/apps/server/tests/test_live_diagnostics_continuous.py
+++ b/apps/server/tests/test_live_diagnostics_continuous.py
@@ -124,8 +124,9 @@ def test_live_matrix_seconds_use_recent_window_during_throttled_emission(monkeyp
         for source_row in final["matrix"].values()
         for cell in source_row.values()
     )
-    # Live matrix is intentionally windowed for UI readability; it should stay bounded.
-    assert 0.0 < max_seconds <= 3.0
+    # Live matrix is intentionally windowed for UI readability; it should stay bounded
+    # by elapsed sample time during this short run.
+    assert 0.0 < max_seconds <= float(len(snapshots))
 
     emitted = sum(len(snapshot.get("events") or []) for snapshot in snapshots)
     assert emitted < len(snapshots)

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -157,7 +157,7 @@
           <div class="panel card dashboard-grid__full">
             <div class="card__header">
               <div class="card__title" data-i18n="dashboard.vibration_count_live">Vibration Count Live</div>
-              <span class="card__time-label mini-label" data-i18n="dashboard.time_window_2s">(last 2 s window)</span>
+              <span class="card__time-label mini-label" data-i18n="dashboard.time_window_2s">(last 5 min window)</span>
             </div>
             <div class="matrix-note"><span data-i18n="dashboard.matrix_note">Levels use peak-over-floor dB bands (L1-L5), grouped by source type.</span></div>
             <div class="matrix-wrap">

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -34,7 +34,7 @@
   "dashboard.rotational.assumptions.gear_ratio": "Gear ratio",
   "dashboard.rotational.assumptions.order_bands": "Order bands",
   "dashboard.time_window_60s": "(last 60 s)",
-  "dashboard.time_window_2s": "(last 2 s window)",
+  "dashboard.time_window_2s": "(last 5 min window)",
   "chart.auto_scale": "Auto scale",
   "history.refresh": "Refresh History",
   "history.table.file": "Run",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -34,7 +34,7 @@
   "dashboard.rotational.assumptions.gear_ratio": "Versnellingsverhouding",
   "dashboard.rotational.assumptions.order_bands": "Ordebanden",
   "dashboard.time_window_60s": "(laatste 60 s)",
-  "dashboard.time_window_2s": "(laatste 2 s venster)",
+  "dashboard.time_window_2s": "(laatste 5 min venster)",
   "chart.auto_scale": "Auto schaal",
   "history.refresh": "Geschiedenis verversen",
   "history.table.file": "Meetrun",


### PR DESCRIPTION
## Summary
- Extend live vibration matrix history window from 2 seconds to 5 minutes for a more useful trend view.
- Keep matrix/count reset semantics at recording start so each run begins at zero.
- Ensure matrix counts are recorded on emitted active-severity heartbeats, not only on escalation transitions, so the panel stays populated during sustained vibration.
- Update dashboard copy to show the new 5-minute window text.

## Changes
- Backend:
  - `apps/server/vibesensor/live_diagnostics.py`
    - `_MATRIX_WINDOW_MS` changed to `5 * 60 * 1000`.
    - Matrix count updates now follow emission heartbeats for active buckets (single + combined trackers).
- UI text:
  - `apps/ui/src/i18n/catalogs/en.json`
  - `apps/ui/src/i18n/catalogs/nl.json`
  - `apps/ui/index.html`
- Tests:
  - `apps/server/tests/test_live_diagnostics_continuous.py`
    - Updated bounded-seconds assertion to match longer matrix window behavior.

## Validation
- `python3 tools/tests/pytest_progress.py --show-test-names -- apps/server/tests/test_live_diagnostics_helpers.py apps/server/tests/test_live_diagnostics_continuous.py`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
