### PR TITLE
Fix update failure diagnostics and sshd first-boot validation

### DIFF
--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -36,6 +36,17 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
 
     const isRunning = status.state === "running";
     const isIdle = status.state === "idle";
+    const hasAssetRelatedIssue = status.issues.some((issue) => {
+      const text = `${issue.message} ${issue.detail}`.toLowerCase();
+      return (
+        text.includes("asset") ||
+        text.includes("artifacts") ||
+        text.includes("stale") ||
+        text.includes("hash") ||
+        text.includes("missing")
+      );
+    });
+    const showRuntimeAssetsCheck = status.state !== "failed" || hasAssetRelatedIssue;
 
     // Toggle buttons
     if (els.updateStartBtn) {
@@ -113,10 +124,12 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_assets"))}</span>`;
       html += `<span>${escapeHtml(status.runtime.public_assets_hash.slice(0, 12))}</span>`;
       html += `</div>`;
-      html += `<div class="update-status-row">`;
-      html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_assets_check"))}</span>`;
-      html += `<span>${escapeHtml(t(status.runtime.assets_verified ? "settings.update.runtime_assets_ok" : "settings.update.runtime_assets_bad"))}</span>`;
-      html += `</div>`;
+      if (showRuntimeAssetsCheck) {
+        html += `<div class="update-status-row">`;
+        html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_assets_check"))}</span>`;
+        html += `<span>${escapeHtml(t(status.runtime.assets_verified ? "settings.update.runtime_assets_ok" : "settings.update.runtime_assets_bad"))}</span>`;
+        html += `</div>`;
+      }
     }
 
     html += `</div>`;

--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -894,6 +894,8 @@ echo "SERVER_STARTUP_SMOKE_OK"
   if ! run_qemu_chroot /bin/bash -lc '
 set -e
 rm -f /etc/ssh/ssh_host_*_key*
+mkdir -p /run/sshd
+chmod 0755 /run/sshd
 if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
   /usr/bin/ssh-keygen -A
 fi


### PR DESCRIPTION
## Summary
- add transient npm/DNS rebuild error detection with single retry in update manager
- report clearer rebuild failure message after retry exhaustion
- hide runtime asset verification row in UI when update failed for non-asset reasons
- fix pi image sshd first-boot readiness validation by creating /run/sshd before sshd -t
- add update-manager tests for transient retry success/failure paths

## Validation
- python3 -m ruff check apps/server/vibesensor/update_manager.py apps/server/tests/test_update_manager.py
- python3 tools/tests/pytest_progress.py -- -m "not selenium" apps/server/tests/test_update_manager.py -k "rebuild or transient"
- cd apps/ui && npm run typecheck
- cd apps/ui && npm run build
