### PR TITLE
CTO remediation: 5-chunk engineering hardening

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,20 +55,21 @@ Current hook behavior:
 - The optional privacy guard only runs when `tools/privacy/privacy_guard.py` exists.
 - If a hook blocks you unexpectedly, use the commands below directly and then investigate instead of guessing.
 
-## Fast validation workflow
+## Validation workflow
 
-Run the smallest relevant checks first, then expand to CI parity before opening or merging a PR.
+Two tiers: use `make test` during iteration, `make test-all` before pushing.
 
 | Goal | Command |
 |---|---|
 | Backend lint | `make lint` |
 | Backend typing | `make typecheck-backend` |
 | Frontend typing | `make ui-typecheck` |
-| Fast backend test loop | `make test-fast` |
+| Fast backend tests | `make test` |
 | Focused backend tests | `pytest -q apps/server/tests/<area>/` |
 | Coverage view | `make coverage` |
 | Full CI-parity suite | `make test-all` |
 | Docs lint | `make docs-lint` |
+| Sync frontend contracts | `make sync-contracts` |
 
 Useful focused examples:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup format lint typecheck-backend typecheck ui-typecheck test test-fast test-all test-ci test-full-suite coverage coverage-html coverage-strict smoke loc docs-lint ai-check ai-test ai-smoke ai-pack ai\:check ai\:test ai\:smoke ai\:pack
+.PHONY: setup format lint typecheck-backend typecheck ui-typecheck test test-fast test-all test-ci test-full-suite sync-contracts coverage coverage-html coverage-strict smoke loc docs-lint ai-check ai-test ai-smoke ai-pack ai\:check ai\:test ai\:smoke ai\:pack
 
 setup:
 	python3 -m pip install --upgrade pip
@@ -22,16 +22,18 @@ typecheck: typecheck-backend ui-typecheck
 test:
 	python3 -m pytest -q -m "not selenium" apps/server/tests
 
-test-fast:
-	python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests
+test-fast: test  # alias — use 'make test'
 
-test-all: test-ci
+test-all:
+	python3 tools/tests/run_ci_parallel.py
 
-test-ci:
-	python3 tools/tests/run_verification.py --suite ci-parity
+test-ci: test-all  # alias — use 'make test-all'
 
 test-full-suite:
 	python3 tools/tests/run_verification.py --suite full-stack
+
+sync-contracts:
+	cd apps/ui && npm run sync:contracts
 
 coverage:
 	python3 tools/tests/run_coverage.py

--- a/apps/server/tests/_paths.py
+++ b/apps/server/tests/_paths.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__all__ = ["TESTS_DIR", "SERVER_ROOT", "REPO_ROOT"]
+__all__ = ["REPO_ROOT", "SERVER_ROOT", "TESTS_DIR"]
 
 # tests/ directory (this file's parent)
 TESTS_DIR = Path(__file__).resolve().parent

--- a/apps/server/tests/_report_helpers.py
+++ b/apps/server/tests/_report_helpers.py
@@ -80,7 +80,7 @@ def report_run_metadata(
                 "statistic": "Peak band RMS vs noise floor",
                 "units": "dB",
                 "definition": "20*log10((peak_band_rms + eps) / (floor + eps))",
-            }
+            },
         },
         "incomplete_for_order_analysis": raw_sample_rate_hz is None,
     }
@@ -113,7 +113,7 @@ def report_sample(
             "amp": peak_amp_g,
             "vibration_strength_db": vibration_strength_db,
             "strength_bucket": strength_bucket,
-        }
+        },
     ]
     if include_secondary_peak:
         peaks.append(
@@ -122,7 +122,7 @@ def report_sample(
                 "amp": peak_amp_g * 0.45,
                 "vibration_strength_db": 14.0,
                 "strength_bucket": None,
-            }
+            },
         )
     return {
         "record_type": "sample",

--- a/apps/server/tests/_scenario_ground_truth_helpers.py
+++ b/apps/server/tests/_scenario_ground_truth_helpers.py
@@ -48,7 +48,7 @@ def idle_phase(
                     top_peaks=peaks,
                     vibration_strength_db=6.0,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 
@@ -82,7 +82,7 @@ def road_noise_phase(
                     top_peaks=peaks,
                     vibration_strength_db=road_vib_db,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 
@@ -120,7 +120,7 @@ def ramp_phase(
                         top_peaks=peaks,
                         vibration_strength_db=road_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
             t += dt_s
     return samples
@@ -161,7 +161,7 @@ def fault_phase(
                         top_peaks=peaks,
                         vibration_strength_db=fault_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
                 continue
 
@@ -178,7 +178,7 @@ def fault_phase(
                     top_peaks=peaks,
                     vibration_strength_db=noise_vib_db,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 

--- a/apps/server/tests/_scenario_regression_helpers.py
+++ b/apps/server/tests/_scenario_regression_helpers.py
@@ -98,7 +98,7 @@ def build_speed_sweep_samples(
                 client_name=client_name,
                 top_peaks=peaks,
                 strength_floor_amp_g=0.003,
-            )
+            ),
         )
     return samples
 

--- a/apps/server/tests/analysis/test_analysis_architecture.py
+++ b/apps/server/tests/analysis/test_analysis_architecture.py
@@ -166,7 +166,7 @@ _ANALYSIS_ONLY_NAMES: frozenset[str] = frozenset(
         "test_plan.py",
         "pattern_parts.py",
         "report_mapping_pipeline.py",
-    }
+    },
 )
 
 

--- a/apps/server/tests/analysis/test_analysis_persistence.py
+++ b/apps/server/tests/analysis/test_analysis_persistence.py
@@ -62,7 +62,7 @@ CREATE TABLE settings_kv (
 CREATE TABLE client_names (
     client_id TEXT PRIMARY KEY, name TEXT NOT NULL, updated_at TEXT NOT NULL
 );
-"""
+""",
     )
     conn.commit()
     conn.close()
@@ -184,7 +184,7 @@ def _sample(i: int) -> dict[str, Any]:
                 "amp": 0.1,
                 "vibration_strength_db": 12.0,
                 "strength_bucket": "l2",
-            }
+            },
         ],
         "vibration_strength_db": 12.0,
         "strength_bucket": "l2",
@@ -224,7 +224,9 @@ def _make_fake_state(history_db: Any) -> Any:
                 "snapshot_for_api": lambda self: [],
                 "get": lambda self, _: None,
                 "set_name": lambda self, cid, name: type(
-                    "U", (), {"client_id": cid, "name": name}
+                    "U",
+                    (),
+                    {"client_id": cid, "name": name},
                 )(),
                 "remove_client": lambda self, _: True,
             },
@@ -282,7 +284,7 @@ def _make_fake_state(history_db: Any) -> Any:
         apply_car_settings=state.apply_car_settings,
         apply_speed_source_settings=state.apply_speed_source_settings,
     )
-    state.diagnostics = SimpleNamespace(
+    state.recording = SimpleNamespace(
         metrics_logger=state.metrics_logger,
     )
     state.persistence = SimpleNamespace(

--- a/apps/server/tests/analysis/test_analysis_settings.py
+++ b/apps/server/tests/analysis/test_analysis_settings.py
@@ -151,7 +151,7 @@ def test_sanitize_clamps_absurd_values(store: AnalysisSettingsStore) -> None:
             "wheel_bandwidth_pct": 99999,
             "speed_uncertainty_pct": 99999,
             "min_abs_band_hz": 99999,
-        }
+        },
     )
     assert out["wheel_bandwidth_pct"] == 100.0
     assert out["speed_uncertainty_pct"] == 100.0
@@ -187,7 +187,10 @@ def test_sanitize_keeps_normal_values_unchanged(store: AnalysisSettingsStore) ->
     ],
 )
 def test_sanitize_clamps_out_of_range(
-    store: AnalysisSettingsStore, field: str, raw_value: float, clamped_value: float
+    store: AnalysisSettingsStore,
+    field: str,
+    raw_value: float,
+    clamped_value: float,
 ) -> None:
     out = store._sanitize({field: raw_value})
     assert out[field] == clamped_value

--- a/apps/server/tests/analysis/test_analysis_settings_source_of_truth.py
+++ b/apps/server/tests/analysis/test_analysis_settings_source_of_truth.py
@@ -87,7 +87,7 @@ class _State:
         self.processor = SimpleNamespace(
             debug_spectrum=lambda _id: {},
             raw_samples=lambda _id, n_samples=1: {},
-            intake_stats=lambda: {},
+            intake_stats=dict,
         )
         self.ingress = SimpleNamespace(
             registry=self.registry,
@@ -101,7 +101,7 @@ class _State:
             apply_car_settings=self.apply_car_settings,
             apply_speed_source_settings=self.apply_speed_source_settings,
         )
-        self.diagnostics = SimpleNamespace(
+        self.recording = SimpleNamespace(
             metrics_logger=self.metrics_logger,
         )
         self.persistence = SimpleNamespace(
@@ -125,7 +125,9 @@ class _State:
 def _route(router, path: str, method: str = "GET"):
     for candidate in router.routes:
         if getattr(candidate, "path", "") == path and method in getattr(
-            candidate, "methods", set()
+            candidate,
+            "methods",
+            set(),
         ):
             return candidate.endpoint
     raise AssertionError(path)
@@ -165,7 +167,7 @@ async def test_analysis_settings_endpoint_updates_active_car_aspects(_wiring) ->
     assert analysis_settings.snapshot()["tire_width_mm"] == 255.0
 
     cars = response_payload(
-        await add_car(CarUpsertRequest(name="Second", aspects={"tire_width_mm": 225.0}))
+        await add_car(CarUpsertRequest(name="Second", aspects={"tire_width_mm": 225.0})),
     )
     second_id = cars["cars"][1]["id"]
     await set_active(ActiveCarRequest(carId=second_id))

--- a/apps/server/tests/analysis/test_analysis_units_db_only.py
+++ b/apps/server/tests/analysis/test_analysis_units_db_only.py
@@ -9,7 +9,7 @@ from _paths import SERVER_ROOT
 from vibesensor.analysis import summarize_run_data
 
 _GUARDED_RAW_ROOTS = frozenset(
-    {"samples", "metadata", "analysis_metadata", "_report_template_data"}
+    {"samples", "metadata", "analysis_metadata", "_report_template_data"},
 )
 
 
@@ -98,7 +98,8 @@ def test_post_analysis_summary_has_no_g_unit_strings(_summary: dict[str, Any]) -
 
 def test_analysis_modules_use_canonical_db_helper() -> None:
     """Analysis modules must import vibration_strength_db_scalar as canonical_vibration_db
-    and call it via the alias, not directly as vibration_strength_db_scalar()."""
+    and call it via the alias, not directly as vibration_strength_db_scalar().
+    """
     analysis_root = SERVER_ROOT / "vibesensor" / "analysis"
 
     direct_users = [

--- a/apps/server/tests/analysis/test_compute_effective_match_rate.py
+++ b/apps/server/tests/analysis/test_compute_effective_match_rate.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Unit tests for _compute_effective_match_rate speed-band rescue logic.
 
 Covers the highest-speed-bin rescue path and per-location fallback.
@@ -62,7 +61,8 @@ def test_highest_bin_qualifies() -> None:
 
 def test_low_speed_fault_not_rescued_when_highest_bin_poor() -> None:
     """Only the highest speed bin is evaluated; a lower bin with strong
-    signal will not be rescued via speed-band path."""
+    signal will not be rescued via speed-band path.
+    """
     eff, band, loc_dom = _run_rescue(
         0.20,
         (
@@ -106,7 +106,8 @@ def test_second_highest_bin_not_considered() -> None:
 
 def test_highest_bin_wins_even_when_lower_bin_has_better_rate() -> None:
     """The highest speed bin is always the rescue candidate, even if a lower
-    bin has a better match rate."""
+    bin has a better match rate.
+    """
     eff, band, _ = _run_rescue(
         0.20,
         (

--- a/apps/server/tests/analysis/test_confidence_threshold_boundaries.py
+++ b/apps/server/tests/analysis/test_confidence_threshold_boundaries.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Confidence threshold boundary tests — multi-profile (≥50 cases per profile).
 
 Tests the analysis pipeline's behaviour at and near critical confidence
@@ -80,7 +79,9 @@ def test_strong_single_sensor_reaches_high_confidence(profile: dict[str, Any], c
 @pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
 def test_strong_4sensor_fault_reaches_medium_confidence(
-    profile: dict[str, Any], corner: str, speed: float
+    profile: dict[str, Any],
+    corner: str,
+    speed: float,
 ) -> None:
     """A strong 4-sensor fault produces ≥0.40 confidence (spatial penalty)."""
     sensor = CORNER_SENSORS[corner]
@@ -141,7 +142,9 @@ def test_negligible_strength_caps_to_medium(profile: dict[str, Any], corner: str
 @pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_HIGH], ids=["low", "high"])
 def test_very_weak_fault_below_nofault_threshold(
-    profile: dict[str, Any], corner: str, speed: float
+    profile: dict[str, Any],
+    corner: str,
+    speed: float,
 ) -> None:
     """A very weak fault should not cross the 0.40 no-fault boundary."""
     sensor = CORNER_SENSORS[corner]
@@ -300,7 +303,10 @@ _SENSOR_CONFIGS = [
 @pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
 @pytest.mark.parametrize(("cfg_name", "sensors"), _SENSOR_CONFIGS, ids=["single", "quad"])
 def test_noise_only_no_spurious_fault(
-    profile: dict[str, Any], cfg_name: str, sensors: list[str], speed: float
+    profile: dict[str, Any],
+    cfg_name: str,
+    sensors: list[str],
+    speed: float,
 ) -> None:
     """Pure noise should never produce a wheel fault at ≥0.40 confidence."""
     samples = make_noise_samples(sensors=sensors, speed_kmh=speed, n_samples=40)

--- a/apps/server/tests/analysis/test_contradictory_phase_signals.py
+++ b/apps/server/tests/analysis/test_contradictory_phase_signals.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Contradictory / phase-inconsistent signal tests (≥50 direct-injection cases).
 
 Tests the analysis pipeline when signals contradict each other across
@@ -147,7 +146,7 @@ def test_engine_idle_then_wheel_cruise(corner: str, idle_name: str, idle_n: int)
                     top_peaks=peaks,
                     vibration_strength_db=18.0,
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
 
     # Phase 2: cruise with wheel fault
@@ -189,7 +188,10 @@ _TRANSIENT_POSITIONS = [
     ids=[p[0] for p in _TRANSIENT_POSITIONS],
 )
 def test_transient_plus_persistent(
-    corner: str, pos_name: str, trans_start: float, fault_start: float
+    corner: str,
+    pos_name: str,
+    trans_start: float,
+    fault_start: float,
 ) -> None:
     """Persistent fault should dominate over transient in combined scenario."""
     sensor = CORNER_SENSORS[corner]
@@ -306,7 +308,7 @@ def test_equal_strength_two_corners(corner_a: str, corner_b: str) -> None:
                     top_peaks=peaks,
                     vibration_strength_db=26.0 if is_fault else 8.0,
                     strength_floor_amp_g=0.004,
-                )
+                ),
             )
 
     summary = run_analysis(samples)
@@ -335,7 +337,10 @@ _CONTRADICTION_TYPES = [
     ids=[c[0] for c in _CONTRADICTION_TYPES],
 )
 def test_profile_phased_contradiction(
-    profile: dict[str, Any], contra_name: str, corner_a: str, corner_b: str
+    profile: dict[str, Any],
+    contra_name: str,
+    corner_a: str,
+    corner_b: str,
 ) -> None:
     """Profile-aware contradictory corners across phases should not crash."""
     sensor_a = CORNER_SENSORS[corner_a]
@@ -392,7 +397,10 @@ _SPEED_COMBOS = [
     ids=[c[0] for c in _SPEED_COMBOS],
 )
 def test_speed_change_between_phases(
-    corner: str, combo_name: str, speed_a: float, speed_b: float
+    corner: str,
+    combo_name: str,
+    speed_a: float,
+    speed_b: float,
 ) -> None:
     """Fault across phases with different speeds: tracking should still find the fault."""
     sensor = CORNER_SENSORS[corner]

--- a/apps/server/tests/analysis/test_diagnosis_robustness_faults.py
+++ b/apps/server/tests/analysis/test_diagnosis_robustness_faults.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 import math
@@ -44,11 +43,14 @@ class TestDualFaultTwoCorners:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
 
         summary = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="dual_fault_test"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="dual_fault_test",
         )
         assert_summary_sections(summary, min_findings=1, min_top_causes=1)
         findings = [
@@ -72,11 +74,13 @@ class TestDualFaultTwoCorners:
             str(row.get("location", "")).lower()
             for row in summary.get("sensor_intensity_by_location", [])[:4]
         }
-        for corner in {"front-right", "rear-left"}:
+        for corner in ("front-right", "rear-left"):
             assert any(corner in loc for loc in intensity_locs)
         if summary.get("top_causes"):
             assert_top_cause_contract(
-                summary["top_causes"][0], expected_source="wheel", confidence_range=(0.15, 1.0)
+                summary["top_causes"][0],
+                expected_source="wheel",
+                confidence_range=(0.15, 1.0),
             )
 
     def test_dual_fault_both_corners_in_intensity_ranking(self) -> None:
@@ -102,11 +106,14 @@ class TestDualFaultTwoCorners:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
 
         intensities = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="dual_fault_intensity"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="dual_fault_intensity",
         ).get("sensor_intensity_by_location", [])
         intensity_locs = {str(row.get("location", "")).lower() for row in intensities[:4]}
         assert any("front-left" in loc for loc in intensity_locs)
@@ -133,10 +140,13 @@ class TestClippedSaturatedData:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         summary = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="saturated_test"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="saturated_test",
         )
         for top_cause in summary.get("top_causes", []):
             assert not math.isnan(top_cause.get("confidence", 0))
@@ -170,10 +180,13 @@ class TestClippedSaturatedData:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         top_causes = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="clipped_location"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="clipped_location",
         ).get("top_causes", [])
         assert_top_cause_contract(
             top_causes[0],

--- a/apps/server/tests/analysis/test_diagnosis_robustness_report_pdf.py
+++ b/apps/server/tests/analysis/test_diagnosis_robustness_report_pdf.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 from io import BytesIO
@@ -36,13 +35,16 @@ class TestPdfContentForDiagnosedScenario:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
 
         from vibesensor.report.pdf_engine import build_report_pdf
 
         summary = summarize_run_data(
-            standard_metadata(language="en"), samples, lang="en", file_name="pdf_diag_test"
+            standard_metadata(language="en"),
+            samples,
+            lang="en",
+            file_name="pdf_diag_test",
         )
         pdf_bytes = build_report_pdf(map_summary(summary))
         text_lower = extract_pdf_text(pdf_bytes).lower()
@@ -72,13 +74,16 @@ class TestPdfContentForDiagnosedScenario:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
 
         from vibesensor.report.pdf_engine import build_report_pdf
 
         summary = summarize_run_data(
-            standard_metadata(language="nl"), samples, lang="nl", file_name="pdf_nl_diag"
+            standard_metadata(language="nl"),
+            samples,
+            lang="nl",
+            file_name="pdf_nl_diag",
         )
         text_lower = extract_pdf_text(build_report_pdf(map_summary(summary))).lower()
         assert "diagnostisch werkformulier" in text_lower

--- a/apps/server/tests/analysis/test_diagnosis_robustness_runtime_inputs.py
+++ b/apps/server/tests/analysis/test_diagnosis_robustness_runtime_inputs.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 import math
@@ -29,10 +28,13 @@ class TestMissingStaleSpeed:
                         top_peaks=[{"hz": 25.0, "amp": 0.005}, {"hz": 50.0, "amp": 0.004}],
                         vibration_strength_db=10.0,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         summary = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="zero_speed"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="zero_speed",
         )
         assert "findings" in summary
 
@@ -56,7 +58,7 @@ class TestMissingStaleSpeed:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         summary = summarize_run_data(standard_metadata(), samples, lang="en", file_name="nan_speed")
         for top_cause in summary.get("top_causes", []):
@@ -82,10 +84,13 @@ class TestMissingStaleSpeed:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         summary = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="stale_speed"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="stale_speed",
         )
         assert_summary_sections(summary, min_findings=0)
 
@@ -112,10 +117,13 @@ class TestSensorDropoutRejoin:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         top_causes = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="dropout_test"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="dropout_test",
         ).get("top_causes", [])
         assert_top_cause_contract(
             top_causes[0],
@@ -145,14 +153,19 @@ class TestSensorDropoutRejoin:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         summary = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="rejoin_test"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="rejoin_test",
         )
         assert_summary_sections(summary, min_top_causes=1)
         assert_top_cause_contract(
-            summary["top_causes"][0], expected_source="wheel", expected_location="front-right"
+            summary["top_causes"][0],
+            expected_source="wheel",
+            expected_location="front-right",
         )
 
 
@@ -202,10 +215,13 @@ class TestSensorNameNormalization:
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         summary = summarize_run_data(
-            standard_metadata(), samples, lang="en", file_name="case_mix_test"
+            standard_metadata(),
+            samples,
+            lang="en",
+            file_name="case_mix_test",
         )
         assert_summary_sections(summary, min_top_causes=1)
         assert "wheel" in str(summary["top_causes"][0].get("source", "")).lower()
@@ -226,7 +242,7 @@ class TestGpsSpeedValidation:
                     "lat": 54.6872,
                     "lon": 25.2797,
                     "speed": speed_value,
-                }
+                },
             ).encode()
             + b"\n"
         )
@@ -245,7 +261,7 @@ class TestGpsSpeedValidation:
                     "lat": 54.6872,
                     "lon": 25.2797,
                     "speed": speed,
-                }
+                },
             ).encode()
             + b"\n"
         )

--- a/apps/server/tests/analysis/test_findings_builder_support.py
+++ b/apps/server/tests/analysis/test_findings_builder_support.py
@@ -17,7 +17,7 @@ def test_collect_order_frequencies_skips_low_confidence_matches() -> None:
                 "confidence_0_to_1": 0.5,
                 "matched_points": [{"matched_hz": 12.0}, {"matched_hz": 13.0}],
             },
-        ]
+        ],
     )
 
     assert frequencies == {12.0, 13.0}
@@ -34,7 +34,7 @@ def test_finalize_findings_orders_reference_diagnostic_then_info() -> None:
                 "confidence_0_to_1": 0.9,
                 "_ranking_score": 5.0,
             },
-        ]
+        ],
     )
 
     assert [finding["finding_id"] for finding in findings] == ["REF_SPEED", "F001", "F002"]

--- a/apps/server/tests/analysis/test_findings_helpers.py
+++ b/apps/server/tests/analysis/test_findings_helpers.py
@@ -100,14 +100,16 @@ class TestSpeedProfileFromPoints:
     def test_phase_weights_longer_than_points_ignores_extras(self) -> None:
         points = [(80.0, 0.02), (90.0, 0.09)]
         peak_speed, _band, _label = _speed_profile_from_points(
-            points, phase_weights=[1.0, 1.0, 0.1, 0.1]
+            points,
+            phase_weights=[1.0, 1.0, 0.1, 0.1],
         )
         assert peak_speed == 90.0
 
     def test_non_positive_or_invalid_phase_weights_fall_back_to_neutral(self) -> None:
         points = [(80.0, 0.04), (90.0, 0.09)]
         peak_speed, _band, _label = _speed_profile_from_points(
-            points, phase_weights=[0.0, float("nan")]
+            points,
+            phase_weights=[0.0, float("nan")],
         )
         assert peak_speed == 90.0
 

--- a/apps/server/tests/analysis/test_findings_subpackage.py
+++ b/apps/server/tests/analysis/test_findings_subpackage.py
@@ -242,7 +242,10 @@ class TestDetectDiffuseExcitation:
 
     def test_single_location_not_diffuse(self) -> None:
         is_diffuse, penalty = _detect_diffuse_excitation(
-            {"front_left"}, {"front_left": 10}, {"front_left": 5}, []
+            {"front_left"},
+            {"front_left": 10},
+            {"front_left": 5},
+            [],
         )
         assert not is_diffuse
         assert penalty == 1.0

--- a/apps/server/tests/analysis/test_localization_and_suppression.py
+++ b/apps/server/tests/analysis/test_localization_and_suppression.py
@@ -144,7 +144,8 @@ class TestSourceAwareLocalization:
 
     def test_wheel_diagnosis_prefers_wheel_sensor_over_cabin(self) -> None:
         """When cabin sensor has higher amplitude but wheel sensors are present,
-        wheel sensor should be selected as fault source for wheel/tire diagnoses."""
+        wheel sensor should be selected as fault source for wheel/tire diagnoses.
+        """
         matches = []
         for i in range(20):
             speed = 60.0 + i * 2
@@ -157,7 +158,7 @@ class TestSourceAwareLocalization:
                     "location": "Driver Seat",
                     "matched_hz": whz,
                     "rel_error": 0.02,
-                }
+                },
             )
             # Wheel sensor: slightly weaker but valid
             matches.append(
@@ -167,7 +168,7 @@ class TestSourceAwareLocalization:
                     "location": "Front Left",
                     "matched_hz": whz,
                     "rel_error": 0.01,
-                }
+                },
             )
 
         _, hotspot = _location_speedbin_summary(
@@ -193,7 +194,7 @@ class TestSourceAwareLocalization:
                     "location": "Engine Bay",
                     "matched_hz": 25.0,
                     "rel_error": 0.02,
-                }
+                },
             )
             matches.append(
                 {
@@ -202,7 +203,7 @@ class TestSourceAwareLocalization:
                     "location": "Front Left",
                     "matched_hz": 25.0,
                     "rel_error": 0.03,
-                }
+                },
             )
 
         _, hotspot = _location_speedbin_summary(
@@ -227,7 +228,7 @@ class TestSourceAwareLocalization:
                     "location": "Driver Seat",
                     "matched_hz": whz,
                     "rel_error": 0.02,
-                }
+                },
             )
             matches.append(
                 {
@@ -236,7 +237,7 @@ class TestSourceAwareLocalization:
                     "location": "Trunk",
                     "matched_hz": whz,
                     "rel_error": 0.03,
-                }
+                },
             )
 
         _, hotspot = _location_speedbin_summary(
@@ -260,7 +261,8 @@ class TestDiffuseExcitationDetection:
 
     def test_uniform_peaks_all_sensors_flags_diffuse(self) -> None:
         """When all sensors show identical peaks, the finding should be flagged
-        as diffuse excitation with reduced confidence."""
+        as diffuse excitation with reduced confidence.
+        """
         sensors = _ALL_WHEEL_SENSORS
         samples: list[dict[str, Any]] = []
         # Use varying speed to avoid constant-speed filter
@@ -276,7 +278,7 @@ class TestDiffuseExcitationDetection:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=24.0,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
@@ -321,7 +323,7 @@ class TestNoFaultSuppression:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=6.0,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         summary = summarize_run_data(metadata, samples, lang="en", file_name="idle_only")
@@ -350,7 +352,7 @@ class TestNoFaultSuppression:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=14.0,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         summary = summarize_run_data(metadata, samples, lang="en", file_name="road_noise")
@@ -432,7 +434,8 @@ class TestUnitConsistency:
                 )
 
     def test_evidence_metrics_include_strength_db(
-        self, fault_findings: list[dict[str, Any]]
+        self,
+        fault_findings: list[dict[str, Any]],
     ) -> None:
         """Evidence metrics should include vibration_strength_db."""
         for f in fault_findings:
@@ -466,7 +469,7 @@ class TestPhaseTimeline:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=10.0,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         summary = summarize_run_data(metadata, samples, lang="en", file_name="timeline_test")
@@ -489,7 +492,7 @@ class TestPhaseTimeline:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=10.0,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         summary = summarize_run_data(metadata, samples, lang="en", file_name="timeline_fields")
@@ -525,7 +528,7 @@ class TestPhasedScenarios:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=10.0,
-                    )
+                    ),
                 )
         # Phase 2: wheel fault at high speed (15-45s)
         for i in range(15, 45):
@@ -545,7 +548,7 @@ class TestPhasedScenarios:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         summary = summarize_run_data(metadata, samples, lang="en", file_name="high_speed_fault")
@@ -589,7 +592,7 @@ class TestPhasedScenarios:
                         client_name=s,
                         top_peaks=peaks,
                         vibration_strength_db=vib_db,
-                    )
+                    ),
                 )
         metadata = _standard_metadata()
         findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")

--- a/apps/server/tests/analysis/test_negative_false_positives.py
+++ b/apps/server/tests/analysis/test_negative_false_positives.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Negative testing suite – False-positive prevention (50+ injected scenarios).
 
 Validates that the analysis pipeline does NOT over-report:
@@ -99,7 +98,10 @@ _param_sensor_config = pytest.mark.parametrize(
 @_param_sensor_config
 @_param_speed
 def test_no_fault_noise_baseline(
-    profile: dict[str, Any], config_name: str, sensors: list[str], speed: float
+    profile: dict[str, Any],
+    config_name: str,
+    sensors: list[str],
+    speed: float,
 ) -> None:
     """Pure road noise across sensor counts → no persistent fault.
 
@@ -114,7 +116,9 @@ def test_no_fault_noise_baseline(
 @_param_profile
 @_param_sensor_config
 def test_no_fault_idle_baseline(
-    profile: dict[str, Any], config_name: str, sensors: list[str]
+    profile: dict[str, Any],
+    config_name: str,
+    sensors: list[str],
 ) -> None:
     """Idle (speed=0) across sensor counts → strict no fault.
 
@@ -128,7 +132,9 @@ def test_no_fault_idle_baseline(
 @_param_profile
 @_param_sensor_config
 def test_no_fault_ramp_baseline(
-    profile: dict[str, Any], config_name: str, sensors: list[str]
+    profile: dict[str, Any],
+    config_name: str,
+    sensors: list[str],
 ) -> None:
     """Speed ramp (20→100 km/h) with no fault → no persistent fault.
 
@@ -204,7 +210,7 @@ def test_transient_only_single_sensor(profile: dict[str, Any], speed: float) -> 
             start_t_s=20,
             spike_amp=0.20,
             spike_vib_db=38.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"transient-1s@{speed}")
@@ -227,7 +233,7 @@ def test_transient_only_four_sensors(profile: dict[str, Any], speed: float) -> N
                 start_t_s=20,
                 spike_amp=0.18,
                 spike_vib_db=36.0,
-            )
+            ),
         )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"transient-4s@{speed}")
@@ -249,7 +255,7 @@ def test_transient_on_one_corner_no_localization(profile: dict[str, Any], corner
             start_t_s=20,
             spike_amp=0.25,
             spike_vib_db=40.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"transient-corner-{corner}")
@@ -291,7 +297,9 @@ def test_diffuse_excitation_not_localized(profile: dict[str, Any], speed: float)
     ids=["8-sensor", "12-sensor"],
 )
 def test_diffuse_excitation_many_sensors(
-    profile: dict[str, Any], config_name: str, sensors: list[str]
+    profile: dict[str, Any],
+    config_name: str,
+    sensors: list[str],
 ) -> None:
     """Uniform vibration on 8/12 sensors → must not localize to a single wheel.
 
@@ -393,7 +401,10 @@ def test_fault_late_onset_clean_early_phase(profile: dict[str, Any], corner: str
     ids=["barely-above-noise", "weak", "marginal"],
 )
 def test_weak_fault_stays_guarded(
-    profile: dict[str, Any], amp: float, vib_db: float, label: str
+    profile: dict[str, Any],
+    amp: float,
+    vib_db: float,
+    label: str,
 ) -> None:
     """Very weak wheel-order signal on noise → confidence must stay below 0.50.
 
@@ -441,7 +452,7 @@ def test_ambiguous_dual_frequency_low_confidence(profile: dict[str, Any]) -> Non
                     top_peaks=peaks,
                     vibration_strength_db=20.0,
                     strength_floor_amp_g=0.004,
-                )
+                ),
             )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     conf = top_confidence(summary)
@@ -533,7 +544,8 @@ def test_engine_vibration_not_reported_as_wheel(profile: dict[str, Any]) -> None
 @_param_profile
 @_param_corner
 def test_wheel_fault_with_engine_noise_no_engine_overreport(
-    profile: dict[str, Any], corner: str
+    profile: dict[str, Any],
+    corner: str,
 ) -> None:
     """Wheel fault + low-level engine noise → engine must not appear above 0.55 confidence.
 
@@ -625,7 +637,7 @@ def test_engine_order_with_transient_no_wheel(profile: dict[str, Any]) -> None:
             start_t_s=20,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_forbidden_systems(

--- a/apps/server/tests/analysis/test_noise_floor_consistency.py
+++ b/apps/server/tests/analysis/test_noise_floor_consistency.py
@@ -52,7 +52,8 @@ _SIZES = [2, 3, 5, 10, 20, 50, 100, 256, 512, 1024]
 @pytest.mark.parametrize("n", _SIZES, ids=[f"n={n}" for n in _SIZES])
 def test_live_matches_core_random(n: int) -> None:
     """SignalProcessor._noise_floor must return the same value as the core lib
-    noise_floor_amp_p20_g for random spectra of varying length."""
+    noise_floor_amp_p20_g for random spectra of varying length.
+    """
     rng = np.random.default_rng(seed=42 + n)
     amps = rng.random(n).astype(np.float32) * 0.05  # realistic g range
 

--- a/apps/server/tests/analysis/test_phased_scenario_diagnosis_attribution.py
+++ b/apps/server/tests/analysis/test_phased_scenario_diagnosis_attribution.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 import pytest
@@ -51,10 +50,12 @@ class TestSpeedBandAttribution:
         speed_band = str(
             extract_top_finding(
                 summarize_run_data(
-                    standard_metadata(), baseline + fault + cool, include_samples=False
-                )
+                    standard_metadata(),
+                    baseline + fault + cool,
+                    include_samples=False,
+                ),
             ).get("strongest_speed_band")
-            or ""
+            or "",
         )
         assert "120" in speed_band or "110" in speed_band
 
@@ -74,7 +75,7 @@ class TestWheelVsEngineDrivelineGating:
                     fault_vib_db=24.0,
                 ),
                 include_samples=False,
-            )
+            ),
         )
         assert "engine" not in str(top.get("suspected_source") or "").lower()
 
@@ -98,9 +99,9 @@ class TestWheelVsEngineDrivelineGating:
         if findings:
             source = str(
                 max(findings, key=lambda f: float(f.get("confidence_0_to_1") or 0)).get(
-                    "suspected_source"
+                    "suspected_source",
                 )
-                or ""
+                or "",
             ).lower()
             assert "wheel" in source or "tire" in source or "unknown" in source
 
@@ -124,13 +125,13 @@ class TestConfidenceWithSpatialAmbiguity:
                         ],
                         vibration_strength_db=22.0,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
         conf = float(
             extract_top_finding(
-                summarize_run_data(standard_metadata(), samples, include_samples=False)
+                summarize_run_data(standard_metadata(), samples, include_samples=False),
             ).get("confidence_0_to_1")
-            or 0
+            or 0,
         )
         assert conf < 0.70
 
@@ -151,9 +152,9 @@ class TestConfidenceWithSpatialAmbiguity:
                         noise_vib_db=6.0,
                     ),
                     include_samples=False,
-                )
+                ),
             ).get("confidence_0_to_1")
-            or 0
+            or 0,
         )
         assert conf >= 0.40
 

--- a/apps/server/tests/analysis/test_phased_scenario_diagnosis_progression.py
+++ b/apps/server/tests/analysis/test_phased_scenario_diagnosis_progression.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 from typing import Any
@@ -30,7 +29,7 @@ class TestScenario1IdleToSpeedUp:
                         client_name=sensor,
                         top_peaks=[{"hz": 13.0, "amp": 0.003}],
                         vibration_strength_db=5.0,
-                    )
+                    ),
                 )
         ramp_samples = build_speed_sweep_fault_samples(
             speed_start_kmh=20.0,
@@ -54,7 +53,9 @@ class TestScenario1IdleToSpeedUp:
             fault_vib_db=24.0,
         )
         summary = summarize_run_data(
-            meta, idle_samples + ramp_samples + fault_samples, include_samples=False
+            meta,
+            idle_samples + ramp_samples + fault_samples,
+            include_samples=False,
         )
         assert_finding_location(summary, "front-right", "Scenario 1")
 
@@ -105,7 +106,7 @@ class TestScenario2StopGoIntermittent:
                         client_name=sensor,
                         top_peaks=[{"hz": 13.0, "amp": 0.003}],
                         vibration_strength_db=5.0,
-                    )
+                    ),
                 )
             t += 1.0
         for _ in range(10):
@@ -117,7 +118,7 @@ class TestScenario2StopGoIntermittent:
                         client_name=sensor,
                         top_peaks=[{"hz": 87.3, "amp": 0.004}],
                         vibration_strength_db=8.0,
-                    )
+                    ),
                 )
             t += 1.0
         samples.extend(
@@ -129,7 +130,7 @@ class TestScenario2StopGoIntermittent:
                 start_t_s=t,
                 fault_amp=0.05,
                 fault_vib_db=22.0,
-            )
+            ),
         )
         t += 15.0
         for _ in range(8):
@@ -141,7 +142,7 @@ class TestScenario2StopGoIntermittent:
                         client_name=sensor,
                         top_peaks=[{"hz": 87.3, "amp": 0.003}],
                         vibration_strength_db=6.0,
-                    )
+                    ),
                 )
             t += 1.0
         samples.extend(
@@ -153,10 +154,12 @@ class TestScenario2StopGoIntermittent:
                 start_t_s=t,
                 fault_amp=0.055,
                 fault_vib_db=23.0,
-            )
+            ),
         )
         assert_finding_location(
-            summarize_run_data(meta, samples, include_samples=False), "rear-left", "Scenario 2"
+            summarize_run_data(meta, samples, include_samples=False),
+            "rear-left",
+            "Scenario 2",
         )
 
     def test_system_is_wheel_not_engine(self) -> None:
@@ -196,10 +199,12 @@ class TestScenario2StopGoIntermittent:
         speed_band = str(
             extract_top_finding(
                 summarize_run_data(
-                    standard_metadata(), samples_50 + samples_60, include_samples=False
-                )
+                    standard_metadata(),
+                    samples_50 + samples_60,
+                    include_samples=False,
+                ),
             ).get("strongest_speed_band")
-            or ""
+            or "",
         )
         band_low = 0
         for part in speed_band.replace("km/h", "").split("-"):
@@ -301,7 +306,7 @@ class TestScenario4CoastDownMidRange:
                     top_peaks=fault_peaks,
                     vibration_strength_db=fault_vib_db,
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
             for other in ["front-right", "rear-left", "rear-right"]:
                 samples.append(
@@ -312,7 +317,7 @@ class TestScenario4CoastDownMidRange:
                         top_peaks=[{"hz": 142.5, "amp": 0.003}, {"hz": 87.3, "amp": 0.003}],
                         vibration_strength_db=8.0,
                         strength_floor_amp_g=0.003,
-                    )
+                    ),
                 )
             t += 1.0
         return samples
@@ -335,9 +340,9 @@ class TestScenario4CoastDownMidRange:
                     standard_metadata(),
                     self.build_coast_down_samples(add_harmonic=False),
                     include_samples=False,
-                )
+                ),
             ).get("strongest_speed_band")
-            or ""
+            or "",
         )
         assert any(str(speed) in speed_band for speed in [70, 80, 90])
 
@@ -356,7 +361,7 @@ class TestScenario5MixedNoiseThenFault:
                         top_peaks=[{"hz": 87.3, "amp": 0.005}, {"hz": 142.5, "amp": 0.004}],
                         vibration_strength_db=10.0,
                         strength_floor_amp_g=0.004,
-                    )
+                    ),
                 )
         fault = build_fault_samples_at_speed(
             speed_kmh=100.0,

--- a/apps/server/tests/analysis/test_plot_data_phase_context.py
+++ b/apps/server/tests/analysis/test_plot_data_phase_context.py
@@ -199,14 +199,14 @@ def test_aggregate_fft_spectrum_presence_ratio_clamped_to_one() -> None:
                 {"hz": 42.0, "amp": 0.1},
                 {"hz": 47.0, "amp": 0.12},
             ],
-        }
+        },
     ]
     # Baseline: single peak at same p95 amplitude from one sample.
     one_peak_sample = [
         {
             "vibration_strength_db": 20.0,
             "top_peaks": [{"hz": 45.0, "amp": 0.12}],
-        }
+        },
     ]
 
     two_result = dict(_aggregate_fft_spectrum(two_peaks_sample, freq_bin_hz=10.0))

--- a/apps/server/tests/analysis/test_ranking_helpers.py
+++ b/apps/server/tests/analysis/test_ranking_helpers.py
@@ -25,7 +25,7 @@ def test_group_findings_by_source_preserves_ranked_signatures() -> None:
                 "confidence_0_to_1": 0.50,
                 "frequency_hz_or_order": "2x engine order",
             },
-        ]
+        ],
     )
 
     assert [rep["suspected_source"] for _score, rep in grouped] == ["wheel/tire", "engine"]

--- a/apps/server/tests/analysis/test_shutdown_analysis.py
+++ b/apps/server/tests/analysis/test_shutdown_analysis.py
@@ -138,7 +138,7 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
                     "history_db_path": str(tmp_path / "history.db"),
                     "shutdown_analysis_timeout_s": 10,
                 },
-            }
+            },
         ),
         encoding="utf-8",
     )

--- a/apps/server/tests/analysis/test_single_source_of_truth.py
+++ b/apps/server/tests/analysis/test_single_source_of_truth.py
@@ -110,7 +110,8 @@ def test_metrics_log_no_old_field_names() -> None:
 
 def test_as_float_single_source_of_truth() -> None:
     """diagnostics_shared.as_float_or_none must be the canonical as_float_or_none
-    from runlog, not a local re-definition."""
+    from runlog, not a local re-definition.
+    """
     from vibesensor.diagnostics_shared import as_float_or_none as diag_as_float
     from vibesensor.runlog import as_float_or_none
 
@@ -121,7 +122,8 @@ def test_as_float_single_source_of_truth() -> None:
 
 def test_percentile_single_source_of_truth() -> None:
     """analysis.helpers.percentile must be imported from
-    vibesensor_core.vibration_strength, not re-defined locally."""
+    vibesensor_core.vibration_strength, not re-defined locally.
+    """
     from vibesensor_core.vibration_strength import percentile as canonical
 
     from vibesensor.analysis.helpers import percentile
@@ -188,7 +190,6 @@ def test_silence_db_constant() -> None:
 
 def test_config_preflight_no_removed_fields() -> None:
     """config_preflight.summarize must not reference removed config fields."""
-
     root = REPO_ROOT
     preflight_path = root / "tools" / "config" / "vibesensor_tools_config" / "config_preflight.py"
     source = preflight_path.read_text(encoding="utf-8")
@@ -199,7 +200,6 @@ def test_config_preflight_no_removed_fields() -> None:
 
 def test_wheel_hz_and_engine_rpm_single_source() -> None:
     """wheel_hz and engine_rpm formulas must not be inlined in consumers."""
-
     root = SERVER_ROOT
     files_to_check = [
         root / "vibesensor" / "metrics_log" / "sample_builder.py",
@@ -216,11 +216,10 @@ def test_wheel_hz_and_engine_rpm_single_source() -> None:
 
 def test_simulator_defaults_match_analysis_settings() -> None:
     """Simulator vehicle defaults must be imported from the canonical source."""
-
     root = REPO_ROOT
     # Read the simulator source to verify it doesn't hardcode tire/vehicle constants
     sim_source = (root / "apps" / "simulator" / "vibesensor_simulator" / "sim_sender.py").read_text(
-        encoding="utf-8"
+        encoding="utf-8",
     )
     # The simulator should NOT contain hardcoded tire/vehicle values as literal assignments
     for line in sim_source.splitlines():
@@ -237,10 +236,9 @@ def test_simulator_defaults_match_analysis_settings() -> None:
 
 def test_simulator_no_production_asserts() -> None:
     """Simulator module-level and standalone functions must not use bare assert."""
-
     root = REPO_ROOT
     sim_source = (root / "apps" / "simulator" / "vibesensor_simulator" / "sim_sender.py").read_text(
-        encoding="utf-8"
+        encoding="utf-8",
     )
     lines = sim_source.splitlines()
     in_method = False
@@ -254,7 +252,7 @@ def test_simulator_no_production_asserts() -> None:
         # Only flag asserts in module-level or standalone functions
         if not in_method and stripped.startswith("assert "):
             raise AssertionError(
-                f"sim_sender.py:{i} uses bare assert in non-method context: {stripped!r}"
+                f"sim_sender.py:{i} uses bare assert in non-method context: {stripped!r}",
             )
 
 
@@ -402,7 +400,7 @@ def test_sanitize_settings_rejects_invalid() -> None:
             "rim_in": 21.0,  # valid
             "speed_uncertainty_pct": -0.5,  # non-negative, should be dropped
             "final_drive_ratio": "not_a_number",  # invalid type
-        }
+        },
     )
     assert "tire_width_mm" not in result
     assert "speed_uncertainty_pct" not in result
@@ -454,7 +452,7 @@ def test_network_ports_single_source_of_truth(monkeypatch: pytest.MonkeyPatch) -
     assert sim_args.server_control_port == expected_control
 
     contracts_h = (root / "firmware" / "esp" / "include" / "vibesensor_contracts.h").read_text(
-        encoding="utf-8"
+        encoding="utf-8",
     )
 
     def _macro(name: str) -> int:

--- a/apps/server/tests/analysis/test_speed_metadata_edge_cases.py
+++ b/apps/server/tests/analysis/test_speed_metadata_edge_cases.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Speed metadata edge-case tests (≥50 direct-injection cases).
 
 Tests robustness of the analysis pipeline under various speed metadata
@@ -66,7 +65,7 @@ def _make_speed_scenario_samples(
                         top_peaks=peaks,
                         vibration_strength_db=fault_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
             else:
                 samples.append(
@@ -80,7 +79,7 @@ def _make_speed_scenario_samples(
                         ],
                         vibration_strength_db=noise_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
     return samples
 
@@ -234,7 +233,9 @@ _CORRUPTION_TYPES = [
 
 
 @pytest.mark.parametrize(
-    ("name", "speed_fn"), _CORRUPTION_TYPES, ids=[c[0] for c in _CORRUPTION_TYPES]
+    ("name", "speed_fn"),
+    _CORRUPTION_TYPES,
+    ids=[c[0] for c in _CORRUPTION_TYPES],
 )
 @pytest.mark.parametrize("fault_sensor", [SENSOR_FL, SENSOR_RR], ids=["FL", "RR"])
 def test_mixed_valid_invalid_speed(name: str, speed_fn: Any, fault_sensor: str) -> None:
@@ -299,7 +300,9 @@ _STEP_CONFIGS = [
 
 
 @pytest.mark.parametrize(
-    ("name", "before", "after"), _STEP_CONFIGS, ids=[c[0] for c in _STEP_CONFIGS]
+    ("name", "before", "after"),
+    _STEP_CONFIGS,
+    ids=[c[0] for c in _STEP_CONFIGS],
 )
 def test_speed_step_change(name: str, before: float, after: float) -> None:
     """Sudden speed step change should not crash or produce NaN."""

--- a/apps/server/tests/analysis/test_strength_buckets.py
+++ b/apps/server/tests/analysis/test_strength_buckets.py
@@ -6,7 +6,9 @@ from vibesensor.diagnostics_shared import severity_from_peak
 
 
 def _run_severity_ticks(
-    db: float, ticks: int, state: dict[str, object] | None = None
+    db: float,
+    ticks: int,
+    state: dict[str, object] | None = None,
 ) -> tuple[dict[str, object], dict[str, object] | None]:
     """Run *ticks* iterations of ``severity_from_peak`` and return (last_out, state)."""
     out: dict[str, object] | None = None

--- a/apps/server/tests/analysis/test_summary_pure_functions.py
+++ b/apps/server/tests/analysis/test_summary_pure_functions.py
@@ -72,7 +72,8 @@ class TestConfidenceLabel:
     def test_negligible_band_caps_high_to_medium(self) -> None:
         """strength_band_key='negligible' must reduce HIGH → MEDIUM."""
         label, tone, _ = confidence_label(
-            CONFIDENCE_HIGH_THRESHOLD + 0.05, strength_band_key="negligible"
+            CONFIDENCE_HIGH_THRESHOLD + 0.05,
+            strength_band_key="negligible",
         )
         assert label == "CONFIDENCE_MEDIUM"
         assert tone == "warn"
@@ -86,7 +87,8 @@ class TestConfidenceLabel:
     def test_non_negligible_band_leaves_high_intact(self) -> None:
         """An unrelated band key must not suppress a HIGH label."""
         label, tone, _ = confidence_label(
-            CONFIDENCE_HIGH_THRESHOLD + 0.05, strength_band_key="strong"
+            CONFIDENCE_HIGH_THRESHOLD + 0.05,
+            strength_band_key="strong",
         )
         assert label == "CONFIDENCE_HIGH"
 

--- a/apps/server/tests/analysis/test_test_plan.py
+++ b/apps/server/tests/analysis/test_test_plan.py
@@ -10,7 +10,7 @@ def test_merge_test_plan_deduplicates_action_ids_case_insensitively() -> None:
                 {"action_id": " WHEEL_BALANCE_AND_RUNOUT ", "what": "A"},
                 {"action_id": "wheel_balance_and_runout", "what": "B"},
             ],
-        }
+        },
     ]
 
     merged = _merge_test_plan(findings, "en")
@@ -26,7 +26,7 @@ def test_merge_test_plan_generated_steps_inherit_normalized_metadata() -> None:
             "strongest_speed_band": " 90-100 km/h ",
             "frequency_hz_or_order": " 12.4 Hz ",
             "confidence_0_to_1": 0.82,
-        }
+        },
     ]
 
     merged = _merge_test_plan(findings, "en")

--- a/apps/server/tests/analysis/test_vibration_math_coverage.py
+++ b/apps/server/tests/analysis/test_vibration_math_coverage.py
@@ -90,7 +90,9 @@ def test_strength_db_explicit_epsilon_override() -> None:
     ],
 )
 def test_strength_db_edge_properties(
-    peak: float, floor: float, check: tuple[str, Any, Any]
+    peak: float,
+    floor: float,
+    check: tuple[str, Any, Any],
 ) -> None:
     """Verify dB edge-case properties: near-zero, large, and negative."""
     result = vibration_strength_db_scalar(peak_band_rms_amp_g=peak, floor_amp_g=floor)

--- a/apps/server/tests/analysis/test_vibration_strength_absolute_metrics.py
+++ b/apps/server/tests/analysis/test_vibration_strength_absolute_metrics.py
@@ -36,7 +36,9 @@ def test_compute_strength_returns_absolute_amplitude_fields() -> None:
     ids=["near-zero-db"],
 )
 def test_near_zero_db_with_meaningful_peak_is_still_labeled_in_db(
-    db_upper: float, peak_lower: float, floor_lower: float
+    db_upper: float,
+    peak_lower: float,
+    floor_lower: float,
 ) -> None:
     freq_hz = [float(i) for i in range(21)]
     combined = [0.03] * 6 + [0.18] * 15

--- a/apps/server/tests/analysis/test_vibration_strength_boundaries.py
+++ b/apps/server/tests/analysis/test_vibration_strength_boundaries.py
@@ -62,7 +62,10 @@ class TestComputeVibrationStrengthBoundaries:
         ],
     )
     def test_degenerate_input_yields_finite_db(
-        self, label: str, freq_hz: list[float], amp: list[float]
+        self,
+        label: str,
+        freq_hz: list[float],
+        amp: list[float],
     ) -> None:
         """Degenerate / edge-case inputs must produce a finite dB value."""
         result = compute_vibration_strength_db(

--- a/apps/server/tests/api/_history_endpoint_helpers.py
+++ b/apps/server/tests/api/_history_endpoint_helpers.py
@@ -56,7 +56,7 @@ def sample(i: int) -> dict[str, Any]:
                 "amp": 0.1,
                 "vibration_strength_db": 12.0,
                 "strength_bucket": "l2",
-            }
+            },
         ],
         "vibration_strength_db": 12.0,
         "strength_bucket": "l2",
@@ -189,6 +189,14 @@ class FakeState:
                     "last_completed_run_id": None,
                     "last_completed_run_error": None,
                 },
+                "persistence": type(
+                    "P",
+                    (),
+                    {
+                        "last_write_duration_s": 0.0,
+                        "max_write_duration_s": 0.0,
+                    },
+                )(),
                 "start_logging": lambda self: {},
                 "stop_logging": lambda self: {},
             },
@@ -208,13 +216,17 @@ class FakeState:
                 },
                 "get": lambda self, _cid: None,
                 "set_name": lambda self, cid, name: type(
-                    "U", (), {"client_id": cid, "name": name}
+                    "U",
+                    (),
+                    {"client_id": cid, "name": name},
                 )(),
                 "remove_client": lambda self, _cid: True,
             },
         )()
         self.control_plane = type(
-            "C", (), {"send_identify": lambda self, _id, _dur: (False, None)}
+            "C",
+            (),
+            {"send_identify": lambda self, _id, _dur: (False, None)},
         )()
         self.gps_monitor = type(
             "G",
@@ -266,7 +278,7 @@ class FakeState:
             apply_car_settings=self.apply_car_settings,
             apply_speed_source_settings=self.apply_speed_source_settings,
         )
-        self.diagnostics = SimpleNamespace(
+        self.recording = SimpleNamespace(
             metrics_logger=self.metrics_logger,
         )
         self.persistence = SimpleNamespace(

--- a/apps/server/tests/api/test_api_history_report_endpoints.py
+++ b/apps/server/tests/api/test_api_history_report_endpoints.py
@@ -85,7 +85,8 @@ async def test_report_pdf_lang_override_when_template_data_persisted() -> None:
 
     with patch("vibesensor.history_reports.map_summary") as patched_map_summary:
         patched_map_summary.side_effect = lambda summary: __import__(
-            "vibesensor.analysis", fromlist=["map_summary"]
+            "vibesensor.analysis",
+            fromlist=["map_summary"],
         ).map_summary(summary)
         nl = await endpoint("run-1", "nl")
         en = await endpoint("run-1", "en")

--- a/apps/server/tests/api/test_api_history_route_state.py
+++ b/apps/server/tests/api/test_api_history_route_state.py
@@ -274,7 +274,9 @@ async def test_history_insights_analyzing_returns_202_json_response() -> None:
     from fastapi.responses import JSONResponse
 
     router = make_status_router(
-        status="analyzing", analysis={"status": "analyzing"}, include_error_message=False
+        status="analyzing",
+        analysis={"status": "analyzing"},
+        include_error_message=False,
     )
     endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
     result = await endpoint("run-1")

--- a/apps/server/tests/api/test_api_response_models.py
+++ b/apps/server/tests/api/test_api_response_models.py
@@ -12,7 +12,7 @@ def _openapi_state() -> MagicMock:
     state = MagicMock()
     state.ingress = MagicMock()
     state.settings = MagicMock()
-    state.diagnostics = MagicMock()
+    state.recording = MagicMock()
     state.persistence = MagicMock()
     state.websocket = MagicMock()
     state.updates = MagicMock()
@@ -84,15 +84,15 @@ def test_openapi_component_shapes_are_not_generic_dict_for_typed_responses(
 
     history_list_properties = components["HistoryListResponse"]["properties"]
     assert history_list_properties["runs"]["items"] == {
-        "$ref": "#/components/schemas/HistoryListEntryResponse"
+        "$ref": "#/components/schemas/HistoryListEntryResponse",
     }
 
     update_status_properties = components["UpdateStatusResponse"]["properties"]
     assert update_status_properties["issues"]["items"] == {
-        "$ref": "#/components/schemas/UpdateIssueResponse"
+        "$ref": "#/components/schemas/UpdateIssueResponse",
     }
     assert update_status_properties["runtime"] == {
-        "$ref": "#/components/schemas/UpdateRuntimeResponse"
+        "$ref": "#/components/schemas/UpdateRuntimeResponse",
     }
     assert update_status_properties["phase_started_at"]["anyOf"][1] == {"type": "null"}
     assert update_status_properties["updated_at"]["anyOf"][1] == {"type": "null"}

--- a/apps/server/tests/api/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/api/test_api_ws_health_and_clients.py
@@ -112,6 +112,6 @@ async def test_identify_client_200_when_sensor_reachable() -> None:
     endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/identify", "POST")
 
     resp = response_payload(
-        await endpoint("aa:bb:cc:dd:ee:ff", type("Req", (), {"duration_ms": 1000})())
+        await endpoint("aa:bb:cc:dd:ee:ff", type("Req", (), {"duration_ms": 1000})()),
     )
     assert resp == {"status": "sent", "cmd_seq": 7}

--- a/apps/server/tests/api/test_http_api_schema_export.py
+++ b/apps/server/tests/api/test_http_api_schema_export.py
@@ -54,5 +54,5 @@ def test_export_schema_matches_committed_schema(schema_text: str) -> None:
 def test_export_schema_contains_typed_history_list_entry(schema_dict: dict[str, Any]) -> None:
     history_response = schema_dict["components"]["schemas"]["HistoryListResponse"]
     assert history_response["properties"]["runs"]["items"] == {
-        "$ref": "#/components/schemas/HistoryListEntryResponse"
+        "$ref": "#/components/schemas/HistoryListEntryResponse",
     }

--- a/apps/server/tests/app/test_app_lifecycle.py
+++ b/apps/server/tests/app/test_app_lifecycle.py
@@ -20,7 +20,7 @@ async def test_lifespan_shutdown_closes_history_db(tmp_path: Path, monkeypatch) 
                     "metrics_log_path": str(tmp_path / "metrics.jsonl"),
                     "history_db_path": str(tmp_path / "history.db"),
                 },
-            }
+            },
         ),
         encoding="utf-8",
     )

--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -11,9 +11,9 @@ def _runtime_app(port: int):
     return SimpleNamespace(
         state=SimpleNamespace(
             runtime=SimpleNamespace(
-                config=SimpleNamespace(server=SimpleNamespace(host="0.0.0.0", port=port))
-            )
-        )
+                config=SimpleNamespace(server=SimpleNamespace(host="0.0.0.0", port=port)),
+            ),
+        ),
     )
 
 
@@ -23,7 +23,9 @@ def _run_main(monkeypatch, *, port: int, fail_port: int | None = None) -> list[i
     from vibesensor import app as app_module
 
     monkeypatch.setattr(
-        app_module.argparse.ArgumentParser, "parse_args", lambda self: Namespace(config=None)
+        app_module.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: Namespace(config=None),
     )
     monkeypatch.setattr(app_module, "create_app", lambda config_path=None: _runtime_app(port))
     calls: list[int] = []

--- a/apps/server/tests/app/test_release_validation.py
+++ b/apps/server/tests/app/test_release_validation.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import yaml
 from _paths import SERVER_ROOT
 
-import vibesensor.release_validation as release_validation
+from vibesensor import release_validation
 from vibesensor.release_validation import (
     build_release_smoke_config,
     run_server_smoke,
@@ -56,9 +56,9 @@ def test_validate_firmware_dist_accepts_generated_manifest(tmp_path: Path) -> No
                         "file": "esp32dev/firmware.bin",
                         "offset": "0x10000",
                         "sha256": hashlib.sha256(b"firmware").hexdigest(),
-                    }
+                    },
                 ],
-            }
+            },
         ],
     }
     (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")

--- a/apps/server/tests/app/test_run_release_smoke.py
+++ b/apps/server/tests/app/test_run_release_smoke.py
@@ -39,12 +39,13 @@ def test_run_release_smoke_builds_ui_and_wheel_then_runs_smoke(monkeypatch, tmp_
     smoke_command = commands[-1]
     assert smoke_command[0][1:4] == ["-m", "vibesensor.release_validation", "smoke-server"]
     assert smoke_command[2] == {
-        "VIBESENSOR_CONTRACTS_DIR": str((repo_root / "libs/shared/contracts").resolve())
+        "VIBESENSOR_CONTRACTS_DIR": str((repo_root / "libs/shared/contracts").resolve()),
     }
 
 
 def test_run_release_smoke_can_reuse_existing_wheel_and_skip_ui_build(
-    monkeypatch, tmp_path: Path
+    monkeypatch,
+    tmp_path: Path,
 ) -> None:
     module, repo_root = _load_release_smoke_runner()
     commands: list[tuple[list[str], Path, dict[str, str] | None]] = []

--- a/apps/server/tests/app/test_runtime.py
+++ b/apps/server/tests/app/test_runtime.py
@@ -111,7 +111,9 @@ class _StubProcessor:
         return list(client_ids)
 
     def compute_all(
-        self, client_ids: list[str], sample_rates_hz: dict[str, int] | None = None
+        self,
+        client_ids: list[str],
+        sample_rates_hz: dict[str, int] | None = None,
     ) -> dict[str, Any]:
         self.compute_all_calls += 1
         return {}
@@ -144,7 +146,7 @@ def _make_runtime(**overrides: Any):
         analysis_settings=overrides.pop("analysis_settings", MagicMock()),
         gps_monitor=overrides.pop("gps_monitor", MagicMock()),
     )
-    diagnostics = runtime_module.RuntimeDiagnosticsSubsystem(
+    diagnostics = runtime_module.RuntimeRecordingSubsystem(
         metrics_logger=overrides.pop("metrics_logger", MagicMock()),
     )
     persistence = runtime_module.RuntimePersistenceSubsystem(
@@ -157,7 +159,7 @@ def _make_runtime(**overrides: Any):
     if persistence.query_service is None:
         settings_store_ref = settings.settings_store
         persistence.bind_history_services(
-            settings_store_ref if not isinstance(settings_store_ref, MagicMock) else None
+            settings_store_ref if not isinstance(settings_store_ref, MagicMock) else None,
         )
     updates = runtime_module.RuntimeUpdateSubsystem(
         update_manager=overrides.pop("update_manager", MagicMock()),
@@ -192,7 +194,7 @@ def _make_runtime(**overrides: Any):
         config=config,
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=diagnostics,
         persistence=persistence,
         updates=updates,
         processing=processing,
@@ -200,7 +202,7 @@ def _make_runtime(**overrides: Any):
         routes=runtime_module.RuntimeRouteServices(
             ingress=ingress,
             settings=settings,
-            diagnostics=diagnostics,
+            recording=diagnostics,
             persistence=persistence,
             updates=updates,
             processing=processing,
@@ -392,7 +394,7 @@ async def test_stop_cancels_tasks_and_closes_resources(monkeypatch) -> None:
             analysis_queue_oldest_age_s=None,
             active_run_id_before_stop=None,
             write_error=None,
-        )
+        ),
     )
 
     history_db = MagicMock()

--- a/apps/server/tests/car_library/test_car_profile_variations.py
+++ b/apps/server/tests/car_library/test_car_profile_variations.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Car profile variation tests (≥50 direct-injection cases).
 
 Validates that the analysis pipeline correctly detects faults across

--- a/apps/server/tests/config/test_config.py
+++ b/apps/server/tests/config/test_config.py
@@ -27,7 +27,8 @@ def cfg_path(tmp_path: Path) -> Path:
 def test_metrics_log_path_required_when_metrics_enabled(cfg_path: Path) -> None:
     _write_config(cfg_path, {"logging": {"log_metrics": True, "metrics_log_path": ""}})
     with pytest.raises(
-        ValueError, match="metrics_log_path must be configured when log_metrics is true"
+        ValueError,
+        match="metrics_log_path must be configured when log_metrics is true",
     ):
         load_config(cfg_path)
 
@@ -59,7 +60,8 @@ def test_dev_and_docker_configs_equivalent() -> None:
     """config.dev.yaml and config.docker.yaml share core settings but Docker
     intentionally overrides environment-specific options (GPS disabled because
     Docker containers have no gpsd, AP self-heal disabled because nmcli/hostapd
-    are absent, rollback_dir uses a container-local path)."""
+    are absent, rollback_dir uses a container-local path).
+    """
     dev_cfg = load_config(SERVER_DIR / "config.dev.yaml")
     docker_cfg = load_config(SERVER_DIR / "config.docker.yaml")
     # Core transport and processing settings must still agree

--- a/apps/server/tests/config/test_config_extended.py
+++ b/apps/server/tests/config/test_config_extended.py
@@ -124,7 +124,7 @@ def test_load_config_ap_self_heal_override(tmp_path: Path) -> None:
                     "min_restart_interval_seconds": 240,
                     "allow_disable_resolved_stub_listener": True,
                     "state_file": "/tmp/hotspot-heal-state.json",
-                }
+                },
             },
         },
     )

--- a/apps/server/tests/config/test_config_validation.py
+++ b/apps/server/tests/config/test_config_validation.py
@@ -24,7 +24,7 @@ def _write_config(path: Path, payload: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_processing(**overrides: int | float | None) -> ProcessingConfig:
+def _make_processing(**overrides: float | None) -> ProcessingConfig:
     """Return a ProcessingConfig with sensible defaults, applying *overrides*."""
     defaults = {
         "sample_rate_hz": 800,

--- a/apps/server/tests/config/test_settings_store.py
+++ b/apps/server/tests/config/test_settings_store.py
@@ -352,7 +352,7 @@ def test_store_invalid_persisted_active_car_id_clears_selection(tmp_path: Path) 
         {
             "cars": [{"id": "car-1", "name": "Only", "type": "sedan", "aspects": {}}],
             "activeCarId": "missing-car",
-        }
+        },
     )
     store = SettingsStore(db=db)
     snap = store.snapshot()

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -59,7 +59,7 @@ class FakeState:
             apply_car_settings=self.apply_car_settings,
             apply_speed_source_settings=self.apply_speed_source_settings,
         )
-        self.diagnostics = SimpleNamespace(
+        self.recording = SimpleNamespace(
             metrics_logger=self.metrics_logger,
         )
         self.persistence = SimpleNamespace(

--- a/apps/server/tests/domain/test_domain_models.py
+++ b/apps/server/tests/domain/test_domain_models.py
@@ -1,5 +1,6 @@
 """Tests for domain_models module: CarConfig, SensorConfig, SpeedSourceConfig,
-RunMetadata, and SensorFrame parsing/serialization."""
+RunMetadata, and SensorFrame parsing/serialization.
+"""
 
 from __future__ import annotations
 
@@ -162,7 +163,7 @@ class TestSpeedSourceConfig:
                 "manualSpeedKph": 80.0,
                 "staleTimeoutS": 5.0,
                 "fallbackMode": "manual",
-            }
+            },
         )
         assert ssc.speed_source == "manual"
         assert ssc.manual_speed_kph == 80.0
@@ -248,7 +249,7 @@ class TestRunMetadata:
                 "run_id": "r3",
                 "raw_sample_rate_hz": float("nan"),
                 "feature_interval_s": float("inf"),
-            }
+            },
         )
         assert rm.raw_sample_rate_hz is None
         assert rm.feature_interval_s is None
@@ -318,7 +319,7 @@ class TestSensorFrame:
             self._minimal_record(
                 speed_kmh=float("nan"),
                 accel_x_g=float("inf"),
-            )
+            ),
         )
         assert sf.speed_kmh is None
         assert sf.accel_x_g is None
@@ -343,7 +344,7 @@ class TestSensorFrame:
                 {"hz": -1.0, "amp": 0.03},  # negative hz
                 {"hz": 30.0, "amp": None},  # None amp
                 {"hz": 0.0, "amp": 0.01},  # zero hz
-            ]
+            ],
         )
         sf = SensorFrame.from_dict(record)
         assert len(sf.top_peaks) == 1
@@ -361,7 +362,7 @@ class TestSensorFrame:
                 top_peaks_x=axis_peaks,
                 top_peaks_y=[{"hz": 0.0, "amp": 0.01}, {"hz": 5.0, "amp": 0.02}],
                 top_peaks_z=[{"hz": 7.0, "amp": None}, {"hz": 6.0, "amp": 0.03}],
-            )
+            ),
         )
         assert len(sf.top_peaks_x) == 3
         assert sf.top_peaks_y == [{"hz": 5.0, "amp": 0.02}]
@@ -373,7 +374,7 @@ class TestSensorFrame:
                 top_peaks_x=[{"hz": 24.0, "amp": 0.04}],
                 top_peaks_y=[{"hz": 25.0, "amp": 0.03}],
                 top_peaks_z=[{"hz": 26.0, "amp": 0.02}],
-            )
+            ),
         )
         d = sf.to_dict()
         sf2 = SensorFrame.from_dict(d)

--- a/apps/server/tests/e2e/test_ui_selenium.py
+++ b/apps/server/tests/e2e/test_ui_selenium.py
@@ -101,9 +101,9 @@ def live_server(tmp_path_factory: pytest.TempPathFactory) -> dict[str, object]:
                     {
                         "id": "d05a00000099",
                         "name": "offline-node",
-                    }
-                ]
-            }
+                    },
+                ],
+            },
         ),
         encoding="utf-8",
     )
@@ -201,7 +201,7 @@ def _activate_settings_subtab(driver: webdriver.Remote, tab_id: str) -> None:
                 "const el=document.getElementById(arguments[0]); return el ? el.hidden : true;",
                 tab_id,
             )
-        )
+        ),
     )
 
 
@@ -281,31 +281,32 @@ def test_all_tabs_render_localized_texts(
 
     nav_texts = driver.execute_script(
         "const nodes = Array.from(document.querySelectorAll('.menu-btn span'));"
-        "return nodes.map((el) => el.textContent.trim());"
+        "return nodes.map((el) => el.textContent.trim());",
     )
     assert nav_texts == labels["nav"]
 
     _activate_tab(driver, "tab-dashboard", "dashboardView")
+    expected = labels["start_recording"]
     wait.until(
-        lambda d: d.find_element(By.ID, "startLoggingBtn").text.strip() == labels["start_recording"]
+        lambda d: d.find_element(By.ID, "startLoggingBtn").text.strip() == expected,
     )
 
     _activate_tab(driver, "tab-history", "historyView")
     wait.until(
         lambda d: (
             d.find_element(By.ID, "refreshHistoryBtn").text.strip() == labels["refresh_history"]
-        )
+        ),
     )
 
     _activate_tab(driver, "tab-settings", "settingsView")
     _activate_settings_subtab(driver, "analysisTab")
     wait.until(
-        lambda d: d.find_element(By.ID, "saveAnalysisBtn").text.strip() == labels["save_analysis"]
+        lambda d: d.find_element(By.ID, "saveAnalysisBtn").text.strip() == labels["save_analysis"],
     )
     _activate_settings_subtab(driver, "sensorsTab")
     headers = driver.execute_script(
         "const headers = Array.from(document.querySelectorAll('.clients-table thead th'));"
-        "return headers.map((el) => el.textContent.trim());"
+        "return headers.map((el) => el.textContent.trim());",
     )
     # The location column label must localize correctly in both languages.
     assert labels["settings_location_header"] in headers
@@ -371,7 +372,7 @@ def test_dutch_logs_uses_domain_terms_not_literal_calque(
     headers = driver.execute_script(
         "const ths = Array.from("
         "document.querySelectorAll('.history-table thead th'));"
-        "return ths.map((th) => th.textContent.trim());"
+        "return ths.map((th) => th.textContent.trim());",
     )
     assert "Meetrun" in headers
 
@@ -400,7 +401,7 @@ def test_offline_client_mac_set_location_and_remove(
         lambda d: d.execute_script(
             "return !!document.querySelector(arguments[0]);",
             row_selector,
-        )
+        ),
     )
 
     mac_text = driver.execute_script(
@@ -423,7 +424,7 @@ def test_offline_client_mac_set_location_and_remove(
                 row_selector,
             )
             == "Trunk"
-        )
+        ),
     )
 
     driver.execute_script("window.confirm = () => true;")
@@ -435,11 +436,11 @@ def test_offline_client_mac_set_location_and_remove(
             "btn.click();"
             "return true;",
             remove_selector,
-        )
+        ),
     )
     wait.until(
         lambda d: d.execute_script(
             "return document.querySelector(arguments[0]) === null;",
             row_selector,
-        )
+        ),
     )

--- a/apps/server/tests/gps/test_gps_iris4_fixes.py
+++ b/apps/server/tests/gps/test_gps_iris4_fixes.py
@@ -37,7 +37,7 @@ def test_valid_fallback_modes_is_frozenset() -> None:
 
 
 def test_resolve_speed_ignores_bool_override() -> None:
-    """bool True/False must not be treated as a valid speed override."""
+    """Bool True/False must not be treated as a valid speed override."""
     monitor = GPSSpeedMonitor(gps_enabled=False)
     monitor.manual_source_selected = True
     # Bypass the typed setter to test the guard directly

--- a/apps/server/tests/gps/test_gps_speed_no_mutation.py
+++ b/apps/server/tests/gps/test_gps_speed_no_mutation.py
@@ -113,7 +113,8 @@ class TestEffectiveSpeedNoMutation:
 class TestStatusDictNoMutation:
     def test_status_dict_does_not_mutate_connection_state(self) -> None:
         """Previously, status_dict() would change connection_state from
-        'connected' to 'stale' as a side effect.  It must no longer do so."""
+        'connected' to 'stale' as a side effect.  It must no longer do so.
+        """
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 5.0
@@ -255,7 +256,8 @@ class TestSpeedResolution:
 class TestGPSTransitions:
     def test_fresh_to_stale_to_fresh(self) -> None:
         """Transition GPS from fresh → stale → fresh.
-        Verify fallback_active and source are consistent at each stage."""
+        Verify fallback_active and source are consistent at each stage.
+        """
         m = GPSSpeedMonitor(gps_enabled=True)
         m.manual_source_selected = False  # GPS primary, override is fallback only
         m.override_speed_mps = 25.0  # manual override for fallback

--- a/apps/server/tests/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/gps/test_gps_speed_run_loop.py
@@ -98,7 +98,8 @@ async def _await_speed(monitor: GPSSpeedMonitor, *, timeout_s: float = 2.5) -> N
     ],
 )
 async def test_run_accepts_valid_tpv_speed(
-    tpv_kwargs: dict[str, object], expected_speed: float
+    tpv_kwargs: dict[str, object],
+    expected_speed: float,
 ) -> None:
     """TPV messages with valid fix mode and speed update monitor.speed_mps."""
     async with _gps_server_scenario(_tpv_line(**tpv_kwargs)) as monitor:
@@ -116,7 +117,8 @@ async def test_run_ignores_non_tpv_messages() -> None:
 
 @pytest.mark.asyncio
 async def test_run_reconnects_on_connection_failure(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """run() retries after ConnectionRefusedError instead of crashing."""
     monitor = GPSSpeedMonitor(gps_enabled=True)

--- a/apps/server/tests/gps/test_gps_speed_status.py
+++ b/apps/server/tests/gps/test_gps_speed_status.py
@@ -119,7 +119,8 @@ class TestFallback:
     def test_stale_gps_triggers_manual_fallback(self) -> None:
         """When GPS data is stale and an override_speed_mps is set,
         effective_speed_mps returns the override (since override always wins).
-        When no override is set, stale GPS triggers fallback → None."""
+        When no override is set, stale GPS triggers fallback → None.
+        """
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
         m.last_update_ts = time.monotonic() - 999
@@ -261,7 +262,7 @@ class TestSpeedSourceConfigFallback:
 
     def test_from_dict_camel_case(self) -> None:
         cfg = SpeedSourceConfig.from_dict(
-            {"speedSource": "gps", "staleTimeoutS": 30, "fallbackMode": "manual"}
+            {"speedSource": "gps", "staleTimeoutS": 30, "fallbackMode": "manual"},
         )
         assert cfg.stale_timeout_s == 30.0
         assert cfg.fallback_mode == "manual"

--- a/apps/server/tests/history/test_history_db_lifecycle.py
+++ b/apps/server/tests/history/test_history_db_lifecycle.py
@@ -360,7 +360,8 @@ def test_read_only_operations_do_not_commit(tmp_path: Path) -> None:
 
 
 def test_get_run_metadata_non_dict_json_returns_none_and_warns(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-bad-meta", "2026-01-01T00:00:00Z", {"source": "test"})

--- a/apps/server/tests/history/test_history_db_structured_storage.py
+++ b/apps/server/tests/history/test_history_db_structured_storage.py
@@ -257,7 +257,8 @@ def test_iter_run_samples_skips_corrupt_rows_and_continues(tmp_path: Path) -> No
 
 
 def test_v2_row_to_dict_non_list_peak_column_warns_and_uses_empty(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-peak-warn", "2026-01-01T00:00:00Z", {"source": "test"})

--- a/apps/server/tests/history/test_history_db_validation.py
+++ b/apps/server/tests/history/test_history_db_validation.py
@@ -97,3 +97,107 @@ def test_sanitize_value_handles_numpy_arrays() -> None:
     result2d = sanitize_value(arr2d)
     assert result2d == [[1.0, 2.0], [3.0, 4.0]]
     json.dumps(result2d)
+
+
+# -- verify_run_integrity tests -----------------------------------------------
+
+
+def test_verify_run_integrity_clean_run(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-ok", "2026-01-01T00:00:00Z", {"sensor_model": "a", "sample_rate_hz": 100})
+    db.append_samples("run-ok", [{"i": i} for i in range(5)])
+    db.finalize_run("run-ok", "2026-01-01T00:10:00Z")
+    db.store_analysis("run-ok", {"findings": [], "top_causes": [], "warnings": []})
+    assert db.verify_run_integrity("run-ok") == []
+
+
+def test_verify_run_integrity_sample_count_mismatch(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-m", "2026-01-01T00:00:00Z", {"sensor_model": "a", "sample_rate_hz": 100})
+    db.append_samples("run-m", [{"i": i} for i in range(5)])
+    db.finalize_run("run-m", "2026-01-01T00:10:00Z")
+    db.store_analysis("run-m", {"findings": [], "top_causes": [], "warnings": []})
+    # Manually corrupt sample_count
+    with db._cursor() as cur:
+        cur.execute("UPDATE runs SET sample_count = 99 WHERE run_id = 'run-m'")
+    problems = db.verify_run_integrity("run-m")
+    assert any("sample_count mismatch" in p for p in problems)
+
+
+def test_verify_run_integrity_complete_without_analysis(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-na", "2026-01-01T00:00:00Z", {"sensor_model": "a", "sample_rate_hz": 100})
+    db.finalize_run("run-na", "2026-01-01T00:10:00Z")
+    # Force status to complete without analysis
+    with db._cursor() as cur:
+        cur.execute("UPDATE runs SET status = 'complete' WHERE run_id = 'run-na'")
+    problems = db.verify_run_integrity("run-na")
+    assert any("missing analysis_json" in p for p in problems)
+
+
+def test_verify_run_integrity_run_not_found(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    assert db.verify_run_integrity("no-such-run") == ["run not found"]
+
+
+# -- metadata validation warning tests ----------------------------------------
+
+
+def test_create_run_warns_on_missing_metadata_keys(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    with caplog.at_level("WARNING"):
+        db.create_run("run-w", "2026-01-01T00:00:00Z", {"source": "test"})
+    assert "missing recommended keys" in caplog.text
+    assert "sensor_model" in caplog.text
+    assert "sample_rate_hz" in caplog.text
+
+
+def test_create_run_no_warning_when_metadata_complete(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    meta = {"sensor_model": "a", "sample_rate_hz": 100}
+    with caplog.at_level("WARNING"):
+        db.create_run("run-ok", "2026-01-01T00:00:00Z", meta)
+    assert "missing recommended keys" not in caplog.text
+
+
+# -- analysis summary validation warning tests --------------------------------
+
+
+def test_store_analysis_warns_on_missing_summary_keys(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    meta = {"sensor_model": "a", "sample_rate_hz": 100}
+    db.create_run("run-w2", "2026-01-01T00:00:00Z", meta)
+    db.finalize_run("run-w2", "2026-01-01T00:10:00Z")
+    with caplog.at_level("WARNING"):
+        db.store_analysis("run-w2", {"score": 42})
+    assert "missing expected keys" in caplog.text
+
+
+# -- atomic state transition tests ---------------------------------------------
+
+
+def test_store_analysis_rejects_terminal_status(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-t", "2026-01-01T00:00:00Z", {"sensor_model": "a", "sample_rate_hz": 100})
+    db.finalize_run("run-t", "2026-01-01T00:10:00Z")
+    db.store_analysis("run-t", {"findings": [], "top_causes": [], "warnings": []})
+    # Second store_analysis should return False (already complete)
+    assert db.store_analysis("run-t", {"findings": []}) is False
+
+
+def test_store_analysis_error_rejects_terminal_status(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-te", "2026-01-01T00:00:00Z", {"sensor_model": "a", "sample_rate_hz": 100})
+    db.finalize_run("run-te", "2026-01-01T00:10:00Z")
+    db.store_analysis("run-te", {"findings": [], "top_causes": [], "warnings": []})
+    # Error after complete should return False
+    assert db.store_analysis_error("run-te", "late failure") is False

--- a/apps/server/tests/history/test_history_http_services.py
+++ b/apps/server/tests/history/test_history_http_services.py
@@ -65,8 +65,8 @@ async def test_report_service_load_report_request_uses_persisted_language() -> N
                 "analysis_version": 3,
                 "sample_count": 12,
                 "analysis": {"lang": "nl", "findings": [], "title": "X"},
-            }
-        )
+            },
+        ),
     )
 
     request = await service.load_report_request("run-1", "en")
@@ -102,7 +102,7 @@ def test_build_run_details_json_strips_internal_analysis_fields() -> None:
             },
             sample_count=5,
             run_id="run-1",
-        )
+        ),
     )
 
     assert payload["sample_count"] == 5
@@ -137,7 +137,7 @@ def test_export_archive_builder_creates_csv_and_json_entries() -> None:
     builder = HistoryExportArchiveBuilder(
         _HistoryDbStub(
             samples=[{"run_id": "run-1", "t_s": 1.0, "custom": "x"}],
-        )
+        ),
     )
 
     spool = builder.build_zip_file(

--- a/apps/server/tests/history/test_history_write_errors.py
+++ b/apps/server/tests/history/test_history_write_errors.py
@@ -40,7 +40,7 @@ _FAKE_LATEST_METRICS: dict = {
                 "amp": 0.12,
                 "vibration_strength_db": 22.0,
                 "strength_bucket": "l2",
-            }
+            },
         ],
         "combined_spectrum_amp_g": [],
     },

--- a/apps/server/tests/history/test_runlog.py
+++ b/apps/server/tests/history/test_runlog.py
@@ -152,7 +152,7 @@ def test_normalize_sample_record_filters_invalid_peaks() -> None:
             {"hz": -1.0, "amp": 0.1},  # invalid hz
             {"hz": 20.0, "amp": None},  # invalid amp
             "not_a_dict",  # not a dict
-        ]
+        ],
     }
     result = normalize_sample_record(record)
     assert len(result["top_peaks"]) == 1
@@ -174,8 +174,8 @@ def test_normalize_sample_record_preserves_optional_peak_metadata() -> None:
                 "amp": 0.22,
                 "vibration_strength_db": 27.5,
                 "strength_bucket": "l4",
-            }
-        ]
+            },
+        ],
     }
     result = normalize_sample_record(record)
     assert result["top_peaks"][0]["vibration_strength_db"] == 27.5
@@ -282,7 +282,8 @@ def test_read_jsonl_run_truncated_last_line(tmp_path: Path) -> None:
 
 
 def test_read_jsonl_run_logs_warning_for_corrupt_lines(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Warnings are logged for each corrupt line, including line numbers."""
     path = tmp_path / "warn.jsonl"
@@ -338,7 +339,8 @@ def test_append_jsonl_records_preserves_unicode_text(tmp_path: Path) -> None:
 
 
 def test_append_jsonl_records_durable_fsync_cadence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = tmp_path / "durable.jsonl"
     fsync_calls: list[int] = []
@@ -386,7 +388,8 @@ def test_bounded_sample_zero_max_items_with_hint_raises() -> None:
 
 
 def test_read_jsonl_run_warns_on_duplicate_metadata(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Second metadata record in the same file logs a warning; first is used."""
     path = tmp_path / "dup_meta.jsonl"
@@ -416,7 +419,8 @@ def test_read_jsonl_run_warns_on_duplicate_metadata(
 
 
 def test_read_jsonl_run_end_record_without_end_time_utc_leaves_metadata_unchanged(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """When the end record has no end_time_utc, metadata is not overwritten with None."""
     path = tmp_path / "no_end_time.jsonl"

--- a/apps/server/tests/history/test_schema_migration.py
+++ b/apps/server/tests/history/test_schema_migration.py
@@ -44,7 +44,7 @@ CREATE TABLE settings_kv (
 CREATE TABLE client_names (
     client_id TEXT PRIMARY KEY, name TEXT NOT NULL, updated_at TEXT NOT NULL
 );
-"""
+""",
     )
     conn.commit()
     conn.close()

--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -37,7 +37,7 @@ def test_smoke_health_route_registered() -> None:
     state = MagicMock()
     state.ingress = MagicMock()
     state.settings = MagicMock()
-    state.diagnostics = MagicMock()
+    state.recording = MagicMock()
     state.persistence = MagicMock()
     state.websocket = MagicMock()
     state.updates = MagicMock()

--- a/apps/server/tests/hygiene/test_type_safety_consolidation.py
+++ b/apps/server/tests/hygiene/test_type_safety_consolidation.py
@@ -114,7 +114,7 @@ class TestClassificationResult:
 class TestMypyEnforcement:
     """pyproject.toml [tool.mypy] files list includes expanded modules."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def mypy_files(self) -> list[str]:
         import tomllib
 

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -1,0 +1,91 @@
+"""Contract bridge tests: Analysis → Report boundary.
+
+These tests validate that the output of ``summarize_run_data()`` is a valid
+input to ``map_summary()``.  They are fast (<5 s), deterministic, and run in
+standard CI so that schema drift between the two subsystems is caught early.
+"""
+
+from __future__ import annotations
+
+from test_support import (
+    ALL_WHEEL_SENSORS,
+    make_fault_samples,
+    make_noise_samples,
+    standard_metadata,
+)
+
+from vibesensor.analysis import SummaryData, map_summary, summarize_run_data
+from vibesensor.report.report_data import ReportTemplateData
+
+
+def _make_small_dataset() -> tuple[dict, list[dict]]:
+    """Return a minimal (metadata, samples) pair with a detectable fault."""
+    meta = standard_metadata(language="en")
+    samples: list[dict] = []
+    samples.extend(make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=15, speed_kmh=60.0))
+    samples.extend(
+        make_fault_samples(
+            fault_sensor="front-left",
+            sensors=ALL_WHEEL_SENSORS,
+            speed_kmh=80.0,
+            n_samples=20,
+        )
+    )
+    return meta, samples
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+def test_analysis_output_accepted_by_report_mapper():
+    """summarize_run_data() output must be accepted by map_summary()."""
+    meta, samples = _make_small_dataset()
+    summary: SummaryData = summarize_run_data(meta, samples, lang="en")
+
+    report_data = map_summary(summary)
+
+    assert isinstance(report_data, ReportTemplateData)
+
+
+def test_report_data_has_populated_fields():
+    """Key report fields must be non-empty after mapping real analysis output."""
+    meta, samples = _make_small_dataset()
+    summary = summarize_run_data(meta, samples, lang="en")
+    report_data = map_summary(summary)
+
+    # Structural: the report must have a title and language
+    assert report_data.title
+    assert report_data.lang == "en"
+
+    # Content: sensor information propagated
+    assert report_data.sensor_count > 0
+    assert len(report_data.sensor_locations) > 0
+
+    # Diagnostic output: observed signature populated
+    assert report_data.observed.certainty_label
+
+
+def test_analysis_without_fault_maps_cleanly():
+    """A run with only road-noise (no fault) must still map without errors."""
+    meta = standard_metadata(language="en")
+    samples = make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=30, speed_kmh=60.0)
+    summary = summarize_run_data(meta, samples, lang="en")
+
+    report_data = map_summary(summary)
+
+    assert isinstance(report_data, ReportTemplateData)
+    assert report_data.lang == "en"
+
+
+def test_multilingual_mapping():
+    """Analysis + report mapping must work for non-English languages."""
+    meta = standard_metadata(language="nl")
+    samples = make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=20, speed_kmh=60.0)
+    summary = summarize_run_data(meta, samples, lang="nl")
+
+    report_data = map_summary(summary)
+
+    assert isinstance(report_data, ReportTemplateData)
+    assert report_data.lang == "nl"

--- a/apps/server/tests/integration/test_contract_persistence_analysis.py
+++ b/apps/server/tests/integration/test_contract_persistence_analysis.py
@@ -1,0 +1,116 @@
+"""Contract bridge tests: Persistence → Analysis boundary.
+
+These tests validate that samples written to :class:`HistoryDB`, read back,
+and then fed into ``summarize_run_data()`` produce valid analysis output.
+They are fast (<5 s), deterministic, and run in standard CI so that schema
+drift between persistence and analysis is caught early.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from test_support import (
+    ALL_WHEEL_SENSORS,
+    make_fault_samples,
+    make_noise_samples,
+    standard_metadata,
+)
+
+from vibesensor.analysis import summarize_run_data
+from vibesensor.history_db import HistoryDB
+
+
+def _create_populated_db(
+    meta: dict,
+    samples: list[dict],
+) -> tuple[HistoryDB, str]:
+    """Create an in-memory DB with a run containing *samples*."""
+    db = HistoryDB(Path(":memory:"))
+    run_id = "contract-test-run"
+    db.create_run(run_id, start_time_utc="2025-01-01T00:00:00Z", metadata=meta)
+    db.append_samples(run_id, samples)
+    return db, run_id
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+def test_persisted_samples_produce_valid_analysis():
+    """Samples round-tripped through the DB must produce valid analysis."""
+    meta = standard_metadata(language="en")
+    samples = make_noise_samples(
+        sensors=ALL_WHEEL_SENSORS,
+        n_samples=15,
+        speed_kmh=60.0,
+    )
+    samples.extend(
+        make_fault_samples(
+            fault_sensor="front-left",
+            sensors=ALL_WHEEL_SENSORS,
+            speed_kmh=80.0,
+            n_samples=15,
+        )
+    )
+
+    db, run_id = _create_populated_db(meta, samples)
+    read_back = db.get_run_samples(run_id)
+
+    summary = summarize_run_data(meta, read_back, lang="en")
+
+    assert "findings" in summary
+    assert summary["rows"] > 0
+
+
+def test_noise_only_round_trip():
+    """A no-fault run round-tripped through the DB must still analyze cleanly."""
+    meta = standard_metadata(language="en")
+    samples = make_noise_samples(
+        sensors=ALL_WHEEL_SENSORS,
+        n_samples=30,
+        speed_kmh=60.0,
+    )
+
+    db, run_id = _create_populated_db(meta, samples)
+    read_back = db.get_run_samples(run_id)
+
+    summary = summarize_run_data(meta, read_back, lang="en")
+
+    assert "findings" in summary
+    assert summary["rows"] == len(samples)
+
+
+def test_sample_count_preserved_through_db():
+    """The DB must not silently drop or duplicate samples."""
+    meta = standard_metadata(language="en")
+    samples = make_noise_samples(
+        sensors=ALL_WHEEL_SENSORS,
+        n_samples=20,
+        speed_kmh=60.0,
+    )
+    original_count = len(samples)
+
+    db, run_id = _create_populated_db(meta, samples)
+    read_back = db.get_run_samples(run_id)
+
+    assert len(read_back) == original_count
+
+
+def test_key_sample_fields_survive_persistence():
+    """Critical sample fields must be preserved through write→read."""
+    meta = standard_metadata(language="en")
+    samples = make_noise_samples(
+        sensors=["front-left"],
+        n_samples=5,
+        speed_kmh=70.0,
+    )
+
+    db, run_id = _create_populated_db(meta, samples)
+    read_back = db.get_run_samples(run_id)
+
+    required_fields = {"t_s", "speed_kmh", "client_name", "vibration_strength_db"}
+    for row in read_back:
+        for field in required_fields:
+            assert field in row, f"Missing field {field!r} after DB round-trip"

--- a/apps/server/tests/integration/test_level_b_single_no_transient.py
+++ b/apps/server/tests/integration/test_level_b_single_no_transient.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Level B – Single sensor, no transient (≥50 direct-injection cases).
 
 Tests the analysis pipeline with exactly ONE sensor and NO transient
@@ -90,7 +89,9 @@ def _run_single_fault(
 @pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize("speed", _SPEEDS, ids=["low", "mid", "high"])
 def test_single_sensor_fault_corner_speed(
-    corner: str, speed: float, profile: dict[str, Any]
+    corner: str,
+    speed: float,
+    profile: dict[str, Any],
 ) -> None:
     """Wheel fault on single sensor at each corner × speed band."""
     summary, top = _run_single_fault(profile, corner, speed_kmh=speed)
@@ -125,10 +126,16 @@ _AMPS = [
 @pytest.mark.parametrize("profile", _OPTIMIZED_CAR_PROFILES, ids=_OPTIMIZED_CAR_PROFILE_IDS)
 @pytest.mark.parametrize("corner", ["FL", "RR"])
 @pytest.mark.parametrize(
-    ("amp_label", "fault_amp", "vib_db"), _AMPS, ids=["amp_low", "amp_med", "amp_high"]
+    ("amp_label", "fault_amp", "vib_db"),
+    _AMPS,
+    ids=["amp_low", "amp_med", "amp_high"],
 )
 def test_single_sensor_amplitude_scaling(
-    corner: str, amp_label: str, fault_amp: float, vib_db: float, profile: dict[str, Any]
+    corner: str,
+    amp_label: str,
+    fault_amp: float,
+    vib_db: float,
+    profile: dict[str, Any],
 ) -> None:
     """Confidence should scale with fault amplitude."""
     summary, top = _run_single_fault(profile, corner, fault_amp=fault_amp, fault_vib_db=vib_db)
@@ -183,8 +190,12 @@ def test_single_sensor_phased_onset(corner: str, profile: dict[str, Any]) -> Non
     samples.extend(make_idle_samples(sensors=[sensor], n_samples=10, start_t_s=0))
     samples.extend(
         make_ramp_samples(
-            sensors=[sensor], speed_start=20, speed_end=80, n_samples=15, start_t_s=10
-        )
+            sensors=[sensor],
+            speed_start=20,
+            speed_end=80,
+            n_samples=15,
+            start_t_s=10,
+        ),
     )
     samples.extend(
         make_profile_fault_samples(
@@ -196,7 +207,7 @@ def test_single_sensor_phased_onset(corner: str, profile: dict[str, Any]) -> Non
             start_t_s=25,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     top = extract_top(summary)
@@ -320,7 +331,8 @@ def test_single_sensor_weak_signal(corner: str, profile: dict[str, Any]) -> None
         assert conf < 0.90, f"Unexpectedly high confidence {conf} for weak {corner}"
     else:
         assert_tolerant_no_fault(
-            summary, msg=f"Weak {corner} should not produce high-confidence wheel fault"
+            summary,
+            msg=f"Weak {corner} should not produce high-confidence wheel fault",
         )
 
 
@@ -354,7 +366,9 @@ def test_single_sensor_speed_sweep_fault(corner: str, profile: dict[str, Any]) -
 @pytest.mark.parametrize("corner", ["FL", "RR"])
 @pytest.mark.parametrize("noise_amp", [0.001, 0.008], ids=["low_noise", "high_noise"])
 def test_single_sensor_noise_floor_variation(
-    corner: str, noise_amp: float, profile: dict[str, Any]
+    corner: str,
+    noise_amp: float,
+    profile: dict[str, Any],
 ) -> None:
     """Fault detection at different noise floor levels."""
     summary, top = _run_single_fault(

--- a/apps/server/tests/integration/test_level_c_single_transient.py
+++ b/apps/server/tests/integration/test_level_c_single_transient.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Level C – Single sensor, transient (≥50 direct-injection cases).
 
 Tests the analysis pipeline with exactly ONE sensor and TRANSIENT spikes
@@ -76,7 +75,7 @@ def _build_fault_with_transient_samples(
             start_t_s=fault_start_t,
             fault_amp=fault_amp,
             fault_vib_db=fault_vib_db,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -86,7 +85,7 @@ def _build_fault_with_transient_samples(
             start_t_s=spike_start_t,
             spike_amp=spike_amp,
             spike_vib_db=spike_vib_db,
-        )
+        ),
     )
     return samples
 
@@ -95,7 +94,9 @@ def _build_fault_with_transient_samples(
 @pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize("speed", _SPEEDS, ids=["low", "mid", "high"])
 def test_fault_with_transient_preserves_diagnosis(
-    corner: str, speed: float, profile: dict[str, Any]
+    corner: str,
+    speed: float,
+    profile: dict[str, Any],
 ) -> None:
     """Persistent wheel fault + short transient → fault still detected."""
     sensor = CORNER_SENSORS[corner]
@@ -128,7 +129,7 @@ def test_transient_only_no_persistent_fault(speed: float, profile: dict[str, Any
             start_t_s=35,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     # Should not produce a high-confidence wheel fault
@@ -156,7 +157,7 @@ def test_multiple_transients_no_false_fault(corner: str, profile: dict[str, Any]
                 spike_amp=0.12,
                 spike_vib_db=33.0,
                 spike_freq_hz=45.0 + t_start,
-            )
+            ),
         )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"multi-transient {corner}")
@@ -174,10 +175,16 @@ _SPIKE_AMPS = [
 @pytest.mark.parametrize("profile", _OPTIMIZED_CAR_PROFILES, ids=_OPTIMIZED_CAR_PROFILE_IDS)
 @pytest.mark.parametrize("corner", ["FL", "RR"])
 @pytest.mark.parametrize(
-    ("label", "amp", "vdb"), _SPIKE_AMPS, ids=["spike_small", "spike_med", "spike_large"]
+    ("label", "amp", "vdb"),
+    _SPIKE_AMPS,
+    ids=["spike_small", "spike_med", "spike_large"],
 )
 def test_transient_amplitude_deweighting(
-    corner: str, label: str, amp: float, vdb: float, profile: dict[str, Any]
+    corner: str,
+    label: str,
+    amp: float,
+    vdb: float,
+    profile: dict[str, Any],
 ) -> None:
     """Persistent fault + transient of varying size → fault still primary."""
     sensor = CORNER_SENSORS[corner]
@@ -208,7 +215,13 @@ def test_phased_onset_with_transient(corner: str, profile: dict[str, Any]) -> No
     samples: list[dict] = []
     samples.extend(make_idle_samples(sensors=[sensor], n_samples=8, start_t_s=0))
     samples.extend(
-        make_ramp_samples(sensors=[sensor], speed_start=20, speed_end=80, n_samples=12, start_t_s=8)
+        make_ramp_samples(
+            sensors=[sensor],
+            speed_start=20,
+            speed_end=80,
+            n_samples=12,
+            start_t_s=8,
+        ),
     )
     samples.extend(
         make_profile_fault_samples(
@@ -220,7 +233,7 @@ def test_phased_onset_with_transient(corner: str, profile: dict[str, Any]) -> No
             start_t_s=20,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -230,7 +243,7 @@ def test_phased_onset_with_transient(corner: str, profile: dict[str, Any]) -> No
             start_t_s=30,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     top = extract_top(summary)
@@ -260,7 +273,7 @@ def test_transient_frequency_variation(freq: float, profile: dict[str, Any]) -> 
             spike_amp=0.15,
             spike_vib_db=35.0,
             spike_freq_hz=freq,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"transient@{freq}Hz")
@@ -284,7 +297,7 @@ def test_long_transient_burst(corner: str, profile: dict[str, Any]) -> None:
             start_t_s=30,
             spike_amp=0.12,
             spike_vib_db=33.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"long-transient {corner}")
@@ -311,7 +324,7 @@ def test_transient_at_wheel_freq_no_false_positive(corner: str, profile: dict[st
             spike_amp=0.18,
             spike_vib_db=36.0,
             spike_freq_hz=whz,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"transient@wheel_hz {corner}")
@@ -335,7 +348,7 @@ def test_diffuse_plus_transient_no_fault(speed: float, profile: dict[str, Any]) 
             start_t_s=35,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"diffuse+transient@{speed}")

--- a/apps/server/tests/integration/test_level_d_multi_no_transient.py
+++ b/apps/server/tests/integration/test_level_d_multi_no_transient.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Level D – Multiple sensors, no transient (≥50 direct-injection cases).
 
 Tests the analysis pipeline with MULTIPLE sensors (2, 4, 8, or 12) and
@@ -125,7 +124,9 @@ def test_4sensor_no_fault(speed: float, profile: dict[str, Any]) -> None:
     ids=["FL_in_FL_RR", "RR_in_FL_RR", "FR_in_FR_RL", "RL_in_FR_RL"],
 )
 def test_2sensor_localization(
-    sensors: list[str], fault_corner: str, profile: dict[str, Any]
+    sensors: list[str],
+    fault_corner: str,
+    profile: dict[str, Any],
 ) -> None:
     """2-sensor pair, fault at one → correct localization."""
     fault_sensor = CORNER_SENSORS[fault_corner]
@@ -153,7 +154,10 @@ def test_2sensor_localization(
 )
 @pytest.mark.parametrize("corner", _CORNERS)
 def test_multi_sensor_fault_localization(
-    corner: str, sensors: list[str], label: str, profile: dict[str, Any]
+    corner: str,
+    sensors: list[str],
+    label: str,
+    profile: dict[str, Any],
 ) -> None:
     """8 or 12 sensors, fault at one wheel corner → correct localization."""
     sensor = CORNER_SENSORS[corner]
@@ -192,7 +196,9 @@ def test_4sensor_diffuse_no_fault(speed: float, profile: dict[str, Any]) -> None
     ids=["2s", "4s", "8s"],
 )
 def test_confidence_scales_with_sensor_count(
-    sensors: list[str], label: str, profile: dict[str, Any]
+    sensors: list[str],
+    label: str,
+    profile: dict[str, Any],
 ) -> None:
     """More sensors → confidence should be reasonable (not inflated beyond reality)."""
     samples = make_profile_fault_samples(
@@ -299,8 +305,12 @@ def test_4sensor_phased_onset(corner: str, profile: dict[str, Any]) -> None:
     samples.extend(make_idle_samples(sensors=_4_SENSORS, n_samples=8, start_t_s=0))
     samples.extend(
         make_ramp_samples(
-            sensors=_4_SENSORS, speed_start=20, speed_end=80, n_samples=12, start_t_s=8
-        )
+            sensors=_4_SENSORS,
+            speed_start=20,
+            speed_end=80,
+            n_samples=12,
+            start_t_s=8,
+        ),
     )
     samples.extend(
         make_profile_fault_samples(
@@ -312,7 +322,7 @@ def test_4sensor_phased_onset(corner: str, profile: dict[str, Any]) -> None:
             start_t_s=20,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"phased 4s {corner}")
@@ -328,7 +338,9 @@ def test_4sensor_phased_onset(corner: str, profile: dict[str, Any]) -> None:
     ids=["8s", "12s"],
 )
 def test_multi_sensor_no_fault_baseline(
-    sensors: list[str], label: str, profile: dict[str, Any]
+    sensors: list[str],
+    label: str,
+    profile: dict[str, Any],
 ) -> None:
     """8 or 12 sensors, all noise → no wheel fault."""
     samples = make_noise_samples(sensors=sensors, speed_kmh=SPEED_MID, n_samples=40)
@@ -346,7 +358,9 @@ def test_multi_sensor_no_fault_baseline(
     ids=["8s_diffuse", "12s_diffuse"],
 )
 def test_multi_sensor_diffuse_no_fault(
-    sensors: list[str], label: str, profile: dict[str, Any]
+    sensors: list[str],
+    label: str,
+    profile: dict[str, Any],
 ) -> None:
     """Diffuse excitation across many sensors → no localized fault."""
     samples = make_diffuse_samples(sensors=sensors, speed_kmh=SPEED_HIGH, n_samples=35)

--- a/apps/server/tests/integration/test_level_e2e_report.py
+++ b/apps/server/tests/integration/test_level_e2e_report.py
@@ -89,7 +89,7 @@ def _build_full_ingestion_scenario() -> tuple[dict[str, Any], list[dict[str, Any
             start_t_s=10,
             noise_amp=0.004,
             vib_db=10.0,
-        )
+        ),
     )
 
     # Phase 3: Cruise at 80 km/h with FL fault (25-70s)
@@ -103,7 +103,7 @@ def _build_full_ingestion_scenario() -> tuple[dict[str, Any], list[dict[str, Any
             fault_amp=0.07,
             fault_vib_db=28.0,
             noise_vib_db=8.0,
-        )
+        ),
     )
 
     # Phase 3b: Transient on FR at 45-47s
@@ -115,7 +115,7 @@ def _build_full_ingestion_scenario() -> tuple[dict[str, Any], list[dict[str, Any
             start_t_s=45,
             spike_amp=0.20,
             spike_vib_db=38.0,
-        )
+        ),
     )
 
     # Phase 4: Deceleration (70-85s)
@@ -128,7 +128,7 @@ def _build_full_ingestion_scenario() -> tuple[dict[str, Any], list[dict[str, Any
             start_t_s=70,
             noise_amp=0.004,
             vib_db=10.0,
-        )
+        ),
     )
 
     # Phase 5: Low-speed cruise with FL fault (85-100s)
@@ -142,7 +142,7 @@ def _build_full_ingestion_scenario() -> tuple[dict[str, Any], list[dict[str, Any
             fault_amp=0.05,
             fault_vib_db=22.0,
             noise_vib_db=8.0,
-        )
+        ),
     )
 
     # Phase 5b: Transient on RR at 95-97s
@@ -154,7 +154,7 @@ def _build_full_ingestion_scenario() -> tuple[dict[str, Any], list[dict[str, Any
             start_t_s=95,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
 
     # Phase 6: Final idle (100-120s)
@@ -289,7 +289,7 @@ def _build_20s_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             speed_end=80,
             n_samples=2,
             start_t_s=3,
-        )
+        ),
     )
     samples.extend(
         make_fault_samples(
@@ -301,7 +301,7 @@ def _build_20s_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             fault_amp=0.07,
             fault_vib_db=28.0,
             noise_vib_db=8.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -311,7 +311,7 @@ def _build_20s_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             start_t_s=10,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     samples.extend(make_idle_samples(sensors=sensors, n_samples=3, start_t_s=17))
 

--- a/apps/server/tests/integration/test_level_e_multi_transient.py
+++ b/apps/server/tests/integration/test_level_e_multi_transient.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Level E – Multiple sensors, transient (≥50 direct-injection cases).
 
 Tests the analysis pipeline with MULTIPLE sensors (2, 4, 8, 12) and
@@ -85,7 +84,7 @@ def test_4sensor_fault_with_transient(corner: str, speed: float, profile: dict[s
             start_t_s=0,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     # Transient on the same fault sensor
     samples.extend(
@@ -96,7 +95,7 @@ def test_4sensor_fault_with_transient(corner: str, speed: float, profile: dict[s
             start_t_s=12,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     top = extract_top(summary)
@@ -130,7 +129,7 @@ def test_4sensor_transient_on_other_sensor(corner: str, profile: dict[str, Any])
             start_t_s=0,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -140,7 +139,7 @@ def test_4sensor_transient_on_other_sensor(corner: str, profile: dict[str, Any])
             start_t_s=15,
             spike_amp=0.20,
             spike_vib_db=38.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"4s other-t {corner}")
@@ -163,7 +162,7 @@ def test_4sensor_transient_only_no_fault(speed: float, profile: dict[str, Any]) 
             start_t_s=35,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"4sensor transient-only@{speed}")
@@ -188,7 +187,7 @@ def test_8sensor_fault_with_transient(corner: str, profile: dict[str, Any]) -> N
             start_t_s=0,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -198,7 +197,7 @@ def test_8sensor_fault_with_transient(corner: str, profile: dict[str, Any]) -> N
             start_t_s=12,
             spike_amp=0.20,
             spike_vib_db=38.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"8s+t {corner}")
@@ -224,7 +223,7 @@ def test_12sensor_fault_with_transient(corner: str, profile: dict[str, Any]) -> 
             start_t_s=0,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -234,7 +233,7 @@ def test_12sensor_fault_with_transient(corner: str, profile: dict[str, Any]) -> 
             start_t_s=12,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"12s+t {corner}")
@@ -255,7 +254,9 @@ def test_12sensor_fault_with_transient(corner: str, profile: dict[str, Any]) -> 
     ids=["FL_2s", "RR_2s", "FR_2s", "RL_2s"],
 )
 def test_2sensor_fault_with_transient(
-    sensors: list[str], fault_corner: str, profile: dict[str, Any]
+    sensors: list[str],
+    fault_corner: str,
+    profile: dict[str, Any],
 ) -> None:
     """2-sensor pair, fault + transient → fault still detected."""
     fault_sensor = CORNER_SENSORS[fault_corner]
@@ -270,7 +271,7 @@ def test_2sensor_fault_with_transient(
             start_t_s=0,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -280,7 +281,7 @@ def test_2sensor_fault_with_transient(
             start_t_s=15,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, fault_sensor, msg=f"2s+t {fault_corner}")
@@ -303,7 +304,7 @@ def test_4sensor_diffuse_transient_no_fault(speed: float, profile: dict[str, Any
             start_t_s=35,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"4s-diffuse+transient@{speed}")
@@ -329,7 +330,7 @@ def test_4sensor_multi_transient_preserves_fault(corner: str, profile: dict[str,
             start_t_s=0,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     # Transient on fault sensor
     samples.extend(
@@ -340,7 +341,7 @@ def test_4sensor_multi_transient_preserves_fault(corner: str, profile: dict[str,
             start_t_s=10,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     # Transient on another sensor
     samples.extend(
@@ -351,7 +352,7 @@ def test_4sensor_multi_transient_preserves_fault(corner: str, profile: dict[str,
             start_t_s=20,
             spike_amp=0.12,
             spike_vib_db=33.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"multi-t {corner}")
@@ -368,7 +369,7 @@ def test_4sensor_phased_onset_with_transient(corner: str, profile: dict[str, Any
     samples: list[dict] = []
     samples.extend(make_idle_samples(sensors=_4S, n_samples=6, start_t_s=0))
     samples.extend(
-        make_ramp_samples(sensors=_4S, speed_start=20, speed_end=80, n_samples=10, start_t_s=6)
+        make_ramp_samples(sensors=_4S, speed_start=20, speed_end=80, n_samples=10, start_t_s=6),
     )
     samples.extend(
         make_profile_fault_samples(
@@ -380,7 +381,7 @@ def test_4sensor_phased_onset_with_transient(corner: str, profile: dict[str, Any
             start_t_s=16,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -390,7 +391,7 @@ def test_4sensor_phased_onset_with_transient(corner: str, profile: dict[str, Any
             start_t_s=28,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"phased+t {corner}")
@@ -416,7 +417,7 @@ def test_4sensor_transfer_with_transient(corner: str, profile: dict[str, Any]) -
             fault_amp=0.07,
             fault_vib_db=28.0,
             transfer_fraction=0.2,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -426,7 +427,7 @@ def test_4sensor_transfer_with_transient(corner: str, profile: dict[str, Any]) -
             start_t_s=12,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"xfer+t {corner}")
@@ -451,7 +452,7 @@ def test_8sensor_vhigh_speed_transient(corner: str, profile: dict[str, Any]) -> 
             start_t_s=0,
             fault_amp=0.08,
             fault_vib_db=30.0,
-        )
+        ),
     )
     samples.extend(
         make_transient_samples(
@@ -461,7 +462,7 @@ def test_8sensor_vhigh_speed_transient(corner: str, profile: dict[str, Any]) -> 
             start_t_s=12,
             spike_amp=0.20,
             spike_vib_db=38.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, sensor, msg=f"8s vhigh+t {corner}")
@@ -484,7 +485,7 @@ def test_12sensor_transient_only_no_fault(speed: float, profile: dict[str, Any])
             start_t_s=35,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"12sensor transient-only@{speed}")
@@ -515,7 +516,7 @@ def test_4sensor_speed_sweep_with_transient(corner: str, profile: dict[str, Any]
             start_t_s=20,
             spike_amp=0.18,
             spike_vib_db=36.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     _assert_fault_at(summary, CORNER_SENSORS[corner], msg=f"sweep+t {corner}")

--- a/apps/server/tests/integration/test_level_f_messy_real_world.py
+++ b/apps/server/tests/integration/test_level_f_messy_real_world.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Level F – Messy real-world scenarios (direct injection, deterministic).
 
 Tests the analysis pipeline with realistic edge cases that simulate
@@ -114,7 +113,8 @@ def test_fault_with_speed_jitter(corner: str, profile: dict[str, Any]) -> None:
         {
             **s,
             "speed_kmh": max(
-                5.0, s["speed_kmh"] + 8.0 * ((_stable_hash(f"jitter-{i}") % 200) / 100.0 - 1.0)
+                5.0,
+                s["speed_kmh"] + 8.0 * ((_stable_hash(f"jitter-{i}") % 200) / 100.0 - 1.0),
             ),
         }
         for i, s in enumerate(fault)
@@ -139,7 +139,7 @@ def test_diffuse_noise_with_pothole_transients(speed: float, profile: dict[str, 
     """
     samples: list[dict] = []
     samples.extend(
-        make_road_phase_samples(sensors=_4S, speed_kmh=speed, smooth_n=25, rough_n=0, pothole_n=0)
+        make_road_phase_samples(sensors=_4S, speed_kmh=speed, smooth_n=25, rough_n=0, pothole_n=0),
     )
     # Add transient bursts on each sensor (simulating potholes)
     for i, sensor in enumerate(_4S):
@@ -152,7 +152,7 @@ def test_diffuse_noise_with_pothole_transients(speed: float, profile: dict[str, 
                 spike_amp=0.12,
                 spike_vib_db=33.0,
                 spike_freq_hz=20.0,
-            )
+            ),
         )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     assert_tolerant_no_fault(summary, msg=f"diffuse+pothole@{speed}")
@@ -179,7 +179,7 @@ def test_overlapping_engine_wheel_harmonics(speed: float, profile: dict[str, Any
             n_samples=15,
             engine_amp=0.03,
             engine_vib_db=20.0,
-        )
+        ),
     )
     # Wheel fault on FL
     samples.extend(
@@ -192,7 +192,7 @@ def test_overlapping_engine_wheel_harmonics(speed: float, profile: dict[str, Any
             start_t_s=15,
             fault_amp=0.07,
             fault_vib_db=28.0,
-        )
+        ),
     )
     summary = run_analysis(samples, metadata=profile_metadata(profile))
     top = extract_top(summary)

--- a/apps/server/tests/integration/test_level_integration.py
+++ b/apps/server/tests/integration/test_level_integration.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Analysis-contract test – direct-injection validation of the full pipeline.
 
 This test exercises the full analysis pipeline end-to-end with a realistic
@@ -61,7 +60,7 @@ def _build_full_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             start_t_s=10,
             noise_amp=0.004,
             vib_db=10.0,
-        )
+        ),
     )
 
     # Phase 3: Cruise at 80 km/h with FL fault (25-70s)
@@ -75,7 +74,7 @@ def _build_full_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             fault_amp=0.07,
             fault_vib_db=28.0,
             noise_vib_db=8.0,
-        )
+        ),
     )
 
     # Phase 3b: Transient on FR at 45-47s (mid-cruise)
@@ -87,7 +86,7 @@ def _build_full_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             start_t_s=45,
             spike_amp=0.20,
             spike_vib_db=38.0,
-        )
+        ),
     )
 
     # Phase 4: Deceleration (70-85s) - no fault peaks
@@ -100,7 +99,7 @@ def _build_full_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             start_t_s=70,
             noise_amp=0.004,
             vib_db=10.0,
-        )
+        ),
     )
 
     # Phase 5: Low-speed cruise with FL fault (85-100s)
@@ -114,7 +113,7 @@ def _build_full_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             fault_amp=0.05,
             fault_vib_db=22.0,
             noise_vib_db=8.0,
-        )
+        ),
     )
 
     # Phase 5b: Transient on RR at 95-97s
@@ -126,7 +125,7 @@ def _build_full_scenario() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             start_t_s=95,
             spike_amp=0.15,
             spike_vib_db=35.0,
-        )
+        ),
     )
 
     # Phase 6: Final idle (100-120s)

--- a/apps/server/tests/integration/test_level_sim_ingestion.py
+++ b/apps/server/tests/integration/test_level_sim_ingestion.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Level SIM – True simulator-ingestion test (slow, needs running server).
 
 This is the one true end-to-end test that exercises the full path:
@@ -166,7 +165,7 @@ class TestSimulatorIngestion:
                 pytest.skip(
                     "Server is reachable but did not persist a new history run after logging "
                     "start/stop; skip simulator-ingestion e2e in this environment "
-                    f"(started={started_run_id})"
+                    f"(started={started_run_id})",
                 )
             self.run_id = sorted(new_runs)[-1]
 

--- a/apps/server/tests/integration/test_level_ui_mock.py
+++ b/apps/server/tests/integration/test_level_ui_mock.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """UI mock test – lightweight deterministic validation.
 
 Mocks a stable analysis response and verifies that the API response
@@ -34,7 +33,7 @@ def _build_stable_analysis() -> dict[str, Any]:
             n_samples=40,
             fault_amp=0.08,
             fault_vib_db=30.0,
-        )
+        ),
     )
     return run_analysis(samples)
 

--- a/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
+++ b/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
@@ -63,7 +63,7 @@ def _register_sensors(registry: ClientRegistry) -> None:
                 name=f"{location}-node",
                 frame_samples=_FRAME_N,
                 firmware_version="fw-test",
-            )
+            ),
         )
         registry.update_from_hello(hello, ("127.0.0.1", 9001))
         registry.set_location(client_id.hex(), location)
@@ -190,10 +190,10 @@ def test_multi_sensor_udp_to_report_pipeline(history_db: HistoryDB, tmp_path: Pa
     assert all(float(r.get("vibration_strength_db", 0.0)) > 0.0 for r in rows[:8])
 
     front_left_mean_db = np.mean(
-        [float(r["vibration_strength_db"]) for r in rows if r["location"] == "front-left"]
+        [float(r["vibration_strength_db"]) for r in rows if r["location"] == "front-left"],
     )
     front_right_mean_db = np.mean(
-        [float(r["vibration_strength_db"]) for r in rows if r["location"] == "front-right"]
+        [float(r["vibration_strength_db"]) for r in rows if r["location"] == "front-right"],
     )
     assert front_left_mean_db > front_right_mean_db
 
@@ -214,6 +214,6 @@ def test_multi_sensor_udp_to_report_pipeline(history_db: HistoryDB, tmp_path: Pa
     assert pdf_bytes.startswith(b"%PDF-")
     assert len(pdf_bytes) > 1000
     pdf_text = "\n".join(
-        filter(None, (page.extract_text() for page in PdfReader(io.BytesIO(pdf_bytes)).pages))
+        filter(None, (page.extract_text() for page in PdfReader(io.BytesIO(pdf_bytes)).pages)),
     ).lower()
     assert "front-left" in pdf_text

--- a/apps/server/tests/integration/test_multi_system_overlap.py
+++ b/apps/server/tests/integration/test_multi_system_overlap.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Multi-system overlap resolution tests (≥50 direct-injection cases).
 
 Tests how the analysis pipeline resolves overlapping system signatures
@@ -105,7 +104,7 @@ def _make_overlap_samples(
                     vibration_strength_db=vib_db,
                     strength_floor_amp_g=0.004,
                     **extra_kw,
-                )
+                ),
             )
     return samples
 
@@ -298,7 +297,10 @@ _ENGINE_ONLY_STRENGTHS = [
     ids=[e[0] for e in _ENGINE_ONLY_STRENGTHS],
 )
 def test_engine_only_no_localized_wheel(
-    speed: float, eng_name: str, engine_amp: float, engine_db: float
+    speed: float,
+    eng_name: str,
+    engine_amp: float,
+    engine_db: float,
 ) -> None:
     """Engine vibration on all sensors should not produce a localized wheel fault."""
     samples = make_engine_order_samples(
@@ -332,7 +334,10 @@ _RELATIVE_STRENGTHS = [
     ids=[s[0] for s in _RELATIVE_STRENGTHS],
 )
 def test_engine_plus_single_sensor_wheel(
-    corner: str, strength_name: str, wheel_amp: float, engine_amp: float
+    corner: str,
+    strength_name: str,
+    wheel_amp: float,
+    engine_amp: float,
 ) -> None:
     """Engine + localized wheel: pipeline should find the localized wheel signal."""
     sensor = CORNER_SENSORS[corner]

--- a/apps/server/tests/integration/test_real_world_scenarios.py
+++ b/apps/server/tests/integration/test_real_world_scenarios.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Real-world scenario tests for the diagnosis pipeline.
 
 Covers:
@@ -97,7 +96,7 @@ def _build_samples(
                     top_peaks=peaks,
                     vibration_strength_db=vib_db,
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
     return samples
 
@@ -109,11 +108,13 @@ def _build_samples(
 
 class TestHealthyVehicleNoFalsePositive:
     """Clean car data (road noise only) must produce zero non-REF findings
-    with confidence above a minimum threshold."""
+    with confidence above a minimum threshold.
+    """
 
     def _road_noise_samples(self, speed_kmh: float, duration_s: int = 40) -> list[dict[str, Any]]:
         """Generate road-noise-only samples: low broadband vibration, no peaks
-        near wheel/engine orders."""
+        near wheel/engine orders.
+        """
         return _build_samples(
             duration_s=duration_s,
             speed_fn=lambda _i: speed_kmh,
@@ -170,7 +171,8 @@ class TestHealthyVehicleNoFalsePositive:
 
 class TestEngineOrderFaultScenario:
     """Engine-order (1x) peaks appearing on all four sensors should be
-    classified as engine-sourced, not wheel-sourced."""
+    classified as engine-sourced, not wheel-sourced.
+    """
 
     def test_engine_1x_all_sensors_classified_as_engine(self) -> None:
         """Engine 1x peaks at RPM-derived frequency on all 4 sensors → engine source."""
@@ -305,7 +307,8 @@ class TestGradualFaultOnset:
 
 class TestBorderlineTwoSourceOverlap:
     """Wheel and engine frequencies happen to be similar at a particular speed/RPM.
-    The pipeline must not crash and should produce a coherent classification."""
+    The pipeline must not crash and should produce a coherent classification.
+    """
 
     def test_overlapping_wheel_and_engine_freq(self) -> None:
         """Wheel_hz ≈ engine_hz: should produce findings without NaN or crash."""

--- a/apps/server/tests/integration/test_scenario_ground_truth_invariants.py
+++ b/apps/server/tests/integration/test_scenario_ground_truth_invariants.py
@@ -204,7 +204,7 @@ class TestSpeedBandMixedPhase:
                 step_duration_s=2.0,
                 sensors=ALL_SENSORS,
                 start_t_s=t,
-            )
+            ),
         )
         t += 8.0
         samples.extend(
@@ -214,7 +214,7 @@ class TestSpeedBandMixedPhase:
                 fault_sensor="front-right",
                 sensors=ALL_SENSORS,
                 start_t_s=t,
-            )
+            ),
         )
 
         summary = summarize_run_data(
@@ -236,7 +236,7 @@ class TestSpeedBandMixedPhase:
                 fault_sensor="rear-left",
                 sensors=ALL_SENSORS,
                 start_t_s=t,
-            )
+            ),
         )
         t += 10.0
         samples.extend(
@@ -245,7 +245,7 @@ class TestSpeedBandMixedPhase:
                 duration_s=5.0,
                 sensors=ALL_SENSORS,
                 start_t_s=t,
-            )
+            ),
         )
         t += 5.0
         samples.extend(
@@ -257,7 +257,7 @@ class TestSpeedBandMixedPhase:
                 start_t_s=t,
                 fault_amp=0.07,
                 fault_vib_db=28.0,
-            )
+            ),
         )
 
         band = str(
@@ -267,9 +267,9 @@ class TestSpeedBandMixedPhase:
                     samples,
                     lang="en",
                     file_name="dominant_band_test",
-                )
+                ),
             ).get("strongest_speed_band")
-            or ""
+            or "",
         )
         assert band and "60" in band
 
@@ -295,7 +295,7 @@ class TestSpeedBandMixedPhase:
                             top_peaks=peaks,
                             vibration_strength_db=vib_db,
                             strength_floor_amp_g=0.003,
-                        )
+                        ),
                     )
                 t += 1.0
         samples.extend(
@@ -307,7 +307,7 @@ class TestSpeedBandMixedPhase:
                 start_t_s=t,
                 fault_amp=0.06,
                 fault_vib_db=26.0,
-            )
+            ),
         )
 
         band = str(
@@ -317,9 +317,9 @@ class TestSpeedBandMixedPhase:
                     samples,
                     lang="en",
                     file_name="accel_weight_test",
-                )
+                ),
             ).get("strongest_speed_band")
-            or ""
+            or "",
         )
         assert band and "100" in band
 
@@ -356,7 +356,7 @@ class TestConfidenceGuardrails:
                         top_peaks=[{"hz": whz, "amp": 0.06}, {"hz": whz * 2, "amp": 0.024}],
                         vibration_strength_db=26.0,
                         strength_floor_amp_g=0.004,
-                    )
+                    ),
                 )
         top_causes = summarize_run_data(
             scenario_metadata(),

--- a/apps/server/tests/integration/test_weird_sensor_mix.py
+++ b/apps/server/tests/integration/test_weird_sensor_mix.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Weird-sensor-mix direct-injection tests.
 
 100 parameterized cases covering ambiguity-aware localization with

--- a/apps/server/tests/metrics_log/test_metrics_log_helpers.py
+++ b/apps/server/tests/metrics_log/test_metrics_log_helpers.py
@@ -145,7 +145,8 @@ def test_stop_without_samples_does_not_persist_history_run(make_logger, fake_his
 
 
 def test_append_records_ignores_stale_recent_metrics_without_new_frames(
-    make_logger, fake_history_db
+    make_logger,
+    fake_history_db,
 ) -> None:
     logger = make_logger(history_db=fake_history_db)
 
@@ -200,7 +201,9 @@ def test_history_run_created_on_first_sample_append(make_logger, fake_history_db
 
 
 def test_stop_logging_flushes_first_pending_sample_batch(
-    make_logger, fake_history_db, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = make_logger(history_db=fake_history_db)
     monkeypatch.setattr(logger, "schedule_post_analysis", lambda _run_id: None)
@@ -219,7 +222,9 @@ def test_stop_logging_flushes_first_pending_sample_batch(
 
 
 def test_start_logging_rollover_flushes_first_pending_sample_batch(
-    make_logger, fake_history_db, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     scheduled: list[str] = []
     logger = make_logger(history_db=fake_history_db)
@@ -243,7 +248,9 @@ def test_start_logging_rollover_flushes_first_pending_sample_batch(
 
 
 def test_finalize_refreshes_run_metadata_from_latest_settings(
-    make_logger, fake_history_db, mutable_fake_settings
+    make_logger,
+    fake_history_db,
+    mutable_fake_settings,
 ) -> None:
     logger = make_logger(analysis_settings=mutable_fake_settings, history_db=fake_history_db)
 
@@ -266,7 +273,8 @@ def test_finalize_refreshes_run_metadata_from_latest_settings(
 
 
 def test_append_records_surfaces_create_run_failure_in_status(
-    make_logger, failing_create_run_db
+    make_logger,
+    failing_create_run_db,
 ) -> None:
     logger = make_logger(history_db=failing_create_run_db)
 
@@ -287,7 +295,8 @@ def test_append_records_surfaces_create_run_failure_in_status(
 
 
 def test_append_records_clears_write_error_after_successful_retry(
-    make_logger, failing_append_once_db
+    make_logger,
+    failing_append_once_db,
 ) -> None:
     logger = make_logger(history_db=failing_append_once_db)
 
@@ -310,7 +319,8 @@ def test_append_records_clears_write_error_after_successful_retry(
 
 
 def test_append_records_reports_timeout_when_no_data_for_threshold(
-    make_logger, no_active_registry
+    make_logger,
+    no_active_registry,
 ) -> None:
     logger = make_logger(registry=no_active_registry)
 
@@ -334,7 +344,9 @@ def test_append_records_reports_timeout_when_no_data_for_threshold(
 
 
 def test_append_records_does_not_timeout_on_brief_gap(
-    make_logger, no_active_registry, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    no_active_registry,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = make_logger(registry=no_active_registry)
 
@@ -359,7 +371,9 @@ def test_append_records_does_not_timeout_on_brief_gap(
 
 
 def test_stop_logging_does_not_block_on_post_analysis(
-    make_logger, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Stopping capture should be fast even when analysis is slow.
 
@@ -400,7 +414,9 @@ def test_stop_logging_does_not_block_on_post_analysis(
 
 
 def test_post_analysis_failure_sets_persistent_error_status(
-    make_logger, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     history_db = HistoryDB(tmp_path / "history.db")
     logger = make_logger(history_db=history_db)
@@ -427,7 +443,8 @@ def test_post_analysis_failure_sets_persistent_error_status(
 
 
 def test_post_analysis_burst_uses_single_daemon_worker(
-    make_logger, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = make_logger(history_db=_NullDB())
 
@@ -463,7 +480,8 @@ def test_post_analysis_burst_uses_single_daemon_worker(
 
 
 def test_shutdown_blocks_new_start_logging_until_wait_completes(
-    make_logger, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = make_logger(history_db=_NullDB())
     logger.start_logging()
@@ -491,7 +509,8 @@ def test_shutdown_blocks_new_start_logging_until_wait_completes(
 
 
 def test_shutdown_report_exposes_timeout_state(
-    make_logger, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = make_logger()
     logger.start_logging()
@@ -521,7 +540,9 @@ def test_shutdown_report_exposes_timeout_state(
 
 
 def test_post_analysis_uses_run_language_from_metadata(
-    make_logger, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     history_db = HistoryDB(tmp_path / "history.db")
     logger = make_logger(history_db=history_db, language_provider=lambda: "nl")
@@ -562,7 +583,7 @@ def test_run_metadata_captures_active_car_snapshot(make_logger) -> None:
                     "final_drive_ratio": 3.15,
                     "current_gear_ratio": 0.81,
                 },
-            }
+            },
         },
     )()
     logger = make_logger(settings_store=settings_store)
@@ -597,7 +618,9 @@ def test_db_persists_when_jsonl_disabled(make_logger, tmp_path: Path) -> None:
 
 
 def test_post_analysis_caps_sample_count_and_stores_sampling_metadata(
-    make_logger, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Reduce the cap so we only need ~250 iterations instead of 13 000 (28 s -> <1 s).
     cap = 200
@@ -633,7 +656,9 @@ def test_post_analysis_caps_sample_count_and_stores_sampling_metadata(
 
 @pytest.mark.asyncio
 async def test_run_offloads_append_records_with_to_thread(
-    make_logger, fake_history_db, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = make_logger(history_db=fake_history_db)
 

--- a/apps/server/tests/metrics_log/test_metrics_logger_lifecycle.py
+++ b/apps/server/tests/metrics_log/test_metrics_logger_lifecycle.py
@@ -13,7 +13,9 @@ from vibesensor.history_db import HistoryDB
 
 
 def test_start_append_stop_produces_complete_run_in_db(
-    make_logger, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Full lifecycle: start -> append -> stop -> analyze -> complete with a real DB."""
     history_db = HistoryDB(tmp_path / "history.db")

--- a/apps/server/tests/metrics_log/test_pipeline_resilience.py
+++ b/apps/server/tests/metrics_log/test_pipeline_resilience.py
@@ -21,7 +21,7 @@ import pytest
 
 from vibesensor.metrics_log.persistence import (
     _MAX_HISTORY_CREATE_RETRIES,
-    _RETRY_COOLDOWN_S,
+    _RETRY_COOLDOWN_BASE_S,
     MetricsPersistenceCoordinator,
 )
 from vibesensor.metrics_log.post_analysis import _WARN_QUEUE_DEPTH, PostAnalysisWorker
@@ -243,7 +243,7 @@ class TestRetryCooldown:
         # Fast-forward past cooldown
         with patch("vibesensor.metrics_log.persistence.time") as mock_time:
             # First call: check if past cooldown (return time after cooldown)
-            mock_time.monotonic.return_value = time.monotonic() + _RETRY_COOLDOWN_S + 1
+            mock_time.monotonic.return_value = time.monotonic() + _RETRY_COOLDOWN_BASE_S + 1
             coord.ensure_history_run_created("run-1", "2025-01-01T00:00:00Z", session_generation=1)
 
         assert coord.history_run_created
@@ -308,7 +308,6 @@ class TestPostAnalysisOutcomeTracking:
         # Note: _run_post_analysis was mocked so the worker loop tracks it
         # but the actual _run_post_analysis doesn't set the outcome.
         # Let's test with a real-ish DB instead.
-        pass
 
     def test_outcome_after_real_analysis_success(self) -> None:
         """Last completed outcome is set after successful analysis."""
@@ -328,7 +327,7 @@ class TestPostAnalysisOutcomeTracking:
                         "strength_bucket": "l1",
                         "peak_amp_g": 0.05,
                         "noise_floor_amp_g": 0.001,
-                    }
+                    },
                 ]
 
             def store_analysis(self, run_id, analysis):

--- a/apps/server/tests/metrics_log/test_post_analysis_worker.py
+++ b/apps/server/tests/metrics_log/test_post_analysis_worker.py
@@ -21,7 +21,6 @@ from vibesensor.metrics_log.post_analysis import PostAnalysisWorker
 @pytest.fixture
 def make_worker():
     """Factory for PostAnalysisWorker with an optional mock ``_run_post_analysis``."""
-
     _sentinel = object()
 
     def _factory(*, run_fn=None, history_db=_sentinel, **kwargs):

--- a/apps/server/tests/metrics_log/test_sample_builder_pure.py
+++ b/apps/server/tests/metrics_log/test_sample_builder_pure.py
@@ -66,8 +66,8 @@ class TestExtractStrengthData:
                     {"hz": 100.0, "amp": 0.0},  # should be filtered
                     {"hz": 200.0, "amp": -1.0},  # should be filtered
                     {"hz": 300.0, "amp": 0.5},  # should be kept
-                ]
-            }
+                ],
+            },
         }
         _, _, _, _, _, peaks = extract_strength_data(metrics)
 
@@ -80,8 +80,8 @@ class TestExtractStrengthData:
             "combined": {
                 "strength_metrics": {
                     "peak_amp_g": 0.88,
-                }
-            }
+                },
+            },
         }
         sm, _, _, peak_g, _, _ = extract_strength_data(metrics)
 

--- a/apps/server/tests/processing/test_buffers_repr_and_fastpath.py
+++ b/apps/server/tests/processing/test_buffers_repr_and_fastpath.py
@@ -53,7 +53,8 @@ class TestInvalidateCachesFastPath:
 
     def test_no_op_when_caches_already_clear(self) -> None:
         """Called on a fresh buffer (caches are None) must not raise or mutate
-        the generation fields."""
+        the generation fields.
+        """
         buf = _make_buf()
         # Confirm caches are already None
         assert buf.cached_spectrum_payload is None

--- a/apps/server/tests/processing/test_clipping_and_saturation.py
+++ b/apps/server/tests/processing/test_clipping_and_saturation.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Clipping / ADC saturation edge-case tests (≥50 direct-injection cases).
 
 Tests the analysis pipeline's robustness when peak amplitudes are clipped
@@ -151,7 +150,9 @@ _DIFFUSE_CLIP_LEVELS = [0.08, 0.05, 0.03, 0.01]
 
 
 @pytest.mark.parametrize(
-    "clip_amp", _DIFFUSE_CLIP_LEVELS, ids=["clip08", "clip05", "clip03", "clip01"]
+    "clip_amp",
+    _DIFFUSE_CLIP_LEVELS,
+    ids=["clip08", "clip05", "clip03", "clip01"],
 )
 @pytest.mark.parametrize("speed", [SPEED_LOW, SPEED_MID, SPEED_HIGH], ids=["low", "mid", "high"])
 def test_diffuse_clipping_no_localized_fault(clip_amp: float, speed: float) -> None:
@@ -249,7 +250,7 @@ def test_clipping_with_speed_variants(speed_name: str, speed_fn: Any, clip_amp: 
                         top_peaks=peaks,
                         vibration_strength_db=26.0,
                         strength_floor_amp_g=0.004,
-                    )
+                    ),
                 )
             else:
                 samples.append(
@@ -260,7 +261,7 @@ def test_clipping_with_speed_variants(speed_name: str, speed_fn: Any, clip_amp: 
                         top_peaks=[{"hz": 142.5, "amp": 0.004}],
                         vibration_strength_db=8.0,
                         strength_floor_amp_g=0.004,
-                    )
+                    ),
                 )
 
     clipped = make_clipped_samples(
@@ -280,7 +281,9 @@ def test_clipping_with_speed_variants(speed_name: str, speed_fn: Any, clip_amp: 
 @pytest.mark.parametrize("corner", _CORNERS)
 @pytest.mark.parametrize("clip_amp", [0.04, 0.02], ids=["clip04", "clip02"])
 def test_profile_clipped_fault_no_crash(
-    profile: dict[str, Any], corner: str, clip_amp: float
+    profile: dict[str, Any],
+    corner: str,
+    clip_amp: float,
 ) -> None:
     """Profile-aware clipped fault should not crash and should produce valid output."""
     sensor = CORNER_SENSORS[corner]
@@ -306,5 +309,6 @@ def test_profile_clipped_fault_no_crash(
     top = extract_top(summary)
     if top and float(top.get("confidence", 0)) > 0.25:
         assert_confidence_label_valid(
-            summary, msg=f"profile={profile['name']} {corner} clip={clip_amp}"
+            summary,
+            msg=f"profile={profile['name']} {corner} clip={clip_amp}",
         )

--- a/apps/server/tests/processing/test_processing_components.py
+++ b/apps/server/tests/processing/test_processing_components.py
@@ -46,7 +46,7 @@ def test_buffer_store_returns_cached_hit_after_committed_generation() -> None:
             strength_metrics={},
             has_fft_data=False,
             duration_s=0.01,
-        )
+        ),
     )
 
     second_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)

--- a/apps/server/tests/processing/test_sample_builder.py
+++ b/apps/server/tests/processing/test_sample_builder.py
@@ -261,7 +261,7 @@ class TestBuildRunMetadata:
                     "tire_aspect_pct": 55.0,
                     "rim_in": 16.0,
                 },
-            )
+            ),
         )
         assert meta["run_id"] == "test-run"
         assert meta["sensor_model"] == "ADXL345"
@@ -274,7 +274,7 @@ class TestBuildRunMetadata:
             **_default_run_metadata_kwargs(
                 run_id="run-lang",
                 language_provider=lambda: "fi",
-            )
+            ),
         )
         assert meta["language"] == "fi"
 
@@ -283,7 +283,7 @@ class TestBuildRunMetadata:
             **_default_run_metadata_kwargs(
                 run_id="run-lang-default",
                 language_provider=lambda: "   ",
-            )
+            ),
         )
         assert meta["language"] == "en"
 

--- a/apps/server/tests/processing/test_time_alignment.py
+++ b/apps/server/tests/processing/test_time_alignment.py
@@ -267,7 +267,8 @@ class TestCmdSyncClockProtocol:
 
 class TestSyncedClockAlignment:
     """When sensors report CMD_SYNC_CLOCK-corrected t0_us, alignment uses
-    the sensor-clock timestamps (more precise than arrival time)."""
+    the sensor-clock timestamps (more precise than arrival time).
+    """
 
     @pytest.mark.parametrize(
         ("t0_us", "expected"),
@@ -292,7 +293,11 @@ class TestSyncedClockAlignment:
         ],
     )
     def test_synced_pair_alignment(
-        self, s1_t0: int, s2_mono: float, s2_t0: int, expected_aligned: bool
+        self,
+        s1_t0: int,
+        s2_mono: float,
+        s2_t0: int,
+        expected_aligned: bool,
     ) -> None:
         proc = _make_processor(sample_rate_hz=200, waveform_seconds=2)
         _fill_sensor(proc, "s1", n_samples=400, mono_time=100.0, t0_us=s1_t0)
@@ -337,7 +342,8 @@ class TestSyncedClockAlignment:
 
     def test_samples_since_t0_accumulates_without_new_t0(self) -> None:
         """When successive ingests don't provide t0_us, samples_since_t0
-        accumulates so the time range remains accurate."""
+        accumulates so the time range remains accurate.
+        """
         proc = _make_processor(sample_rate_hz=200, waveform_seconds=2)
         _fill_sensor(proc, "s1", n_samples=100, mono_time=100.0, t0_us=50_000_000)
         _fill_sensor(proc, "s1", n_samples=100, mono_time=100.5)  # no t0_us
@@ -353,7 +359,8 @@ class TestSyncedClockAlignment:
 
 class TestAnalysisTimeRangeEdgeCases:
     """Tests for Fix 9 (negative samples_since_t0 guard) and Fix 10
-    (waveform_seconds <= 0 early return) in analysis_time_range."""
+    (waveform_seconds <= 0 early return) in analysis_time_range.
+    """
 
     def test_negative_samples_since_t0_clamped_to_zero(self) -> None:
         """Fix 9: samples_since_t0 < 0 must not produce end_us < last_t0_us.

--- a/apps/server/tests/regression/analysis/test_analysis_pipeline_guard_regressions.py
+++ b/apps/server/tests/regression/analysis/test_analysis_pipeline_guard_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Analysis pipeline guard regressions.

--- a/apps/server/tests/regression/analysis/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/regression/analysis/test_analysis_pipeline_integration_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Analysis pipeline integration regressions.
@@ -379,7 +379,11 @@ def test_end_to_end_pipeline(db: HistoryDB) -> None:
     read_samples = db.get_run_samples(run_id)
     normalized = [normalize_sample_record(s) for s in read_samples]
     summary = summarize_run_data(
-        metadata, normalized, lang="en", file_name=run_id, include_samples=False
+        metadata,
+        normalized,
+        lang="en",
+        file_name=run_id,
+        include_samples=False,
     )
     assert isinstance(summary, dict)
     assert "findings" in summary

--- a/apps/server/tests/regression/analysis/test_confidence_scoring_regressions.py
+++ b/apps/server/tests/regression/analysis/test_confidence_scoring_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Confidence and scoring regressions:
@@ -26,7 +26,8 @@ from vibesensor.analysis.findings.order_findings import (
 
 class TestRankingScoreErrorDenominator:
     """The ranking_score error term must use the same compliance-adjusted
-    denominator as the confidence formula (0.25 * compliance)."""
+    denominator as the confidence formula (0.25 * compliance).
+    """
 
     def test_no_hardcoded_denominator_in_ranking(self) -> None:
         """Source must not hardcode 0.5 denominator for ranking error.
@@ -53,7 +54,8 @@ class TestRankingScoreErrorDenominator:
 
 class TestSuppressEngineAliasesFilterBeforeSlice:
     """Suppressed engine findings must not consume top-5 slots, preventing
-    valid findings at position 6+ from being returned."""
+    valid findings at position 6+ from being returned.
+    """
 
     def test_valid_finding_not_lost_after_suppression(self) -> None:
         # Build 7 findings: 2 wheel, 3 engine (will be suppressed below
@@ -156,7 +158,8 @@ class TestSuppressEngineAliasesFilterBeforeSlice:
 
 class TestSingleSensorNotTriplePenalised:
     """Single-sensor findings must not be triple-penalised by stacking
-    localization_confidence + weak_spatial + sensor_count penalties."""
+    localization_confidence + weak_spatial + sensor_count penalties.
+    """
 
     def test_single_sensor_reasonable_confidence(self) -> None:
         # Good evidence on single sensor: high match rate, low error,
@@ -188,7 +191,8 @@ class TestSingleSensorNotTriplePenalised:
 
     def test_sensor_scale_not_applied_when_localization_low(self) -> None:
         """When localization_confidence is very low (already heavily penalised),
-        the explicit sensor-count scale should NOT stack on top."""
+        the explicit sensor-count scale should NOT stack on top.
+        """
         # Call twice: once with n_connected=1, once with n_connected=3
         # (n_connected=3 avoids sensor scale entirely).
         kwargs = {
@@ -227,7 +231,8 @@ class TestPersistentPeakNegligibleCapAligned:
     """The negligible-strength cap for persistent peaks must be 0.40,
     matching the order-finding cap, so that a weak order finding at
     ~0.37 confidence always suppresses persistent peaks at the same
-    frequency."""
+    frequency.
+    """
 
     def test_persistent_peak_cap_value_in_source(self) -> None:
         src = inspect.getsource(fmod_persistent._build_persistent_peak_findings)

--- a/apps/server/tests/regression/analysis/test_findings_ranking_and_guardrail_regressions.py
+++ b/apps/server/tests/regression/analysis/test_findings_ranking_and_guardrail_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Findings ranking and analysis guardrail regressions:
@@ -26,7 +26,8 @@ from vibesensor.runlog import append_jsonl_records
 
 class TestRankingScoreSyncAfterSuppression:
     """Regression: _suppress_engine_aliases must update _ranking_score
-    in the finding dict when suppressing confidence."""
+    in the finding dict when suppressing confidence.
+    """
 
     def test_ranking_score_updated(self) -> None:
         findings = [
@@ -59,7 +60,8 @@ class TestRankingScoreSyncAfterSuppression:
 
 class TestNegligibleCapAligned:
     """Regression: negligible-strength confidence cap must not exceed
-    TIER_B_CEILING (0.40)."""
+    TIER_B_CEILING (0.40).
+    """
 
     def test_order_cap_value_in_source(self) -> None:
         # After refactoring the literal 0.40 to a named constant, verify
@@ -96,7 +98,7 @@ class TestHistoryDbCloseLocked:
             __import__(
                 "vibesensor.history_db",
                 fromlist=["HistoryDB"],
-            ).HistoryDB.close
+            ).HistoryDB.close,
         )
         assert "self._lock" in source, "close() must use self._lock"
 
@@ -163,7 +165,8 @@ class TestSuppressEngineAliasesCapRaised:
 
 class TestWorkerPoolDeterministic:
     """Regression: test_worker_pool should use np.random.default_rng,
-    not np.random.seed (global state mutation)."""
+    not np.random.seed (global state mutation).
+    """
 
     def test_no_global_seed_in_source(self) -> None:
         import tests.app.test_worker_pool as mod
@@ -180,7 +183,8 @@ _UNSEEDED_RANDOM_MODULES = [
 
 class TestNoUnseededRandomInTests:
     """Guardrail: test files must use np.random.default_rng(seed), never
-    the unseeded global PRNG functions like np.random.randn or np.random.rand."""
+    the unseeded global PRNG functions like np.random.randn or np.random.rand.
+    """
 
     @pytest.mark.parametrize("modpath", _UNSEEDED_RANDOM_MODULES)
     def test_no_unseeded_randn(self, modpath: str) -> None:

--- a/apps/server/tests/regression/analysis/test_order_analysis_input_regressions.py
+++ b/apps/server/tests/regression/analysis/test_order_analysis_input_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Order analysis and numeric input guard regressions.
@@ -113,7 +113,10 @@ class TestDriveshaftHz:
         ids=["no-tire-circ", "zero-final-drive", "negative-final-drive"],
     )
     def test_driveshaft_hz_returns_none(
-        self, sample: dict, overrides: dict, tire_m: float | None
+        self,
+        sample: dict,
+        overrides: dict,
+        tire_m: float | None,
     ) -> None:
         assert _driveshaft_hz(sample, overrides, tire_circumference_m=tire_m) is None
 

--- a/apps/server/tests/regression/analysis/test_spectrum_and_peak_selection_regressions.py
+++ b/apps/server/tests/regression/analysis/test_spectrum_and_peak_selection_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Spectrum smoothing and peak-selection regressions:
@@ -19,7 +19,8 @@ from vibesensor.processing import SignalProcessor
 class TestSmoothSpectrumEdgePadding:
     """Regression: _smooth_spectrum must not attenuate edge bins via
     zero-padding.  Using edge-replication prevents artificial reduction
-    of boundary amplitudes."""
+    of boundary amplitudes.
+    """
 
     def test_constant_signal_unchanged(self) -> None:
         """A constant-amplitude spectrum must be unchanged after smoothing."""
@@ -29,7 +30,8 @@ class TestSmoothSpectrumEdgePadding:
 
     def test_edge_not_attenuated(self) -> None:
         """First and last bins must not be reduced compared to the raw value
-        when the signal is constant near the boundary."""
+        when the signal is constant near the boundary.
+        """
         amps = np.full(20, 1.0, dtype=np.float32)
         smoothed = SignalProcessor._smooth_spectrum(amps, bins=5)
         # With zero-padding the first bin would be ~0.6; with edge-pad it stays 1.0.
@@ -60,7 +62,8 @@ class TestSmoothSpectrumEdgePadding:
 
 class TestTopPeaksLastBin:
     """Regression: _top_peaks must consider the final spectrum bin as a
-    valid peak candidate, not silently skip it."""
+    valid peak candidate, not silently skip it.
+    """
 
     def test_peak_at_last_bin_detected(self) -> None:
         """A clear peak at the last frequency bin must appear in results."""
@@ -92,7 +95,8 @@ class TestTopPeaksLastBin:
 
 class TestCoreStrengthLastBin:
     """Regression: compute_vibration_strength_db must consider the last
-    spectrum bin as a peak candidate."""
+    spectrum bin as a peak candidate.
+    """
 
     def test_peak_at_last_bin_detected_in_core(self) -> None:
         n = 50

--- a/apps/server/tests/regression/analysis/test_strength_and_reason_selection_regressions.py
+++ b/apps/server/tests/regression/analysis/test_strength_and_reason_selection_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Strength labeling and reason-selection regressions.

--- a/apps/server/tests/regression/audits/test_analysis_pipeline_audit.py
+++ b/apps/server/tests/regression/audits/test_analysis_pipeline_audit.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """
@@ -76,7 +76,8 @@ class TestFinding1_FirstValidBinZeroed:
     def test_first_valid_bin_suppressed_in_combined_spectrum(self):
         """When spectrum_min_hz > 0, bin 0 of the sliced spectrum is a
         real analysis frequency, yet it is zeroed before being fed to
-        combined_spectrum_amp_g."""
+        combined_spectrum_amp_g.
+        """
         sp = _make_signal_processor(sample_rate_hz=512, fft_n=512)
         # Inject a 6 Hz sinusoid — should appear in the first few bins
         t = np.arange(512, dtype=np.float32) / 512
@@ -162,7 +163,8 @@ class TestFinding2_DoubleBinRemoval:
 
 class TestFinding3_BucketVsLabelInconsistency:
     """FIXED: bucket_for_strength now returns 'l0' for negative dB,
-    consistent with strength_label returning 'negligible'."""
+    consistent with strength_label returning 'negligible'.
+    """
 
     @pytest.mark.parametrize("db_value", [-5.0, -0.1, -20.0])
     def test_negative_db_inconsistency(self, db_value: float):
@@ -283,7 +285,8 @@ class TestFinding6_CombinedSpectrumInheritsZeroedBin:
 
     def test_combined_spectrum_preserves_bin0(self):
         """FIXED: combined spectrum bin 0 should NOT be zeroed for
-        broadband input because axis_amp_slices now uses amp_slice."""
+        broadband input because axis_amp_slices now uses amp_slice.
+        """
         sp = _make_signal_processor(sample_rate_hz=256, fft_n=256)
         rng = np.random.default_rng(42)
         block = rng.standard_normal((3, 256)).astype(np.float32) * 0.1

--- a/apps/server/tests/regression/audits/test_coverage_gap_audit_round2.py
+++ b/apps/server/tests/regression/audits/test_coverage_gap_audit_round2.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Coverage-gap audit (round 2).
@@ -87,7 +87,8 @@ def history_db(tmp_path: Path) -> Iterator[HistoryDB]:
 
 class TestDebugSpectrumAndRawSamples:
     """debug_spectrum() and raw_samples() are only tested indirectly via API
-    mocks.  Direct unit tests ensure correctness of the returned data."""
+    mocks.  Direct unit tests ensure correctness of the returned data.
+    """
 
     def test_debug_spectrum_insufficient_samples(self) -> None:
         proc = _proc(fft_n=512)
@@ -156,7 +157,8 @@ class TestDebugSpectrumAndRawSamples:
 
 class TestMultiSpectrumAlignment:
     """multi_spectrum_payload with multiple sensors should include alignment
-    metadata only when ≥ 2 sensors have spectrum data."""
+    metadata only when ≥ 2 sensors have spectrum data.
+    """
 
     def test_single_sensor_no_alignment_key(self) -> None:
         proc = _proc()
@@ -249,7 +251,7 @@ class TestWSHubRunLoop:
             tick_count += 1
 
         task = asyncio.create_task(
-            hub.run(hz=100, payload_builder=lambda _: {"ok": True}, on_tick=on_tick)
+            hub.run(hz=100, payload_builder=lambda _: {"ok": True}, on_tick=on_tick),
         )
         await asyncio.sleep(0.15)
         task.cancel()

--- a/apps/server/tests/regression/audits/test_coverage_gap_audit_top10.py
+++ b/apps/server/tests/regression/audits/test_coverage_gap_audit_top10.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Coverage-gap audit: top 10 untested critical code paths.
@@ -225,7 +225,9 @@ class TestComputeOrderConfidence:
         ],
     )
     def test_penalty_reduces_confidence(
-        self, normal_kw: dict[str, Any], penalty_kw: dict[str, Any]
+        self,
+        normal_kw: dict[str, Any],
+        penalty_kw: dict[str, Any],
     ) -> None:
         assert self._call(**penalty_kw) < self._call(**normal_kw)
 
@@ -277,7 +279,7 @@ class TestDetectDiffuseExcitation:
         possible = {"front_left": 20, "rear": 20}
         matched = {"front_left": 15, "rear": 14}
         pts = [{"location": "front_left", "amp": 0.30}] * 15 + [
-            {"location": "rear", "amp": 0.05}
+            {"location": "rear", "amp": 0.05},
         ] * 14
         is_diff, penalty = _detect_diffuse_excitation(locs, possible, matched, pts)
         assert not is_diff, "Strong amplitude dominance should NOT be diffuse"
@@ -293,7 +295,10 @@ class TestDetectDiffuseExcitation:
     def test_empty_matched_points(self) -> None:
         locs = {"a", "b"}
         is_diff, penalty = _detect_diffuse_excitation(
-            locs, {"a": 20, "b": 20}, {"a": 15, "b": 15}, []
+            locs,
+            {"a": 20, "b": 20},
+            {"a": 15, "b": 15},
+            [],
         )
         # With no amplitude data, amplitude check defaults to uniform
         assert isinstance(is_diff, bool)
@@ -399,7 +404,7 @@ class TestBuildRunSuitabilityChecks:
                     "samples": [
                         {"client_id": "c1", "frames_dropped_total": 0},
                         {"client_id": "c1", "frames_dropped_total": 10},
-                    ]
+                    ],
                 },
                 "SUITABILITY_CHECK_FRAME_INTEGRITY",
                 id="frame_integrity_dropped",
@@ -441,7 +446,7 @@ class TestBuildPhaseTimeline:
                 "finding_id": "F001",
                 "confidence_0_to_1": 0.60,
                 "phase_evidence": {"phases_detected": ["cruise"]},
-            }
+            },
         ]
         entries = _build_phase_timeline(segs, findings, min_confidence=0.25)
         assert len(entries) == 2
@@ -501,7 +506,7 @@ class TestComputeAccelStatistics:
                 "accel_y_g": 0.2,
                 "accel_z_g": 1.0,
                 "vibration_strength_db": 12.0,
-            }
+            },
         ]
         result = _compute_accel_statistics(samples, "ADXL345")
         assert len(result["accel_x_vals"]) == 1
@@ -608,7 +613,7 @@ class TestExtractStrengthData:
                 "peak_amp_g": 0.02,
                 "noise_floor_amp_g": 0.001,
                 "top_peaks": [{"hz": 45.0, "amp": 0.015}],
-            }
+            },
         }
         strength, db, bucket, peak, floor, peaks = extract_strength_data(metrics)
         assert db == pytest.approx(18.5)
@@ -623,8 +628,8 @@ class TestExtractStrengthData:
                     "vibration_strength_db": 12.0,
                     "strength_bucket": "l2",
                     "top_peaks": [],
-                }
-            }
+                },
+            },
         }
         strength, db, bucket, _, _, _ = extract_strength_data(metrics)
         assert db == pytest.approx(12.0)
@@ -641,7 +646,7 @@ class TestExtractStrengthData:
                     {"hz": 50.0, "amp": 0.01},  # valid
                     "not_a_dict",  # invalid type
                 ],
-            }
+            },
         }
         _, _, _, _, _, peaks = extract_strength_data(metrics)
         assert len(peaks) == 1
@@ -653,7 +658,7 @@ class TestExtractStrengthData:
                 "vibration_strength_db": 5.0,
                 "strength_bucket": "",
                 "top_peaks": [],
-            }
+            },
         }
         _, _, bucket, _, _, _ = extract_strength_data(metrics)
         assert bucket is None
@@ -674,7 +679,8 @@ class TestResolveSpeedContext:
     def test_no_speed_available(self) -> None:
         logger, _ = _make_metrics_logger()
         speed_kmh, gps_speed, source, rpm, fdr, gr = resolve_speed_context(
-            logger.gps_monitor, logger.analysis_settings.snapshot()
+            logger.gps_monitor,
+            logger.analysis_settings.snapshot(),
         )
         assert speed_kmh is None
         assert rpm is None
@@ -684,7 +690,8 @@ class TestResolveSpeedContext:
         gps_mock.speed_mps = 10.0  # 36 km/h
         gps_mock.resolve_speed.return_value = MagicMock(source="gps", speed_mps=10.0)
         speed_kmh, gps_speed, source, rpm, _, _ = resolve_speed_context(
-            logger.gps_monitor, logger.analysis_settings.snapshot()
+            logger.gps_monitor,
+            logger.analysis_settings.snapshot(),
         )
         assert speed_kmh == pytest.approx(36.0, rel=0.01)
         assert gps_speed == pytest.approx(36.0, rel=0.01)
@@ -696,7 +703,8 @@ class TestResolveSpeedContext:
         gps_mock.override_speed_mps = 20.0  # 72 km/h
         gps_mock.resolve_speed.return_value = MagicMock(source="manual", speed_mps=20.0)
         speed_kmh, _, source, _, _, _ = resolve_speed_context(
-            logger.gps_monitor, logger.analysis_settings.snapshot()
+            logger.gps_monitor,
+            logger.analysis_settings.snapshot(),
         )
         assert speed_kmh == pytest.approx(72.0, rel=0.01)
         assert source == "manual"
@@ -714,7 +722,8 @@ class TestResolveSpeedContext:
             "tire_deflection_factor": None,
         }
         _, _, _, rpm, _, _ = resolve_speed_context(
-            logger.gps_monitor, logger.analysis_settings.snapshot()
+            logger.gps_monitor,
+            logger.analysis_settings.snapshot(),
         )
         assert rpm is None, "Without gear_ratio, RPM should not be estimated"
 
@@ -771,7 +780,7 @@ class TestSummarizeRunDataEdgeCases:
                 "accel_z_g": 1.0,
                 "vibration_strength_db": 5.0,
                 "strength_bucket": "l1",
-            }
+            },
         ]
         summary = summarize_run_data(self._MINIMAL_META, samples, lang="en")
         assert summary["rows"] == 1

--- a/apps/server/tests/regression/audits/test_report_pipeline_audit.py
+++ b/apps/server/tests/regression/audits/test_report_pipeline_audit.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Report pipeline audit — tests covering 10 findings from the report-generation
@@ -180,7 +180,7 @@ class TestNextStepFieldsNotRendered:
                 "test_plan": [step],
                 "findings": [finding],
                 "top_causes": [top_cause],
-            }
+            },
         )
         data = map_summary(summary)
         # Find the step that came from our test_plan (not Tier A guidance)
@@ -245,7 +245,7 @@ class TestTopCausesFallbackBypassesPersistenceRanking:
             overrides={
                 "findings": findings,
                 "top_causes": [],  # empty → forces fallback
-            }
+            },
         )
         data = map_summary(summary)
         # The observed primary system comes from findings_non_ref[0],
@@ -337,9 +337,9 @@ class TestSystemFindingCardToneUnused:
                         "confidence_tone": "success",
                         "signatures_observed": ["1x wheel"],
                         "strongest_location": "front-left wheel",
-                    }
+                    },
                 ],
-            }
+            },
         )
         data = map_summary(summary)
         assert len(data.system_cards) >= 1
@@ -366,7 +366,8 @@ class TestDataTrustPanelOverflow:
 
     def test_data_trust_panel_renders(self) -> None:
         """Verify that the data-trust section renders without crashing,
-        even with many items."""
+        even with many items.
+        """
         source = inspect.getsource(_page1)
         # The data-trust section exists in _page1.
         assert "Data Trust" in source
@@ -395,7 +396,8 @@ class TestPeaksTableFixedHeight:
 
     def test_fixed_height_with_many_rows(self) -> None:
         """Eight peaks in data; the builder forwards all of them and the
-        renderer trims via a y_bottom guard at render time."""
+        renderer trims via a y_bottom guard at render time.
+        """
         rows = [_make_peaks_table_row(rank=i, frequency_hz=20.0 + i * 5) for i in range(1, 9)]
         summary = _make_minimal_summary(overrides={"plots": {"peaks_table": rows}})
         data = map_summary(summary)

--- a/apps/server/tests/regression/cross_cutting/test_exception_discipline.py
+++ b/apps/server/tests/regression/cross_cutting/test_exception_discipline.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Exception discipline: narrowed catches let code bugs propagate.
 
 After Chunk 3 exception narrowing, catches that previously used bare
@@ -43,19 +42,17 @@ class TestHistoryDBExceptionDiscipline:
     def test_type_error_in_write_tx_propagates(self, tmp_path: Path) -> None:
         """TypeError inside a write transaction must not be silently caught."""
         db = HistoryDB(tmp_path / "test.db")
-        with pytest.raises(TypeError):
-            with db.write_transaction_cursor() as cur:
-                cur.execute("SELECT 1")
-                raise TypeError("simulated code bug")
+        with pytest.raises(TypeError), db.write_transaction_cursor() as cur:
+            cur.execute("SELECT 1")
+            raise TypeError("simulated code bug")
         db.close()
 
     def test_attribute_error_in_cursor_propagates(self, tmp_path: Path) -> None:
         """AttributeError must not be silently caught."""
         db = HistoryDB(tmp_path / "test.db")
-        with pytest.raises(AttributeError):
-            with db._cursor() as cur:
-                cur.execute("SELECT 1")
-                raise AttributeError("simulated code bug")
+        with pytest.raises(AttributeError), db._cursor() as cur:
+            cur.execute("SELECT 1")
+            raise AttributeError("simulated code bug")
         db.close()
 
 

--- a/apps/server/tests/regression/cross_cutting/test_multi_domain_regressions.py
+++ b/apps/server/tests/regression/cross_cutting/test_multi_domain_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Cross-cutting multi-domain regressions.
@@ -396,7 +396,7 @@ class TestBug20PlotDataOrZero:
         # Verify the fixed pattern preserves 0.0
         item = {"presence_ratio": 0.0, "burstiness": 0.0, "persistence_score": 0.0}
         presence = float(
-            item.get("presence_ratio") if item.get("presence_ratio") is not None else 0.0
+            item.get("presence_ratio") if item.get("presence_ratio") is not None else 0.0,
         )
         assert presence == 0.0
         # Old behavior: float(item.get("presence_ratio") or 0.0) would also
@@ -405,6 +405,6 @@ class TestBug20PlotDataOrZero:
     def test_none_presence_ratio_defaults_to_zero(self) -> None:
         item: dict = {"presence_ratio": None}
         presence = float(
-            item.get("presence_ratio") if item.get("presence_ratio") is not None else 0.0
+            item.get("presence_ratio") if item.get("presence_ratio") is not None else 0.0,
         )
         assert presence == 0.0

--- a/apps/server/tests/regression/cross_cutting/test_refactor_contract_regressions.py
+++ b/apps/server/tests/regression/cross_cutting/test_refactor_contract_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Cross-module refactor-contract regressions.
@@ -88,17 +88,26 @@ class TestRegistryNamedConstants:
 
     def test_restart_detection_uses_named_constant(self, registry: ClientRegistry) -> None:
         """Sending a seq far below last_seq should trigger reset detection,
-        proving _RESTART_SEQ_GAP is wired into the logic."""
+        proving _RESTART_SEQ_GAP is wired into the logic.
+        """
         registry.update_from_hello(_hello(), ("10.4.0.2", 9010), now=1.0)
 
         high_seq = _RESTART_SEQ_GAP + 100
         msg_high = DataMessage(
-            client_id=_CLIENT_ID, seq=high_seq, t0_us=10, sample_count=200, samples=_SAMPLES_200X3
+            client_id=_CLIENT_ID,
+            seq=high_seq,
+            t0_us=10,
+            sample_count=200,
+            samples=_SAMPLES_200X3,
         )
         registry.update_from_data(msg_high, ("10.4.0.2", 50000), now=2.0)
 
         msg_low = DataMessage(
-            client_id=_CLIENT_ID, seq=0, t0_us=20, sample_count=200, samples=_SAMPLES_200X3
+            client_id=_CLIENT_ID,
+            seq=0,
+            t0_us=20,
+            sample_count=200,
+            samples=_SAMPLES_200X3,
         )
         result = registry.update_from_data(msg_low, ("10.4.0.2", 50000), now=3.0)
         assert result.reset_detected
@@ -108,18 +117,28 @@ class TestRegistryNamedConstants:
         client_id = bytes.fromhex("112233445566")
 
         registry.update_from_hello(
-            _hello(client_id, frame_samples=200), ("10.4.0.2", 9010), now=1.0
+            _hello(client_id, frame_samples=200),
+            ("10.4.0.2", 9010),
+            now=1.0,
         )
 
         msg0 = DataMessage(
-            client_id=client_id, seq=0, t0_us=0, sample_count=200, samples=_SAMPLES_200X3
+            client_id=client_id,
+            seq=0,
+            t0_us=0,
+            sample_count=200,
+            samples=_SAMPLES_200X3,
         )
         registry.update_from_data(msg0, ("10.4.0.2", 50000), now=2.0)
 
         # Expected delta = 200/800 * 1e6 = 250000 µs
         # Actual delta = 300000 µs → jitter = 50000 µs
         msg1 = DataMessage(
-            client_id=client_id, seq=1, t0_us=300_000, sample_count=200, samples=_SAMPLES_200X3
+            client_id=client_id,
+            seq=1,
+            t0_us=300_000,
+            sample_count=200,
+            samples=_SAMPLES_200X3,
         )
         registry.update_from_data(msg1, ("10.4.0.2", 50000), now=3.0)
 
@@ -303,7 +322,8 @@ def test_download_chunk_constant() -> None:
 class TestVersionComparisonWarning:
     def test_logs_warning_on_unparseable_version(self) -> None:
         """When packaging cannot parse versions, a warning should be logged
-        instead of silently swallowing the exception."""
+        instead of silently swallowing the exception.
+        """
         config = ReleaseFetcherConfig(server_repo="owner/repo")
         fetcher = ServerReleaseFetcher(config)
 

--- a/apps/server/tests/regression/cross_cutting/test_report_delivery_and_stream_resilience_regressions.py
+++ b/apps/server/tests/regression/cross_cutting/test_report_delivery_and_stream_resilience_regressions.py
@@ -193,7 +193,7 @@ class TestWebSocketHubCircuitBreaker:
                 await asyncio.sleep(0.005)
 
         task = asyncio.create_task(
-            hub.run(hz=200, payload_builder=dummy_builder, on_tick=failing_tick)
+            hub.run(hz=200, payload_builder=dummy_builder, on_tick=failing_tick),
         )
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(stop_after_4(), timeout=5.0)

--- a/apps/server/tests/regression/cross_cutting/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/regression/cross_cutting/test_review_guardrails_core_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Cross-cutting review guardrail regressions (core set).
@@ -73,7 +73,7 @@ class TestDomainModelsPublicAPI:
 
 class TestCarLibraryImport:
     def test_copy_at_module_level(self) -> None:
-        """copy should be importable from car_library's module scope."""
+        """Copy should be importable from car_library's module scope."""
         import vibesensor.car_library as cl
 
         source = inspect.getsource(cl)
@@ -192,7 +192,9 @@ class TestSeverityFromPeakReturnType:
     )
     def test_returns_dict(self, db: float, sensor_count: int, prior_state) -> None:
         result = severity_from_peak(
-            vibration_strength_db=db, sensor_count=sensor_count, prior_state=prior_state
+            vibration_strength_db=db,
+            sensor_count=sensor_count,
+            prior_state=prior_state,
         )
         assert isinstance(result, dict)
         assert "key" in result

--- a/apps/server/tests/regression/cross_cutting/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/regression/cross_cutting/test_review_guardrails_extended_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Cross-cutting review guardrail regressions (extended set).

--- a/apps/server/tests/regression/report/test_report_rendering_regressions.py
+++ b/apps/server/tests/regression/report/test_report_rendering_regressions.py
@@ -91,7 +91,7 @@ class TestNextStepFieldsRendered:
                     confirm="movement increases",
                     falsify="mount remains rigid",
                     eta="15 min",
-                )
+                ),
             ],
         )
 

--- a/apps/server/tests/regression/runtime/test_api_history_processing_regressions.py
+++ b/apps/server/tests/regression/runtime/test_api_history_processing_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Runtime regressions spanning API, history, and processing boundaries."""
@@ -117,7 +117,9 @@ class TestProcessingZeroSampleRate:
         assert result.get("waveform") == {} or result.get("metrics") == {}
 
     @pytest.mark.parametrize(
-        ("sr", "expect_empty"), [(0, True), (800, False)], ids=["zero", "normal"]
+        ("sr", "expect_empty"),
+        [(0, True), (800, False)],
+        ids=["zero", "normal"],
     )
     def test_fft_params(self, sr: int, *, expect_empty: bool) -> None:
         proc = self._make_processor(800)

--- a/apps/server/tests/regression/runtime/test_concurrency_generation_guard_regressions.py
+++ b/apps/server/tests/regression/runtime/test_concurrency_generation_guard_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Concurrency and generation-guard regressions.
@@ -42,7 +42,7 @@ def _make_logger(tmp_path: Path, **overrides):
             "accel_scale_g_per_lsb",
             "persist_history_db",
             "no_data_timeout_s",
-        }
+        },
     )
     config_overrides = {k: overrides.pop(k) for k in list(overrides) if k in _CONFIG_FIELDS}
     config = MetricsLoggerConfig(
@@ -78,7 +78,8 @@ def _make_logger(tmp_path: Path, **overrides):
 
 class TestAutoStopGenerationGuard:
     """stop_logging(_only_if_generation=N) must be a no-op when session has
-    already advanced past generation N."""
+    already advanced past generation N.
+    """
 
     def test_stale_generation_does_not_stop_new_session(self, tmp_path: Path) -> None:
         logger, db = _make_logger(tmp_path)
@@ -206,7 +207,9 @@ class TestFinalizeReturnGatesAnalysis:
     """When _finalize_run_locked fails, stop_logging must NOT schedule analysis."""
 
     def test_analysis_not_scheduled_when_finalize_fails(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         logger, db = _make_logger(
             tmp_path,

--- a/apps/server/tests/regression/runtime/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/regression/runtime/test_io_and_time_guard_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """I/O cleanup, time-source, and report-cli guard regressions.
@@ -53,7 +53,8 @@ def _make_summary(report_date: str, **overrides: Any) -> dict[str, Any]:
 
 class TestFirmwareCacheRefreshUnboundGuard:
     """target/old_current must be defined before the try block so the
-    except handler never raises UnboundLocalError."""
+    except handler never raises UnboundLocalError.
+    """
 
     def test_exception_before_activation_does_not_raise_unbound(self, tmp_path: Path) -> None:
         """If download_bundle raises, the except block should not crash."""
@@ -200,7 +201,9 @@ class TestReportCliErrorHandling:
             patch(
                 "vibesensor.report_cli.parse_args",
                 return_value=MagicMock(
-                    input=run_file, output=tmp_path / "out.pdf", summary_json=None
+                    input=run_file,
+                    output=tmp_path / "out.pdf",
+                    summary_json=None,
                 ),
             ),
         ):

--- a/apps/server/tests/regression/runtime/test_metrics_cache_and_settings_regressions.py
+++ b/apps/server/tests/regression/runtime/test_metrics_cache_and_settings_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Metrics cache, settings rollback, and counter-delta regressions."""

--- a/apps/server/tests/regression/runtime/test_runtime_fallbacks_regressions.py
+++ b/apps/server/tests/regression/runtime/test_runtime_fallbacks_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Runtime fallback and error-guard regressions.
@@ -24,7 +24,8 @@ from vibesensor.history_db import HistoryDB
 
 class TestStrengthFloorFallback:
     """Regression: strength_floor_amp_g must not return 0.0 when all bins
-    are within peak exclusion zones, since 0.0 floor produces ~140 dB."""
+    are within peak exclusion zones, since 0.0 floor produces ~140 dB.
+    """
 
     def test_all_bins_excluded_falls_back_to_p20(self) -> None:
         """When every bin is excluded by peaks, fall back to P20 noise floor."""
@@ -75,7 +76,8 @@ class TestStrengthFloorFallback:
 
 class TestWheelFocusFromLocation:
     """Regression: _wheel_focus_from_location must match label_for_code() outputs
-    which use spaces (e.g. 'Front Left Wheel'), not hyphens."""
+    which use spaces (e.g. 'Front Left Wheel'), not hyphens.
+    """
 
     @pytest.mark.parametrize(
         ("label", "expected_key"),

--- a/apps/server/tests/regression/runtime/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/regression/runtime/test_runtime_nan_and_update_guard_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Runtime NaN handling and update-manager guard regressions:
@@ -359,7 +359,6 @@ class TestFirmwareCacheRestore:
 
     def test_old_current_restored_on_rename_failure(self, tmp_path):
         """If extract_dir.rename(target) fails, old_current should be restored."""
-
         current = tmp_path / "current"
         current.mkdir()
         (current / "marker.txt").write_text("old_firmware")

--- a/apps/server/tests/regression/runtime/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/regression/runtime/test_runtime_quality_pass_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Runtime quality-pass regressions (issues 20–24).
@@ -32,7 +32,11 @@ def _make_history_db(tmp_path: Path, name: str = "history.db") -> HistoryDB:
 
 
 def _seeded_history_db(
-    tmp_path: Path, run_id: str, n_samples: int, *, name: str = "history.db"
+    tmp_path: Path,
+    run_id: str,
+    n_samples: int,
+    *,
+    name: str = "history.db",
 ) -> HistoryDB:
     """Create a HistoryDB with one run containing *n_samples* rows."""
     db = _make_history_db(tmp_path, name)
@@ -56,7 +60,8 @@ def _make_tone_chunk(freq_hz: float, n_samples: int, sample_rate_hz: int) -> np.
 
 def test_ring_buffer_wraparound_returns_correct_latest_data() -> None:
     """Ingest more samples than the buffer capacity and verify the
-    latest window returns the *most recent* data, not early data."""
+    latest window returns the *most recent* data, not early data.
+    """
     sample_rate_hz = 800
     processor = SignalProcessor(
         sample_rate_hz=sample_rate_hz,
@@ -218,7 +223,7 @@ CREATE TABLE samples (
     sample_json TEXT NOT NULL,
     FOREIGN KEY (run_id) REFERENCES runs(run_id)
 );
-"""
+""",
     )
     conn.commit()
     conn.close()

--- a/apps/server/tests/regression/runtime/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/regression/runtime/test_runtime_queue_and_export_regressions.py
@@ -62,7 +62,9 @@ _DEAD_FUNCTION_CASES = [
 
 class TestDeadFunctionsRemoved:
     @pytest.mark.parametrize(
-        ("rel_path", "forbidden"), _DEAD_FUNCTION_CASES, ids=[c[1] for c in _DEAD_FUNCTION_CASES]
+        ("rel_path", "forbidden"),
+        _DEAD_FUNCTION_CASES,
+        ids=[c[1] for c in _DEAD_FUNCTION_CASES],
     )
     def test_dead_function_absent(self, rel_path: str, forbidden: str) -> None:
         text = (SERVER_ROOT / rel_path).read_text()

--- a/apps/server/tests/regression/runtime/test_runtime_validation_and_schema_regressions.py
+++ b/apps/server/tests/regression/runtime/test_runtime_validation_and_schema_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Runtime validation and schema-recovery regressions.
@@ -112,7 +112,7 @@ class TestConfidenceNanGuard:
         confidence = _safe_confidence(raw)
         assert abs(confidence - expected) < 1e-6
         # Verify formatting doesn't crash
-        f"({confidence * 100.0:.0f}%)"  # noqa: B018
+        f"({confidence * 100.0:.0f}%)"
 
 
 # ------------------------------------------------------------------
@@ -185,7 +185,8 @@ class TestSettingsStoreRollbackSafety:
 
     def test_rollback_preserves_dict_identity(self) -> None:
         """After a failed persist, the car.aspects dict object
-        should still be the same object (not replaced)."""
+        should still be the same object (not replaced).
+        """
         store = SettingsStore(db=None)
         car_data = store.add_car({"name": "TestCar", "type": "sedan"})
         car_id = car_data["cars"][0]["id"]

--- a/apps/server/tests/regression/runtime/test_strength_and_spectrum_runtime_regressions.py
+++ b/apps/server/tests/regression/runtime/test_strength_and_spectrum_runtime_regressions.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E402, E501
+# ruff: noqa: E402
 from __future__ import annotations
 
 """Strength bucketing and combined-spectrum runtime regressions:
@@ -25,7 +25,8 @@ from vibesensor.processing.fft import compute_fft_spectrum
 
 class TestBucketForStrengthNegativeDB:
     """Regression: bucket_for_strength must return 'l0' for negative dB,
-    not None."""
+    not None.
+    """
 
     @pytest.mark.parametrize(
         ("db_val", "expected"),
@@ -44,11 +45,13 @@ class TestBucketForStrengthNegativeDB:
 class TestCombinedSpectrumNotZeroed:
     """Regression: axis_amp_slices must use amp_slice (original), not
     amp_for_peaks (which has DC bin zeroed). Otherwise the combined
-    spectrum inherits the artificial zero."""
+    spectrum inherits the artificial zero.
+    """
 
     def test_amp_slice_used_not_amp_for_peaks(self) -> None:
         """Verify source code appends amp_slice (not amp_for_peaks)
-        to axis_amp_slices."""
+        to axis_amp_slices.
+        """
         src = inspect.getsource(compute_fft_spectrum)
         # Find the line that appends to axis_amp_slices
         match = re.search(r"axis_amp_slices\.append\((\w+)\)", src)
@@ -63,7 +66,8 @@ class TestCombinedSpectrumNotZeroed:
 class TestNoiseFloorNoDoubleRemoval:
     """Regression: _noise_floor must not skip amps[1:] before delegating
     to noise_floor_amp_p20_g, since the caller already provides the
-    analysis-band slice (DC already removed)."""
+    analysis-band slice (DC already removed).
+    """
 
     def test_all_bins_included(self) -> None:
         amps = np.array([0.010, 0.012, 0.009, 0.011, 0.013], dtype=np.float32)
@@ -83,7 +87,8 @@ class TestNoiseFloorNoDoubleRemoval:
 
 class TestOrderToleranceScalesWithCompliance:
     """Regression: order tolerance must scale with path_compliance so
-    wheel hypotheses (compliance=1.5) get a wider matching window."""
+    wheel hypotheses (compliance=1.5) get a wider matching window.
+    """
 
     def test_compliance_1_baseline(self) -> None:
         predicted_hz = 20.0
@@ -109,7 +114,8 @@ class TestOrderToleranceScalesWithCompliance:
 
 class TestDeadDbValueRemoved:
     """Regression: _top_strength_values should not contain unused db_value
-    variable."""
+    variable.
+    """
 
     def test_no_db_value_in_source(self) -> None:
         source = inspect.getsource(top_strength_values)

--- a/apps/server/tests/report/_report_pdf_test_helpers.py
+++ b/apps/server/tests/report/_report_pdf_test_helpers.py
@@ -18,12 +18,12 @@ from vibesensor.report.pdf_page1 import _draw_system_card
 from vibesensor.report.report_data import PartSuggestion, SystemFindingCard
 
 __all__ = [
+    "KMH_TO_MPS",
+    "RUN_END",
     "BytesIO",
     "Canvas",
-    "KMH_TO_MPS",
     "PartSuggestion",
     "PdfReader",
-    "RUN_END",
     "SystemFindingCard",
     "__version__",
     "_draw_system_card",
@@ -34,8 +34,8 @@ __all__ = [
     "map_summary",
     "run_metadata",
     "sample",
-    "summarize_log",
     "suitability_by_key",
+    "summarize_log",
     "write_jsonl",
 ]
 

--- a/apps/server/tests/report/test_hotspot_parsers.py
+++ b/apps/server/tests/report/test_hotspot_parsers.py
@@ -108,7 +108,10 @@ class TestExpectedIpMatch:
         ],
     )
     def test_compares_ip_part_only(
-        self, expected_cidr: str, actual_cidr: str | None, is_match: bool
+        self,
+        expected_cidr: str,
+        actual_cidr: str | None,
+        is_match: bool,
     ) -> None:
         assert expected_ip_match(expected_cidr, actual_cidr) is is_match
 

--- a/apps/server/tests/report/test_hotspot_self_heal.py
+++ b/apps/server/tests/report/test_hotspot_self_heal.py
@@ -73,7 +73,7 @@ def _nmcli_modify_cmd(ap: APConfig) -> tuple[str, ...]:
                 "wpa-psk",
                 "802-11-wireless-security.psk",
                 ap.psk,
-            ]
+            ],
         )
     return tuple(base)
 
@@ -105,7 +105,8 @@ def _self_heal_cfg(
 
 def _ap_cfg(tmp_path: Path, *, allow_disable_resolved_stub_listener: bool = False) -> APConfig:
     self_heal = _self_heal_cfg(
-        tmp_path, allow_disable_resolved_stub_listener=allow_disable_resolved_stub_listener
+        tmp_path,
+        allow_disable_resolved_stub_listener=allow_disable_resolved_stub_listener,
     )
     return APConfig(
         ssid="VibeSensor",
@@ -129,12 +130,12 @@ def _healthy_responses(ap: APConfig) -> dict[tuple[str, ...], list[CommandResult
         ("nmcli", "general", "status"): [_ok("STATE connected")],
         ("nmcli", "connection", "show", ap.con_name): [_ok("connection.id:VibeSensor-AP")],
         ("nmcli", "connection", "show", "--active"): [
-            _ok(f"NAME  DEVICE\n{ap.con_name}  {ap.ifname}")
+            _ok(f"NAME  DEVICE\n{ap.con_name}  {ap.ifname}"),
         ],
         ("ip", "addr", "show", "dev", ap.ifname): [_ok("3: wlan0\n    inet 10.4.0.1/24")],
         ("rfkill", "list"): [_ok("0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no")],
         ("ip", "link", "show", "dev", ap.ifname): [
-            _ok("2: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP")
+            _ok("2: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP"),
         ],
         ("nmcli", "-t", "-f", "NAME", "connection", "show"): [_ok(f"{ap.con_name}\n")],
         ("nmcli", "connection", "delete", ap.con_name): [_ok("")],
@@ -154,13 +155,13 @@ def _healthy_responses(ap: APConfig) -> dict[tuple[str, ...], list[CommandResult
             ap.ssid,
         ): [_ok("")],
         ("nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"): [
-            _ok(f"{ap.con_name}:{ap.ifname}\n")
+            _ok(f"{ap.con_name}:{ap.ifname}\n"),
         ],
         ("iw", "dev", ap.ifname, "info"): [
-            _ok("Interface wlan0\n\ttype AP\n\tchannel 7 (2442 MHz)")
+            _ok("Interface wlan0\n\ttype AP\n\tchannel 7 (2442 MHz)"),
         ],
         ("ip", "-4", "addr", "show", "dev", ap.ifname): [
-            _ok("3: wlan0\n    inet 10.4.0.1/24 brd 10.4.0.255 scope global wlan0")
+            _ok("3: wlan0\n    inet 10.4.0.1/24 brd 10.4.0.255 scope global wlan0"),
         ],
         (
             "journalctl",
@@ -228,7 +229,7 @@ def _collect_health_for(
             {
                 ("ip", "link", "show", "dev", "wlan0"): [
                     _ok("2: wlan0: <BROADCAST,MULTICAST> mtu 1500 state DOWN"),
-                ]
+                ],
             },
             "iface_up",
             False,
@@ -326,7 +327,7 @@ def test_ensure_ap_connection_open_mode_recreates_without_security_keys(tmp_path
             ): [_ok("")],
             _nmcli_modify_cmd(ap): [_ok("")],
             ("nmcli", "--wait", "12", "connection", "up", ap.con_name): [_ok("")],
-        }
+        },
     )
 
     ok = _ensure_ap_connection(ap, runner)

--- a/apps/server/tests/report/test_i18n_separation.py
+++ b/apps/server/tests/report/test_i18n_separation.py
@@ -115,7 +115,7 @@ def _make_analysis_summary() -> dict:
                     {"hz": 12.5 + rng.gauss(0, 0.2), "amp": 0.05},
                 ],
                 "strength_floor_amp_g": 0.005,
-            }
+            },
         )
     return summarize_run_data(metadata, samples, lang="en", include_samples=False)
 
@@ -201,7 +201,7 @@ def test_analysis_output_contains_no_translated_strings() -> None:
 
     violations = _check_no_translated_strings(summary, "summary")
     assert not violations, "Analysis output contains translated strings:\n" + "\n".join(
-        violations[:10]
+        violations[:10],
     )
 
 

--- a/apps/server/tests/report/test_report_analysis_findings_integration.py
+++ b/apps/server/tests/report/test_report_analysis_findings_integration.py
@@ -67,7 +67,7 @@ def test_build_findings_orders_informational_transients_after_diagnostics(
                 "severity": "diagnostic",
                 "suspected_source": "wheel/tire",
                 "confidence_0_to_1": 0.30,
-            }
+            },
         ]
 
     def _fake_persistent_peaks(**_kwargs) -> list[dict[str, object]]:
@@ -78,7 +78,7 @@ def test_build_findings_orders_informational_transients_after_diagnostics(
                 "suspected_source": "transient_impact",
                 "peak_classification": "transient",
                 "confidence_0_to_1": 0.22,
-            }
+            },
         ]
 
     monkeypatch.setattr(findings_builder_module, "_build_order_findings", _fake_order_findings)
@@ -120,9 +120,9 @@ def test_build_findings_detects_sparse_high_speed_only_fault() -> None:
                 **_make_sample(float(idx), speed_kmh, 0.03 if high_speed_band else 0.01),
                 "strength_floor_amp_g": 0.003,
                 "top_peaks": [
-                    {"hz": wh, "amp": 0.03} if high_speed_band else {"hz": wh + 7.0, "amp": 0.01}
+                    {"hz": wh, "amp": 0.03} if high_speed_band else {"hz": wh + 7.0, "amp": 0.01},
                 ],
-            }
+            },
         )
 
     findings = build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
@@ -154,7 +154,7 @@ def test_build_order_findings_min_match_threshold_stays_below_confidence_cutoff(
                 "strength_floor_amp_g": 1000.0,
                 "top_peaks": [{"hz": 5.5 if matched else 20.0, "amp": 0.001}],
                 "location": "front_left",
-            }
+            },
         )
 
     findings = call_build_order_findings(samples)
@@ -177,7 +177,7 @@ def test_build_findings_order_exposes_structured_speed_profile() -> None:
                 **_make_sample(float(idx), speed_kmh, amp),
                 "strength_floor_amp_g": 0.002,
                 "top_peaks": [{"hz": wh, "amp": amp}],
-            }
+            },
         )
 
     findings = build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
@@ -211,7 +211,7 @@ def test_build_findings_detects_driveline_2x_order() -> None:
                 **_make_sample(float(idx), speed_kmh, 0.04),
                 "strength_floor_amp_g": 0.002,
                 "top_peaks": [{"hz": wh * 3.08 * 2.0, "amp": 0.04}],
-            }
+            },
         )
 
     findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
@@ -244,7 +244,7 @@ def test_build_findings_persistent_peak_exposes_structured_speed_profile() -> No
                 **_make_sample(float(idx), speed_kmh, amp),
                 "strength_floor_amp_g": 0.002,
                 "top_peaks": [{"hz": 73.0, "amp": max(0.004, amp)}],
-            }
+            },
         )
 
     findings = build_findings_for_samples(metadata=metadata, samples=samples, lang="en")
@@ -280,7 +280,7 @@ def test_speed_band_semantics_are_aligned_across_findings_and_peak_table() -> No
                 **_make_sample(float(idx), speed_val, amp),
                 "strength_floor_amp_g": 0.003,
                 "top_peaks": [{"hz": wh, "amp": amp}, {"hz": 43.0, "amp": amp}],
-            }
+            },
         )
 
     findings = build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
@@ -358,9 +358,9 @@ def test_build_findings_passes_focused_speed_band_to_location_summary(
                 **_make_sample(float(idx), speed_kmh, 0.03 if high_speed_band else 0.01),
                 "strength_floor_amp_g": 0.003,
                 "top_peaks": [
-                    {"hz": wh, "amp": 0.03} if high_speed_band else {"hz": wh + 7.0, "amp": 0.01}
+                    {"hz": wh, "amp": 0.03} if high_speed_band else {"hz": wh + 7.0, "amp": 0.01},
                 ],
-            }
+            },
         )
 
     findings = build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")

--- a/apps/server/tests/report/test_report_analysis_helpers.py
+++ b/apps/server/tests/report/test_report_analysis_helpers.py
@@ -339,7 +339,7 @@ def test_sample_top_peaks_filters_sub_min_analysis_freq() -> None:
             {"hz": 4.9, "amp": 0.08},  # below MIN_ANALYSIS_FREQ_HZ
             {"hz": 5.0, "amp": 0.07},  # at boundary — should pass
             {"hz": 15.0, "amp": 0.05},  # well above — should pass
-        ]
+        ],
     }
     peaks = _sample_top_peaks(sample)
     assert len(peaks) == 2
@@ -377,7 +377,7 @@ def test_locations_connected_throughout_requires_mid_run_continuity() -> None:
     samples = []
     for t_s in (0.0, 1.0, 2.0, 8.0, 9.0, 10.0):
         samples.append({"t_s": t_s, "client_name": "Front Left"})
-    for t_s in range(0, 11):
+    for t_s in range(11):
         samples.append({"t_s": float(t_s), "client_name": "Rear Right"})
     connected = _locations_connected_throughout_run(samples)
     assert connected == {"Rear Right"}
@@ -397,7 +397,7 @@ def test_locations_connected_throughout_deduplicates_timestamps() -> None:
     for _ in range(10):
         samples.append({"t_s": 0.0, "client_name": "Front Left"})
         samples.append({"t_s": 10.0, "client_name": "Front Left"})
-    for t_s in range(0, 11):
+    for t_s in range(11):
         samples.append({"t_s": float(t_s), "client_name": "Rear Right"})
     connected = _locations_connected_throughout_run(samples)
     assert connected == {"Rear Right"}

--- a/apps/server/tests/report/test_report_analysis_localization_integration.py
+++ b/apps/server/tests/report/test_report_analysis_localization_integration.py
@@ -71,8 +71,8 @@ def test_most_likely_origin_summary_uses_adaptive_weak_spatial_fallback() -> Non
                 "weak_spatial_separation": False,
                 "location_hotspot": {"location_count": 3},
                 "confidence_0_to_1": 0.8,
-            }
-        ]
+            },
+        ],
     )
     assert origin["weak_spatial_separation"] is True
 
@@ -206,7 +206,7 @@ def test_build_findings_penalizes_low_localization_confidence(
         speed = 70.0 + idx
         wh = wheel_hz_from_speed_kmh(speed, 2.036) or 10.0
         samples.append(
-            {**_make_sample(float(idx), speed, 0.03), "top_peaks": [{"hz": wh, "amp": 0.03}]}
+            {**_make_sample(float(idx), speed, 0.03), "top_peaks": [{"hz": wh, "amp": 0.03}]},
         )
 
     monkeypatch.setattr(
@@ -224,7 +224,7 @@ def test_build_findings_penalizes_low_localization_confidence(
         ),
     )
     high_conf = max_non_ref_confidence(
-        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
+        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en"),
     )
 
     monkeypatch.setattr(
@@ -242,7 +242,7 @@ def test_build_findings_penalizes_low_localization_confidence(
         ),
     )
     low_conf = max_non_ref_confidence(
-        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
+        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en"),
     )
 
     assert low_conf < high_conf
@@ -256,7 +256,7 @@ def test_build_findings_penalizes_weak_spatial_separation_by_dominance_ratio(
         speed = 65.0 + idx
         wh = wheel_hz_from_speed_kmh(speed, 2.036) or 10.0
         samples.append(
-            {**_make_sample(float(idx), speed, 0.03), "top_peaks": [{"hz": wh, "amp": 0.03}]}
+            {**_make_sample(float(idx), speed, 0.03), "top_peaks": [{"hz": wh, "amp": 0.03}]},
         )
 
     monkeypatch.setattr(
@@ -274,7 +274,7 @@ def test_build_findings_penalizes_weak_spatial_separation_by_dominance_ratio(
         ),
     )
     baseline_conf = max_non_ref_confidence(
-        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
+        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en"),
     )
 
     monkeypatch.setattr(
@@ -292,7 +292,7 @@ def test_build_findings_penalizes_weak_spatial_separation_by_dominance_ratio(
         ),
     )
     weak_conf = max_non_ref_confidence(
-        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
+        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en"),
     )
 
     monkeypatch.setattr(
@@ -310,7 +310,7 @@ def test_build_findings_penalizes_weak_spatial_separation_by_dominance_ratio(
         ),
     )
     near_tie_conf = max_non_ref_confidence(
-        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")
+        build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en"),
     )
 
     assert weak_conf <= (baseline_conf * 0.80) + 1e-9
@@ -329,7 +329,7 @@ def test_build_findings_excludes_partial_coverage_sensor_from_strongest_location
                 "client_name": "Front Left",
                 "strength_floor_amp_g": 0.002,
                 "top_peaks": [{"hz": wh, "amp": 0.02}],
-            }
+            },
         )
         if idx < 6:
             samples.append(
@@ -338,7 +338,7 @@ def test_build_findings_excludes_partial_coverage_sensor_from_strongest_location
                     "client_name": "Rear Right",
                     "strength_floor_amp_g": 0.002,
                     "top_peaks": [{"hz": wh, "amp": 0.05}],
-                }
+                },
             )
 
     findings = build_findings_for_samples(metadata=wheel_metadata(), samples=samples, lang="en")

--- a/apps/server/tests/report/test_report_analysis_phase_flow.py
+++ b/apps/server/tests/report/test_report_analysis_phase_flow.py
@@ -118,7 +118,7 @@ def test_build_findings_per_phase_confidence_flows_through_pipeline() -> None:
                 "strength_floor_amp_g": 0.002,
                 "top_peaks": [{"hz": wh, "amp": 0.05}],
                 "location": "front_left",
-            }
+            },
         )
 
     findings = (

--- a/apps/server/tests/report/test_report_analysis_separation.py
+++ b/apps/server/tests/report/test_report_analysis_separation.py
@@ -56,7 +56,7 @@ def test_report_module_does_not_import_analysis(module_path: Path) -> None:
             if node.level and node.level > 0:
                 if full.startswith("analysis"):
                     violations.append(
-                        f"line {node.lineno}: from {'.' * node.level}{full} import ..."
+                        f"line {node.lineno}: from {'.' * node.level}{full} import ...",
                     )
             elif "analysis" in full.split("."):
                 violations.append(f"line {node.lineno}: from {full} import ...")

--- a/apps/server/tests/report/test_report_content_coverage.py
+++ b/apps/server/tests/report/test_report_content_coverage.py
@@ -44,7 +44,7 @@ def _make_run_jsonl(tmp_path: Path, *, tire_circumference_m: float = 2.20) -> Pa
         speed = 40 + idx
         wheel_hz = (speed * KMH_TO_MPS) / tire_circumference_m
         records.append(
-            _sample(idx, speed_kmh=float(speed), dominant_freq_hz=wheel_hz, peak_amp_g=0.09)
+            _sample(idx, speed_kmh=float(speed), dominant_freq_hz=wheel_hz, peak_amp_g=0.09),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -133,7 +133,7 @@ def test_select_top_causes_excludes_informational_transient_findings(
             "peak_classification": "transient",
             "confidence_0_to_1": confidence,
             "frequency_hz_or_order": freq_hz,
-        }
+        },
     ]
     causes = select_top_causes(findings)
     assert causes == []
@@ -164,7 +164,8 @@ def test_select_top_causes_prefers_diagnostic_over_info() -> None:
 
 def test_select_top_causes_prefers_cruise_phase_evidence() -> None:
     """A finding with strong cruise-phase evidence should rank above one with
-    equal raw confidence but no cruise evidence."""
+    equal raw confidence but no cruise evidence.
+    """
     findings = [
         {
             "finding_id": "F_A",
@@ -202,7 +203,7 @@ def test_select_top_causes_phase_evidence_in_output() -> None:
             "confidence_0_to_1": 0.75,
             "frequency_hz_or_order": "1x wheel order",
             "phase_evidence": phase_ev,
-        }
+        },
     ]
     causes = select_top_causes(findings)
     assert len(causes) == 1
@@ -218,7 +219,7 @@ def test_select_top_causes_no_phase_evidence_still_works() -> None:
             "suspected_source": "engine",
             "confidence_0_to_1": 0.55,
             "frequency_hz_or_order": "2x engine order",
-        }
+        },
     ]
     causes = select_top_causes(findings)
     assert len(causes) == 1

--- a/apps/server/tests/report/test_report_data_from_dict.py
+++ b/apps/server/tests/report/test_report_data_from_dict.py
@@ -192,7 +192,7 @@ class TestReportTemplateDataFromDict:
                 "data_trust": None,
                 "peak_rows": 42,
                 "pattern_evidence": [],
-            }
+            },
         )
 
         assert result.system_cards == []

--- a/apps/server/tests/report/test_report_data_strength_db_source.py
+++ b/apps/server/tests/report/test_report_data_strength_db_source.py
@@ -71,7 +71,7 @@ def test_map_summary_falls_back_to_actionable_findings_when_top_cause_is_placeho
             "suspected_source": "wheel/tire",
             "strongest_location": "rear-left",
             "strongest_speed_band": "40-60 km/h",
-        }
+        },
     )
     summary["top_causes"] = [
         {
@@ -79,7 +79,7 @@ def test_map_summary_falls_back_to_actionable_findings_when_top_cause_is_placeho
             "strongest_location": "unknown",
             "strongest_speed_band": "100-110 km/h",
             "confidence_0_to_1": 0.95,
-        }
+        },
     ]
 
     data = map_summary(summary)
@@ -95,7 +95,7 @@ def test_map_summary_pattern_evidence_uses_same_primary_candidate_as_observed() 
             "strongest_location": "rear-left",
             "strongest_speed_band": "40-60 km/h",
             "signatures_observed": ["1x wheel order"],
-        }
+        },
     )
     summary["top_causes"] = [
         {
@@ -105,7 +105,7 @@ def test_map_summary_pattern_evidence_uses_same_primary_candidate_as_observed() 
             "confidence_0_to_1": 0.95,
             "weak_spatial_separation": False,
             "signatures_observed": ["reference gap"],
-        }
+        },
     ]
 
     data = map_summary(summary)
@@ -126,8 +126,8 @@ def test_map_summary_peak_rows_render_missing_values_as_dashes() -> None:
                     "order_label": "",
                     "peak_classification": "persistent",
                     "typical_speed_band": "any",
-                }
-            ]
+                },
+            ],
         },
     )
 
@@ -156,8 +156,8 @@ def test_map_summary_peak_rows_use_source_hint_for_system_label() -> None:
                     "peak_classification": "patterned",
                     "source": "wheel/tire",
                     "typical_speed_band": "60-80 km/h",
-                }
-            ]
+                },
+            ],
         },
     )
 

--- a/apps/server/tests/report/test_report_floor_estimation.py
+++ b/apps/server/tests/report/test_report_floor_estimation.py
@@ -29,7 +29,7 @@ def test_estimate_strength_floor_amp_g_uses_consistent_policy() -> None:
     amps = [0.1, 0.2, 0.3]
     expected = percentile(sorted(amps), 0.20)
     assert _estimate_strength_floor_amp_g(_sample([(10.0, a) for a in amps])) == pytest.approx(
-        expected
+        expected,
     )
 
 

--- a/apps/server/tests/report/test_report_i18n.py
+++ b/apps/server/tests/report/test_report_i18n.py
@@ -49,7 +49,8 @@ def test_missing_translation_file_is_deterministic(monkeypatch: pytest.MonkeyPat
 
 
 def test_corrupt_translation_file_is_deterministic(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broken = tmp_path / "report_i18n.json"
     broken.write_text("{broken", encoding="utf-8")
@@ -113,7 +114,8 @@ def test_dutch_translation_audit_round_2() -> None:
     assert report_i18n.tr("nl", "CONFIDENCE_LABEL") == "Betrouwbaarheid"
     assert report_i18n.tr("nl", "FINAL_DRIVE_RATIO_LABEL") == "Eindoverbrenging"
     assert "hogere orden" in report_i18n.tr(
-        "nl", "CHECK_DRIVESHAFT_RUNOUT_AND_JOINT_CONDITION_FOR_HIGHER"
+        "nl",
+        "CHECK_DRIVESHAFT_RUNOUT_AND_JOINT_CONDITION_FOR_HIGHER",
     )
     assert "ordereferenties" in report_i18n.tr("nl", "SUITABILITY_REFERENCE_COMPLETENESS_PASS")
     assert "ordereferenties" in report_i18n.tr("nl", "SUITABILITY_REFERENCE_COMPLETENESS_WARN")
@@ -121,7 +123,8 @@ def test_dutch_translation_audit_round_2() -> None:
     assert "aanvullende data" in report_i18n.tr("nl", "NO_NEXT_STEPS")
     assert report_i18n.tr("nl", "METRIC_LABEL") == "Meetwaarde"
     assert "Snelheidsdata" in report_i18n.tr(
-        "nl", "SPEED_DATA_MISSING_OR_INSUFFICIENT_SPEED_BINNED_AND"
+        "nl",
+        "SPEED_DATA_MISSING_OR_INSUFFICIENT_SPEED_BINNED_AND",
     )
 
 
@@ -207,7 +210,7 @@ def test_dutch_translation_audit_round_4() -> None:
 
     # Natural Dutch: "bedrijfsconditie" -> "bedrijfsomstandigheid"
     assert "bedrijfsomstandigheid" in _nl(
-        "PEAK_FREQUENCY_SHIFTS_RANDOMLY_WITH_NO_REPEATABLE_OPERATING"
+        "PEAK_FREQUENCY_SHIFTS_RANDOMLY_WITH_NO_REPEATABLE_OPERATING",
     )
 
     # Anglicism removal: "motororde-matching" -> "motororde-vergelijking"
@@ -246,7 +249,7 @@ def test_dutch_translation_audit_round_4() -> None:
 
     # Interfixed s: "snelheid-" -> "snelheids-"
     assert "snelheids- en versnellingsstromen" in _nl(
-        "VERIFY_TIMESTAMP_ALIGNMENT_BETWEEN_SPEED_AND_ACCELERATION_STREAM"
+        "VERIFY_TIMESTAMP_ALIGNMENT_BETWEEN_SPEED_AND_ACCELERATION_STREAM",
     )
 
     # Passive construction: "komen door" -> "worden veroorzaakt door"

--- a/apps/server/tests/report/test_report_mapping_component_splits.py
+++ b/apps/server/tests/report/test_report_mapping_component_splits.py
@@ -20,7 +20,7 @@ def test_collect_location_intensity_prefers_p95_then_mean() -> None:
         [
             {"location": "Front Left", "p95_intensity_db": 20.0},
             {"location": "Front Left", "mean_intensity_db": 18.0},
-        ]
+        ],
     ) == {"Front Left": [20.0, 18.0]}
 
 

--- a/apps/server/tests/report/test_report_mapping_pipeline.py
+++ b/apps/server/tests/report/test_report_mapping_pipeline.py
@@ -17,7 +17,7 @@ def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> 
             "sensor_locations_connected_throughout": ["rear-right"],
             "speed_stats": {},
             "most_likely_origin": {},
-        }
+        },
     )
 
     assert context.sensor_locations_active == ["rear-right"]
@@ -41,7 +41,7 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
                     "strongest_speed_band": "50-80 km/h",
                     "confidence_0_to_1": 0.71,
                     "evidence_metrics": {"vibration_strength_db": 21.0},
-                }
+                },
             ],
             "top_causes": [
                 {
@@ -50,11 +50,11 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
                     "strongest_location": "front-left",
                     "strongest_speed_band": "50-80 km/h",
                     "confidence": 0.71,
-                }
+                },
             ],
             "speed_stats": {"steady_speed": False},
             "most_likely_origin": {},
-        }
+        },
     )
 
     def tr(key: str, **_kw: object) -> str:

--- a/apps/server/tests/report/test_report_metrics_consistency.py
+++ b/apps/server/tests/report/test_report_metrics_consistency.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Five-scenario report consistency tests.
 
 Each scenario generates analysis output via the builders, builds
@@ -88,7 +87,10 @@ def _build_single_wheel_fault() -> ScenarioPair:
 
 def _build_high_speed_fault() -> ScenarioPair:
     samples = make_noise_samples(
-        sensors=ALL_WHEEL_SENSORS, speed_kmh=40.0, n_samples=15, start_t_s=0.0
+        sensors=ALL_WHEEL_SENSORS,
+        speed_kmh=40.0,
+        n_samples=15,
+        start_t_s=0.0,
     )
     samples += make_fault_samples(
         fault_sensor=SENSOR_FR,
@@ -106,7 +108,11 @@ def _build_mixed_noise_fault() -> ScenarioPair:
     sensors = ALL_WHEEL_SENSORS
     samples = make_idle_samples(sensors=sensors, n_samples=5, start_t_s=0.0)
     samples += make_ramp_samples(
-        sensors=sensors, speed_start=0.0, speed_end=80.0, n_samples=10, start_t_s=5.0
+        sensors=sensors,
+        speed_start=0.0,
+        speed_end=80.0,
+        n_samples=10,
+        start_t_s=5.0,
     )
     samples += make_fault_samples(
         fault_sensor=SENSOR_RL,
@@ -117,13 +123,25 @@ def _build_mixed_noise_fault() -> ScenarioPair:
         fault_amp=0.05,
     )
     samples += make_transient_samples(
-        sensor=SENSOR_FL, speed_kmh=80.0, n_samples=3, start_t_s=45.0, spike_amp=0.12
+        sensor=SENSOR_FL,
+        speed_kmh=80.0,
+        n_samples=3,
+        start_t_s=45.0,
+        spike_amp=0.12,
     )
     samples += make_transient_samples(
-        sensor=SENSOR_RR, speed_kmh=80.0, n_samples=2, start_t_s=48.0, spike_amp=0.10
+        sensor=SENSOR_RR,
+        speed_kmh=80.0,
+        n_samples=2,
+        start_t_s=48.0,
+        spike_amp=0.10,
     )
     samples += make_ramp_samples(
-        sensors=sensors, speed_start=80.0, speed_end=0.0, n_samples=10, start_t_s=50.0
+        sensors=sensors,
+        speed_start=80.0,
+        speed_end=0.0,
+        n_samples=10,
+        start_t_s=50.0,
     )
     summary = run_analysis(samples, standard_metadata())
     return summary, _build_report_data(summary)
@@ -442,7 +460,7 @@ class TestScenario5SparseSensors:
     def test_sensor_count_accurate(self, scenario: ScenarioPair) -> None:
         summary, rd = scenario
         connected = summary.get("sensor_locations_connected_throughout") or summary.get(
-            "sensor_locations"
+            "sensor_locations",
         )
         assert rd.sensor_count == len(connected or [])
 
@@ -469,7 +487,8 @@ class TestAllFiveScenariosPass:
 
     @pytest.fixture(params=sorted(_SCENARIO_BUILDERS), scope="class")
     def named_scenario(
-        self, request: pytest.FixtureRequest
+        self,
+        request: pytest.FixtureRequest,
     ) -> tuple[str, dict, ReportTemplateData]:
         name: str = request.param
         summary, rd = _SCENARIO_BUILDERS[name]()

--- a/apps/server/tests/report/test_report_new_modules_mapping.py
+++ b/apps/server/tests/report/test_report_new_modules_mapping.py
@@ -40,7 +40,7 @@ def test_map_summary_basic(tmp_path: Path) -> None:
         speed = 50 + idx
         wheel_hz = (speed * (1000.0 / 3600.0)) / 2.2
         records.append(
-            _sample(idx, speed_kmh=float(speed), dominant_freq_hz=wheel_hz, peak_amp_g=0.09)
+            _sample(idx, speed_kmh=float(speed), dominant_freq_hz=wheel_hz, peak_amp_g=0.09),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -122,7 +122,10 @@ def test_most_likely_origin_summary_weak_spatial_disambiguates_location() -> Non
     ids=["acceleration_en", "deceleration_nl"],
 )
 def test_most_likely_origin_summary_phase_onset(
-    phase: str, location: str, speed_band: str, confidence: float
+    phase: str,
+    location: str,
+    speed_band: str,
+    confidence: float,
 ) -> None:
     findings = [
         {
@@ -133,7 +136,7 @@ def test_most_likely_origin_summary_phase_onset(
             "strongest_speed_band": speed_band,
             "dominant_phase": phase,
             "confidence_0_to_1": confidence,
-        }
+        },
     ]
 
     origin = summarize_origin(findings)
@@ -159,7 +162,7 @@ def test_most_likely_origin_summary_no_phase_onset_for_cruise() -> None:
             "strongest_speed_band": "80-100 km/h",
             "dominant_phase": "cruise",
             "confidence_0_to_1": 0.80,
-        }
+        },
     ]
 
     origin = summarize_origin(findings)
@@ -175,7 +178,7 @@ def test_most_likely_origin_summary_no_phase_onset_when_absent() -> None:
             "weak_spatial_separation": False,
             "strongest_speed_band": "80-100 km/h",
             "confidence_0_to_1": 0.80,
-        }
+        },
     ]
 
     origin = summarize_origin(findings)
@@ -194,7 +197,7 @@ def test_most_likely_origin_summary_no_phase_onset_when_absent() -> None:
                 "weak_spatial_separation": True,
                 "signatures_observed": ["1x wheel order"],
                 "confidence_tone": "warn",
-            }
+            },
         ],
         most_likely_origin={
             "location": "Rear Left / Front Right",
@@ -222,8 +225,8 @@ def test_map_summary_peak_rows_use_persistence_metrics() -> None:
                     "persistence_score": 0.0867,
                     "peak_classification": "patterned",
                     "typical_speed_band": "60-80 km/h",
-                }
-            ]
+                },
+            ],
         },
     )
     data = map_summary(summary)
@@ -251,8 +254,8 @@ def test_map_summary_peak_rows_render_baseline_noise_label() -> None:
                     "persistence_score": 0.001,
                     "peak_classification": "baseline_noise",
                     "typical_speed_band": "any",
-                }
-            ]
+                },
+            ],
         },
     )
     data = map_summary(summary)
@@ -268,7 +271,7 @@ def test_map_summary_data_trust_keeps_warning_detail() -> None:
                 "check": "SUITABILITY_CHECK_FRAME_INTEGRITY",
                 "state": "warn",
                 "explanation": "3 dropped frames, 2 queue overflows detected.",
-            }
+            },
         ],
     )
     data = map_summary(summary)
@@ -286,7 +289,7 @@ def test_map_summary_data_trust_literal_check_labels() -> None:
                 "check": "Frame integrity",
                 "state": "warn",
                 "explanation": "3 dropped frames, 2 queue overflows detected.",
-            }
+            },
         ],
     )
     data = map_summary(summary)
@@ -303,7 +306,7 @@ def test_map_summary_data_trust_includes_run_context_warnings() -> None:
                 "severity": "warn",
                 "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
                 "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-            }
+            },
         ],
     )
     data = map_summary(summary)
@@ -320,7 +323,7 @@ def test_map_summary_data_trust_check_labels_follow_lang_for_same_summary_data()
                 "check": "SUITABILITY_CHECK_SPEED_VARIATION",
                 "state": "pass",
                 "explanation": "Wide enough speed sweep for order tracking.",
-            }
+            },
         ],
     )
 
@@ -344,7 +347,7 @@ def test_map_summary_certainty_reason_ignores_unrelated_reference_gap() -> None:
                 "strongest_location": "Front Left",
                 "strongest_speed_band": "60-80 km/h",
                 "confidence": 0.82,
-            }
+            },
         ],
         findings=[{"finding_id": "REF_ENGINE"}],
     )
@@ -363,7 +366,7 @@ def test_map_summary_certainty_reason_keeps_relevant_reference_gap() -> None:
                 "strongest_location": "Engine Bay",
                 "strongest_speed_band": "60-80 km/h",
                 "confidence": 0.82,
-            }
+            },
         ],
         findings=[{"finding_id": "REF_ENGINE"}],
     )

--- a/apps/server/tests/report/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/report/test_report_new_modules_pdf_layout.py
@@ -48,7 +48,7 @@ def test_report_pdf_two_pages(tmp_path: Path) -> None:
         speed = 40 + idx
         wheel_hz = (speed * (1000.0 / 3600.0)) / 2.2
         records.append(
-            _sample(idx, speed_kmh=float(speed), dominant_freq_hz=wheel_hz, peak_amp_g=0.09)
+            _sample(idx, speed_kmh=float(speed), dominant_freq_hz=wheel_hz, peak_amp_g=0.09),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)

--- a/apps/server/tests/report/test_report_pdf_ocr_text_fidelity.py
+++ b/apps/server/tests/report/test_report_pdf_ocr_text_fidelity.py
@@ -64,10 +64,10 @@ def _write_sparse_fixture(run_path: Path) -> None:
                     "statistic": "Peak band RMS vs noise floor",
                     "units": "dB",
                     "definition": "20*log10((peak_band_rms + eps) / (floor + eps))",
-                }
+                },
             },
             "incomplete_for_order_analysis": False,
-        }
+        },
     ]
 
     for idx in range(18):
@@ -107,11 +107,11 @@ def _write_sparse_fixture(run_path: Path) -> None:
                         "amp": peak_amp,
                         "vibration_strength_db": db_value,
                         "strength_bucket": "l2" if db_value > 20 else "l1",
-                    }
+                    },
                 ],
                 "vibration_strength_db": db_value,
                 "strength_bucket": "l2" if db_value > 20 else "l1",
-            }
+            },
         )
 
     records.append(
@@ -119,7 +119,7 @@ def _write_sparse_fixture(run_path: Path) -> None:
             "record_type": "run_end",
             "schema_version": "v2-jsonl",
             "run_id": "run-ocr-hotspots",
-        }
+        },
     )
 
     write_jsonl(run_path, records)

--- a/apps/server/tests/report/test_report_pdf_rendering.py
+++ b/apps/server/tests/report/test_report_pdf_rendering.py
@@ -33,7 +33,7 @@ def test_report_pdf_uses_a4_portrait_media_box(tmp_path: Path) -> None:
                 speed_kmh=55.0 + idx,
                 dominant_freq_hz=14.0 + (idx * 0.2),
                 peak_amp_g=0.07 + (idx * 0.0006),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -74,7 +74,7 @@ def test_report_pdf_footer_contains_version_marker(tmp_path: Path, monkeypatch) 
                 speed_kmh=48.0 + idx,
                 dominant_freq_hz=16.0,
                 peak_amp_g=0.05 + (idx * 0.001),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -105,7 +105,7 @@ def test_report_pdf_worksheet_has_single_next_steps_heading(tmp_path: Path) -> N
                 speed_kmh=speed,
                 dominant_freq_hz=wheel_hz,
                 peak_amp_g=0.08 + (idx * 0.0005),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -133,7 +133,7 @@ def test_report_pdf_nl_localizes_header_metadata_labels(tmp_path: Path) -> None:
     text_blob = "\n".join(
         (page.extract_text() or "")
         for page in PdfReader(
-            BytesIO(build_report_pdf(map_summary(summarize_log(run_path, lang="nl"))))
+            BytesIO(build_report_pdf(map_summary(summarize_log(run_path, lang="nl")))),
         ).pages
     )
     assert "Duur:" in text_blob
@@ -149,7 +149,7 @@ def test_report_pdf_header_contains_firmware_version(tmp_path: Path) -> None:
             run_id="run-01",
             raw_sample_rate_hz=800,
             firmware_version="esp-fw-1.2.3",
-        )
+        ),
     ]
     for idx in range(10):
         records.append(
@@ -158,7 +158,7 @@ def test_report_pdf_header_contains_firmware_version(tmp_path: Path) -> None:
                 speed_kmh=50.0 + idx,
                 dominant_freq_hz=15.0,
                 peak_amp_g=0.06 + (idx * 0.0007),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -200,7 +200,7 @@ def test_car_diagram_wheel_labels_stay_within_bounds_without_overlap() -> None:
                 "front-right wheel",
                 "rear-left wheel",
                 "rear-right wheel",
-            ]
+            ],
         },
         [],
         content_width=300.0,

--- a/apps/server/tests/report/test_report_persistence_classification.py
+++ b/apps/server/tests/report/test_report_persistence_classification.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 import pytest

--- a/apps/server/tests/report/test_report_persistence_findings.py
+++ b/apps/server/tests/report/test_report_persistence_findings.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 from _report_persistence_helpers import (
@@ -43,7 +42,7 @@ class TestBuildPersistentPeakFindings:
         for i in range(20):
             peaks = [{"hz": 40.0, "amp": 0.06}] if i < 16 else []
             samples.append(
-                sample(float(i) * 0.5, 80.0, peaks, client_name=locations[i % len(locations)])
+                sample(float(i) * 0.5, 80.0, peaks, client_name=locations[i % len(locations)]),
             )
 
         findings = build_findings(samples)
@@ -143,7 +142,7 @@ class TestBuildPersistentPeakFindings:
                         amp = 0.20 if (speed, location) == (35.0, "Front Left") else 0.05
                         peaks.append({"hz": 25.0, "amp": amp})
                     samples.append(
-                        sample(float(len(samples)) * 0.5, speed, peaks, client_name=location)
+                        sample(float(len(samples)) * 0.5, speed, peaks, client_name=location),
                     )
 
         findings = build_findings(samples)
@@ -152,7 +151,8 @@ class TestBuildPersistentPeakFindings:
 
         rows = _top_peaks_table_rows(samples, top_n=12, freq_bin_hz=1.0)
         row_25 = next(
-            (row for row in rows if abs(float(row.get("frequency_hz", 0.0)) - 25.0) <= 0.5), None
+            (row for row in rows if abs(float(row.get("frequency_hz", 0.0)) - 25.0) <= 0.5),
+            None,
         )
         assert row_25 is not None
         assert row_25["peak_classification"] == "baseline_noise"
@@ -169,7 +169,7 @@ class TestBuildPersistentPeakFindings:
                         amp = 0.20 if (speed, rep) == (35.0, 0) else 0.05
                         peaks.append({"hz": 25.0, "amp": amp})
                     samples.append(
-                        sample(float(len(samples)) * 0.5, speed, peaks, client_name=location)
+                        sample(float(len(samples)) * 0.5, speed, peaks, client_name=location),
                     )
 
         findings = build_findings(samples)
@@ -231,7 +231,8 @@ class TestPersistentPeakFindingsPhaseAwareness:
             phases.append(DrivingPhase.DECELERATION)
 
         phase_presence = next(
-            iter(findings_at_freq(build_findings(samples, per_sample_phases=phases), "35.0")), None
+            iter(findings_at_freq(build_findings(samples, per_sample_phases=phases), "35.0")),
+            None,
         ).get("phase_presence")
         assert "cruise" in phase_presence
         assert "acceleration" in phase_presence
@@ -253,7 +254,9 @@ class TestPersistentPeakFindingsPhaseAwareness:
 
     def test_phase_presence_via_build_findings_integration(self) -> None:
         findings = build_findings_for_samples(
-            metadata=make_metadata(), samples=uniform_samples(25, 40.0, 0.06), lang="en"
+            metadata=make_metadata(),
+            samples=uniform_samples(25, 40.0, 0.06),
+            lang="en",
         )
         phase_presence = findings_at_freq(findings, "41")[0].get("phase_presence")
         assert isinstance(phase_presence, dict)
@@ -261,7 +264,8 @@ class TestPersistentPeakFindingsPhaseAwareness:
 
     def test_phase_presence_ignored_when_length_mismatch(self) -> None:
         findings = build_findings(
-            uniform_samples(10, 40.0, 0.06), per_sample_phases=[DrivingPhase.CRUISE] * 5
+            uniform_samples(10, 40.0, 0.06),
+            per_sample_phases=[DrivingPhase.CRUISE] * 5,
         )
         for finding in findings:
             assert finding.get("phase_presence") is None
@@ -279,13 +283,13 @@ class TestAnnotatePeaksWithOrderLabels:
                         {"matched_hz": 11.0},
                         {"matched_hz": 11.2},
                     ],
-                }
+                },
             ],
             "plots": {
                 "peaks_table": [
                     {"frequency_hz": 11.0, "order_label": ""},
                     {"frequency_hz": 25.0, "order_label": ""},
-                ]
+                ],
             },
         }
         annotate_peaks_with_order_labels(summary)
@@ -299,7 +303,7 @@ class TestAnnotatePeaksWithOrderLabels:
                     "finding_id": "F_ORDER",
                     "frequency_hz_or_order": "1x wheel order",
                     "matched_points": [{"matched_hz": 50.0}],
-                }
+                },
             ],
             "plots": {"peaks_table": [{"frequency_hz": 11.0, "order_label": ""}]},
         }
@@ -324,7 +328,7 @@ class TestAnnotatePeaksWithOrderLabels:
                     "finding_id": "F_PEAK",
                     "frequency_hz_or_order": "41.0 Hz",
                     "matched_points": [{"matched_hz": 41.0}],
-                }
+                },
             ],
             "plots": {"peaks_table": [{"frequency_hz": 41.0, "order_label": ""}]},
         }
@@ -350,7 +354,7 @@ class TestAnnotatePeaksWithOrderLabels:
                     {"frequency_hz": 11.0, "order_label": ""},
                     {"frequency_hz": 25.0, "order_label": ""},
                     {"frequency_hz": 60.0, "order_label": ""},
-                ]
+                ],
             },
         }
         annotate_peaks_with_order_labels(summary)
@@ -363,8 +367,8 @@ class TestAnnotatePeaksWithOrderLabels:
             "findings": [],
             "plots": {
                 "peaks_table": [
-                    {"frequency_hz": 11.0, "order_label": "", "peak_classification": "patterned"}
-                ]
+                    {"frequency_hz": 11.0, "order_label": "", "peak_classification": "patterned"},
+                ],
             },
         }
         annotate_peaks_with_order_labels(summary)

--- a/apps/server/tests/report/test_report_persistence_summary.py
+++ b/apps/server/tests/report/test_report_persistence_summary.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from __future__ import annotations
 
 from _report_persistence_helpers import make_metadata, sample, summarize, uniform_samples
@@ -53,7 +52,7 @@ class TestSummarizeRunDataPersistence:
     def test_summary_includes_run_noise_baseline(self) -> None:
         assert (
             summarize(uniform_samples(10, 20.0, 0.04, strength_floor_amp_g=0.02)).get(
-                "run_noise_baseline_db"
+                "run_noise_baseline_db",
             )
             is not None
         )
@@ -147,6 +146,8 @@ class TestRobustness:
 
     def test_build_findings_for_samples_works(self) -> None:
         findings = build_findings_for_samples(
-            metadata=make_metadata(), samples=uniform_samples(15, 15.0, 0.02), lang="en"
+            metadata=make_metadata(),
+            samples=uniform_samples(15, 15.0, 0.02),
+            lang="en",
         )
         assert isinstance(findings, list)

--- a/apps/server/tests/report/test_report_scenario_output_regression.py
+++ b/apps/server/tests/report/test_report_scenario_output_regression.py
@@ -42,7 +42,7 @@ class TestMultiSensorLocalization:
                     client_id="sensor-A",
                     top_peaks=[{"hz": wheel_hz, "amp": 0.06}],
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
             samples.append(
                 make_sample(
@@ -53,7 +53,7 @@ class TestMultiSensorLocalization:
                     client_id="sensor-B",
                     top_peaks=[{"hz": wheel_hz, "amp": 0.02}],
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
 
         summary = summarize_run_data(standard_metadata(), samples, include_samples=False)

--- a/apps/server/tests/report/test_report_scenario_phase_regression.py
+++ b/apps/server/tests/report/test_report_scenario_phase_regression.py
@@ -45,7 +45,7 @@ class TestPhaseSegmentation:
                 (5, 30.0, 50.0),
                 (3, 0.0, 0.0),
                 (5, 30.0, 50.0),
-            ]
+            ],
         )
         per_sample, _segments = segment_run_phases(samples)
         idle_count = sum(1 for phase in per_sample if phase == DrivingPhase.IDLE)
@@ -156,7 +156,7 @@ class TestSensorIntensityPhaseContext:
                     "speed_kmh": 0.0,
                     "vibration_strength_db": 4.0,
                     "location_key": "front-left",
-                }
+                },
             )
         for idx in range(5, 15):
             samples.append(
@@ -165,7 +165,7 @@ class TestSensorIntensityPhaseContext:
                     "speed_kmh": 60.0,
                     "vibration_strength_db": 22.0,
                     "location_key": "front-left",
-                }
+                },
             )
 
         per_sample_phases, _ = segment_run_phases(samples)
@@ -181,7 +181,7 @@ class TestSensorIntensityPhaseContext:
 
     def test_phase_intensity_absent_without_phases(self) -> None:
         rows = _sensor_intensity_by_location(
-            [{"t_s": 0.0, "speed_kmh": 60.0, "vibration_strength_db": 22.0, "location_key": "fl"}]
+            [{"t_s": 0.0, "speed_kmh": 60.0, "vibration_strength_db": 22.0, "location_key": "fl"}],
         )
         for row in rows:
             assert row.get("phase_intensity") is None

--- a/apps/server/tests/report/test_report_strength_label_peak_amp.py
+++ b/apps/server/tests/report/test_report_strength_label_peak_amp.py
@@ -36,7 +36,7 @@ def test_map_summary_strength_label_includes_peak_amp_when_available() -> None:
             {
                 "finding_id": "F_ORDER",
                 "amplitude_metric": {"value": 0.032, "units": "g"},
-            }
+            },
         ],
         sensor_intensity_by_location=[{"p95_intensity_db": 22.0}],
     )
@@ -79,7 +79,7 @@ def test_map_summary_strength_label_uses_finding_db_when_sensor_rows_missing() -
                 "finding_id": "F_ORDER",
                 "amplitude_metric": {"value": 0.015, "units": "g"},
                 "evidence_metrics": {"vibration_strength_db": 23.4},
-            }
+            },
         ],
     )
     data = map_summary(summary)

--- a/apps/server/tests/report/test_report_summary_basics.py
+++ b/apps/server/tests/report/test_report_summary_basics.py
@@ -24,7 +24,7 @@ def test_complete_run_has_speed_bins_findings_and_plots(tmp_path: Path) -> None:
             run_id="run-01",
             raw_sample_rate_hz=800,
             tire_circumference_m=circumference_m,
-        )
+        ),
     ]
     for idx in range(30):
         speed = 40 + idx
@@ -35,7 +35,7 @@ def test_complete_run_has_speed_bins_findings_and_plots(tmp_path: Path) -> None:
                 speed_kmh=float(speed),
                 dominant_freq_hz=wheel_hz,
                 peak_amp_g=0.09 + (idx * 0.001),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -162,7 +162,7 @@ def test_missing_raw_sample_rate_adds_reference_finding(tmp_path: Path) -> None:
                 speed_kmh=float(60 + idx),
                 dominant_freq_hz=20.0,
                 peak_amp_g=0.06 + (idx * 0.0005),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -198,7 +198,7 @@ def test_derive_references_from_vehicle_parameters(tmp_path: Path) -> None:
             rim_in=21,
             final_drive_ratio=3.08,
             current_gear_ratio=0.64,
-        )
+        ),
     ]
     for idx in range(28):
         records.append(
@@ -207,7 +207,7 @@ def test_derive_references_from_vehicle_parameters(tmp_path: Path) -> None:
                 speed_kmh=float(45 + idx),
                 dominant_freq_hz=6.5 + (idx * 0.05),
                 peak_amp_g=0.08 + (idx * 0.0008),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -224,7 +224,7 @@ def test_metadata_accel_scale_and_units_are_exposed(tmp_path: Path) -> None:
             raw_sample_rate_hz=800,
             tire_circumference_m=2.2,
             accel_scale_g_per_lsb=1.0 / 256.0,
-        )
+        ),
     ]
     for idx in range(10):
         speed = 50 + idx
@@ -235,7 +235,7 @@ def test_metadata_accel_scale_and_units_are_exposed(tmp_path: Path) -> None:
                 speed_kmh=float(speed),
                 dominant_freq_hz=wheel_hz,
                 peak_amp_g=0.08 + (idx * 0.0006),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)
@@ -255,7 +255,7 @@ def test_steady_speed_report_wording(tmp_path: Path) -> None:
                 speed_kmh=100.0 + ((idx % 3) * 0.4),
                 dominant_freq_hz=22.0 + (idx * 0.02),
                 peak_amp_g=0.08 + (idx * 0.0003),
-            )
+            ),
         )
     records.append(RUN_END)
     write_jsonl(run_path, records)

--- a/apps/server/tests/test_support/assertions.py
+++ b/apps/server/tests/test_support/assertions.py
@@ -53,7 +53,8 @@ def _top_cause_or_fail(summary: dict[str, Any], msg: str = "") -> dict[str, Any]
 
 
 def _iter_causes_at_or_above(
-    summary: dict[str, Any], confidence_threshold: float
+    summary: dict[str, Any],
+    confidence_threshold: float,
 ) -> Iterator[tuple[dict[str, Any], float]]:
     for cause in _top_causes(summary):
         confidence = _cause_confidence(cause)
@@ -133,7 +134,7 @@ def assert_tolerant_no_fault(summary: dict[str, Any], msg: str = "") -> None:
         if "wheel" in src:
             loc = c.get("strongest_location") or ""
             raise AssertionError(
-                f"Tolerant no-fault violated: {src} @ {loc} conf={conf:.2f}. {msg}"
+                f"Tolerant no-fault violated: {src} @ {loc} conf={conf:.2f}. {msg}",
             )
 
 
@@ -264,7 +265,7 @@ def assert_forbidden_systems(
                 loc = c.get("strongest_location") or ""
                 raise AssertionError(
                     f"Forbidden system '{keyword}' found: {src} @ {loc} "
-                    f"conf={conf:.3f} (threshold={confidence_threshold}). {msg}"
+                    f"conf={conf:.3f} (threshold={confidence_threshold}). {msg}",
                 )
 
 
@@ -286,7 +287,7 @@ def assert_only_allowed_systems(
             loc = c.get("strongest_location") or ""
             raise AssertionError(
                 f"Unexpected system '{src}' @ {loc} conf={conf:.3f} "
-                f"(allowed={allowed}, threshold={confidence_threshold}). {msg}"
+                f"(allowed={allowed}, threshold={confidence_threshold}). {msg}",
             )
 
 
@@ -305,7 +306,7 @@ def assert_no_persistent_fault(
         loc = c.get("strongest_location") or ""
         raise AssertionError(
             f"Unexpected persistent fault: {src} @ {loc} "
-            f"conf={conf:.3f} (threshold={confidence_threshold}). {msg}"
+            f"conf={conf:.3f} (threshold={confidence_threshold}). {msg}",
         )
 
 
@@ -326,7 +327,7 @@ def assert_no_localized_wheel(
             loc = c.get("strongest_location") or ""
             if loc:  # has a location → localized → false positive
                 raise AssertionError(
-                    f"Wheel/tire falsely localized to '{loc}' conf={conf:.3f}. {msg}"
+                    f"Wheel/tire falsely localized to '{loc}' conf={conf:.3f}. {msg}",
                 )
 
 
@@ -369,7 +370,7 @@ def assert_no_exact_corner_claim(
                 src = _cause_source(c)
                 raise AssertionError(
                     f"Exact corner claim '{loc}' from {src} conf={conf:.3f} "
-                    f"(threshold={confidence_threshold}). {msg}"
+                    f"(threshold={confidence_threshold}). {msg}",
                 )
 
 
@@ -420,5 +421,5 @@ def assert_max_wheel_confidence(
             loc = c.get("strongest_location") or ""
             raise AssertionError(
                 f"Wheel/tire confidence {conf:.3f} exceeds max {max_confidence:.2f} "
-                f"at '{loc}'. {msg}"
+                f"at '{loc}'. {msg}",
             )

--- a/apps/server/tests/test_support/core.py
+++ b/apps/server/tests/test_support/core.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Core metadata, vehicle-profile, and frequency helpers for tests."""
 
 from __future__ import annotations
@@ -219,7 +218,7 @@ def _profile_metadata_base(
             ),
             final_drive_ratio=final_drive_ratio,
             current_gear_ratio=current_gear_ratio,
-        ).items()
+        ).items(),
     )
 
 
@@ -233,7 +232,7 @@ def profile_metadata(profile: dict[str, Any], **overrides: Any) -> dict[str, Any
             profile.get("tire_deflection_factor"),
             profile["final_drive_ratio"],
             profile["current_gear_ratio"],
-        )
+        ),
     )
     meta.update(overrides)
     return meta
@@ -283,7 +282,9 @@ def wheel_hz(speed_kmh: float) -> float:
 
 
 def engine_hz(
-    speed_kmh: float, gear_ratio: float = GEAR_RATIO, final_drive: float = FINAL_DRIVE
+    speed_kmh: float,
+    gear_ratio: float = GEAR_RATIO,
+    final_drive: float = FINAL_DRIVE,
 ) -> float:
     """Rough engine-1x Hz from speed (2-stroke assumption for simplicity)."""
     whz = wheel_hz(speed_kmh)

--- a/apps/server/tests/test_support/fault_scenarios.py
+++ b/apps/server/tests/test_support/fault_scenarios.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Fault-oriented synthetic scenario builders for tests."""
 
 from __future__ import annotations
@@ -53,7 +52,7 @@ def make_fault_samples(
                         top_peaks=peaks,
                         vibration_strength_db=fault_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
             else:
                 transfer = _fault_transfer_fraction(
@@ -80,7 +79,7 @@ def make_fault_samples(
                         top_peaks=other_peaks,
                         vibration_strength_db=noise_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
     return samples
 
@@ -192,7 +191,7 @@ def make_engine_order_samples(
                     vibration_strength_db=engine_vib_db,
                     strength_floor_amp_g=noise_amp,
                     engine_rpm=ehz * 60.0,
-                )
+                ),
             )
     return samples
 
@@ -242,7 +241,7 @@ def make_dual_fault_samples(
                         top_peaks=peaks,
                         vibration_strength_db=fault_vib_db_1,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
             elif sensor == fault_sensor_2:
                 transfer_1 = _fault_transfer_fraction(
@@ -265,7 +264,7 @@ def make_dual_fault_samples(
                         top_peaks=peaks,
                         vibration_strength_db=fault_vib_db_2,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
             else:
                 transfer_1 = _fault_transfer_fraction(
@@ -294,7 +293,7 @@ def make_dual_fault_samples(
                         top_peaks=peaks,
                         vibration_strength_db=noise_vib_db,
                         strength_floor_amp_g=noise_amp,
-                    )
+                    ),
                 )
     return samples
 
@@ -332,7 +331,7 @@ def make_speed_sweep_fault_samples(
                 noise_amp=noise_amp,
                 fault_vib_db=fault_vib_db,
                 noise_vib_db=noise_vib_db,
-            )
+            ),
         )
         t += samples_per_step * dt_s
     return samples
@@ -439,7 +438,7 @@ def make_profile_speed_sweep_fault_samples(
                 noise_amp=noise_amp,
                 fault_vib_db=fault_vib_db,
                 noise_vib_db=noise_vib_db,
-            )
+            ),
         )
         t += samples_per_step * dt_s
     return samples

--- a/apps/server/tests/test_support/perturbation_scenarios.py
+++ b/apps/server/tests/test_support/perturbation_scenarios.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Perturbation and transport-noise scenario builders for tests."""
 
 from __future__ import annotations
@@ -89,7 +88,7 @@ def make_speed_jitter_samples(
                     top_peaks=peaks,
                     vibration_strength_db=vib_db,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 

--- a/apps/server/tests/test_support/sample_scenarios.py
+++ b/apps/server/tests/test_support/sample_scenarios.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Baseline sample and non-fault scenario builders for tests."""
 
 from __future__ import annotations
@@ -83,7 +82,7 @@ def make_noise_samples(
                     top_peaks=peaks,
                     vibration_strength_db=vib_db,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 
@@ -115,7 +114,7 @@ def make_transient_samples(
                 top_peaks=peaks,
                 vibration_strength_db=spike_vib_db,
                 strength_floor_amp_g=0.003,
-            )
+            ),
         )
     return samples
 
@@ -149,7 +148,7 @@ def make_diffuse_samples(
                     top_peaks=peaks,
                     vibration_strength_db=vib_db,
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
     return samples
 
@@ -179,7 +178,7 @@ def make_idle_samples(
                     top_peaks=peaks,
                     vibration_strength_db=6.0,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 
@@ -214,7 +213,7 @@ def make_ramp_samples(
                     top_peaks=peaks,
                     vibration_strength_db=vib_db,
                     strength_floor_amp_g=noise_amp,
-                )
+                ),
             )
     return samples
 
@@ -250,7 +249,7 @@ def make_road_phase_samples(
                     top_peaks=peaks,
                     vibration_strength_db=8.0,
                     strength_floor_amp_g=smooth_amp,
-                )
+                ),
             )
         t += dt_s
 
@@ -270,7 +269,7 @@ def make_road_phase_samples(
                     top_peaks=peaks,
                     vibration_strength_db=18.0,
                     strength_floor_amp_g=rough_amp,
-                )
+                ),
             )
         t += dt_s
 
@@ -289,7 +288,7 @@ def make_road_phase_samples(
                     top_peaks=peaks,
                     vibration_strength_db=35.0,
                     strength_floor_amp_g=0.003,
-                )
+                ),
             )
         t += dt_s
 

--- a/apps/server/tests/update/_update_manager_test_helpers.py
+++ b/apps/server/tests/update/_update_manager_test_helpers.py
@@ -76,7 +76,7 @@ def seed_runtime_artifacts(repo: Path, mgr: UpdateManager, *, valid: bool = True
     (repo / "apps" / "ui" / "package.json").write_text('{"name":"ui"}\n')
     (repo / "apps" / "ui" / "package-lock.json").write_text('{"name":"ui","lockfileVersion":3}\n')
     (repo / "apps" / "server" / "vibesensor" / "static" / "index.html").write_text(
-        "<html>ok</html>\n"
+        "<html>ok</html>\n",
     )
     details = mgr._collect_runtime_details()
     metadata = {
@@ -85,7 +85,8 @@ def seed_runtime_artifacts(repo: Path, mgr: UpdateManager, *, valid: bool = True
         "git_commit": "deadbeef",
     }
     (repo / "apps" / "server" / "vibesensor" / "static" / ".vibesensor-ui-build.json").write_text(
-        json.dumps(metadata), encoding="utf-8"
+        json.dumps(metadata),
+        encoding="utf-8",
     )
 
 

--- a/apps/server/tests/update/test_esp_flash_manager.py
+++ b/apps/server/tests/update/test_esp_flash_manager.py
@@ -111,7 +111,7 @@ def _make_bundle(bundle_dir: Path) -> None:
                         "sha256": bins["partitions.bin"],
                     },
                 ],
-            }
+            },
         ],
     }
     (bundle_dir / "flash.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
@@ -131,7 +131,8 @@ def _make_cache(tmp_path: Path, *, with_current: bool = False, with_baseline: bo
             "source": "downloaded",
         }
         (cache_dir / "current" / "_meta.json").write_text(
-            json.dumps(meta, indent=2), encoding="utf-8"
+            json.dumps(meta, indent=2),
+            encoding="utf-8",
         )
     if with_baseline:
         _make_bundle(cache_dir / "baseline")
@@ -143,7 +144,8 @@ def _make_cache(tmp_path: Path, *, with_current: bool = False, with_baseline: bo
             "source": "baseline",
         }
         (cache_dir / "baseline" / "_meta.json").write_text(
-            json.dumps(meta, indent=2), encoding="utf-8"
+            json.dumps(meta, indent=2),
+            encoding="utf-8",
         )
     return cache_dir
 
@@ -279,7 +281,7 @@ async def test_port_discovery_returns_metadata(tmp_path: Path) -> None:
             "vid": 6790,
             "pid": 29987,
             "serial_number": "abc",
-        }
+        },
     ]
 
 

--- a/apps/server/tests/update/test_firmware_cache.py
+++ b/apps/server/tests/update/test_firmware_cache.py
@@ -53,7 +53,7 @@ def _make_zip(entries: dict[str, str | bytes]) -> io.BytesIO:
                     "draft": False,
                     "prerelease": False,
                     "assets": [
-                        {"name": "vibesensor-fw-v2026.2.27.zip", "url": "https://api.github.com/b"}
+                        {"name": "vibesensor-fw-v2026.2.27.zip", "url": "https://api.github.com/b"},
                     ],
                 },
             ],
@@ -86,7 +86,7 @@ def _make_zip(entries: dict[str, str | bytes]) -> io.BytesIO:
                         {
                             "name": "vibesensor-fw-v2026.2.28-rc1.zip",
                             "url": "https://api.github.com/c",
-                        }
+                        },
                     ],
                 },
             ],
@@ -114,9 +114,12 @@ def test_find_release_raises_when_no_firmware_assets() -> None:
             "draft": False,
             "prerelease": False,
             "assets": [
-                {"name": "vibesensor-2026.2.27-py3-none-any.whl", "url": "https://api.github.com/a"}
+                {
+                    "name": "vibesensor-2026.2.27-py3-none-any.whl",
+                    "url": "https://api.github.com/a",
+                },
             ],
-        }
+        },
     ]
 
     fetcher._api_get = lambda _url: releases  # type: ignore[method-assign]

--- a/apps/server/tests/update/test_release_fetcher.py
+++ b/apps/server/tests/update/test_release_fetcher.py
@@ -168,7 +168,7 @@ class TestServerReleaseFetcher:
                         "draft": False,
                         "prerelease": False,
                         "assets": [{"name": "vibesensor-fw-v2025.6.15.zip", "url": "https://a"}],
-                    }
+                    },
                 ],
                 id="firmware-only-tags",
             ),

--- a/apps/server/tests/update/test_update_installer_verification.py
+++ b/apps/server/tests/update/test_update_installer_verification.py
@@ -119,7 +119,7 @@ async def test_snapshot_for_rollback_fails_when_metadata_write_fails(tmp_path: P
 
     assert not (rollback_dir / "rollback_snapshot.json").exists()
     assert any(
-        "Rollback metadata could not be written" == issue.message for issue in tracker.status.issues
+        issue.message == "Rollback metadata could not be written" for issue in tracker.status.issues
     )
 
 
@@ -132,7 +132,7 @@ async def test_install_release_rejects_corrupt_downloaded_wheel(tmp_path: Path) 
     assert await installer.install_release(broken_wheel, "2025.6.15") is False
     assert tracker.status.state.value == "failed"
     assert not commands.calls
-    assert any("Downloaded wheel is corrupt" == issue.message for issue in tracker.status.issues)
+    assert any(issue.message == "Downloaded wheel is corrupt" for issue in tracker.status.issues)
 
 
 @pytest.mark.asyncio
@@ -148,7 +148,7 @@ async def test_rollback_rejects_checksum_mismatch(tmp_path: Path) -> None:
                 "version": "2025.6.14",
                 "wheel_name": wheel_path.name,
                 "sha256": "0" * 64,
-            }
+            },
         )
         + "\n",
         encoding="utf-8",
@@ -157,7 +157,7 @@ async def test_rollback_rejects_checksum_mismatch(tmp_path: Path) -> None:
     assert await installer.rollback() is False
     assert not commands.calls
     assert any(
-        "Rollback wheel checksum mismatch" == issue.message for issue in tracker.status.issues
+        issue.message == "Rollback wheel checksum mismatch" for issue in tracker.status.issues
     )
 
 

--- a/apps/server/tests/update/test_update_manager_api.py
+++ b/apps/server/tests/update/test_update_manager_api.py
@@ -15,7 +15,7 @@ class TestUpdateApiEndpoints:
         state = MagicMock()
         state.ingress = MagicMock()
         state.settings = MagicMock()
-        state.diagnostics = MagicMock()
+        state.recording = MagicMock()
         state.persistence = MagicMock()
         state.websocket = MagicMock()
         state.processing = MagicMock()

--- a/apps/server/tests/update/test_update_manager_async.py
+++ b/apps/server/tests/update/test_update_manager_async.py
@@ -258,7 +258,7 @@ class TestUpdateManagerAsync:
             for call in runner.calls
         )
         assert any(
-            "Could not verify free disk space" == issue.message for issue in manager.status.issues
+            issue.message == "Could not verify free disk space" for issue in manager.status.issues
         )
 
     async def test_sha256_mismatch_aborts_install(self, tmp_path) -> None:
@@ -324,7 +324,7 @@ class TestUpdateManagerAsync:
         manager, _runner, _ = setup_update_env(tmp_path)
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:
             mock_fetcher.return_value.check_update_available.side_effect = RuntimeError(
-                "API rate limit exceeded"
+                "API rate limit exceeded",
             )
             await run_update(manager, "TestNet", "pass")
         assert manager.status.state == UpdateState.failed

--- a/apps/server/tests/update/test_update_manager_models.py
+++ b/apps/server/tests/update/test_update_manager_models.py
@@ -115,7 +115,7 @@ class TestParseWifiDiagnostics:
         log_dir = tmp_path / "wifi"
         log_dir.mkdir()
         (log_dir / "hotspot.log").write_text(
-            "2024-01-01 INFO normaline\n2024-01-01 ERROR something failed\n2024-01-01 INFO ok\n"
+            "2024-01-01 INFO normaline\n2024-01-01 ERROR something failed\n2024-01-01 INFO ok\n",
         )
         issues = parse_wifi_diagnostics(str(log_dir))
         assert any(

--- a/apps/server/tests/update/test_update_models_roundtrip.py
+++ b/apps/server/tests/update/test_update_models_roundtrip.py
@@ -79,7 +79,7 @@ class TestUpdateJobStatusRoundTrip:
                 "issues": ["bad", {"phase": "downloading", "message": "warn", "detail": 99}],
                 "log_tail": ["ok", 7, None],
                 "runtime": ["not-a-dict"],
-            }
+            },
         )
 
         assert status.runtime == {}

--- a/apps/server/tests/update/test_update_state_persistence.py
+++ b/apps/server/tests/update/test_update_state_persistence.py
@@ -175,7 +175,9 @@ class TestUpdateStateStore:
         ],
     )
     def test_load_returns_none_for_bad_input(
-        self, tmp_path: Path, file_content: str | None
+        self,
+        tmp_path: Path,
+        file_content: str | None,
     ) -> None:
         path = tmp_path / "state.json"
         if file_content is not None:
@@ -252,7 +254,7 @@ class TestStartupRecovery:
                 started_at=time.time() - 60,
                 ssid="CrashNet",
                 log_tail=["some log"],
-            )
+            ),
         )
         mgr = make_mgr()
 
@@ -288,7 +290,7 @@ class TestStartupRecovery:
                 phase=UpdatePhase.done,
                 started_at=time.time() - 60,
                 finished_at=time.time() - 30,
-            )
+            ),
         )
         mgr = make_mgr()
 
@@ -304,7 +306,7 @@ class TestStartupRecovery:
                 state=UpdateState.running,
                 phase=UpdatePhase.connecting_wifi,
                 started_at=time.time() - 60,
-            )
+            ),
         )
         mgr = make_mgr()
 
@@ -323,7 +325,7 @@ class TestStartupRecovery:
                 state=UpdateState.running,
                 phase=UpdatePhase.downloading,
                 started_at=time.time() - 60,
-            )
+            ),
         )
         runner.default_response = (1, "", "nmcli not found")
         mgr = make_mgr()
@@ -381,8 +383,8 @@ class TestPersistenceDuringLifecycle:
                     phase="diagnostics",
                     message="Wi-Fi warning",
                     detail="dns probe failed once",
-                )
-            ]
+                ),
+            ],
         )
 
         loaded = store.load()
@@ -441,7 +443,7 @@ class TestPersistenceDuringLifecycle:
                 last_success_at=1700000120.0,
                 ssid="DoneNet",
                 exit_code=0,
-            )
+            ),
         )
         mgr = make_mgr()
 

--- a/apps/server/tests/update/test_update_validation.py
+++ b/apps/server/tests/update/test_update_validation.py
@@ -44,5 +44,5 @@ async def test_validation_fails_when_rollback_dir_probe_fails(monkeypatch, tmp_p
     assert result is False
     assert tracker.status.state.value == "failed"
     assert any(
-        "Rollback directory is not writable" == issue.message for issue in tracker.status.issues
+        issue.message == "Rollback directory is not writable" for issue in tracker.status.issues
     )

--- a/apps/server/tests/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/websocket/test_build_ws_payload.py
@@ -150,11 +150,11 @@ def _make_state(
         analysis_settings=_StubAnalysisSettings(),  # type: ignore[arg-type]
         gps_monitor=_StubGPS(),  # type: ignore[arg-type]
     )
-    diagnostics = runtime_module.RuntimeDiagnosticsSubsystem(
+    diagnostics = runtime_module.RuntimeRecordingSubsystem(
         metrics_logger=_StubMetricsLogger(),  # type: ignore[arg-type]
     )
     persistence = runtime_module.RuntimePersistenceSubsystem(  # type: ignore[arg-type]
-        history_db=_SENTINEL
+        history_db=_SENTINEL,
     )
     updates = runtime_module.RuntimeUpdateSubsystem(
         update_manager=_SENTINEL,  # type: ignore[arg-type]
@@ -191,11 +191,11 @@ def _make_state(
             processing=_StubProcessingConfig(
                 ui_push_hz=ui_push_hz,
                 ui_heavy_push_hz=ui_heavy_push_hz,
-            )
+            ),
         ),  # type: ignore[arg-type]
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=diagnostics,
         persistence=persistence,
         updates=updates,
         processing=processing,
@@ -203,7 +203,7 @@ def _make_state(
         routes=runtime_module.RuntimeRouteServices(
             ingress=ingress,
             settings=settings,
-            diagnostics=diagnostics,
+            recording=diagnostics,
             persistence=persistence,
             updates=updates,
             processing=processing,

--- a/apps/server/tests/websocket/test_ws_hub.py
+++ b/apps/server/tests/websocket/test_ws_hub.py
@@ -152,7 +152,8 @@ async def test_broadcast_builds_payload_once_per_unique_selection() -> None:
 @pytest.mark.asyncio
 async def test_payload_error_does_not_block_other_clients() -> None:
     """A payload build failure for one client_id must not prevent other clients
-    from receiving their data."""
+    from receiving their data.
+    """
     hub = WebSocketHub()
     good_ws = _make_ws()
     bad_ws = _make_ws()
@@ -200,7 +201,8 @@ async def test_payload_error_logged_at_error_level(caplog) -> None:
 @pytest.mark.asyncio
 async def test_payload_error_affected_count_logged(caplog) -> None:
     """When multiple connections share a failing client_id the summary log
-    reports the total affected count."""
+    reports the total affected count.
+    """
     hub = WebSocketHub()
     ws1 = _make_ws()
     ws2 = _make_ws()
@@ -231,7 +233,8 @@ async def test_payload_error_affected_count_logged(caplog) -> None:
 @pytest.mark.asyncio
 async def test_error_payload_is_cached_per_client_id() -> None:
     """The error payload should be cached so payload_builder is called only
-    once per unique client_id, even on failure."""
+    once per unique client_id, even on failure.
+    """
     hub = WebSocketHub()
     ws1 = _make_ws()
     ws2 = _make_ws()

--- a/apps/server/tests/websocket/test_ws_models.py
+++ b/apps/server/tests/websocket/test_ws_models.py
@@ -85,7 +85,7 @@ class TestLiveWsPayloadModel:
                     "aaa": SpectrumSeries(
                         combined_spectrum_amp_g=[0.01, 0.02, 0.03],
                         strength_metrics={"vibration_strength_db": 5.0},
-                    )
+                    ),
                 },
             ),
         )
@@ -182,7 +182,7 @@ class TestMultiSpectrumFreqDedup:
             {
                 "aaa": {"freq": freq, "amp": amp},
                 "bbb": {"freq": freq, "amp": amp},
-            }
+            },
         )
         result = proc.multi_spectrum_payload(["aaa", "bbb"])
         assert result["freq"] == pytest.approx(freq, abs=1e-4)
@@ -198,7 +198,7 @@ class TestMultiSpectrumFreqDedup:
             {
                 "aaa": {"freq": [10.0, 20.0, 30.0], "amp": [0.01, 0.02, 0.03]},
                 "bbb": {"freq": [15.0, 25.0, 35.0], "amp": [0.01, 0.02, 0.03]},
-            }
+            },
         )
         result = proc.multi_spectrum_payload(["aaa", "bbb"])
         # Shared freq should be empty on mismatch
@@ -216,7 +216,7 @@ class TestMultiSpectrumFreqDedup:
         proc = self._make_processor_with_clients(
             {
                 "aaa": {"freq": [10.0, 20.0], "amp": [0.01, 0.02]},
-            }
+            },
         )
         result = proc.multi_spectrum_payload(["aaa"])
         assert result["freq"] == pytest.approx([10.0, 20.0], abs=1e-4)
@@ -238,7 +238,7 @@ class TestMultiSpectrumFreqDedup:
                 "aaa": {"freq": freq, "amp": amp},
                 "bbb": {"freq": freq, "amp": amp},
                 "ccc": {"freq": freq, "amp": amp},
-            }
+            },
         )
         result = proc.multi_spectrum_payload(["aaa", "bbb", "ccc"])
         serialized = json.dumps(result)

--- a/apps/server/vibesensor/analysis/diagnosis_candidates.py
+++ b/apps/server/vibesensor/analysis/diagnosis_candidates.py
@@ -43,7 +43,7 @@ def is_actionable_cause(cause: TopCause) -> bool:
     """Whether a cause is actionable enough to prefer in report rendering."""
     source = str(cause.get("source") or cause.get("suspected_source") or "").strip().lower()
     return source not in _PLACEHOLDER_SOURCES or is_actionable_location(
-        cause.get("strongest_location")
+        cause.get("strongest_location"),
     )
 
 

--- a/apps/server/vibesensor/analysis/findings/builder.py
+++ b/apps/server/vibesensor/analysis/findings/builder.py
@@ -72,7 +72,7 @@ def _build_findings(
         prepare_analysis_samples(
             samples,
             per_sample_phases=per_sample_phases,
-            phase_segmenter=cast(PhaseSegmenter, segment_run_phases),
+            phase_segmenter=cast("PhaseSegmenter", segment_run_phases),
         )
     )
 
@@ -98,6 +98,6 @@ def _build_findings(
             lang=lang,
             per_sample_phases=analysis_phases,
             run_noise_baseline_g=(run_noise_baseline_g if not use_filtered_samples else None),
-        )
+        ),
     )
     return finalize_findings(findings)

--- a/apps/server/vibesensor/analysis/findings/builder_support.py
+++ b/apps/server/vibesensor/analysis/findings/builder_support.py
@@ -21,7 +21,7 @@ from .reference_checks import _reference_missing_finding
 
 _MIN_DIAGNOSTIC_SAMPLES = 5
 PhaseSegmenter = Callable[[list[Sample]], tuple[list[DrivingPhase], list[PhaseSegment]]]
-_DEFAULT_PHASE_SEGMENTER = cast(PhaseSegmenter, segment_run_phases)
+_DEFAULT_PHASE_SEGMENTER = cast("PhaseSegmenter", segment_run_phases)
 
 
 def build_reference_findings(
@@ -49,7 +49,7 @@ def build_reference_findings(
                     _i18n_ref("RECORD_VEHICLE_SPEED_FOR_MOST_SAMPLES_GPS_OR"),
                     _i18n_ref("VERIFY_TIMESTAMP_ALIGNMENT_BETWEEN_SPEED_AND_ACCELERATION_STREAM"),
                 ],
-            )
+            ),
         )
 
     if speed_sufficient and not (tire_circumference_m and tire_circumference_m > 0):
@@ -64,7 +64,7 @@ def build_reference_findings(
                     _i18n_ref("PROVIDE_TIRE_CIRCUMFERENCE_OR_TIRE_SIZE_WIDTH_ASPECT"),
                     _i18n_ref("RE_RUN_WITH_MEASURED_LOADED_TIRE_CIRCUMFERENCE"),
                 ],
-            )
+            ),
         )
 
     engine_ref_sufficient = has_engine_reference(
@@ -90,7 +90,7 @@ def build_reference_findings(
                     _i18n_ref("LOG_ENGINE_RPM_FROM_CAN_OBD_FOR_THE"),
                     _i18n_ref("KEEP_TIMESTAMP_BASE_SHARED_WITH_ACCELEROMETER_AND_SPEED"),
                 ],
-            )
+            ),
         )
 
     if raw_sample_rate_hz is None or raw_sample_rate_hz <= 0:
@@ -100,7 +100,7 @@ def build_reference_findings(
                 suspected_source="unknown",
                 evidence_summary=_i18n_ref("RAW_ACCELEROMETER_SAMPLE_RATE_IS_MISSING_SO_DOMINANT"),
                 quick_checks=[_i18n_ref("RECORD_THE_TRUE_ACCELEROMETER_SAMPLE_RATE_IN_RUN")],
-            )
+            ),
         )
     return findings, engine_ref_sufficient
 

--- a/apps/server/vibesensor/analysis/findings/intensity.py
+++ b/apps/server/vibesensor/analysis/findings/intensity.py
@@ -98,7 +98,7 @@ def _phase_speed_breakdown(
                 "max_speed_kmh": max(speed_vals) if speed_vals else None,
                 "mean_vibration_strength_db": _mean(amp_vals) if amp_vals else None,
                 "max_vibration_strength_db": max(amp_vals) if amp_vals else None,
-            }
+            },
         )
     return rows
 
@@ -128,7 +128,7 @@ def _speed_breakdown(samples: list[Sample]) -> list[SpeedBreakdownRow]:
                 "count": counts[label],
                 "mean_vibration_strength_db": _mean(values) if values else None,
                 "max_vibration_strength_db": max(values) if values else None,
-            }
+            },
         )
     return rows
 
@@ -200,7 +200,8 @@ def _sensor_intensity_by_location(
     if include_locations is not None:
         target_locations |= set(include_locations)
     max_sample_count = max(
-        (sample_counts.get(location, 0) for location in target_locations), default=0
+        (sample_counts.get(location, 0) for location in target_locations),
+        default=0,
     )
 
     for location in sorted(target_locations):
@@ -225,7 +226,7 @@ def _sensor_intensity_by_location(
         sample_coverage_ratio = (sample_count / max_sample_count) if max_sample_count > 0 else 1.0
         sample_coverage_warning = max_sample_count >= 5 and sample_coverage_ratio <= 0.20
         partial_coverage = bool(
-            connected_locations is not None and location not in connected_locations
+            connected_locations is not None and location not in connected_locations,
         )
         # Per-phase intensity summary for this location (issue #192)
         location_phase_intensity: JsonObject | None = None
@@ -256,7 +257,7 @@ def _sensor_intensity_by_location(
                 "queue_overflow_drops_delta": overflow_delta,
                 "strength_bucket_distribution": bucket_distribution,
                 "phase_intensity": location_phase_intensity,
-            }
+            },
         )
     rows.sort(
         key=lambda row: (

--- a/apps/server/vibesensor/analysis/findings/order_findings.py
+++ b/apps/server/vibesensor/analysis/findings/order_findings.py
@@ -54,7 +54,7 @@ from .speed_profile import _speed_profile_from_points
 _NEGLIGIBLE_STRENGTH_CONF_CAP = _NEGLIGIBLE_STRENGTH_CONF_CAP_IMPORTED
 
 
-def _order_label(order: int | float, order_label_base: str) -> str:
+def _order_label(order: float, order_label_base: str) -> str:
     return _order_label_impl(int(order), order_label_base)
 
 
@@ -100,8 +100,7 @@ def _compute_effective_match_rate(
             loc_matched = matched_by_location.get(loc, 0)
             if loc_possible >= ORDER_MIN_COVERAGE_POINTS and loc_matched >= ORDER_MIN_MATCH_POINTS:
                 loc_rate = loc_matched / max(1, loc_possible)
-                if loc_rate > best_loc_rate:
-                    best_loc_rate = loc_rate
+                best_loc_rate = max(best_loc_rate, loc_rate)
         if best_loc_rate >= min_match_rate:
             effective_match_rate = best_loc_rate
             per_location_dominant = True

--- a/apps/server/vibesensor/analysis/findings/order_matching.py
+++ b/apps/server/vibesensor/analysis/findings/order_matching.py
@@ -112,7 +112,7 @@ def match_samples_for_hypothesis(
                     if has_phases and per_sample_phases is not None
                     else None
                 ),
-            }
+            },
         )
 
     return OrderMatchAccumulator(

--- a/apps/server/vibesensor/analysis/findings/order_support.py
+++ b/apps/server/vibesensor/analysis/findings/order_support.py
@@ -14,7 +14,7 @@ _PHASE_ONSET_RELEVANT: frozenset[str] = frozenset(
         DrivingPhase.ACCELERATION.value,
         DrivingPhase.DECELERATION.value,
         DrivingPhase.COAST_DOWN.value,
-    }
+    },
 )
 
 
@@ -49,7 +49,7 @@ def compute_matched_speed_phase_evidence(
     peak_speed_kmh, speed_window_kmh, strongest_speed_band = speed_profile_from_points(
         speed_points,
         allowed_speed_bins=[focused_speed_band] if focused_speed_band else None,
-        phase_weights=speed_phase_weights if speed_phase_weights else None,
+        phase_weights=speed_phase_weights or None,
     )
     if not strongest_speed_band:
         strongest_speed_band = hotspot_speed_band

--- a/apps/server/vibesensor/analysis/findings/persistent_findings.py
+++ b/apps/server/vibesensor/analysis/findings/persistent_findings.py
@@ -85,15 +85,15 @@ class _PeakBinStats:
     __slots__ = (
         "bin_amps",
         "bin_floors",
-        "bin_speeds",
-        "bin_speed_amp_pairs",
         "bin_location_counts",
-        "bin_speed_bin_counts",
         "bin_phase_counts",
-        "total_speed_bin_counts",
-        "total_locations",
-        "total_location_sample_counts",
+        "bin_speed_amp_pairs",
+        "bin_speed_bin_counts",
+        "bin_speeds",
         "n_samples",
+        "total_location_sample_counts",
+        "total_locations",
+        "total_speed_bin_counts",
     )
 
     def __init__(self) -> None:
@@ -313,8 +313,7 @@ def _build_persistent_peak_findings(
                 loc_total = total_location_sample_counts.get(loc, 0)
                 if loc_total >= 3:
                     loc_presence = loc_hits / loc_total
-                    if loc_presence > presence_ratio:
-                        presence_ratio = loc_presence
+                    presence_ratio = max(presence_ratio, loc_presence)
 
         median_amp = percentile(sorted_amps, 0.50) if count >= 2 else sorted_amps[0]
         p95_amp = percentile(sorted_amps, 0.95) if count >= 2 else sorted_amps[-1]
@@ -398,7 +397,7 @@ def _build_persistent_peak_findings(
                 confidence = min(confidence, 0.40)
 
         peak_speed_kmh, speed_window_kmh, derived_speed_band = _speed_profile_from_points(
-            bin_speed_amp_pairs.get(bin_center, [])
+            bin_speed_amp_pairs.get(bin_center, []),
         )
         speed_band = derived_speed_band or "-"
 

--- a/apps/server/vibesensor/analysis/helpers.py
+++ b/apps/server/vibesensor/analysis/helpers.py
@@ -75,7 +75,7 @@ def _validate_required_strength_metrics(samples: list[Sample]) -> None:
     # explicit None-check to make the intent clear.
     raise ValueError(
         f"Missing required precomputed strength metrics in sample index "
-        f"{first_bad_idx}: vibration_strength_db"
+        f"{first_bad_idx}: vibration_strength_db",
     )
 
 
@@ -230,7 +230,7 @@ def _speed_stats_by_phase(
     for phase_key in phase_sample_counts:
         stats = dict(_speed_stats(phase_speeds.get(phase_key, [])))
         stats["sample_count"] = phase_sample_counts[phase_key]
-        result[phase_key] = cast(PhaseSpeedStats, stats)
+        result[phase_key] = cast("PhaseSpeedStats", stats)
     return result
 
 
@@ -273,7 +273,7 @@ def _effective_engine_rpm(
 
     speed_kmh = _as_float(sample.get("speed_kmh"))
     final_drive_ratio = _as_float(sample.get("final_drive_ratio")) or _as_float(
-        metadata.get("final_drive_ratio")
+        metadata.get("final_drive_ratio"),
     )
     gear_val = _as_float(sample.get("gear"))
     gear_ratio = gear_val if gear_val is not None else _as_float(metadata.get("current_gear_ratio"))

--- a/apps/server/vibesensor/analysis/order_analysis.py
+++ b/apps/server/vibesensor/analysis/order_analysis.py
@@ -167,7 +167,6 @@ def _finding_actions_for_source(
         similar intensities, which weakens spatial localisation confidence.
 
     """
-
     location = strongest_location.strip()
     speed_band = strongest_speed_band.strip()
     # Only include speed_hint param when a speed band is available; passing an
@@ -216,7 +215,8 @@ def _finding_actions_for_source(
             {
                 "action_id": "driveline_inspection",
                 "what": _i18n_ref(
-                    "ACTION_DRIVELINE_INSPECTION_WHAT", driveline_focus=driveline_focus
+                    "ACTION_DRIVELINE_INSPECTION_WHAT",
+                    driveline_focus=driveline_focus,
                 ),
                 "why": _i18n_ref("ACTION_DRIVELINE_INSPECTION_WHY"),
                 "confirm": _i18n_ref("ACTION_DRIVELINE_INSPECTION_CONFIRM"),
@@ -262,5 +262,5 @@ def _finding_actions_for_source(
             "confirm": _i18n_ref("ACTION_GENERAL_INSPECTION_CONFIRM"),
             "falsify": _i18n_ref("ACTION_GENERAL_INSPECTION_FALSIFY"),
             "eta": "20-35 min",
-        }
+        },
     ]

--- a/apps/server/vibesensor/analysis/phase_segmentation.py
+++ b/apps/server/vibesensor/analysis/phase_segmentation.py
@@ -84,10 +84,14 @@ def _estimate_speed_derivative(
         return None
     # Look backward and forward for valid speed+time pairs
     prev_speed, prev_time = _find_nearest_valid(
-        speeds, times, range(idx - 1, max(-1, idx - window - 1), -1)
+        speeds,
+        times,
+        range(idx - 1, max(-1, idx - window - 1), -1),
     )
     next_speed, next_time = _find_nearest_valid(
-        speeds, times, range(idx + 1, min(n, idx + window + 1))
+        speeds,
+        times,
+        range(idx + 1, min(n, idx + window + 1)),
     )
 
     if (
@@ -147,7 +151,7 @@ _MOVING_PHASES = frozenset(
         DrivingPhase.CRUISE,
         DrivingPhase.DECELERATION,
         DrivingPhase.COAST_DOWN,
-    }
+    },
 )
 
 
@@ -271,7 +275,7 @@ def segment_run_phases(
                 speed_min_kmh=min(seg_speeds) if seg_speeds else None,
                 speed_max_kmh=max(seg_speeds) if seg_speeds else None,
                 sample_count=seg_end - seg_start + 1,
-            )
+            ),
         )
         seg_start = i
 

--- a/apps/server/vibesensor/analysis/plot_peak_table.py
+++ b/apps/server/vibesensor/analysis/plot_peak_table.py
@@ -150,7 +150,7 @@ def top_peaks_table_rows(
                 if total_count <= 0:
                     continue
                 hit_rates.append(
-                    float(bucket.speed_bin_counts.get(speed_bin, 0)) / float(total_count)
+                    float(bucket.speed_bin_counts.get(speed_bin, 0)) / float(total_count),
                 )
             if hit_rates:
                 hit_rate_mean = sum(hit_rates) / len(hit_rates)
@@ -211,6 +211,6 @@ def top_peaks_table_rows(
                     speed_uniformity=item.speed_uniformity,
                 ),
                 typical_speed_band=speed_band,
-            )
+            ),
         )
     return rows

--- a/apps/server/vibesensor/analysis/plot_series.py
+++ b/apps/server/vibesensor/analysis/plot_series.py
@@ -138,7 +138,7 @@ def build_plot_series(
                 predicted_points.append((speed, predicted_hz))
         if matched_points:
             matched_by_finding.append(
-                MatchedAmpVsSpeedSeries(label=finding_label, points=matched_points)
+                MatchedAmpVsSpeedSeries(label=finding_label, points=matched_points),
             )
         if freq_points:
             freq_vs_speed_by_finding.append(
@@ -146,7 +146,7 @@ def build_plot_series(
                     label=finding_label,
                     matched=freq_points,
                     predicted=predicted_points,
-                )
+                ),
             )
 
     steady_speed_distribution = build_steady_speed_distribution(
@@ -203,7 +203,7 @@ def build_amp_vs_phase(summary: SummaryData) -> list[AmpVsPhaseRow]:
                 mean_vib_db=mean_vib,
                 max_vib_db=_as_float(row.get("max_vibration_strength_db")),
                 mean_speed_kmh=_as_float(row.get("mean_speed_kmh")),
-            )
+            ),
         )
     return amp_vs_phase
 
@@ -221,13 +221,13 @@ def serialize_phase_context(
                 phase=phase_value,
                 start_t_s=segment.start_t_s,
                 end_t_s=segment.end_t_s,
-            )
+            ),
         )
         phase_boundaries.append(
             PhaseBoundary(
                 phase=phase_value,
                 t_s=segment.start_t_s,
                 end_t_s=segment.end_t_s,
-            )
+            ),
         )
     return phase_segments_out, phase_boundaries

--- a/apps/server/vibesensor/analysis/plot_spectrum.py
+++ b/apps/server/vibesensor/analysis/plot_spectrum.py
@@ -104,7 +104,7 @@ def scan_peak_samples(samples: list[Sample]) -> PeakSampleScan:
                 floor_amp_g=floor_amp,
                 location=location,
                 speed_bin=speed_bin,
-            )
+            ),
         )
 
     return PeakSampleScan(
@@ -243,7 +243,7 @@ def spectrogram_from_peaks(
     freq_bin_hz = max(2.0, freq_cap_hz / 45.0)
 
     cell_by_bin: defaultdict[tuple[float, float], list[tuple[float, float | None]]] = defaultdict(
-        list
+        list,
     )
     x_sample_counts: defaultdict[float, int] = defaultdict(int)
     if aggregation == "persistence":
@@ -297,8 +297,7 @@ def spectrogram_from_peaks(
         else:
             val = max(amp for amp, _floor in amp_floor_pairs)
         cells[yi][xi] = val
-        if val > max_amp:
-            max_amp = val
+        max_amp = max(max_amp, val)
 
     return SpectrogramResult(
         x_axis=x_axis,

--- a/apps/server/vibesensor/analysis/report_mapping_actions.py
+++ b/apps/server/vibesensor/analysis/report_mapping_actions.py
@@ -38,7 +38,7 @@ def build_next_steps_from_summary(
                 confirm=_resolve_optional_step_value(step.get("confirm"), lang=lang, tr=tr),
                 falsify=_resolve_optional_step_value(step.get("falsify"), lang=lang, tr=tr),
                 eta=str(step.get("eta") or "") or None,
-            )
+            ),
         )
     return next_steps
 
@@ -77,7 +77,7 @@ def build_data_trust_from_summary(
                 check=check_text,
                 state=str(item.get("state") or "warn"),
                 detail=detail,
-            )
+            ),
         )
     for warning in summary.get("warnings", []):
         if not isinstance(warning, dict):
@@ -87,7 +87,7 @@ def build_data_trust_from_summary(
                 check=_resolve_detail_text(warning.get("title"), lang=lang, tr=tr) or "",
                 state=str(warning.get("severity") or "warn"),
                 detail=_resolve_detail_text(warning.get("detail"), lang=lang, tr=tr),
-            )
+            ),
         )
     return data_trust
 

--- a/apps/server/vibesensor/analysis/report_mapping_context.py
+++ b/apps/server/vibesensor/analysis/report_mapping_context.py
@@ -91,16 +91,16 @@ def resolve_primary_candidate(
     primary_candidate = primary_candidates[0] if primary_candidates else None
     if primary_candidate:
         primary_source = primary_candidate.get("source") or primary_candidate.get(
-            "suspected_source"
+            "suspected_source",
         )
         primary_system = human_source(primary_source, tr=tr)
         primary_location = origin_location or str(
-            primary_candidate.get("strongest_location") or tr("UNKNOWN")
+            primary_candidate.get("strongest_location") or tr("UNKNOWN"),
         )
         primary_speed = str(
             primary_candidate.get("strongest_speed_band")
             or primary_candidate.get("speed_band")
-            or tr("UNKNOWN")
+            or tr("UNKNOWN"),
         )
         conf = extract_confidence(primary_candidate)
     else:

--- a/apps/server/vibesensor/analysis/report_mapping_pipeline.py
+++ b/apps/server/vibesensor/analysis/report_mapping_pipeline.py
@@ -90,7 +90,7 @@ def resolve_primary_report_candidate(
     strength_db = top_strength_values(summary, effective_causes=context.top_causes)
     strength_text_value = strength_text(strength_db, lang=lang)
     weak_spatial = bool(
-        primary_candidate.get("weak_spatial_separation") if primary_candidate else False
+        primary_candidate.get("weak_spatial_separation") if primary_candidate else False,
     )
     sensor_count = resolve_sensor_count(summary, context.sensor_locations_active)
     has_ref_gaps = has_relevant_reference_gap(context.findings, primary_source)
@@ -161,10 +161,8 @@ def _build_report_template_data(
     primary = resolve_primary_report_candidate(summary, context=context, tr=tr, lang=lang)
     observed = build_observed_signature(primary)
     system_cards = build_system_cards(
-        context.top_causes,
-        context.findings_non_ref,
-        context.findings,
-        primary.tier,
+        context,
+        primary,
         lang,
         tr,
     )
@@ -177,17 +175,8 @@ def _build_report_template_data(
     )
     data_trust = build_data_trust_from_summary(summary, lang=lang, tr=tr)
     pattern_evidence = build_pattern_evidence(
-        context.top_causes,
-        primary.primary_candidate,
-        context.origin,
-        primary.primary_location,
-        primary.primary_speed,
-        primary.strength_text,
-        primary.strength_db,
-        primary.certainty_label_text,
-        primary.certainty_pct,
-        primary.certainty_reason,
-        primary.weak_spatial,
+        context,
+        primary,
         lang,
         tr,
     )

--- a/apps/server/vibesensor/analysis/report_mapping_systems.py
+++ b/apps/server/vibesensor/analysis/report_mapping_systems.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from .. import __version__
 from ..report.report_data import PartSuggestion, PatternEvidence, SystemFindingCard
 from ..runlog import as_float_or_none as _as_float
-from ._types import CandidateFinding, Finding, MetadataDict, OriginSummary, SummaryData, is_finding
+from ._types import CandidateFinding, Finding, MetadataDict, OriginSummary, SummaryData
 from .pattern_parts import parts_for_pattern, why_parts_listed
 from .report_mapping_common import (
     finding_strength_db,
@@ -17,6 +17,7 @@ from .report_mapping_common import (
     order_label_human,
     resolve_i18n,
 )
+from .report_mapping_models import PrimaryCandidateContext, ReportMappingContext
 
 
 def top_strength_values(
@@ -30,14 +31,15 @@ def top_strength_values(
     for cause in causes:
         if not isinstance(cause, dict):
             continue
+        finding_id = cause.get("finding_id")
         for finding in all_findings:
-            if not is_finding(finding):
+            if not isinstance(finding, dict):
                 continue
-            if finding.get("finding_id") != cause.get("finding_id"):
+            if finding.get("finding_id") != finding_id:
                 continue
-            finding_db = finding_strength_db(finding)
-            if finding_db is not None:
-                return finding_db
+            db = finding_strength_db(finding)
+            if db is not None:
+                return db
     sensor_rows = [
         _as_float(row.get("p95_intensity_db"))
         for row in summary.get("sensor_intensity_by_location", [])
@@ -61,17 +63,16 @@ def has_relevant_reference_gap(findings: list[Finding], primary_source: object) 
 
 
 def build_system_cards(
-    top_causes: list[CandidateFinding],
-    findings_non_ref: list[Finding],
-    findings: list[Finding],
-    tier: str,
+    context: ReportMappingContext,
+    primary: PrimaryCandidateContext,
     lang: str,
     tr: Callable,
 ) -> list[SystemFindingCard]:
     """Build system finding cards for the report template."""
+    tier = primary.tier
     if tier == "A":
         return []
-    card_sources = top_causes or findings_non_ref or findings
+    card_sources = context.top_causes or context.findings_non_ref or context.findings
     cards: list[SystemFindingCard] = []
     for cause in card_sources[:2]:
         source = cause.get("source") or cause.get("suspected_source") or "unknown"
@@ -95,7 +96,7 @@ def build_system_cards(
                 pattern_summary=pattern_text,
                 parts=card_parts,
                 tone=cause.get("confidence_tone", "neutral"),
-            )
+            ),
         )
     return cards
 
@@ -108,38 +109,32 @@ def humanize_signatures(signatures: object, *, lang: str) -> list[str]:
 
 
 def build_pattern_evidence(
-    top_causes: list[CandidateFinding],
-    primary_candidate: CandidateFinding | None,
-    origin: OriginSummary,
-    primary_location: str,
-    primary_speed: str,
-    strength_text: str,
-    db_val: float | None,
-    cert_label_text: str,
-    cert_pct: str,
-    cert_reason: str,
-    weak_spatial: bool,
+    context: ReportMappingContext,
+    primary: PrimaryCandidateContext,
     lang: str,
     tr: Callable,
 ) -> PatternEvidence:
     """Build the pattern-evidence block for the report template."""
     systems_raw = [
         human_source(cause.get("source") or cause.get("suspected_source"), tr=tr)
-        for cause in top_causes[:3]
+        for cause in context.top_causes[:3]
     ]
     systems = list(dict.fromkeys(systems_raw))
-    interpretation = resolve_interpretation(origin, lang=lang, tr=tr)
-    source_for_why, order_label_for_why = resolve_parts_context(primary_candidate, lang=lang)
+    interpretation = resolve_interpretation(context.origin, lang=lang, tr=tr)
+    source_for_why, order_label_for_why = resolve_parts_context(
+        primary.primary_candidate,
+        lang=lang,
+    )
     return PatternEvidence(
         matched_systems=systems,
-        strongest_location=primary_location,
-        speed_band=primary_speed,
-        strength_label=strength_text,
-        strength_peak_db=db_val,
-        certainty_label=cert_label_text,
-        certainty_pct=cert_pct,
-        certainty_reason=cert_reason,
-        warning=cert_reason if weak_spatial else None,
+        strongest_location=primary.primary_location,
+        speed_band=primary.primary_speed,
+        strength_label=primary.strength_text,
+        strength_peak_db=primary.strength_db,
+        certainty_label=primary.certainty_label_text,
+        certainty_pct=primary.certainty_pct,
+        certainty_reason=primary.certainty_reason,
+        warning=primary.certainty_reason if primary.weak_spatial else None,
         interpretation=interpretation or None,
         why_parts_text=why_parts_listed(source_for_why, order_label_for_why, lang=lang),
     )
@@ -162,7 +157,7 @@ def resolve_parts_context(
     source_for_why = str(
         (primary_candidate.get("source") or primary_candidate.get("suspected_source"))
         if primary_candidate
-        else ""
+        else "",
     )
     signatures = primary_candidate.get("signatures_observed", []) if primary_candidate else []
     order_label = order_label_human(lang, str(signatures[0])) if signatures else None

--- a/apps/server/vibesensor/analysis/summary_builder.py
+++ b/apps/server/vibesensor/analysis/summary_builder.py
@@ -134,7 +134,7 @@ def prepare_run_data(
     speed_breakdown_skipped_reason: I18nRef | None = None
     if not speed_sufficient:
         speed_breakdown_skipped_reason = _i18n_ref(
-            "SPEED_DATA_MISSING_OR_INSUFFICIENT_SPEED_BINNED_AND"
+            "SPEED_DATA_MISSING_OR_INSUFFICIENT_SPEED_BINNED_AND",
         )
 
     return PreparedRunData(

--- a/apps/server/vibesensor/analysis/summary_payload.py
+++ b/apps/server/vibesensor/analysis/summary_payload.py
@@ -49,7 +49,7 @@ def build_sensor_analysis(
             label
             for sample in samples
             if isinstance(sample, dict) and (label := _location_label(sample, lang=language))
-        }
+        },
     )
     connected_locations = _locations_connected_throughout_run(samples, lang=language)
     sensor_intensity_by_location = _sensor_intensity_by_location(
@@ -198,7 +198,7 @@ def summarize_display_location(
             candidate
             for idx, candidate in enumerate(display_locations)
             if candidate and candidate not in display_locations[:idx]
-        ]
+        ],
     )
 
 

--- a/apps/server/vibesensor/analysis/summary_phases.py
+++ b/apps/server/vibesensor/analysis/summary_phases.py
@@ -99,7 +99,7 @@ def noise_baseline_db(run_noise_baseline_g: float | None) -> float | None:
         canonical_vibration_db(
             peak_band_rms_amp_g=max(MEMS_NOISE_FLOOR_G, run_noise_baseline_g),
             floor_amp_g=MEMS_NOISE_FLOOR_G,
-        )
+        ),
     )
 
 

--- a/apps/server/vibesensor/analysis/summary_suitability.py
+++ b/apps/server/vibesensor/analysis/summary_suitability.py
@@ -186,7 +186,7 @@ def build_run_suitability_checks(
                     total_overflow=total_overflow,
                 )
             ),
-        }
+        },
     )
     return run_suitability
 

--- a/apps/server/vibesensor/analysis/test_plan.py
+++ b/apps/server/vibesensor/analysis/test_plan.py
@@ -109,7 +109,7 @@ def _merge_test_plan(
                         finding_confidence=finding_confidence,
                         finding_speed_band=finding_speed_band,
                         finding_frequency=finding_frequency,
-                    )
+                    ),
                 )
             continue
         source = _normalized_lower_text(finding.get("suspected_source"))
@@ -126,7 +126,7 @@ def _merge_test_plan(
                     finding_confidence=finding_confidence,
                     finding_speed_band=finding_speed_band,
                     finding_frequency=finding_frequency,
-                )
+                ),
             )
 
     dedup: dict[str, TestStep] = {}
@@ -157,7 +157,7 @@ def _merge_test_plan(
                 "FALSIFY_NO_ABNORMAL_PLAY_WEAR_OR_LOOSENESS",
             ),
             "eta": "20-35 min",
-        }
+        },
     ]
 
 
@@ -320,7 +320,7 @@ def _location_speedbin_summary(
                 "speed_kmh": speed,
                 "matched_hz": _as_float(row.get("matched_hz")),
                 "rel_error": _as_float(row.get("rel_error")),
-            }
+            },
         )
 
     if not grouped:

--- a/apps/server/vibesensor/analysis/top_cause_selection.py
+++ b/apps/server/vibesensor/analysis/top_cause_selection.py
@@ -90,6 +90,6 @@ def select_top_causes(
                 "diffuse_excitation": representative.get("diffuse_excitation", False),
                 "diagnostic_caveat": representative.get("diagnostic_caveat"),
                 "phase_evidence": representative.get("phase_evidence"),
-            }
+            },
         )
     return result

--- a/apps/server/vibesensor/analysis_settings.py
+++ b/apps/server/vibesensor/analysis_settings.py
@@ -7,10 +7,10 @@ geometry helpers, and ``AnalysisSettingsStore`` for runtime settings management.
 from __future__ import annotations
 
 __all__ = [
-    "AnalysisSettingsStore",
     "DEFAULT_ANALYSIS_SETTINGS",
     "NON_NEGATIVE_KEYS",
     "POSITIVE_REQUIRED_KEYS",
+    "AnalysisSettingsStore",
     "engine_rpm_from_wheel_hz",
     "sanitize_settings",
     "tire_circumference_m_from_spec",
@@ -40,7 +40,7 @@ POSITIVE_REQUIRED_KEYS: frozenset[str] = frozenset(
         "engine_bandwidth_pct",
         "max_band_half_width_pct",
         "tire_deflection_factor",
-    }
+    },
 )
 NON_NEGATIVE_KEYS: frozenset[str] = frozenset(
     {
@@ -49,7 +49,7 @@ NON_NEGATIVE_KEYS: frozenset[str] = frozenset(
         "final_drive_uncertainty_pct",
         "gear_uncertainty_pct",
         "min_abs_band_hz",
-    }
+    },
 )
 
 _BOUNDS: dict[str, tuple[float, float]] = {
@@ -190,7 +190,9 @@ def wheel_hz_from_speed_mps(speed_mps: float, tire_circumference_m: float) -> fl
 
 
 def engine_rpm_from_wheel_hz(
-    wheel_hz: float, final_drive_ratio: float, gear_ratio: float
+    wheel_hz: float,
+    final_drive_ratio: float,
+    gear_ratio: float,
 ) -> float | None:
     """Engine RPM from wheel Hz, final-drive ratio, and current gear ratio.
 

--- a/apps/server/vibesensor/api_models.py
+++ b/apps/server/vibesensor/api_models.py
@@ -294,6 +294,7 @@ class HealthResponse(BaseModel):
     startup_state: str
     startup_phase: str
     startup_error: str | None
+    startup_warnings: list[str] = []
     background_task_failures: dict[str, str]
     processing_state: str
     processing_failures: int
@@ -306,6 +307,12 @@ class HealthResponse(BaseModel):
     data_loss: HealthDataLossResponse
     persistence: HealthPersistenceResponse
     intake_stats: HealthIntakeStatsResponse
+
+    tick_duration_s: float = 0.0
+    max_tick_duration_s: float = 0.0
+    tick_count: int = 0
+    db_last_write_duration_s: float = 0.0
+    db_max_write_duration_s: float = 0.0
 
 
 class CarResponse(BaseModel):

--- a/apps/server/vibesensor/bootstrap.py
+++ b/apps/server/vibesensor/bootstrap.py
@@ -12,10 +12,10 @@ from .runtime import (
     build_runtime_state,
 )
 from .runtime.builders import (
-    build_diagnostics_subsystem,
     build_ingress_subsystem,
     build_persistence_subsystem,
     build_processing_subsystem,
+    build_recording_subsystem,
     build_route_services,
     build_settings_subsystem,
     build_update_subsystem,
@@ -38,7 +38,7 @@ def build_services(config: AppConfig) -> RuntimeState:
         gps_enabled=config.gps.gps_enabled,
     )
     persistence.bind_history_services(settings.settings_store)
-    diagnostics = build_diagnostics_subsystem(
+    recording = build_recording_subsystem(
         config=config,
         ingress=ingress,
         settings=settings,
@@ -56,7 +56,7 @@ def build_services(config: AppConfig) -> RuntimeState:
         config=config,
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=recording,
         persistence=persistence,
         updates=updates,
         processing=processing,
@@ -64,7 +64,7 @@ def build_services(config: AppConfig) -> RuntimeState:
         routes=build_route_services(
             ingress=ingress,
             settings=settings,
-            diagnostics=diagnostics,
+            recording=recording,
             persistence=persistence,
             updates=updates,
             processing=processing,

--- a/apps/server/vibesensor/config.py
+++ b/apps/server/vibesensor/config.py
@@ -19,21 +19,21 @@ from .constants import NUMERIC_TYPES
 from .json_types import JsonObject, is_json_object
 
 __all__ = [
-    "AppConfig",
-    "APConfig",
-    "APSelfHealConfig",
     "DEFAULT_CONFIG",
     "DEFAULT_UDP_CONTROL_PORT",
     "DEFAULT_UDP_DATA_PORT",
+    "REPO_DIR",
+    "SERVER_DIR",
+    "VALID_24GHZ_CHANNELS",
+    "APConfig",
+    "APSelfHealConfig",
+    "AppConfig",
     "GPSConfig",
     "LoggingConfig",
     "ProcessingConfig",
-    "REPO_DIR",
-    "SERVER_DIR",
     "ServerConfig",
     "UDPConfig",
     "UpdateConfig",
-    "VALID_24GHZ_CHANNELS",
     "documented_default_config",
     "load_config",
 ]
@@ -201,13 +201,13 @@ class APSelfHealConfig:
             val = getattr(self, field_name)
             if not isinstance(val, int) or val < 1:
                 raise ValueError(
-                    f"ap.self_heal.{field_name} must be a positive integer, got {val!r}"
+                    f"ap.self_heal.{field_name} must be a positive integer, got {val!r}",
                 )
         mri = self.min_restart_interval_seconds
         if not isinstance(mri, int) or mri < 0:
             raise ValueError(
                 "ap.self_heal.min_restart_interval_seconds must be a non-negative integer,"
-                f" got {mri!r}"
+                f" got {mri!r}",
             )
 
 
@@ -253,7 +253,7 @@ class UDPConfig:
                 raise ValueError(f"UDPConfig.{name} must be 1–65535, got {val!r}")
         if not isinstance(self.data_queue_maxsize, int) or self.data_queue_maxsize < 1:
             raise ValueError(
-                f"UDPConfig.data_queue_maxsize must be ≥1, got {self.data_queue_maxsize!r}"
+                f"UDPConfig.data_queue_maxsize must be ≥1, got {self.data_queue_maxsize!r}",
             )
 
 
@@ -483,7 +483,8 @@ def load_config(config_path: Path | None = None) -> AppConfig:
     storage_cfg = _require_config_section(merged.get("storage", {}), "storage")
     update_cfg = _require_config_section(merged.get("update", {}), "update")
     default_logging_cfg = _require_config_section(
-        DEFAULT_CONFIG.get("logging", {}), "default logging"
+        DEFAULT_CONFIG.get("logging", {}),
+        "default logging",
     )
     default_gps_cfg = _require_config_section(DEFAULT_CONFIG.get("gps", {}), "default gps")
     default_update_cfg = _require_config_section(
@@ -491,14 +492,15 @@ def load_config(config_path: Path | None = None) -> AppConfig:
         "default update",
     )
     default_storage_cfg = _require_config_section(
-        DEFAULT_CONFIG.get("storage", {}), "default storage"
+        DEFAULT_CONFIG.get("storage", {}),
+        "default storage",
     )
     metrics_log_path_raw = logging_cfg.get("metrics_log_path")
     log_metrics = bool(logging_cfg.get("log_metrics", True))
     if not isinstance(metrics_log_path_raw, str) or not metrics_log_path_raw.strip():
         if log_metrics:
             raise ValueError(
-                "logging.metrics_log_path must be configured when log_metrics is true."
+                "logging.metrics_log_path must be configured when log_metrics is true.",
             )
         metrics_log_path_raw = str(default_logging_cfg["metrics_log_path"])
     metrics_log_path = _resolve_config_path(metrics_log_path_raw, path)
@@ -558,7 +560,7 @@ def load_config(config_path: Path | None = None) -> AppConfig:
                     "ap.self_heal.min_restart_interval_seconds",
                 ),
                 allow_disable_resolved_stub_listener=bool(
-                    self_heal_cfg.get("allow_disable_resolved_stub_listener", False)
+                    self_heal_cfg.get("allow_disable_resolved_stub_listener", False),
                 ),
                 state_file=_resolve_config_path(
                     str(self_heal_cfg.get("state_file", str(self_heal_defaults["state_file"]))),
@@ -582,28 +584,35 @@ def load_config(config_path: Path | None = None) -> AppConfig:
         ),
         processing=ProcessingConfig(
             sample_rate_hz=_coerce_int(
-                processing_cfg["sample_rate_hz"], "processing.sample_rate_hz"
+                processing_cfg["sample_rate_hz"],
+                "processing.sample_rate_hz",
             ),
             waveform_seconds=_coerce_int(
-                processing_cfg["waveform_seconds"], "processing.waveform_seconds"
+                processing_cfg["waveform_seconds"],
+                "processing.waveform_seconds",
             ),
             waveform_display_hz=_coerce_int(
-                processing_cfg["waveform_display_hz"], "processing.waveform_display_hz"
+                processing_cfg["waveform_display_hz"],
+                "processing.waveform_display_hz",
             ),
             ui_push_hz=_coerce_int(processing_cfg["ui_push_hz"], "processing.ui_push_hz"),
             ui_heavy_push_hz=_coerce_int(
-                processing_cfg.get("ui_heavy_push_hz", 4), "processing.ui_heavy_push_hz"
+                processing_cfg.get("ui_heavy_push_hz", 4),
+                "processing.ui_heavy_push_hz",
             ),
             fft_update_hz=_coerce_int(processing_cfg["fft_update_hz"], "processing.fft_update_hz"),
             fft_n=_coerce_int(processing_cfg["fft_n"], "processing.fft_n"),
             spectrum_min_hz=_coerce_float(
-                processing_cfg.get("spectrum_min_hz", 5.0), "processing.spectrum_min_hz"
+                processing_cfg.get("spectrum_min_hz", 5.0),
+                "processing.spectrum_min_hz",
             ),
             spectrum_max_hz=_coerce_float(
-                processing_cfg["spectrum_max_hz"], "processing.spectrum_max_hz"
+                processing_cfg["spectrum_max_hz"],
+                "processing.spectrum_max_hz",
             ),
             client_ttl_seconds=_coerce_int(
-                processing_cfg.get("client_ttl_seconds", 120), "processing.client_ttl_seconds"
+                processing_cfg.get("client_ttl_seconds", 120),
+                "processing.client_ttl_seconds",
             ),
             accel_scale_g_per_lsb=accel_scale,
         ),  # NOTE: ProcessingConfig.__post_init__ validates & clamps all fields
@@ -624,12 +633,12 @@ def load_config(config_path: Path | None = None) -> AppConfig:
                     logging_cfg.get(
                         "history_db_path",
                         str(metrics_log_path.parent / "history.db"),
-                    )
+                    ),
                 ),
                 path,
             ),
             persist_history_db=bool(
-                logging_cfg.get("persist_history_db", default_logging_cfg["persist_history_db"])
+                logging_cfg.get("persist_history_db", default_logging_cfg["persist_history_db"]),
             ),
             shutdown_analysis_timeout_s=_coerce_float(
                 logging_cfg.get(
@@ -654,12 +663,12 @@ def load_config(config_path: Path | None = None) -> AppConfig:
         update=UpdateConfig(
             server_repo=str(update_cfg.get("server_repo", default_update_cfg["server_repo"])),
             rollback_dir=Path(
-                str(update_cfg.get("rollback_dir", default_update_cfg["rollback_dir"]))
+                str(update_cfg.get("rollback_dir", default_update_cfg["rollback_dir"])),
             ),
         ),
         clients_json_path=_resolve_config_path(
             str(
-                storage_cfg.get("clients_json_path", str(default_storage_cfg["clients_json_path"]))
+                storage_cfg.get("clients_json_path", str(default_storage_cfg["clients_json_path"])),
             ),
             path,
         ),

--- a/apps/server/vibesensor/diagnostics_shared.py
+++ b/apps/server/vibesensor/diagnostics_shared.py
@@ -177,13 +177,13 @@ def build_order_bands(
                 "key": "driveshaft_engine_1x",
                 "center_hz": drive_hz,
                 "tolerance": max(drive_tol, engine_tol),
-            }
+            },
         )
     else:
         bands.append({"key": "driveshaft_1x", "center_hz": drive_hz, "tolerance": drive_tol})
         bands.append({"key": "engine_1x", "center_hz": engine_hz, "tolerance": engine_tol})
     bands.append(
-        {"key": "engine_2x", "center_hz": engine_hz * HARMONIC_2X, "tolerance": engine_tol}
+        {"key": "engine_2x", "center_hz": engine_hz * HARMONIC_2X, "tolerance": engine_tol},
     )
     return bands
 
@@ -233,10 +233,12 @@ def vehicle_orders_hz(
         tire_uncertainty_pct,
     )
     drive_uncertainty_pct = combined_relative_uncertainty(
-        wheel_uncertainty_pct, final_drive_uncertainty_pct
+        wheel_uncertainty_pct,
+        final_drive_uncertainty_pct,
     )
     engine_uncertainty_pct = combined_relative_uncertainty(
-        drive_uncertainty_pct, gear_uncertainty_pct
+        drive_uncertainty_pct,
+        gear_uncertainty_pct,
     )
     return {
         "wheel_hz": wheel_hz,
@@ -330,7 +332,7 @@ def classify_peak_hz(
                     "hz": wheel_2x_hz,
                     "tol": max(wheel_tol, engine_tol),
                     "key": "wheel2_eng1",
-                }
+                },
             )
         else:
             candidates.append({"hz": wheel_2x_hz, "tol": wheel_tol, "key": "wheel2"})
@@ -345,14 +347,14 @@ def classify_peak_hz(
                     "hz": drive_hz,
                     "tol": max(drive_tol, engine_tol),
                     "key": "shaft_eng1",
-                }
+                },
             )
         else:
             candidates.extend(
                 [
                     {"hz": drive_hz, "tol": drive_tol, "key": "shaft1"},
                     {"hz": engine_hz, "tol": engine_tol, "key": "eng1"},
-                ]
+                ],
             )
         candidates.append({"hz": engine_hz * HARMONIC_2X, "tol": engine_tol, "key": "eng2"})
 
@@ -425,7 +427,7 @@ def severity_from_peak(
                 last_confirmed_hz = as_float_or_none(state.get("last_confirmed_hz"))
                 assert peak_hz_value is not None and freq_bin_hz is not None
                 if last_confirmed_hz is not None and abs(
-                    float(peak_hz_value) - last_confirmed_hz
+                    float(peak_hz_value) - last_confirmed_hz,
                 ) > float(freq_bin_hz):
                     state["consecutive_up"] = 1
                     state["last_confirmed_hz"] = peak_hz_value

--- a/apps/server/vibesensor/domain_models.py
+++ b/apps/server/vibesensor/domain_models.py
@@ -32,13 +32,13 @@ _isfinite = math.isfinite
 _LOGGER = logging.getLogger(__name__)
 
 __all__ = [
+    "DEFAULT_CAR_ASPECTS",
     "RUN_END_TYPE",
     "RUN_METADATA_TYPE",
     "RUN_SAMPLE_TYPE",
     "RUN_SCHEMA_VERSION",
     "VALID_FALLBACK_MODES",
     "VALID_SPEED_SOURCES",
-    "DEFAULT_CAR_ASPECTS",
     "CarConfig",
     "RunMetadata",
     "SensorConfig",
@@ -64,7 +64,7 @@ VALID_SPEED_SOURCES: tuple[str, ...] = ("gps", "obd2", "manual")
 VALID_FALLBACK_MODES: tuple[str, ...] = ("manual",)
 
 DEFAULT_CAR_ASPECTS: Final[MappingProxyType[str, float]] = MappingProxyType(
-    DEFAULT_ANALYSIS_SETTINGS
+    DEFAULT_ANALYSIS_SETTINGS,
 )
 
 

--- a/apps/server/vibesensor/esp_flash_manager.py
+++ b/apps/server/vibesensor/esp_flash_manager.py
@@ -200,7 +200,7 @@ class SerialPortProvider:
                         vid=getattr(row, "vid", None),
                         pid=getattr(row, "pid", None),
                         serial_number=str(getattr(row, "serial_number", "") or "") or None,
-                    )
+                    ),
                 )
             return pyserial_ports
         except (ImportError, OSError):
@@ -342,7 +342,7 @@ class EspFlashManager:
             if any(p.port == configured for p in ports):
                 return configured
             raise ValueError(
-                f"Selected serial port {configured} not found. Check cable/permissions and retry."
+                f"Selected serial port {configured} not found. Check cable/permissions and retry.",
             )
         if not ports:
             raise ValueError("No serial ports detected. Connect your ESP board and retry.")
@@ -425,7 +425,7 @@ class EspFlashManager:
             self._append_log(
                 "No valid firmware bundle found in cache. "
                 "Run the updater while online (vibesensor-fw-refresh) "
-                "or reinstall Pi image with embedded baseline."
+                "or reinstall Pi image with embedded baseline.",
             )
             self._finalize(
                 state=EspFlashState.failed,
@@ -441,7 +441,7 @@ class EspFlashManager:
             source_label = meta.source if meta else "unknown"
             tag_label = meta.tag if meta else "unknown"
             self._append_log(
-                f"Using {source_label} firmware bundle (tag={tag_label}) from {bundle_dir}"
+                f"Using {source_label} firmware bundle (tag={tag_label}) from {bundle_dir}",
             )
 
             # Load and validate manifest
@@ -490,7 +490,10 @@ class EspFlashManager:
 
             erase_cmd = [*port_prefix, "erase_flash"]
             erase_rc = await self._run_flash_step(
-                "erasing", erase_cmd, cwd=bundle_dir, timeout_s=45
+                "erasing",
+                erase_cmd,
+                cwd=bundle_dir,
+                timeout_s=45,
             )
             if self._check_cancelled():
                 return

--- a/apps/server/vibesensor/firmware_cache.py
+++ b/apps/server/vibesensor/firmware_cache.py
@@ -145,7 +145,7 @@ def _safe_extractall(zf: zipfile.ZipFile, dest: Path) -> None:
         target = (dest / member.filename).resolve()
         if not target.is_relative_to(dest_resolved):
             raise ValueError(
-                f"Zip entry '{member.filename}' would extract outside the target directory"
+                f"Zip entry '{member.filename}' would extract outside the target directory",
             )
     zf.extractall(dest)
 
@@ -242,7 +242,7 @@ def parse_manifest(data: JsonObject) -> FlashManifest:
                             file=file_name,
                             offset=offset,
                             sha256=str(sha256) if isinstance(sha256, str) else "",
-                        )
+                        ),
                     )
             name = env_data.get("name")
             if isinstance(name, str) and name:
@@ -263,7 +263,7 @@ def validate_bundle(bundle_dir: Path) -> FlashManifest:
     if not manifest_path.is_file():
         raise ValueError(
             f"Firmware bundle is missing manifest ({_MANIFEST_FILE}) in {bundle_dir}. "
-            "Run the updater while online or reinstall the Pi image."
+            "Run the updater while online or reinstall the Pi image.",
         )
     try:
         manifest_data = _read_json_file(manifest_path)
@@ -273,7 +273,7 @@ def validate_bundle(bundle_dir: Path) -> FlashManifest:
     manifest = parse_manifest(manifest_data)
     if not manifest.environments:
         raise ValueError(
-            f"Firmware manifest in {bundle_dir} has no environments. The bundle may be incomplete."
+            f"Firmware manifest in {bundle_dir} has no environments. The bundle may be incomplete.",
         )
 
     for env in manifest.environments:
@@ -282,14 +282,14 @@ def validate_bundle(bundle_dir: Path) -> FlashManifest:
             if not seg_path.is_file():
                 raise ValueError(
                     f"Firmware bundle is missing referenced binary '{seg.file}' in {bundle_dir}. "
-                    "The bundle is incomplete."
+                    "The bundle is incomplete.",
                 )
             if seg.sha256:
                 actual = hashlib.sha256(seg_path.read_bytes()).hexdigest()
                 if actual != seg.sha256:
                     raise ValueError(
                         f"Checksum mismatch for '{seg.file}': expected {seg.sha256}, "
-                        f"got {actual}. The bundle may be corrupt."
+                        f"got {actual}. The bundle may be corrupt.",
                     )
     return manifest
 
@@ -363,7 +363,7 @@ class GitHubReleaseFetcher(GitHubAPIClient):
                         if total > _MAX_DOWNLOAD_BYTES:
                             raise ValueError(
                                 f"Firmware asset exceeds {_MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB "
-                                f"size limit; aborting download to prevent OOM."
+                                f"size limit; aborting download to prevent OOM.",
                             )
                         tmp_f.write(chunk)
                 Path(tmp_path).replace(dest)
@@ -424,7 +424,7 @@ class GitHubReleaseFetcher(GitHubAPIClient):
 
         raise ValueError(
             f"No eligible firmware release found for channel '{self._config.channel}' "
-            f"in {self._config.firmware_repo}"
+            f"in {self._config.firmware_repo}",
         )
 
     @staticmethod
@@ -440,7 +440,7 @@ class GitHubReleaseFetcher(GitHubAPIClient):
                 return asset
         raise ValueError(
             f"No firmware bundle asset found in release '{release.get('tag_name', '?')}'. "
-            "Expected an asset named vibesensor-fw-*.zip"
+            "Expected an asset named vibesensor-fw-*.zip",
         )
 
     def download_bundle(self, asset: GitHubReleaseAssetPayload, dest_dir: Path) -> Path:

--- a/apps/server/vibesensor/history_db/_migrations.py
+++ b/apps/server/vibesensor/history_db/_migrations.py
@@ -57,7 +57,7 @@ def run_migrations(
     if from_version >= to_version:
         raise ValueError(
             f"Cannot migrate from v{from_version} to v{to_version} "
-            "(source must be older than target)"
+            "(source must be older than target)",
         )
 
     cur = conn.cursor()
@@ -68,7 +68,7 @@ def run_migrations(
             if fn is None:
                 raise RuntimeError(
                     f"No migration registered for v{step} → v{step + 1}. "
-                    f"Cannot upgrade from schema v{from_version} to v{to_version}."
+                    f"Cannot upgrade from schema v{from_version} to v{to_version}.",
                 )
             fn(cur)
         cur.execute(

--- a/apps/server/vibesensor/history_db/_run_reads.py
+++ b/apps/server/vibesensor/history_db/_run_reads.py
@@ -56,8 +56,7 @@ class HistoryRunReadMixin:
 
     def list_runs(self: HistoryCursorProvider, limit: int = 500) -> list[JsonObject]:
         with self._cursor(commit=False) as cur:
-            if limit < 0:
-                limit = 0
+            limit = max(limit, 0)
             if limit > 0:
                 cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
@@ -69,7 +68,7 @@ class HistoryRunReadMixin:
                 cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
                     "r.created_at, r.error_message, r.sample_count, r.analysis_version "
-                    "FROM runs r ORDER BY r.created_at DESC"
+                    "FROM runs r ORDER BY r.created_at DESC",
                 )
             rows = cur.fetchall()
         result: list[JsonObject] = []
@@ -148,7 +147,10 @@ class HistoryRunReadMixin:
         return rows
 
     def iter_run_samples(
-        self: HistoryCursorProvider, run_id: str, batch_size: int = 1000, offset: int = 0
+        self: HistoryCursorProvider,
+        run_id: str,
+        batch_size: int = 1000,
+        offset: int = 0,
     ) -> Iterator[list[JsonObject]]:
         if offset < 0:
             raise ValueError(f"iter_run_samples: offset must be >= 0, got {offset}")
@@ -163,7 +165,7 @@ class HistoryRunReadMixin:
         if table not in ALLOWED_SAMPLE_TABLES:
             raise ValueError(
                 f"_resolve_keyset_offset: invalid table name {table!r}; "
-                f"must be one of {sorted(ALLOWED_SAMPLE_TABLES)}"
+                f"must be one of {sorted(ALLOWED_SAMPLE_TABLES)}",
             )
         with self._cursor(commit=False) as cur:
             cur.execute(
@@ -174,7 +176,10 @@ class HistoryRunReadMixin:
         return int(row[0]) if row else None
 
     def _iter_v2_samples(
-        self: HistoryCursorProvider, run_id: str, batch_size: int = 1000, offset: int = 0
+        self: HistoryCursorProvider,
+        run_id: str,
+        batch_size: int = 1000,
+        offset: int = 0,
     ) -> Iterator[list[JsonObject]]:
         size = max(1, batch_size)
         last_id: int | None = None
@@ -267,7 +272,7 @@ class HistoryRunReadMixin:
         with self._cursor(commit=False) as cur:
             cur.execute(
                 "SELECT run_id FROM runs WHERE status = 'recording' "
-                "ORDER BY created_at DESC LIMIT 1"
+                "ORDER BY created_at DESC LIMIT 1",
             )
             row = cur.fetchone()
         return str(row[0]) if row else None
@@ -276,14 +281,14 @@ class HistoryRunReadMixin:
         with self._cursor(commit=False) as cur:
             cur.execute(
                 "SELECT run_id FROM runs WHERE status = 'analyzing' "
-                "ORDER BY created_at ASC LIMIT 1000"
+                "ORDER BY created_at ASC LIMIT 1000",
             )
             return [str(row[0]) for row in cur.fetchall()]
 
     def analyzing_run_health(self: HistoryCursorProvider) -> JsonObject:
         with self._cursor(commit=False) as cur:
             cur.execute(
-                "SELECT COUNT(*), MIN(analysis_started_at) FROM runs WHERE status = 'analyzing'"
+                "SELECT COUNT(*), MIN(analysis_started_at) FROM runs WHERE status = 'analyzing'",
             )
             row = cur.fetchone()
         count = int(row[0]) if row and row[0] is not None else 0
@@ -308,3 +313,30 @@ class HistoryRunReadMixin:
         if oldest_started_at is not None:
             result["analyzing_oldest_started_at"] = oldest_started_at
         return result
+
+    def verify_run_integrity(self: HistoryCursorProvider, run_id: str) -> list[str]:
+        """Check a completed run for consistency issues. Returns a list of problem descriptions."""
+        problems: list[str] = []
+        with self._cursor(commit=False) as cur:
+            cur.execute(
+                "SELECT status, sample_count, analysis_json FROM runs WHERE run_id = ?",
+                (run_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return ["run not found"]
+            status, stored_count, analysis_raw = row[0], row[1], row[2]
+            if status == "complete" and not analysis_raw:
+                problems.append("complete run missing analysis_json")
+            if stored_count is not None:
+                cur.execute(
+                    "SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?",
+                    (run_id,),
+                )
+                actual_count = int(cur.fetchone()[0])
+                stored_int = int(stored_count)
+                if actual_count != stored_int:
+                    problems.append(
+                        f"sample_count mismatch: stored={stored_int}, actual={actual_count}",
+                    )
+        return problems

--- a/apps/server/vibesensor/history_db/_run_writes.py
+++ b/apps/server/vibesensor/history_db/_run_writes.py
@@ -16,6 +16,11 @@ from ._typing import HistoryCursorProvider
 
 LOGGER = logging.getLogger(__name__)
 
+_RECOMMENDED_METADATA_KEYS: frozenset[str] = frozenset({"sensor_model", "sample_rate_hz"})
+
+
+_EXPECTED_ANALYSIS_KEYS: frozenset[str] = frozenset({"findings", "top_causes", "warnings"})
+
 
 class HistoryRunWriteMixin:
     """Mixin providing run mutation and persistence methods."""
@@ -52,6 +57,13 @@ class HistoryRunWriteMixin:
         start_time_utc: str,
         metadata: JsonObject,
     ) -> None:
+        missing = _RECOMMENDED_METADATA_KEYS - metadata.keys()
+        if missing:
+            LOGGER.warning(
+                "create_run %s: metadata missing recommended keys: %s",
+                run_id,
+                ", ".join(sorted(missing)),
+            )
         now = utc_now_iso()
         with self._cursor() as cur:
             cur.execute(
@@ -163,52 +175,58 @@ class HistoryRunWriteMixin:
         run_id: str,
         analysis: JsonObject,
     ) -> bool:
+        missing = _EXPECTED_ANALYSIS_KEYS - analysis.keys()
+        if missing:
+            LOGGER.warning(
+                "store_analysis %s: summary missing expected keys: %s",
+                run_id,
+                ", ".join(sorted(missing)),
+            )
         now = utc_now_iso()
         with self._cursor() as cur:
+            cur.execute(
+                "UPDATE runs SET status = 'complete', analysis_json = ?, "
+                "analysis_version = ?, analysis_completed_at = ? "
+                "WHERE run_id = ? AND status IN ('recording', 'analyzing')",
+                (
+                    safe_json_dumps(wrap_analysis_for_storage(analysis)),
+                    ANALYSIS_SCHEMA_VERSION,
+                    now,
+                    run_id,
+                ),
+            )
+            if int(cur.rowcount) > 0:
+                return True
             current_status = self._run_status(cur, run_id)
             if current_status == RunStatus.COMPLETE:
                 LOGGER.warning(
                     "store_analysis for run %s: skipped — already complete",
                     run_id,
                 )
-                return False
-            if not can_transition_run(current_status, RunStatus.COMPLETE):
+            elif not can_transition_run(current_status, RunStatus.COMPLETE):
                 self._log_transition_skip(run_id, current_status, RunStatus.COMPLETE)
-                return False
-            cur.execute(
-                "UPDATE runs SET status = 'complete', analysis_json = ?, "
-                "analysis_version = ?, analysis_completed_at = ? "
-                "WHERE run_id = ? AND status = ?",
-                (
-                    safe_json_dumps(wrap_analysis_for_storage(analysis)),
-                    ANALYSIS_SCHEMA_VERSION,
-                    now,
-                    run_id,
-                    current_status,
-                ),
-            )
-            return bool(int(cur.rowcount) > 0)
+            return False
 
     def store_analysis_error(self: HistoryCursorProvider, run_id: str, error: str) -> bool:
         now = utc_now_iso()
         with self._cursor() as cur:
+            cur.execute(
+                "UPDATE runs SET status = 'error', error_message = ?, "
+                "analysis_completed_at = ? "
+                "WHERE run_id = ? AND status IN ('recording', 'analyzing')",
+                (error, now, run_id),
+            )
+            if int(cur.rowcount) > 0:
+                return True
             current_status = self._run_status(cur, run_id)
             if current_status == RunStatus.COMPLETE:
                 LOGGER.warning(
                     "store_analysis_error for run %s: skipped — already complete",
                     run_id,
                 )
-                return False
-            if not can_transition_run(current_status, RunStatus.ERROR):
+            elif not can_transition_run(current_status, RunStatus.ERROR):
                 self._log_transition_skip(run_id, current_status, RunStatus.ERROR)
-                return False
-            cur.execute(
-                "UPDATE runs SET status = 'error', error_message = ?, "
-                "analysis_completed_at = ? "
-                "WHERE run_id = ? AND status = ?",
-                (error, now, run_id, current_status),
-            )
-            return bool(int(cur.rowcount) > 0)
+            return False
 
     def delete_run(self: HistoryCursorProvider, run_id: str) -> bool:
         with self._cursor() as cur:

--- a/apps/server/vibesensor/history_db/_schema.py
+++ b/apps/server/vibesensor/history_db/_schema.py
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 
 CREATE TABLE IF NOT EXISTS runs (
     run_id                  TEXT PRIMARY KEY,
-    status                  TEXT NOT NULL DEFAULT 'recording',
+    status                  TEXT NOT NULL DEFAULT 'recording'
+                            CHECK (status IN ('recording', 'analyzing', 'complete', 'error')),
     start_time_utc          TEXT NOT NULL,
     end_time_utc            TEXT,
     metadata_json           TEXT NOT NULL,
@@ -124,7 +125,7 @@ class HistorySchemaMixin:
             if version > SCHEMA_VERSION:
                 raise RuntimeError(
                     f"History DB schema version {version} is newer than "
-                    f"supported {SCHEMA_VERSION}. Cannot downgrade."
+                    f"supported {SCHEMA_VERSION}. Cannot downgrade.",
                 )
             # -- Migrate forward: older version → current -----------------
             db_path = getattr(self, "db_path", None)  # HistoryDB exposes this

--- a/apps/server/vibesensor/history_db/_settings.py
+++ b/apps/server/vibesensor/history_db/_settings.py
@@ -21,7 +21,7 @@ class HistorySettingsStoreMixin:
             row = cur.fetchone()
         if row is None:
             return None
-        return cast(JsonValue | None, safe_json_loads(row[0], context=f"setting {key}"))
+        return cast("JsonValue | None", safe_json_loads(row[0], context=f"setting {key}"))
 
     def set_setting(self: HistoryCursorProvider, key: str, value: JsonValue) -> None:
         now = utc_now_iso()

--- a/apps/server/vibesensor/history_db/_typing.py
+++ b/apps/server/vibesensor/history_db/_typing.py
@@ -22,7 +22,9 @@ class HistoryCursorProvider(Protocol):
 
     @staticmethod
     def _log_transition_skip(
-        run_id: str, current_status: str | None, target_status: str
+        run_id: str,
+        current_status: str | None,
+        target_status: str,
     ) -> None: ...
 
     def get_setting(self, key: str) -> JsonValue | None: ...

--- a/apps/server/vibesensor/history_exports.py
+++ b/apps/server/vibesensor/history_exports.py
@@ -114,7 +114,7 @@ class HistoryExportDownload:
 class HistoryExportService:
     """Build ZIP exports for history runs without route-local business logic."""
 
-    __slots__ = ("_history_db", "_archive_builder")
+    __slots__ = ("_archive_builder", "_history_db")
 
     def __init__(self, history_db: HistoryDB) -> None:
         self._history_db = history_db
@@ -148,7 +148,7 @@ class HistoryExportArchiveBuilder:
         sample_count = 0
         safe_name = safe_filename(run_id)
         spool: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(
-            max_size=EXPORT_SPOOL_THRESHOLD
+            max_size=EXPORT_SPOOL_THRESHOLD,
         )
         try:
             with zipfile.ZipFile(spool, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:

--- a/apps/server/vibesensor/history_helpers.py
+++ b/apps/server/vibesensor/history_helpers.py
@@ -31,7 +31,7 @@ async def async_require_run(history_db: HistoryDB, run_id: str) -> HistoryRunPay
         raise HTTPException(status_code=404, detail="Run not found")
     if not is_json_object(run):
         raise HTTPException(status_code=500, detail="Run data is corrupt")
-    return cast(HistoryRunPayload, run)
+    return cast("HistoryRunPayload", run)
 
 
 def strip_internal_fields(analysis: JsonObject) -> JsonObject:

--- a/apps/server/vibesensor/history_reports.py
+++ b/apps/server/vibesensor/history_reports.py
@@ -111,8 +111,8 @@ class HistoryReportService:
     def _build_pdf_bytes(analysis_summary: JsonObject) -> bytes:
         from .analysis import SummaryData
 
-        mapped_summary = map_summary(cast(SummaryData, analysis_summary))
-        return cast(bytes, build_report_pdf(mapped_summary))
+        mapped_summary = map_summary(cast("SummaryData", analysis_summary))
+        return cast("bytes", build_report_pdf(mapped_summary))
 
     @staticmethod
     def _metadata_cache_token(metadata: object) -> str:

--- a/apps/server/vibesensor/history_runs.py
+++ b/apps/server/vibesensor/history_runs.py
@@ -42,7 +42,7 @@ class HistoryRunQueryService(HistoryRunService):
 
     async def list_runs(self) -> list[HistoryRunListEntryPayload]:
         return cast(
-            list[HistoryRunListEntryPayload],
+            "list[HistoryRunListEntryPayload]",
             await asyncio.to_thread(self._history_db.list_runs),
         )
 

--- a/apps/server/vibesensor/hotspot_parsers.py
+++ b/apps/server/vibesensor/hotspot_parsers.py
@@ -48,7 +48,7 @@ def parse_active_conn_device(con_name: str, stdout: str) -> tuple[bool, str | No
             continue
         name, device = parts
         if name == con_name:
-            return True, device if device else None
+            return True, device or None
     return False, None
 
 
@@ -143,7 +143,9 @@ class HealStateStore:
             return {str(k): float(v) for k, v in data.items() if isinstance(v, (int, float))}
         except (json.JSONDecodeError, OSError, ValueError):
             LOGGER.warning(
-                "HealStateStore: ignoring corrupt state file %s", self._path, exc_info=True
+                "HealStateStore: ignoring corrupt state file %s",
+                self._path,
+                exc_info=True,
             )
             return {}
 

--- a/apps/server/vibesensor/hotspot_self_heal.py
+++ b/apps/server/vibesensor/hotspot_self_heal.py
@@ -29,7 +29,7 @@ from .hotspot_parsers import (
 LOGGER = logging.getLogger("vibesensor.hotspot.selfheal")
 
 _DHCP_BAD_SIGNALS: frozenset[str] = frozenset(
-    {"dhcp_no_range", "dhcp_dnsmasq_start_failed", "port53_conflict"}
+    {"dhcp_no_range", "dhcp_dnsmasq_start_failed", "port53_conflict"},
 )
 
 _FALLBACK_CHANNELS: tuple[int, ...] = (1, 6, 11)
@@ -245,7 +245,7 @@ def collect_health(ap: APConfig, self_heal: APSelfHealConfig, runner: CommandRun
 def _ensure_ap_connection(ap: APConfig, runner: CommandRunner, channel: int | None = None) -> bool:
     configured_channel = channel if channel is not None else ap.channel
     con_names = parse_active_connection_names(
-        runner.run(["nmcli", "-t", "-f", "NAME", "connection", "show"], timeout_s=8).stdout
+        runner.run(["nmcli", "-t", "-f", "NAME", "connection", "show"], timeout_s=8).stdout,
     )
     if not ap.psk and ap.con_name in con_names:
         # Recreate open AP profiles to guarantee no stale security fields remain.
@@ -294,7 +294,12 @@ def _ensure_ap_connection(ap: APConfig, runner: CommandRunner, channel: int | No
     ]
     if ap.psk:
         modify_args.extend(
-            ["802-11-wireless-security.key-mgmt", "wpa-psk", "802-11-wireless-security.psk", ap.psk]
+            [
+                "802-11-wireless-security.key-mgmt",
+                "wpa-psk",
+                "802-11-wireless-security.psk",
+                ap.psk,
+            ]
         )
 
     modified = runner.run(modify_args, timeout_s=10)
@@ -422,7 +427,7 @@ def run_self_heal_once(
                     detected="NetworkManager inactive",
                     action="systemctl restart NetworkManager",
                     helped=False,
-                )
+                ),
             )
         else:
             actions.append(
@@ -431,7 +436,7 @@ def run_self_heal_once(
                     detected="NetworkManager inactive",
                     action="restart skipped by backoff",
                     helped=False,
-                )
+                ),
             )
 
     if not health.wifi_radio_on:
@@ -442,7 +447,7 @@ def run_self_heal_once(
                 detected="Wi-Fi radio disabled",
                 action="nmcli radio wifi on",
                 helped=False,
-            )
+            ),
         )
 
     if health.rfkill_blocked:
@@ -453,7 +458,7 @@ def run_self_heal_once(
                 detected="rfkill blocked",
                 action="rfkill unblock wifi",
                 helped=False,
-            )
+            ),
         )
 
     if not health.iface_up and health.iface_exists:
@@ -464,7 +469,7 @@ def run_self_heal_once(
                 detected="interface down",
                 action=f"ip link set {ap.ifname} up",
                 helped=False,
-            )
+            ),
         )
 
     if not health.ap_conn_exists or not health.ap_conn_active:
@@ -482,7 +487,7 @@ def run_self_heal_once(
                             detected="configured AP channel failed",
                             action=f"ap recreated on fallback channel {fallback_channel}",
                             helped=False,
-                        )
+                        ),
                     )
                     ensured = True
                     break
@@ -492,7 +497,7 @@ def run_self_heal_once(
                 detected="AP connection missing/inactive",
                 action="ensure AP connection and bring it up",
                 helped=False,
-            )
+            ),
         )
 
     if health.ap_conn_active and (not health.iface_up or not health.ap_mode):
@@ -503,7 +508,7 @@ def run_self_heal_once(
                 detected="AP active but interface down or not in AP mode",
                 action="nmcli connection down/up and ip link up",
                 helped=False,
-            )
+            ),
         )
 
     if not health.dhcp_ok:
@@ -515,7 +520,7 @@ def run_self_heal_once(
                     detected=f"port 53 conflict ({health.port53_conflict})",
                     action=message,
                     helped=False,
-                )
+                ),
             )
         _ensure_ap_connection(ap, runner)
         if state_store.allow("restart_networkmanager", self_heal.min_restart_interval_seconds):
@@ -527,7 +532,7 @@ def run_self_heal_once(
                     detected="DHCP path unhealthy",
                     action="re-applied AP connection and restarted NetworkManager",
                     helped=False,
-                )
+                ),
             )
         else:
             actions.append(
@@ -536,7 +541,7 @@ def run_self_heal_once(
                     detected="DHCP path unhealthy",
                     action="restart skipped by backoff; AP re-applied",
                     helped=False,
-                )
+                ),
             )
 
     healed = collect_health(ap, self_heal, runner)

--- a/apps/server/vibesensor/http_api_schema_export.py
+++ b/apps/server/vibesensor/http_api_schema_export.py
@@ -43,7 +43,7 @@ def _build_openapi_app() -> FastAPI:
             apply_car_settings=placeholder,
             apply_speed_source_settings=placeholder,
         ),
-        diagnostics=SimpleNamespace(
+        recording=SimpleNamespace(
             metrics_logger=placeholder,
         ),
         persistence=SimpleNamespace(

--- a/apps/server/vibesensor/locations.py
+++ b/apps/server/vibesensor/locations.py
@@ -43,7 +43,7 @@ WHEEL_LOCATION_CODES: frozenset[str] = frozenset(
         "front_right_wheel",
         "rear_left_wheel",
         "rear_right_wheel",
-    }
+    },
 )
 
 # Human-readable label substrings that identify a wheel/corner sensor.

--- a/apps/server/vibesensor/metrics_log/__init__.py
+++ b/apps/server/vibesensor/metrics_log/__init__.py
@@ -20,14 +20,14 @@ imports continue to work without changes.
 """
 
 from .logger import (
-    MetricsLogger,  # noqa: F401
-    MetricsLoggerConfig,  # noqa: F401
-    MetricsShutdownReport,  # noqa: F401
+    MetricsLogger,
+    MetricsLoggerConfig,
+    MetricsShutdownReport,
 )
 from .post_analysis import (
-    PostAnalysisWorker,  # noqa: F401
+    PostAnalysisWorker,
 )
-from .sample_builder import (  # noqa: F401
+from .sample_builder import (
     build_run_metadata,
     build_sample_records,
     dominant_hz_from_strength,

--- a/apps/server/vibesensor/metrics_log/logger.py
+++ b/apps/server/vibesensor/metrics_log/logger.py
@@ -148,6 +148,10 @@ class MetricsLogger:
         self._session.enabled = value
 
     @property
+    def persistence(self) -> MetricsPersistenceCoordinator:
+        return self._persistence
+
+    @property
     def _run_id(self) -> str | None:
         return self._session.run_id
 
@@ -236,7 +240,7 @@ class MetricsLogger:
         with self._lock:
             if self._session.shutdown_requested:
                 LOGGER.info(
-                    "Ignoring start_logging() while metrics logger shutdown is in progress."
+                    "Ignoring start_logging() while metrics logger shutdown is in progress.",
                 )
                 return self.status()
             if self.enabled and self._run_id:
@@ -261,12 +265,14 @@ class MetricsLogger:
         return result
 
     def stop_logging(
-        self, *, _only_if_generation: int | None = None
+        self,
+        *,
+        _only_if_generation: int | None = None,
     ) -> dict[str, str | bool | int | None]:
         flush_snapshot: MetricsSessionSnapshot | None = None
         with self._lock:
             if _only_if_generation is not None and not self._session.matches_generation(
-                _only_if_generation
+                _only_if_generation,
             ):
                 return self.status()
             flush_snapshot = self._pending_flush_snapshot_locked()
@@ -279,7 +285,7 @@ class MetricsLogger:
             )
         with self._lock:
             if _only_if_generation is not None and not self._session.matches_generation(
-                _only_if_generation
+                _only_if_generation,
             ):
                 return self.status()
             run_id_to_analyze = self._persistence.ready_for_analysis(self._run_id)
@@ -313,7 +319,11 @@ class MetricsLogger:
         )
 
     def _build_sample_records(
-        self, *, run_id: str, t_s: float, timestamp_utc: str
+        self,
+        *,
+        run_id: str,
+        t_s: float,
+        timestamp_utc: str,
     ) -> list[dict[str, object]]:
         return build_sample_records(
             run_id=run_id,
@@ -333,7 +343,11 @@ class MetricsLogger:
         )
 
     def _ensure_history_run_created(
-        self, run_id: str, start_time_utc: str, *, session_generation: int
+        self,
+        run_id: str,
+        start_time_utc: str,
+        *,
+        session_generation: int,
     ) -> None:
         self._persistence.ensure_history_run_created(
             run_id,
@@ -382,7 +396,7 @@ class MetricsLogger:
                 session_generation=session_generation,
             )
         return self._session.matches_generation(
-            session_generation
+            session_generation,
         ) and self._session.should_auto_stop(now_mono_s=now_mono_s)
 
     def _finalize_run_locked(self) -> bool:

--- a/apps/server/vibesensor/metrics_log/persistence.py
+++ b/apps/server/vibesensor/metrics_log/persistence.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 _MAX_HISTORY_CREATE_RETRIES = 5
-_RETRY_COOLDOWN_S = 30.0
-"""Seconds to wait before retrying DB run creation after exhausting max retries."""
+_RETRY_COOLDOWN_BASE_S = 2.0
+"""Base seconds for exponential backoff between retry cycles (doubles each cycle, capped at 10s)."""
 
 _MAX_APPEND_RETRIES = 3
 _APPEND_RETRY_DELAYS_S = (0.1, 0.3)
@@ -47,10 +47,13 @@ class MetricsPersistenceCoordinator:
         self._lock = RLock()
         self._history_run_created = False
         self._history_create_fail_count = 0
+        self._retry_cycle_count = 0
         self._written_sample_count = 0
         self._dropped_sample_count = 0
         self._last_write_error: str | None = None
         self._retry_after_mono_s: float = 0.0
+        self._last_write_duration_s: float = 0.0
+        self._max_write_duration_s: float = 0.0
 
     @property
     def write_error(self) -> str | None:
@@ -87,10 +90,21 @@ class MetricsPersistenceCoordinator:
         with self._lock:
             return self._dropped_sample_count
 
+    @property
+    def last_write_duration_s(self) -> float:
+        with self._lock:
+            return self._last_write_duration_s
+
+    @property
+    def max_write_duration_s(self) -> float:
+        with self._lock:
+            return self._max_write_duration_s
+
     def reset_for_new_session(self) -> None:
         with self._lock:
             self._history_run_created = False
             self._history_create_fail_count = 0
+            self._retry_cycle_count = 0
             self._written_sample_count = 0
             self._dropped_sample_count = 0
             self._last_write_error = None
@@ -111,7 +125,11 @@ class MetricsPersistenceCoordinator:
             return None
 
     def ensure_history_run_created(
-        self, run_id: str, start_time_utc: str, *, session_generation: int
+        self,
+        run_id: str,
+        start_time_utc: str,
+        *,
+        session_generation: int,
     ) -> None:
         with self._lock:
             if not self._generation_matches(session_generation):
@@ -119,12 +137,15 @@ class MetricsPersistenceCoordinator:
             if self._history_db is None or self._history_run_created:
                 return
             if self._history_create_fail_count >= _MAX_HISTORY_CREATE_RETRIES:
-                # Retry after cooldown instead of giving up forever
+                # Retry after exponential backoff instead of giving up forever
                 if time.monotonic() < self._retry_after_mono_s:
                     return
+                self._retry_cycle_count += 1
                 LOGGER.info(
-                    "Retry cooldown expired for run %s; resetting failure counter and retrying",
+                    "Retry cooldown expired for run %s; resetting "
+                    "failure counter and retrying (cycle %d)",
                     run_id,
+                    self._retry_cycle_count,
                 )
                 self._history_create_fail_count = 0
         metadata = self._metadata_builder(run_id, start_time_utc)
@@ -135,6 +156,7 @@ class MetricsPersistenceCoordinator:
                     return
                 self._history_run_created = True
                 self._history_create_fail_count = 0
+                self._retry_cycle_count = 0
                 self._retry_after_mono_s = 0.0
             self.clear_last_write_error()
         except (sqlite3.Error, OSError) as exc:
@@ -144,7 +166,8 @@ class MetricsPersistenceCoordinator:
                 self._history_create_fail_count += 1
                 fail_count = self._history_create_fail_count
                 if fail_count >= _MAX_HISTORY_CREATE_RETRIES:
-                    self._retry_after_mono_s = time.monotonic() + _RETRY_COOLDOWN_S
+                    cooldown = min(10.0, _RETRY_COOLDOWN_BASE_S * (2**self._retry_cycle_count))
+                    self._retry_after_mono_s = time.monotonic() + cooldown
             msg = (
                 f"history create_run failed"
                 f" (attempt {fail_count}"
@@ -152,12 +175,13 @@ class MetricsPersistenceCoordinator:
             )
             self.set_last_write_error(msg)
             if fail_count >= _MAX_HISTORY_CREATE_RETRIES:
+                cooldown = min(10.0, _RETRY_COOLDOWN_BASE_S * (2**self._retry_cycle_count))
                 LOGGER.error(
                     "Persistent DB failure after %d attempts for run %s — "
-                    "samples will be dropped until retry in %.0fs. Error: %s",
+                    "samples will be dropped until retry in %.1fs. Error: %s",
                     fail_count,
                     run_id,
-                    _RETRY_COOLDOWN_S,
+                    cooldown,
                     exc,
                     exc_info=True,
                 )
@@ -180,7 +204,9 @@ class MetricsPersistenceCoordinator:
             return AppendRowsResult(history_created=self.history_run_created, rows_written=0)
         if self._history_db is not None and self._persist_history_db:
             self.ensure_history_run_created(
-                run_id, start_time_utc, session_generation=session_generation
+                run_id,
+                start_time_utc,
+                session_generation=session_generation,
             )
             with self._lock:
                 if not self._generation_matches(session_generation):
@@ -190,11 +216,16 @@ class MetricsPersistenceCoordinator:
                 last_exc: Exception | None = None
                 for attempt in range(_MAX_APPEND_RETRIES):
                     try:
+                        write_start = time.monotonic()
                         self._history_db.append_samples(run_id, rows)  # type: ignore[arg-type]
+                        write_dur = time.monotonic() - write_start
                         with self._lock:
                             if not self._generation_matches(session_generation):
                                 return AppendRowsResult(history_created=True, rows_written=0)
                             self._written_sample_count += len(rows)
+                            self._last_write_duration_s = write_dur
+                            if write_dur > self._max_write_duration_s:
+                                self._max_write_duration_s = write_dur
                         self.clear_last_write_error()
                         return AppendRowsResult(history_created=True, rows_written=len(rows))
                     except (sqlite3.Error, OSError) as exc:

--- a/apps/server/vibesensor/metrics_log/post_analysis.py
+++ b/apps/server/vibesensor/metrics_log/post_analysis.py
@@ -88,7 +88,7 @@ class PostAnalysisWorker:
             return bool(
                 self._analysis_active_run_id
                 or self._analysis_queue
-                or (self._analysis_thread and self._analysis_thread.is_alive())
+                or (self._analysis_thread and self._analysis_thread.is_alive()),
             )
 
     @property
@@ -175,7 +175,7 @@ class PostAnalysisWorker:
             worker = Thread(
                 target=self._worker_loop,
                 name="metrics-post-analysis-worker",
-                daemon=True,
+                daemon=False,
             )
             self._analysis_thread = worker
             worker.start()
@@ -224,7 +224,9 @@ class PostAnalysisWorker:
                     db.store_analysis_error(run_id, error_msg)
                 except sqlite3.Error:
                     LOGGER.warning(
-                        "Failed to store analysis error for run %s", run_id, exc_info=True
+                        "Failed to store analysis error for run %s",
+                        run_id,
+                        exc_info=True,
                     )
                 return
             language = str(metadata.get("language") or "en")
@@ -238,7 +240,8 @@ class PostAnalysisWorker:
                     for sample in batch
                 )
                 samples, total_sample_count, stride = bounded_sample(
-                    normalized_iter, max_items=_MAX_POST_ANALYSIS_SAMPLES
+                    normalized_iter,
+                    max_items=_MAX_POST_ANALYSIS_SAMPLES,
                 )
             if not samples:
                 error_msg = "No samples collected during run"
@@ -249,7 +252,11 @@ class PostAnalysisWorker:
                 db.store_analysis_error(run_id, error_msg)
                 return
             summary = summarize_run_data(
-                metadata, samples, lang=language, file_name=run_id, include_samples=False
+                metadata,
+                samples,
+                lang=language,
+                file_name=run_id,
+                include_samples=False,
             )
             summary["analysis_metadata"] = {
                 "analyzed_sample_count": len(samples),
@@ -271,7 +278,7 @@ class PostAnalysisWorker:
                         "check_key": "SUITABILITY_CHECK_ANALYSIS_SAMPLING",
                         "state": "warn",
                         "explanation": explanation,
-                    }
+                    },
                 )
             db.store_analysis(run_id, summary)  # type: ignore[arg-type]
 

--- a/apps/server/vibesensor/metrics_log/sample_builder.py
+++ b/apps/server/vibesensor/metrics_log/sample_builder.py
@@ -261,9 +261,10 @@ def build_sample_records(
     active_client_ids = sorted(
         set(
             processor.clients_with_recent_data(
-                registry.active_client_ids(), max_age_s=_LIVE_SAMPLE_WINDOW_S
-            )
-        )
+                registry.active_client_ids(),
+                max_age_s=_LIVE_SAMPLE_WINDOW_S,
+            ),
+        ),
     )
     for client_id in active_client_ids:
         record = registry.get(client_id)

--- a/apps/server/vibesensor/metrics_log/session_state.py
+++ b/apps/server/vibesensor/metrics_log/session_state.py
@@ -145,7 +145,10 @@ class MetricsSessionState:
             )
 
     def pending_flush_snapshot(
-        self, *, current_total: int, history_run_created: bool
+        self,
+        *,
+        current_total: int,
+        history_run_created: bool,
     ) -> MetricsSessionSnapshot | None:
         with self._lock:
             if (

--- a/apps/server/vibesensor/processing/__init__.py
+++ b/apps/server/vibesensor/processing/__init__.py
@@ -18,14 +18,14 @@ All public symbols are re-exported here so that existing
 continue to work without changes.
 """
 
-from .buffers import ClientBuffer  # noqa: F401
+from .buffers import ClientBuffer
 from .processor import (
-    MAX_CLIENT_SAMPLE_RATE_HZ,  # noqa: F401
-    SignalProcessor,  # noqa: F401
+    MAX_CLIENT_SAMPLE_RATE_HZ,
+    SignalProcessor,
 )
 
 __all__ = [
-    "ClientBuffer",
     "MAX_CLIENT_SAMPLE_RATE_HZ",
+    "ClientBuffer",
     "SignalProcessor",
 ]

--- a/apps/server/vibesensor/processing/buffers.py
+++ b/apps/server/vibesensor/processing/buffers.py
@@ -18,7 +18,7 @@ from .payload import SelectedClientPayload, SpectrumSeriesPayload
 
 
 def _empty_strength_metrics() -> StrengthMetricsPayload:
-    return cast(StrengthMetricsPayload, {})
+    return cast("StrengthMetricsPayload", {})
 
 
 @dataclass(slots=True, eq=False, repr=False)

--- a/apps/server/vibesensor/processing/compute.py
+++ b/apps/server/vibesensor/processing/compute.py
@@ -103,7 +103,7 @@ class SignalMetricsComputer:
         if time_window_detrended.size > 0:
             vib_mag = np.sqrt(np.sum(np.square(time_window_detrended, dtype=np.float64), axis=0))
             vib_mag_rms = _finite_or_zero(
-                float(np.sqrt(np.mean(np.square(vib_mag), dtype=np.float64)))
+                float(np.sqrt(np.mean(np.square(vib_mag), dtype=np.float64))),
             )
             vib_mag_p2p = _finite_or_zero(float(np.max(vib_mag) - np.min(vib_mag)))
         else:
@@ -127,7 +127,7 @@ class SignalMetricsComputer:
             for axis in fft_result["axis_peaks"]:
                 default_axis_metrics: AxisMetrics = {"rms": 0.0, "p2p": 0.0, "peaks": []}
                 axis_metrics = cast(
-                    AxisMetrics,
+                    "AxisMetrics",
                     metrics.setdefault(axis, default_axis_metrics),
                 )
                 axis_metrics["peaks"] = fft_result["axis_peaks"][axis]
@@ -135,7 +135,7 @@ class SignalMetricsComputer:
             if fft_result["axis_amp_slices"]:
                 combined_amp = fft_result["combined_amp"]
                 strength_metrics = fft_result["strength_metrics"]
-                combined_metrics = cast(CombinedMetrics, metrics["combined"])
+                combined_metrics = cast("CombinedMetrics", metrics["combined"])
                 combined_metrics["peaks"] = list(strength_metrics["top_peaks"])
                 combined_metrics["strength_metrics"] = strength_metrics
                 metrics["strength_metrics"] = strength_metrics
@@ -158,7 +158,7 @@ class SignalMetricsComputer:
 
     @staticmethod
     def smooth_spectrum(amps: np.ndarray, bins: int = 5) -> np.ndarray:
-        return cast(np.ndarray, smooth_spectrum(np.asarray(amps, dtype=np.float32), bins=bins))
+        return cast("np.ndarray", smooth_spectrum(np.asarray(amps, dtype=np.float32), bins=bins))
 
     @staticmethod
     def noise_floor(amps: np.ndarray) -> float:

--- a/apps/server/vibesensor/processing/fft.py
+++ b/apps/server/vibesensor/processing/fft.py
@@ -168,7 +168,7 @@ def top_peaks(
                 "snr_ratio": (
                     (raw_amp + STRENGTH_EPSILON_MIN_G) / (floor_amp + STRENGTH_EPSILON_MIN_G)
                 ),
-            }
+            },
         )
     return peaks
 
@@ -219,7 +219,7 @@ def compute_fft_spectrum(
     fft_n = fft_window.shape[0]
     if fft_block.shape[1] != fft_n:
         raise ValueError(
-            f"fft_block column count {fft_block.shape[1]} does not match fft_window length {fft_n}"
+            f"fft_block column count {fft_block.shape[1]} does not match fft_window length {fft_n}",
         )
     if spike_filter_enabled:
         fft_block = medfilt3(fft_block)

--- a/apps/server/vibesensor/processing/payload.py
+++ b/apps/server/vibesensor/processing/payload.py
@@ -105,6 +105,7 @@ def build_multi_spectrum_payload(
         Callable to produce per-client spectrum (already under the same lock).
     analysis_time_range_fn:
         Callable to derive (start_s, end_s, synced) for a buffer.
+
     """
     shared_freq: np.ndarray | None = None
     clients: dict[str, SpectrumSeriesPayload] = {}
@@ -203,6 +204,7 @@ def build_selected_payload(
         Target display refresh rate for waveform decimation.
     latest_fn:
         Callable ``(buf, n) -> ndarray`` to extract the latest *n* samples.
+
     """
     sr = buf.sample_rate_hz or sample_rate_hz
     no_data = buf.count == 0

--- a/apps/server/vibesensor/processing/processor.py
+++ b/apps/server/vibesensor/processing/processor.py
@@ -239,7 +239,7 @@ class SignalProcessor:
     def intake_stats(self) -> IntakeStatsPayload:
         stats = self._store.intake_stats()
         if self._worker_pool is not None:
-            stats["worker_pool"] = cast(JsonObject, self._worker_pool.stats())
+            stats["worker_pool"] = cast("JsonObject", self._worker_pool.stats())
         return stats
 
     def _analysis_time_range(self, buf: ClientBuffer) -> tuple[float, float, bool] | None:

--- a/apps/server/vibesensor/processing/time_align.py
+++ b/apps/server/vibesensor/processing/time_align.py
@@ -119,6 +119,7 @@ def analysis_time_range(
     samples_since_t0:
         Number of samples ingested since ``last_t0_us`` was recorded; used to
         advance the end-of-window pointer to the newest sample.
+
     """
     if count == 0 or last_ingest_mono_s <= 0:
         return None

--- a/apps/server/vibesensor/processing/views.py
+++ b/apps/server/vibesensor/processing/views.py
@@ -107,7 +107,7 @@ class SignalProcessorViews:
                     "x_amp_g": float(axis_amps["x"][index]),
                     "y_amp_g": float(axis_amps["y"][index]),
                     "z_amp_g": float(axis_amps["z"][index]),
-                }
+                },
             )
 
         raw_stats: DebugSpectrumStatsPayload = {

--- a/apps/server/vibesensor/registry.py
+++ b/apps/server/vibesensor/registry.py
@@ -161,8 +161,7 @@ class ClientRecord:
     def record_seq(self, seq: int) -> None:
         """Add *seq* to the dedup window and update the running max."""
         self._seen_seqs.add(seq)
-        if seq > self._seen_seqs_max:
-            self._seen_seqs_max = seq
+        self._seen_seqs_max = max(self._seen_seqs_max, seq)
 
     def prune_seqs(self, window_size: int) -> None:
         """Discard old entries so the window stays bounded to *window_size*."""
@@ -470,7 +469,10 @@ class ClientRegistry:
             return self._clients.get(normalized)
 
     def active_client_ids(
-        self, now: float | None = None, *, now_mono: float | None = None
+        self,
+        now: float | None = None,
+        *,
+        now_mono: float | None = None,
     ) -> list[str]:
         with self._lock:
             mono_now = self._resolve_now_mono(now_mono)
@@ -560,7 +562,10 @@ class ClientRegistry:
         }
 
     def snapshot_for_api(
-        self, now: float | None = None, *, now_mono: float | None = None
+        self,
+        now: float | None = None,
+        *,
+        now_mono: float | None = None,
     ) -> list[ClientApiRow]:
         with self._lock:
             now_ts = self._resolve_now_wall(now)
@@ -577,7 +582,7 @@ class ClientRegistry:
                                 name=self._user_names.get(client_id, f"client-{client_id[-4:]}"),
                                 connected=False,
                             ),
-                        )
+                        ),
                     )
                     continue
                 age_ms = (
@@ -585,7 +590,7 @@ class ClientRegistry:
                 )
                 connected = bool(
                     record.last_seen_mono
-                    and (mono_now - record.last_seen_mono) <= self._stale_ttl_seconds
+                    and (mono_now - record.last_seen_mono) <= self._stale_ttl_seconds,
                 )
                 rows.append(
                     self._client_api_row(
@@ -624,6 +629,6 @@ class ClientRegistry:
                                 }
                             ),
                         ),
-                    )
+                    ),
                 )
             return rows

--- a/apps/server/vibesensor/release_fetcher.py
+++ b/apps/server/vibesensor/release_fetcher.py
@@ -184,7 +184,7 @@ class ServerReleaseFetcher(GitHubAPIClient):
             )
 
         raise ValueError(
-            f"No server release found with tag 'server-v*' in {self._config.server_repo}"
+            f"No server release found with tag 'server-v*' in {self._config.server_repo}",
         )
 
     @staticmethod
@@ -271,7 +271,7 @@ def fetch_latest_wheel_cli() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
-        description="Fetch the latest VibeSensor server wheel from GitHub Releases"
+        description="Fetch the latest VibeSensor server wheel from GitHub Releases",
     )
     parser.add_argument("--repo", default="", help="GitHub owner/repo")
     parser.add_argument("--dest", default=".", help="Destination directory for the wheel")

--- a/apps/server/vibesensor/release_validation.py
+++ b/apps/server/vibesensor/release_validation.py
@@ -51,7 +51,7 @@ def build_release_smoke_config(
     if udp_control_port > 65535:
         raise ValueError(
             f"Release smoke UDP ports exceed range for HTTP port {port}: "
-            f"{udp_data_port}, {udp_control_port}"
+            f"{udp_data_port}, {udp_control_port}",
         )
     data.setdefault("udp", {})
     data["udp"]["data_listen"] = f"{host}:{udp_data_port}"
@@ -148,7 +148,7 @@ def validate_firmware_dist(dist_dir: Path) -> list[str]:
             if sha256 != actual_sha:
                 errors.append(
                     f"{seg_prefix} sha256 mismatch for {file_name}: "
-                    f"expected {sha256}, got {actual_sha}"
+                    f"expected {sha256}, got {actual_sha}",
                 )
 
         if not firmware_seen:
@@ -191,7 +191,7 @@ _SMOKE_SERVER_BOOTSTRAP = "\n".join(
         "    port=runtime.config.server.port,",
         "    log_level='info',",
         ")",
-    ]
+    ],
 )
 
 
@@ -255,7 +255,7 @@ def run_server_smoke(
                 if process.poll() is not None:
                     output = process.stdout.read() if process.stdout is not None else ""
                     raise RuntimeError(
-                        f"Release smoke server exited before becoming healthy.\nOutput:\n{output}"
+                        f"Release smoke server exited before becoming healthy.\nOutput:\n{output}",
                     )
                 try:
                     status, content_type, body = _read_http(health_url)
@@ -284,7 +284,7 @@ def run_server_smoke(
             raise RuntimeError(
                 "Release smoke validation timed out waiting for server readiness.\n"
                 f"Last error: {last_error}\n"
-                f"Output:\n{output}"
+                f"Output:\n{output}",
             )
         finally:
             _terminate_process(process)

--- a/apps/server/vibesensor/report/pdf_diagram_layout.py
+++ b/apps/server/vibesensor/report/pdf_diagram_layout.py
@@ -30,7 +30,8 @@ def _label_bbox(
 
 
 def _boxes_overlap(
-    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
 ) -> bool:
     return min(a[2], b[2]) > max(a[0], b[0]) and min(a[3], b[3]) > max(a[1], b[1])
 
@@ -168,7 +169,7 @@ def _build_sensor_render_plan(
         )
         markers.append(marker)
         occupied_boxes.append(
-            (px - radius - 1.0, py - radius - 1.0, px + radius + 1.0, py + radius + 1.0)
+            (px - radius - 1.0, py - radius - 1.0, px + radius + 1.0, py + radius + 1.0),
         )
 
     marker_by_name = {marker.name: marker for marker in markers}
@@ -180,7 +181,8 @@ def _build_sensor_render_plan(
         if marker.state in label_states or marker.name in highlight
     }
     for name in sorted(
-        labeled_names, key=lambda value: (location_points[value][1], location_points[value][0])
+        labeled_names,
+        key=lambda value: (location_points[value][1], location_points[value][0]),
     ):
         px, py = location_points[name]
         marker = marker_by_name.get(name)

--- a/apps/server/vibesensor/report/pdf_diagram_render.py
+++ b/apps/server/vibesensor/report/pdf_diagram_render.py
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
 
 
 def _location_points(
-    *, car_x: float, car_y: float, car_w: float, car_h: float
+    *,
+    car_x: float,
+    car_y: float,
+    car_w: float,
+    car_h: float,
 ) -> dict[str, tuple[float, float]]:
     center_x = car_x + (car_w / 2)
     center_y = car_y + (car_h / 2)
@@ -37,7 +41,8 @@ def _location_points(
 
 
 def _extract_amp_by_location(
-    summary: dict[str, object], location_rows: list[dict[str, object]]
+    summary: dict[str, object],
+    location_rows: list[dict[str, object]],
 ) -> tuple[set[str], dict[str, float]]:
     connected_locations = {
         _canonical_location(loc) for loc in summary.get("sensor_locations", []) if str(loc).strip()
@@ -102,7 +107,7 @@ def _draw_vehicle_shell(
             fillColor=color_surface,
             strokeColor=color_border,
             strokeWidth=1.4,
-        )
+        ),
     )
     drawing.add(
         Rect(
@@ -115,7 +120,7 @@ def _draw_vehicle_shell(
             fillColor=hex_color("#ffffff"),
             strokeColor=color_row_border,
             strokeWidth=0.7,
-        )
+        ),
     )
     drawing.add(
         Line(
@@ -125,7 +130,7 @@ def _draw_vehicle_shell(
             y0 + car_h - 18,
             strokeColor=color_row_border,
             strokeWidth=0.8,
-        )
+        ),
     )
     front_axle_y = y0 + (car_h * 0.84)
     rear_axle_y = y0 + (car_h * 0.16)
@@ -140,7 +145,7 @@ def _draw_vehicle_shell(
                 axle_y,
                 strokeColor=color_row_border,
                 strokeWidth=0.6,
-            )
+            ),
         )
     wheel_fill = hex_color("#f8fbff")
     wheel_stroke = hex_color(REPORT_COLORS["axis"])
@@ -151,7 +156,7 @@ def _draw_vehicle_shell(
         (wheel_x_right, rear_axle_y),
     ):
         drawing.add(
-            Circle(wx, wy, 11, fillColor=wheel_fill, strokeColor=wheel_stroke, strokeWidth=1.0)
+            Circle(wx, wy, 11, fillColor=wheel_fill, strokeColor=wheel_stroke, strokeWidth=1.0),
         )
     drawing.add(
         String(
@@ -161,7 +166,7 @@ def _draw_vehicle_shell(
             fontName="Helvetica-Bold",
             fontSize=8,
             fillColor=color_text_primary,
-        )
+        ),
     )
     drawing.add(
         String(
@@ -171,7 +176,7 @@ def _draw_vehicle_shell(
             fontName="Helvetica-Bold",
             fontSize=8,
             fillColor=color_text_primary,
-        )
+        ),
     )
 
 
@@ -187,7 +192,7 @@ def _draw_markers_and_labels(drawing: Any, *, markers: list, labels: list, hex_c
                 fillColor=hex_color(marker.fill),
                 strokeColor=hex_color(marker.stroke),
                 strokeWidth=marker.stroke_width,
-            )
+            ),
         )
     for label in labels:
         drawing.add(
@@ -198,7 +203,7 @@ def _draw_markers_and_labels(drawing: Any, *, markers: list, labels: list, hex_c
                 fontSize=label.font_size,
                 textAnchor=label.anchor,
                 fillColor=hex_color(label.color),
-            )
+            ),
         )
 
 
@@ -229,7 +234,7 @@ def _draw_source_legend(
             fontName="Helvetica-Bold",
             fontSize=6,
             fillColor=color_text_primary,
-        )
+        ),
     )
     if single_sensor:
         drawing.add(
@@ -240,7 +245,7 @@ def _draw_source_legend(
                 fontName="Helvetica",
                 fontSize=6,
                 fillColor=hex_color(REPORT_COLORS["text_muted"]),
-            )
+            ),
         )
     max_x = diagram_width - 8.0
     item_gap = 5.0
@@ -256,7 +261,9 @@ def _draw_source_legend(
         ly = swatch_y - (row * row_gap)
         swatch_color = hex_color(color_hex)
         drawing.add(
-            Circle(lx + 4, ly, 3, fillColor=swatch_color, strokeColor=swatch_color, strokeWidth=0.8)
+            Circle(
+                lx + 4, ly, 3, fillColor=swatch_color, strokeColor=swatch_color, strokeWidth=0.8
+            ),
         )
         drawing.add(
             String(
@@ -266,7 +273,7 @@ def _draw_source_legend(
                 fontName="Helvetica",
                 fontSize=5.5,
                 fillColor=hex_color(REPORT_COLORS["text_secondary"]),
-            )
+            ),
         )
         cursor_x += item_w
 
@@ -299,7 +306,7 @@ def car_location_diagram(
     rendered_ratio = car_h / car_w if car_w > 0 else 0.0
     if abs(rendered_ratio - length_width_ratio) / length_width_ratio >= 0.02:
         raise ValueError(
-            f"Car visual aspect ratio violated: rendered {rendered_ratio:.4f} vs source {length_width_ratio:.4f}"
+            f"Car visual aspect ratio violated: rendered {rendered_ratio:.4f} vs source {length_width_ratio:.4f}",
         )
 
     color_surface = hex_color(REPORT_COLORS["surface"])

--- a/apps/server/vibesensor/report/pdf_layout.py
+++ b/apps/server/vibesensor/report/pdf_layout.py
@@ -55,5 +55,5 @@ def assert_aspect_preserved(
         delta = abs(drawn_ratio - src_ratio) / src_ratio
         raise AssertionError(
             f"Car visual aspect ratio distorted. src={src_ratio:.4f}, "
-            f"drawn={drawn_ratio:.4f}, delta={delta:.2%}"
+            f"drawn={drawn_ratio:.4f}, delta={delta:.2%}",
         )

--- a/apps/server/vibesensor/report/pdf_page1.py
+++ b/apps/server/vibesensor/report/pdf_page1.py
@@ -55,7 +55,10 @@ def _label_width(c: Canvas, label: str, *, default_w: float, col_w: float) -> fl
 
 
 def _column_height(
-    rows: list[tuple[str, str, float]], *, available_w: float, row_gap: float
+    rows: list[tuple[str, str, float]],
+    *,
+    available_w: float,
+    row_gap: float,
 ) -> float:
     return _column_height_impl(rows, available_w=available_w, row_gap=row_gap)
 
@@ -181,7 +184,10 @@ def _draw_bottom_row_panels(
 
 
 def _page1(
-    c: Canvas, data: ReportTemplateData, *, ctx: PdfRenderContext | None = None
+    c: Canvas,
+    data: ReportTemplateData,
+    *,
+    ctx: PdfRenderContext | None = None,
 ) -> list[NextStep]:
     """Render the full page-1 worksheet layout."""
     render_ctx = ctx or PdfRenderContext.from_data(data)
@@ -214,7 +220,8 @@ def _draw_system_card(
 
     tone_bg = REPORT_COLORS.get(f"card_{card.tone}_bg", REPORT_COLORS["card_neutral_bg"])
     tone_border = REPORT_COLORS.get(
-        f"card_{card.tone}_border", REPORT_COLORS["card_neutral_border"]
+        f"card_{card.tone}_border",
+        REPORT_COLORS["card_neutral_border"],
     )
     c.setFillColor(_hex(tone_bg))
     c.setStrokeColor(_hex(tone_border))

--- a/apps/server/vibesensor/report/pdf_page1_sections.py
+++ b/apps/server/vibesensor/report/pdf_page1_sections.py
@@ -38,7 +38,10 @@ def label_width(c: Canvas, label: str, *, default_w: float, col_w: float) -> flo
 
 
 def column_height(
-    rows: list[tuple[str, str, float]], *, available_w: float, row_gap: float
+    rows: list[tuple[str, str, float]],
+    *,
+    available_w: float,
+    row_gap: float,
 ) -> float:
     if not rows:
         return 0.0
@@ -91,7 +94,7 @@ def build_header_rows(
                     default_w=left_lbl_default,
                     col_w=left_col_w,
                 ),
-            )
+            ),
         )
     if data.end_time_utc:
         left_rows.append(
@@ -99,7 +102,7 @@ def build_header_rows(
                 tr("END_TIME_UTC"),
                 data.end_time_utc,
                 label_width(c, tr("END_TIME_UTC"), default_w=left_lbl_default, col_w=left_col_w),
-            )
+            ),
         )
 
     right_pairs: list[tuple[str, str]] = []
@@ -233,7 +236,12 @@ def render_observed_signature_panel(
     )
     oy -= obs_step
     _draw_kv(
-        c, ox, oy, tr("SPEED_BAND"), _safe(data.observed.speed_band, na), label_w=OBSERVED_LABEL_W
+        c,
+        ox,
+        oy,
+        tr("SPEED_BAND"),
+        _safe(data.observed.speed_band, na),
+        label_w=OBSERVED_LABEL_W,
     )
     oy -= obs_step
     _draw_kv(

--- a/apps/server/vibesensor/report/pdf_page2.py
+++ b/apps/server/vibesensor/report/pdf_page2.py
@@ -101,11 +101,24 @@ def _draw_pattern_evidence(
 
     systems_text = ", ".join(ev.matched_systems) if ev.matched_systems else na
     ry = _draw_kv(
-        c, rx, ry, tr("MATCHED_SYSTEMS"), systems_text, label_w=label_w, fs=7, value_w=val_w
+        c,
+        rx,
+        ry,
+        tr("MATCHED_SYSTEMS"),
+        systems_text,
+        label_w=label_w,
+        fs=7,
+        value_w=val_w,
     )
     ry -= 1.0 * mm
     ry = _draw_kv(
-        c, rx, ry, tr("STRONGEST_SENSOR"), _safe(ev.strongest_location, na), label_w=label_w, fs=7
+        c,
+        rx,
+        ry,
+        tr("STRONGEST_SENSOR"),
+        _safe(ev.strongest_location, na),
+        label_w=label_w,
+        fs=7,
     )
     ry -= 1.0 * mm
     ry = _draw_kv(c, rx, ry, tr("SPEED_BAND"), _safe(ev.speed_band, na), label_w=label_w, fs=7)
@@ -149,12 +162,24 @@ def _draw_pattern_evidence(
         c.drawString(rx, ry, f"\u26a0 {tr('WARNING_LABEL')}")
         ry -= 3.0 * mm
         ry = _draw_text(
-            c, rx, ry, w - 8 * mm, ev.warning, size=FS_SMALL, color=WARN_CLR, max_lines=3
+            c,
+            rx,
+            ry,
+            w - 8 * mm,
+            ev.warning,
+            size=FS_SMALL,
+            color=WARN_CLR,
+            max_lines=3,
         )
         ry -= 1.5 * mm
 
     ry = _draw_section_block(
-        c, rx, ry, w - 8 * mm, tr("INTERPRETATION"), _safe(ev.interpretation, na)
+        c,
+        rx,
+        ry,
+        w - 8 * mm,
+        tr("INTERPRETATION"),
+        _safe(ev.interpretation, na),
     )
     _draw_section_block(
         c,

--- a/apps/server/vibesensor/routes/__init__.py
+++ b/apps/server/vibesensor/routes/__init__.py
@@ -40,8 +40,8 @@ def create_router(services: RuntimeRouteServices) -> APIRouter:
             services.processing.health_state,
             services.ingress.processor,
             services.ingress.registry,
-            services.diagnostics.metrics_logger,
-        )
+            services.recording.metrics_logger,
+        ),
     )
     router.include_router(
         create_settings_routes(
@@ -50,31 +50,31 @@ def create_router(services: RuntimeRouteServices) -> APIRouter:
             services.settings.analysis_settings,
             services.settings.apply_car_settings,
             services.settings.apply_speed_source_settings,
-        )
+        ),
     )
     router.include_router(
         create_client_routes(
             services.ingress.registry,
             services.ingress.control_plane,
             services.settings.settings_store,
-        )
+        ),
     )
     router.include_router(
         create_recording_routes(
-            services.diagnostics.metrics_logger,
-        )
+            services.recording.metrics_logger,
+        ),
     )
     router.include_router(
         create_history_routes(
             services.persistence,
-        )
+        ),
     )
     router.include_router(create_websocket_routes(services.websocket.hub))
     router.include_router(
         create_update_routes(
             services.updates.update_manager,
             services.updates.esp_flash_manager,
-        )
+        ),
     )
     router.include_router(create_car_library_routes())
     router.include_router(create_debug_routes(services.ingress.processor))

--- a/apps/server/vibesensor/routes/debug.py
+++ b/apps/server/vibesensor/routes/debug.py
@@ -33,7 +33,8 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
         result = processor.debug_spectrum(normalized)
         if isinstance(result, dict) and "error" in result:
             raise HTTPException(
-                status_code=404, detail=cast(DebugSpectrumErrorPayload, result)["error"]
+                status_code=404,
+                detail=cast("DebugSpectrumErrorPayload", result)["error"],
             )
         return result
 
@@ -47,7 +48,8 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
         result = processor.raw_samples(normalized, n_samples=n)
         if isinstance(result, dict) and "error" in result:
             raise HTTPException(
-                status_code=404, detail=cast(RawSamplesErrorPayload, result)["error"]
+                status_code=404,
+                detail=cast("RawSamplesErrorPayload", result)["error"],
             )
         return result
 

--- a/apps/server/vibesensor/routes/health.py
+++ b/apps/server/vibesensor/routes/health.py
@@ -45,6 +45,8 @@ def create_health_routes(
         if health_state.background_task_failures:
             degradation_reasons.append("background_task_failures")
             has_error = True
+        if health_state.startup_warnings:
+            degradation_reasons.append("startup_warnings")
         if loop_state.processing_state != "ok":
             degradation_reasons.append(f"processing_state:{loop_state.processing_state}")
             has_error = True
@@ -82,6 +84,7 @@ def create_health_routes(
             startup_state=health_state.startup_state,
             startup_phase=health_state.startup_phase,
             startup_error=health_state.startup_error,
+            startup_warnings=list(health_state.startup_warnings),
             background_task_failures=dict(health_state.background_task_failures),
             processing_state=loop_state.processing_state,
             processing_failures=failures,
@@ -93,6 +96,11 @@ def create_health_routes(
             data_loss=data_loss,
             persistence=persistence,
             intake_stats=processor.intake_stats(),
+            tick_duration_s=loop_state.last_tick_duration_s,
+            max_tick_duration_s=loop_state.max_tick_duration_s,
+            tick_count=loop_state.tick_count,
+            db_last_write_duration_s=metrics_logger.persistence.last_write_duration_s,
+            db_max_write_duration_s=metrics_logger.persistence.max_write_duration_s,
         )
 
     return router

--- a/apps/server/vibesensor/routes/history.py
+++ b/apps/server/vibesensor/routes/history.py
@@ -60,7 +60,8 @@ def create_history_routes(
 
     @router.get("/api/history/{run_id}/report.pdf", response_class=Response)
     async def download_history_report_pdf(
-        run_id: str, lang: str | None = Query(default=None)
+        run_id: str,
+        lang: str | None = Query(default=None),
     ) -> Response:
         pdf = await report_service.build_pdf(run_id, lang)
         pdf_headers = {

--- a/apps/server/vibesensor/run_context.py
+++ b/apps/server/vibesensor/run_context.py
@@ -92,7 +92,7 @@ def build_summary_warnings(
                 "applies_to": "order_analysis",
                 "title": _i18n_ref("RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"),
                 "detail": _i18n_ref("RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"),
-            }
+            },
         )
     return warnings
 
@@ -132,7 +132,7 @@ def localize_warning_list(
                 "applies_to": str(warning.get("applies_to") or "order_analysis"),
                 "title": _resolve_i18n(lang, warning.get("title")),
                 "detail": _resolve_optional_i18n(lang, warning.get("detail")),
-            }
+            },
         )
     return localized
 

--- a/apps/server/vibesensor/runlog.py
+++ b/apps/server/vibesensor/runlog.py
@@ -47,24 +47,24 @@ def _sanitize_non_finite(obj: JsonValue) -> JsonValue:
 
 
 __all__ = [
-    "RUN_SCHEMA_VERSION",
+    "RUN_END_TYPE",
     "RUN_METADATA_TYPE",
     "RUN_SAMPLE_TYPE",
-    "RUN_END_TYPE",
+    "RUN_SCHEMA_VERSION",
     "RunData",
     "RunEndRecord",
-    "utc_now_iso",
-    "parse_iso8601",
+    "append_jsonl_records",
     "as_float_or_none",
     "as_int_or_none",
-    "default_units",
-    "default_amplitude_definitions",
-    "create_run_metadata",
-    "create_run_end_record",
-    "normalize_sample_record",
-    "append_jsonl_records",
-    "read_jsonl_run",
     "bounded_sample",
+    "create_run_end_record",
+    "create_run_metadata",
+    "default_amplitude_definitions",
+    "default_units",
+    "normalize_sample_record",
+    "parse_iso8601",
+    "read_jsonl_run",
+    "utc_now_iso",
 ]
 
 
@@ -188,6 +188,7 @@ def bounded_sample(
     ------
     ValueError
         If *max_items* is not a positive integer.
+
     """
     if max_items <= 0:
         raise ValueError(f"bounded_sample: max_items must be >= 1, got {max_items}")

--- a/apps/server/vibesensor/runtime/__init__.py
+++ b/apps/server/vibesensor/runtime/__init__.py
@@ -24,10 +24,10 @@ from .rotational_speeds import (
     rotational_basis_speed_source as _rotational_basis_speed_source,
 )
 from .subsystems import (
-    RuntimeDiagnosticsSubsystem,
     RuntimeIngressSubsystem,
     RuntimePersistenceSubsystem,
     RuntimeProcessingSubsystem,
+    RuntimeRecordingSubsystem,
     RuntimeRouteServices,
     RuntimeSettingsSubsystem,
     RuntimeUpdateSubsystem,
@@ -36,19 +36,19 @@ from .subsystems import (
 from .ws_broadcast import WsBroadcastCache
 
 __all__ = [
-    "RuntimeState",
-    "build_runtime_state",
-    "RuntimeIngressSubsystem",
-    "RuntimeSettingsSubsystem",
-    "RuntimeDiagnosticsSubsystem",
-    "RuntimePersistenceSubsystem",
-    "RuntimeUpdateSubsystem",
-    "RuntimeProcessingSubsystem",
-    "RuntimeWebsocketSubsystem",
-    "RuntimeRouteServices",
     "ProcessingLoopState",
     "RuntimeHealthState",
+    "RuntimeIngressSubsystem",
+    "RuntimePersistenceSubsystem",
+    "RuntimeProcessingSubsystem",
+    "RuntimeRecordingSubsystem",
+    "RuntimeRouteServices",
+    "RuntimeSettingsSubsystem",
+    "RuntimeState",
+    "RuntimeUpdateSubsystem",
+    "RuntimeWebsocketSubsystem",
     "WsBroadcastCache",
     "_build_rotational_speeds_payload",
     "_rotational_basis_speed_source",
+    "build_runtime_state",
 ]

--- a/apps/server/vibesensor/runtime/_state.py
+++ b/apps/server/vibesensor/runtime/_state.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from ..config import AppConfig
 from .lifecycle import LifecycleManager
 from .subsystems import (
-    RuntimeDiagnosticsSubsystem,
     RuntimeIngressSubsystem,
     RuntimePersistenceSubsystem,
     RuntimeProcessingSubsystem,
+    RuntimeRecordingSubsystem,
     RuntimeRouteServices,
     RuntimeSettingsSubsystem,
     RuntimeUpdateSubsystem,
@@ -25,7 +25,7 @@ class RuntimeState:
     config: AppConfig
     ingress: RuntimeIngressSubsystem
     settings: RuntimeSettingsSubsystem
-    diagnostics: RuntimeDiagnosticsSubsystem
+    recording: RuntimeRecordingSubsystem
     persistence: RuntimePersistenceSubsystem
     updates: RuntimeUpdateSubsystem
     processing: RuntimeProcessingSubsystem

--- a/apps/server/vibesensor/runtime/builders.py
+++ b/apps/server/vibesensor/runtime/builders.py
@@ -22,10 +22,10 @@ from .health_state import RuntimeHealthState
 from .lifecycle import LifecycleManager
 from .processing_loop import ProcessingLoop, ProcessingLoopState
 from .subsystems import (
-    RuntimeDiagnosticsSubsystem,
     RuntimeIngressSubsystem,
     RuntimePersistenceSubsystem,
     RuntimeProcessingSubsystem,
+    RuntimeRecordingSubsystem,
     RuntimeRouteServices,
     RuntimeSettingsSubsystem,
     RuntimeUpdateSubsystem,
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 
 def resolve_accel_scale_g_per_lsb(config: AppConfig) -> float:
     return cast(
-        float,
+        "float",
         (
             config.processing.accel_scale_g_per_lsb
             if config.processing.accel_scale_g_per_lsb is not None
@@ -106,14 +106,14 @@ def build_settings_subsystem(
     )
 
 
-def build_diagnostics_subsystem(
+def build_recording_subsystem(
     *,
     config: AppConfig,
     ingress: RuntimeIngressSubsystem,
     settings: RuntimeSettingsSubsystem,
     persistence: RuntimePersistenceSubsystem,
     accel_scale_g_per_lsb: float,
-) -> RuntimeDiagnosticsSubsystem:
+) -> RuntimeRecordingSubsystem:
     metrics_logger = MetricsLogger(
         MetricsLoggerConfig(
             enabled=config.logging.log_metrics,
@@ -136,14 +136,14 @@ def build_diagnostics_subsystem(
         settings_store=settings.settings_store,
         language_provider=lambda: settings.settings_store.language,
     )
-    diagnostics = RuntimeDiagnosticsSubsystem(
+    recording = RuntimeRecordingSubsystem(
         metrics_logger=metrics_logger,
     )
     requeue_stale_analysis_runs(
         persistence=persistence,
-        diagnostics=diagnostics,
+        recording=recording,
     )
-    return diagnostics
+    return recording
 
 
 def build_update_subsystem(*, config: AppConfig) -> RuntimeUpdateSubsystem:
@@ -197,7 +197,7 @@ def build_route_services(
     *,
     ingress: RuntimeIngressSubsystem,
     settings: RuntimeSettingsSubsystem,
-    diagnostics: RuntimeDiagnosticsSubsystem,
+    recording: RuntimeRecordingSubsystem,
     persistence: RuntimePersistenceSubsystem,
     updates: RuntimeUpdateSubsystem,
     processing: RuntimeProcessingSubsystem,
@@ -206,7 +206,7 @@ def build_route_services(
     return RuntimeRouteServices(
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=recording,
         persistence=persistence,
         updates=updates,
         processing=processing,
@@ -219,7 +219,7 @@ def build_lifecycle_manager(
     config: AppConfig,
     ingress: RuntimeIngressSubsystem,
     settings: RuntimeSettingsSubsystem,
-    diagnostics: RuntimeDiagnosticsSubsystem,
+    recording: RuntimeRecordingSubsystem,
     persistence: RuntimePersistenceSubsystem,
     updates: RuntimeUpdateSubsystem,
     processing: RuntimeProcessingSubsystem,
@@ -229,7 +229,7 @@ def build_lifecycle_manager(
         config=config,
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=recording,
         persistence=persistence,
         updates=updates,
         processing=processing,
@@ -240,11 +240,11 @@ def build_lifecycle_manager(
 def requeue_stale_analysis_runs(
     *,
     persistence: RuntimePersistenceSubsystem,
-    diagnostics: RuntimeDiagnosticsSubsystem,
+    recording: RuntimeRecordingSubsystem,
 ) -> None:
     stale_analyzing = persistence.history_db.stale_analyzing_run_ids()
     for stale_run_id in stale_analyzing:
         LOGGER.info("Re-queuing stuck analyzing run %s for re-analysis", stale_run_id)
-        diagnostics.metrics_logger.schedule_post_analysis(stale_run_id)
+        recording.metrics_logger.schedule_post_analysis(stale_run_id)
     if stale_analyzing:
         LOGGER.info("Re-queued %d stuck analyzing run(s)", len(stale_analyzing))

--- a/apps/server/vibesensor/runtime/composition.py
+++ b/apps/server/vibesensor/runtime/composition.py
@@ -11,10 +11,10 @@ from ._state import RuntimeState
 from .builders import build_lifecycle_manager
 from .lifecycle import LifecycleManager
 from .subsystems import (
-    RuntimeDiagnosticsSubsystem,
     RuntimeIngressSubsystem,
     RuntimePersistenceSubsystem,
     RuntimeProcessingSubsystem,
+    RuntimeRecordingSubsystem,
     RuntimeRouteServices,
     RuntimeSettingsSubsystem,
     RuntimeUpdateSubsystem,
@@ -27,7 +27,7 @@ def build_runtime_state(
     config: AppConfig,
     ingress: RuntimeIngressSubsystem,
     settings: RuntimeSettingsSubsystem,
-    diagnostics: RuntimeDiagnosticsSubsystem,
+    recording: RuntimeRecordingSubsystem,
     persistence: RuntimePersistenceSubsystem,
     updates: RuntimeUpdateSubsystem,
     processing: RuntimeProcessingSubsystem,
@@ -39,7 +39,7 @@ def build_runtime_state(
         config=config,
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=recording,
         persistence=persistence,
         updates=updates,
         processing=processing,
@@ -49,7 +49,7 @@ def build_runtime_state(
         config=config,
         ingress=ingress,
         settings=settings,
-        diagnostics=diagnostics,
+        recording=recording,
         persistence=persistence,
         updates=updates,
         processing=processing,

--- a/apps/server/vibesensor/runtime/health_state.py
+++ b/apps/server/vibesensor/runtime/health_state.py
@@ -11,6 +11,7 @@ class RuntimeHealthState:
     startup_phase: str = "bootstrap"
     startup_error: str | None = None
     background_task_failures: dict[str, str] = field(default_factory=dict)
+    startup_warnings: list[str] = field(default_factory=list)
 
     def set_phase(self, phase: str) -> None:
         self.startup_phase = phase

--- a/apps/server/vibesensor/runtime/lifecycle.py
+++ b/apps/server/vibesensor/runtime/lifecycle.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import shutil
 from collections.abc import Coroutine
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..udp_data_rx import start_udp_data_receiver
@@ -20,10 +22,10 @@ from ..udp_data_rx import start_udp_data_receiver
 if TYPE_CHECKING:
     from ..config import AppConfig
     from .subsystems import (
-        RuntimeDiagnosticsSubsystem,
         RuntimeIngressSubsystem,
         RuntimePersistenceSubsystem,
         RuntimeProcessingSubsystem,
+        RuntimeRecordingSubsystem,
         RuntimeSettingsSubsystem,
         RuntimeUpdateSubsystem,
         RuntimeWebsocketSubsystem,
@@ -37,17 +39,17 @@ class LifecycleManager:
 
     __slots__ = (
         "_config",
-        "_ingress",
-        "_settings",
-        "_diagnostics",
-        "_persistence",
-        "_updates",
-        "_processing",
-        "_websocket",
-        "_health_state",
-        "tasks",
-        "_data_transport",
         "_data_consumer_task",
+        "_data_transport",
+        "_health_state",
+        "_ingress",
+        "_persistence",
+        "_processing",
+        "_recording",
+        "_settings",
+        "_updates",
+        "_websocket",
+        "tasks",
     )
 
     def __init__(
@@ -56,7 +58,7 @@ class LifecycleManager:
         config: AppConfig,
         ingress: RuntimeIngressSubsystem,
         settings: RuntimeSettingsSubsystem,
-        diagnostics: RuntimeDiagnosticsSubsystem,
+        recording: RuntimeRecordingSubsystem,
         persistence: RuntimePersistenceSubsystem,
         updates: RuntimeUpdateSubsystem,
         processing: RuntimeProcessingSubsystem,
@@ -65,7 +67,7 @@ class LifecycleManager:
         self._config = config
         self._ingress = ingress
         self._settings = settings
-        self._diagnostics = diagnostics
+        self._recording = recording
         self._persistence = persistence
         self._updates = updates
         self._processing = processing
@@ -108,10 +110,34 @@ class LifecycleManager:
         self._monitor_task(task)
         return task
 
+    _LOW_DISK_THRESHOLD_MB = 100
+
+    def _validate_startup(self) -> None:
+        """Run lightweight startup precondition checks (warnings only)."""
+        try:
+            db_path = self._config.logging.history_db_path
+            data_dir = Path(db_path).parent if db_path else None
+        except (AttributeError, TypeError):
+            return
+        if data_dir is None or str(db_path) == ":memory:":
+            return
+        try:
+            free_mb = shutil.disk_usage(data_dir).free // (1024 * 1024)
+            if free_mb < self._LOW_DISK_THRESHOLD_MB:
+                msg = f"low disk space: {free_mb}MB free on {data_dir}"
+                self._health_state.startup_warnings.append(msg)
+                LOGGER.warning("Startup check: %s", msg)
+        except OSError:
+            LOGGER.debug(
+                "Startup check: unable to query disk usage for %s",
+                data_dir,
+            )
+
     async def start(self) -> None:
         """Launch UDP receiver, control plane, and background async tasks."""
         phase = "starting"
         self._health_state.set_phase(phase)
+        self._validate_startup()
         try:
             phase = "udp_receiver"
             self._health_state.set_phase(phase)
@@ -143,12 +169,12 @@ class LifecycleManager:
                         on_tick=self._websocket.broadcast.on_tick,
                     ),
                     name=phase,
-                )
+                ),
             )
 
             phase = "metrics-log"
             self._health_state.set_phase(phase)
-            self.tasks.append(self._start_task(self._diagnostics.metrics_logger.run(), name=phase))
+            self.tasks.append(self._start_task(self._recording.metrics_logger.run(), name=phase))
 
             phase = "gps-speed"
             self._health_state.set_phase(phase)
@@ -159,7 +185,7 @@ class LifecycleManager:
                         port=self._config.gps.gpsd_port,
                     ),
                     name=phase,
-                )
+                ),
             )
 
             phase = "update-startup-recover"
@@ -168,7 +194,7 @@ class LifecycleManager:
                 self._start_task(
                     self._updates.update_manager.startup_recover(),
                     name=phase,
-                )
+                ),
             )
             self._health_state.mark_ready()
         except Exception as exc:
@@ -222,7 +248,7 @@ class LifecycleManager:
 
         analysis_timeout_s = self._config.logging.shutdown_analysis_timeout_s
         shutdown_report = await asyncio.to_thread(
-            self._diagnostics.metrics_logger.shutdown_report,
+            self._recording.metrics_logger.shutdown_report,
             analysis_timeout_s,
         )
         if not shutdown_report.completed:

--- a/apps/server/vibesensor/runtime/processing_loop.py
+++ b/apps/server/vibesensor/runtime/processing_loop.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -20,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 MAX_CONSECUTIVE_FAILURES = 25
 """After this many consecutive processing failures, enter fatal backoff."""
 
-FAILURE_BACKOFF_S = 30
+FAILURE_BACKOFF_S = 5
 """Seconds to sleep on fatal failure threshold before resetting."""
 
 STALE_DATA_AGE_S = 2.0
@@ -53,17 +54,20 @@ class ProcessingLoopState:
     last_failure_message: str | None = None
     sample_rate_mismatch_logged: set[str] = field(default_factory=set)
     frame_size_mismatch_logged: set[str] = field(default_factory=set)
+    last_tick_duration_s: float = 0.0
+    max_tick_duration_s: float = 0.0
+    tick_count: int = 0
 
 
 class ProcessingLoop:
     """Async processing tick loop: evict stale clients, compute metrics, handle failures."""
 
     __slots__ = (
-        "state",
-        "_fft_update_hz",
-        "_sample_rate_hz",
         "_fft_n",
+        "_fft_update_hz",
         "_ingress",
+        "_sample_rate_hz",
+        "state",
     )
 
     def __init__(
@@ -108,7 +112,8 @@ class ProcessingLoop:
             self._ingress.registry.evict_stale()
             active_ids = self._ingress.registry.active_client_ids()
             fresh_ids = self._ingress.processor.clients_with_recent_data(
-                active_ids, max_age_s=STALE_DATA_AGE_S
+                active_ids,
+                max_age_s=STALE_DATA_AGE_S,
             )
         except Exception as exc:
             raise ProcessingLoopError("ingress_state", exc) from exc
@@ -180,7 +185,13 @@ class ProcessingLoop:
                 if _sync_clock_tick >= _SYNC_CLOCK_EVERY_N_TICKS:
                     _sync_clock_tick = 0
                     sync_clock = True
+                tick_start = time.monotonic()
                 await self._run_tick(sync_clock=sync_clock)
+                tick_dur = time.monotonic() - tick_start
+                self.state.last_tick_duration_s = tick_dur
+                if tick_dur > self.state.max_tick_duration_s:
+                    self.state.max_tick_duration_s = tick_dur
+                self.state.tick_count += 1
                 consecutive_failures = 0
                 self.state.processing_state = "ok"
             except ProcessingLoopError as exc:

--- a/apps/server/vibesensor/runtime/subsystems.py
+++ b/apps/server/vibesensor/runtime/subsystems.py
@@ -45,7 +45,7 @@ class RuntimeSettingsSubsystem:
 
 
 @dataclass(slots=True)
-class RuntimeDiagnosticsSubsystem:
+class RuntimeRecordingSubsystem:
     metrics_logger: MetricsLogger
 
 
@@ -88,7 +88,7 @@ class RuntimeWebsocketSubsystem:
 class RuntimeRouteServices:
     ingress: RuntimeIngressSubsystem
     settings: RuntimeSettingsSubsystem
-    diagnostics: RuntimeDiagnosticsSubsystem
+    recording: RuntimeRecordingSubsystem
     persistence: RuntimePersistenceSubsystem
     updates: RuntimeUpdateSubsystem
     processing: RuntimeProcessingSubsystem

--- a/apps/server/vibesensor/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/runtime/ws_broadcast.py
@@ -47,11 +47,11 @@ class WsBroadcastService:
     """WebSocket payload assembly: tick management and cached payload building."""
 
     __slots__ = (
-        "cache",
-        "_ui_push_hz",
-        "_ui_heavy_push_hz",
         "_ingress",
         "_settings",
+        "_ui_heavy_push_hz",
+        "_ui_push_hz",
+        "cache",
     )
 
     def __init__(

--- a/apps/server/vibesensor/settings_store.py
+++ b/apps/server/vibesensor/settings_store.py
@@ -137,7 +137,7 @@ class SettingsStore:
                     "obd2Config": raw.get("obd2Config"),
                     "staleTimeoutS": raw.get("staleTimeoutS"),
                     "fallbackMode": raw.get("fallbackMode"),
-                }
+                },
             )
             self._language = _coerce_language(raw.get("language"))
             self._speed_unit = _coerce_speed_unit(raw.get("speedUnit"))
@@ -161,7 +161,7 @@ class SettingsStore:
             return
         payload = self.snapshot()
         try:
-            self._db.set_settings_snapshot(cast(JsonObject, payload))
+            self._db.set_settings_snapshot(cast("JsonObject", payload))
         except (sqlite3.Error, OSError) as exc:
             LOGGER.error("Failed to persist settings to SQLite", exc_info=True)
             raise PersistenceError("Failed to persist settings to SQLite") from exc
@@ -269,7 +269,8 @@ class SettingsStore:
             return self.get_cars()
 
     def update_active_car_aspects(
-        self, aspects: AnalysisSettingsPayload
+        self,
+        aspects: AnalysisSettingsPayload,
     ) -> AnalysisSettingsPayload:
         with self._lock:
             car = self._find_car(self._active_car_id)
@@ -338,7 +339,7 @@ class SettingsStore:
             old_name, old_location = existing.name, existing.location
             if "name" in data:
                 name = _clamp_str(data["name"], 64)
-                existing.name = name if name else sensor_id
+                existing.name = name or sensor_id
             if "location" in data:
                 existing.location = _clamp_str(data["location"], 64)
             self._sensors[sensor_id] = existing

--- a/apps/server/vibesensor/udp_control_tx.py
+++ b/apps/server/vibesensor/udp_control_tx.py
@@ -41,7 +41,7 @@ class ControlDatagramProtocol(asyncio.DatagramProtocol):
         self.transport: asyncio.DatagramTransport | None = None
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        self.transport = cast(asyncio.DatagramTransport, transport)
+        self.transport = cast("asyncio.DatagramTransport", transport)
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         if not data:

--- a/apps/server/vibesensor/udp_data_rx.py
+++ b/apps/server/vibesensor/udp_data_rx.py
@@ -37,7 +37,7 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
         self.processor = processor
         self.transport: asyncio.DatagramTransport | None = None
         self._queue: asyncio.Queue[tuple[bytes, tuple[str, int]]] = asyncio.Queue(
-            maxsize=max(1, queue_maxsize)
+            maxsize=max(1, queue_maxsize),
         )
         self._queue_drop_log_interval_s = max(0.0, float(queue_drop_log_interval_s))
         self._last_queue_drop_log_ts = 0.0
@@ -45,7 +45,7 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         """Store the transport reference when the datagram endpoint is established."""
-        self.transport = cast(asyncio.DatagramTransport, transport)
+        self.transport = cast("asyncio.DatagramTransport", transport)
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         """Enqueue an incoming datagram for background processing."""
@@ -122,7 +122,10 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                 record = registry.get(client_id)
                 sample_rate_hz = record.sample_rate_hz if record is not None else None
                 processor.ingest(
-                    client_id, msg.samples, sample_rate_hz=sample_rate_hz, t0_us=msg.t0_us
+                    client_id,
+                    msg.samples,
+                    sample_rate_hz=sample_rate_hz,
+                    t0_us=msg.t0_us,
                 )
             transport = self.transport
             if transport is not None:

--- a/apps/server/vibesensor/update/commands.py
+++ b/apps/server/vibesensor/update/commands.py
@@ -12,7 +12,7 @@ _SENSITIVE_KEYS: frozenset[str] = frozenset(
         "secret",
         "key",
         "802-11-wireless-security.psk",
-    }
+    },
 )
 
 

--- a/apps/server/vibesensor/update/installer.py
+++ b/apps/server/vibesensor/update/installer.py
@@ -35,7 +35,7 @@ class UpdateInstallerConfig:
 class UpdateInstaller:
     """Owns install, rollback snapshotting, rollback, and firmware cache refresh."""
 
-    __slots__ = ("_commands", "_tracker", "_config")
+    __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
         self,
@@ -292,7 +292,7 @@ class UpdateInstaller:
                         version=current_version,
                         wheel_name=promoted_wheel.name,
                         sha256=rollback_sha256,
-                    )
+                    ),
                 )
             except OSError as exc:
                 self._tracker.add_issue(
@@ -304,7 +304,7 @@ class UpdateInstaller:
             self._prune_rollback_wheels(keep_name=promoted_wheel.name)
             self._tracker.log(
                 "Rollback snapshot created successfully "
-                f"(wheel={promoted_wheel.name}, sha256={rollback_sha256})"
+                f"(wheel={promoted_wheel.name}, sha256={rollback_sha256})",
             )
             return True
 
@@ -375,7 +375,7 @@ class UpdateInstaller:
             expected_version = wheel_parts[1] if len(wheel_parts) >= 2 else ""
             self._tracker.log(
                 "Rollback metadata missing; falling back to newest "
-                "rollback wheel without checksum pin"
+                "rollback wheel without checksum pin",
             )
 
         if not self._validate_wheel_file(
@@ -427,7 +427,7 @@ class UpdateInstaller:
             )
             self._tracker.log(
                 "WARNING: rolled-back version mismatch "
-                f"(wheel={expected_version}, import={rolled_back_version})"
+                f"(wheel={expected_version}, import={rolled_back_version})",
             )
         self._tracker.log(f"Rolled back to {wheel.name} (verified version={rolled_back_version})")
         return True

--- a/apps/server/vibesensor/update/manager.py
+++ b/apps/server/vibesensor/update/manager.py
@@ -68,7 +68,7 @@ class UpdateManager:
         self._ap_con_name = ap_con_name
         self._wifi_ifname = wifi_ifname
         self._rollback_dir = Path(
-            rollback_dir or os.environ.get("VIBESENSOR_ROLLBACK_DIR", DEFAULT_ROLLBACK_DIR)
+            rollback_dir or os.environ.get("VIBESENSOR_ROLLBACK_DIR", DEFAULT_ROLLBACK_DIR),
         )
         self._server_repo = server_repo or os.environ.get("VIBESENSOR_SERVER_REPO", "")
         self._state_store = state_store or UpdateStateStore()

--- a/apps/server/vibesensor/update/models.py
+++ b/apps/server/vibesensor/update/models.py
@@ -175,7 +175,7 @@ class UpdateJobStatus:
                         phase=str(issue_raw.get("phase", "")),
                         message=str(issue_raw.get("message", "")),
                         detail=str(issue_raw.get("detail", "")),
-                    )
+                    ),
                 )
         log_tail_raw = data.get("log_tail")
         log_tail = (

--- a/apps/server/vibesensor/update/network.py
+++ b/apps/server/vibesensor/update/network.py
@@ -53,7 +53,7 @@ def parse_wifi_diagnostics(log_dir: str = _WIFI_DIAG_DIR) -> list[UpdateIssue]:
                             phase="diagnostics",
                             message="Hotspot summary reports failure",
                             detail=sanitized,
-                        )
+                        ),
                     )
         except OSError:
             LOGGER.debug("Unable to read wifi summary diagnostics from %s", summary, exc_info=True)
@@ -73,7 +73,7 @@ def parse_wifi_diagnostics(log_dir: str = _WIFI_DIAG_DIR) -> list[UpdateIssue]:
                             phase="diagnostics",
                             message="Hotspot log issue",
                             detail=sanitized,
-                        )
+                        ),
                     )
                     if len(hotspot_issues) >= _MAX_HOTSPOT_LOG_ISSUES:
                         break

--- a/apps/server/vibesensor/update/releases.py
+++ b/apps/server/vibesensor/update/releases.py
@@ -27,7 +27,7 @@ class UpdateReleaseCheck:
 class UpdateReleaseService:
     """Checks GitHub releases and downloads the selected wheel."""
 
-    __slots__ = ("_tracker", "_config")
+    __slots__ = ("_config", "_tracker")
 
     def __init__(self, *, tracker: UpdateStatusTracker, config: UpdateReleaseConfig) -> None:
         self._tracker = tracker
@@ -40,7 +40,7 @@ class UpdateReleaseService:
             ReleaseFetcherConfig(
                 server_repo=self._config.server_repo,
                 rollback_dir=str(self._config.rollback_dir),
-            )
+            ),
         )
         try:
             release = await asyncio.to_thread(fetcher.check_update_available, current_version)
@@ -56,7 +56,7 @@ class UpdateReleaseService:
                 latest_tag = latest_release.tag
         except Exception as exc:
             self._tracker.log(
-                f"Could not resolve the latest release tag for ESP firmware sync: {exc}"
+                f"Could not resolve the latest release tag for ESP firmware sync: {exc}",
             )
         return UpdateReleaseCheck(release=None, latest_tag=latest_tag)
 
@@ -67,7 +67,7 @@ class UpdateReleaseService:
             ReleaseFetcherConfig(
                 server_repo=self._config.server_repo,
                 rollback_dir=str(self._config.rollback_dir),
-            )
+            ),
         )
         try:
             return await asyncio.to_thread(fetcher.download_wheel, release, staging_dir)

--- a/apps/server/vibesensor/update/service_control.py
+++ b/apps/server/vibesensor/update/service_control.py
@@ -20,7 +20,7 @@ class UpdateServiceControlConfig:
 class UpdateServiceController:
     """Owns systemd drop-in management and restart scheduling."""
 
-    __slots__ = ("_commands", "_tracker", "_config")
+    __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
         self,

--- a/apps/server/vibesensor/update/state_store.py
+++ b/apps/server/vibesensor/update/state_store.py
@@ -28,7 +28,7 @@ class UpdateStateStore:
 
     def __init__(self, path: str | Path | None = None) -> None:
         self._path = Path(
-            path or os.environ.get("VIBESENSOR_UPDATE_STATE_PATH", DEFAULT_STATE_PATH)
+            path or os.environ.get("VIBESENSOR_UPDATE_STATE_PATH", DEFAULT_STATE_PATH),
         )
 
     @property

--- a/apps/server/vibesensor/update/status.py
+++ b/apps/server/vibesensor/update/status.py
@@ -20,7 +20,7 @@ def _phase_name(phase: UpdatePhase | str) -> str:
 class UpdateStatusTracker:
     """Owns update job state, persistence, redaction, and issue reporting."""
 
-    __slots__ = ("_state_store", "_status", "_redact_secrets")
+    __slots__ = ("_redact_secrets", "_state_store", "_status")
 
     def __init__(
         self,
@@ -118,7 +118,7 @@ class UpdateStatusTracker:
                 phase=_phase_name(phase),
                 message=self.redact(message),
                 detail=self.redact(sanitize_log_line(detail)),
-            )
+            ),
         )
         self._touch()
         self.persist()
@@ -130,7 +130,7 @@ class UpdateStatusTracker:
                     phase=issue.phase,
                     message=self.redact(issue.message),
                     detail=self.redact(issue.detail),
-                )
+                ),
             )
         if issues:
             self._touch()

--- a/apps/server/vibesensor/update/validation.py
+++ b/apps/server/vibesensor/update/validation.py
@@ -21,7 +21,7 @@ class UpdateValidationConfig:
 class UpdatePrerequisiteValidator:
     """Validates tool availability, privilege access, and disk space."""
 
-    __slots__ = ("_commands", "_tracker", "_config")
+    __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
         self,

--- a/apps/server/vibesensor/update/wifi.py
+++ b/apps/server/vibesensor/update/wifi.py
@@ -53,7 +53,7 @@ class UpdateWifiConfig:
 class UpdateWifiController:
     """Owns hotspot shutdown, uplink connection, DNS readiness, and restore."""
 
-    __slots__ = ("_commands", "_tracker", "_config")
+    __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
         self,
@@ -123,8 +123,9 @@ class UpdateWifiController:
             return False
         if not await self._bring_uplink_up(ssid):
             return False
+        fallback = self._config.uplink_fallback_dns
         self._tracker.log(
-            f"Wi-Fi connected successfully (client DNS fallback={self._config.uplink_fallback_dns})"
+            f"Wi-Fi connected successfully (client DNS fallback={fallback})",
         )
         return await self._wait_for_dns_ready()
 
@@ -289,7 +290,7 @@ class UpdateWifiController:
             if "No network with SSID" not in (stderr or ""):
                 break
             self._tracker.log(
-                f"SSID '{ssid}' not found on connect attempt {attempt}; rescanning and retrying"
+                f"SSID '{ssid}' not found on connect attempt {attempt}; rescanning and retrying",
             )
             await self._commands.run(
                 [
@@ -320,7 +321,7 @@ class UpdateWifiController:
     async def _wait_for_dns_ready(self) -> bool:
         self._tracker.log(
             "Validating uplink internet/DNS readiness for at least "
-            f"{int(self._config.dns_ready_min_wait_s)}s..."
+            f"{int(self._config.dns_ready_min_wait_s)}s...",
         )
         deadline = time.monotonic() + self._config.dns_ready_min_wait_s
         last_error = ""

--- a/apps/server/vibesensor/update/workflow.py
+++ b/apps/server/vibesensor/update/workflow.py
@@ -74,7 +74,7 @@ class UpdateWorkflow:
             self.tracker.log(
                 "Downloaded "
                 f"{wheel_path.name} "
-                f"(sha256={getattr(release_check.release, 'sha256', '')})"
+                f"(sha256={getattr(release_check.release, 'sha256', '')})",
             )
             if not await self.releases.verify_download(release_check.release, wheel_path):
                 return

--- a/apps/server/vibesensor/worker_pool.py
+++ b/apps/server/vibesensor/worker_pool.py
@@ -92,9 +92,9 @@ class WorkerPool:
         "_queued_tasks",
         "_rejected_tasks",
         "_running_tasks",
-        "_total_tasks",
         "_total_run_s",
         "_total_submit_wait_s",
+        "_total_tasks",
     )
 
     def __init__(
@@ -182,6 +182,7 @@ class WorkerPool:
             Optional per-call capacity wait timeout. ``None`` uses the pool
             default from ``submit_timeout_s``. If the timeout expires before a
             slot becomes available, :class:`TimeoutError` is raised.
+
         """
         effective_timeout = self._default_submit_timeout_s
         if timeout_s is not None:
@@ -214,7 +215,7 @@ class WorkerPool:
             raise RuntimeError("WorkerPool is shut down") from exc
 
         future.add_done_callback(
-            lambda _: self._release_completed_task(started=bool(state["started"]))
+            lambda _: self._release_completed_task(started=bool(state["started"])),
         )
         return future
 
@@ -240,6 +241,7 @@ class WorkerPool:
             If the pool has already been shut down.
         TimeoutError
             If waiting for capacity exceeds the effective timeout.
+
         """
         if not items:
             return {}
@@ -287,6 +289,7 @@ class WorkerPool:
 
         Blocked submitters are woken immediately and will raise
         :class:`RuntimeError` instead of waiting for capacity.
+
         """
         with self._condition:
             self._alive = False

--- a/apps/server/vibesensor/ws_hub.py
+++ b/apps/server/vibesensor/ws_hub.py
@@ -22,7 +22,7 @@ from .payload_types import LiveWsPayload
 
 LOGGER = logging.getLogger(__name__)
 
-__all__ = ["WebSocketHub", "WSConnection"]
+__all__ = ["WSConnection", "WebSocketHub"]
 
 
 def _ws_debug_enabled() -> bool:
@@ -135,7 +135,7 @@ class WebSocketHub:
             return bool(
                 current is not None
                 and not current.closing
-                and current.connection_id == conn.connection_id
+                and current.connection_id == conn.connection_id,
             )
 
     async def _mark_snapshot_closing(self, conn: _WSConnectionSnapshot) -> bool:
@@ -278,7 +278,7 @@ class WebSocketHub:
                     debug_info=debug_info,
                 )
                 for conn in conns
-            )
+            ),
         )
         for conn in dead_ws:
             if conn is not None:

--- a/apps/server/vibesensor/ws_models.py
+++ b/apps/server/vibesensor/ws_models.py
@@ -20,16 +20,16 @@ SCHEMA_VERSION: str = "1"
 __all__ = [
     "SCHEMA_VERSION",
     "AlignmentInfo",
+    "ClientInfoModel",
     "FrequencyWarning",
     "LiveWsPayload",
     "OrderBand",
     "RotationalSpeedValue",
     "RotationalSpeeds",
-    "ClientInfoModel",
-    "StrengthMetricsModel",
     "SpectraPayload",
     "SpectrumPeak",
     "SpectrumSeries",
+    "StrengthMetricsModel",
 ]
 
 
@@ -96,7 +96,7 @@ class ClientInfoModel(BaseModel):
     reset_count: int = 0
     last_reset_time: float | None = None
     timing_health: TimingHealthPayload = Field(
-        default_factory=lambda: {"jitter_us_ema": 0.0, "drift_us_total": 0.0}
+        default_factory=lambda: {"jitter_us_ema": 0.0, "drift_us_total": 0.0},
     )
 
 

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -1774,6 +1774,16 @@
           "data_loss": {
             "$ref": "#/components/schemas/HealthDataLossResponse"
           },
+          "db_last_write_duration_s": {
+            "default": 0.0,
+            "title": "Db Last Write Duration S",
+            "type": "number"
+          },
+          "db_max_write_duration_s": {
+            "default": 0.0,
+            "title": "Db Max Write Duration S",
+            "type": "number"
+          },
           "degradation_reasons": {
             "items": {
               "type": "string"
@@ -1787,6 +1797,11 @@
           },
           "intake_stats": {
             "$ref": "#/components/schemas/HealthIntakeStatsResponse"
+          },
+          "max_tick_duration_s": {
+            "default": 0.0,
+            "title": "Max Tick Duration S",
+            "type": "number"
           },
           "persistence": {
             "$ref": "#/components/schemas/HealthPersistenceResponse"
@@ -1840,6 +1855,14 @@
             "title": "Startup State",
             "type": "string"
           },
+          "startup_warnings": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Startup Warnings",
+            "type": "array"
+          },
           "status": {
             "enum": [
               "ok",
@@ -1848,6 +1871,16 @@
             ],
             "title": "Status",
             "type": "string"
+          },
+          "tick_count": {
+            "default": 0,
+            "title": "Tick Count",
+            "type": "integer"
+          },
+          "tick_duration_s": {
+            "default": 0.0,
+            "title": "Tick Duration S",
+            "type": "number"
           }
         },
         "required": [

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -824,11 +824,26 @@ export interface components {
         [key: string]: string;
       };
       data_loss: components["schemas"]["HealthDataLossResponse"];
+      /**
+       * Db Last Write Duration S
+       * @default 0
+       */
+      db_last_write_duration_s?: number;
+      /**
+       * Db Max Write Duration S
+       * @default 0
+       */
+      db_max_write_duration_s?: number;
       /** Degradation Reasons */
       degradation_reasons: string[];
       /** Frame Size Mismatch Count */
       frame_size_mismatch_count: number;
       intake_stats: components["schemas"]["HealthIntakeStatsResponse"];
+      /**
+       * Max Tick Duration S
+       * @default 0
+       */
+      max_tick_duration_s?: number;
       persistence: components["schemas"]["HealthPersistenceResponse"];
       /** Processing Failure Categories */
       processing_failure_categories: {
@@ -849,10 +864,25 @@ export interface components {
       /** Startup State */
       startup_state: string;
       /**
+       * Startup Warnings
+       * @default []
+       */
+      startup_warnings?: string[];
+      /**
        * Status
        * @enum {string}
        */
       status: "ok" | "warn" | "degraded";
+      /**
+       * Tick Count
+       * @default 0
+       */
+      tick_count?: number;
+      /**
+       * Tick Duration S
+       * @default 0
+       */
+      tick_duration_s?: number;
     };
     /**
      * HistoryInsightWarningResponse

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -30,7 +30,7 @@ One row per recording session.
 | Column | Type | Description |
 |--------|------|-------------|
 | `run_id` | TEXT PK | UUID for the run |
-| `status` | TEXT | `recording` → `analyzing` → `complete` (or `error`) |
+| `status` | TEXT | `recording` → `analyzing` → `complete` (or `error`). CHECK constraint enforces valid values on new databases. Transitions are enforced atomically via WHERE guards. |
 | `start_time_utc` | TEXT | ISO-8601 start time |
 | `end_time_utc` | TEXT | ISO-8601 end time (set on finalize) |
 | `metadata_json` | TEXT | Run-level metadata (car config, language, sensor model, etc.) |

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -21,7 +21,11 @@ curl -sf http://10.4.0.1/api/clients || curl -sf http://10.4.0.1:8000/api/client
 When interpreting `/api/health`, check `startup_state`, `startup_phase`, and
 `background_task_failures` before chasing downstream symptoms. A healthy boot
 should reach `startup_state: ready` with an empty `background_task_failures`
-map.
+map. The response also includes operational metrics:
+
+- `startup_warnings` — precondition issues detected at boot (e.g. low disk space)
+- `tick_duration_s` / `max_tick_duration_s` / `tick_count` — processing loop timing
+- `db_last_write_duration_s` / `db_max_write_duration_s` — DB write latency
 
 ## Diagnose high dropped frames
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,15 +78,27 @@ Regression coverage is grouped by intent:
 
 Prefer focused files grouped by behavior or maintenance boundary. Recent high-churn suites in `api/`, `report/`, `update/`, `analysis/`, and `apps/ui/tests/` are intentionally split into smaller behavior-focused files plus local helper modules such as `_history_endpoint_helpers.py`, `_report_persistence_helpers.py`, `_report_pdf_test_helpers.py`, `_update_manager_test_helpers.py`, `_diagnosis_robustness_helpers.py`, `_phased_scenario_helpers.py`, and `smoke.helpers.ts` so failures stay easy to diagnose without centralizing unrelated assertions in one mega-file.
 
+## Contract bridge tests
+
+Contract bridge tests live in `apps/server/tests/integration/` and validate that data produced by one subsystem is accepted by the next. They catch schema drift at subsystem boundaries that unit tests miss.
+
+| File | Boundary |
+|---|---|
+| `test_contract_analysis_report.py` | `summarize_run_data()` → `map_summary()` |
+| `test_contract_persistence_analysis.py` | `HistoryDB` write → read → `summarize_run_data()` |
+
+These tests run in standard CI (no special markers). They use minimal synthetic data and complete in under 5 seconds.
+
 ## Running tests
 
-```bash
-# Canonical verification entry points
-python3 tools/tests/run_verification.py --suite ci-parity
-python3 tools/tests/run_verification.py --suite full-stack
+Two tiers: `make test` for iteration, `make test-all` before pushing.
 
-# Full backend suite (excludes selenium)
-pytest -q -m "not selenium" apps/server/tests
+```bash
+# Fast iteration — backend unit tests (excludes selenium)
+make test
+
+# Full CI-parity — all blocking CI jobs in parallel
+make test-all
 
 # Single feature area
 pytest -q apps/server/tests/report/
@@ -97,14 +109,13 @@ pytest -q apps/server/tests/update/
 pytest -q apps/server/tests/integration/
 pytest -q apps/server/tests/regression/report/
 
-# Progress output for a faster local loop
-python3 tools/tests/pytest_progress.py --show-test-names -- -m "not selenium" apps/server/tests
+# Focused CI job groups
+python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests
+python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
+python3 tools/tests/run_ci_parallel.py --job release-smoke
 
-# CI-parity job groups
-make test-all
-python3 tools/tests/run_verification.py --suite ci-parity --job backend-quality --job backend-typecheck --job backend-tests
-python3 tools/tests/run_verification.py --suite ci-parity --job frontend-typecheck --job ui-smoke
-python3 tools/tests/run_verification.py --suite ci-parity --job release-smoke
+# Full-stack (Docker-backed)
+make test-full-suite
 ```
 
 `release-smoke` is the packaged-artifact gate. It builds or reuses the server


### PR DESCRIPTION
## Summary

Five-chunk CTO-level engineering remediation addressing 30 findings from a comprehensive review. All changes validated: **5011 tests pass, lint clean, mypy clean (131 files)**.

---

### Chunk 1 — Naming & Reliability
- Rename `RuntimeDiagnosticsSubsystem` → `RuntimeRecordingSubsystem` (reflects actual responsibility)
- Fix `daemon=True` → `daemon=False` on post-analysis thread (prevents silent data loss on shutdown)
- Add exponential backoff to persistence retries (2s base, 10s cap, was fixed 30s)
- Reduce processing loop failure backoff from 30s to 5s

### Chunk 2 — API Ergonomics
- Refactor `build_pattern_evidence()` from 13 → 4 params via context objects
- Refactor `build_system_cards()` from 6 → 4 params
- Add `ReportMappingContext` and `PrimaryCandidateContext` dataclasses

### Chunk 3 — Data Persistence Integrity
- Add `CHECK` constraint on `runs.status` column
- Make `store_analysis()`/`store_analysis_error()` fully atomic (WHERE-first pattern)
- Add metadata and analysis summary validation warnings at write boundaries
- Add `verify_run_integrity()` method for consistency checks
- 9 new tests for validation and atomic transitions

### Chunk 4 — Operational Readiness
- Add tick duration tracking to `ProcessingLoopState`
- Add DB write timing to `MetricsPersistenceCoordinator`
- Add startup disk space validation in `LifecycleManager`
- Extend `/api/health` with operational metrics (`startup_warnings`, `tick_duration_s`, `db_last_write_duration_s`, etc.)

### Chunk 5 — Developer Experience
- Add 8 contract bridge tests (analysis→report boundary, persistence→analysis boundary)
- Consolidate Makefile test targets to two-tier workflow: `make test` + `make test-all`
- Add `make sync-contracts` target
- Update `CONTRIBUTING.md` and `docs/testing.md`

---

**274 files changed**, +1638 −1178