### PR TITLE
refactor: domain model cleanup — remove TopCause, slim Report, optimize from_payload

### DIFF
--- a/apps/server/tests/domain/test_core.py
+++ b/apps/server/tests/domain/test_core.py
@@ -15,7 +15,11 @@ from vibesensor.domain import (
     transition_run,
 )
 from vibesensor.strength_bands import BANDS
-from vibesensor.vibration_strength import vibration_strength_db_scalar
+from vibesensor.vibration_strength import (
+    compute_db,
+    compute_db_or_none,
+    vibration_strength_db_scalar,
+)
 
 _NOW = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
 
@@ -135,25 +139,25 @@ class TestVibrationReading:
             assert reading.get_severity_level() == band["key"]
 
     def test_compute_db_matches_scalar_function(self) -> None:
-        """VibrationReading.compute_db must match vibration_strength_db_scalar."""
-        result = VibrationReading.compute_db(0.05, 0.001)
+        """compute_db must match vibration_strength_db_scalar."""
+        result = compute_db(0.05, 0.001)
         expected = vibration_strength_db_scalar(peak_band_rms_amp_g=0.05, floor_amp_g=0.001)
         assert result == pytest.approx(expected)
 
     def test_compute_db_zero_floor(self) -> None:
         """compute_db handles zero noise floor without error."""
-        result = VibrationReading.compute_db(0.05, 0.0)
+        result = compute_db(0.05, 0.0)
         assert math.isfinite(result)
 
     def test_compute_db_or_none_returns_none_for_missing(self) -> None:
-        assert VibrationReading.compute_db_or_none(None, 0.001) is None
-        assert VibrationReading.compute_db_or_none(0.05, None) is None
-        assert VibrationReading.compute_db_or_none(None, None) is None
+        assert compute_db_or_none(None, 0.001) is None
+        assert compute_db_or_none(0.05, None) is None
+        assert compute_db_or_none(None, None) is None
 
     def test_compute_db_or_none_returns_float_for_valid(self) -> None:
-        result = VibrationReading.compute_db_or_none(0.05, 0.001)
+        result = compute_db_or_none(0.05, 0.001)
         assert result is not None
-        expected = VibrationReading.compute_db(0.05, 0.001)
+        expected = compute_db(0.05, 0.001)
         assert result == pytest.approx(expected)
 
 

--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -372,7 +372,6 @@ class TestReport:
         assert r.lang == "de"
         assert r.sample_count == 500
         assert r.sensor_count == 3
-        assert r.finding_count == 2
         assert r.car_name == "BMW 3"
         assert r.car_type == "sedan"
         assert r.report_date == "2025-01-15"
@@ -383,7 +382,6 @@ class TestReport:
 
         r = build_report_from_summary({"run_id": "r1"})
         assert r.run_id == "r1"
-        assert r.finding_count == 0
         assert r.sample_count == 0
         assert r.car_name is None
 
@@ -665,45 +663,28 @@ class TestAnalysisWindowEnrichments:
         assert aw.speed_range_text is None
 
 
-class TestReportEnrichments:
-    """Tests for enriched Report domain object."""
+class TestReportValidation:
+    """Tests for Report __post_init__ validation."""
 
-    def test_has_findings(self) -> None:
-        r = Report(run_id="r1", findings=(Finding(finding_id="F001"),))
-        assert r.has_findings
+    def test_empty_run_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="run_id must be non-empty"):
+            Report(run_id="")
 
-    def test_no_findings(self) -> None:
-        r = Report(run_id="r1")
-        assert not r.has_findings
-        assert r.is_empty
+    def test_negative_duration_rejected(self) -> None:
+        with pytest.raises(ValueError, match="duration_s must be non-negative"):
+            Report(run_id="r1", duration_s=-1.0)
 
-    def test_diagnostic_findings(self) -> None:
-        findings = (
-            Finding(finding_id="F001", severity="diagnostic"),
-            Finding(finding_id="REF_SPEED", severity="info"),
-            Finding(finding_id="F002", severity="high"),
-        )
-        r = Report(run_id="r1", findings=findings)
-        diags = r.diagnostic_findings
-        assert len(diags) == 2
-        assert diags[0].finding_id == "F001"
-        assert diags[1].finding_id == "F002"
+    def test_zero_duration_allowed(self) -> None:
+        r = Report(run_id="r1", duration_s=0.0)
+        assert r.duration_s == 0.0
 
-    def test_primary_finding(self) -> None:
-        findings = (
-            Finding(finding_id="F001", severity="diagnostic"),
-            Finding(finding_id="F002", severity="diagnostic"),
-        )
-        r = Report(run_id="r1", findings=findings)
-        assert r.primary_finding is not None
-        assert r.primary_finding.finding_id == "F001"
+    def test_from_summary_empty_run_id_gets_fallback(self) -> None:
+        from vibesensor.report.mapping import build_report_from_summary
 
-    def test_primary_finding_none(self) -> None:
-        r = Report(run_id="r1", findings=(Finding(finding_id="REF_SPEED"),))
-        assert r.primary_finding is None
-        assert r.is_empty
+        r = build_report_from_summary({"run_id": ""})
+        assert r.run_id == "unknown"
 
-    def test_from_summary_creates_domain_findings(self) -> None:
+    def test_from_summary_creates_metadata(self) -> None:
         from vibesensor.report.mapping import build_report_from_summary
 
         summary: dict[str, object] = {
@@ -714,18 +695,11 @@ class TestReportEnrichments:
                     "suspected_source": "bearing",
                     "confidence": 0.8,
                 },
-                {
-                    "finding_id": "REF_SPEED",
-                    "suspected_source": "speed",
-                    "confidence": None,
-                },
             ],
         }
         r = build_report_from_summary(summary)
-        assert len(r.findings) == 2
-        assert r.findings[0].finding_id == "F001"
-        assert r.findings[0].confidence == 0.8
-        assert r.findings[1].is_reference
+        assert r.run_id == "run-1"
+        assert r.lang == "en"
 
 
 class TestRunEnrichments:

--- a/apps/server/tests/report/test_report_new_modules_mapping.py
+++ b/apps/server/tests/report/test_report_new_modules_mapping.py
@@ -363,6 +363,7 @@ def test_map_summary_certainty_reason_keeps_relevant_reference_gap() -> None:
         sensor_count_used=4,
         top_causes=[
             {
+                "finding_id": "F_ENGINE",
                 "suspected_source": "engine",
                 "strongest_location": "Engine Bay",
                 "strongest_speed_band": "60-80 km/h",

--- a/apps/server/vibesensor/analysis/_types.py
+++ b/apps/server/vibesensor/analysis/_types.py
@@ -152,28 +152,6 @@ class FindingPayload(TypedDict, total=False):
     diagnostic_caveat: JsonValue
 
 
-class TopCause(TypedDict, total=False):
-    finding_id: str
-    suspected_source: str
-    confidence: float | None
-    confidence_label_key: str
-    confidence_tone: str
-    confidence_pct: str
-    order: str
-    signatures_observed: list[str]
-    grouped_count: int
-    strongest_location: str | None
-    dominance_ratio: float | None
-    strongest_speed_band: str | None
-    weak_spatial_separation: bool
-    diffuse_excitation: bool
-    diagnostic_caveat: JsonValue
-    phase_evidence: PhaseEvidence | None
-
-
-CandidateFinding: TypeAlias = FindingPayload | TopCause
-
-
 class SpeedStats(TypedDict):
     min_kmh: float | None
     max_kmh: float | None
@@ -306,7 +284,7 @@ class AnalysisSummary(TypedDict):
     run_noise_baseline_db: float | None
     speed_breakdown_skipped_reason: I18nRef | None
     findings: list[FindingPayload]
-    top_causes: list[TopCause]
+    top_causes: list[FindingPayload]
     most_likely_origin: SuspectedVibrationOrigin
     test_plan: list[TestStep]
     phase_timeline: list[PhaseTimelineEntry]
@@ -337,16 +315,6 @@ def is_finding(value: object) -> TypeGuard[FindingPayload]:
     other dict-shaped objects.
     """
     return isinstance(value, dict) and "finding_id" in value
-
-
-def is_top_cause(value: object) -> TypeGuard[TopCause]:
-    """Narrow a runtime value to the top-cause summary shape.
-
-    Checks for ``isinstance(value, dict)`` *and* the presence of a key
-    characteristic of top-cause entries (``strongest_location`` or ``source``),
-    which helps distinguish a TopCause from other dict-shaped objects.
-    """
-    return isinstance(value, dict) and ("strongest_location" in value or "source" in value)
 
 
 # NOTE: The backward-compatible ``Finding = FindingPayload`` alias has been

--- a/apps/server/vibesensor/analysis/diagnosis_candidates.py
+++ b/apps/server/vibesensor/analysis/diagnosis_candidates.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from ..domain import Finding as DomainFinding
-from ._types import CandidateFinding, FindingPayload, TopCause, is_finding, is_top_cause
+from ._types import FindingPayload, is_finding
 
 
 def non_reference_findings(items: Sequence[object]) -> list[FindingPayload]:
@@ -22,19 +22,10 @@ def non_reference_findings(items: Sequence[object]) -> list[FindingPayload]:
     ]
 
 
-def non_reference_top_causes(items: Sequence[object]) -> list[TopCause]:
-    """Return well-formed top-cause dicts excluding ``REF_*`` entries."""
-    return [
-        item
-        for item in items
-        if is_top_cause(item) and not DomainFinding.from_payload(item).is_reference
-    ]
-
-
 def select_effective_top_causes(
     top_causes: Sequence[object],
     findings: Sequence[object],
-) -> tuple[list[FindingPayload], list[FindingPayload], list[TopCause], list[CandidateFinding]]:
+) -> tuple[list[FindingPayload], list[FindingPayload], list[FindingPayload], list[FindingPayload]]:
     """Return report-ready cause/finding collections.
 
     Returns ``(all_findings, findings_non_ref, top_causes_all, effective_top_causes)``.
@@ -44,20 +35,24 @@ def select_effective_top_causes(
     """
     all_findings = [item for item in findings if is_finding(item)]
     findings_non_ref = non_reference_findings(all_findings)
-    top_causes_all = [item for item in top_causes if is_top_cause(item)]
-    top_causes_non_ref = non_reference_top_causes(top_causes_all)
+    top_causes_all = [item for item in top_causes if is_finding(item)]
+
+    # Materialize domain objects once to avoid repeated from_payload calls
+    top_cause_pairs = [(tc, DomainFinding.from_payload(tc)) for tc in top_causes_all]
+    top_causes_non_ref = [tc for tc, d in top_cause_pairs if not d.is_reference]
     top_causes_actionable = [
-        cause for cause in top_causes_non_ref if DomainFinding.from_payload(cause).is_actionable
+        tc for tc, d in top_cause_pairs if not d.is_reference and d.is_actionable
     ]
-    effective_top_causes: list[CandidateFinding]
+
+    effective_top_causes: list[FindingPayload]
     if top_causes_actionable:
-        effective_top_causes = [candidate for candidate in top_causes_actionable]
+        effective_top_causes = list(top_causes_actionable)
     elif findings_non_ref:
-        effective_top_causes = [candidate for candidate in findings_non_ref]
+        effective_top_causes = list(findings_non_ref)
     elif top_causes_non_ref:
-        effective_top_causes = [candidate for candidate in top_causes_non_ref]
+        effective_top_causes = list(top_causes_non_ref)
     else:
-        effective_top_causes = [candidate for candidate in top_causes_all]
+        effective_top_causes = list(top_causes_all)
     return all_findings, findings_non_ref, top_causes_all, effective_top_causes
 
 

--- a/apps/server/vibesensor/analysis/findings.py
+++ b/apps/server/vibesensor/analysis/findings.py
@@ -279,7 +279,8 @@ def collect_order_frequencies(order_findings: list[FindingPayload]) -> set[float
     """Collect matched order frequencies used to suppress duplicate persistent findings."""
     order_freqs: set[float] = set()
     for order_finding in order_findings:
-        conf = DomainFinding.from_payload(order_finding).effective_confidence
+        raw_conf = order_finding.get("confidence")
+        conf = float(raw_conf) if raw_conf is not None else 0.0
         if conf < ORDER_SUPPRESS_PERSISTENT_MIN_CONF:
             continue
         points = order_finding.get("matched_points")

--- a/apps/server/vibesensor/analysis/plots.py
+++ b/apps/server/vibesensor/analysis/plots.py
@@ -11,8 +11,7 @@ from dataclasses import dataclass, field
 from math import floor
 from typing import Literal, Required, TypedDict
 
-from vibesensor.domain import VibrationReading
-from vibesensor.vibration_strength import percentile
+from vibesensor.vibration_strength import compute_db, compute_db_or_none, percentile
 
 from ..constants import MEMS_NOISE_FLOOR_G
 from ..json_utils import as_float_or_none as _as_float
@@ -648,7 +647,7 @@ def top_peaks_table_rows(
                 )
 
     run_noise_baseline_db: float | None = (
-        VibrationReading.compute_db(
+        compute_db(
             _effective_baseline_floor(run_noise_baseline_g),
             MEMS_NOISE_FLOOR_G,
         )
@@ -665,9 +664,9 @@ def top_peaks_table_rows(
         p95_amp = safe_percentile(amps, 0.95)
         max_amp = amps[-1] if amps else 0.0
         floor_amp_val = safe_percentile(floor_amps, 0.50) if floor_amps else None
-        max_intensity_db = VibrationReading.compute_db_or_none(max_amp, floor_amp_val)
-        median_intensity_db = VibrationReading.compute_db_or_none(median_amp, floor_amp_val)
-        p95_intensity_db = VibrationReading.compute_db_or_none(p95_amp, floor_amp_val)
+        max_intensity_db = compute_db_or_none(max_amp, floor_amp_val)
+        median_intensity_db = compute_db_or_none(median_amp, floor_amp_val)
+        p95_intensity_db = compute_db_or_none(p95_amp, floor_amp_val)
         burstiness = (max_amp / median_amp) if median_amp > 1e-9 else 0.0
         spatial_uniformity: float | None = None
         if len(total_locations) >= 2:
@@ -694,9 +693,7 @@ def top_peaks_table_rows(
         bucket.run_noise_baseline_db = run_noise_baseline_db
         bucket.median_vs_run_noise_ratio = median_amp / baseline_floor
         bucket.p95_vs_run_noise_ratio = p95_amp / baseline_floor
-        bucket.strength_floor_db = VibrationReading.compute_db_or_none(
-            floor_amp_val, MEMS_NOISE_FLOOR_G
-        )
+        bucket.strength_floor_db = compute_db_or_none(floor_amp_val, MEMS_NOISE_FLOOR_G)
         bucket.strength_db = p95_intensity_db
         bucket.presence_ratio = presence_ratio
         bucket.burstiness = burstiness

--- a/apps/server/vibesensor/analysis/summary_builder.py
+++ b/apps/server/vibesensor/analysis/summary_builder.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from statistics import median as _median
 
 from vibesensor.analysis.analysis_window import AnalysisWindow
-from vibesensor.domain import VibrationReading
+from vibesensor.vibration_strength import compute_db
 
 from ..constants import MEMS_NOISE_FLOOR_G, SPEED_COVERAGE_MIN_PCT, SPEED_MIN_POINTS
 from ..json_utils import as_float_or_none as _as_float
@@ -38,7 +38,6 @@ from ._types import (
     SpeedStats,
     SuspectedVibrationOrigin,
     TestStep,
-    TopCause,
     i18n_ref,
     is_json_object,
 )
@@ -363,7 +362,7 @@ def noise_baseline_db(run_noise_baseline_g: float | None) -> float | None:
     """Convert a run noise baseline amplitude in g to dB, or return None."""
     if run_noise_baseline_g is None:
         return None
-    return VibrationReading.compute_db(
+    return compute_db(
         max(MEMS_NOISE_FLOOR_G, run_noise_baseline_g),
         MEMS_NOISE_FLOOR_G,
     )
@@ -694,7 +693,7 @@ def build_summary_payload(
     run_noise_baseline_g: float | None,
     speed_breakdown_skipped_reason: I18nRef | None,
     findings: list[FindingPayload],
-    top_causes: list[TopCause],
+    top_causes: list[FindingPayload],
     most_likely_origin: SuspectedVibrationOrigin,
     test_plan: list[TestStep],
     phase_timeline: list[PhaseTimelineEntry],
@@ -930,7 +929,7 @@ def build_findings_bundle(
     SuspectedVibrationOrigin,
     list[TestStep],
     list[PhaseTimelineEntry],
-    list[TopCause],
+    list[FindingPayload],
 ]:
     """Build findings plus derived diagnosis narrative fields."""
     builder = findings_builder or _build_findings

--- a/apps/server/vibesensor/analysis/top_cause_selection.py
+++ b/apps/server/vibesensor/analysis/top_cause_selection.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from dataclasses import replace as _replace
 
 from ..domain import Finding
-from ._types import FindingPayload, TopCause
+from ._types import FindingPayload
 from .strength_labels import (
     CONFIDENCE_HIGH_THRESHOLD,
     CONFIDENCE_MEDIUM_THRESHOLD,
@@ -28,8 +28,8 @@ def _build_top_cause(
     finding: FindingPayload,
     *,
     strength_band_key: str | None = None,
-) -> TopCause:
-    """Build a ``TopCause`` dict from a (grouped) FindingPayload."""
+) -> FindingPayload:
+    """Enrich a (grouped) FindingPayload with confidence presentation fields."""
     domain = Finding.from_payload(finding)
     # Apply severity default and extract analysis-specific order key
     severity_raw = str(finding.get("severity") or "diagnostic").strip().lower()
@@ -40,26 +40,16 @@ def _build_top_cause(
         domain.effective_confidence,
         strength_band_key=strength_band_key,
     )
-    return {
-        "finding_id": domain.finding_id,
-        "suspected_source": domain.suspected_source,
-        "confidence": domain.confidence,
-        "confidence_label_key": label_key,
-        "confidence_tone": tone,
-        "confidence_pct": pct_text,
-        "order": domain.order,
-        "signatures_observed": finding.get("signatures_observed", []),
-        "grouped_count": finding.get("grouped_count", 1),
-        "strongest_location": domain.strongest_location,
-        "dominance_ratio": domain.dominance_ratio,
-        "strongest_speed_band": domain.strongest_speed_band,
-        "weak_spatial_separation": domain.weak_spatial_separation,
-        "diffuse_excitation": domain.diffuse_excitation,
-        "diagnostic_caveat": finding.get("diagnostic_caveat"),
-        "phase_evidence": (
-            {"cruise_fraction": domain.cruise_fraction} if domain.cruise_fraction else None
-        ),
-    }
+    result: FindingPayload = {**finding}
+    result["confidence_label_key"] = label_key
+    result["confidence_tone"] = tone
+    result["confidence_pct"] = pct_text
+    # Normalize order field from domain object
+    result["order"] = domain.order
+    result["phase_evidence"] = (
+        {"cruise_fraction": domain.cruise_fraction} if domain.cruise_fraction else None
+    )
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -76,10 +66,15 @@ def group_findings_by_source(
         source = str(finding.get("suspected_source") or "unknown").strip().lower()
         groups[source].append(finding)
 
+    # Pre-compute domain objects to avoid repeated from_payload in sort key
+    domain_cache: dict[int, Finding] = {}
+    for finding in diag_findings:
+        domain_cache[id(finding)] = Finding.from_payload(finding)
+
     grouped: list[tuple[float, FindingPayload]] = []
     for members in groups.values():
         members_scored = sorted(
-            ((Finding.from_payload(member).phase_adjusted_score, member) for member in members),
+            ((domain_cache[id(member)].phase_adjusted_score, member) for member in members),
             key=lambda item: item[0],
             reverse=True,
         )
@@ -132,7 +127,7 @@ def select_top_causes(
     drop_off_points: float = 15.0,
     max_causes: int = 3,
     strength_band_key: str | None = None,
-) -> list[TopCause]:
+) -> list[FindingPayload]:
     """Group findings by source, rank the strongest group per source, and trim by drop-off."""
     diagnostic_findings = [
         finding

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -219,7 +219,7 @@ class Finding:
         ignoring serialization-only keys present in the full payload.
 
         Reads ``suspected_source`` with fallback to ``source`` for backward
-        compatibility with ``TopCause`` dicts that use the ``source`` key.
+        compatibility with legacy dicts that used the ``source`` key.
         """
 
         def _str(key: str, *fallback_keys: str) -> str:

--- a/apps/server/vibesensor/domain/measurement.py
+++ b/apps/server/vibesensor/domain/measurement.py
@@ -133,35 +133,3 @@ class VibrationReading:
         ====  ===========
         """
         return bucket_for_strength(self.intensity_db)
-
-    # -- factory methods ----------------------------------------------------
-
-    @staticmethod
-    def compute_db(peak_amplitude_g: float, noise_floor_g: float) -> float:
-        """Compute vibration strength in dB from amplitude pair.
-
-        Uses the canonical formula:
-        ``20 × log₁₀((peak + ε) / (floor + ε))``
-        where ``ε = max(1e-9, floor × 0.05)``.
-
-        This is a convenience entry point for code that has pre-computed
-        amplitude values but does not need a full ``VibrationReading``
-        object (e.g. aggregate statistics in the analysis pipeline).
-        """
-        return vibration_strength_db_scalar(
-            peak_band_rms_amp_g=peak_amplitude_g,
-            floor_amp_g=noise_floor_g,
-        )
-
-    @staticmethod
-    def compute_db_or_none(
-        peak_amplitude_g: float | None,
-        noise_floor_g: float | None,
-    ) -> float | None:
-        """Like :meth:`compute_db` but returns ``None`` when either input is ``None``."""
-        if peak_amplitude_g is None or noise_floor_g is None:
-            return None
-        return vibration_strength_db_scalar(
-            peak_band_rms_amp_g=peak_amplitude_g,
-            floor_amp_g=noise_floor_g,
-        )

--- a/apps/server/vibesensor/domain/report.py
+++ b/apps/server/vibesensor/domain/report.py
@@ -1,15 +1,15 @@
-"""The assembled output of a diagnostic run.
+"""Report metadata carrier for a diagnostic run.
 
-``Report`` is the primary domain object for a rendered or ready-to-render
-report.  ``ReportTemplateData`` in ``report.report_data`` remains as the
-PDF-rendering adapter.
+``Report`` holds run-level identity and metadata used by the rendering
+pipeline.  Finding-level data flows through the raw analysis summary
+dicts (``ReportMappingContext``) rather than through this object.
+``ReportTemplateData`` in ``report.report_data`` is the PDF-rendering
+adapter.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-from .finding import Finding
 
 __all__ = [
     "Report",
@@ -18,15 +18,11 @@ __all__ = [
 
 @dataclass(frozen=True, slots=True)
 class Report:
-    """The assembled output of a diagnostic run.
+    """Run-level metadata carrier consumed by the report rendering pipeline.
 
-    This is the primary domain object for a rendered or ready-to-render
-    report.  ``ReportTemplateData`` in ``report.report_data`` remains as
-    the PDF-rendering adapter.
-
-    The :attr:`findings` tuple holds domain :class:`Finding` objects
-    extracted from the analysis summary, giving the report first-class
-    access to its diagnostic conclusions.
+    Finding-level data flows through the analysis summary dicts and
+    :class:`~vibesensor.report.mapping.ReportMappingContext`, not
+    through this object.
     """
 
     run_id: str
@@ -38,34 +34,9 @@ class Report:
     duration_s: float | None = None
     sample_count: int = 0
     sensor_count: int = 0
-    findings: tuple[Finding, ...] = ()
 
-    # -- queries -----------------------------------------------------------
-
-    @property
-    def finding_count(self) -> int:
-        """Total number of findings (derived from findings tuple)."""
-        return len(self.findings)
-
-    # -- queries -----------------------------------------------------------
-
-    @property
-    def has_findings(self) -> bool:
-        """Whether this report contains any findings."""
-        return bool(self.findings)
-
-    @property
-    def diagnostic_findings(self) -> list[Finding]:
-        """Return only diagnostic (non-reference, non-info) findings."""
-        return [f for f in self.findings if f.is_diagnostic]
-
-    @property
-    def primary_finding(self) -> Finding | None:
-        """The top-ranked diagnostic finding, or ``None``."""
-        diags = self.diagnostic_findings
-        return diags[0] if diags else None
-
-    @property
-    def is_empty(self) -> bool:
-        """Whether the report has no diagnostic content."""
-        return not self.diagnostic_findings
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise ValueError("run_id must be non-empty")
+        if self.duration_s is not None and self.duration_s < 0:
+            raise ValueError("duration_s must be non-negative")

--- a/apps/server/vibesensor/report/mapping.py
+++ b/apps/server/vibesensor/report/mapping.py
@@ -12,7 +12,6 @@ from statistics import mean as _mean
 from .. import __version__
 from ..analysis._types import (
     AnalysisSummary,
-    CandidateFinding,
     FindingPayload,
     IntensityRow,
     JsonValue,
@@ -21,7 +20,6 @@ from ..analysis._types import (
     SpeedStats,
     SuspectedVibrationOrigin,
     TestStep,
-    TopCause,
 )
 from ..analysis.diagnosis_candidates import normalize_origin_location, select_effective_top_causes
 from ..analysis.helpers import PHASE_I18N_KEYS
@@ -32,7 +30,7 @@ from ..analysis.strength_labels import (
     strength_label,
     strength_text,
 )
-from ..domain import Finding, Report, VibrationSource
+from ..domain import Report, VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from ..report_i18n import normalize_lang
 from ..report_i18n import tr as _tr
@@ -69,7 +67,7 @@ class ReportMappingContext:
     car_name: str | None
     car_type: str | None
     date_str: str
-    top_causes: list[CandidateFinding]
+    top_causes: list[FindingPayload]
     findings_non_ref: list[FindingPayload]
     findings: list[FindingPayload]
     speed_stats: SpeedStats
@@ -88,7 +86,7 @@ class ReportMappingContext:
 
     # -- candidate selection ------------------------------------------------
 
-    def top_report_candidate(self) -> CandidateFinding | None:
+    def top_report_candidate(self) -> FindingPayload | None:
         """Return the primary report candidate (first effective top cause or finding)."""
         candidates = self.top_causes or self.findings_non_ref
         return candidates[0] if candidates else None
@@ -138,7 +136,7 @@ class ReportMappingContext:
 class PrimaryCandidateContext:
     """Primary report candidate resolved from top causes or findings."""
 
-    primary_candidate: CandidateFinding | None
+    primary_candidate: FindingPayload | None
     primary_source: object
     primary_system: str
     primary_location: str
@@ -260,7 +258,7 @@ def peak_classification_text(value: object, tr: Callable[..., str]) -> str:
     return str(value).replace("_", " ").title()
 
 
-def extract_confidence(item: FindingPayload | TopCause) -> float:
+def extract_confidence(item: FindingPayload) -> float:
     """Return the confidence value from a cause/finding dict."""
     value = _as_float(item.get("confidence"))
     return value if value is not None else 0.0
@@ -366,7 +364,7 @@ class SummaryView:
         return list(raw) if isinstance(raw, list) else []
 
     @property
-    def top_causes(self) -> list[TopCause]:
+    def top_causes(self) -> list[FindingPayload]:
         raw = self._d.get("top_causes", [])
         return list(raw) if isinstance(raw, list) else []
 
@@ -651,7 +649,7 @@ def _resolve_detail_text(value: object, *, lang: str, tr: Callable) -> str | Non
 def top_strength_values(
     summary: AnalysisSummary,
     *,
-    effective_causes: list[CandidateFinding] | None = None,
+    effective_causes: list[FindingPayload] | None = None,
 ) -> float | None:
     """Return the best available vibration strength in dB for report text."""
     causes = effective_causes if effective_causes is not None else summary.get("top_causes", [])
@@ -779,7 +777,7 @@ def resolve_interpretation(origin: SuspectedVibrationOrigin, *, lang: str, tr: C
 
 
 def resolve_parts_context(
-    primary_candidate: CandidateFinding | None,
+    primary_candidate: FindingPayload | None,
     *,
     lang: str,
 ) -> tuple[str, str | None]:
@@ -972,10 +970,8 @@ def resolve_primary_report_candidate(
 def build_report_from_summary(summary: dict[str, object]) -> Report:
     """Create a domain Report from a ``SummaryData`` dict.
 
-    This is the adapter bridge between the raw analysis-summary JSON
-    shape and the typed domain ``Report``.  It extracts key metadata
-    fields and constructs domain :class:`Finding` objects from the
-    ``findings`` list.
+    Extracts run-level metadata.  Finding-level data is handled
+    separately by :func:`prepare_report_mapping_context`.
     """
     meta = summary.get("metadata") or {}
     if not isinstance(meta, dict):
@@ -989,13 +985,6 @@ def build_report_from_summary(summary: dict[str, object]) -> Report:
         car_name = str(raw_name) if raw_name else None
         raw_type = car_cfg.get("car_type")
         car_type = str(raw_type) if raw_type else None
-
-    raw_findings = summary.get("findings")
-    finding_list: list[Finding] = []
-    if isinstance(raw_findings, list):
-        for item in raw_findings:
-            if isinstance(item, dict):
-                finding_list.append(Finding.from_payload(item))
 
     rows = summary.get("rows")
     sample_count = int(rows) if isinstance(rows, (int, float, str)) else 0
@@ -1014,8 +1003,10 @@ def build_report_from_summary(summary: dict[str, object]) -> Report:
     report_date = summary.get("report_date")
     report_date_str = str(report_date) if isinstance(report_date, str) else None
 
+    run_id = str(summary.get("run_id", ""))
+
     return Report(
-        run_id=str(summary.get("run_id", "")),
+        run_id=run_id or "unknown",
         lang=str(summary.get("lang", "en")),
         car_name=car_name,
         car_type=car_type,
@@ -1023,7 +1014,6 @@ def build_report_from_summary(summary: dict[str, object]) -> Report:
         duration_s=duration_s,
         sample_count=sample_count,
         sensor_count=sensor_count,
-        findings=tuple(finding_list),
     )
 
 

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -25,6 +25,8 @@ from typing_extensions import TypedDict
 from .strength_bands import bucket_for_strength
 
 __all__ = [
+    "compute_db",
+    "compute_db_or_none",
     "empty_vibration_strength_metrics",
     "PEAK_BANDWIDTH_HZ",
     "PEAK_SEPARATION_HZ",
@@ -374,3 +376,34 @@ def compute_vibration_strength_db(
         "strength_bucket": bucket_for_strength(top_db),
         "top_peaks": list(chosen),
     }
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrappers for callers that already have amplitude pairs
+# ---------------------------------------------------------------------------
+
+
+def compute_db(peak_amplitude_g: float, noise_floor_g: float) -> float:
+    """Compute vibration strength in dB from an amplitude pair.
+
+    Uses the canonical formula:
+    ``20 × log₁₀((peak + ε) / (floor + ε))``
+    where ``ε = max(1e-9, floor × 0.05)``.
+    """
+    return vibration_strength_db_scalar(
+        peak_band_rms_amp_g=peak_amplitude_g,
+        floor_amp_g=noise_floor_g,
+    )
+
+
+def compute_db_or_none(
+    peak_amplitude_g: float | None,
+    noise_floor_g: float | None,
+) -> float | None:
+    """Like :func:`compute_db` but returns ``None`` when either input is ``None``."""
+    if peak_amplitude_g is None or noise_floor_g is None:
+        return None
+    return vibration_strength_db_scalar(
+        peak_band_rms_amp_g=peak_amplitude_g,
+        floor_amp_g=noise_floor_g,
+    )

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -16,9 +16,8 @@ SpeedSource ──configures──▶ Run   [AnalysisWindow] (analysis-layer typ
 Measurement ──recorded in──▶ Run       ▼
   │                              Finding (richest: classification,
   │ converts to                   ranking, actionability, scoring)
-  ▼                                    │ collected by
-VibrationReading (dB)                  ▼
-                                 Report (assembled output)
+  ▼
+VibrationReading (dB)            Report (metadata carrier)
 ```
 
 ### Central objects in the workflow
@@ -27,7 +26,7 @@ VibrationReading (dB)                  ▼
 |--------|------|--------------------|
 | **Run** | Aggregate root | Lifecycle (start/stop/stopped), status transitions, phase tracking |
 | **Finding** | Richest domain object | Kind (diagnostic/reference/informational), classification, actionability, surfacing, confidence thresholds, deterministic ranking, phase-adjusted scoring (flat `cruise_fraction`), vibration-source enum (`VibrationSource`), speed-band helper functions (`speed_bin_label`, `speed_band_sort_key`), REF_ prefix cross-check warning |
-| **Report** | Assembled output | Finding queries (`finding_count` property), primary-finding selection, raw temporal values (`report_date`, `duration_s`); construction from analysis summary delegated to `report/mapping.py` |
+| **Report** | Metadata carrier | Run identity, language, car info, temporal metadata; finding-level data flows through `ReportMappingContext` (raw analysis dicts), not this object.  Construction from analysis summary delegated to `report/mapping.py` |
 
 ### Supporting domain objects
 
@@ -37,14 +36,14 @@ VibrationReading (dB)                  ▼
 | **Sensor** | Accelerometer node | Display name, placement status queries |
 | **SensorPlacement** | Mounting position | Position category classification (wheel/drivetrain/body) |
 | **Measurement** | Raw sample value object | Conversion to VibrationReading (dB) |
-| **VibrationReading** | Processed dB value object | Severity level lookup, dB computation |
+| **VibrationReading** | Processed dB value object | Severity level lookup.  dB computation entry points are the free functions `compute_db()` / `compute_db_or_none()` in `vibration_strength.py` |
 | **SpeedSource** | Speed acquisition config | Source-kind classification (via `SpeedSourceKind` StrEnum), effective speed resolution, cross-field invariant (MANUAL requires `manual_speed_kmh > 0`) |
 
 ### Object containment and derivation
 
 - **Sensor** contains an optional **SensorPlacement**.
 - **Run** tracks lifecycle via ``start()``/``stop()`` guards and an ``is_recording`` property.  Reading accumulation is handled by the recording pipeline, not the domain object.
-- **Report** contains a tuple of **Finding** instances.
+- **Report** is a metadata carrier; finding-level data flows through `ReportMappingContext`.
 - **Finding** is derived from analysis of **AnalysisWindow** data (analysis-layer type, not a domain object).
 - **Car** aspects (tire dimensions) drive order-analysis hypothesis generation.
 - **SpeedSource** configures how speed is obtained during a **Run**.
@@ -61,8 +60,8 @@ These types exist only at boundaries and should not own domain behavior:
 | `SensorFrame` | `protocol.py` | Binary protocol → raw sample data |
 | `RunMetadata` | `backend_types.py` | Run-level configuration snapshot |
 | `PhaseEvidence` | `analysis/_types.py` | Phase evidence TypedDict for pipeline serialization |
-| `FindingPayload` | `analysis/_types.py` | Dict-based analysis pipeline payload |
-| `AnalysisSummary` | `analysis/_types.py` | Analysis summary TypedDict |
+| `FindingPayload` | `analysis/_types.py` | Dict-based analysis pipeline payload (also used for top causes after TopCause TypedDict removal) |
+| `AnalysisSummary` | `analysis/_types.py` | Analysis summary TypedDict (`.top_causes` is `list[FindingPayload]`) |
 | `SuspectedVibrationOrigin` | `analysis/_types.py` | Origin summary TypedDict (key: `suspected_source`) |
 | `LocalizationAssessment` | `analysis/summary_builder.py` | Spatial interpretation of finding evidence |
 | `ReportTemplateData` | `report/report_data.py` | PDF-rendering data classes |
@@ -85,7 +84,7 @@ within `apps/server/vibesensor/domain/`:
 | `car.py` | `Car`, `TireSpec` | Vehicle geometry and tire computation |
 | `driving_phase.py` | `DrivingPhase` | Driving-phase StrEnum (the `AnalysisWindow` class itself lives in `analysis/analysis_window.py`) |
 | `finding.py` | `FindingKind`, `VibrationSource`, `Finding`, `speed_bin_label`, `speed_band_sort_key` | Richest domain object (kind, classification, ranking, scoring, dB strength, vibration-source enum, speed-band helper functions, flat `cruise_fraction` for phase adjustment) |
-| `report.py` | `Report` | Assembled diagnostic output (construction from analysis summary lives in `report/mapping.py::build_report_from_summary()`) |
+| `report.py` | `Report` | Metadata carrier for run identity and rendering context (construction from analysis summary lives in `report/mapping.py::build_report_from_summary()`) |
 | `run_status.py` | `RunStatus`, `RUN_TRANSITIONS`, `transition_run` | Persisted run lifecycle state machine (enforcing) |
 
 All domain objects are re-exported from `vibesensor.domain` (the package


### PR DESCRIPTION
## Summary

Domain model cleanup: removes redundant types, scopes Report to its actual role, and reduces wasteful object construction — without adding new abstractions.

**Net: –105 lines** (150 added, 255 removed across 15 files).

## Changes

### 1. TopCause consolidation (C1: 6-agent consensus)
- **Removed** `TopCause` TypedDict, `CandidateFinding` type alias, and `is_top_cause()` guard from `_types.py`
- `AnalysisSummary.top_causes` is now `list[FindingPayload]` (single dict shape everywhere)
- `_build_top_cause()` enriches a *copy* of the source FindingPayload with confidence labels instead of building a stripped TopCause
- Updated all consumers: `diagnosis_candidates.py`, `summary_builder.py`, `report/mapping.py`
- `Finding.from_payload()` docstring updated to remove TopCause reference

### 2. VibrationReading static method cleanup (C2)
- Added `compute_db()` and `compute_db_or_none()` as free functions in `vibration_strength.py`
- Updated callers (`analysis/plots.py`, `analysis/summary_builder.py`) to use free functions
- Removed dead static methods from `VibrationReading` class (no production callers)

### 3. Report scoped to metadata carrier (C3+C5)
- **Removed** `findings` field and all dead query properties (`finding_count`, `has_findings`, `diagnostic_findings`, `primary_finding`, `is_empty`) — none were used by the rendering pipeline
- Added `__post_init__` validation: `run_id` must be non-empty, `duration_s` must be non-negative
- `build_report_from_summary()` no longer constructs `Finding` domain objects (removed `Finding` import from `mapping.py`)

### 4. from_payload hot-loop optimization (C4)
- `select_effective_top_causes()`: domain objects materialized once, reused for `is_reference` + `is_actionable`
- `group_findings_by_source()`: domain objects cached per finding via `id()` dict
- `collect_order_frequencies()`: `effective_confidence` inlined (trivial `confidence or 0.0`)

### 5. Documentation
- Updated `docs/domain-model.md`: Report is now "metadata carrier", relationship diagram updated, TopCause removal noted, VibrationReading dB entry points documented

## Validation
- All 5048 backend tests pass
- `ruff check` clean
- `ruff format` clean
- `mypy` clean (129 source files)
- `docs-lint` clean