### PR TITLE
Updater+Pi-image: guarantee firmware bundle availability for ESP flash

### DIFF
--- a/apps/server/tests/test_ai_smoke.py
+++ b/apps/server/tests/test_ai_smoke.py
@@ -44,6 +44,9 @@ def test_smoke_build_wrapper_asserts_hotspot_requirements() -> None:
     assert "99-vibesensor-dnsmasq.conf" in text, "build wrapper must assert DNS drop-in"
     assert "firmware" in text, "build wrapper must handle ESP firmware cache/baseline"
     assert "flash.json" in text, "build wrapper must validate firmware manifest"
+    assert "vibesensor-fw-refresh" in text, (
+        "build wrapper must call firmware cache refresh CLI entrypoint"
+    )
     assert "10-vibesensor-hostkeys.conf" in text, (
         "build wrapper must include ssh host-key bootstrap drop-in"
     )

--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -338,10 +338,11 @@ cat >/tmp/vibesensor-fw-baseline.sh <<'FW_BASELINE_EOF'
 set -euo pipefail
 
 VENV_PYTHON="/opt/VibeSensor/apps/server/.venv/bin/python"
+VENV_FW_REFRESH="/opt/VibeSensor/apps/server/.venv/bin/vibesensor-fw-refresh"
 FW_CACHE_DIR="/var/lib/vibesensor/firmware"
 
 echo "Refreshing ESP firmware cache (embedding baseline)..."
-"${VENV_PYTHON}" -m vibesensor.firmware_cache refresh_cache_cli \
+"${VENV_FW_REFRESH}" \
   --cache-dir "${FW_CACHE_DIR}" 2>&1 || true
 
 # If refresh succeeded, copy the downloaded cache as the baseline


### PR DESCRIPTION
## Summary
- move updater firmware cache refresh to run immediately after git sync and before long rebuild/sync steps
- keep backend reinstall afterward, but ensure ESP bundle availability is no longer blocked behind npm rebuild timeouts
- fix Pi image baseline embed path to call the real  CLI entrypoint
- add regression checks for refresh-before-rebuild ordering and build wrapper CLI usage

## Root cause
Two issues combined:
1. updater refreshed firmware only after rebuild/sync, so if rebuild timed out ( path), flash still had no local bundle.
2. pi-image baseline embed used a module invocation pattern that did not reliably execute refresh, so some images shipped without baseline bundle.

## Runtime verification on 10.4.0.1
- updater timed out in rebuild phase (), leaving no firmware bundle
- seeded bundle and verified ESP flash succeeds end-to-end via API logs

## Validation
- ...................................................................      [100%]
67 passed in 3.03s
- ruff check apps/server/vibesensor apps/server/tests apps/simulator libs/core/python libs/shared/python
All checks passed!
ruff format --check apps/server/vibesensor apps/server/tests apps/simulator libs/core/python libs/shared/python
168 files already formatted
- 