### PR TITLE
Allow multi-hour AI runs in canonical instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,8 @@ Execution model
 - Avoid over-conservative blocking behavior: do not delay a clear in-scope fix for exhaustive hypotheticals or speculative edge cases.
 - Use bounded risk, not risk avoidance: keep changes reversible, test quickly, and correct fast when validation fails.
 - Continue autonomously on clearly adjacent in-scope issues.
-- Stop only when all plan items are validated complete, no similar in-scope issues remain, a real blocker exists, or the time budget is reached.
-- Long deep runs are allowed and preferred for medium or large work.
+- Stop only when all plan items are validated complete, no similar in-scope issues remain, a real blocker exists, or the user explicitly asks to pause.
+- Long deep runs are allowed and preferred for medium or large work; multi-hour runs are acceptable when needed to complete in-scope work well.
 
 Documentation maintenance
 - After every meaningful code change, check whether docs, repo maps, runbooks, READMEs, and instruction files that reference the touched area are now stale.

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -18,8 +18,8 @@ Canonical agent workflow (shared source of truth)
   1. all plan items are complete and validated,
   2. no similar in-scope issues remain,
   3. a real blocker exists (credentials/hardware/external dependency),
-  4. time budget is reached.
-- Long, thorough runs are allowed and preferred for deeper tasks; a 45–60 minute run is acceptable for medium/large changes.
+  4. the user explicitly asks to pause.
+- Long, thorough runs are allowed and preferred for deeper tasks; multi-hour runs are acceptable when needed to complete in-scope work well.
 - Context/noise control:
   - avoid scanning generated/build/cache/vendor artifacts unless debugging them (`artifacts/`, `.cache/`, `node_modules/`, `dist/`, `.venv/`, `.pytest_cache/`, `.ruff_cache/`),
   - use focused file reads and scoped searches,


### PR DESCRIPTION
## Summary\n- remove time-budget-based stop condition from canonical AI instructions\n- make user-requested pause the stop trigger instead\n- explicitly allow multi-hour deep runs when needed for in-scope completion\n\n## Files\n- .github/copilot-instructions.md\n- .github/instructions/general.instructions.md