### PR TITLE
Harden updater Wi-Fi auth and codify wheel-first deployment policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,16 @@ Execution model
 - Stop only when all plan items are validated complete, no similar in-scope issues remain, a real blocker exists, or time budget is reached.
 - Long deep runs are allowed and preferred for deeper tasks; 45–60 minutes is acceptable for medium/large work.
 
+Updater delivery model (authoritative)
+- Production updater behavior is wheel-based: devices fetch release wheels and install them (`apps/server/vibesensor/update_manager.py`).
+- Do not treat in-place edits under `/opt/VibeSensor/.../site-packages` as a normal deployment mechanism.
+- Emergency-only exception: direct on-device patching is allowed for live incident mitigation when updater path itself is broken.
+- If emergency patching is used, always follow up by:
+	1. implementing the same fix in-repo,
+	2. validating tests/lint,
+	3. opening and merging a PR,
+	4. re-running updater successfully so the device returns to wheel-managed state.
+
 Common commands
 - `python -m pip install -e "./apps/server[dev]"`
 - `make lint`

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -24,6 +24,11 @@ Canonical agent workflow (shared source of truth)
   - when adding large inline data definitions, move them into appropriate data files (`.json`, `.yaml`, etc.),
   - do not create duplicate parallel implementations when extending existing logic is cleaner.
 
+Updater deployment policy
+- Treat updater delivery as wheel-first. Runtime fixes must land in repo code and flow through PR/CI; avoid relying on ad-hoc runtime file edits.
+- Emergency-only exception: if updater path is broken on a live device, temporary in-place patching on the device is allowed strictly to restore service.
+- After any emergency in-place patch, complete the follow-up loop in the same run when feasible: repo fix + tests/lint + PR green + merge + successful updater rerun on device.
+
 Validation (always required)
 - Pull request default mode: after opening or updating a PR, check CI/review status, fix all blocking issues, push updates, and keep monitoring until required checks are green.
 - For every PR, use `python3 tools/ci/watch_pr_checks.py --pr <PR_NUMBER> --interval 30 --repo Skamba/VibeSensor` as the default monitor.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Each component has its own README with setup instructions and details.
 ## Docs Index (source of truth)
 
 - Setup & deployment: [README.md](README.md), [apps/server/README.md](apps/server/README.md), [firmware/esp/README.md](firmware/esp/README.md), [infra/pi-image/pi-gen/README.md](infra/pi-image/pi-gen/README.md)
+- Updater architecture & policy: [apps/server/README.md](apps/server/README.md)
 - Wire protocol and ports: [docs/protocol.md](docs/protocol.md)
 - Run/report schema: [docs/run_schema_v2.md](docs/run_schema_v2.md)
 - Report/design language: [docs/design_language.md](docs/design_language.md)

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -130,6 +130,29 @@ before switching to AP mode.
 Behavior: scan for uplink SSID (up to 10 s) → connect and wait for update →
 disconnect → start hotspot. If SSID not found, start hotspot directly.
 
+## Updater Delivery Model
+
+Production devices use a wheel-based updater flow:
+- API trigger: `POST /api/settings/update/start`
+- Runtime orchestrator: `vibesensor/update_manager.py`
+- Package source: GitHub Releases wheel artifacts
+
+Expected behavior:
+1. hotspot down,
+2. uplink connect,
+3. release check/download,
+4. wheel install,
+5. hotspot restore,
+6. service restart.
+
+Normal operations should not depend on manual edits in
+`/opt/VibeSensor/apps/server/.venv/lib/python*/site-packages`.
+
+Emergency incident handling (when updater path itself is broken):
+- temporary in-place patching is allowed to restore service quickly,
+- but must be followed by the same fix in-repo, tests/lint, PR merge, and a
+  successful updater run so the device returns to wheel-managed state.
+
 ## API Reference
 
 ### Health

--- a/apps/server/vibesensor/update_manager.py
+++ b/apps/server/vibesensor/update_manager.py
@@ -685,8 +685,6 @@ class UpdateManager:
             "ssid",
             ssid,
         ]
-        if password:
-            add_cmd.extend(["wifi-sec.key-mgmt", "wpa-psk", "wifi-sec.psk", password])
 
         rc, _, stderr = await self._run_cmd(
             add_cmd,
@@ -723,6 +721,26 @@ class UpdateManager:
             self._add_issue("connecting_wifi", "Failed to configure uplink", stderr)
             self._status.state = UpdateState.failed
             return
+
+        if password:
+            rc, _, stderr = await self._run_cmd(
+                [
+                    "nmcli",
+                    "connection",
+                    "modify",
+                    UPLINK_CONNECTION_NAME,
+                    "wifi-sec.key-mgmt",
+                    "wpa-psk",
+                    "wifi-sec.psk",
+                    password,
+                ],
+                phase="connecting_wifi",
+                sudo=True,
+            )
+            if rc != 0:
+                self._add_issue("connecting_wifi", "Failed to set Wi-Fi credentials", stderr)
+                self._status.state = UpdateState.failed
+                return
 
         rc = 1
         stderr = ""

--- a/docs/ai/runbooks.md
+++ b/docs/ai/runbooks.md
@@ -44,6 +44,17 @@ make test-all
 python3 tools/tests/run_ci_parallel.py --job preflight --job tests
 ```
 
+## Updater incident runbook (wheel-first)
+
+- Default updater model is wheel-based (`vibesensor/update_manager.py` installs release wheels).
+- Do not use direct runtime file patching as normal delivery.
+- Emergency-only path: if updater itself is broken on a live Pi, apply a temporary in-place patch to restore service.
+- Mandatory follow-up after emergency patching:
+  1. same fix in repo,
+  2. targeted tests + lint,
+  3. PR to green + merge,
+  4. rerun updater on device and confirm success (`state=success`) so device returns to wheel-managed state.
+
 ## Context bundle
 ```bash
 scripts/ai/task ai:pack


### PR DESCRIPTION
## Summary
- fix updater Wi-Fi credential handling for WPA networks by applying PSK reliably in the uplink profile flow
- retain DNS readiness gating before update checks
- document wheel-first updater delivery model and emergency-only in-place patch policy in AI instructions and runbooks
- update backend/top-level docs to clarify normal updater flow vs incident fallback

## Validation
- cd apps/server && ruff check vibesensor/update_manager.py tests/test_update_manager.py
- python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests/test_update_manager.py -k "dns_not_ready_fails_with_clear_issue or password_is_applied_via_connection_modify"