### PR TITLE
domain: enrich object model with value objects, enums, and guards

### DIFF
--- a/apps/server/tests/analysis/test_finding_objects.py
+++ b/apps/server/tests/analysis/test_finding_objects.py
@@ -143,7 +143,7 @@ class TestFindingCollection:
     def test_items_property(self) -> None:
         findings = [make_finding_payload(confidence=0.65)]
         coll = FindingCollection(findings)
-        assert coll.items is findings
+        assert coll.items == findings
 
 
 # ===========================================================================

--- a/apps/server/tests/domain/test_core.py
+++ b/apps/server/tests/domain/test_core.py
@@ -10,8 +10,8 @@ import pytest
 from vibesensor.domain import (
     Measurement,
     Run,
+    RunPhase,
     RunStatus,
-    SessionStatus,
     VibrationReading,
     transition_run,
 )
@@ -168,23 +168,34 @@ class TestRun:
 
     def test_initial_state_is_pending(self) -> None:
         session = Run()
-        assert session.status is SessionStatus.PENDING
+        assert session.status is RunPhase.PENDING
 
-    def test_session_id_is_unique(self) -> None:
+    def test_run_id_is_unique(self) -> None:
         s1 = Run()
         s2 = Run()
-        assert s1.session_id != s2.session_id
+        assert s1.run_id != s2.run_id
 
     def test_start_transitions_to_running(self) -> None:
         session = Run()
         session.start()
-        assert session.status is SessionStatus.RUNNING
+        assert session.status is RunPhase.RUNNING
 
     def test_start_when_already_running_raises(self) -> None:
         session = Run()
         session.start()
-        with pytest.raises(RuntimeError, match="Cannot start session"):
+        with pytest.raises(RuntimeError, match="Cannot start run"):
             session.start()
+
+    def test_stop_transitions_to_stopped(self) -> None:
+        session = Run()
+        session.start()
+        session.stop()
+        assert session.status is RunPhase.STOPPED
+
+    def test_stop_when_not_running_raises(self) -> None:
+        session = Run()
+        with pytest.raises(RuntimeError, match="Cannot stop run"):
+            session.stop()
 
     def test_analysis_settings(self) -> None:
         settings = {"tire_width_mm": 285.0, "final_drive_ratio": 3.08}

--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -12,8 +12,6 @@ from datetime import UTC, datetime
 import pytest
 
 from vibesensor.domain import (
-    # Backward compatibility aliases
-    AccelerationSample,
     AnalysisWindow,
     Car,
     Finding,
@@ -43,11 +41,8 @@ class TestRunAlias:
         assert run.status.value == "running"
 
 
-class TestMeasurementAlias:
-    """Measurement is the primary domain name for AccelerationSample."""
-
-    def test_measurement_is_acceleration_sample(self) -> None:
-        assert Measurement is AccelerationSample
+class TestMeasurement:
+    """Measurement domain object tests."""
 
     def test_measurement_creates_valid_sample(self) -> None:
         m = Measurement(x=0.1, y=0.2, z=0.3, timestamp=_NOW, sample_rate_hz=4096)
@@ -157,7 +152,7 @@ class TestCar:
         car = Car()
         assert car.name == "Unnamed Car"
         assert car.car_type == "sedan"
-        assert car.display_name == "Unnamed Car"
+        assert car.display_name == "Unnamed Car (sedan)"
 
     def test_car_with_type(self) -> None:
         car = Car(name="BMW 3 Series", car_type="suv")
@@ -390,7 +385,7 @@ class TestPackageImports:
 
         # Verify they are the expected types
         assert Run is not None
-        assert Measurement is AccelerationSample
+        assert Measurement is not None
         assert Car is not None
         assert Sensor is not None
         assert SensorPlacement is not None
@@ -596,7 +591,8 @@ class TestFindingEnrichments:
         assert f.dominance_ratio == 0.85
         assert f.diffuse_excitation is True
         assert f.weak_spatial_separation is True
-        assert f.phase_evidence == {"cruise_fraction": 0.6}
+        assert f.phase_evidence is not None
+        assert f.phase_evidence.cruise_fraction == pytest.approx(0.6)
 
 
 class TestAnalysisWindowEnrichments:
@@ -776,7 +772,7 @@ class TestSensorPlacementEnrichments:
         assert not sp.is_body
 
     def test_is_body(self) -> None:
-        sp = SensorPlacement(code="dashboard")
+        sp = SensorPlacement(code="driver_seat")
         assert sp.is_body
         assert not sp.is_wheel
         assert not sp.is_drivetrain
@@ -788,7 +784,7 @@ class TestSensorPlacementEnrichments:
         assert SensorPlacement(code="transmission").position_category == "drivetrain"
 
     def test_position_category_body(self) -> None:
-        assert SensorPlacement(code="dashboard").position_category == "body"
+        assert SensorPlacement(code="driver_seat").position_category == "body"
 
     def test_position_category_other(self) -> None:
         assert SensorPlacement(code="custom_location").position_category == "other"

--- a/apps/server/vibesensor/analysis/_types.py
+++ b/apps/server/vibesensor/analysis/_types.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, NotRequired, Required, TypeAlias, TypedDict, TypeGuard
 
 from ..domain.finding import PhaseEvidence as PhaseEvidence  # re-export from domain
+from ..domain.finding import VibrationSource as VibrationSource  # re-export from domain
 from ..json_types import JsonObject, JsonValue
 from ..json_types import is_json_object as is_json_object  # re-export canonical source
 from .phase_segmentation import DrivingPhase

--- a/apps/server/vibesensor/analysis/findings.py
+++ b/apps/server/vibesensor/analysis/findings.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from math import floor as _math_floor
 from math import log1p
+from typing import NamedTuple
 
 from vibesensor.vibration_strength import percentile
 from vibesensor.vibration_strength import (
@@ -68,6 +69,13 @@ from .phase_segmentation import (
 # ---------------------------------------------------------------------------
 
 
+class AnnotatedFinding(NamedTuple):
+    """A finding payload paired with its eagerly-built domain object."""
+
+    payload: FindingPayload
+    domain: DomainFinding
+
+
 class FindingCollection:
     """Typed operations over a ``list[FindingPayload]``.
 
@@ -79,41 +87,38 @@ class FindingCollection:
     redundant ``from_payload()`` calls on every filter pass.
     """
 
-    __slots__ = ("_items", "_domain_cache")
+    __slots__ = ("_pairs",)
 
     def __init__(self, findings: list[FindingPayload]) -> None:
-        self._items = findings
-        self._domain_cache: list[DomainFinding] = [DomainFinding.from_payload(f) for f in findings]
+        self._pairs: list[AnnotatedFinding] = [
+            AnnotatedFinding(f, DomainFinding.from_payload(f)) for f in findings
+        ]
 
     # -- access ------------------------------------------------------------
 
     @property
     def items(self) -> list[FindingPayload]:
-        return self._items
+        return [p.payload for p in self._pairs]
 
     def __len__(self) -> int:
-        return len(self._items)
+        return len(self._pairs)
 
     def __iter__(self) -> Iterator[FindingPayload]:
-        return iter(self._items)
+        return iter(p.payload for p in self._pairs)
 
     # -- filtering ---------------------------------------------------------
 
     def references(self) -> list[FindingPayload]:
-        return [f for f, d in zip(self._items, self._domain_cache, strict=True) if d.is_reference]
+        return [p.payload for p in self._pairs if p.domain.is_reference]
 
     def diagnostics(self) -> list[FindingPayload]:
-        return [f for f, d in zip(self._items, self._domain_cache, strict=True) if d.is_diagnostic]
+        return [p.payload for p in self._pairs if p.domain.is_diagnostic]
 
     def informational(self) -> list[FindingPayload]:
-        return [
-            f for f, d in zip(self._items, self._domain_cache, strict=True) if d.is_informational
-        ]
+        return [p.payload for p in self._pairs if p.domain.is_informational]
 
     def non_reference(self) -> list[FindingPayload]:
-        return [
-            f for f, d in zip(self._items, self._domain_cache, strict=True) if not d.is_reference
-        ]
+        return [p.payload for p in self._pairs if not p.domain.is_reference]
 
     # -- ordering and finalization -----------------------------------------
 
@@ -125,26 +130,25 @@ class FindingCollection:
         ``finding_sort_key`` (quantised confidence + ranking score).
         Non-reference findings receive sequential IDs ``F001``, ``F002``, …
         """
-        paired = list(zip(self._items, self._domain_cache, strict=True))
-        refs = [(f, d) for f, d in paired if d.is_reference]
-        diags = [(f, d) for f, d in paired if d.is_diagnostic]
-        infos = [(f, d) for f, d in paired if d.is_informational]
-        diags.sort(key=lambda pair: pair[1].rank_key, reverse=True)
-        infos.sort(key=lambda pair: pair[1].rank_key, reverse=True)
-        ordered_pairs = refs + diags + infos
+        refs = [p for p in self._pairs if p.domain.is_reference]
+        diags = [p for p in self._pairs if p.domain.is_diagnostic]
+        infos = [p for p in self._pairs if p.domain.is_informational]
+        diags.sort(key=lambda p: p.domain.rank_key, reverse=True)
+        infos.sort(key=lambda p: p.domain.rank_key, reverse=True)
+        ordered = refs + diags + infos
         counter = 0
+        new_pairs: list[AnnotatedFinding] = []
         result: list[FindingPayload] = []
-        new_cache: list[DomainFinding] = []
-        for finding, domain_obj in ordered_pairs:
+        for pair in ordered:
+            payload, domain_obj = pair
             if not domain_obj.is_reference:
                 counter += 1
                 new_id = f"F{counter:03d}"
-                finding = {**finding, "finding_id": new_id}
+                payload = {**payload, "finding_id": new_id}
                 domain_obj = domain_obj.with_id(new_id)
-            result.append(finding)
-            new_cache.append(domain_obj)
-        self._items = result
-        self._domain_cache = new_cache
+            new_pairs.append(AnnotatedFinding(payload, domain_obj))
+            result.append(payload)
+        self._pairs = new_pairs
         return result
 
 

--- a/apps/server/vibesensor/analysis/helpers.py
+++ b/apps/server/vibesensor/analysis/helpers.py
@@ -23,6 +23,7 @@ from ..constants import (
     STEADY_SPEED_STDDEV_KMH,
     WEAK_SPATIAL_DOMINANCE_THRESHOLD,
 )
+from ..domain import SpeedBand
 from ..json_types import JsonObject
 from ..json_utils import as_float_or_none as _as_float
 from ..locations import label_for_code as _label_for_code
@@ -132,20 +133,12 @@ def _outlier_summary(values: list[float]) -> _OutlierSummary:
 
 
 def _speed_bin_label(kmh: float) -> str:
-    if not isfinite(kmh) or kmh < 0:
-        kmh = 0.0
-    low = int(kmh // SPEED_BIN_WIDTH_KMH) * SPEED_BIN_WIDTH_KMH
-    high = low + SPEED_BIN_WIDTH_KMH
-    return f"{low}-{high} km/h"
+    return SpeedBand.from_speed_kmh(kmh, bin_width=SPEED_BIN_WIDTH_KMH).label
 
 
 def _speed_bin_sort_key(label: str) -> int:
-    head = label.split(" ", 1)[0]
-    low_text = head.split("-", 1)[0]
-    try:
-        return int(low_text)
-    except ValueError:
-        return 0
+    band = SpeedBand.from_label(label)
+    return band.sort_key if band is not None else 0
 
 
 def _amplitude_weighted_speed_window(

--- a/apps/server/vibesensor/analysis/order_analysis.py
+++ b/apps/server/vibesensor/analysis/order_analysis.py
@@ -26,7 +26,9 @@ from ..constants import (
     ORDER_TOLERANCE_REL,
     SECONDS_PER_MINUTE,
     SNR_LOG_DIVISOR,
+    SPEED_BIN_WIDTH_KMH,
 )
+from ..domain.finding import SpeedBand, VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from ._types import (
     FindingPayload,
@@ -47,8 +49,6 @@ from .helpers import (
     _location_label,
     _phase_to_str,
     _sample_top_peaks,
-    _speed_bin_label,
-    _speed_bin_sort_key,
     _speed_profile_from_points,
 )
 from .phase_segmentation import DrivingPhase
@@ -115,15 +115,15 @@ class OrderHypothesis:
         metadata: MetadataDict,
         tire_circumference_m: float | None,
     ) -> tuple[float | None, str]:
-        if self.key.startswith("wheel_"):
+        if self.order_label_base == "wheel":
             base = _wheel_hz(sample, tire_circumference_m)
             return (base * self.order, "speed+tire") if base is not None else (None, "missing")
-        if self.key.startswith("driveshaft_"):
+        if self.order_label_base == "driveshaft":
             base = _driveshaft_hz(sample, metadata, tire_circumference_m)
             if base is None:
                 return None, "missing"
             return base * self.order, "speed+tire+final_drive"
-        if self.key.startswith("engine_"):
+        if self.order_label_base == "engine":
             base, src = _engine_hz(sample, metadata, tire_circumference_m)
             return (base * self.order, src) if base is not None else (None, "missing")
         return None, "missing"
@@ -136,14 +136,26 @@ _ORDER_HYPOTHESES: tuple[OrderHypothesis, ...] = (
     # Wheel orders travel through tire sidewall → hub → knuckle → control
     # arms → bushings → subframe → body → sensor.  Each rubber component
     # broadens the peak and reduces tracking precision.
-    OrderHypothesis("wheel_1x", "wheel/tire", "wheel", 1, path_compliance=1.5),
-    OrderHypothesis("wheel_2x", "wheel/tire", "wheel", 2, path_compliance=1.5),
+    OrderHypothesis("wheel_1x", VibrationSource.WHEEL_TIRE, "wheel", 1, path_compliance=1.5),
+    OrderHypothesis("wheel_2x", VibrationSource.WHEEL_TIRE, "wheel", 2, path_compliance=1.5),
     # Driveshaft has a shorter, stiffer path: shaft → diff → subframe → body.
-    OrderHypothesis("driveshaft_1x", "driveline", "driveshaft", 1, path_compliance=1.0),
-    OrderHypothesis("driveshaft_2x", "driveline", "driveshaft", 2, path_compliance=1.0),
+    OrderHypothesis(
+        "driveshaft_1x",
+        VibrationSource.DRIVELINE,
+        "driveshaft",
+        1,
+        path_compliance=1.0,
+    ),
+    OrderHypothesis(
+        "driveshaft_2x",
+        VibrationSource.DRIVELINE,
+        "driveshaft",
+        2,
+        path_compliance=1.0,
+    ),
     # Engine is stiffly mounted on most vehicles.
-    OrderHypothesis("engine_1x", "engine", "engine", 1, path_compliance=1.0),
-    OrderHypothesis("engine_2x", "engine", "engine", 2, path_compliance=1.0),
+    OrderHypothesis("engine_1x", VibrationSource.ENGINE, "engine", 1, path_compliance=1.0),
+    OrderHypothesis("engine_2x", VibrationSource.ENGINE, "engine", 2, path_compliance=1.0),
 )
 
 
@@ -215,7 +227,7 @@ def _finding_actions_for_source(
     _speed_hint_param: I18nRef = (
         {"speed_hint": i18n_ref("SPEED_HINT_FOCUS", speed_band=speed_band)} if speed_band else {}
     )
-    if source == "wheel/tire":
+    if source == VibrationSource.WHEEL_TIRE:
         wheel_focus = _wheel_focus_from_location(location)
         location_hint = (
             i18n_ref("LOCATION_HINT_NEAR", location=location)
@@ -244,7 +256,7 @@ def _finding_actions_for_source(
                 "eta": "10-20 min",
             },
         ]
-    if source == "driveline":
+    if source == VibrationSource.DRIVELINE:
         driveline_focus = (
             i18n_ref("LOCATION_HINT_NEAR_SHORT", location=location)
             if location
@@ -271,7 +283,7 @@ def _finding_actions_for_source(
                 "eta": "10-20 min",
             },
         ]
-    if source == "engine":
+    if source == VibrationSource.ENGINE:
         return [
             {
                 "action_id": "engine_mounts_and_accessories",
@@ -426,7 +438,7 @@ def match_samples_for_hypothesis(
             possible_by_location[sample_location] += 1
         sample_speed = _as_float(sample.get("speed_kmh"))
         sample_speed_bin = (
-            _speed_bin_label(sample_speed)
+            SpeedBand.from_speed_kmh(sample_speed, bin_width=SPEED_BIN_WIDTH_KMH).label
             if sample_speed is not None and sample_speed > 0
             else None
         )
@@ -700,13 +712,13 @@ def suppress_engine_aliases(
         (
             _as_float(finding.get("confidence")) or 0.0
             for _, finding in findings
-            if _normalized_source(finding) == "wheel/tire"
+            if _normalized_source(finding) == VibrationSource.WHEEL_TIRE
         ),
         default=0.0,
     )
     if best_wheel_conf > 0:
         for index, (ranking_score, finding) in enumerate(findings):
-            if _normalized_source(finding) != "engine":
+            if _normalized_source(finding) != VibrationSource.ENGINE:
                 continue
             eng_conf = _as_float(finding.get("confidence")) or 0.0
             if eng_conf <= best_wheel_conf * _HARMONIC_ALIAS_RATIO:
@@ -1086,7 +1098,10 @@ def _compute_effective_match_rate(
     effective_match_rate = match_rate
     focused_speed_band: str | None = None
     if match_rate < min_match_rate and possible_by_speed_bin:
-        highest_speed_bin = max(possible_by_speed_bin.keys(), key=_speed_bin_sort_key)
+        highest_speed_bin = max(
+            possible_by_speed_bin.keys(),
+            key=lambda k: b.sort_key if (b := SpeedBand.from_label(k)) else 0,
+        )
         focused_possible = int(possible_by_speed_bin[highest_speed_bin])
         focused_matched = int(matched_by_speed_bin.get(highest_speed_bin, 0))
         focused_rate = focused_matched / max(1, focused_possible)

--- a/apps/server/vibesensor/analysis/pattern_parts.py
+++ b/apps/server/vibesensor/analysis/pattern_parts.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from functools import lru_cache
 
+from vibesensor.domain import VibrationSource
+
 # ---------------------------------------------------------------------------
 # Static mapping tables
 # ---------------------------------------------------------------------------
@@ -19,17 +21,17 @@ from functools import lru_cache
 
 _SYSTEM_PARTS: dict[tuple[str, str], list[tuple[str, str, str]]] = {
     # Wheel / Tire
-    ("wheel/tire", "1x"): [
+    (VibrationSource.WHEEL_TIRE, "1x"): [
         ("flat_spot", "Tire flat spot / out-of-round", "Band platte plek / niet-rond"),
         ("wheel_balance", "Wheel balance weights", "Wielbalanseringsgewichten"),
         ("hub_bearing", "Wheel hub bearing", "Wielnaaf-lager"),
     ],
-    ("wheel/tire", "2x"): [
+    (VibrationSource.WHEEL_TIRE, "2x"): [
         ("hub_bearing", "Wheel hub bearing", "Wielnaaf-lager"),
         ("brake_disc", "Brake disc runout / warping", "Remschijf-slingering / vervorming"),
         ("cv_joint", "CV joint / drive shaft", "Homokineet / aandrijfas"),
     ],
-    ("wheel/tire", "higher"): [
+    (VibrationSource.WHEEL_TIRE, "higher"): [
         (
             "hub_bearing",
             "Wheel hub bearing (advanced wear)",
@@ -37,44 +39,44 @@ _SYSTEM_PARTS: dict[tuple[str, str], list[tuple[str, str, str]]] = {
         ),
         ("brake_caliper", "Brake caliper / pad contact", "Remklauw / blokcontact"),
     ],
-    ("wheel/tire", "*"): [
+    (VibrationSource.WHEEL_TIRE, "*"): [
         ("flat_spot", "Tire flat spot / out-of-round", "Band platte plek / niet-rond"),
         ("wheel_balance", "Wheel balance weights", "Wielbalanseringsgewichten"),
         ("hub_bearing", "Wheel hub bearing", "Wielnaaf-lager"),
     ],
-    ("driveline", "1x"): [
+    (VibrationSource.DRIVELINE, "1x"): [
         ("center_bearing", "Center support bearing", "Middensteunlager"),
         ("u_joint", "Universal joint / flex disc", "Kruiskoppeling / flexschijf"),
         ("prop_shaft", "Propshaft imbalance", "Cardanas-onbalans"),
     ],
-    ("driveline", "2x"): [
+    (VibrationSource.DRIVELINE, "2x"): [
         ("u_joint", "Universal joint / flex disc", "Kruiskoppeling / flexschijf"),
         ("diff_mount", "Differential mount", "Differentieelophanging"),
     ],
-    ("driveline", "higher"): [
+    (VibrationSource.DRIVELINE, "higher"): [
         ("spline_wear", "Spline wear / slip joint", "Slijtage van tandkoppeling"),
         ("diff_gear", "Differential gear wear", "Slijtage differentieel-tandwiel"),
     ],
-    ("driveline", "*"): [
+    (VibrationSource.DRIVELINE, "*"): [
         ("center_bearing", "Center support bearing", "Middensteunlager"),
         ("u_joint", "Universal joint / flex disc", "Kruiskoppeling / flexschijf"),
         ("prop_shaft", "Propshaft imbalance", "Cardanas-onbalans"),
     ],
     # Engine
-    ("engine", "1x"): [
+    (VibrationSource.ENGINE, "1x"): [
         ("engine_mount", "Engine / transmission mount", "Motor- / versnellingsbaksteun"),
         ("accessory_belt", "Accessory belt / tensioner", "Hulpaandrijfriem / spanrol"),
     ],
-    ("engine", "2x"): [
+    (VibrationSource.ENGINE, "2x"): [
         ("engine_mount", "Engine / transmission mount", "Motor- / versnellingsbaksteun"),
         ("misfire", "Cylinder misfire / injector", "Cilindermisfire / injector"),
         ("exhaust_mount", "Exhaust mount / heat shield", "Uitlaatophanging / hitteschild"),
     ],
-    ("engine", "higher"): [
+    (VibrationSource.ENGINE, "higher"): [
         ("accessory_belt", "Accessory belt / tensioner", "Hulpaandrijfriem / spanrol"),
         ("valve_train", "Valve train / timing chain", "Kleppentrein / distributieketting"),
     ],
-    ("engine", "*"): [
+    (VibrationSource.ENGINE, "*"): [
         ("engine_mount", "Engine / transmission mount", "Motor- / versnellingsbaksteun"),
         ("accessory_belt", "Accessory belt / tensioner", "Hulpaandrijfriem / spanrol"),
     ],
@@ -156,9 +158,9 @@ def parts_for_pattern(
 
 _SRC_PHRASES: dict[str, tuple[str, str, str, str]] = {
     # (order_en, order_nl, general_en, general_nl_prefix)
-    "wheel/tire": ("wheel-order", "wielorde", "wheel/tire", "wiel-/band"),
-    "driveline": ("driveshaft-order", "cardanasorde", "driveline", "aandrijflijn"),
-    "engine": ("engine-order", "motororde", "engine", "motor"),
+    VibrationSource.WHEEL_TIRE: ("wheel-order", "wielorde", "wheel/tire", "wiel-/band"),
+    VibrationSource.DRIVELINE: ("driveshaft-order", "cardanasorde", "driveline", "aandrijflijn"),
+    VibrationSource.ENGINE: ("engine-order", "motororde", "engine", "motor"),
 }
 
 

--- a/apps/server/vibesensor/analysis/test_plan.py
+++ b/apps/server/vibesensor/analysis/test_plan.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from math import ceil, floor, log1p, pow
 
 from ..constants import MULTI_SENSOR_CORROBORATION_DB
+from ..domain import VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from ..locations import has_any_wheel_location, is_wheel_location
 from ._types import FindingPayload, JsonObject, LocationHotspot, MatchedPoint, TestStep, i18n_ref
@@ -229,7 +230,7 @@ def _score_locations_in_bin(
 
     # Source-aware localization: for wheel/tire diagnoses prefer wheel
     # sensors as the fault source.
-    _prefer_wheel = (suspected_source or "").strip().lower() == "wheel/tire"
+    _prefer_wheel = (suspected_source or "").strip().lower() == VibrationSource.WHEEL_TIRE
     if _prefer_wheel:
         wheel_ranked = [item for item in ranked_for_winner if is_wheel_location(item[0])]
         if wheel_ranked:

--- a/apps/server/vibesensor/analysis/top_cause_selection.py
+++ b/apps/server/vibesensor/analysis/top_cause_selection.py
@@ -114,7 +114,7 @@ class OrderAssessment:
             "weak_spatial_separation": df.weak_spatial_separation,
             "diffuse_excitation": df.diffuse_excitation,
             "diagnostic_caveat": self.diagnostic_caveat,
-            "phase_evidence": df.phase_evidence,
+            "phase_evidence": df.phase_evidence.to_dict() or None if df.phase_evidence else None,
         }
 
 

--- a/apps/server/vibesensor/analysis_settings.py
+++ b/apps/server/vibesensor/analysis_settings.py
@@ -20,10 +20,11 @@ __all__ = [
 
 import logging
 from collections.abc import Mapping
-from math import isfinite, pi
+from math import isfinite
 from threading import RLock
 
 from .constants import KMH_TO_MPS, SECONDS_PER_MINUTE
+from .domain import TireSpec
 
 LOGGER = logging.getLogger(__name__)
 
@@ -146,27 +147,15 @@ def tire_circumference_m_from_spec(
     """Compute tire circumference in metres from width/aspect/rim spec."""
     if tire_width_mm is None or tire_aspect_pct is None or rim_in is None:
         return None
-    if not isfinite(tire_width_mm) or not isfinite(tire_aspect_pct) or not isfinite(rim_in):
-        return None
-    if tire_width_mm <= 0 or tire_aspect_pct <= 0 or rim_in <= 0:
-        return None
-    sidewall_mm = tire_width_mm * (tire_aspect_pct / 100.0)
-    diameter_mm = (rim_in * 25.4) + (2.0 * sidewall_mm)
-    diameter_m = diameter_mm / 1000.0
-    if diameter_m <= 0:
-        return None
-    circumference = diameter_m * pi
-    # Apply loaded rolling-radius deflection factor (default ~3%).
-    # Under vehicle weight the effective rolling circumference is shorter
-    # than the unloaded specification diameter, which shifts all predicted
-    # rotational-order frequencies upward to match reality.
-    if (
-        deflection_factor is not None
-        and isfinite(deflection_factor)
-        and 0 < deflection_factor <= 1.0
-    ):
-        circumference *= deflection_factor
-    return circumference
+    spec = TireSpec.from_aspects(
+        {
+            "tire_width_mm": tire_width_mm,
+            "tire_aspect_pct": tire_aspect_pct,
+            "rim_in": rim_in,
+        },
+        deflection_factor=deflection_factor if deflection_factor is not None else 1.0,
+    )
+    return spec.circumference_m if spec is not None else None
 
 
 def wheel_hz_from_speed_kmh(speed_kmh: float, tire_circumference_m: float) -> float | None:

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -19,7 +19,6 @@ Run
     Aggregate root representing a complete diagnostic measurement session.
 Measurement
     Value object representing a single multi-axis acceleration sample.
-    (``AccelerationSample`` is kept as a compatibility alias.)
 SpeedSource
     How vehicle speed is obtained during a run.
 AnalysisWindow
@@ -34,35 +33,46 @@ VibrationReading
 
 from .analysis_window import AnalysisWindow, DrivingPhase
 from .car import Car, TireSpec
-from .finding import Finding, FindingKind, PhaseEvidence
-from .measurement import AccelerationSample, Measurement, VibrationReading
+from .finding import (
+    ConfidenceTier,
+    Finding,
+    FindingKind,
+    PhaseContext,
+    PhaseEvidence,
+    SpeedBand,
+    VibrationSource,
+)
+from .measurement import Measurement, VibrationReading
 from .report import Report
 from .run_status import RUN_TRANSITIONS, RunStatus, transition_run
 from .sensor import Sensor, SensorPlacement
-from .session import Run, SessionStatus
+from .session import Run, RunPhase
 from .speed_source import SpeedSource, SpeedSourceKind
 
 __all__ = [
     # Primary domain names (prefer these)
     "AnalysisWindow",
     "Car",
+    "ConfidenceTier",
     "DrivingPhase",
     "Finding",
     "FindingKind",
     "Measurement",
+    "PhaseContext",
     "PhaseEvidence",
     "RUN_TRANSITIONS",
     "Report",
     "Run",
+    "RunPhase",
     "RunStatus",
     "Sensor",
     "SensorPlacement",
+    "SpeedBand",
     "SpeedSource",
     "SpeedSourceKind",
     "TireSpec",
+    "VibrationSource",
     "transition_run",
-    # Existing names (backward compatibility)
-    "AccelerationSample",
-    "SessionStatus",
+    # Existing names
     "VibrationReading",
 ]

--- a/apps/server/vibesensor/domain/analysis_window.py
+++ b/apps/server/vibesensor/domain/analysis_window.py
@@ -48,12 +48,18 @@ class AnalysisWindow:
     speed_min_kmh: float | None = None
     speed_max_kmh: float | None = None
 
+    def __post_init__(self) -> None:
+        if self.start_idx < 0:
+            raise ValueError(f"start_idx must be non-negative, got {self.start_idx}")
+        if self.end_idx < self.start_idx:
+            raise ValueError(f"end_idx ({self.end_idx}) must be >= start_idx ({self.start_idx})")
+
     # -- queries -----------------------------------------------------------
 
     @property
     def sample_count(self) -> int:
         """Number of samples in this window."""
-        return max(0, self.end_idx - self.start_idx)
+        return self.end_idx - self.start_idx
 
     @property
     def duration_s(self) -> float | None:

--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -30,9 +30,15 @@ class TireSpec:
     width_mm: float
     aspect_pct: float
     rim_in: float
+    deflection_factor: float = 1.0
 
     @classmethod
-    def from_aspects(cls, aspects: dict[str, float]) -> TireSpec | None:
+    def from_aspects(
+        cls,
+        aspects: dict[str, float],
+        *,
+        deflection_factor: float = 1.0,
+    ) -> TireSpec | None:
         """Return a ``TireSpec`` if all three dimensions are present and valid."""
         width = aspects.get("tire_width_mm")
         aspect = aspects.get("tire_aspect_pct")
@@ -43,7 +49,10 @@ class TireSpec:
             return None
         if width <= 0 or aspect <= 0 or rim <= 0:
             return None
-        return cls(width_mm=width, aspect_pct=aspect, rim_in=rim)
+        df = float(deflection_factor) if math.isfinite(deflection_factor) else 1.0
+        if df <= 0 or df > 1.0:
+            df = 1.0
+        return cls(width_mm=width, aspect_pct=aspect, rim_in=rim, deflection_factor=df)
 
     @property
     def sidewall_mm(self) -> float:
@@ -57,8 +66,8 @@ class TireSpec:
 
     @property
     def circumference_m(self) -> float:
-        """Tire circumference in metres."""
-        return self.diameter_mm / 1000.0 * math.pi
+        """Tire circumference in metres (deflection-adjusted)."""
+        return self.diameter_mm / 1000.0 * math.pi * self.deflection_factor
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,12 +85,22 @@ class Car:
     aspects: dict[str, float] = field(default_factory=dict)
     variant: str | None = None
 
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            object.__setattr__(self, "name", "Unnamed Car")
+        for key in ("tire_width_mm", "tire_aspect_pct", "rim_in"):
+            val = self.aspects.get(key)
+            if val is not None and (not math.isfinite(val) or val < 0):
+                raise ValueError(
+                    f"Car.aspects[{key!r}] must be a positive finite number, got {val}"
+                )
+
     # -- queries -----------------------------------------------------------
 
     @property
     def display_name(self) -> str:
-        """Human-readable name with optional type suffix."""
-        if self.car_type and self.car_type != "sedan":
+        """Human-readable name with type suffix."""
+        if self.car_type:
             return f"{self.name} ({self.car_type})"
         return self.name
 

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -8,23 +8,41 @@ phase-adjusted scoring.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import ClassVar, Final, TypedDict
 
 __all__ = [
+    "ConfidenceTier",
     "Finding",
     "FindingKind",
+    "PhaseContext",
     "PhaseEvidence",
+    "SpeedBand",
+    "VibrationSource",
 ]
 
 
-class PhaseEvidence(TypedDict, total=False):
-    """Phase context evidence attached to a finding."""
+# ── Enums ─────────────────────────────────────────────────────────────────────
 
-    cruise_fraction: float
-    phases_detected: list[str]
+
+class VibrationSource(StrEnum):
+    """Canonical mechanical vibration source categories.
+
+    Compares equal to plain strings (``VibrationSource.ENGINE == "engine"``),
+    so serialised payloads and dict-keyed lookups work without migration.
+    """
+
+    WHEEL_TIRE = "wheel/tire"
+    DRIVELINE = "driveline"
+    ENGINE = "engine"
+    BODY_RESONANCE = "body resonance"
+    TRANSIENT_IMPACT = "transient_impact"
+    BASELINE_NOISE = "baseline_noise"
+    UNKNOWN_RESONANCE = "unknown_resonance"
+    UNKNOWN = "unknown"
 
 
 class FindingKind(StrEnum):
@@ -33,6 +51,100 @@ class FindingKind(StrEnum):
     REFERENCE = "reference"
     INFORMATIONAL = "informational"
     DIAGNOSTIC = "diagnostic"
+
+
+class ConfidenceTier(StrEnum):
+    """Confidence classification tier for findings."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+# ── Value objects ─────────────────────────────────────────────────────────────
+
+
+class PhaseEvidence(TypedDict, total=False):
+    """Phase context evidence attached to a finding (serialization shape)."""
+
+    cruise_fraction: float
+    phases_detected: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseContext:
+    """Parsed phase-context evidence for domain use.
+
+    Use :meth:`from_dict` to safely parse a raw dict or ``None`` value.
+    """
+
+    cruise_fraction: float = 0.0
+    phases_detected: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, object] | None) -> PhaseContext:
+        """Create from a raw dict, handling missing or malformed values."""
+        if not isinstance(raw, dict):
+            return cls()
+        try:
+            cruise = float(raw.get("cruise_fraction", 0.0))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            cruise = 0.0
+        phases = raw.get("phases_detected", ())
+        if isinstance(phases, list):
+            phases_t = tuple(str(p) for p in phases)
+        else:
+            phases_t = ()
+        return cls(cruise_fraction=cruise, phases_detected=phases_t)
+
+    def to_dict(self) -> PhaseEvidence:
+        """Serialize to a ``PhaseEvidence`` TypedDict."""
+        result: PhaseEvidence = {}
+        if self.cruise_fraction:
+            result["cruise_fraction"] = self.cruise_fraction
+        if self.phases_detected:
+            result["phases_detected"] = list(self.phases_detected)
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class SpeedBand:
+    """A speed-range bin used for amplitude-weighted matching.
+
+    Encapsulates the encode/decode round-trip that previously lived in
+    ``_speed_bin_label`` / ``_speed_bin_sort_key`` helper functions.
+    """
+
+    low_kmh: int
+    high_kmh: int
+
+    @classmethod
+    def from_speed_kmh(cls, kmh: float, bin_width: int = 10) -> SpeedBand:
+        """Create a speed band from a speed value."""
+        if not math.isfinite(kmh) or kmh < 0:
+            kmh = 0.0
+        low = int(kmh // bin_width) * bin_width
+        return cls(low_kmh=low, high_kmh=low + bin_width)
+
+    @classmethod
+    def from_label(cls, label: str) -> SpeedBand | None:
+        """Parse a label like ``'80-100 km/h'`` back to a SpeedBand."""
+        head = label.split(" ", 1)[0]
+        parts = head.split("-", 1)
+        try:
+            return cls(low_kmh=int(parts[0]), high_kmh=int(parts[1]))
+        except (ValueError, IndexError):
+            return None
+
+    @property
+    def label(self) -> str:
+        """Human-readable speed range label."""
+        return f"{self.low_kmh}-{self.high_kmh} km/h"
+
+    @property
+    def sort_key(self) -> int:
+        """Integer sort key for ordering speed bands."""
+        return self.low_kmh
 
 
 _KIND_AUTO: Final = FindingKind.DIAGNOSTIC
@@ -86,14 +198,20 @@ class Finding:
     diffuse_excitation: bool = False
     weak_spatial_separation: bool = False
     vibration_strength_db: float | None = None
-    phase_evidence: PhaseEvidence | None = field(default=None, hash=False)
+    phase_evidence: PhaseContext | None = field(default=None, hash=False)
 
     def __post_init__(self) -> None:
-        """Auto-derive ``kind`` when constructed directly without explicit kind."""
+        """Auto-derive ``kind`` and validate invariants."""
         if self.kind is _KIND_AUTO:
             derived = self._kind_from_fields(self.finding_id, self.severity)
             if derived is not _KIND_AUTO:
                 object.__setattr__(self, "kind", derived)
+        if self.confidence is not None and not (0.0 <= self.confidence <= 1.0):
+            raise ValueError(f"Finding.confidence must be in [0, 1], got {self.confidence}")
+        # Coerce dict → PhaseContext for convenience.
+        pe = self.phase_evidence
+        if isinstance(pe, dict):
+            object.__setattr__(self, "phase_evidence", PhaseContext.from_dict(pe))
 
     @staticmethod
     def _kind_from_fields(finding_id: str, severity: str) -> FindingKind:
@@ -112,7 +230,7 @@ class Finding:
     """Confidence quantisation step to prevent jitter-driven reordering."""
 
     _PLACEHOLDER_SOURCES: ClassVar[frozenset[str]] = frozenset(
-        {"unknown_resonance", "unknown"},
+        {VibrationSource.UNKNOWN_RESONANCE, VibrationSource.UNKNOWN},
     )
     """Suspected sources that are considered placeholder / unresolved."""
 
@@ -180,9 +298,7 @@ class Finding:
                 pass
 
         phase_ev = payload.get("phase_evidence")
-        phase_evidence: PhaseEvidence | None = None
-        if isinstance(phase_ev, dict):
-            phase_evidence = phase_ev  # type: ignore[assignment]
+        phase_evidence = PhaseContext.from_dict(phase_ev if isinstance(phase_ev, dict) else None)
 
         # Extract vibration_strength_db from evidence_metrics
         vib_db: float | None = None
@@ -286,6 +402,11 @@ class Finding:
 
     # -- actionability / surfacing ------------------------------------------
 
+    @classmethod
+    def is_unknown_location(cls, location: object) -> bool:
+        """Whether a location value carries no actionable spatial information."""
+        return str(location or "").strip().lower() in cls._UNKNOWN_LOCATIONS
+
     @property
     def is_actionable(self) -> bool:
         """Whether this finding identifies a meaningful mechanical component.
@@ -296,8 +417,7 @@ class Finding:
         """
         if self.source_normalized not in self._PLACEHOLDER_SOURCES:
             return True
-        location = (self.strongest_location or "").strip().lower()
-        return location not in self._UNKNOWN_LOCATIONS
+        return not self.is_unknown_location(self.strongest_location)
 
     @property
     def should_surface(self) -> bool:
@@ -326,6 +446,21 @@ class Finding:
         quantised = round(self.effective_confidence / step) * step
         return (quantised, self.ranking_score)
 
+    # -- confidence classification ------------------------------------------
+
+    _CONFIDENCE_HIGH_THRESHOLD: ClassVar[float] = 0.70
+    _CONFIDENCE_MEDIUM_THRESHOLD: ClassVar[float] = 0.40
+
+    @property
+    def confidence_tier(self) -> ConfidenceTier:
+        """Classify confidence into HIGH / MEDIUM / LOW tier."""
+        conf = self.effective_confidence
+        if conf >= self._CONFIDENCE_HIGH_THRESHOLD:
+            return ConfidenceTier.HIGH
+        if conf >= self._CONFIDENCE_MEDIUM_THRESHOLD:
+            return ConfidenceTier.MEDIUM
+        return ConfidenceTier.LOW
+
     @property
     def phase_adjusted_score(self) -> float:
         """Phase-aware ranking score used for top-cause selection.
@@ -334,14 +469,8 @@ class Finding:
         constant-speed conditions produce the most reliable spectral
         evidence.
         """
-        cruise_fraction = 0.0
-        if isinstance(self.phase_evidence, dict):
-            raw = self.phase_evidence.get("cruise_fraction", 0.0)
-            try:
-                cruise_fraction = float(raw)
-            except (TypeError, ValueError):
-                pass
-        return self.effective_confidence * (0.85 + 0.15 * cruise_fraction)
+        cf = self.phase_evidence.cruise_fraction if self.phase_evidence else 0.0
+        return self.effective_confidence * (0.85 + 0.15 * cf)
 
     def is_stronger_than(self, other: Finding) -> bool:
         """Whether this finding ranks higher than *other*."""

--- a/apps/server/vibesensor/domain/measurement.py
+++ b/apps/server/vibesensor/domain/measurement.py
@@ -16,7 +16,6 @@ from vibesensor.strength_bands import bucket_for_strength
 from vibesensor.vibration_strength import vibration_strength_db_scalar
 
 __all__ = [
-    "AccelerationSample",
     "Measurement",
     "VibrationReading",
 ]
@@ -87,10 +86,6 @@ class Measurement:
             noise_floor_g=noise_floor,
             sensor_id=self.sensor_id,
         )
-
-
-# Backward-compatibility alias
-AccelerationSample = Measurement
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/domain/report.py
+++ b/apps/server/vibesensor/domain/report.py
@@ -38,8 +38,14 @@ class Report:
     duration_text: str | None = None
     sample_count: int = 0
     sensor_count: int = 0
-    finding_count: int = 0
     findings: tuple[Finding, ...] = ()
+
+    # -- queries -----------------------------------------------------------
+
+    @property
+    def finding_count(self) -> int:
+        """Total number of findings (derived from findings tuple)."""
+        return len(self.findings)
 
     # -- queries -----------------------------------------------------------
 
@@ -93,7 +99,6 @@ class Report:
             for item in raw_findings:
                 if isinstance(item, dict):
                     finding_list.append(Finding.from_payload(item))
-        finding_count = len(raw_findings) if isinstance(raw_findings, list) else 0
 
         rows = summary.get("rows")
         sample_count = int(rows) if isinstance(rows, (int, float, str)) else 0
@@ -128,6 +133,5 @@ class Report:
             duration_text=duration_text,
             sample_count=sample_count,
             sensor_count=sensor_count,
-            finding_count=finding_count,
             findings=tuple(finding_list),
         )

--- a/apps/server/vibesensor/domain/run_status.py
+++ b/apps/server/vibesensor/domain/run_status.py
@@ -5,8 +5,8 @@ strings (``RunStatus.COMPLETE == "complete"``), preserving backward
 compatibility with SQLite storage and existing dict-based code paths.
 
 This tracks the *persisted* run lifecycle in the database.  The
-*in-memory* session lifecycle is tracked by ``SessionStatus`` in
-``domain/session.py`` (PENDING → RUNNING).  Route handlers bridge the
+*in-memory* run phase is tracked by ``RunPhase`` in
+``domain/session.py`` (PENDING → RUNNING → STOPPED).  Route handlers bridge the
 two models; see ``session.py`` module docstring for details.
 """
 

--- a/apps/server/vibesensor/domain/sensor.py
+++ b/apps/server/vibesensor/domain/sensor.py
@@ -40,19 +40,18 @@ class SensorPlacement:
     _DRIVETRAIN_CODES: frozenset[str] = frozenset(
         {
             "transmission",
-            "transfer_case",
-            "rear_differential",
-            "front_differential",
-            "driveshaft",
+            "driveshaft_tunnel",
         },
     )
 
     _BODY_CODES: frozenset[str] = frozenset(
         {
-            "steering_column",
-            "dashboard",
-            "seat_rail",
-            "floor_center",
+            "driver_seat",
+            "front_passenger_seat",
+            "rear_left_seat",
+            "rear_center_seat",
+            "rear_right_seat",
+            "trunk",
         },
     )
 

--- a/apps/server/vibesensor/domain/session.py
+++ b/apps/server/vibesensor/domain/session.py
@@ -1,13 +1,13 @@
-"""Aggregate root for a vibration-diagnostic measurement session.
+"""Aggregate root for a vibration-diagnostic measurement run.
 
-``Run`` tracks the in-memory lifecycle of a single diagnostic session.
-``SessionStatus`` covers the in-memory states (PENDING → RUNNING).
+``Run`` tracks the in-memory lifecycle of a single diagnostic run.
+``RunPhase`` covers the in-memory states (PENDING → RUNNING → STOPPED).
 
 The *persisted* run lifecycle is tracked by ``RunStatus`` in
 ``domain/run_status.py`` (RECORDING → ANALYZING → COMPLETE | ERROR).
 Route handlers bridge the two: ``Run.start()`` coincides with creating
-a DB row in RECORDING status, and discarding the ``Run`` object
-coincides with transitioning the DB row to ANALYZING.
+a DB row in RECORDING status, and ``Run.stop()`` coincides with
+transitioning the DB row to ANALYZING.
 """
 
 from __future__ import annotations
@@ -18,53 +18,67 @@ from enum import StrEnum
 
 __all__ = [
     "Run",
-    "SessionStatus",
+    "RunPhase",
 ]
 
 
-class SessionStatus(StrEnum):
+class RunPhase(StrEnum):
     """Lifecycle states of a :class:`Run` (in-memory session only)."""
 
     PENDING = "pending"
     RUNNING = "running"
+    STOPPED = "stopped"
 
 
 @dataclass
 class Run:
-    """Aggregate root for a vibration-diagnostic measurement session.
+    """Aggregate root for a vibration-diagnostic measurement run.
 
     Tracks the in-memory lifecycle for one diagnostic run.  The ``Run``
     object is created with status PENDING, transitioned to RUNNING via
-    :meth:`start`, and then discarded when the recording stops.  There
-    is no ``stop()`` method — the route handler simply drops the
-    reference.
+    :meth:`start`, and then to STOPPED via :meth:`stop`.
 
     Parameters
     ----------
-    session_id:
-        Unique session identifier (UUID hex string).
+    run_id:
+        Unique run identifier (UUID hex string).
     analysis_settings:
-        Snapshot of analysis settings active at session start.
+        Snapshot of analysis settings active at run start.
     """
 
-    session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    run_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     analysis_settings: dict[str, float] = field(default_factory=dict)
 
-    status: SessionStatus = field(default=SessionStatus.PENDING, init=False)
+    status: RunPhase = field(default=RunPhase.PENDING, init=False)
 
     # -- lifecycle ----------------------------------------------------------
 
     def start(self) -> None:
-        """Transition the session to *running*.
+        """Transition the run to *running*.
 
         Raises
         ------
         RuntimeError
-            If the session has already been started.
+            If the run has already been started.
         """
-        if self.status is not SessionStatus.PENDING:
+        if self.status is not RunPhase.PENDING:
             raise RuntimeError(
-                f"Cannot start session in '{self.status.value}' state; "
-                f"expected '{SessionStatus.PENDING.value}'."
+                f"Cannot start run in '{self.status.value}' state; "
+                f"expected '{RunPhase.PENDING.value}'."
             )
-        self.status = SessionStatus.RUNNING
+        self.status = RunPhase.RUNNING
+
+    def stop(self) -> None:
+        """Transition the run to *stopped*.
+
+        Raises
+        ------
+        RuntimeError
+            If the run is not currently running.
+        """
+        if self.status is not RunPhase.RUNNING:
+            raise RuntimeError(
+                f"Cannot stop run in '{self.status.value}' state; "
+                f"expected '{RunPhase.RUNNING.value}'."
+            )
+        self.status = RunPhase.STOPPED

--- a/apps/server/vibesensor/metrics_log/logger.py
+++ b/apps/server/vibesensor/metrics_log/logger.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ..constants import NUMERIC_TYPES
-from ..domain import Run, SessionStatus
+from ..domain import Run, RunPhase
 from ..runlog import utc_now_iso
 from .post_analysis import PostAnalysisWorker
 from .sample_builder import (
@@ -149,11 +149,11 @@ class RunRecorder:
         self._live_start_mono_s = time.monotonic()
 
         # --- Session state ---
-        # The Run domain object owns the session identity
-        # (session_id) and lifecycle status (pending → running → stopped).
+        # The Run domain object owns run identity
+        # (run_id) and lifecycle status (pending → running → stopped).
         # Infrastructure-level concerns (monotonic timestamps, frame counts,
         # timeout tracking) remain as standalone fields.
-        self._diagnostic_session: Run | None = None
+        self._current_run: Run | None = None
         self._sess_no_data_timeout_s: float = max(1.0, float(config.no_data_timeout_s))
         self._sess_run_start_utc: str | None = None
         self._sess_run_start_mono_s: float | None = None
@@ -192,15 +192,8 @@ class RunRecorder:
 
     @property
     def enabled(self) -> bool:
-        ds = self._diagnostic_session
-        return ds is not None and ds.status is SessionStatus.RUNNING
-
-    @enabled.setter
-    def enabled(self, value: bool) -> None:
-        # Setting ``True`` is a no-op — use ``start_recording()`` to begin a
-        # new session.  Setting ``False`` gracefully stops any running session.
-        if not value and self._diagnostic_session is not None:
-            self._diagnostic_session = None
+        run = self._current_run
+        return run is not None and run.status is RunPhase.RUNNING
 
     @property
     def last_write_duration_s(self) -> float:
@@ -212,8 +205,8 @@ class RunRecorder:
 
     @property
     def _run_id(self) -> str | None:
-        ds = self._diagnostic_session
-        return ds.session_id if ds is not None else None
+        run = self._current_run
+        return run.run_id if run is not None else None
 
     # -----------------------------------------------------------------------
     # Session state
@@ -229,11 +222,11 @@ class RunRecorder:
     ) -> MetricsSessionSnapshot:
         with self._lock:
             session = Run(
-                session_id=run_id,
+                run_id=run_id,
                 analysis_settings=dict(self.analysis_settings.snapshot()),
             )
             session.start()
-            self._diagnostic_session = session
+            self._current_run = session
             self._sess_run_start_utc = start_time_utc
             self._sess_run_start_mono_s = start_mono_s
             self._sess_last_data_progress_mono_s = start_mono_s
@@ -247,7 +240,10 @@ class RunRecorder:
 
     def _sess_stop(self) -> None:
         with self._lock:
-            self._diagnostic_session = None
+            run = self._current_run
+            if run is not None and run.status is RunPhase.RUNNING:
+                run.stop()
+            self._current_run = None
             self._sess_run_start_utc = None
             self._sess_run_start_mono_s = None
             self._sess_last_data_progress_mono_s = None

--- a/apps/server/vibesensor/registry.py
+++ b/apps/server/vibesensor/registry.py
@@ -421,6 +421,11 @@ class ClientRegistry:
         The value is stripped of leading/trailing whitespace and capped at
         64 UTF-8 bytes to bound stored string size (consistent with the
         32-byte cap applied to client names).
+
+        Raises
+        ------
+        ValueError
+            If the location is already assigned to a different client.
         """
         clean = location.strip()
         # Cap at 64 UTF-8 bytes without splitting multi-byte characters.
@@ -428,6 +433,18 @@ class ClientRegistry:
         if len(encoded) > 64:
             clean = encoded[:64].decode("utf-8", errors="ignore")
         with self._lock:
+            if clean:
+                conflict = next(
+                    (
+                        cid
+                        for cid, rec in self._clients.items()
+                        if cid != _normalize_client_id(client_id) and rec.location_code == clean
+                    ),
+                    None,
+                )
+                if conflict is not None:
+                    conflict_name = self._clients[conflict].name or conflict
+                    raise ValueError(f"Location '{clean}' already assigned to {conflict_name}")
             record = self._get_or_create(client_id)
             record.location_code = clean
             return record

--- a/apps/server/vibesensor/report/mapping.py
+++ b/apps/server/vibesensor/report/mapping.py
@@ -32,7 +32,7 @@ from ..analysis.strength_labels import (
     strength_label,
     strength_text,
 )
-from ..domain import Report
+from ..domain import Report, VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from ..report_i18n import normalize_lang
 from ..report_i18n import tr as _tr
@@ -196,17 +196,21 @@ def is_i18n_ref(value: object) -> bool:
 def human_source(source: object, *, tr: Callable[[str], str]) -> str:
     """Resolve a source code to its user-facing label."""
     raw = str(source or "").strip().lower()
-    mapping = {
-        "wheel/tire": tr("SOURCE_WHEEL_TIRE"),
-        "driveline": tr("SOURCE_DRIVELINE"),
-        "engine": tr("SOURCE_ENGINE"),
-        "body resonance": tr("SOURCE_BODY_RESONANCE"),
-        "transient_impact": tr("SOURCE_TRANSIENT_IMPACT"),
-        "baseline_noise": tr("SOURCE_BASELINE_NOISE"),
-        "unknown_resonance": tr("SOURCE_UNKNOWN_RESONANCE"),
-        "unknown": tr("UNKNOWN"),
+    mapping: dict[VibrationSource, str] = {
+        VibrationSource.WHEEL_TIRE: tr("SOURCE_WHEEL_TIRE"),
+        VibrationSource.DRIVELINE: tr("SOURCE_DRIVELINE"),
+        VibrationSource.ENGINE: tr("SOURCE_ENGINE"),
+        VibrationSource.BODY_RESONANCE: tr("SOURCE_BODY_RESONANCE"),
+        VibrationSource.TRANSIENT_IMPACT: tr("SOURCE_TRANSIENT_IMPACT"),
+        VibrationSource.BASELINE_NOISE: tr("SOURCE_BASELINE_NOISE"),
+        VibrationSource.UNKNOWN_RESONANCE: tr("SOURCE_UNKNOWN_RESONANCE"),
+        VibrationSource.UNKNOWN: tr("UNKNOWN"),
     }
-    return mapping.get(raw, raw.replace("_", " ").title() if raw else tr("UNKNOWN"))
+    try:
+        key = VibrationSource(raw)
+    except ValueError:
+        return raw.replace("_", " ").title() if raw else tr("UNKNOWN")
+    return mapping.get(key, tr("UNKNOWN"))
 
 
 def resolve_i18n(
@@ -484,11 +488,15 @@ def peak_row_system_label(row: PeakTableRow, *, order: str, tr: Callable[..., st
     """Resolve the system label shown for one peak row."""
     order_lower = order.lower()
     source_hint = str(row.get("source") or "").strip().lower()
-    if source_hint == "wheel/tire" or "wheel" in order_lower:
+    if source_hint == VibrationSource.WHEEL_TIRE or "wheel" in order_lower:
         return str(tr("SOURCE_WHEEL_TIRE"))
-    if source_hint == "engine" or "engine" in order_lower:
+    if source_hint == VibrationSource.ENGINE or "engine" in order_lower:
         return str(tr("SOURCE_ENGINE"))
-    if source_hint == "driveline" or "driveshaft" in order_lower or "drive" in order_lower:
+    if (
+        source_hint == VibrationSource.DRIVELINE
+        or "driveshaft" in order_lower
+        or "drive" in order_lower
+    ):
         return str(tr("SOURCE_DRIVELINE"))
     if "transient" in order_lower:
         return str(tr("SOURCE_TRANSIENT_IMPACT"))
@@ -679,9 +687,12 @@ def has_relevant_reference_gap(findings: list[FindingPayload], primary_source: o
         finding_id = str(finding.get("finding_id") or "").strip().upper()
         if finding_id in {"REF_SPEED", "REF_SAMPLE_RATE"}:
             return True
-        if finding_id == "REF_WHEEL" and source in {"wheel/tire", "driveline"}:
+        if finding_id == "REF_WHEEL" and source in {
+            VibrationSource.WHEEL_TIRE,
+            VibrationSource.DRIVELINE,
+        }:
             return True
-        if finding_id == "REF_ENGINE" and source == "engine":
+        if finding_id == "REF_ENGINE" and source == VibrationSource.ENGINE:
             return True
     return False
 

--- a/apps/server/vibesensor/report/pdf_diagram_render.py
+++ b/apps/server/vibesensor/report/pdf_diagram_render.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
+from ..domain import VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from .pdf_style import (
     BMW_LENGTH_MM as _BMW_LENGTH_MM,
@@ -288,7 +289,11 @@ def _canonical_location(raw: object) -> str:
 
 def _source_color(source: object) -> str:
     src = str(source or "unknown").strip().lower()
-    return FINDING_SOURCE_COLORS.get(src, FINDING_SOURCE_COLORS["unknown"])
+    try:
+        key = VibrationSource(src)
+    except ValueError:
+        key = VibrationSource.UNKNOWN
+    return FINDING_SOURCE_COLORS.get(key, FINDING_SOURCE_COLORS[VibrationSource.UNKNOWN])
 
 
 def _location_points(
@@ -500,9 +505,9 @@ def _draw_source_legend(
     from reportlab.graphics.shapes import Circle, String
 
     legend_items = [
-        (tr("SOURCE_WHEEL_TIRE"), FINDING_SOURCE_COLORS["wheel/tire"]),
-        (tr("SOURCE_DRIVELINE"), FINDING_SOURCE_COLORS["driveline"]),
-        (tr("SOURCE_ENGINE"), FINDING_SOURCE_COLORS["engine"]),
+        (tr("SOURCE_WHEEL_TIRE"), FINDING_SOURCE_COLORS[VibrationSource.WHEEL_TIRE]),
+        (tr("SOURCE_DRIVELINE"), FINDING_SOURCE_COLORS[VibrationSource.DRIVELINE]),
+        (tr("SOURCE_ENGINE"), FINDING_SOURCE_COLORS[VibrationSource.ENGINE]),
     ]
     legend_x = 8.0
     title_y = 30.0

--- a/apps/server/vibesensor/report/pdf_style.py
+++ b/apps/server/vibesensor/report/pdf_style.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 
+from ..domain import VibrationSource
 from ..report_i18n import tr as _tr
 from .report_data import ReportTemplateData
 
@@ -40,10 +41,10 @@ REPORT_COLORS = {
 }
 
 FINDING_SOURCE_COLORS = {
-    "wheel/tire": "#0f9d58",
-    "driveline": "#7c3aed",
-    "engine": "#c5221f",
-    "unknown": "#52555e",
+    VibrationSource.WHEEL_TIRE: "#0f9d58",
+    VibrationSource.DRIVELINE: "#7c3aed",
+    VibrationSource.ENGINE: "#c5221f",
+    VibrationSource.UNKNOWN: "#52555e",
 }
 
 # ── Style Constants ──────────────────────────────────────────────────────────

--- a/apps/server/vibesensor/routes/clients.py
+++ b/apps/server/vibesensor/routes/clients.py
@@ -77,34 +77,26 @@ def create_client_routes(
             if label is None:
                 raise HTTPException(status_code=400, detail="Unknown location_code")
 
-            conflict = next(
-                (
-                    row
-                    for row in registry.snapshot_for_api()
-                    if row["id"] != normalized_client_id and row.get("location_code") == code
-                ),
-                None,
-            )
-            if conflict is not None:
-                other_name = conflict.get("name") or "another sensor"
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Location already assigned to {other_name}",
-                )
+            try:
+                registry.set_location(normalized_client_id, code)
+            except ValueError as exc:
+                raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-            updated = registry.set_name(normalized_client_id, label)
+            registry.set_name(normalized_client_id, label)
         else:
             # Empty location_code → clear the assignment
-            updated = registry.clear_name(normalized_client_id)
+            registry.set_location(normalized_client_id, code)
+            registry.clear_name(normalized_client_id)
 
-        registry.set_location(normalized_client_id, code)
-        mac = client_id_mac(updated.client_id)
+        updated = registry.get(normalized_client_id)
+        name = updated.name if updated else None
+        mac = client_id_mac(normalized_client_id)
         await asyncio.to_thread(settings_store.set_sensor, mac, {"location_code": code})
         return SetClientLocationResponse(
-            id=updated.client_id,
+            id=normalized_client_id,
             mac_address=mac,
             location_code=code,
-            name=updated.name,
+            name=name,
         )
 
     @router.delete("/api/clients/{client_id}", response_model=RemoveClientResponse)

--- a/apps/server/vibesensor/run_context.py
+++ b/apps/server/vibesensor/run_context.py
@@ -219,17 +219,8 @@ def _resolve_optional_i18n(lang: str, value: object) -> str | None:
 
 
 def _resolve_i18n(lang: str, value: object) -> str:
-    if isinstance(value, list):
-        return " ".join(_resolve_i18n(lang, item) for item in value if item)
-    if not isinstance(value, dict) or "_i18n_key" not in value:
-        return str(value or "")
-    key = str(value.get("_i18n_key") or "")
-    params: dict[str, object] = {}
-    for param_key, param_value in value.items():
-        if param_key == "_i18n_key":
-            continue
-        if isinstance(param_value, (dict, list)):
-            params[param_key] = _resolve_i18n(lang, param_value)
-        else:
-            params[param_key] = param_value
-    return str(_tr(lang, key, **params))
+    from functools import partial
+
+    from .report.mapping import resolve_i18n
+
+    return resolve_i18n(lang, value, tr=partial(_tr, lang))

--- a/apps/server/vibesensor/settings_store.py
+++ b/apps/server/vibesensor/settings_store.py
@@ -200,15 +200,13 @@ class SettingsStore:
         """Push current speed-source config into the GPS monitor."""
         if self._gps_monitor is None:
             return
-        ss = self.get_speed_source()
-        self._gps_monitor.set_manual_source_selected(ss["speedSource"] == "manual")
-        if ss["manualSpeedKph"] is not None:
-            self._gps_monitor.set_speed_override_kmh(ss["manualSpeedKph"])
-        else:
-            self._gps_monitor.set_speed_override_kmh(None)
+        ss = self.speed_source()
+        raw = self.get_speed_source()
+        self._gps_monitor.set_manual_source_selected(ss.is_manual)
+        self._gps_monitor.set_speed_override_kmh(ss.effective_speed_kmh)
         self._gps_monitor.set_fallback_settings(
-            stale_timeout_s=ss.get("staleTimeoutS"),
-            fallback_mode=ss.get("fallbackMode"),
+            stale_timeout_s=raw.get("staleTimeoutS"),
+            fallback_mode=ss.fallback_mode,
         )
 
     def sync_all(self) -> None:

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -31,12 +31,12 @@
   `analysis/findings.py` and `analysis/top_cause_selection.py` delegate
   classification and ranking logic to the domain `Finding`.
 - `domain/`: DDD-aligned domain model package.  Each primary domain object
-  lives in its own dedicated file: `car.py` (Car), `sensor.py` (Sensor,
-  SensorPlacement), `measurement.py` (Measurement/AccelerationSample,
-  VibrationReading), `session.py` (Run, SessionStatus),
+  lives in its own dedicated file: `car.py` (Car, TireSpec), `sensor.py` (Sensor,
+  SensorPlacement), `measurement.py` (Measurement,
+  VibrationReading), `session.py` (Run, RunPhase),
   `speed_source.py` (SpeedSource), `analysis_window.py` (DrivingPhase, AnalysisWindow),
-  `finding.py` (FindingKind, PhaseEvidence, Finding), `report.py` (Report),
-  `run_status.py` (RunStatus, RUN_TRANSITIONS).  All are plain dataclasses with no external coupling.
+  `finding.py` (FindingKind, VibrationSource, ConfidenceTier, PhaseContext, PhaseEvidence, SpeedBand, Finding), `report.py` (Report),
+  `run_status.py` (RunStatus, RUN_TRANSITIONS).  All are plain frozen dataclasses with no external coupling.
   Domain objects own classification, ranking, actionability, surfacing,
   and query logic; pipeline adapters (OrderAssessment) in
   `analysis/` delegate to them.  See `docs/domain-model.md` for the full

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -25,26 +25,26 @@ VibrationReading (dB)                  ▼
 
 | Object | Role | Key owned behavior |
 |--------|------|--------------------|
-| **Run** | Aggregate root | Lifecycle (start/stop), status transitions |
-| **Finding** | Richest domain object | Kind (diagnostic/reference/informational), classification, actionability, surfacing, confidence quantisation, deterministic ranking, phase-adjusted scoring |
-| **Report** | Assembled output | Finding queries, primary-finding selection |
+| **Run** | Aggregate root | Lifecycle (start/stop/stopped), status transitions, phase tracking |
+| **Finding** | Richest domain object | Kind (diagnostic/reference/informational), classification, actionability, surfacing, confidence quantisation (via `ConfidenceTier`), deterministic ranking, phase-adjusted scoring (via `PhaseContext`), vibration-source classification (via `VibrationSource`) |
+| **Report** | Assembled output | Finding queries (`finding_count` property), primary-finding selection |
 
 ### Supporting domain objects
 
 | Object | Role | Key owned behavior |
 |--------|------|--------------------|
-| **Car** | Vehicle under test | Tire-circumference computation from aspect specs |
+| **Car** | Vehicle under test | Tire-circumference computation from aspect specs (via `TireSpec`), display name (always includes type), dimension validation |
 | **Sensor** | Accelerometer node | Display name, placement status queries |
 | **SensorPlacement** | Mounting position | Position category classification (wheel/drivetrain/body) |
 | **Measurement** | Raw sample value object | Conversion to VibrationReading (dB) |
 | **VibrationReading** | Processed dB value object | Severity level lookup, dB computation |
 | **SpeedSource** | Speed acquisition config | Source-kind classification, effective speed resolution |
-| **AnalysisWindow** | Analysis chunk | Phase classification, speed containment, analyzability |
+| **AnalysisWindow** | Analysis chunk | Phase classification, speed containment, analyzability, index-range validation |
 
 ### Object containment and derivation
 
 - **Sensor** contains an optional **SensorPlacement**.
-- **Run** tracks lifecycle status (via **RunStatus**).  Reading accumulation is handled by the recording pipeline, not the domain object.
+- **Run** tracks lifecycle status (via **RunPhase**: PENDING → RUNNING → STOPPED).  Reading accumulation is handled by the recording pipeline, not the domain object.
 - **Report** contains a tuple of **Finding** instances.
 - **Finding** is derived from analysis of **AnalysisWindow** data.
 - **AnalysisWindow** is derived from phase segmentation of a **Run**.
@@ -77,13 +77,13 @@ within `apps/server/vibesensor/domain/`:
 
 | File | Domain objects | Rationale |
 |------|---------------|-----------|
-| `measurement.py` | `AccelerationSample` (`Measurement`), `VibrationReading` | Tightly coupled raw-sample-to-reading pipeline |
-| `session.py` | `SessionStatus`, `Run` | Aggregate root with in-memory lifecycle (PENDING → RUNNING) |
+| `measurement.py` | `Measurement`, `VibrationReading` | Tightly coupled raw-sample-to-reading pipeline |
+| `session.py` | `RunPhase`, `Run` | Aggregate root with in-memory lifecycle (PENDING → RUNNING → STOPPED) |
 | `speed_source.py` | `SpeedSourceKind`, `SpeedSource` | Independent speed acquisition concern |
 | `sensor.py` | `SensorPlacement`, `Sensor` | Tightly coupled sensor-and-position pair |
 | `car.py` | `Car`, `TireSpec` | Vehicle geometry and tire computation |
 | `analysis_window.py` | `DrivingPhase`, `AnalysisWindow` | Driving-phase enum and phase-aligned analysis chunk |
-| `finding.py` | `FindingKind`, `PhaseEvidence`, `Finding` | Richest domain object (kind, classification, ranking, scoring, dB strength) |
+| `finding.py` | `FindingKind`, `VibrationSource`, `ConfidenceTier`, `PhaseContext`, `PhaseEvidence`, `SpeedBand`, `Finding` | Richest domain object (kind, classification, ranking, scoring, dB strength, vibration-source enum, speed-band binning, phase-context evidence) |
 | `report.py` | `Report` | Assembled diagnostic output |
 | `run_status.py` | `RunStatus`, `RUN_TRANSITIONS`, `transition_run` | Persisted run lifecycle state machine (enforcing) |
 


### PR DESCRIPTION
## Summary

Enriches the domain model with proper value objects, enums, and validation guards across 5 implementation chunks. Affects 30 files (+487/-288 lines).

## Changes by Chunk

### Chunk 1: Domain Value Objects and Enums
- **`VibrationSource(StrEnum)`** — 8 canonical source identifiers replacing scattered string constants across `order_analysis`, `pattern_parts`, `mapping`, `pdf_style`, `pdf_diagram_render`
- **`PhaseContext`** — frozen dataclass replacing raw dict `phase_evidence` with `from_dict()` factory and `to_dict()` serialization
- **`SpeedBand`** — frozen dataclass encoding/decoding speed-bin labels (consolidates `_speed_bin_label`/`_speed_bin_sort_key` helpers)
- **`ConfidenceTier(StrEnum)`** — HIGH/MEDIUM/LOW confidence classification with threshold ClassVars
- **Confidence guard** — `Finding.__post_init__` now rejects confidence values outside [0, 1]
- **Remove `AccelerationSample`** backward-compat alias from `measurement.py`
- **`Finding.is_unknown_location()`** classmethod for location classification

### Chunk 2: Run Lifecycle
- **`SessionStatus` → `RunPhase`** with PENDING/RUNNING/STOPPED states
- **`Run.session_id` → `Run.run_id`**
- **`Run.stop()`** method with state guard (raises ValueError if not RUNNING)
- `RunRecorder` (metrics_log/logger.py) updated for new naming

### Chunk 3: Finding Model
- **`AnnotatedFinding(NamedTuple)`** pairing payload and domain Finding objects
- **`FindingCollection`** rewritten with single `_pairs` list (eliminated parallel-list fragility)
- **`Report.finding_count`** converted from stored field to computed `@property`

### Chunk 4: Car and Sensor
- **`Car.__post_init__`** with name defaulting and tire dimension validation
- **`Car.display_name`** always shows type suffix (removed sedan suppression)
- **`TireSpec.deflection_factor`** field for circumference computation
- Domain `SpeedSource` usage in `settings_store._sync_speed_source()`
- Sensor conflict check moved to `registry.set_location()` (domain boundary enforcement)
- `_DRIVETRAIN_CODES`/`_BODY_CODES` aligned with `LOCATION_CODES` vocabulary

### Chunk 5: Cross-cutting
- `_resolve_i18n` consolidated to delegate to `report/mapping.resolve_i18n` (single implementation)
- **`AnalysisWindow.__post_init__`** — validates `start_idx >= 0` and `end_idx >= start_idx`
- **`PhaseContext.to_dict()`** serialization back to `PhaseEvidence` TypedDict

## Docs Updated
- `docs/domain-model.md` — updated file layout table, new types, RunPhase naming
- `docs/ai/repo-map.md` — reflects new domain object inventory

## Validation
- ✅ 5071 tests pass
- ✅ Lint clean (ruff check + ruff format)
- ✅ Type check clean (mypy)
- ✅ Schema exports unchanged