### PR TITLE
Firmware: align ESP with Atom Lite + ADXL345, single-LED identify

### DIFF
--- a/firmware/esp/README.md
+++ b/firmware/esp/README.md
@@ -9,7 +9,7 @@ accelerometer at 800 Hz and streams samples to the Pi server over UDP.
 - HELLO + DATA protocol packets
 - Buffered frame queue to reduce sample loss during short Wi-Fi stalls
 - UDP command listener for identify blink with ACK response
-- Identify command triggers RGB LED wave animation on ATOM LEDs
+- Identify command blinks only the single onboard RGB LED on ATOM Lite
 - ADXL345 I2C driver at 800 Hz with error-checked initialisation
 - No synthetic vibration injection in production builds
 
@@ -34,8 +34,8 @@ firmware/esp/
 ## Error Handling
 
 - **I2C init**: Every register write during `ADXL345::begin()` is validated;
-  if any write fails the sensor is marked unavailable and the firmware falls
-  back to synthetic waveform generation.
+  if any write fails the sensor is marked unavailable and sampling falls back
+  to holding the last real sample (or zeros until one real sample exists).
 - **I2C reads**: `read_reg()` and `read_multi()` return zeros on bus errors.
   This is safe because the caller (`read_samples()`) only processes FIFO
   entries reported by the hardware status register.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -8,7 +8,7 @@ Bill of materials for the VibeSensor prototype.
 |---|------|------|
 | 1 | Raspberry Pi 3 A+ | Wi-Fi AP, server, web UI host |
 | 2 | M5Stack ATOM Lite ESP32 | Sensor node — samples accelerometer, streams UDP |
-| 3 | M5Stack ADXL345 3-Axis Accelerometer Unit | Vibration measurement (3-axis, 800 Hz) |
+| 3 | M5Stack Accel Unit (ADXL345) | Vibration measurement (3-axis, 800 Hz) |
 | 4 | M5Stack Atomic Battery Base (200 mAh) | Portable power for the ATOM Lite node |
 
 Multiple sensor nodes (items 2-4) can connect to a single Pi simultaneously.


### PR DESCRIPTION
## Summary
- align identify behavior to the Atom Lite single onboard RGB LED
- remove matrix-style multi-pixel wave assumptions from firmware
- update firmware and hardware docs to reflect Atom Lite + M5Stack Accel Unit (ADXL345)

## Validation
- cd firmware/esp && pio run
