### PR TITLE
Align AI instructions with CI and add parallel local CI runner

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai_change_request.md
+++ b/.github/ISSUE_TEMPLATE/ai_change_request.md
@@ -24,6 +24,8 @@ assignees: []
 scripts/ai/task ai:check
 scripts/ai/task ai:test -- apps/server/tests/test_config.py -k my_case -q
 make test-all
+# (optional faster CI-parity subset)
+python3 tools/tests/run_ci_parallel.py --job preflight --job tests
 ```
 
 ## Acceptance Criteria

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,8 @@ Execution model
 Common commands
 - `python -m pip install -e "./apps/server[dev]"`
 - `make lint`
-- `make test-all`
+- `make test-all` (CI-parity local suite: `preflight` + `tests` + `e2e` jobs in parallel)
+- `python3 tools/tests/run_ci_parallel.py --job preflight --job tests` (faster local subset)
 - `python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests`
 - `python3 tools/ci/watch_pr_checks.py --pr <PR_NUMBER> --interval 30 --repo Skamba/VibeSensor`
 - `cd apps/ui && npm ci && npm run typecheck && npm run build`

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -30,7 +30,8 @@ Validation (always required)
 - Treat watcher exit `RESULT=NON_GREEN` as fail-fast: inspect the latest failing run immediately, implement the minimal fix, push, and restart the watcher.
 - Treat watcher exit `RESULT=ALL_GREEN` as the merge-ready gate for CI checks.
 - Test in this order: targeted tests first, then broader relevant suites.
-- Test suite for CI alignment: `make test-all`.
+- CI-parity suite (same command groups as `.github/workflows/ci.yml`, run in parallel locally): `make test-all` (`python3 tools/tests/run_ci_parallel.py`).
+- Optional CI-parity subset jobs for faster loops: `python3 tools/tests/run_ci_parallel.py --job preflight --job tests`.
 - Optional focused backend pytest: `python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests`.
 - Run lint (`ruff check`) before pushing changes.
 - After any backend or frontend change, rebuild and test via Docker before considering the work done:

--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -4,6 +4,7 @@ applyTo: "docker-compose.yml,.github/workflows/**"
 Infra / Docker / CI
 - Shared workflow/validation rules live in `.github/instructions/general.instructions.md`; this file only captures infra-specific deltas.
 - Local dev: `docker compose build --pull` then `docker compose up -d`.
-- CI: `.github/workflows/ci.yml` shows steps used in CI (setup Python/Node, pip install -e "./apps/server[dev]", ruff, UI checks, and `make test-all`).
+- CI: `.github/workflows/ci.yml` is authoritative for job commands (`preflight`, `tests`, `e2e`).
+- Local CI-parity run: `make test-all` (runs `python3 tools/tests/run_ci_parallel.py`, which mirrors those CI job command groups in parallel).
 - Keep CI steps maintainable; larger CI/workflow updates are allowed when needed. If adding new test dependencies, update `apps/server/pyproject.toml` so CI installs them via the editable install.
 - Avoid embedding secrets in workflow files; use repository secrets for tokens.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -3,7 +3,8 @@ applyTo: "apps/server/tests/**"
 ---
 Tests
 - Shared workflow/validation rules live in `.github/instructions/general.instructions.md`; this file only captures test-specific deltas.
-- Default CI-aligned test suite: `make test-all` (runs `python3 tools/tests/run_full_suite.py`).
+- Default CI-aligned test suite: `make test-all` (runs `python3 tools/tests/run_ci_parallel.py` to mirror CI `preflight`, `tests`, and `e2e` job groups in parallel).
+- Optional CI job subset for faster local iteration: `python3 tools/tests/run_ci_parallel.py --job preflight --job tests`.
 - Optional focused backend pytest run (for faster iteration, not a CI substitute): `python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests`.
 - Selenium UI tests are present but skipped in CI; mark them explicitly with the `selenium` marker.
 - New backend features should include focused unit tests under `apps/server/tests/`; larger/breaking changes can include broader integration coverage when useful.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup format lint test test-fast test-all smoke loc docs-lint ai-check ai-test ai-smoke ai-pack ai\:check ai\:test ai\:smoke ai\:pack
+.PHONY: setup format lint test test-fast test-all test-ci test-full-suite smoke loc docs-lint ai-check ai-test ai-smoke ai-pack ai\:check ai\:test ai\:smoke ai\:pack
 
 setup:
 	python3 -m pip install -e "./apps/server[dev]"
@@ -17,7 +17,12 @@ test:
 test-fast:
 	python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests
 
-test-all:
+test-all: test-ci
+
+test-ci:
+	python3 tools/tests/run_ci_parallel.py
+
+test-full-suite:
 	python3 tools/tests/run_full_suite.py
 
 smoke:

--- a/docs/ai/context.md
+++ b/docs/ai/context.md
@@ -37,7 +37,7 @@ VibeSensor is an offline vehicle vibration diagnostics system. A Raspberry Pi ho
 - WS payload/UI contracts can change; update server, UI, and tests together when changing (`clients`, `diagnostics`, `spectra`, `selected`).
 - Hotspot startup must succeed offline (no runtime apt installs in hotspot script).
 - Pi image output must include `/opt/VibeSensor`, `vibesensor-hotspot.service`, and `/etc/vibesensor/config.yaml`.
-- CI verification suite is `make test-all` (full-suite harness in `tools/tests/run_full_suite.py`).
+- CI verification suite is `make test-all` (`tools/tests/run_ci_parallel.py`, matching CI `preflight` + `tests` + `e2e` groups in parallel).
 
 ## Coding Conventions
 - Python style: Ruff-enforced, explicit signatures, small focused modules.

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -11,9 +11,9 @@
 - Implication: avoid introducing threshold checks against raw g-values.
 
 ## D3: Default CI validation mode
-- Decision: use the GitHub CI verification suite (`make test-all`) for change verification.
+- Decision: use the GitHub CI verification suite (`make test-all`) for change verification; local execution must mirror CI job groups.
 - Rationale: keeps local/AI validation aligned with required CI gates and avoids mismatch-driven regressions.
-- Implication: optional focused pytest/smoke loops may be used during iteration, but final verification should use `make test-all`.
+- Implication: optional focused pytest/smoke loops may be used during iteration, but final verification should use `make test-all` (`tools/tests/run_ci_parallel.py`) which runs CI-equivalent `preflight`, `tests`, and `e2e` groups in parallel.
 
 ## D4: Deterministic image outputs
 - Decision: custom pi-gen stage must export uniquely suffixed artifact and self-validate rootfs contents.

--- a/docs/ai/handoff.md
+++ b/docs/ai/handoff.md
@@ -17,6 +17,7 @@ Use this format for future AI requests.
 
 ## 5) Validation
 - Start with targeted checks, then run CI-aligned checks (`make test-all`) before finalizing.
+  - `make test-all` maps to `tools/tests/run_ci_parallel.py` and runs CI-equivalent `preflight`, `tests`, and `e2e` groups in parallel locally.
 
 ## 6) Deliverable
 - Expected changed files + acceptance criteria.

--- a/docs/ai/map.md
+++ b/docs/ai/map.md
@@ -20,7 +20,7 @@
 - `apps/simulator/ws_smoke.py` - websocket smoke verifier.
 - `apps/ui/src/main.ts` - UI state reducer/render orchestration.
 - `apps/ui/src/ws.ts` - websocket client and payload contract handling.
-- `.github/workflows/ci.yml` - CI critical checks and `make test-all` verification flow.
+- `.github/workflows/ci.yml` - CI critical checks; local mirror is `make test-all` via `tools/tests/run_ci_parallel.py`.
 
 ## Module Boundaries
 - **Acquisition**: `udp_data_rx.py`, `registry.py`.

--- a/docs/ai/runbooks.md
+++ b/docs/ai/runbooks.md
@@ -37,6 +37,13 @@ scripts/ai/task ai:smoke
 make ai-smoke
 ```
 
+## CI-parity suite (parallel)
+```bash
+make test-all
+# or select CI job groups
+python3 tools/tests/run_ci_parallel.py --job preflight --job tests
+```
+
 ## Context bundle
 ```bash
 scripts/ai/task ai:pack

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci_local"
+PRINT_LOCK = threading.Lock()
+RESULT_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class Step:
+    label: str
+    cmd: list[str]
+    cwd: Path = ROOT
+
+
+@dataclass(frozen=True)
+class JobResult:
+    name: str
+    ok: bool
+    failed_step: str | None
+    return_code: int
+    duration_s: float
+    log_path: Path
+
+
+def _emit(line: str) -> None:
+    with PRINT_LOCK:
+        print(line, flush=True)
+
+
+def _format_cmd(cmd: list[str]) -> str:
+    return shlex.join(cmd)
+
+
+def _run_step(step: Step, log_file) -> int:
+    log_file.write(f"$ {_format_cmd(step.cmd)}\n")
+    proc = subprocess.run(
+        step.cmd,
+        cwd=str(step.cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    output = proc.stdout or ""
+    if output:
+        log_file.write(output)
+        if not output.endswith("\n"):
+            log_file.write("\n")
+    log_file.flush()
+    return proc.returncode
+
+
+def _run_job(name: str, steps: list[Step], results: dict[str, JobResult]) -> None:
+    started = time.monotonic()
+    log_path = LOG_DIR / f"{name}.log"
+    _emit(f"[{name}] start ({len(steps)} steps)")
+    failed_step: str | None = None
+    failed_code = 0
+    with log_path.open("w", encoding="utf-8") as log_file:
+        for step in steps:
+            _emit(f"[{name}] step: {step.label}")
+            step_started = time.monotonic()
+            rc = _run_step(step, log_file)
+            step_elapsed = time.monotonic() - step_started
+            if rc != 0:
+                failed_step = step.label
+                failed_code = rc
+                _emit(
+                    f"[{name}] fail at '{step.label}' (exit {rc}) after {step_elapsed:.1f}s; log: {log_path}"
+                )
+                break
+            _emit(f"[{name}] ok '{step.label}' in {step_elapsed:.1f}s")
+
+    elapsed = time.monotonic() - started
+    ok = failed_step is None
+    if ok:
+        _emit(f"[{name}] success in {elapsed:.1f}s")
+    with RESULT_LOCK:
+        results[name] = JobResult(
+            name=name,
+            ok=ok,
+            failed_step=failed_step,
+            return_code=failed_code,
+            duration_s=elapsed,
+            log_path=log_path,
+        )
+
+
+def _bootstrap_steps(python_cmd: str, run_npm_ci: bool) -> list[Step]:
+    steps = [
+        Step(
+            "python deps: pip upgrade",
+            [python_cmd, "-m", "pip", "install", "--upgrade", "pip"],
+        ),
+        Step(
+            "python deps: editable install",
+            [python_cmd, "-m", "pip", "install", "-e", "./apps/server[dev]"],
+        ),
+    ]
+    if run_npm_ci:
+        steps.append(Step("ui deps: npm ci", ["npm", "ci"], cwd=ROOT / "apps" / "ui"))
+    return steps
+
+
+def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
+    return {
+        "preflight": [
+            Step(
+                "ruff check",
+                [
+                    "ruff",
+                    "check",
+                    "apps/server/vibesensor",
+                    "apps/server/tests",
+                    "apps/simulator",
+                    "libs/core/python",
+                    "libs/shared/python",
+                ],
+            ),
+            Step(
+                "ruff format --check",
+                [
+                    "ruff",
+                    "format",
+                    "--check",
+                    "apps/server/vibesensor",
+                    "apps/server/tests",
+                    "apps/simulator",
+                    "libs/core/python",
+                    "libs/shared/python",
+                ],
+            ),
+            Step("line endings", [python_cmd, "tools/config/check_line_endings.py"]),
+            Step(
+                "config preflight (example)",
+                [
+                    python_cmd,
+                    "tools/config/config_preflight.py",
+                    "apps/server/config.example.yaml",
+                ],
+            ),
+            Step(
+                "config preflight (dev)",
+                [
+                    python_cmd,
+                    "tools/config/config_preflight.py",
+                    "apps/server/config.dev.yaml",
+                ],
+            ),
+            Step(
+                "verify no path indirections",
+                [python_cmd, "tools/dev/verify_no_path_indirections.py"],
+            ),
+        ],
+        "tests": [
+            Step("ui sync", [python_cmd, "tools/sync_ui_to_pi_public.py"]),
+            Step("ui typecheck", ["npm", "run", "typecheck"], cwd=ROOT / "apps" / "ui"),
+            Step(
+                "playwright install chromium",
+                ["npx", "playwright", "install", "chromium"],
+                cwd=ROOT / "apps" / "ui",
+            ),
+            Step("ui smoke", ["npm", "run", "test:smoke"], cwd=ROOT / "apps" / "ui"),
+            Step(
+                "backend tests (non-selenium)",
+                [
+                    python_cmd,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "-m",
+                    "not selenium",
+                    "apps/server/tests",
+                ],
+            ),
+        ],
+        "e2e": [
+            Step(
+                "docker-backed e2e suite",
+                [
+                    python_cmd,
+                    "tools/tests/run_full_suite.py",
+                    "--skip-ui-sync",
+                    "--skip-ui-smoke",
+                    "--skip-unit-tests",
+                ],
+            ),
+        ],
+    }
+
+
+def _run_bootstrap(steps: list[Step]) -> int:
+    if not steps:
+        return 0
+    bootstrap_log = LOG_DIR / "bootstrap.log"
+    _emit(f"[bootstrap] start ({len(steps)} steps)")
+    with bootstrap_log.open("w", encoding="utf-8") as log_file:
+        for step in steps:
+            _emit(f"[bootstrap] step: {step.label}")
+            started = time.monotonic()
+            rc = _run_step(step, log_file)
+            elapsed = time.monotonic() - started
+            if rc != 0:
+                _emit(
+                    f"[bootstrap] fail at '{step.label}' (exit {rc}) after {elapsed:.1f}s; log: {bootstrap_log}"
+                )
+                return rc
+            _emit(f"[bootstrap] ok '{step.label}' in {elapsed:.1f}s")
+    _emit("[bootstrap] success")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run local CI-equivalent checks with the same command groups as .github/workflows/ci.yml, "
+            "executed in parallel."
+        )
+    )
+    parser.add_argument(
+        "--job",
+        action="append",
+        choices=["preflight", "tests", "e2e"],
+        help="Run only selected job(s). Repeat to run multiple jobs.",
+    )
+    parser.add_argument(
+        "--skip-bootstrap",
+        action="store_true",
+        help="Skip shared local dependency bootstrap (pip install + optional npm ci).",
+    )
+    parser.add_argument(
+        "--skip-npm-ci",
+        action="store_true",
+        help="Skip npm ci bootstrap even when node_modules is missing.",
+    )
+    args = parser.parse_args()
+
+    python_cmd = sys.executable
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    run_npm_ci = (
+        not args.skip_npm_ci and not (ROOT / "apps" / "ui" / "node_modules").exists()
+    )
+    bootstrap_steps = (
+        [] if args.skip_bootstrap else _bootstrap_steps(python_cmd, run_npm_ci)
+    )
+    bootstrap_rc = _run_bootstrap(bootstrap_steps)
+    if bootstrap_rc != 0:
+        return bootstrap_rc
+
+    all_jobs = _job_steps(python_cmd)
+    selected_jobs = args.job if args.job else ["preflight", "tests", "e2e"]
+
+    started = time.monotonic()
+    results: dict[str, JobResult] = {}
+    threads: list[threading.Thread] = []
+    for job_name in selected_jobs:
+        thread = threading.Thread(
+            target=_run_job,
+            args=(job_name, all_jobs[job_name], results),
+            daemon=False,
+        )
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    elapsed = time.monotonic() - started
+    _emit("\n=== ci-local summary ===")
+    overall_ok = True
+    for job_name in selected_jobs:
+        result = results[job_name]
+        if result.ok:
+            _emit(
+                f"- {job_name}: PASS ({result.duration_s:.1f}s) log={result.log_path}"
+            )
+            continue
+        overall_ok = False
+        _emit(
+            f"- {job_name}: FAIL at '{result.failed_step}' (exit {result.return_code}) "
+            f"after {result.duration_s:.1f}s log={result.log_path}"
+        )
+
+    _emit(f"total wall time: {elapsed:.1f}s")
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add a local CI-parity runner at \n- run CI-equivalent , , and  job groups in parallel locally\n- wire python3 tools/tests/run_ci_parallel.py
[bootstrap] start (2 steps)
[bootstrap] step: python deps: pip upgrade
[bootstrap] fail at 'python deps: pip upgrade' (exit 1) after 0.3s; log: <repo-root>/artifacts/ai/logs/ci_local/bootstrap.log to the new runner and keep  for the legacy sequential harness\n- update AI instruction/docs files to reference the CI-parity suite and optional subset jobs\n\n## Validation\n- ruff check tools/tests/run_ci_parallel.py\n- ruff format --check tools/tests/run_ci_parallel.py\n- python3 -m py_compile tools/tests/run_ci_parallel.py\n- python3 tools/tests/run_ci_parallel.py --help