### PR TITLE
fix: add missing 'check' field to suitability boundary payload

### DIFF
--- a/apps/server/vibesensor/boundaries/run_suitability.py
+++ b/apps/server/vibesensor/boundaries/run_suitability.py
@@ -95,6 +95,7 @@ def _payload_for_check(
         explanation = fallback.get("explanation", explanation)
 
     return {
+        "check": check.check_key,
         "check_key": check.check_key,
         "state": check.state,
         "explanation": explanation,


### PR DESCRIPTION
## Problem

PR #678 (domain model implementation) introduced `_payload_for_check()` in `boundaries/run_suitability.py` which returned `check_key` but not the `check` field. The `RunSuitabilityCheck` TypedDict contract, report mapping (`mapping.py:631`), and E2E tests all read `item.get("check")`.

This caused the insights API to return `None` for the `check` field in suitability items, breaking:

- `test_e2e_docker_user_journeys[language_pdf]` — `AssertionError: assert 'SUITABILITY_CHECK_SPEED_VARIATION' in {'None'}`
- `test_language_and_speed_unit_validation_e2e` — same assertion

## Fix

Add `"check": check.check_key` to the dict returned by `_payload_for_check()`, making the output conform to the `RunSuitabilityCheck` TypedDict contract.

## Validation

- All local CI-parity checks pass (`make test-all`): backend-quality, backend-typecheck, frontend-typecheck, ui-smoke, release-smoke, backend-tests, **e2e** ✅
- `make lint` ✅
- `make typecheck-backend` ✅