### PR TITLE
Fix confidence-threshold constants and out-of-order sequence regression

### DIFF
--- a/apps/server/vibesensor/analysis/strength_labels.py
+++ b/apps/server/vibesensor/analysis/strength_labels.py
@@ -11,6 +11,9 @@ import math
 
 from vibesensor_core.strength_bands import BANDS
 
+CONFIDENCE_HIGH_THRESHOLD = 0.70
+CONFIDENCE_MEDIUM_THRESHOLD = 0.40
+
 # ---------------------------------------------------------------------------
 # Strength labels  (vibration_strength_db → natural-language band)
 # ---------------------------------------------------------------------------
@@ -134,11 +137,11 @@ def _select_reason_key(
         return "single_sensor"
     if steady_speed:
         return "narrow_speed_range"
-    if confidence >= 0.70:
+    if confidence >= CONFIDENCE_HIGH_THRESHOLD:
         if weak_spatial:
             return "weak_spatial_separation"
         return "strong_order_match"
-    if confidence >= 0.40:
+    if confidence >= CONFIDENCE_MEDIUM_THRESHOLD:
         if weak_spatial:
             return "weak_spatial_separation"
         return "moderate_order_match"
@@ -182,9 +185,9 @@ def certainty_label(
         confidence_0_to_1 = 0.0
         pct_text = "0%"
 
-    if confidence_0_to_1 >= 0.70:
+    if confidence_0_to_1 >= CONFIDENCE_HIGH_THRESHOLD:
         level_key, label_en, label_nl = "high", "High", "Hoog"
-    elif confidence_0_to_1 >= 0.40:
+    elif confidence_0_to_1 >= CONFIDENCE_MEDIUM_THRESHOLD:
         level_key, label_en, label_nl = "medium", "Medium", "Gemiddeld"
     else:
         level_key, label_en, label_nl = "low", "Low", "Laag"


### PR DESCRIPTION
## Summary
- export shared confidence threshold constants from analysis/strength_labels.py and consume them from analysis/summary.py
- preserve registry last_seq monotonic progression so out-of-order UDP packets do not regress sequence state

## Validation
- python3 tools/tests/pytest_progress.py --show-test-names -- apps/server/tests/test_registry.py apps/server/tests/test_report_content_coverage.py apps/server/tests/test_20_bug_fixes.py apps/server/tests/test_run2_cycle2_fixes.py
- <repo-root>/.venv/bin/python tools/tests/run_ci_parallel.py --job preflight --job tests
