### PR TITLE
Ignore backend build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ apps/ui/dist/
 apps/ui/.npm-ci-lock.sha256
 apps/ui/.playwright-chromium-installed
 apps/server/vibesensor/static/
+apps/server/build/
+apps/server/dist/
 
 # Playwright test artifacts
 apps/ui/tests/test-results/


### PR DESCRIPTION
## Summary
- ignore generated backend packaging output under apps/server/build and apps/server/dist
- prevent local wheel/build artifacts from appearing as outstanding changes on main
- clean up the remaining symptom without touching source behavior

## Validation
- git check-ignore -v apps/server/build apps/server/dist
- git status --short
