### PR TITLE
Fix Pi ESP flashing: build from source offline with preloaded toolchain

### DIFF
--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -33,6 +33,14 @@ else
   SERVICE_USER="$(id -un)"
 fi
 
+run_as_service_user() {
+  if [ "$(id -u)" -eq 0 ]; then
+    runuser -u "${SERVICE_USER}" -- "$@"
+  else
+    sudo -u "${SERVICE_USER}" "$@"
+  fi
+}
+
 run_as_root apt-get update
 run_as_root apt-get install -y \
   git \
@@ -61,6 +69,7 @@ run_as_root install -d -m 0755 /var/log/vibesensor
 run_as_root install -d -m 0755 /var/log/wifi
 run_as_root chown "${SERVICE_USER}:${SERVICE_USER}" /var/lib/vibesensor /var/log/vibesensor
 run_as_root chown -R "${SERVICE_USER}:${SERVICE_USER}" "${PI_DIR}"
+run_as_service_user "${VENV_DIR}/bin/python" -m platformio pkg install --global --platform espressif32
 run_as_root tee /etc/tmpfiles.d/vibesensor-wifi.conf >/dev/null <<'EOF'
 d /var/log/wifi 0755 root root -
 EOF

--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -322,6 +322,8 @@ python3 -m venv /opt/VibeSensor/apps/server/.venv
   --no-build-isolation \
   -e /opt/VibeSensor/apps/server \
   --quiet
+install -d -o 1000 -g 1000 /home/pi/.platformio
+su - pi -c '/opt/VibeSensor/apps/server/.venv/bin/python -m platformio pkg install --global --platform espressif32'
 chown -R 1000:1000 /opt/VibeSensor/apps/server/.venv
 CHROOT_EOF
 


### PR DESCRIPTION
## Summary\n- Make ESP flash flow compile firmware from current  sources before esptool flash.\n- Add read-only checkout support by staging firmware sources into a temporary writable workspace.\n- Add offline guard: fail fast with actionable message when  PlatformIO platform is not locally cached.\n- Seed offline PlatformIO cache during Pi install/update/image build (Platform Manager: espressif32@6.12.0 is already installed
Tool Manager: toolchain-xtensa-esp32@8.4.0+2021r2-patch5 is already installed
Tool Manager: tool-esptoolpy@2.40900.250804 is already installed).\n\n## Why\nPi flash jobs must work without internet at runtime while still flashing firmware built from the Pi's current git sources.\n\n## Validation\n- 7 files reformatted, 183 files left unchanged + All checks passed! on changed Python files\n- ..................................................                       [100%]
50 passed in 3.14s (50 passed)\n- Live Pi patch verified via API:  now enters source-build path and reports missing offline platform cache explicitly when unavailable.