### PR TITLE
Speed up default E2E by excluding long_sim in routine runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,4 @@ jobs:
 
       - name: Docker-backed e2e suite (skip already-owned checks)
         run: |
-          python3 tools/tests/run_full_suite.py --skip-ui-sync --skip-ui-smoke --skip-unit-tests
+          python3 tools/tests/run_full_suite.py --skip-ui-sync --skip-ui-smoke --skip-unit-tests --fast-e2e

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -193,6 +193,7 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                     "--skip-ui-sync",
                     "--skip-ui-smoke",
                     "--skip-unit-tests",
+                    "--fast-e2e",
                 ],
             ),
         ],

--- a/tools/tests/run_full_suite.py
+++ b/tools/tests/run_full_suite.py
@@ -87,7 +87,24 @@ def main() -> int:
         action="store_true",
         help="Skip backend unit/integration pytest suite in apps/server/tests.",
     )
+    parser.add_argument(
+        "--fast-e2e",
+        action="store_true",
+        help="Run only fast docker e2e tests (exclude long_sim-marked scenarios).",
+    )
+    parser.add_argument(
+        "--pytest-marker",
+        default=None,
+        help=(
+            "Override pytest marker expression for apps/server/tests_e2e "
+            "(for example: 'e2e and not long_sim')."
+        ),
+    )
     args = parser.parse_args()
+
+    e2e_marker_expr = args.pytest_marker
+    if e2e_marker_expr is None:
+        e2e_marker_expr = "e2e and not long_sim" if args.fast_e2e else "e2e"
 
     data_dir = Path(tempfile.mkdtemp(prefix="vibesensor-e2e-data-"))
     shutil.copytree(ROOT / "apps" / "server" / "data", data_dir, dirs_exist_ok=True)
@@ -172,6 +189,8 @@ def main() -> int:
                 "-m",
                 "pytest",
                 "-q",
+                "-m",
+                e2e_marker_expr,
                 "apps/server/tests_e2e",
             ],
             env=env,


### PR DESCRIPTION
Summary:\n- add a fast E2E mode to the docker-backed suite (--fast-e2e)\n- keep full E2E behavior as default unless fast mode is explicitly requested\n- run PR CI and local CI-parity e2e jobs in fast mode to reduce feedback time\n\nValidation:\n- ruff check tools/tests/run_full_suite.py tools/tests/run_ci_parallel.py\n- python3 -m pytest -q -m "e2e and not long_sim" --collect-only apps/server/tests_e2e\n\nNotes:\n- full coverage remains available via python3 tools/tests/run_full_suite.py (without --fast-e2e)