### PR TITLE
Refactor analysis around canonical domain aggregates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,8 @@ Architectural constraints
 Domain model
 - Domain objects own behavior (classification, ranking, lifecycle, computation).  Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
 - Each primary domain object lives in its own file under `vibesensor/domain/`.  Consumers import from `vibesensor.domain`, not from individual module files.
+- The core diagnostic aggregates are `DiagnosticCase` and `TestRun`; `RunAnalysisResult` is retained as a run-focused projection for boundary consumers.
+- Boundary decoders/serializers live under `apps/server/vibesensor/boundaries/`; do not rebuild payload-driven business logic in report/history/runtime consumers.
 - See `docs/domain-model.md` for the full relationship map, adapter inventory, and modeling rules.
 
 Common commands

--- a/apps/server/tests/analysis/test_test_plan.py
+++ b/apps/server/tests/analysis/test_test_plan.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from vibesensor.analysis.test_plan import _merge_test_plan
+from vibesensor.analysis.test_plan import _merge_test_plan, build_domain_test_plan
 
 
 def test_merge_test_plan_deduplicates_action_ids_case_insensitively() -> None:
@@ -35,3 +35,32 @@ def test_merge_test_plan_generated_steps_inherit_normalized_metadata() -> None:
         assert step.get("certainty_0_to_1") == "0.8200"
         assert step.get("speed_band") == "90-100 km/h"
         assert step.get("frequency_hz_or_order") == "12.4 Hz"
+
+
+def test_build_domain_test_plan_normalizes_boundary_step_values() -> None:
+    findings = [
+        {
+            "actions": [
+                {
+                    "action_id": " wheel_balance_and_runout ",
+                    "what": {"_i18n_key": "ACTION_WHEEL_BALANCE_WHAT"},
+                    "why": {"_i18n_key": "ACTION_WHEEL_BALANCE_WHY"},
+                    "confirm": {"_i18n_key": "ACTION_WHEEL_BALANCE_CONFIRM"},
+                    "falsify": {"_i18n_key": "ACTION_WHEEL_BALANCE_FALSIFY"},
+                    "eta": " 10 min ",
+                }
+            ]
+        }
+    ]
+
+    plan = build_domain_test_plan(findings, "en")
+
+    assert len(plan.actions) == 1
+    action = plan.actions[0]
+    assert action.action_id == "wheel_balance_and_runout"
+    assert action.what == "ACTION_WHEEL_BALANCE_WHAT"
+    assert action.why == "ACTION_WHEEL_BALANCE_WHY"
+    assert action.confirm == "ACTION_WHEEL_BALANCE_CONFIRM"
+    assert action.falsify == "ACTION_WHEEL_BALANCE_FALSIFY"
+    assert action.eta == "10 min"
+    assert plan.requires_additional_data is False

--- a/apps/server/tests/history/test_history_http_services.py
+++ b/apps/server/tests/history/test_history_http_services.py
@@ -71,6 +71,43 @@ async def test_report_service_load_report_request_uses_persisted_language() -> N
 
 
 @pytest.mark.asyncio
+async def test_run_service_projects_persisted_summary_through_domain() -> None:
+    service = HistoryRunService(
+        _HistoryDbStub(
+            run={
+                "run_id": "run-1",
+                "status": "complete",
+                "analysis": {
+                    "lang": "en",
+                    "findings": [
+                        {
+                            "finding_id": "F001",
+                            "suspected_source": "wheel/tire",
+                            "strongest_location": "front-left",
+                            "strongest_speed_band": "50-80 km/h",
+                            "confidence": 0.71,
+                            "evidence_metrics": {"vibration_strength_db": 21.0},
+                        },
+                    ],
+                    "top_causes": [],
+                    "test_plan": [],
+                    "run_suitability": [],
+                    "most_likely_origin": {},
+                    "_internal": {"secret": True},
+                },
+            },
+        ),
+    )
+
+    run = await service.get_run("run-1")
+
+    analysis = run["analysis"]
+    assert analysis["top_causes"][0]["finding_id"] == "F001"
+    assert analysis["most_likely_origin"]["suspected_source"] == "wheel/tire"
+    assert "_internal" not in analysis
+
+
+@pytest.mark.asyncio
 async def test_report_pdf_cache_builds_once_per_key() -> None:
     cache = HistoryReportPdfCache()
     calls = 0
@@ -101,6 +138,35 @@ def test_build_run_details_json_strips_internal_analysis_fields() -> None:
 
     assert payload["sample_count"] == 5
     assert payload["analysis"] == {"visible": 1}
+
+
+def test_build_run_details_json_projects_analysis_through_domain() -> None:
+    payload = json.loads(
+        build_run_details_json(
+            {
+                "run_id": "run-1",
+                "analysis": {
+                    "findings": [
+                        {
+                            "finding_id": "F001",
+                            "suspected_source": "wheel/tire",
+                            "strongest_location": "front-left",
+                            "confidence": 0.71,
+                        },
+                    ],
+                    "top_causes": [],
+                    "most_likely_origin": {},
+                    "test_plan": [],
+                    "run_suitability": [],
+                },
+            },
+            sample_count=5,
+            run_id="run-1",
+        ),
+    )
+
+    assert payload["analysis"]["top_causes"][0]["finding_id"] == "F001"
+    assert payload["analysis"]["most_likely_origin"]["suspected_source"] == "wheel/tire"
 
 
 def test_build_run_details_json_sanitizes_non_finite_floats() -> None:

--- a/apps/server/tests/hygiene/test_domain_architecture.py
+++ b/apps/server/tests/hygiene/test_domain_architecture.py
@@ -692,3 +692,99 @@ def test_confidence_assessment_tier_matches_domain_finding() -> None:
             f"ConfidenceAssessment.assess({conf}).label_key must match "
             f"Finding.classify_confidence({conf})[0]"
         )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ConfigurationSnapshot",
+        "DiagnosticCase",
+        "DrivingSegment",
+        "Hypothesis",
+        "Observation",
+        "RecommendedAction",
+        "Signature",
+        "Symptom",
+        "TestPlan",
+        "TestRun",
+        "VibrationOrigin",
+    ],
+)
+def test_new_domain_objects_are_exported(name: str) -> None:
+    import importlib
+
+    mod = importlib.import_module("vibesensor.domain")
+    assert hasattr(mod, name), f"{name} must be exported from vibesensor.domain"
+
+
+def test_run_analysis_builds_test_run_and_diagnostic_case() -> None:
+    from vibesensor.analysis.summary_builder import RunAnalysis
+    from vibesensor.domain import DiagnosticCase, TestRun
+
+    metadata = {
+        "run_id": "domain-case-guard",
+        "car_name": "Guard Car",
+        "car_type": "sedan",
+        "language": "en",
+    }
+    samples = [
+        {
+            "t_s": float(i),
+            "accel_x": 0.01,
+            "accel_y": 0.01,
+            "accel_z": 1.0,
+            "accel_mag": 1.0,
+            "speed_kmh": 80.0,
+            "vibration_strength_db": 5.0,
+        }
+        for i in range(30)
+    ]
+    analysis = RunAnalysis(metadata, samples)
+    analysis.summarize()
+
+    assert analysis.test_run is not None
+    assert analysis.diagnostic_case is not None
+    assert isinstance(analysis.test_run, TestRun)
+    assert isinstance(analysis.diagnostic_case, DiagnosticCase)
+    assert analysis.diagnostic_case.primary_run is not None
+    assert analysis.diagnostic_case.primary_run.run_id == analysis.test_run.run_id
+
+
+def test_boundary_decoder_builds_diagnostic_case_from_summary() -> None:
+    from tests.test_support.findings import make_finding_payload
+    from vibesensor.boundaries import diagnostic_case_from_summary
+
+    summary = {
+        "run_id": "summary-case-guard",
+        "metadata": {"car_name": "Guard Car", "car_type": "sedan"},
+        "findings": [make_finding_payload(finding_id="F001", confidence=0.80)],
+        "top_causes": [make_finding_payload(finding_id="F001", confidence=0.80)],
+        "test_plan": [
+            {
+                "action_id": "check-wheel",
+                "what": {"_i18n_key": "ACTION_WHEEL_BALANCE_WHAT"},
+                "why": {"_i18n_key": "ACTION_WHEEL_BALANCE_WHY"},
+            }
+        ],
+    }
+    diagnostic_case = diagnostic_case_from_summary(summary)
+    assert diagnostic_case.test_runs
+    assert diagnostic_case.findings
+    assert diagnostic_case.primary_run is not None
+
+
+def test_finding_from_payload_populates_origin_and_signatures() -> None:
+    from vibesensor.domain import Finding
+
+    payload = {
+        "finding_id": "F001",
+        "suspected_source": "wheel/tire",
+        "confidence": 0.85,
+        "strongest_speed_band": "80-90 km/h",
+        "signatures_observed": ["1x wheel order", "2x wheel order"],
+        "location_hotspot": {"location": "FL wheel", "dominance_ratio": 0.75},
+    }
+    finding = Finding.from_payload(payload)
+    assert finding.origin is not None
+    assert len(finding.signatures) == 2
+    assert finding.origin.display_location == "Fl Wheel"

--- a/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
@@ -96,7 +96,7 @@ class TestExportZipFiltersInternals:
         helper_text = (SERVER_ROOT / "vibesensor" / "history_services" / "helpers.py").read_text()
         export_text = (SERVER_ROOT / "vibesensor" / "history_services" / "exports.py").read_text()
         assert 'if not key.startswith("_")' in helper_text
-        assert "strip_internal_fields(analysis)" in export_text
+        assert "strip_internal_fields(project_summary_through_domain(analysis))" in export_text
 
 
 # ---------------------------------------------------------------------------
@@ -126,3 +126,9 @@ class TestAnalysisQueueContract:
         text = (SERVER_ROOT / "vibesensor" / "metrics_log" / "post_analysis.py").read_text()
         assert "self._analysis_queue: deque[_QueuedRun] = deque()" in text
         assert "evicting run" not in text
+
+    def test_post_analysis_projects_summary_through_domain(self) -> None:
+        """Post-analysis must canonicalize persisted summaries via the shared boundary helper."""
+        text = (SERVER_ROOT / "vibesensor" / "metrics_log" / "post_analysis.py").read_text()
+        assert "from ..boundaries.diagnostic_case import project_summary_through_domain" in text
+        assert "summary = project_summary_through_domain(summary)" in text

--- a/apps/server/tests/report/test_summary_view.py
+++ b/apps/server/tests/report/test_summary_view.py
@@ -1,9 +1,29 @@
-"""Tests for SummaryView typed accessor."""
+"""Tests for explicit summary boundary helper functions."""
 
 from __future__ import annotations
 
 from vibesensor.analysis._types import AnalysisSummary
-from vibesensor.report.mapping import SummaryView
+from vibesensor.report.mapping import (
+    summary_end_time_utc,
+    summary_findings,
+    summary_firmware_version,
+    summary_metadata,
+    summary_origin,
+    summary_raw_sample_rate_hz,
+    summary_record_length,
+    summary_row_count,
+    summary_run_suitability,
+    summary_sample_rate_hz_text,
+    summary_sensor_count_used,
+    summary_sensor_intensity_by_location,
+    summary_sensor_locations_active,
+    summary_sensor_model,
+    summary_speed_stats,
+    summary_start_time_utc,
+    summary_test_plan,
+    summary_top_causes,
+    summary_warnings,
+)
 
 
 def _minimal_summary(**overrides: object) -> AnalysisSummary:
@@ -50,100 +70,82 @@ def _minimal_summary(**overrides: object) -> AnalysisSummary:
     return base  # type: ignore[return-value]
 
 
-class TestSummaryView:
+class TestSummaryHelpers:
     def test_metadata(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.metadata["car_name"] == "Test Car"
+        assert summary_metadata(_minimal_summary())["car_name"] == "Test Car"
 
     def test_row_count(self) -> None:
-        view = SummaryView(_minimal_summary(rows=42))
-        assert view.row_count == 42
+        assert summary_row_count(_minimal_summary(rows=42)) == 42
 
     def test_record_length(self) -> None:
-        view = SummaryView(_minimal_summary(record_length="1:30"))
-        assert view.record_length == "1:30"
+        assert summary_record_length(_minimal_summary(record_length="1:30")) == "1:30"
 
     def test_record_length_none(self) -> None:
-        view = SummaryView(_minimal_summary(record_length=None))
-        assert view.record_length is None
+        assert summary_record_length(_minimal_summary(record_length=None)) is None
 
     def test_start_time_utc(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.start_time_utc == "2025-01-01T10:00:00Z"
+        assert summary_start_time_utc(_minimal_summary()) == "2025-01-01T10:00:00Z"
 
     def test_end_time_utc(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.end_time_utc == "2025-01-01T10:00:05Z"
+        assert summary_end_time_utc(_minimal_summary()) == "2025-01-01T10:00:05Z"
 
     def test_raw_sample_rate_hz(self) -> None:
-        view = SummaryView(_minimal_summary(raw_sample_rate_hz=200.0))
-        assert view.raw_sample_rate_hz == 200.0
+        assert summary_raw_sample_rate_hz(_minimal_summary(raw_sample_rate_hz=200.0)) == 200.0
 
     def test_sensor_model(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.sensor_model == "MPU6050"
+        assert summary_sensor_model(_minimal_summary()) == "MPU6050"
 
     def test_firmware_version(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.firmware_version == "1.0.0"
+        assert summary_firmware_version(_minimal_summary()) == "1.0.0"
 
     def test_sensor_count_used(self) -> None:
-        view = SummaryView(_minimal_summary(sensor_count_used=3))
-        assert view.sensor_count_used == 3
+        assert summary_sensor_count_used(_minimal_summary(sensor_count_used=3)) == 3
 
     def test_findings_empty(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.findings == []
+        assert summary_findings(_minimal_summary()) == []
 
     def test_top_causes_empty(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.top_causes == []
+        assert summary_top_causes(_minimal_summary()) == []
 
     def test_speed_stats(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.speed_stats["min_kmh"] == 50.0
+        assert summary_speed_stats(_minimal_summary())["min_kmh"] == 50.0
 
     def test_origin(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.origin["location"] == "front_left"
+        assert summary_origin(_minimal_summary())["location"] == "front_left"
 
     def test_sensor_locations_active_prefers_connected(self) -> None:
-        view = SummaryView(_minimal_summary())
-        assert view.sensor_locations_active == ["front_left"]
+        assert summary_sensor_locations_active(_minimal_summary()) == ["front_left"]
 
     def test_sensor_locations_active_fallback(self) -> None:
-        view = SummaryView(_minimal_summary(sensor_locations_connected_throughout=[]))
-        assert "front_left" in view.sensor_locations_active
+        assert "front_left" in summary_sensor_locations_active(
+            _minimal_summary(sensor_locations_connected_throughout=[])
+        )
 
     def test_sample_rate_hz_text(self) -> None:
-        view = SummaryView(_minimal_summary(raw_sample_rate_hz=100.0))
-        assert view.sample_rate_hz_text == "100"
+        assert summary_sample_rate_hz_text(_minimal_summary(raw_sample_rate_hz=100.0)) == "100"
 
     def test_sample_rate_hz_text_none(self) -> None:
-        view = SummaryView(_minimal_summary(raw_sample_rate_hz=None))
-        assert view.sample_rate_hz_text is None
-
-    def test_data_returns_underlying_dict(self) -> None:
-        summary = _minimal_summary()
-        view = SummaryView(summary)
-        assert view.data is summary
+        assert summary_sample_rate_hz_text(_minimal_summary(raw_sample_rate_hz=None)) is None
 
     def test_test_plan(self) -> None:
         plan = [{"what": "test something", "why": "to verify"}]
-        view = SummaryView(_minimal_summary(test_plan=plan))
-        assert len(view.test_plan) == 1
+        assert len(summary_test_plan(_minimal_summary(test_plan=plan))) == 1
 
     def test_run_suitability(self) -> None:
         checks = [{"check": "SPEED", "state": "pass", "explanation": "ok"}]
-        view = SummaryView(_minimal_summary(run_suitability=checks))
-        assert len(view.run_suitability) == 1
+        assert len(summary_run_suitability(_minimal_summary(run_suitability=checks))) == 1
 
     def test_warnings(self) -> None:
         warns = [{"title": "Low data", "severity": "warn"}]
-        view = SummaryView(_minimal_summary(warnings=warns))
-        assert len(view.warnings) == 1
+        assert len(summary_warnings(_minimal_summary(warnings=warns))) == 1
 
     def test_sensor_intensity_by_location(self) -> None:
         intensity = [{"location": "front_left", "p95_intensity_db": 25.0}]
-        view = SummaryView(_minimal_summary(sensor_intensity_by_location=intensity))
-        assert len(view.sensor_intensity_by_location) == 1
+        assert (
+            len(
+                summary_sensor_intensity_by_location(
+                    _minimal_summary(sensor_intensity_by_location=intensity)
+                )
+            )
+            == 1
+        )

--- a/apps/server/vibesensor/analysis/summary_builder.py
+++ b/apps/server/vibesensor/analysis/summary_builder.py
@@ -14,8 +14,26 @@ from vibesensor.analysis.analysis_window import AnalysisWindow
 from vibesensor.vibration_strength import compute_db
 
 from ..constants import MEMS_NOISE_FLOOR_G, SPEED_COVERAGE_MIN_PCT, SPEED_MIN_POINTS
-from ..domain import Finding as DomainFinding
-from ..domain import RunAnalysisResult
+from ..domain import (
+    Car,
+    ConfigurationSnapshot,
+    DiagnosticCase,
+    Run,
+    RunAnalysisResult,
+    Symptom,
+    TestRun,
+)
+from ..domain import (
+    DrivingSegment as DomainDrivingSegment,
+)
+from ..domain import (
+    Finding as DomainFinding,
+)
+from ..domain.services import (
+    evaluate_hypotheses,
+    extract_observations_from_findings,
+    recognize_signatures,
+)
 from ..json_utils import as_float_or_none as _as_float
 from ..report_i18n import normalize_lang
 from ..run_context import build_summary_warnings, order_reference_context_complete
@@ -72,7 +90,7 @@ from .helpers import (
 from .phase_segmentation import DrivingPhase, PhaseSegment, segment_run_phases
 from .plots import _plot_data
 from .strength_labels import strength_label as _strength_label
-from .test_plan import _merge_test_plan
+from .test_plan import _merge_test_plan, build_domain_test_plan
 from .top_cause_selection import select_top_causes
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -359,6 +377,63 @@ def serialize_phase_segments(phase_segments: list[PhaseSegment]) -> list[PhaseSe
         }
         for seg in phase_segments
     ]
+
+
+def build_domain_driving_segments(
+    phase_segments: list[PhaseSegment],
+) -> tuple[DomainDrivingSegment, ...]:
+    return tuple(
+        DomainDrivingSegment(
+            phase=segment.phase,
+            start_idx=segment.start_idx,
+            end_idx=segment.end_idx,
+            start_t_s=(
+                None
+                if isinstance(segment.start_t_s, float) and math.isnan(segment.start_t_s)
+                else segment.start_t_s
+            ),
+            end_t_s=(
+                None
+                if isinstance(segment.end_t_s, float) and math.isnan(segment.end_t_s)
+                else segment.end_t_s
+            ),
+            speed_min_kmh=segment.speed_min_kmh,
+            speed_max_kmh=segment.speed_max_kmh,
+            sample_count=segment.sample_count,
+        )
+        for segment in phase_segments
+    )
+
+
+def build_domain_car(metadata: MetadataDict) -> Car | None:
+    car_name = str(metadata.get("car_name") or "").strip()
+    car_type = str(metadata.get("car_type") or "").strip()
+    aspects = {
+        key: value
+        for key in ("tire_width_mm", "tire_aspect_pct", "rim_in")
+        if isinstance((value := _as_float(metadata.get(key))), float)
+    }
+    if not car_name and not car_type and not aspects:
+        return None
+    return Car(
+        name=car_name or "Unnamed Car",
+        car_type=car_type or "sedan",
+        aspects=aspects,
+        variant=str(metadata.get("car_variant") or "").strip() or None,
+    )
+
+
+def build_domain_symptoms(metadata: MetadataDict) -> tuple[Symptom, ...]:
+    complaint = str(metadata.get("symptom") or metadata.get("complaint") or "").strip()
+    if not complaint:
+        return (Symptom.unspecified(),)
+    return (
+        Symptom(
+            description=complaint,
+            onset=str(metadata.get("symptom_onset") or "").strip(),
+            context=str(metadata.get("symptom_context") or "").strip(),
+        ),
+    )
 
 
 def noise_baseline_db(run_noise_baseline_g: float | None) -> float | None:
@@ -1100,6 +1175,8 @@ class RunAnalysis:
         "_prepared",
         "_accel_stats",
         "_analysis_result",
+        "_test_run",
+        "_diagnostic_case",
     )
 
     def __init__(
@@ -1119,6 +1196,8 @@ class RunAnalysis:
         self._include_samples = include_samples
         self._findings_builder = findings_builder
         self._analysis_result: RunAnalysisResult | None = None
+        self._test_run: TestRun | None = None
+        self._diagnostic_case: DiagnosticCase | None = None
 
         _validate_required_strength_metrics(samples)
         self._prepared = prepare_run_data(metadata, samples, file_name=file_name)
@@ -1144,6 +1223,14 @@ class RunAnalysis:
     def analysis_result(self) -> RunAnalysisResult | None:
         """Domain aggregate produced by :meth:`summarize`, or ``None``."""
         return self._analysis_result
+
+    @property
+    def test_run(self) -> TestRun | None:
+        return self._test_run
+
+    @property
+    def diagnostic_case(self) -> DiagnosticCase | None:
+        return self._diagnostic_case
 
     # -- orchestration -----------------------------------------------------
 
@@ -1222,16 +1309,35 @@ class RunAnalysis:
             tuple(enriched_domain_top_causes) if enriched_domain_top_causes else domain_top_causes
         )
 
-        self._analysis_result = RunAnalysisResult(
-            run_id=self._prepared.run_id,
+        observations = extract_observations_from_findings(domain_findings, findings)
+        signatures = recognize_signatures(observations)
+        hypotheses = evaluate_hypotheses(signatures)
+        configuration_snapshot = ConfigurationSnapshot.from_metadata(self._metadata)
+        driving_segments = build_domain_driving_segments(self._prepared.phase_segments)
+        domain_test_plan = build_domain_test_plan(findings, self._language)
+        self._test_run = TestRun(
+            run=Run(run_id=self._prepared.run_id, analysis_settings={}),
+            configuration_snapshot=configuration_snapshot,
+            driving_segments=driving_segments,
+            observations=observations,
+            signatures=signatures,
+            hypotheses=hypotheses,
             findings=domain_findings,
             top_causes=final_top_causes,
-            duration_s=self._prepared.duration_s,
-            sample_count=len(self._samples),
-            sensor_count=len(sensor_locations),
-            lang=self._language,
             speed_profile=speed_profile,
             suitability=domain_suitability,
+            test_plan=domain_test_plan,
+        )
+        self._diagnostic_case = DiagnosticCase.start(
+            car=build_domain_car(self._metadata),
+            symptoms=build_domain_symptoms(self._metadata),
+            configuration_snapshots=(configuration_snapshot,),
+            test_plan=domain_test_plan,
+        ).add_run(self._test_run)
+
+        self._analysis_result = RunAnalysisResult.from_test_run(
+            self._test_run,
+            lang=self._language,
         )
 
         summary = build_summary_payload(

--- a/apps/server/vibesensor/analysis/test_plan.py
+++ b/apps/server/vibesensor/analysis/test_plan.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from math import ceil, floor, log1p, pow
 
 from ..constants import MULTI_SENSOR_CORROBORATION_DB
-from ..domain import VibrationSource
+from ..domain import RecommendedAction, TestPlan, VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from ..locations import has_any_wheel_location, is_wheel_location
 from ._types import (
@@ -167,6 +167,38 @@ def _merge_test_plan(
             "eta": "20-35 min",
         },
     ]
+
+
+def _step_text(value: object) -> str:
+    if isinstance(value, dict):
+        key = value.get("_i18n_key")
+        if key is not None:
+            return str(key)
+    return _normalized_text(value)
+
+
+def build_domain_test_plan(findings: list[FindingPayload], lang: str) -> TestPlan:
+    steps = _merge_test_plan(findings, lang)
+    actions: list[RecommendedAction] = []
+    for priority, step in enumerate(steps, start=1):
+        action_id = _normalized_lower_text(step.get("action_id"))
+        if not action_id:
+            continue
+        actions.append(
+            RecommendedAction(
+                action_id=action_id,
+                what=_step_text(step.get("what")),
+                why=_step_text(step.get("why")),
+                confirm=_step_text(step.get("confirm")),
+                falsify=_step_text(step.get("falsify")),
+                eta=_normalized_text(step.get("eta")) or None,
+                priority=priority,
+            )
+        )
+    return TestPlan(
+        actions=tuple(actions),
+        requires_additional_data=not bool(findings),
+    )
 
 
 def _score_locations_in_bin(

--- a/apps/server/vibesensor/boundaries/__init__.py
+++ b/apps/server/vibesensor/boundaries/__init__.py
@@ -1,0 +1,5 @@
+"""Boundary serializers and decoders for domain-first core models."""
+
+from .diagnostic_case import diagnostic_case_from_summary, test_run_from_summary
+
+__all__ = ["diagnostic_case_from_summary", "test_run_from_summary"]

--- a/apps/server/vibesensor/boundaries/diagnostic_case.py
+++ b/apps/server/vibesensor/boundaries/diagnostic_case.py
@@ -1,0 +1,392 @@
+"""Domain <-> summary boundary conversions for diagnostic cases and runs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ..domain.car import Car
+from ..domain.configuration_snapshot import ConfigurationSnapshot
+from ..domain.diagnostic_case import DiagnosticCase
+from ..domain.driving_phase import DrivingPhase
+from ..domain.driving_segment import DrivingSegment
+from ..domain.finding import Finding
+from ..domain.hypothesis import Hypothesis, HypothesisStatus
+from ..domain.recommended_action import RecommendedAction
+from ..domain.run import Run
+from ..domain.run_analysis_result import RunAnalysisResult
+from ..domain.run_suitability import RunSuitability
+from ..domain.signature import Signature
+from ..domain.speed_profile import SpeedProfile
+from ..domain.symptom import Symptom
+from ..domain.test_plan import TestPlan
+from ..domain.test_run import TestRun
+from ..domain.vibration_origin import VibrationOrigin
+
+
+def _as_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _actions_from_steps(steps: object) -> tuple[RecommendedAction, ...]:
+    if not isinstance(steps, list):
+        return ()
+    actions: list[RecommendedAction] = []
+    for idx, step in enumerate(steps):
+        if not isinstance(step, Mapping):
+            continue
+        actions.append(
+            RecommendedAction(
+                action_id=str(step.get("action_id") or f"action-{idx + 1}"),
+                what=str(step.get("what") or ""),
+                why=str(step.get("why") or ""),
+                confirm=str(step.get("confirm") or ""),
+                falsify=str(step.get("falsify") or ""),
+                eta=str(step.get("eta") or "") or None,
+                priority=idx,
+            )
+        )
+    return tuple(actions)
+
+
+def _segments_from_summary(summary: Mapping[str, object]) -> tuple[DrivingSegment, ...]:
+    raw_segments = summary.get("phase_segments")
+    if not isinstance(raw_segments, list):
+        return ()
+    segments: list[DrivingSegment] = []
+    for segment in raw_segments:
+        if not isinstance(segment, Mapping):
+            continue
+        phase_raw = str(segment.get("phase") or "cruise").upper()
+        try:
+            phase = DrivingPhase[phase_raw]
+        except KeyError:
+            phase = DrivingPhase.CRUISE
+        segments.append(
+            DrivingSegment(
+                phase=phase,
+                start_idx=int(_as_float(segment.get("start_idx")) or 0),
+                end_idx=int(_as_float(segment.get("end_idx")) or 0),
+                start_t_s=_as_float(segment.get("start_t_s")),
+                end_t_s=_as_float(segment.get("end_t_s")),
+                speed_min_kmh=_as_float(segment.get("speed_min_kmh")),
+                speed_max_kmh=_as_float(segment.get("speed_max_kmh")),
+                sample_count=int(_as_float(segment.get("sample_count")) or 0),
+            )
+        )
+    return tuple(segments)
+
+
+def _signatures_from_finding(
+    finding: Finding,
+    payload: Mapping[str, object],
+) -> tuple[Signature, ...]:
+    raw_signatures = payload.get("signatures_observed")
+    if not isinstance(raw_signatures, list):
+        return ()
+    return tuple(
+        Signature.from_label(
+            str(label),
+            source=finding.suspected_source,
+            support_score=finding.effective_confidence,
+        )
+        for label in raw_signatures[:3]
+        if str(label).strip()
+    )
+
+
+def _hypothesis_from_finding(finding: Finding, signatures: tuple[Signature, ...]) -> Hypothesis:
+    status = (
+        HypothesisStatus.SUPPORTED
+        if finding.effective_confidence >= 0.4
+        else HypothesisStatus.INCONCLUSIVE
+    )
+    return Hypothesis(
+        hypothesis_id=finding.finding_id or f"hyp-{finding.suspected_source}",
+        source=finding.suspected_source,
+        signature_keys=tuple(signature.key for signature in signatures),
+        support_score=finding.effective_confidence,
+        contradiction_score=0.0,
+        status=status,
+        rationale=(
+            (finding.confidence_assessment.reason,)
+            if finding.confidence_assessment and finding.confidence_assessment.reason
+            else ()
+        ),
+    )
+
+
+def _payloads_by_id(items: object) -> dict[str, Mapping[str, object]]:
+    if not isinstance(items, list):
+        return {}
+    payloads: dict[str, Mapping[str, object]] = {}
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        finding_id = str(item.get("finding_id") or "").strip()
+        if finding_id and finding_id not in payloads:
+            payloads[finding_id] = item
+    return payloads
+
+
+def finding_payload_from_domain(
+    finding: Finding,
+    *,
+    primary: Mapping[str, Mapping[str, object]],
+    secondary: Mapping[str, Mapping[str, object]],
+) -> dict[str, object]:
+    if finding.finding_id:
+        payload = primary.get(finding.finding_id) or secondary.get(finding.finding_id)
+        if payload is not None:
+            return dict(payload)
+
+    payload: dict[str, object] = {
+        "finding_id": finding.finding_id,
+        "suspected_source": str(finding.suspected_source),
+        "confidence": finding.confidence,
+        "strongest_location": finding.strongest_location,
+        "strongest_speed_band": finding.strongest_speed_band,
+        "weak_spatial_separation": finding.weak_spatial_separation,
+        "dominance_ratio": finding.dominance_ratio,
+        "signatures_observed": list(finding.signature_labels),
+    }
+    if finding.vibration_strength_db is not None:
+        payload["evidence_metrics"] = {"vibration_strength_db": finding.vibration_strength_db}
+    if finding.location is not None:
+        payload["location_hotspot"] = {
+            "best_location": finding.location.best_location,
+            "alternative_locations": list(finding.location.alternative_locations),
+            "dominance_ratio": finding.location.dominance_ratio,
+            "weak_spatial_separation": not finding.location.is_well_localized,
+        }
+    if finding.origin is not None:
+        payload["evidence_summary"] = finding.origin.reason
+        if finding.origin.dominant_phase is not None:
+            payload["dominant_phase"] = finding.origin.dominant_phase
+    return payload
+
+
+def _origin_payload_from_aggregate(
+    aggregate: RunAnalysisResult,
+    fallback: object,
+) -> dict[str, object]:
+    if not isinstance(fallback, Mapping):
+        fallback_payload: dict[str, object] = {}
+    else:
+        fallback_payload = dict(fallback)
+
+    primary = aggregate.primary_finding
+    if primary is None:
+        return fallback_payload
+
+    origin = primary.origin
+    hotspot = primary.location
+    fallback_location = str(fallback_payload.get("location") or "").strip()
+    fallback_explanation = str(fallback_payload.get("explanation") or "").strip()
+    if origin is None and hotspot is None:
+        return fallback_payload
+    if hotspot is None and fallback_location and fallback_location.lower() != "unknown":
+        return fallback_payload
+    if origin is not None and not origin.reason and fallback_explanation:
+        return fallback_payload
+
+    return {
+        "location": (
+            origin.display_location
+            if origin is not None
+            else str(primary.strongest_location or "unknown")
+        ),
+        "alternative_locations": (
+            list(hotspot.alternative_locations) if hotspot is not None else []
+        ),
+        "suspected_source": str(primary.suspected_source),
+        "dominance_ratio": primary.dominance_ratio,
+        "weak_spatial_separation": primary.weak_spatial_separation,
+        "explanation": origin.explanation if origin is not None else "",
+    }
+
+
+def _steps_from_test_plan(test_plan: TestPlan) -> list[dict[str, object]]:
+    return [
+        {
+            "action_id": action.action_id,
+            "what": action.what,
+            "why": action.why,
+            "confirm": action.confirm,
+            "falsify": action.falsify,
+            "eta": action.eta,
+        }
+        for action in test_plan.prioritized_actions
+    ]
+
+
+def _has_structured_step_content(steps: object) -> bool:
+    if not isinstance(steps, list):
+        return False
+    for step in steps:
+        if not isinstance(step, Mapping):
+            continue
+        for key in ("what", "why", "confirm", "falsify"):
+            value = step.get(key)
+            if isinstance(value, (Mapping, list)):
+                return True
+    return False
+
+
+def _checks_from_suitability(suitability: RunSuitability | None) -> list[dict[str, object]]:
+    if suitability is None:
+        return []
+    return [
+        {
+            "check": check.check_key,
+            "check_key": check.check_key,
+            "state": check.state,
+            "explanation": check.explanation,
+        }
+        for check in suitability.checks
+    ]
+
+
+def _enrich_findings(raw_findings: object) -> tuple[Finding, ...]:
+    if not isinstance(raw_findings, list):
+        return ()
+    enriched: list[Finding] = []
+    for payload in raw_findings:
+        if not isinstance(payload, Mapping):
+            continue
+        finding = Finding.from_payload(payload)
+        signatures = _signatures_from_finding(finding, payload)
+        origin = VibrationOrigin(
+            suspected_source=finding.suspected_source,
+            hotspot=finding.location,
+            dominance_ratio=finding.dominance_ratio,
+            speed_band=finding.strongest_speed_band,
+            dominant_phase=str(payload.get("dominant_phase") or "") or None,
+            reason=str(payload.get("evidence_summary") or ""),
+        )
+        enriched.append(finding.with_origin_and_signatures(origin=origin, signatures=signatures))
+    return tuple(enriched)
+
+
+def test_run_from_summary(summary: Mapping[str, object]) -> TestRun:
+    metadata = summary.get("metadata")
+    meta = metadata if isinstance(metadata, Mapping) else {}
+    findings = _enrich_findings(summary.get("findings"))
+    top_causes = _enrich_findings(summary.get("top_causes"))
+    actions = _actions_from_steps(summary.get("test_plan"))
+    speed_stats = summary.get("speed_stats")
+    phase_info = summary.get("phase_info")
+    if not isinstance(phase_info, Mapping):
+        phase_info = summary.get("phase_summary")
+    speed_profile = (
+        SpeedProfile.from_stats(
+            speed_stats,
+            phase_info if isinstance(phase_info, Mapping) else None,
+        )
+        if isinstance(speed_stats, Mapping)
+        else None
+    )
+    run_suitability = summary.get("run_suitability")
+    suitability = (
+        RunSuitability.from_checks(run_suitability) if isinstance(run_suitability, list) else None
+    )
+
+    signatures: list[Signature] = []
+    hypotheses: list[Hypothesis] = []
+    raw_findings = summary.get("findings") if isinstance(summary.get("findings"), list) else []
+    for payload, finding in zip(raw_findings, findings, strict=False):
+        if not isinstance(payload, Mapping):
+            continue
+        finding_signatures = _signatures_from_finding(finding, payload)
+        signatures.extend(finding_signatures)
+        hypotheses.append(_hypothesis_from_finding(finding, finding_signatures))
+
+    return TestRun(
+        run=Run(run_id=str(summary.get("run_id") or "unknown")),
+        configuration_snapshot=ConfigurationSnapshot.from_metadata(meta),
+        driving_segments=_segments_from_summary(summary),
+        signatures=tuple(dict.fromkeys(signatures)),
+        hypotheses=tuple(hypotheses),
+        findings=findings,
+        top_causes=top_causes,
+        speed_profile=speed_profile,
+        suitability=suitability,
+        test_plan=TestPlan(
+            actions=actions,
+            requires_additional_data=not bool(findings),
+        ),
+    )
+
+
+def diagnostic_case_from_summary(summary: Mapping[str, object]) -> DiagnosticCase:
+    metadata = summary.get("metadata")
+    meta = metadata if isinstance(metadata, Mapping) else {}
+    car = Car(
+        name=str(meta.get("car_name") or meta.get("name") or "Unnamed Car"),
+        car_type=str(meta.get("car_type") or "sedan"),
+        aspects={
+            key: float(value)
+            for key in ("tire_width_mm", "tire_aspect_pct", "rim_in")
+            if (value := meta.get(key)) is not None
+        },
+    )
+    symptom_text = str(meta.get("symptom") or meta.get("complaint") or "").strip()
+    symptom = Symptom(description=symptom_text) if symptom_text else Symptom.unspecified()
+    test_run = test_run_from_summary(summary)
+    case = DiagnosticCase.start(
+        car=car,
+        symptoms=(symptom,),
+        configuration_snapshots=(test_run.configuration_snapshot,),
+        test_plan=test_run.test_plan,
+    )
+    return case.add_run(test_run)
+
+
+def run_analysis_result_from_summary(summary: Mapping[str, object]) -> RunAnalysisResult:
+    return RunAnalysisResult.from_test_run(test_run_from_summary(summary))
+
+
+def project_summary_through_domain(summary: Mapping[str, object]) -> dict[str, object]:
+    """Return *summary* with domain-owned fields rebuilt from aggregates."""
+    projected = dict(summary)
+    raw_findings = summary.get("findings")
+    raw_top_causes = summary.get("top_causes")
+    if not isinstance(raw_findings, list) and not isinstance(raw_top_causes, list):
+        return projected
+
+    aggregate = run_analysis_result_from_summary(summary)
+    test_run = aggregate.test_run
+
+    findings_by_id = _payloads_by_id(summary.get("findings"))
+    top_causes_by_id = _payloads_by_id(summary.get("top_causes"))
+
+    projected["findings"] = [
+        finding_payload_from_domain(
+            finding,
+            primary=findings_by_id,
+            secondary=top_causes_by_id,
+        )
+        for finding in aggregate.findings
+    ]
+    projected["top_causes"] = [
+        finding_payload_from_domain(
+            finding,
+            primary=top_causes_by_id,
+            secondary=findings_by_id,
+        )
+        for finding in aggregate.effective_top_causes()
+    ]
+    projected["most_likely_origin"] = _origin_payload_from_aggregate(
+        aggregate,
+        summary.get("most_likely_origin"),
+    )
+    if test_run is not None:
+        if not _has_structured_step_content(summary.get("test_plan")):
+            projected["test_plan"] = _steps_from_test_plan(test_run.test_plan)
+        projected["run_suitability"] = _checks_from_suitability(test_run.suitability)
+
+    return projected

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -43,7 +43,10 @@ VibrationReading
 
 from .car import Car, TireSpec
 from .confidence_assessment import ConfidenceAssessment
+from .configuration_snapshot import ConfigurationSnapshot
+from .diagnostic_case import DiagnosticCase
 from .driving_phase import DrivingPhase
+from .driving_segment import DrivingSegment
 from .finding import (
     Finding,
     FindingKind,
@@ -52,27 +55,42 @@ from .finding import (
     speed_bin_label,
 )
 from .finding_evidence import FindingEvidence
+from .hypothesis import Hypothesis, HypothesisStatus
 from .location_hotspot import LocationHotspot
 from .measurement import Measurement, VibrationReading
+from .observation import Observation
+from .recommended_action import RecommendedAction
 from .report import Report
 from .run import Run
 from .run_analysis_result import RunAnalysisResult
 from .run_status import RUN_TRANSITIONS, RunStatus, transition_run
 from .run_suitability import RunSuitability, SuitabilityCheck
 from .sensor import Sensor, SensorPlacement
+from .signature import Signature
 from .speed_profile import SpeedProfile
 from .speed_source import SpeedSource, SpeedSourceKind
+from .symptom import Symptom
+from .test_plan import TestPlan
+from .test_run import TestRun
+from .vibration_origin import VibrationOrigin
 
 __all__ = [
     # Primary domain names (prefer these)
     "Car",
+    "ConfigurationSnapshot",
     "ConfidenceAssessment",
+    "DiagnosticCase",
+    "DrivingSegment",
     "DrivingPhase",
     "Finding",
     "FindingEvidence",
     "FindingKind",
+    "Hypothesis",
+    "HypothesisStatus",
     "LocationHotspot",
     "Measurement",
+    "Observation",
+    "RecommendedAction",
     "RUN_TRANSITIONS",
     "Report",
     "Run",
@@ -81,14 +99,19 @@ __all__ = [
     "RunSuitability",
     "Sensor",
     "SensorPlacement",
+    "Signature",
     "SpeedProfile",
     "speed_band_sort_key",
     "speed_bin_label",
     "SpeedSource",
     "SpeedSourceKind",
+    "Symptom",
     "SuitabilityCheck",
+    "TestPlan",
+    "TestRun",
     "TireSpec",
     "VibrationSource",
+    "VibrationOrigin",
     "transition_run",
     # Existing names
     "VibrationReading",

--- a/apps/server/vibesensor/domain/configuration_snapshot.py
+++ b/apps/server/vibesensor/domain/configuration_snapshot.py
@@ -1,0 +1,65 @@
+"""Immutable diagnostic configuration captured for a case stage or test run."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+from .car import TireSpec
+
+__all__ = ["ConfigurationSnapshot"]
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigurationSnapshot:
+    """Vehicle/setup state relevant for interpreting a run."""
+
+    sensor_model: str | None = None
+    firmware_version: str | None = None
+    raw_sample_rate_hz: float | None = None
+    feature_interval_s: float | None = None
+    final_drive_ratio: float | None = None
+    tire_spec: TireSpec | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.metadata, MappingProxyType):
+            object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+    @property
+    def has_order_reference_context(self) -> bool:
+        """Whether enough mechanical reference data exists for order analysis."""
+        return self.tire_spec is not None and self.final_drive_ratio is not None
+
+    @classmethod
+    def from_metadata(cls, metadata: Mapping[str, object]) -> ConfigurationSnapshot:
+        def _coerce_float(value: object) -> float | None:
+            if isinstance(value, bool):
+                return float(value)
+            if isinstance(value, int | float | str):
+                return float(value)
+            return None
+
+        tire_spec = TireSpec.from_aspects(
+            {
+                key: coerced
+                for key in ("tire_width_mm", "tire_aspect_pct", "rim_in")
+                if (value := metadata.get(key)) is not None
+                if (coerced := _coerce_float(value)) is not None
+            },
+            deflection_factor=_coerce_float(metadata.get("tire_deflection_factor", 1.0)) or 1.0,
+        )
+
+        def _as_float(key: str) -> float | None:
+            return _coerce_float(metadata.get(key))
+
+        return cls(
+            sensor_model=str(metadata.get("sensor_model") or "").strip() or None,
+            firmware_version=str(metadata.get("firmware_version") or "").strip() or None,
+            raw_sample_rate_hz=_as_float("raw_sample_rate_hz"),
+            feature_interval_s=_as_float("feature_interval_s"),
+            final_drive_ratio=_as_float("final_drive_ratio"),
+            tire_spec=tire_spec,
+            metadata=metadata,
+        )

--- a/apps/server/vibesensor/domain/diagnostic_case.py
+++ b/apps/server/vibesensor/domain/diagnostic_case.py
@@ -1,0 +1,112 @@
+"""Case-level aggregate for one diagnostic problem over one investigation episode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from uuid import uuid4
+
+from .car import Car
+from .configuration_snapshot import ConfigurationSnapshot
+from .finding import Finding
+from .hypothesis import Hypothesis
+from .recommended_action import RecommendedAction
+from .symptom import Symptom
+from .test_plan import TestPlan
+from .test_run import TestRun
+
+__all__ = ["DiagnosticCase"]
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticCase:
+    """Top-level aggregate for the diagnostic problem under investigation."""
+
+    case_id: str
+    car: Car | None = None
+    symptoms: tuple[Symptom, ...] = ()
+    configuration_snapshots: tuple[ConfigurationSnapshot, ...] = ()
+    test_plan: TestPlan = TestPlan()
+    test_runs: tuple[TestRun, ...] = ()
+    hypotheses: tuple[Hypothesis, ...] = ()
+    findings: tuple[Finding, ...] = ()
+    recommended_actions: tuple[RecommendedAction, ...] = ()
+
+    _EMPTY_TEST_PLAN = TestPlan()
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        car: Car | None = None,
+        symptoms: tuple[Symptom, ...] = (),
+        configuration_snapshots: tuple[ConfigurationSnapshot, ...] = (),
+        test_plan: TestPlan | None = None,
+    ) -> DiagnosticCase:
+        return cls(
+            case_id=uuid4().hex,
+            car=car,
+            symptoms=symptoms or (Symptom.unspecified(),),
+            configuration_snapshots=configuration_snapshots,
+            test_plan=test_plan or cls._EMPTY_TEST_PLAN,
+        )
+
+    def add_run(self, test_run: TestRun) -> DiagnosticCase:
+        snapshots = self.configuration_snapshots
+        if test_run.configuration_snapshot not in snapshots:
+            snapshots = (*snapshots, test_run.configuration_snapshot)
+        updated = replace(
+            self,
+            test_runs=(*self.test_runs, test_run),
+            configuration_snapshots=snapshots,
+        )
+        return updated.reconcile()
+
+    def reconcile(self) -> DiagnosticCase:
+        """Produce case-level conclusions from the contributing runs."""
+        hypotheses: dict[str, Hypothesis] = {}
+        findings: dict[tuple[str, str | None], Finding] = {}
+        actions: dict[str, RecommendedAction] = {
+            action.action_id: action for action in self.test_plan.prioritized_actions
+        }
+        for test_run in self.test_runs:
+            for hypothesis in test_run.hypotheses:
+                existing = hypotheses.get(hypothesis.hypothesis_id)
+                if existing is None or hypothesis.support_score > existing.support_score:
+                    hypotheses[hypothesis.hypothesis_id] = hypothesis
+            for finding in test_run.effective_top_causes():
+                key = (str(finding.suspected_source), finding.strongest_location)
+                existing_finding = findings.get(key)
+                if (
+                    existing_finding is None
+                    or finding.phase_adjusted_score > existing_finding.phase_adjusted_score
+                ):
+                    findings[key] = finding
+            for action in test_run.recommended_actions:
+                if (
+                    action.action_id not in actions
+                    or action.priority < actions[action.action_id].priority
+                ):
+                    actions[action.action_id] = action
+        return replace(
+            self,
+            hypotheses=tuple(
+                sorted(
+                    hypotheses.values(),
+                    key=lambda item: (-item.support_score, item.hypothesis_id),
+                )
+            ),
+            findings=tuple(sorted(findings.values(), key=lambda item: item.rank_key, reverse=True)),
+            recommended_actions=tuple(sorted(actions.values(), key=RecommendedAction.sort_key)),
+        )
+
+    @property
+    def primary_run(self) -> TestRun | None:
+        return self.test_runs[-1] if self.test_runs else None
+
+    @property
+    def is_complete(self) -> bool:
+        return bool(self.findings) and not self.test_plan.needs_more_data()
+
+    @property
+    def needs_more_data(self) -> bool:
+        return not self.is_complete

--- a/apps/server/vibesensor/domain/driving_segment.py
+++ b/apps/server/vibesensor/domain/driving_segment.py
@@ -1,0 +1,27 @@
+"""Meaningful portion of a test run used for interpretation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .driving_phase import DrivingPhase
+
+__all__ = ["DrivingSegment"]
+
+
+@dataclass(frozen=True, slots=True)
+class DrivingSegment:
+    """Phase-aligned segment of a run."""
+
+    phase: DrivingPhase
+    start_idx: int
+    end_idx: int
+    start_t_s: float | None = None
+    end_t_s: float | None = None
+    speed_min_kmh: float | None = None
+    speed_max_kmh: float | None = None
+    sample_count: int = 0
+
+    @property
+    def is_diagnostically_usable(self) -> bool:
+        return self.sample_count > 0 and self.phase is not DrivingPhase.IDLE

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from .confidence_assessment import ConfidenceAssessment
     from .finding_evidence import FindingEvidence
     from .location_hotspot import LocationHotspot
+    from .signature import Signature
+    from .vibration_origin import VibrationOrigin
 
 __all__ = [
     "Finding",
@@ -140,6 +142,8 @@ class Finding:
     evidence: FindingEvidence | None = None
     location: LocationHotspot | None = None
     confidence_assessment: ConfidenceAssessment | None = None
+    origin: VibrationOrigin | None = None
+    signatures: tuple[Signature, ...] = ()
 
     def __post_init__(self) -> None:
         """Auto-derive ``kind`` and validate invariants."""
@@ -304,6 +308,8 @@ class Finding:
         # Build domain value objects from nested dicts when available
         from .finding_evidence import FindingEvidence as _FE
         from .location_hotspot import LocationHotspot as _LH
+        from .signature import Signature as _Signature
+        from .vibration_origin import VibrationOrigin as _Origin
 
         evidence = _FE.from_metrics_dict(ev_metrics) if isinstance(ev_metrics, dict) else None
         hotspot_raw = payload.get("location_hotspot")
@@ -323,6 +329,29 @@ class Finding:
             finding_id,
             severity,
             explicit_kind=str(explicit) if isinstance(explicit, str) else None,
+        )
+        raw_signatures = payload.get("signatures_observed")
+        signatures = (
+            tuple(
+                _Signature.from_label(
+                    str(label),
+                    source=source,
+                    support_score=confidence or 0.0,
+                )
+                for label in raw_signatures[:3]
+                if str(label).strip()
+            )
+            if isinstance(raw_signatures, list)
+            else ()
+        )
+        dominant_phase = str(payload.get("dominant_phase") or "").strip() or None
+        origin = _Origin(
+            suspected_source=source,
+            hotspot=location,
+            dominance_ratio=dominance_ratio,
+            speed_band=str(band) if band is not None else None,
+            dominant_phase=dominant_phase,
+            reason=_str("evidence_summary"),
         )
 
         return cls(
@@ -344,6 +373,8 @@ class Finding:
             cruise_fraction=cruise_fraction,
             evidence=evidence,
             location=location,
+            origin=origin,
+            signatures=signatures,
         )
 
     # -- identity mutation (frozen ⇒ returns new instance) -----------------
@@ -351,6 +382,15 @@ class Finding:
     def with_id(self, finding_id: str) -> Finding:
         """Return a copy of this finding with a new ``finding_id``."""
         return replace(self, finding_id=finding_id)
+
+    def with_origin_and_signatures(
+        self,
+        *,
+        origin: VibrationOrigin | None,
+        signatures: tuple[Signature, ...],
+    ) -> Finding:
+        """Return a copy enriched with explicit origin and signatures."""
+        return replace(self, origin=origin, signatures=signatures)
 
     # -- classification ----------------------------------------------------
 
@@ -378,6 +418,10 @@ class Finding:
     def source_normalized(self) -> str:
         """Lower-cased, stripped suspected source for comparison."""
         return self.suspected_source.strip().lower()
+
+    @property
+    def signature_labels(self) -> tuple[str, ...]:
+        return tuple(signature.label for signature in self.signatures)
 
     # -- effective confidence -----------------------------------------------
 

--- a/apps/server/vibesensor/domain/hypothesis.py
+++ b/apps/server/vibesensor/domain/hypothesis.py
@@ -1,0 +1,73 @@
+"""Possible explanation for the complaint under investigation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import StrEnum
+
+from .finding import VibrationSource
+
+__all__ = ["Hypothesis", "HypothesisStatus"]
+
+
+class HypothesisStatus(StrEnum):
+    CANDIDATE = "candidate"
+    SUPPORTED = "supported"
+    INCONCLUSIVE = "inconclusive"
+    CONTRADICTED = "contradicted"
+    REJECTED = "rejected"
+    RETIRED = "retired"
+
+
+@dataclass(frozen=True, slots=True)
+class Hypothesis:
+    """A candidate explanation with support/contradiction state."""
+
+    hypothesis_id: str
+    source: VibrationSource
+    signature_keys: tuple[str, ...] = ()
+    support_score: float = 0.0
+    contradiction_score: float = 0.0
+    status: HypothesisStatus = HypothesisStatus.CANDIDATE
+    rationale: tuple[str, ...] = ()
+
+    @property
+    def is_supported(self) -> bool:
+        return self.status is HypothesisStatus.SUPPORTED
+
+    @property
+    def ready_for_finding(self) -> bool:
+        return (
+            self.status is HypothesisStatus.SUPPORTED
+            and self.support_score > self.contradiction_score
+        )
+
+    def support_with(self, signature_key: str, score: float, reason: str = "") -> Hypothesis:
+        signatures = self.signature_keys
+        if signature_key and signature_key not in signatures:
+            signatures = (*signatures, signature_key)
+        return replace(
+            self,
+            signature_keys=signatures,
+            support_score=self.support_score + max(score, 0.0),
+            status=HypothesisStatus.SUPPORTED,
+            rationale=(*self.rationale, reason) if reason else self.rationale,
+        )
+
+    def contradict_with(self, score: float, reason: str = "") -> Hypothesis:
+        status = HypothesisStatus.CONTRADICTED
+        if self.contradiction_score + max(score, 0.0) > self.support_score:
+            status = HypothesisStatus.REJECTED
+        return replace(
+            self,
+            contradiction_score=self.contradiction_score + max(score, 0.0),
+            status=status,
+            rationale=(*self.rationale, reason) if reason else self.rationale,
+        )
+
+    def retire(self, reason: str = "") -> Hypothesis:
+        return replace(
+            self,
+            status=HypothesisStatus.RETIRED,
+            rationale=(*self.rationale, reason) if reason else self.rationale,
+        )

--- a/apps/server/vibesensor/domain/observation.py
+++ b/apps/server/vibesensor/domain/observation.py
@@ -1,0 +1,29 @@
+"""Meaningful fact extracted from processed run data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .driving_phase import DrivingPhase
+from .finding import VibrationSource
+
+__all__ = ["Observation"]
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """One diagnostically meaningful observation."""
+
+    observation_id: str
+    kind: str
+    source: VibrationSource
+    signature_key: str
+    magnitude_db: float | None = None
+    speed_band: str | None = None
+    phase: DrivingPhase | None = None
+    location: str | None = None
+    support_score: float = 0.0
+
+    @property
+    def supports_signature(self) -> bool:
+        return bool(self.signature_key.strip()) and self.support_score > 0.0

--- a/apps/server/vibesensor/domain/recommended_action.py
+++ b/apps/server/vibesensor/domain/recommended_action.py
@@ -1,0 +1,23 @@
+"""Recommended diagnostic or repair follow-up action."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["RecommendedAction"]
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendedAction:
+    """A concrete next step derived from findings or unresolved hypotheses."""
+
+    action_id: str
+    what: str
+    why: str = ""
+    confirm: str = ""
+    falsify: str = ""
+    eta: str | None = None
+    priority: int = 100
+
+    def sort_key(self) -> tuple[int, str]:
+        return (self.priority, self.action_id)

--- a/apps/server/vibesensor/domain/run_analysis_result.py
+++ b/apps/server/vibesensor/domain/run_analysis_result.py
@@ -25,6 +25,7 @@ from .finding import Finding, VibrationSource
 if TYPE_CHECKING:
     from .run_suitability import RunSuitability
     from .speed_profile import SpeedProfile
+    from .test_run import TestRun
 
 __all__ = ["RunAnalysisResult"]
 
@@ -51,6 +52,7 @@ class RunAnalysisResult:
     # Run-level domain value objects (optional — populated when available)
     speed_profile: SpeedProfile | None = None
     suitability: RunSuitability | None = None
+    test_run: TestRun | None = None
 
     def __post_init__(self) -> None:
         if not self.run_id:
@@ -69,18 +71,9 @@ class RunAnalysisResult:
         work identically whether the analysis was just run in-process or
         loaded from history.
         """
-        raw_findings = summary.get("findings")
-        raw_top_causes = summary.get("top_causes")
+        from ..boundaries.diagnostic_case import test_run_from_summary
 
-        findings_list = list(raw_findings) if isinstance(raw_findings, list) else []
-        top_causes_list = list(raw_top_causes) if isinstance(raw_top_causes, list) else []
-
-        domain_findings = tuple(
-            Finding.from_payload(f) for f in findings_list if isinstance(f, dict)
-        )
-        domain_top_causes = tuple(
-            Finding.from_payload(tc) for tc in top_causes_list if isinstance(tc, dict)
-        )
+        projected_test_run = test_run_from_summary(summary)
 
         run_id = str(summary.get("run_id", "")) or "unknown"
 
@@ -100,36 +93,33 @@ class RunAnalysisResult:
 
         lang = str(summary.get("lang", "en"))
 
-        # Build run-level domain value objects from summary dicts
-        from .run_suitability import RunSuitability as _RS
-        from .speed_profile import SpeedProfile as _SP
-
-        speed_stats_raw = summary.get("speed_stats")
-        phase_summary_raw = summary.get("phase_summary")
-        speed_profile = (
-            _SP.from_stats(
-                speed_stats_raw,
-                phase_summary_raw if isinstance(phase_summary_raw, dict) else None,
-            )
-            if isinstance(speed_stats_raw, dict)
-            else None
-        )
-
-        suitability_raw = summary.get("run_suitability")
-        suitability = (
-            _RS.from_checks(suitability_raw) if isinstance(suitability_raw, list) else None
-        )
-
         return cls(
             run_id=run_id,
-            findings=domain_findings,
-            top_causes=domain_top_causes,
+            findings=projected_test_run.findings,
+            top_causes=projected_test_run.top_causes,
             duration_s=duration_s,
-            sample_count=sample_count,
+            sample_count=(
+                sample_count
+                or sum(segment.sample_count for segment in projected_test_run.driving_segments)
+            ),
             sensor_count=sensor_count,
             lang=lang,
-            speed_profile=speed_profile,
-            suitability=suitability,
+            speed_profile=projected_test_run.speed_profile,
+            suitability=projected_test_run.suitability,
+            test_run=projected_test_run,
+        )
+
+    @classmethod
+    def from_test_run(cls, test_run: TestRun, *, lang: str = "en") -> RunAnalysisResult:
+        return cls(
+            run_id=test_run.run_id,
+            findings=test_run.findings,
+            top_causes=test_run.top_causes,
+            sample_count=sum(segment.sample_count for segment in test_run.driving_segments),
+            lang=lang,
+            speed_profile=test_run.speed_profile,
+            suitability=test_run.suitability,
+            test_run=test_run,
         )
 
     # -- finding queries ---------------------------------------------------

--- a/apps/server/vibesensor/domain/services/__init__.py
+++ b/apps/server/vibesensor/domain/services/__init__.py
@@ -1,0 +1,15 @@
+"""Domain services coordinating domain objects without payload-first logic."""
+
+from .case_reconciliation import reconcile_case
+from .finding_synthesis import synthesize_origin
+from .hypothesis_evaluation import evaluate_hypotheses
+from .observation_extraction import extract_observations_from_findings
+from .signature_recognition import recognize_signatures
+
+__all__ = [
+    "extract_observations_from_findings",
+    "recognize_signatures",
+    "evaluate_hypotheses",
+    "synthesize_origin",
+    "reconcile_case",
+]

--- a/apps/server/vibesensor/domain/services/case_reconciliation.py
+++ b/apps/server/vibesensor/domain/services/case_reconciliation.py
@@ -1,0 +1,10 @@
+"""Case reconciliation service."""
+
+from __future__ import annotations
+
+from ..diagnostic_case import DiagnosticCase
+
+
+def reconcile_case(case: DiagnosticCase) -> DiagnosticCase:
+    """Reconcile run-level state into case-level conclusions."""
+    return case.reconcile()

--- a/apps/server/vibesensor/domain/services/finding_synthesis.py
+++ b/apps/server/vibesensor/domain/services/finding_synthesis.py
@@ -1,0 +1,19 @@
+"""Finding-adjacent synthesis helpers for origin semantics."""
+
+from __future__ import annotations
+
+from ..finding import Finding
+from ..vibration_origin import VibrationOrigin
+
+
+def synthesize_origin(finding: Finding) -> VibrationOrigin:
+    """Build the canonical origin object for a finding."""
+    if finding.origin is not None:
+        return finding.origin
+    return VibrationOrigin(
+        suspected_source=finding.suspected_source,
+        hotspot=finding.location,
+        dominance_ratio=finding.dominance_ratio,
+        speed_band=finding.strongest_speed_band,
+        reason=finding.finding_id,
+    )

--- a/apps/server/vibesensor/domain/services/hypothesis_evaluation.py
+++ b/apps/server/vibesensor/domain/services/hypothesis_evaluation.py
@@ -1,0 +1,30 @@
+"""Hypothesis evaluation service."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ..hypothesis import Hypothesis, HypothesisStatus
+from ..signature import Signature
+
+
+def evaluate_hypotheses(signatures: Sequence[Signature]) -> tuple[Hypothesis, ...]:
+    hypotheses: list[Hypothesis] = []
+    for signature in signatures:
+        status = (
+            HypothesisStatus.SUPPORTED
+            if signature.support_score >= 0.4
+            else HypothesisStatus.INCONCLUSIVE
+        )
+        hypotheses.append(
+            Hypothesis(
+                hypothesis_id=f"hyp-{signature.key}",
+                source=signature.source,
+                signature_keys=(signature.key,),
+                support_score=signature.support_score,
+                contradiction_score=0.0,
+                status=status,
+                rationale=(f"Supported by {signature.label}",),
+            )
+        )
+    return tuple(hypotheses)

--- a/apps/server/vibesensor/domain/services/observation_extraction.py
+++ b/apps/server/vibesensor/domain/services/observation_extraction.py
@@ -1,0 +1,42 @@
+"""Observation extraction service."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ..driving_phase import DrivingPhase
+from ..finding import Finding
+from ..observation import Observation
+
+
+def extract_observations_from_findings(
+    findings: Sequence[Finding],
+    payloads: Sequence[Mapping[str, object]] | None = None,
+) -> tuple[Observation, ...]:
+    """Derive diagnostically meaningful observations from finding evidence."""
+    payload_map = list(payloads or ())
+    observations: list[Observation] = []
+    for idx, finding in enumerate(findings, start=1):
+        payload = payload_map[idx - 1] if idx - 1 < len(payload_map) else {}
+        dominant_phase = str(payload.get("dominant_phase") or "").upper() if payload else ""
+        phase = DrivingPhase[dominant_phase] if dominant_phase in DrivingPhase.__members__ else None
+        signature_labels = finding.signature_labels or (
+            str(payload.get("frequency_hz_or_order") or ""),
+        )
+        for sig_idx, signature_label in enumerate(signature_labels, start=1):
+            if not signature_label.strip():
+                continue
+            observations.append(
+                Observation(
+                    observation_id=f"{finding.finding_id or idx}-obs-{sig_idx}",
+                    kind="signature-support",
+                    source=finding.suspected_source,
+                    signature_key=signature_label.strip().lower().replace(" ", "_"),
+                    magnitude_db=finding.vibration_strength_db,
+                    speed_band=finding.strongest_speed_band,
+                    phase=phase,
+                    location=finding.strongest_location,
+                    support_score=finding.effective_confidence,
+                )
+            )
+    return tuple(observations)

--- a/apps/server/vibesensor/domain/services/signature_recognition.py
+++ b/apps/server/vibesensor/domain/services/signature_recognition.py
@@ -1,0 +1,27 @@
+"""Signature recognition service."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+
+from ..observation import Observation
+from ..signature import Signature
+
+
+def recognize_signatures(observations: Sequence[Observation]) -> tuple[Signature, ...]:
+    grouped: dict[tuple[str, str], list[Observation]] = defaultdict(list)
+    for observation in observations:
+        grouped[(str(observation.source), observation.signature_key)].append(observation)
+    signatures: list[Signature] = []
+    for (_source_raw, signature_key), grouped_observations in grouped.items():
+        signatures.append(
+            Signature(
+                key=signature_key,
+                source=grouped_observations[0].source,
+                label=grouped_observations[0].signature_key.replace("_", " "),
+                observation_ids=tuple(obs.observation_id for obs in grouped_observations),
+                support_score=max(obs.support_score for obs in grouped_observations),
+            )
+        )
+    return tuple(sorted(signatures, key=lambda item: (-item.support_score, item.key)))

--- a/apps/server/vibesensor/domain/signature.py
+++ b/apps/server/vibesensor/domain/signature.py
@@ -1,0 +1,42 @@
+"""Coherent vibration pattern assembled from observations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .finding import VibrationSource
+
+__all__ = ["Signature"]
+
+
+@dataclass(frozen=True, slots=True)
+class Signature:
+    """A meaningful vibration pattern with supporting observations."""
+
+    key: str
+    source: VibrationSource
+    label: str
+    observation_ids: tuple[str, ...] = ()
+    support_score: float = 0.0
+
+    @property
+    def is_consistent(self) -> bool:
+        return len(self.observation_ids) > 0 and self.support_score > 0.0
+
+    @classmethod
+    def from_label(
+        cls,
+        label: str,
+        *,
+        source: VibrationSource,
+        observation_ids: tuple[str, ...] = (),
+        support_score: float = 0.0,
+    ) -> Signature:
+        key = label.strip().lower().replace("/", "_").replace(" ", "_") or "unknown_signature"
+        return cls(
+            key=key,
+            source=source,
+            label=label.strip() or "unknown signature",
+            observation_ids=observation_ids,
+            support_score=support_score,
+        )

--- a/apps/server/vibesensor/domain/symptom.py
+++ b/apps/server/vibesensor/domain/symptom.py
@@ -1,0 +1,34 @@
+"""Complaint framing for a diagnostic case."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["Symptom"]
+
+
+@dataclass(frozen=True, slots=True)
+class Symptom:
+    """The complaint or observed problem motivating diagnosis."""
+
+    description: str
+    onset: str = ""
+    context: str = ""
+
+    @classmethod
+    def unspecified(cls) -> Symptom:
+        return cls(description="unspecified complaint")
+
+    @property
+    def is_unspecified(self) -> bool:
+        return self.description.strip().lower() == "unspecified complaint"
+
+    @property
+    def is_speed_dependent(self) -> bool:
+        text = f"{self.description} {self.context}".lower()
+        return any(token in text for token in ("speed", "km/h", "cruise", "driving"))
+
+    @property
+    def is_transient(self) -> bool:
+        text = f"{self.description} {self.context} {self.onset}".lower()
+        return any(token in text for token in ("intermittent", "transient", "sometimes"))

--- a/apps/server/vibesensor/domain/test_plan.py
+++ b/apps/server/vibesensor/domain/test_plan.py
@@ -1,0 +1,28 @@
+"""Diagnostic test plan and next-step ownership."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .recommended_action import RecommendedAction
+
+__all__ = ["TestPlan"]
+
+
+@dataclass(frozen=True, slots=True)
+class TestPlan:
+    """The intended diagnostic approach and next recommended actions."""
+
+    actions: tuple[RecommendedAction, ...] = ()
+    requires_additional_data: bool = False
+
+    @property
+    def prioritized_actions(self) -> tuple[RecommendedAction, ...]:
+        return tuple(sorted(self.actions, key=RecommendedAction.sort_key))
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.requires_additional_data and not self.actions
+
+    def needs_more_data(self) -> bool:
+        return self.requires_additional_data or not self.actions

--- a/apps/server/vibesensor/domain/test_run.py
+++ b/apps/server/vibesensor/domain/test_run.py
@@ -1,0 +1,106 @@
+"""Run-level aggregate within a diagnostic case."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .configuration_snapshot import ConfigurationSnapshot
+from .driving_segment import DrivingSegment
+from .finding import Finding, VibrationSource
+from .hypothesis import Hypothesis
+from .observation import Observation
+from .recommended_action import RecommendedAction
+from .run import Run
+from .run_suitability import RunSuitability
+from .signature import Signature
+from .speed_profile import SpeedProfile
+from .test_plan import TestPlan
+
+__all__ = ["TestRun"]
+
+
+@dataclass(frozen=True, slots=True)
+class TestRun:
+    """Canonical run-level diagnostic aggregate."""
+
+    run: Run
+    configuration_snapshot: ConfigurationSnapshot
+    driving_segments: tuple[DrivingSegment, ...] = ()
+    observations: tuple[Observation, ...] = ()
+    signatures: tuple[Signature, ...] = ()
+    hypotheses: tuple[Hypothesis, ...] = ()
+    findings: tuple[Finding, ...] = ()
+    top_causes: tuple[Finding, ...] = ()
+    speed_profile: SpeedProfile | None = None
+    suitability: RunSuitability | None = None
+    test_plan: TestPlan = TestPlan()
+
+    @property
+    def run_id(self) -> str:
+        return self.run.run_id
+
+    @property
+    def diagnostic_findings(self) -> tuple[Finding, ...]:
+        return tuple(f for f in self.findings if f.is_diagnostic)
+
+    @property
+    def non_reference_findings(self) -> tuple[Finding, ...]:
+        return tuple(f for f in self.findings if not f.is_reference)
+
+    @property
+    def primary_finding(self) -> Finding | None:
+        if self.top_causes:
+            return self.top_causes[0]
+        diagnostics = self.diagnostic_findings
+        return diagnostics[0] if diagnostics else None
+
+    @property
+    def primary_source(self) -> VibrationSource | None:
+        finding = self.primary_finding
+        return finding.suspected_source if finding is not None else None
+
+    @property
+    def primary_location(self) -> str | None:
+        finding = self.primary_finding
+        return finding.strongest_location if finding is not None else None
+
+    def effective_top_causes(self) -> tuple[Finding, ...]:
+        actionable_tc = tuple(f for f in self.top_causes if not f.is_reference and f.is_actionable)
+        if actionable_tc:
+            return actionable_tc
+        if self.non_reference_findings:
+            return self.non_reference_findings
+        non_ref_tc = tuple(f for f in self.top_causes if not f.is_reference)
+        if non_ref_tc:
+            return non_ref_tc
+        return self.top_causes
+
+    def has_relevant_reference_gap(self, primary_source: VibrationSource | str) -> bool:
+        source_str = str(primary_source).strip().lower()
+        for finding in self.findings:
+            if not finding.is_reference:
+                continue
+            fid = finding.finding_id.strip().upper()
+            if fid in {"REF_SPEED", "REF_SAMPLE_RATE"}:
+                return True
+            if fid == "REF_WHEEL" and source_str in {
+                str(VibrationSource.WHEEL_TIRE),
+                str(VibrationSource.DRIVELINE),
+            }:
+                return True
+            if fid == "REF_ENGINE" and source_str == str(VibrationSource.ENGINE):
+                return True
+        return False
+
+    def top_strength_db(self) -> float | None:
+        for finding in self.effective_top_causes():
+            if finding.vibration_strength_db is not None:
+                return finding.vibration_strength_db
+        for finding in self.findings:
+            if finding.vibration_strength_db is not None:
+                return finding.vibration_strength_db
+        return None
+
+    @property
+    def recommended_actions(self) -> tuple[RecommendedAction, ...]:
+        return self.test_plan.prioritized_actions

--- a/apps/server/vibesensor/domain/vibration_origin.py
+++ b/apps/server/vibesensor/domain/vibration_origin.py
@@ -1,0 +1,43 @@
+"""Source/origin semantics for a diagnostic finding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .finding import VibrationSource
+from .location_hotspot import LocationHotspot
+
+__all__ = ["VibrationOrigin"]
+
+
+@dataclass(frozen=True, slots=True)
+class VibrationOrigin:
+    """Suspected source/origin conclusion with ambiguity and rationale."""
+
+    suspected_source: VibrationSource
+    hotspot: LocationHotspot | None = None
+    dominance_ratio: float | None = None
+    speed_band: str | None = None
+    dominant_phase: str | None = None
+    reason: str = ""
+
+    @property
+    def is_ambiguous(self) -> bool:
+        return bool(self.hotspot and (self.hotspot.ambiguous or not self.hotspot.is_well_localized))
+
+    @property
+    def display_location(self) -> str:
+        if self.hotspot is None:
+            return "Unknown"
+        return self.hotspot.display_location
+
+    @property
+    def explanation(self) -> str:
+        parts: list[str] = []
+        if self.reason:
+            parts.append(self.reason)
+        if self.speed_band:
+            parts.append(f"speed band {self.speed_band}")
+        if self.dominant_phase:
+            parts.append(f"dominant phase {self.dominant_phase}")
+        return "; ".join(parts)

--- a/apps/server/vibesensor/history_services/exports.py
+++ b/apps/server/vibesensor/history_services/exports.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeGuard
 
 from ..backend_types import HistoryRunPayload
+from ..boundaries.diagnostic_case import project_summary_through_domain
 from ..json_types import JsonObject, JsonValue, is_json_object
 from ..json_utils import sanitize_for_json
 from .helpers import async_require_run, safe_filename, strip_internal_fields
@@ -168,7 +169,7 @@ def build_run_details_json(
     run_details["sample_count"] = sample_count
     analysis = run_details.get("analysis")
     if is_json_object(analysis):
-        run_details["analysis"] = strip_internal_fields(analysis)
+        run_details["analysis"] = strip_internal_fields(project_summary_through_domain(analysis))
     sanitized, had_non_finite = sanitize_for_json(run_details)
     if had_non_finite:
         LOGGER.warning("Export run %s: sanitized non-finite floats in analysis data", run_id)

--- a/apps/server/vibesensor/history_services/reports.py
+++ b/apps/server/vibesensor/history_services/reports.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from ..backend_types import CarConfigPayload, HistoryRunPayload
+from ..boundaries.diagnostic_case import project_summary_through_domain
 from ..exceptions import AnalysisNotReadyError, ProcessingError
 from ..json_types import JsonObject, is_json_object
 from ..report.mapping import map_summary
@@ -98,6 +99,7 @@ class HistoryReportService:
             analysis,
             current_active_car_snapshot=current_active_car_snapshot,
         )
+        analysis_summary = project_summary_through_domain(analysis_summary)
         cache_key = self._report_pdf_cache_key(
             run,
             run_id,

--- a/apps/server/vibesensor/history_services/runs.py
+++ b/apps/server/vibesensor/history_services/runs.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING, Never, cast
 
 from ..backend_types import HistoryRunListEntryPayload, HistoryRunPayload
+from ..boundaries.diagnostic_case import project_summary_through_domain
 from ..exceptions import AnalysisNotReadyError, RunNotFoundError
 from ..history_db import RunStatus
 from ..json_types import JsonObject, is_json_object
@@ -41,7 +42,11 @@ class HistoryRunService:
         run = await async_require_run(self._history_db, run_id)
         analysis = run.get("analysis")
         if is_json_object(analysis):
-            updated_run: HistoryRunPayload = {**run, "analysis": strip_internal_fields(analysis)}
+            projected_analysis = project_summary_through_domain(analysis)
+            updated_run: HistoryRunPayload = {
+                **run,
+                "analysis": strip_internal_fields(projected_analysis),
+            }
             return updated_run
         return run
 
@@ -55,7 +60,7 @@ class HistoryRunService:
         if run["status"] == RunStatus.ANALYZING:
             return None
 
-        analysis = require_analysis_ready(run)
+        analysis = project_summary_through_domain(require_analysis_ready(run))
         current_active_car_snapshot = (
             self._settings_store.active_car_snapshot() if self._settings_store is not None else None
         )

--- a/apps/server/vibesensor/metrics_log/post_analysis.py
+++ b/apps/server/vibesensor/metrics_log/post_analysis.py
@@ -211,6 +211,7 @@ class PostAnalysisWorker:
         LOGGER.info("Analysis started for run %s", run_id)
         try:
             from ..analysis import summarize_run_data
+            from ..boundaries.diagnostic_case import project_summary_through_domain
 
             metadata = db.get_run_metadata(run_id)
             if metadata is None:
@@ -274,7 +275,8 @@ class PostAnalysisWorker:
                         "explanation": explanation,
                     },
                 )
-            db.store_analysis(run_id, summary)  # type: ignore[arg-type]
+            summary = project_summary_through_domain(summary)
+            db.store_analysis(run_id, summary)
 
             duration_s = time.monotonic() - analysis_start
             LOGGER.info(

--- a/apps/server/vibesensor/report/mapping.py
+++ b/apps/server/vibesensor/report/mapping.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections import defaultdict
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from statistics import mean as _mean
 
 from .. import __version__
@@ -30,6 +30,7 @@ from ..analysis.strength_labels import (
     strength_label,
     strength_text,
 )
+from ..boundaries.diagnostic_case import finding_payload_from_domain
 from ..domain import Finding, Report, RunAnalysisResult, VibrationSource
 from ..json_utils import as_float_or_none as _as_float
 from ..report_i18n import normalize_lang
@@ -90,13 +91,29 @@ class ReportMappingContext:
     firmware_version: str | None
     # Domain aggregate for domain-first decisions.
     domain_aggregate: RunAnalysisResult | None = None
+    finding_payloads_by_id: dict[str, FindingPayload] = field(default_factory=dict)
+    top_cause_payloads_by_id: dict[str, FindingPayload] = field(default_factory=dict)
 
     # -- candidate selection ------------------------------------------------
 
     def top_report_candidate(self) -> FindingPayload | None:
         """Return the primary report candidate (first effective top cause or finding)."""
+        if self.domain_aggregate is not None:
+            effective = self.domain_aggregate.effective_top_causes()
+            if effective:
+                payload = self.payload_for_finding(effective[0])
+                if payload is not None:
+                    return payload
         candidates = self.top_causes or self.findings_non_ref
         return candidates[0] if candidates else None
+
+    def payload_for_finding(self, finding: Finding) -> FindingPayload | None:
+        if finding.finding_id:
+            payload = self.top_cause_payloads_by_id.get(finding.finding_id)
+            if payload is not None:
+                return payload
+            return self.finding_payloads_by_id.get(finding.finding_id)
+        return None
 
     # -- display helpers ----------------------------------------------------
 
@@ -303,121 +320,135 @@ _EMPTY_ORIGIN: SuspectedVibrationOrigin = {
 }
 
 
-class SummaryView:
-    """Typed accessor over a ``SummaryData`` dict for report mapping.
+def summary_metadata(summary: AnalysisSummary) -> MetadataDict:
+    return summary.get("metadata") or {}
 
-    Replaces scattered ``summary.get(...)`` chains with typed properties
-    that centralise default handling and type coercion.  The underlying
-    dict is **not** copied – mutations through the view are visible in
-    the original dict and vice-versa.
-    """
 
-    __slots__ = ("_d",)
+def summary_report_date(summary: AnalysisSummary) -> str:
+    return str(summary.get("report_date") or "")
 
-    def __init__(self, summary: AnalysisSummary) -> None:
-        self._d = summary
 
-    @property
-    def data(self) -> AnalysisSummary:
-        return self._d
+def summary_row_count(summary: AnalysisSummary) -> int:
+    return int(_as_float(summary.get("rows")) or 0)
 
-    # -- metadata ----------------------------------------------------------
 
-    @property
-    def metadata(self) -> MetadataDict:
-        return self._d.get("metadata") or {}
+def summary_record_length(summary: AnalysisSummary) -> str | None:
+    return str(summary.get("record_length") or "") or None
 
-    @property
-    def report_date(self) -> str:
-        return str(self._d.get("report_date") or "")
 
-    @property
-    def row_count(self) -> int:
-        return int(_as_float(self._d.get("rows")) or 0)
+def summary_start_time_utc(summary: AnalysisSummary) -> str | None:
+    return str(summary.get("start_time_utc") or "").strip() or None
 
-    @property
-    def record_length(self) -> str | None:
-        return str(self._d.get("record_length") or "") or None
 
-    @property
-    def start_time_utc(self) -> str | None:
-        return str(self._d.get("start_time_utc") or "").strip() or None
+def summary_end_time_utc(summary: AnalysisSummary) -> str | None:
+    return str(summary.get("end_time_utc") or "").strip() or None
 
-    @property
-    def end_time_utc(self) -> str | None:
-        return str(self._d.get("end_time_utc") or "").strip() or None
 
-    @property
-    def raw_sample_rate_hz(self) -> float | None:
-        return _as_float(self._d.get("raw_sample_rate_hz"))
+def summary_raw_sample_rate_hz(summary: AnalysisSummary) -> float | None:
+    return _as_float(summary.get("raw_sample_rate_hz"))
 
-    @property
-    def sensor_model(self) -> str | None:
-        return str(self._d.get("sensor_model") or "").strip() or None
 
-    @property
-    def firmware_version(self) -> str | None:
-        return str(self._d.get("firmware_version") or "").strip() or None
+def summary_sensor_model(summary: AnalysisSummary) -> str | None:
+    return str(summary.get("sensor_model") or "").strip() or None
 
-    @property
-    def sensor_count_used(self) -> int:
-        return int(_as_float(self._d.get("sensor_count_used")) or 0)
 
-    # -- collections -------------------------------------------------------
+def summary_firmware_version(summary: AnalysisSummary) -> str | None:
+    return str(summary.get("firmware_version") or "").strip() or None
 
-    @property
-    def findings(self) -> list[FindingPayload]:
-        raw = self._d.get("findings", [])
-        return list(raw) if isinstance(raw, list) else []
 
-    @property
-    def top_causes(self) -> list[FindingPayload]:
-        raw = self._d.get("top_causes", [])
-        return list(raw) if isinstance(raw, list) else []
+def summary_sensor_count_used(summary: AnalysisSummary) -> int:
+    return int(_as_float(summary.get("sensor_count_used")) or 0)
 
-    @property
-    def speed_stats(self) -> SpeedStats:
-        return self._d.get("speed_stats") or _EMPTY_SPEED_STATS
 
-    @property
-    def origin(self) -> SuspectedVibrationOrigin:
-        return self._d.get("most_likely_origin") or _EMPTY_ORIGIN
+def summary_findings(summary: AnalysisSummary) -> list[FindingPayload]:
+    raw = summary.get("findings", [])
+    return list(raw) if isinstance(raw, list) else []
 
-    @property
-    def test_plan(self) -> list[TestStep]:
-        return [step for step in self._d.get("test_plan", []) if isinstance(step, dict)]
 
-    @property
-    def run_suitability(self) -> list[RunSuitabilityCheck]:
-        return [item for item in self._d.get("run_suitability", []) if isinstance(item, dict)]
+def summary_top_causes(summary: AnalysisSummary) -> list[FindingPayload]:
+    raw = summary.get("top_causes", [])
+    return list(raw) if isinstance(raw, list) else []
 
-    @property
-    def warnings(self) -> list[object]:
-        return list(self._d.get("warnings", []))
 
-    @property
-    def sensor_intensity_by_location(self) -> list[IntensityRow]:
-        return [
-            row for row in self._d.get("sensor_intensity_by_location", []) if isinstance(row, dict)
-        ]
+def summary_speed_stats(summary: AnalysisSummary) -> SpeedStats:
+    return summary.get("speed_stats") or _EMPTY_SPEED_STATS
 
-    # -- sensor locations --------------------------------------------------
 
-    @property
-    def sensor_locations_active(self) -> list[str]:
-        """Return active sensor locations (connected-throughout, fallback to all)."""
-        connected = self._d.get("sensor_locations_connected_throughout", [])
-        active = [str(loc) for loc in connected if str(loc).strip()]
-        if not active:
-            active = [str(loc) for loc in self._d.get("sensor_locations", []) if str(loc).strip()]
-        return active
+def summary_origin(summary: AnalysisSummary) -> SuspectedVibrationOrigin:
+    return summary.get("most_likely_origin") or _EMPTY_ORIGIN
 
-    # -- display helpers ---------------------------------------------------
 
-    @property
-    def sample_rate_hz_text(self) -> str | None:
-        rate = self.raw_sample_rate_hz
-        return f"{rate:g}" if rate is not None else None
+def summary_test_plan(summary: AnalysisSummary) -> list[TestStep]:
+    return [step for step in summary.get("test_plan", []) if isinstance(step, dict)]
+
+
+def summary_run_suitability(summary: AnalysisSummary) -> list[RunSuitabilityCheck]:
+    return [item for item in summary.get("run_suitability", []) if isinstance(item, dict)]
+
+
+def summary_warnings(summary: AnalysisSummary) -> list[object]:
+    return list(summary.get("warnings", []))
+
+
+def summary_sensor_intensity_by_location(summary: AnalysisSummary) -> list[IntensityRow]:
+    return [row for row in summary.get("sensor_intensity_by_location", []) if isinstance(row, dict)]
+
+
+def summary_sensor_locations_active(summary: AnalysisSummary) -> list[str]:
+    connected = summary.get("sensor_locations_connected_throughout", [])
+    active = [str(loc) for loc in connected if str(loc).strip()]
+    if not active:
+        active = [str(loc) for loc in summary.get("sensor_locations", []) if str(loc).strip()]
+    return active
+
+
+def summary_sample_rate_hz_text(summary: AnalysisSummary) -> str | None:
+    rate = summary_raw_sample_rate_hz(summary)
+    return f"{rate:g}" if rate is not None else None
+
+
+def _payloads_by_id(items: list[FindingPayload]) -> dict[str, FindingPayload]:
+    payloads: dict[str, FindingPayload] = {}
+    for item in items:
+        finding_id = str(item.get("finding_id") or "").strip()
+        if finding_id and finding_id not in payloads:
+            payloads[finding_id] = item
+    return payloads
+
+
+def _origin_from_aggregate(
+    aggregate: RunAnalysisResult | None,
+    fallback: SuspectedVibrationOrigin,
+) -> SuspectedVibrationOrigin:
+    if aggregate is None or aggregate.primary_finding is None:
+        return fallback
+
+    primary = aggregate.primary_finding
+    origin = primary.origin
+    hotspot = primary.location
+    fallback_location = str(fallback.get("location") or "").strip()
+    fallback_explanation = str(fallback.get("explanation") or "").strip()
+    if origin is None and hotspot is None:
+        return fallback
+    if hotspot is None and fallback_location and fallback_location.lower() != "unknown":
+        return fallback
+    if origin is not None and not origin.reason and fallback_explanation:
+        return fallback
+
+    return {
+        "location": (
+            origin.display_location
+            if origin is not None
+            else str(primary.strongest_location or "unknown")
+        ),
+        "alternative_locations": (
+            list(hotspot.alternative_locations) if hotspot is not None else []
+        ),
+        "suspected_source": str(primary.suspected_source),
+        "dominance_ratio": primary.dominance_ratio,
+        "weak_spatial_separation": primary.weak_spatial_separation,
+        "explanation": origin.explanation if origin is not None else "",
+    }
 
 
 def normalized_origin_location(origin: SuspectedVibrationOrigin) -> str:
@@ -429,7 +460,7 @@ def resolve_sensor_count(summary: AnalysisSummary, sensor_locations_active: list
     """Resolve the effective sensor count used by report certainty logic."""
     sensor_count = len(sensor_locations_active)
     if sensor_count <= 0:
-        sensor_count = SummaryView(summary).sensor_count_used
+        sensor_count = summary_sensor_count_used(summary)
     return sensor_count
 
 
@@ -551,6 +582,7 @@ def collect_location_intensity(sensor_intensity: list[dict]) -> dict[str, list[f
 def build_next_steps_from_summary(
     summary: AnalysisSummary,
     *,
+    aggregate: RunAnalysisResult | None,
     tier: str,
     cert_reason: str,
     lang: str,
@@ -568,8 +600,25 @@ def build_next_steps_from_summary(
         ]
 
     next_steps: list[NextStep] = []
-    view = SummaryView(summary)
-    for step in view.test_plan:
+    summary_steps = summary_test_plan(summary)
+    if (
+        aggregate is not None
+        and aggregate.test_run is not None
+        and not _summary_has_structured_step_content(summary_steps)
+    ):
+        for action in aggregate.test_run.recommended_actions:
+            next_steps.append(
+                NextStep(
+                    action=_resolve_step_value(action.what, lang=lang, tr=tr),
+                    why=_resolve_optional_step_value(action.why, lang=lang, tr=tr),
+                    confirm=_resolve_optional_step_value(action.confirm, lang=lang, tr=tr),
+                    falsify=_resolve_optional_step_value(action.falsify, lang=lang, tr=tr),
+                    eta=action.eta,
+                ),
+            )
+        if next_steps:
+            return next_steps
+    for step in summary_steps:
         next_steps.append(
             NextStep(
                 action=_resolve_step_value(step.get("what"), lang=lang, tr=tr),
@@ -582,8 +631,21 @@ def build_next_steps_from_summary(
     return next_steps
 
 
+def _summary_has_structured_step_content(steps: list[TestStep]) -> bool:
+    for step in steps:
+        for key in ("what", "why", "confirm", "falsify"):
+            value = step.get(key)
+            if isinstance(value, (dict, list)):
+                return True
+    return False
+
+
 def _resolve_step_value(value: object, *, lang: str, tr: Callable) -> str:
     """Resolve a required step field into report text."""
+    if isinstance(value, str) and value.isupper() and "_" in value:
+        translated = str(tr(value))
+        if translated and translated != value:
+            return translated
     return resolve_i18n(lang, value, tr=tr) if is_i18n_ref(value) else str(value or "")
 
 
@@ -601,23 +663,33 @@ def _resolve_optional_step_value(
 def build_data_trust_from_summary(
     summary: AnalysisSummary,
     *,
+    aggregate: RunAnalysisResult | None,
     lang: str,
     tr: Callable,
 ) -> list[DataTrustItem]:
     """Build the data-trust checklist from run_suitability items."""
-    view = SummaryView(summary)
     data_trust: list[DataTrustItem] = []
-    for item in view.run_suitability:
-        check_text = _resolve_check_text(item.get("check"), lang=lang, tr=tr)
-        detail = _resolve_detail_text(item.get("explanation"), lang=lang, tr=tr)
-        data_trust.append(
-            DataTrustItem(
-                check=check_text,
-                state=str(item.get("state") or "warn"),
-                detail=detail,
-            ),
-        )
-    for warning in view.warnings:
+    if aggregate is not None and aggregate.suitability is not None:
+        for item in aggregate.suitability.checks:
+            data_trust.append(
+                DataTrustItem(
+                    check=_resolve_check_text(item.check_key, lang=lang, tr=tr),
+                    state=item.state,
+                    detail=_resolve_detail_text(item.explanation, lang=lang, tr=tr),
+                ),
+            )
+    else:
+        for summary_item in summary_run_suitability(summary):
+            check_text = _resolve_check_text(summary_item.get("check"), lang=lang, tr=tr)
+            detail = _resolve_detail_text(summary_item.get("explanation"), lang=lang, tr=tr)
+            data_trust.append(
+                DataTrustItem(
+                    check=check_text,
+                    state=str(summary_item.get("state") or "warn"),
+                    detail=detail,
+                ),
+            )
+    for warning in summary_warnings(summary):
         if not isinstance(warning, dict):
             continue
         data_trust.append(
@@ -770,8 +842,13 @@ def build_system_cards(
             location = str(cause.get("strongest_location") or tr("UNKNOWN"))
             tone = cause.get("confidence_tone", "neutral")
 
-        # Rendering detail: signatures come from payload (enriched during top-cause selection)
-        signatures_human = humanize_signatures(cause.get("signatures_observed", []), lang=lang)
+        # Rendering detail: prefer domain signatures, fall back to payload enrichment.
+        signature_values: object
+        if domain_finding and domain_finding.signature_labels:
+            signature_values = list(domain_finding.signature_labels)
+        else:
+            signature_values = cause.get("signatures_observed", [])
+        signatures_human = humanize_signatures(signature_values, lang=lang)
         pattern_text = ", ".join(signatures_human) if signatures_human else tr("UNKNOWN")
         order_label = signatures_human[0] if signatures_human else None
         parts_list = parts_for_pattern(str(source), order_label, lang=lang)
@@ -813,8 +890,10 @@ def build_pattern_evidence(
     """
     # Domain-first: use aggregate effective top causes for matched systems
     aggregate = context.domain_aggregate
+    domain_primary = None
     if aggregate:
         effective = aggregate.effective_top_causes()
+        domain_primary = effective[0] if effective else aggregate.primary_finding
         systems_raw = [human_source(str(f.suspected_source), tr=tr) for f in effective[:3]]
     else:
         systems_raw = [
@@ -824,6 +903,7 @@ def build_pattern_evidence(
     interpretation = resolve_interpretation(context.origin, lang=lang, tr=tr)
     source_for_why, order_label_for_why = resolve_parts_context(
         primary.primary_candidate,
+        domain_finding=domain_primary,
         lang=lang,
     )
     return PatternEvidence(
@@ -852,14 +932,22 @@ def resolve_interpretation(origin: SuspectedVibrationOrigin, *, lang: str, tr: C
 def resolve_parts_context(
     primary_candidate: FindingPayload | None,
     *,
+    domain_finding: Finding | None = None,
     lang: str,
 ) -> tuple[str, str | None]:
     """Resolve source/order context used for why-parts-listed text."""
-    source_for_why = str(
-        primary_candidate.get("suspected_source", "") if primary_candidate else "",
-    )
-    signatures = primary_candidate.get("signatures_observed", []) if primary_candidate else []
-    order_label = order_label_human(lang, str(signatures[0])) if signatures else None
+    if domain_finding is not None:
+        source_for_why = str(domain_finding.suspected_source)
+        signatures: object = list(domain_finding.signature_labels)
+    else:
+        source_for_why = str(
+            primary_candidate.get("suspected_source", "") if primary_candidate else "",
+        )
+        signatures = primary_candidate.get("signatures_observed", []) if primary_candidate else []
+    if isinstance(signatures, list) and signatures:
+        order_label = order_label_human(lang, str(signatures[0]))
+    else:
+        order_label = None
     return source_for_why, order_label
 
 
@@ -934,25 +1022,57 @@ def prepare_report_mapping_context(
     so that downstream business decisions (effective-cause selection,
     reference-gap detection, strength lookup) are domain-first.
     """
-    view = SummaryView(summary)
-    meta = view.metadata
+    meta = summary_metadata(summary)
     car_name = str(meta.get("car_name") or "").strip() or None
     car_type = str(meta.get("car_type") or "").strip() or None
-    report_date = view.report_date or utc_now_iso()
+    report_date = summary_report_date(summary) or utc_now_iso()
     date_str = str(report_date)[:19].replace("T", " ") + " UTC"
 
-    findings, findings_non_ref, _top_causes_all, top_causes = select_effective_top_causes(
-        view.top_causes,
-        view.findings,
-    )
+    summary_findings_all = summary_findings(summary)
+    summary_top_causes_all = summary_top_causes(summary)
+    summary_findings_by_id = _payloads_by_id(summary_findings_all)
+    summary_top_causes_by_id = _payloads_by_id(summary_top_causes_all)
 
-    speed_stats = view.speed_stats
-    origin = view.origin
-    origin_location = normalized_origin_location(origin)
-    sensor_locations_active = view.sensor_locations_active
+    speed_stats = summary_speed_stats(summary)
+    origin = summary_origin(summary)
+    sensor_locations_active = summary_sensor_locations_active(summary)
 
     # Build domain aggregate for domain-first decisions downstream
     domain_aggregate = RunAnalysisResult.from_summary(summary)
+
+    if domain_aggregate is not None:
+        findings = [
+            finding_payload_from_domain(
+                finding,
+                primary=summary_findings_by_id,
+                secondary=summary_top_causes_by_id,
+            )
+            for finding in domain_aggregate.findings
+        ]
+        findings_non_ref = [
+            finding_payload_from_domain(
+                finding,
+                primary=summary_findings_by_id,
+                secondary=summary_top_causes_by_id,
+            )
+            for finding in domain_aggregate.non_reference_findings
+        ]
+        top_causes = [
+            finding_payload_from_domain(
+                finding,
+                primary=summary_top_causes_by_id,
+                secondary=summary_findings_by_id,
+            )
+            for finding in domain_aggregate.effective_top_causes()
+        ]
+        origin = _origin_from_aggregate(domain_aggregate, origin)
+    else:
+        findings, findings_non_ref, _top_causes_all, top_causes = select_effective_top_causes(
+            summary_top_causes_all,
+            summary_findings_all,
+        )
+
+    origin_location = normalized_origin_location(origin)
 
     return ReportMappingContext(
         meta=meta,
@@ -966,15 +1086,17 @@ def prepare_report_mapping_context(
         origin=origin,
         origin_location=origin_location,
         sensor_locations_active=sensor_locations_active,
-        duration_text=view.record_length,
-        start_time_utc=view.start_time_utc,
-        end_time_utc=view.end_time_utc,
-        sample_rate_hz=view.sample_rate_hz_text,
+        duration_text=summary_record_length(summary),
+        start_time_utc=summary_start_time_utc(summary),
+        end_time_utc=summary_end_time_utc(summary),
+        sample_rate_hz=summary_sample_rate_hz_text(summary),
         tire_spec_text=tire_spec_text(meta),
-        sample_count=view.row_count,
-        sensor_model=view.sensor_model,
-        firmware_version=view.firmware_version,
+        sample_count=summary_row_count(summary),
+        sensor_model=summary_sensor_model(summary),
+        firmware_version=summary_firmware_version(summary),
         domain_aggregate=domain_aggregate,
+        finding_payloads_by_id=summary_findings_by_id,
+        top_cause_payloads_by_id=summary_top_causes_by_id,
     )
 
 
@@ -1196,7 +1318,6 @@ def _build_report_template_data(
     The *report* domain object provides high-level metadata; rendering-
     specific fields are resolved from the full *summary* dict.
     """
-    view = SummaryView(summary)
     context = prepare_report_mapping_context(summary)
     primary = resolve_primary_report_candidate(summary, context=context, tr=tr, lang=lang)
     observed = context.observed_signature(primary)
@@ -1208,12 +1329,18 @@ def _build_report_template_data(
     )
     next_steps = build_next_steps_from_summary(
         summary,
+        aggregate=context.domain_aggregate,
         tier=primary.tier,
         cert_reason=primary.certainty_reason,
         lang=lang,
         tr=tr,
     )
-    data_trust = build_data_trust_from_summary(summary, lang=lang, tr=tr)
+    data_trust = build_data_trust_from_summary(
+        summary,
+        aggregate=context.domain_aggregate,
+        lang=lang,
+        tr=tr,
+    )
     pattern_evidence = build_pattern_evidence(
         context,
         primary,
@@ -1224,7 +1351,7 @@ def _build_report_template_data(
     version_marker = build_version_marker()
 
     raw_sensor_intensity = filter_active_sensor_intensity(
-        view.sensor_intensity_by_location,
+        summary_sensor_intensity_by_location(summary),
         context.sensor_locations_active,
     )
     hotspot_rows = compute_location_hotspot_rows(raw_sensor_intensity)

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -37,16 +37,30 @@
 - `domain/`: DDD-aligned domain model package.  Each primary domain object
   lives in its own dedicated file: `car.py` (Car, TireSpec), `sensor.py` (Sensor,
   SensorPlacement), `measurement.py` (Measurement,
-  VibrationReading), `run.py` (Run),
+  VibrationReading), `run.py` (Run lifecycle), `test_run.py` (TestRun aggregate),
+  `diagnostic_case.py` (DiagnosticCase aggregate),
+  `configuration_snapshot.py`, `symptom.py`, `test_plan.py`,
+  `recommended_action.py`, `driving_segment.py`, `observation.py`,
+  `signature.py`, `hypothesis.py`, and `vibration_origin.py`,
   `speed_source.py` (SpeedSource), `driving_phase.py` (DrivingPhase),
   `finding.py` (FindingKind, VibrationSource, Finding, speed_bin_label, speed_band_sort_key), `report.py` (Report),
-  `run_status.py` (RunStatus, RUN_TRANSITIONS).  All are plain frozen dataclasses with no external coupling.
-  Domain objects own classification, ranking, actionability, surfacing,
-  and query logic; pipeline adapters in `analysis/` delegate to them.  See `docs/domain-model.md` for the full
-  relationship map and modeling rules.
+  `run_status.py` (RunStatus, RUN_TRANSITIONS). `domain/services/` owns
+  observation extraction, signature recognition, hypothesis evaluation,
+  finding synthesis, and case reconciliation. Domain objects own
+  classification, ranking, actionability, surfacing, lifecycle, and
+  query logic; pipeline adapters in `analysis/` delegate to them. See
+  `docs/domain-model.md` for the full relationship map and modeling rules.
+- `boundaries/`: explicit ingress/egress decoders and serializers between
+  domain aggregates (`DiagnosticCase`, `TestRun`, `RunAnalysisResult`) and
+  summary/persistence/report payload shapes, including the shared
+  `diagnostic_case.py::project_summary_through_domain()` projection helper
+  used by report/history/export/post-analysis boundaries.
 - `metrics_log/`: recording pipeline package; `logger.py` owns the `RunRecorder` class (formerly `MetricsLogger`) which directly manages session state and persistence coordination (no private helper classes), enriching status/health payloads with sample counts and analysis results; `post_analysis.py` owns the background analysis queue with outcome tracking; `sample_builder.py` owns pure sample-building functions.
 - `history_db/`: SQLite-backed history and settings persistence (3 files: `__init__.py` with `HistoryDB` class consolidating connection management, settings KV, client names, and all run reads/writes; `_schema.py` with DDL and `ANALYSIS_SCHEMA_VERSION`; `_samples.py` for v2 sample serialization). `RunStatus` and state-transition logic live in `domain/run_status.py`. Incompatible older schemas raise a clear error directing the user to delete the DB file.
-- `history_services/`: focused history service layer (run query/delete, reports, exports, helpers) above `history_db/`.
+- `history_services/`: focused history service layer (run query/delete,
+  reports, exports, helpers) above `history_db/`; run/report services project
+  persisted analyses through reconstructed domain aggregates before returning
+  API payloads, building PDFs, or emitting exports.
 - `hotspot/`: Wi-Fi AP monitoring, text parsing, and self-heal logic.
 - `runlog.py`: JSONL run-file I/O and normalization.
 - `report/`: PDF renderer, report-template builders, pattern-to-parts mapping (`pattern_parts.py`), and analysis-summary-to-domain-Report factory (`mapping.py::build_report_from_summary()`).

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -12,9 +12,16 @@ summary payloads, report templates, API shapes, or persistence rows.
 
 ## Implementation status
 
-The model below describes the **current** implemented state.  Where a concept
-is aspirational (not yet in code), it is marked as **(planned)**.  The
-implemented subset is production-ready and enforced by architecture tests.
+The model below describes the target architecture and the **currently landed**
+subset. The backend now creates a canonical `DiagnosticCase` and `TestRun`
+during run analysis, and `RunAnalysisResult` has been reduced toward a
+run-focused projection over that run aggregate. Report mapping, history
+services, history exports, and post-analysis persistence now reconstruct that
+projection and re-project canonical report/history fields from the domain model
+before storing, rendering, or returning payloads. Raw summary payloads remain
+at transport and rendering boundaries, but backend business decisions in those
+paths now flow through reconstructed domain aggregates rather than treating the
+payloads as the primary model.
 
 ## Purpose
 
@@ -64,7 +71,7 @@ objects are derived edge forms of these concepts.
 
 ## Top-level aggregate
 
-The natural top-level aggregate is **`DiagnosticCase`** **(planned)**.
+The natural top-level aggregate is **`DiagnosticCase`**.
 
 `DiagnosticCase` represents the complete diagnostic problem—spanning one or
 more runs and their conclusions—rather than a single run or report. It owns the
@@ -81,24 +88,25 @@ case-level identity and consistency boundaries for:
 
 ### Current implementation
 
-The system currently operates with a single-run focus.  The primary domain
-aggregate is **`RunAnalysisResult`** (`domain/run_analysis_result.py`), which
-represents the finalized output of analyzing one diagnostic run.
+`RunAnalysis.summarize()` now builds a `DiagnosticCase` and a canonical
+`TestRun` during analysis orchestration without reconstructing those objects
+from a temporary summary payload. `DiagnosticCase` reconciles case-level
+findings and actions from the contributing runs, and `TestRun` owns the
+run-contained observations, signatures, hypotheses, findings, `SpeedProfile`,
+and `RunSuitability`.
 
-`RunAnalysisResult` owns:
+`RunAnalysisResult` (`domain/run_analysis_result.py`) remains implemented as a
+run-focused projection for downstream consumers that still expect a run-level
+aggregate. Report/history code paths, exports, and post-analysis persistence
+now reconstruct that projection at the boundary and derive canonical
+`top_causes`, `most_likely_origin`, `test_plan`, and `run_suitability` fields
+from it, so persisted payloads are no longer the business truth in those
+areas. Remaining raw payload handling in the repo is transport/rendering detail
+rather than business-truth ownership.
 
-- the ranked domain `Finding` objects
-- the selected top causes
-- core queries for downstream ranking, selection, and report generation
-  (`effective_top_causes`, `has_relevant_reference_gap`, `top_strength_db`,
-  `primary_source`, `primary_location`, `primary_finding`)
-
-The run-level lifecycle object is **`Run`** (`domain/run.py`), which tracks
-recording state transitions (start → stop) and holds run identity.
-
-In refactoring terms, today's `Run` should evolve toward a `TestRun` that
-lives inside a `DiagnosticCase` aggregate when multi-run analysis is
-implemented.
+The lifecycle object **`Run`** (`domain/run.py`) remains the recording-time
+identity/lifecycle component. `TestRun` composes that lifecycle object rather
+than replacing it with raw ids.
 
 What belongs on `DiagnosticCase`:
 
@@ -164,10 +172,11 @@ Interpretation rules:
 
 | Object | Status | What it represents | What it owns | What it does **not** own |
 |---|---|---|---|---|
-| **RunAnalysisResult** | ✅ Implemented | Finalized analysis result for one run | ranked domain `Finding` objects, top causes, core queries (effective_top_causes, primary_finding, primary_source, primary_location, has_relevant_reference_gap, top_strength_db); optionally `SpeedProfile` and `RunSuitability` | rendering, transport schemas, signal-processing algorithms |
-| **Run** | ✅ Implemented | Run lifecycle and identity | start/stop state transitions, run_id, analysis_settings | analysis results, report rendering |
-| **DiagnosticCase** | 🔮 Planned | One diagnostic problem for one vehicle | case lifecycle, hypothesis set, run set, findings, actions, cross-run consistency | rendering, transport schemas, signal-processing algorithms |
-| **TestPlan** | 🔮 Planned | The intended diagnostic approach | planned runs, comparison strategy, required evidence, next-step intent | execution telemetry, report layout |
+| **RunAnalysisResult** | ✅ Implemented | Run-focused projection over a `TestRun` | run-level finding queries used by legacy/report/history boundaries | case reconciliation, rendering, transport schemas, signal-processing algorithms |
+| **Run** | ✅ Implemented | Recording-time run lifecycle and identity | start/stop state transitions, run_id, analysis_settings | findings, reports, case reconciliation |
+| **DiagnosticCase** | ✅ Implemented | One diagnostic problem for one vehicle | case lifecycle, run set, reconciled hypotheses/findings, recommended actions, cross-run consistency | rendering, transport schemas, signal-processing algorithms |
+| **TestRun** | ✅ Implemented | Run-level aggregate inside the case boundary | configuration snapshot, segments, observations, signatures, hypotheses, findings, speed profile, suitability, actions | rendering, transport schemas, signal-processing algorithms |
+| **TestPlan** | ✅ Implemented | The intended diagnostic approach | prioritized next actions and whether more data is required | execution telemetry, report layout |
 
 ### Entities
 
@@ -177,12 +186,12 @@ Interpretation rules:
 | **Sensor** | ✅ Implemented | A physical measurement source | owns identity, placement, availability, and suitability for evidence interpretation |
 | **Finding** | ✅ Implemented | A justified conclusion | owns finding identity, kind, severity, actionability, confidence classification (label/tone/pct), surfacing, ranking, phase-adjusted scoring; optionally carries `FindingEvidence`, `LocationHotspot`, and `ConfidenceAssessment` domain value objects |
 | **Report** | ✅ Implemented | Run-level metadata for rendering | owns run_id, lang, car info, dates, counts (thin metadata, not business logic) |
-| **Symptom** | 🔮 Planned | A complaint or observed problem | owns symptom wording, onset/context, and diagnostic framing |
-| **DrivingSegment** | 🔮 Planned | A meaningful portion of a run | owns segment boundaries, maneuver/phase meaning |
-| **Observation** | 🔮 Planned | A notable fact extracted from run data | owns observation type, magnitude, conditions |
-| **Signature** | 🔮 Planned | A coherent vibration pattern built from observations | owns pattern identity, pattern-level consistency |
-| **Hypothesis** | 🔮 Planned | A possible explanation of the complaint | owns support/contradiction state, status, and rationale |
-| **RecommendedAction** | 🔮 Planned | A next diagnostic or repair step | owns action intent, priority |
+| **Symptom** | ✅ Implemented | A complaint or observed problem | owns symptom wording, onset/context, and diagnostic framing |
+| **DrivingSegment** | ✅ Implemented | A meaningful portion of a run | owns segment boundaries, maneuver/phase meaning, and diagnostic usability |
+| **Observation** | ✅ Implemented | A notable fact extracted from run data | owns observation type, magnitude, conditions, and signature support semantics |
+| **Signature** | ✅ Implemented | A coherent vibration pattern built from observations | owns pattern identity and pattern-level consistency |
+| **Hypothesis** | ✅ Implemented | A possible explanation of the complaint | owns support/contradiction state, status, and rationale |
+| **RecommendedAction** | ✅ Implemented | A next diagnostic or repair step | owns action intent and priority |
 
 ### Value objects
 
@@ -199,8 +208,8 @@ Interpretation rules:
 | **ConfidenceAssessment** | ✅ Implemented | Why confidence is high, low, or withheld | tier (A/B/C), is_conclusive, needs_more_data, reason, downgraded |
 | **SpeedProfile** | ✅ Implemented | Run speed behavior as a diagnostic concept | is_adequate_for_diagnosis, has_steady_cruise, speed_range_kmh, cruise_fraction |
 | **RunSuitability** | ✅ Implemented | Whether a run is trustworthy enough | overall (pass/caution/fail), is_usable, failed_checks, warning_checks |
-| **ConfigurationSnapshot** | 🔮 Planned | Vehicle/setup state at a specific moment | immutable diagnostic context for interpreting a run |
-| **VibrationOrigin** | 🔮 Planned | Suspected source/origin conclusion | source semantics, dominance, ambiguity |
+| **ConfigurationSnapshot** | ✅ Implemented | Vehicle/setup state at a specific moment | immutable diagnostic context for interpreting a run |
+| **VibrationOrigin** | ✅ Implemented | Suspected source/origin conclusion | source semantics, dominance, ambiguity |
 
 ## Domain services
 
@@ -436,7 +445,14 @@ The following guardrails are enforced by tests in
 - `select_top_causes()` returns domain `Finding` objects
 - `RunAnalysis.summarize()` populates `analysis_result` as `RunAnalysisResult`
   with `speed_profile`, `suitability`, and `ConfidenceAssessment` on top causes
+- `RunAnalysis.summarize()` also publishes canonical `test_run` and
+  `diagnostic_case` aggregates
 - Report mapping context builds a domain aggregate
+- history run/report services and exports project persisted summaries through
+  reconstructed domain aggregates before returning API payloads, building PDFs,
+  or emitting ZIP/JSON exports
+- post-analysis canonicalizes summaries through the shared domain projection
+  helper before storing them in history
 - `non_reference_findings()` uses domain classification
 - `build_system_cards()` reads confidence tone from domain `Finding`, not
   from enriched payload dicts
@@ -444,6 +460,14 @@ The following guardrails are enforced by tests in
   `RunSuitability`, and `SuitabilityCheck` are frozen dataclasses exported
   from `vibesensor.domain`
 - `ConfidenceAssessment.tier` is consistent with `Finding.classify_confidence()`
+- `DiagnosticCase`, `TestRun`, `ConfigurationSnapshot`, `Symptom`,
+  `DrivingSegment`, `Observation`, `Signature`, `Hypothesis`,
+  `RecommendedAction`, and `VibrationOrigin` are exported from
+  `vibesensor.domain`
+- explicit boundary decoders reconstruct `DiagnosticCase` / `TestRun` from
+  persisted or transported summary payloads
+- remaining raw payload handling is transport/rendering detail, not business
+  decision-making
 
 ## Current package layout
 
@@ -462,25 +486,24 @@ The domain package (`vibesensor/domain/`) mirrors the human concepts above:
 | `run_suitability.py` | `RunSuitability`, `SuitabilityCheck` | ✅ |
 | `speed_profile.py` | `SpeedProfile` | ✅ |
 | `car.py` | `Car`, `TireSpec` | ✅ |
+| `configuration_snapshot.py` | `ConfigurationSnapshot` | ✅ |
+| `diagnostic_case.py` | `DiagnosticCase` | ✅ |
+| `driving_segment.py` | `DrivingSegment` | ✅ |
+| `hypothesis.py` | `Hypothesis`, `HypothesisStatus` | ✅ |
 | `sensor.py` | `Sensor`, `SensorPlacement` | ✅ |
+| `observation.py` | `Observation` | ✅ |
+| `recommended_action.py` | `RecommendedAction` | ✅ |
+| `signature.py` | `Signature` | ✅ |
 | `speed_source.py` | `SpeedSource`, `SpeedSourceKind` | ✅ |
+| `symptom.py` | `Symptom` | ✅ |
+| `test_plan.py` | `TestPlan` | ✅ |
+| `test_run.py` | `TestRun` | ✅ |
+| `vibration_origin.py` | `VibrationOrigin` | ✅ |
 | `driving_phase.py` | `DrivingPhase` | ✅ |
 | `measurement.py` | `Measurement`, `VibrationReading` | ✅ |
 | `report.py` | `Report` | ✅ |
-
-### Target additions (planned)
-
-| File | Primary object(s) |
-|---|---|
-| `diagnostic_case.py` | `DiagnosticCase` |
-| `configuration_snapshot.py` | `ConfigurationSnapshot` |
-| `symptom.py` | `Symptom` |
-| `test_plan.py` | `TestPlan`, `RecommendedAction` |
-| `observation.py` | `Observation` |
-| `signature.py` | `Signature` |
-| `hypothesis.py` | `Hypothesis` |
-| `vibration_origin.py` | `VibrationOrigin` |
-| `services/` | domain services for observation extraction, signature recognition, hypothesis evaluation, finding synthesis, case reconciliation |
+| `services/` | observation extraction, signature recognition, hypothesis evaluation, finding synthesis, case reconciliation | ✅ |
+| `boundaries/` | explicit summary decoders / projections between domain and payload shapes | ✅ |
 
 The exact file split may change, but the conceptual split should not: the model
 must be built around the human diagnostic concepts, not around transport or


### PR DESCRIPTION
## Summary
- introduce canonical domain aggregates and supporting domain services for diagnostic cases and test runs
- project summaries through shared boundary adapters so report, history, export, and post-analysis consumers use aggregate-derived business truth
- update docs and architecture tests to reflect the aggregate-first domain model

## Validation
- ./.venv/bin/python -m pytest -q --tb=short apps/server/tests
- ./.venv/bin/python tools/tests/run_e2e_parallel.py --shards 3 --fast-e2e
- make typecheck-backend
- ruff check apps/server
- ./.tools/act/act -j backend-quality -W .github/workflows/ci.yml
- ./.tools/act/act -j backend-typecheck -W .github/workflows/ci.yml
- ./.tools/act/act -j frontend-typecheck -W .github/workflows/ci.yml
