### PR TITLE
Enforce dB-only offline analysis/report outputs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,8 @@
 Repository overview
 - VibeSensor: Python-based data-collection and analysis backend (located in `apps/server/`), a small web UI (`apps/ui/`) built with Node, and device/firmware helpers under `firmware/esp/` and `hardware/`.
 - Key runtime artifacts: Docker Compose stack at `docker-compose.yml` and `apps/server/` Python package (`apps/server/pyproject.toml`). PDF report generation lives in `apps/server/vibesensor/report/pdf_builder.py`.
+- Units policy: raw ingest/sample acceleration values may use g, but post-stop analysis outputs (persisted summaries/findings/report-template artifacts) must expose vibration strength/intensity in dB only.
+- Canonical dB definition: `libs/core/python/vibesensor_core/vibration_strength.py::vibration_strength_db_scalar()` (`20*log10((peak+eps)/(floor+eps))`, `eps=max(1e-9, floor*0.05)`).
 
 Source-of-truth note
 - This file is the canonical short AI guide; `AGENTS.md` and `CLAUDE.md` should remain pointers to this file to prevent drift.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ No internet connection required. No cloud. Everything runs locally on the Pi.
 - Ruff linting and TypeScript type checking enforced in CI
 - Custom binary UDP protocol with sequence-based loss detection
 
+## Units
+
+- Raw sensor samples may contain acceleration values in g (for example `accel_x_g`, `accel_y_g`, `accel_z_g`) and related ingest-time/raw-spectrum amplitudes.
+- Post-stop analysis outputs (persisted analysis summaries, findings metrics, report-template artifacts, and report-facing strength fields) are dB-only.
+- The canonical vibration-strength definition is implemented in `libs/core/python/vibesensor_core/vibration_strength.py` via `vibration_strength_db_scalar()` and follows:
+  - `20*log10((peak_band_rms_amp_g + eps) / (floor_amp_g + eps))`
+  - `eps = max(1e-9, floor_amp_g * 0.05)`
+
 ## System Architecture
 
 ```

--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -679,6 +679,10 @@
     "en": "p95 peak amplitude across matched samples.",
     "nl": "p95 piekamplitude over overeenkomende samples."
   },
+  "METRIC_VIBRATION_STRENGTH_DB": {
+    "en": "Vibration strength in dB using the canonical peak-vs-floor definition.",
+    "nl": "Trillingssterkte in dB met de canonieke piek-tegen-vloerdefinitie."
+  },
   "MISSING": {
     "en": "Missing %",
     "nl": "Ontbreekt %"
@@ -854,6 +858,10 @@
   "PEAK_AMP_G": {
     "en": "Peak Amp (g)",
     "nl": "Piekamplitude (g)"
+  },
+  "PEAK_DB": {
+    "en": "Peak (dB)",
+    "nl": "Piek (dB)"
   },
   "PEAK_DISAPPEARS_AFTER_SENSOR_REMOUNT_OR_CABLE_RESEAT": {
     "en": "Peak disappears after sensor remount or cable reseat.",

--- a/apps/server/tests/test_analysis_units_db_only.py
+++ b/apps/server/tests/test_analysis_units_db_only.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from vibesensor.analysis.summary import summarize_run_data
+
+
+def _metadata() -> dict[str, Any]:
+    return {
+        "run_id": "unit-guard-run",
+        "language": "en",
+        "raw_sample_rate_hz": 400.0,
+        "tire_circumference_m": 2.1,
+        "final_drive_ratio": 3.7,
+        "current_gear_ratio": 0.8,
+    }
+
+
+def _samples() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for idx in range(24):
+        rows.append(
+            {
+                "t_s": float(idx) * 0.25,
+                "speed_kmh": 70.0 + (idx % 6),
+                "accel_x_g": 0.02,
+                "accel_y_g": 0.015,
+                "accel_z_g": 0.01,
+                "vibration_strength_db": 22.0 + (idx % 5),
+                "dominant_freq_hz": 30.0,
+                "top_peaks": [
+                    {"hz": 30.0, "amp": 0.08},
+                    {"hz": 60.0, "amp": 0.03},
+                    {"hz": 90.0, "amp": 0.02},
+                ],
+                "client_name": "rear-left wheel",
+                "strength_floor_amp_g": 0.01,
+            }
+        )
+    return rows
+
+
+def _walk(node: Any, *, path: tuple[str, ...] = ()) -> Iterator[tuple[tuple[str, ...], Any]]:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            key_text = str(key)
+            next_path = (*path, key_text)
+            yield (next_path, value)
+            yield from _walk(value, path=next_path)
+        return
+    if isinstance(node, list):
+        for idx, item in enumerate(node):
+            next_path = (*path, f"[{idx}]")
+            yield (next_path, item)
+            yield from _walk(item, path=next_path)
+
+
+def _is_guarded_raw_path(path: tuple[str, ...]) -> bool:
+    if not path:
+        return False
+    return path[0] in {"samples", "metadata", "analysis_metadata", "_report_template_data"}
+
+
+def test_post_analysis_summary_has_no_g_suffixed_output_fields() -> None:
+    metadata = _metadata()
+    samples = _samples()
+    summary = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+
+    offending_paths: list[str] = []
+    for path, _value in _walk(summary):
+        if _is_guarded_raw_path(path):
+            continue
+        if path and path[-1].endswith("_g"):
+            offending_paths.append(".".join(path))
+
+    assert not offending_paths, (
+        "Post-stop analysis output contains g-suffixed fields: "
+        + ", ".join(sorted(offending_paths))
+    )
+
+
+def test_post_analysis_summary_has_no_g_unit_strings() -> None:
+    metadata = _metadata()
+    samples = _samples()
+    summary = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+
+    offending_strings: list[str] = []
+    for path, value in _walk(summary):
+        if _is_guarded_raw_path(path):
+            continue
+        if isinstance(value, str) and " g" in value:
+            offending_strings.append(f"{'.'.join(path)}={value!r}")
+
+    assert not offending_strings, (
+        "Post-stop analysis output contains g-formatted strings: " + "; ".join(offending_strings)
+    )
+
+
+def test_analysis_modules_use_canonical_db_helper() -> None:
+    analysis_root = Path(__file__).resolve().parents[1] / "vibesensor" / "analysis"
+    canonical_module = analysis_root / "db_units.py"
+    assert canonical_module.exists()
+
+    direct_users: list[str] = []
+    for py_file in sorted(analysis_root.rglob("*.py")):
+        text = py_file.read_text(encoding="utf-8")
+        if "vibration_strength_db_scalar(" in text and py_file.name != "db_units.py":
+            direct_users.append(str(py_file.relative_to(analysis_root)))
+
+    assert not direct_users, (
+        "Analysis modules must use canonical_vibration_db() from db_units.py; "
+        "direct vibration_strength_db_scalar() calls found in: " + ", ".join(direct_users)
+    )

--- a/apps/server/tests/test_i18n_separation.py
+++ b/apps/server/tests/test_i18n_separation.py
@@ -240,7 +240,7 @@ def test_report_renders_in_en_and_nl_from_same_analysis() -> None:
 
     # Numeric values must be identical
     assert report_en.observed.certainty_pct == report_nl.observed.certainty_pct
-    assert report_en.observed.strength_peak_amp_g == report_nl.observed.strength_peak_amp_g
+    assert report_en.observed.strength_peak_db == report_nl.observed.strength_peak_db
 
     # Translated content must differ
     if report_en.data_trust and report_nl.data_trust:

--- a/apps/server/tests/test_localization_and_suppression.py
+++ b/apps/server/tests/test_localization_and_suppression.py
@@ -483,8 +483,8 @@ class TestConfidenceCalibration:
 class TestUnitConsistency:
     """Amplitude units must be consistent end-to-end."""
 
-    def test_findings_amplitude_units_are_g(self) -> None:
-        """All finding amplitude_metric.units must be 'g'."""
+    def test_findings_amplitude_units_are_db(self) -> None:
+        """All finding amplitude_metric.units must be 'dB'."""
         sensors = _ALL_WHEEL_SENSORS
         samples: list[dict[str, Any]] = []
         for i in range(30):
@@ -511,8 +511,8 @@ class TestUnitConsistency:
         for f in findings:
             amp_metric = f.get("amplitude_metric")
             if isinstance(amp_metric, dict) and amp_metric.get("value") is not None:
-                assert amp_metric.get("units") == "g", (
-                    f"Expected 'g' units, got {amp_metric.get('units')}"
+                assert amp_metric.get("units") == "dB", (
+                    f"Expected 'dB' units, got {amp_metric.get('units')}"
                 )
 
     def test_evidence_metrics_include_strength_db(self) -> None:

--- a/apps/server/tests/test_report_content_coverage.py
+++ b/apps/server/tests/test_report_content_coverage.py
@@ -346,7 +346,7 @@ _SECTION_HEADING_KEYS = [
 ]
 
 _PEAK_TABLE_COLUMN_KEYS = [
-    "PEAK_AMP_G",
+    "PEAK_DB",
     "STRENGTH_DB",
 ]
 

--- a/apps/server/tests/test_report_data_strength_db_source.py
+++ b/apps/server/tests/test_report_data_strength_db_source.py
@@ -39,7 +39,7 @@ def test_map_summary_strength_label_uses_finding_db_when_sensor_rows_missing() -
 
     assert data.observed.strength_label is not None
     assert "23.4 dB" in data.observed.strength_label
-    assert "0.015 g peak" in data.observed.strength_label
+    assert " g" not in data.observed.strength_label
 
 
 def test_map_summary_strength_label_derives_db_from_finding_amp_and_floor() -> None:
@@ -58,7 +58,7 @@ def test_map_summary_strength_label_derives_db_from_finding_amp_and_floor() -> N
 
     assert data.observed.strength_label is not None
     assert f"{expected_db:.1f} dB" in data.observed.strength_label
-    assert "0.015 g peak" in data.observed.strength_label
+    assert " g" not in data.observed.strength_label
 
 
 def test_map_summary_prefers_non_ref_top_cause_for_observed_location() -> None:
@@ -175,7 +175,7 @@ def test_map_summary_peak_rows_render_missing_values_as_dashes() -> None:
     row = data.peak_rows[0]
     assert row.rank == "—"
     assert row.freq_hz == "—"
-    assert row.amp_g == "—"
+    assert row.peak_db == "—"
 
 
 def test_map_summary_peak_rows_use_source_hint_for_system_label() -> None:
@@ -192,7 +192,7 @@ def test_map_summary_peak_rows_use_source_hint_for_system_label() -> None:
                     "rank": 1,
                     "frequency_hz": 33.0,
                     "order_label": "",
-                    "p95_amp_g": 0.12,
+                    "p95_intensity_db": 18.4,
                     "strength_db": 18.4,
                     "presence_ratio": 0.85,
                     "persistence_score": 0.0867,

--- a/apps/server/tests/test_report_floor_estimation.py
+++ b/apps/server/tests/test_report_floor_estimation.py
@@ -44,4 +44,4 @@ def test_run_noise_baseline_and_peak_table_share_floor_estimate() -> None:
 
     rows = _top_peaks_table_rows(samples, top_n=12, freq_bin_hz=1.0, run_noise_baseline_g=baseline)
     row_30 = next(row for row in rows if float(row["frequency_hz"]) == 30.0)
-    assert row_30["strength_floor_amp_g"] == pytest.approx(0.01)
+    assert row_30["strength_floor_db"] is not None

--- a/apps/server/tests/test_report_i18n.py
+++ b/apps/server/tests/test_report_i18n.py
@@ -391,8 +391,7 @@ def test_dutch_translation_audit_round_5() -> None:
     # "Bewijsoverzicht" → "Bewijssamenvatting"
     assert nl("EVIDENCE_SNAPSHOT") == "Bewijssamenvatting"
 
-    # Avoid abbreviation: "Piekamp (g)" → "Piekamplitude (g)"
-    assert nl("PEAK_AMP_G") == "Piekamplitude (g)"
+    assert nl("PEAK_DB") == "Piek (dB)"
 
     # Natural Dutch: "Analyse per snelheidsband"
     assert nl("SPEED_BINNED_ANALYSIS") == "Analyse per snelheidsband"

--- a/apps/server/tests/test_report_metrics_consistency.py
+++ b/apps/server/tests/test_report_metrics_consistency.py
@@ -121,9 +121,9 @@ def _assert_cross_section_consistency(rd: ReportTemplateData) -> None:
         f"Strength label mismatch: observed='{obs.strength_label}' vs "
         f"pattern_evidence='{pe.strength_label}'"
     )
-    assert obs.strength_peak_amp_g == pe.strength_peak_amp_g, (
-        f"Strength peak amp mismatch: observed={obs.strength_peak_amp_g} vs "
-        f"pattern_evidence={pe.strength_peak_amp_g}"
+    assert obs.strength_peak_db == pe.strength_peak_db, (
+        f"Strength peak dB mismatch: observed={obs.strength_peak_db} vs "
+        f"pattern_evidence={pe.strength_peak_db}"
     )
     assert obs.certainty_label == pe.certainty_label, (
         f"Certainty label mismatch: observed='{obs.certainty_label}' vs "
@@ -171,18 +171,15 @@ def _assert_unit_consistency(rd: ReportTemplateData) -> None:
     # Strength label should contain "dB" if a dB value is present
     sl = rd.observed.strength_label or ""
     if "dB" in sl:
-        assert "g peak" in sl or rd.observed.strength_peak_amp_g is None, (
-            f"Strength label has dB but missing g peak format: '{sl}'"
-        )
+        assert " g" not in sl, f"Strength label must be dB-only: '{sl}'"
 
-    # Peak rows: amplitude should be in g, strength in dB
+    # Peak rows: all strength columns should be dB-formatted numeric strings
     for pr in rd.peak_rows:
-        if pr.amp_g != "\u2014":
-            # Should be a float string (e.g. "0.0600")
+        if pr.peak_db != "\u2014":
             try:
-                float(pr.amp_g)
+                float(pr.peak_db)
             except ValueError:
-                pytest.fail(f"Peak row amp_g not a valid float: '{pr.amp_g}'")
+                pytest.fail(f"Peak row peak_db not a valid float: '{pr.peak_db}'")
         if pr.strength_db != "\u2014":
             try:
                 float(pr.strength_db)

--- a/apps/server/tests/test_report_new_modules.py
+++ b/apps/server/tests/test_report_new_modules.py
@@ -550,8 +550,8 @@ def test_map_summary_peak_rows_use_persistence_metrics() -> None:
                     "rank": 1,
                     "frequency_hz": 33.0,
                     "order_label": "",
-                    "max_amp_g": 0.9,
-                    "p95_amp_g": 0.12,
+                    "max_intensity_db": 22.0,
+                    "p95_intensity_db": 18.4,
                     "strength_db": 18.4,
                     "presence_ratio": 0.85,
                     "persistence_score": 0.0867,
@@ -564,7 +564,7 @@ def test_map_summary_peak_rows_use_persistence_metrics() -> None:
     data = map_summary(summary)
     assert data.peak_rows
     row = data.peak_rows[0]
-    assert row.amp_g == "0.1200"
+    assert row.peak_db == "18.4"
     assert row.strength_db == "18.4"
     assert "patterned" in row.relevance
     assert "85%" in row.relevance
@@ -584,8 +584,8 @@ def test_map_summary_peak_rows_render_baseline_noise_label() -> None:
                     "rank": 1,
                     "frequency_hz": 18.0,
                     "order_label": "",
-                    "max_amp_g": 0.01,
-                    "p95_amp_g": 0.009,
+                    "max_intensity_db": 2.1,
+                    "p95_intensity_db": 2.1,
                     "strength_db": 2.1,
                     "presence_ratio": 0.1,
                     "persistence_score": 0.001,

--- a/apps/server/tests/test_report_pdf_helpers_location_hotspots.py
+++ b/apps/server/tests/test_report_pdf_helpers_location_hotspots.py
@@ -47,7 +47,7 @@ def test_location_hotspots_fallback_uses_db_unit() -> None:
     assert " g" not in summary
 
 
-def test_location_hotspots_matched_points_uses_g_unit() -> None:
+def test_location_hotspots_matched_points_still_uses_db_unit() -> None:
     rows, summary, _, _ = location_hotspots(
         [{"client_name": "front-left wheel", "vibration_strength_db": 22.5}],
         [{"matched_points": [{"location": "front-left wheel", "amp": 0.15}]}],
@@ -55,7 +55,7 @@ def test_location_hotspots_matched_points_uses_g_unit() -> None:
         text_fn=_text_fn,
     )
 
-    assert rows[0]["unit"] == "g"
-    assert "peak_g" in rows[0]
-    assert "peak_db" not in rows[0]
-    assert "0.1500 g" in summary
+    assert rows[0]["unit"] == "db"
+    assert "peak_db" in rows[0]
+    assert "peak_g" not in rows[0]
+    assert "dB" in summary

--- a/apps/server/tests/test_report_strength_label_peak_amp.py
+++ b/apps/server/tests/test_report_strength_label_peak_amp.py
@@ -8,10 +8,10 @@ from vibesensor.report.pdf_builder import _strength_with_peak
 
 
 def test_strength_text_value_with_peak_amp() -> None:
-    txt = strength_text(22.0, lang="en", peak_amp_g=0.032)
+    txt = strength_text(22.0, lang="en")
     assert "Moderate" in txt
     assert "22.0 dB" in txt
-    assert "0.032 g peak" in txt
+    assert " g" not in txt
 
 
 def test_map_summary_strength_label_includes_peak_amp_when_available() -> None:
@@ -41,11 +41,11 @@ def test_map_summary_strength_label_includes_peak_amp_when_available() -> None:
     data = map_summary(summary)
     assert data.observed.strength_label is not None
     assert "22.0 dB" in data.observed.strength_label
-    assert "0.032 g peak" in data.observed.strength_label
-    assert data.observed.strength_peak_amp_g == 0.032
+    assert " g" not in data.observed.strength_label
+    assert data.observed.strength_peak_db == 22.0
     assert data.pattern_evidence.strength_label is not None
-    assert "0.032 g peak" in data.pattern_evidence.strength_label
-    assert data.pattern_evidence.strength_peak_amp_g == 0.032
+    assert " g" not in data.pattern_evidence.strength_label
+    assert data.pattern_evidence.strength_peak_db == 22.0
 
 
 def test_map_summary_strength_label_falls_back_to_db_only_without_peak_amp() -> None:
@@ -62,18 +62,18 @@ def test_map_summary_strength_label_falls_back_to_db_only_without_peak_amp() -> 
     assert data.observed.strength_label is not None
     assert "22.0 dB" in data.observed.strength_label
     assert "g peak" not in data.observed.strength_label
-    assert data.observed.strength_peak_amp_g is None
-    assert data.pattern_evidence.strength_peak_amp_g is None
+    assert data.observed.strength_peak_db == 22.0
+    assert data.pattern_evidence.strength_peak_db == 22.0
 
 
 def test_strength_with_peak_appends_only_when_label_lacks_peak_text() -> None:
     assert (
         _strength_with_peak("Moderate (22.0 dB)", 0.032, fallback="N/A")
-        == "Moderate (22.0 dB) · 0.032 g peak"
+        == "Moderate (22.0 dB) · 0.0 dB peak"
     )
     assert (
-        _strength_with_peak("Moderate (22.0 dB · 0.032 g peak)", 0.032, fallback="N/A")
-        == "Moderate (22.0 dB · 0.032 g peak)"
+        _strength_with_peak("Moderate (22.0 dB · 0.0 dB peak)", 0.032, fallback="N/A")
+        == "Moderate (22.0 dB · 0.0 dB peak)"
     )
 
 
@@ -105,8 +105,8 @@ def test_map_summary_strength_label_uses_finding_db_when_sensor_rows_missing() -
     data = map_summary(summary)
     assert data.observed.strength_label is not None
     assert "23.4 dB" in data.observed.strength_label
-    assert "0.015 g peak" in data.observed.strength_label
-    assert data.observed.strength_peak_amp_g == 0.015
+    assert " g" not in data.observed.strength_label
+    assert data.observed.strength_peak_db == 23.4
 
 
 def test_map_summary_strength_label_derives_db_from_finding_amp_and_floor() -> None:
@@ -140,8 +140,8 @@ def test_map_summary_strength_label_derives_db_from_finding_amp_and_floor() -> N
     data = map_summary(summary)
     assert data.observed.strength_label is not None
     assert f"{expected_db:.1f} dB" in data.observed.strength_label
-    assert "0.015 g peak" in data.observed.strength_label
-    assert data.observed.strength_peak_amp_g == 0.015
+    assert " g" not in data.observed.strength_label
+    assert data.observed.strength_peak_db is not None
 
 
 def test_map_summary_strength_label_keeps_db_and_peak_from_same_finding() -> None:

--- a/apps/server/tests/test_reports.py
+++ b/apps/server/tests/test_reports.py
@@ -450,7 +450,7 @@ def test_metadata_accel_scale_and_units_are_exposed(tmp_path: Path) -> None:
     _write_jsonl(run_path, records)
 
     summary = summarize_log(run_path)
-    assert summary["accel_scale_g_per_lsb"] == (1.0 / 256.0)
+    assert summary["accel_scale_per_lsb"] == (1.0 / 256.0)
     units = summary["metadata"]["units"]
     assert units["accel_x_g"] == "g"
     assert units["vibration_strength_db"] == "dB"

--- a/apps/server/tests/test_vibration_strength_absolute_metrics.py
+++ b/apps/server/tests/test_vibration_strength_absolute_metrics.py
@@ -16,7 +16,7 @@ def test_compute_strength_returns_absolute_amplitude_fields() -> None:
     assert isinstance(result["noise_floor_amp_g"], float)
 
 
-def test_near_zero_db_with_meaningful_peak_is_labeled_with_peak_amplitude() -> None:
+def test_near_zero_db_with_meaningful_peak_is_still_labeled_in_db() -> None:
     freq_hz = [float(i) for i in range(21)]
     combined = [0.03] * 6 + [0.18] * 15
     combined[12] = 0.20
@@ -30,10 +30,5 @@ def test_near_zero_db_with_meaningful_peak_is_labeled_with_peak_amplitude() -> N
     assert result["peak_amp_g"] > 0.18
     assert result["noise_floor_amp_g"] >= 0.17
 
-    label = strength_text(
-        result["vibration_strength_db"],
-        lang="en",
-        peak_amp_g=result["peak_amp_g"],
-    )
+    label = strength_text(result["vibration_strength_db"], lang="en")
     assert "dB" in label
-    assert "g peak" in label

--- a/apps/server/vibesensor/analysis/db_units.py
+++ b/apps/server/vibesensor/analysis/db_units.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from vibesensor_core.vibration_strength import vibration_strength_db_scalar
+
+
+def canonical_vibration_db(*, peak_band_rms_amp_g: float, floor_amp_g: float) -> float:
+    return vibration_strength_db_scalar(
+        peak_band_rms_amp_g=peak_band_rms_amp_g,
+        floor_amp_g=floor_amp_g,
+    )

--- a/apps/server/vibesensor/analysis/strength_labels.py
+++ b/apps/server/vibesensor/analysis/strength_labels.py
@@ -64,14 +64,11 @@ def strength_text(
     db_value: float | None,
     *,
     lang: str = "en",
-    peak_amp_g: float | None = None,
 ) -> str:
-    """Return a formatted strength string like ``'Moderate (22.0 dB · 0.032 g peak)'``."""
+    """Return a formatted strength string like ``'Moderate (22.0 dB)'``."""
     _, label = strength_label(db_value, lang=lang)
     if db_value is None:
         return label
-    if peak_amp_g is not None:
-        return f"{label} ({db_value:.1f} dB · {peak_amp_g:.3f} g peak)"
     return f"{label} ({db_value:.1f} dB)"
 
 

--- a/apps/server/vibesensor/report/pdf_builder.py
+++ b/apps/server/vibesensor/report/pdf_builder.py
@@ -82,16 +82,16 @@ def _safe(v: str | None, fallback: str = "—") -> str:
 
 def _strength_with_peak(
     strength_label: str | None,
-    peak_amp_g: float | None,
+    peak_db: float | None,
     *,
     fallback: str,
 ) -> str:
     base = _safe(strength_label, fallback)
-    if peak_amp_g is None:
+    if peak_db is None:
         return base
-    if "g peak" in base.lower():
+    if "db peak" in base.lower():
         return base
-    return f"{base} · {peak_amp_g:.3f} g peak"
+    return f"{base} · {peak_db:.1f} dB peak"
 
 
 def _draw_panel(
@@ -446,7 +446,7 @@ def _page1(c: Canvas, data: ReportTemplateData) -> list[NextStep]:  # noqa: C901
         oy,
         tr("STRENGTH"),
         _strength_with_peak(
-            data.observed.strength_label, data.observed.strength_peak_amp_g, fallback=na
+            data.observed.strength_label, data.observed.strength_peak_db, fallback=na
         ),
         label_w=lw,
     )
@@ -869,7 +869,7 @@ def _draw_pattern_evidence(
         rx,
         ry,
         tr("STRENGTH"),
-        _strength_with_peak(ev.strength_label, ev.strength_peak_amp_g, fallback=na),
+        _strength_with_peak(ev.strength_label, ev.strength_peak_db, fallback=na),
         label_w=lw,
         fs=7,
         value_w=val_w,
@@ -939,7 +939,7 @@ def _draw_peaks_table(
         (tr("SYSTEM"), 24 * mm),
         (tr("FREQUENCY_HZ"), 18 * mm),
         (tr("ORDER_LABEL"), 24 * mm),
-        (tr("PEAK_AMP_G"), 18 * mm),
+        (tr("PEAK_DB"), 18 * mm),
         (tr("STRENGTH_DB"), 16 * mm),
         (tr("SPEED_BAND"), 22 * mm),
     ]
@@ -986,7 +986,7 @@ def _draw_peaks_table(
             row.system,
             row.freq_hz,
             row.order,
-            row.amp_g,
+            row.peak_db,
             row.strength_db,
             row.speed_band,
             row.relevance,

--- a/apps/server/vibesensor/report/pdf_diagram.py
+++ b/apps/server/vibesensor/report/pdf_diagram.py
@@ -434,9 +434,7 @@ def car_location_diagram(
         unit = str(row.get("unit") or "").strip().lower()
         mean_val = _as_float(row.get("mean_value"))
         if mean_val is None:
-            mean_val = (
-                _as_float(row.get("mean_db")) if unit == "db" else _as_float(row.get("mean_g"))
-            )
+            mean_val = _as_float(row.get("mean_db")) if unit == "db" else None
         if loc and loc not in amp_by_location and mean_val is not None and mean_val > 0:
             amp_by_location[loc] = mean_val
     connected_locations.update(amp_by_location.keys())

--- a/apps/server/vibesensor/report/report_data.py
+++ b/apps/server/vibesensor/report/report_data.py
@@ -28,7 +28,7 @@ class ObservedSignature:
     speed_band: str | None = None
     phase: str | None = None
     strength_label: str | None = None
-    strength_peak_amp_g: float | None = None
+    strength_peak_db: float | None = None
     certainty_label: str | None = None
     certainty_pct: str | None = None
     certainty_reason: str | None = None
@@ -73,7 +73,7 @@ class PatternEvidence:
     strongest_location: str | None = None
     speed_band: str | None = None
     strength_label: str | None = None
-    strength_peak_amp_g: float | None = None
+    strength_peak_db: float | None = None
     certainty_label: str | None = None
     certainty_pct: str | None = None
     certainty_reason: str | None = None
@@ -88,7 +88,7 @@ class PeakRow:
     system: str
     freq_hz: str
     order: str
-    amp_g: str
+    peak_db: str
     strength_db: str
     speed_band: str
     relevance: str

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -110,6 +110,9 @@ After `summarize_run_data()` returns, the orchestrator in
 Report endpoints read the persisted analysis and use
 `_report_template_data` for PDF rendering without re-running analysis.
 
+Persisted post-stop analysis strength/intensity outputs are dB-only. Raw ingest/sample
+acceleration fields may still be expressed in g.
+
 ## Module Map
 
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,10 +27,14 @@ above the floor.
 The canonical implementation lives in `libs/core/python/vibesensor_core/vibration_strength.py`:
 
 - `compute_vibration_strength_db()` — full pipeline (spectrum → peaks → dB metric)
-- `_vibration_strength_db_scalar()` — low-level scalar helper (private)
+- `vibration_strength_db_scalar()` — low-level scalar helper (canonical)
 
 No other module may re-implement this formula. Use `bucket_for_strength()` for severity
 classification — never compare raw dB values against band thresholds inline.
+
+For post-stop persisted analysis/report artifacts (`summarize_run_data()` output,
+`_report_template_data`, report-facing strength/intensity fields), expose dB-only
+strength values. Raw ingest/sample fields may still carry g-based units.
 
 ## Severity Bands (l1–l5)
 


### PR DESCRIPTION
## Summary\n- remove g-based post-stop analysis/report outputs and unify on canonical dB strength\n- add centralized analysis helper for canonical dB conversion\n- migrate report data model + PDF rendering to dB peak fields\n- update docs and copilot instructions with explicit units policy\n- add anti-drift tests preventing g output fields/strings in post-stop artifacts\n\n## Validation\n- python3 tools/tests/run_ci_parallel.py --skip-bootstrap --job preflight --job tests --job e2e\n- docker compose build --pull\n- docker compose up -d\n- docker compose ps\n- vibesensor-sim --count 5 --duration 10 --no-interactive\n