### PR TITLE
Fix ESP flash failures in offline hotspot mode

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "PyYAML>=6,<7",
   "reportlab>=4,<5",
   "platformio>=6,<7",
+  "esptool>=4,<5",
 ]
 
 [project.optional-dependencies]

--- a/apps/server/tests/test_ai_smoke.py
+++ b/apps/server/tests/test_ai_smoke.py
@@ -51,3 +51,4 @@ def test_smoke_server_pyproject_includes_platformio_for_esp_flash() -> None:
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     text = pyproject.read_text(encoding="utf-8")
     assert "platformio" in text, "Server dependencies must include platformio for ESP flash"
+    assert "esptool" in text, "Server dependencies must include esptool for offline ESP flash"


### PR DESCRIPTION
## Summary
- add timeout failover for PlatformIO erase (25s) to avoid hanging when hotspot mode has no upstream route
- add offline fallback flow using `esptool` with prebuilt artifacts at `firmware/esp/.pio/build/m5stack_atom`
- add reliable reset/baud settings for offline write (`--before default_reset --after hard_reset --baud 115200`)
- keep read-only firmware handling by cloning to temporary writable workspace when needed
- add regression tests for fallback behavior and keep smoke guard for ESP flash dependencies

## Live validation on 10.4.0.1
- reproduced `Failed — Flash erase step failed` with `HTTPClientError` due offline PlatformIO platform install
- deployed patch + restarted service
- verified full ESP flash succeeds via API with logs showing timeout -> offline erase -> offline write -> success

## Validation
- `ruff check apps/server/vibesensor/esp_flash_manager.py apps/server/tests/test_esp_flash_manager.py apps/server/tests/test_ai_smoke.py apps/server/pyproject.toml`
- `pytest -q apps/server/tests/test_esp_flash_manager.py apps/server/tests/test_ai_smoke.py`
