### PR TITLE
Optimize e2e test performance with faster polling and parallel shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,4 +142,4 @@ jobs:
 
       - name: Docker-backed e2e suite (skip already-owned checks)
         run: |
-          python3 tools/tests/run_e2e_parallel.py --shards 2 --fast-e2e
+          python3 tools/tests/run_e2e_parallel.py --shards 3 --fast-e2e

--- a/apps/server/tests_e2e/e2e_helpers.py
+++ b/apps/server/tests_e2e/e2e_helpers.py
@@ -159,7 +159,7 @@ def wait_for(
     predicate,
     *,
     timeout_s: float,
-    interval_s: float = 1.0,
+    interval_s: float = 0.5,
     message: str,
 ):
     deadline = time.monotonic() + timeout_s
@@ -187,7 +187,7 @@ def wait_run_status(
     return wait_for(
         _check,
         timeout_s=timeout_s,
-        interval_s=1.0,
+        interval_s=0.5,
         message=f"Run {run_id} did not reach statuses {statuses}",
     )
 

--- a/tools/tests/run_full_suite.py
+++ b/tools/tests/run_full_suite.py
@@ -66,7 +66,7 @@ def _wait_health(base_url: str, timeout_s: float = 60.0) -> None:
                     return
         except (URLError, TimeoutError, OSError):
             pass
-        time.sleep(1.0)
+        time.sleep(0.5)
     raise RuntimeError("Container did not become healthy in time")
 
 
@@ -243,7 +243,7 @@ def main() -> int:
                 "VIBESENSOR_SIM_DATA_PORT": str(args.sim_data_port),
                 "VIBESENSOR_SIM_CONTROL_PORT": str(args.sim_control_port),
                 "VIBESENSOR_SIM_CLIENT_CONTROL_BASE": str(args.sim_client_control_base),
-                "VIBESENSOR_SIM_DURATION": "12",
+                "VIBESENSOR_SIM_DURATION": "8",
                 "VIBESENSOR_SIM_DURATION_LONG": "20",
                 "VIBESENSOR_SIM_LOG": str(sim_log),
             }


### PR DESCRIPTION
## Summary
This PR optimizes end-to-end test execution by reducing polling intervals and increasing test parallelization, improving overall test suite performance.

## Key Changes
- **Reduced polling intervals**: Decreased `interval_s` from 1.0 to 0.5 seconds in e2e helper functions (`wait_for` and `wait_for_run_status`) to enable faster detection of state changes
- **Faster health checks**: Reduced sleep interval from 1.0 to 0.5 seconds in container health check polling (`_wait_health`)
- **Shorter simulation duration**: Reduced `VIBESENSOR_SIM_DURATION` from 12 to 8 seconds for faster test execution
- **Increased test parallelization**: Increased CI e2e test shards from 2 to 3 for better parallel execution

## Implementation Details
These changes work together to accelerate the e2e test suite:
- The polling interval reductions allow tests to respond more quickly to state changes without adding significant overhead
- The shorter simulation duration reduces per-test execution time
- The additional shard distributes the test load across more parallel workers, reducing total CI runtime

https://claude.ai/code/session_01Hz5kjSSvNbD5iRkLYT1q55