### PR TITLE
refactor: replace loose dict patterns with typed domain snapshots

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -10,7 +10,12 @@ Backend (python `apps/server/`)
 	- `apps/server/vibesensor/infra/runtime/`: subsystem ownership, lifecycle coordination, processing loop, and websocket broadcast state; routes receive `RuntimeState` directly.
 	- `apps/server/vibesensor/adapters/persistence/history_db/`: SQLite-backed history and settings persistence.
 	- `apps/server/vibesensor/adapters/pdf/pdf_engine.py`: public PDF renderer entrypoint and page orchestration.
-	- `apps/server/vibesensor/domain/`: DDD-aligned domain model package. Primary domain objects live under `vibesensor/domain/`; closely related value objects may share a file with their parent aggregate. Includes `FindingKind` enum, `RunStatus` state machine, and all domain queries. See `docs/domain-model.md` for the full relationship map and file layout.
+	- `apps/server/vibesensor/domain/`: DDD-aligned domain model package. Primary domain objects live under `vibesensor/domain/`; closely related value objects may share a file with their parent aggregate. Includes `FindingKind` enum, `RunStatus` state machine, and all domain queries. Key domain files and types:
+		- `car.py`: Car, TireSpec, OrderReferenceSpec, CarSnapshot
+		- `snapshots.py`: AnalysisSettingsSnapshot, RunContextSnapshot, SpeedStatsSnapshot, PhaseSummarySnapshot
+		- `strength_metrics.py`: StrengthMetrics, StrengthPeak
+		- `finding.py`: Finding, FindingEvidence (with `from_metrics()` factory and `with_confidence_assessment()` method)
+		- See `docs/domain-model.md` for the full relationship map and file layout.
 - Domain-first modeling rules:
 	- Domain objects own behavior (classification, ranking, lifecycle, computation). Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
 	- Each primary domain object lives under `vibesensor/domain/`; closely related value objects may share a file with their parent aggregate. Consumers import from `vibesensor.domain`, not from individual module files.

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -86,6 +86,9 @@ select = ["E", "F", "I", "UP", "B"]
 python_version = "3.11"
 files = [
   "vibesensor/app",
+  "vibesensor/domain/snapshots.py",
+  "vibesensor/domain/strength_metrics.py",
+  "vibesensor/domain/car.py",
   "vibesensor/shared/types/api_models.py",
   "vibesensor/shared/types/backend_types.py",
   "vibesensor/adapters/gps/gps_speed.py",

--- a/apps/server/tests/adapters/http/test_api_history_route_state.py
+++ b/apps/server/tests/adapters/http/test_api_history_route_state.py
@@ -19,6 +19,7 @@ from _history_endpoint_helpers import (
 from fastapi import HTTPException
 
 from vibesensor.adapters.http import create_router
+from vibesensor.domain import CarSnapshot
 from vibesensor.use_cases.diagnostics import summarize_run_data
 
 
@@ -180,18 +181,18 @@ async def test_history_insights_localizes_and_adds_run_context_warnings() -> Non
         analysis=analysis,
         samples=samples,
     )
-    state.settings_store.active_car_snapshot = lambda: {
-        "id": "car-b",
-        "name": "Daily Car",
-        "type": "wagon",
-        "aspects": {
+    state.settings_store.active_car_snapshot = lambda: CarSnapshot(
+        car_id="car-b",
+        name="Daily Car",
+        car_type="wagon",
+        aspects={
             "tire_width_mm": 225.0,
             "tire_aspect_pct": 45.0,
             "rim_in": 18.0,
             "final_drive_ratio": 2.91,
             "current_gear_ratio": 0.72,
         },
-    }
+    )
     endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
 
     payload = response_payload(await endpoint("run-1", "nl"))

--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -7,6 +7,8 @@ os.environ.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from vibesensor.domain import AnalysisSettingsSnapshot
+
 if TYPE_CHECKING:
     from vibesensor.infra.runtime import RuntimeState
 
@@ -100,15 +102,15 @@ class _StubSettingsStore:
     def get_speed_source(self) -> dict[str, Any]:
         return {"speedSource": "gps"}
 
-    def analysis_settings_snapshot(self) -> dict[str, float]:
+    def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
         self.snapshot_calls += 1
-        return {
-            "tire_width_mm": 285.0,
-            "tire_aspect_pct": 30.0,
-            "rim_in": 21.0,
-            "final_drive_ratio": 3.08,
-            "current_gear_ratio": 0.64,
-        }
+        return AnalysisSettingsSnapshot(
+            tire_width_mm=285.0,
+            tire_aspect_pct=30.0,
+            rim_in=21.0,
+            final_drive_ratio=3.08,
+            current_gear_ratio=0.64,
+        )
 
 
 @dataclass(slots=True)

--- a/apps/server/tests/domain/test_car_domain.py
+++ b/apps/server/tests/domain/test_car_domain.py
@@ -1,0 +1,204 @@
+"""Tests for OrderReferenceSpec and CarSnapshot domain objects."""
+
+from __future__ import annotations
+
+from vibesensor.domain import Car, CarSnapshot, OrderReferenceSpec
+
+# ---------------------------------------------------------------------------
+# OrderReferenceSpec tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrderReferenceSpecFromSettings:
+    def test_returns_none_when_missing_tire_keys(self) -> None:
+        assert OrderReferenceSpec.from_settings({"final_drive_ratio": 3.0}) is None
+
+    def test_returns_spec_with_complete_tire_keys(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+            "final_drive_ratio": 3.08,
+            "current_gear_ratio": 0.64,
+            "wheel_bandwidth_pct": 5.0,
+            "driveshaft_bandwidth_pct": 4.5,
+            "engine_bandwidth_pct": 5.2,
+            "speed_uncertainty_pct": 1.0,
+            "tire_diameter_uncertainty_pct": 1.0,
+            "final_drive_uncertainty_pct": 0.1,
+            "gear_uncertainty_pct": 0.2,
+            "min_abs_band_hz": 0.2,
+            "max_band_half_width_pct": 6.0,
+        }
+        spec = OrderReferenceSpec.from_settings(settings, deflection_factor=0.97)
+        assert spec is not None
+        assert spec.tire_spec.width_mm == 285.0
+        assert spec.final_drive_ratio == 3.08
+        assert spec.current_gear_ratio == 0.64
+        assert spec.tire_spec.deflection_factor == 0.97
+
+    def test_missing_non_tire_keys_default_to_zero(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 205.0,
+            "tire_aspect_pct": 55.0,
+            "rim_in": 16.0,
+        }
+        spec = OrderReferenceSpec.from_settings(settings)
+        assert spec is not None
+        assert spec.final_drive_ratio == 0.0
+        assert spec.wheel_bandwidth_pct == 0.0
+
+    def test_tire_circumference(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+        }
+        spec = OrderReferenceSpec.from_settings(settings)
+        assert spec is not None
+        assert spec.tire_circumference_m > 0
+        assert spec.tire_circumference_m == spec.tire_spec.circumference_m
+
+    def test_has_engine_reference(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+            "current_gear_ratio": 0.64,
+        }
+        spec = OrderReferenceSpec.from_settings(settings)
+        assert spec is not None
+        assert spec.has_engine_reference is True
+
+    def test_no_engine_reference_when_zero(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+            "current_gear_ratio": 0.0,
+        }
+        spec = OrderReferenceSpec.from_settings(settings)
+        assert spec is not None
+        assert spec.has_engine_reference is False
+
+    def test_is_complete(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+            "final_drive_ratio": 3.08,
+        }
+        spec = OrderReferenceSpec.from_settings(settings)
+        assert spec is not None
+        assert spec.is_complete is True
+
+    def test_not_complete_without_drive_ratio(self) -> None:
+        settings: dict[str, float] = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+        }
+        spec = OrderReferenceSpec.from_settings(settings)
+        assert spec is not None
+        assert spec.is_complete is False
+
+
+class TestCarOrderReferenceSpec:
+    def test_car_with_tire_aspects_has_spec(self) -> None:
+        car = Car(
+            aspects={
+                "tire_width_mm": 285.0,
+                "tire_aspect_pct": 30.0,
+                "rim_in": 21.0,
+                "final_drive_ratio": 3.08,
+            },
+        )
+        assert car.order_reference_spec is not None
+        assert car.order_reference_spec.final_drive_ratio == 3.08
+
+    def test_car_without_tire_aspects_has_none(self) -> None:
+        car = Car(aspects={"final_drive_ratio": 3.08})
+        assert car.order_reference_spec is None
+
+    def test_car_empty_aspects_has_none(self) -> None:
+        car = Car()
+        assert car.order_reference_spec is None
+
+    def test_car_with_deflection_factor(self) -> None:
+        car = Car(
+            aspects={
+                "tire_width_mm": 285.0,
+                "tire_aspect_pct": 30.0,
+                "rim_in": 21.0,
+                "tire_deflection_factor": 0.97,
+            },
+        )
+        assert car.order_reference_spec is not None
+        assert car.order_reference_spec.tire_spec.deflection_factor == 0.97
+
+
+# ---------------------------------------------------------------------------
+# CarSnapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestCarSnapshot:
+    def test_from_dict_empty(self) -> None:
+        snap = CarSnapshot.from_dict({})
+        assert snap.car_id is None
+        assert snap.name is None
+        assert snap.car_type is None
+        assert snap.variant is None
+        assert dict(snap.aspects) == {}
+
+    def test_from_dict_full(self) -> None:
+        snap = CarSnapshot.from_dict(
+            {
+                "id": "abc123",
+                "name": "Test Car",
+                "car_type": "sedan",
+                "variant": "sport",
+                "aspects": {"tire_width_mm": 205.0, "tire_aspect_pct": 55.0},
+            }
+        )
+        assert snap.car_id == "abc123"
+        assert snap.name == "Test Car"
+        assert snap.car_type == "sedan"
+        assert snap.variant == "sport"
+        assert snap.aspects["tire_width_mm"] == 205.0
+
+    def test_from_dict_with_car_id_key(self) -> None:
+        snap = CarSnapshot.from_dict({"car_id": "xyz"})
+        assert snap.car_id == "xyz"
+
+    def test_to_dict_round_trip(self) -> None:
+        original = CarSnapshot(
+            car_id="abc",
+            name="Test",
+            car_type="suv",
+            variant=None,
+            aspects={"tire_width_mm": 205.0},
+        )
+        d = original.to_dict()
+        assert d["id"] == "abc"
+        assert d["name"] == "Test"
+        reconstructed = CarSnapshot.from_dict(d)
+        assert reconstructed.car_id == original.car_id
+        assert reconstructed.name == original.name
+
+    def test_aspects_frozen(self) -> None:
+        snap = CarSnapshot(aspects={"a": 1.0})
+        try:
+            snap.aspects["b"] = 2.0  # type: ignore[index]
+            raise AssertionError("Should not allow mutation")  # noqa: TRY301
+        except TypeError:
+            pass  # MappingProxyType raises TypeError on mutation
+
+    def test_whitespace_name_becomes_none(self) -> None:
+        snap = CarSnapshot.from_dict({"name": "  "})
+        assert snap.name is None
+
+    def test_invalid_aspects_skipped(self) -> None:
+        snap = CarSnapshot.from_dict({"aspects": {"a": "not_a_number", "b": 1.5}})
+        assert "a" not in snap.aspects
+        assert snap.aspects["b"] == 1.5

--- a/apps/server/tests/domain/test_domain_value_objects.py
+++ b/apps/server/tests/domain/test_domain_value_objects.py
@@ -39,12 +39,12 @@ from vibesensor.domain import (
 from vibesensor.domain import (
     TestPlan as DomainTestPlan,
 )
+from vibesensor.domain.snapshots import PhaseSummarySnapshot, SpeedStatsSnapshot
 from vibesensor.shared.boundaries.diagnostic_case import (
     run_suitability_from_payload,
     speed_profile_from_stats,
 )
 from vibesensor.shared.boundaries.finding import (
-    finding_evidence_from_metrics,
     finding_from_payload,
 )
 from vibesensor.shared.boundaries.vibration_origin import (
@@ -138,7 +138,7 @@ class TestFindingEvidence:
             "per_phase_confidence": {"cruise": 0.9, "accel": 0.6},
             "vibration_strength_db": 25.3,
         }
-        e = finding_evidence_from_metrics(d)
+        e = FindingEvidence.from_metrics(d)
         assert e.match_rate == 0.85
         assert e.snr_db == 12.5
         assert e.presence_ratio == 0.7
@@ -149,13 +149,18 @@ class TestFindingEvidence:
         assert ("cruise", 0.9) in e.phase_confidences
 
     def test_from_metrics_dict_empty(self) -> None:
-        e = finding_evidence_from_metrics({})
+        e = FindingEvidence.from_metrics({})
         assert e.match_rate == 0.0
         assert e.snr_db is None
         assert e.phase_confidences == ()
 
-    def test_from_metrics_dict_snr_ratio_fallback(self) -> None:
-        e = finding_evidence_from_metrics({"snr_ratio": 8.0})
+    def test_from_metrics_domain_uses_canonical_keys_only(self) -> None:
+        """Domain factory does not handle legacy snr_ratio alias."""
+        e = FindingEvidence.from_metrics({"snr_ratio": 8.0})
+        assert e.snr_db is None  # legacy alias not recognized by domain
+
+    def test_from_metrics_snr_db_canonical(self) -> None:
+        e = FindingEvidence.from_metrics({"snr_db": 8.0})
         assert e.snr_db == 8.0
 
 
@@ -742,21 +747,21 @@ class TestSpeedProfile:
         ).supports_steady_state_diagnosis
 
     def test_from_stats_full(self) -> None:
-        speed_stats = {
-            "min_kmh": 30.0,
-            "max_kmh": 90.0,
-            "mean_kmh": 60.0,
-            "stddev_kmh": 15.0,
-            "steady_speed": True,
-            "sample_count": 500,
-        }
-        phase_summary = {
-            "has_cruise": True,
-            "has_acceleration": True,
-            "cruise_pct": 65.0,
-            "idle_pct": 10.0,
-            "speed_unknown_pct": 5.0,
-        }
+        speed_stats = SpeedStatsSnapshot(
+            min_kmh=30.0,
+            max_kmh=90.0,
+            mean_kmh=60.0,
+            stddev_kmh=15.0,
+            steady_speed=True,
+            sample_count=500,
+        )
+        phase_summary = PhaseSummarySnapshot(
+            has_cruise=True,
+            has_acceleration=True,
+            cruise_pct=65.0,
+            idle_pct=10.0,
+            speed_unknown_pct=5.0,
+        )
         sp = speed_profile_from_stats(speed_stats, phase_summary)
         assert sp.min_kmh == 30.0
         assert sp.max_kmh == 90.0
@@ -774,7 +779,7 @@ class TestSpeedProfile:
         assert sp.sample_count == 500
 
     def test_from_stats_empty(self) -> None:
-        sp = speed_profile_from_stats({})
+        sp = speed_profile_from_stats(SpeedStatsSnapshot())
         assert sp.min_kmh == 0.0
         assert sp.max_kmh == 0.0
         assert not sp.steady_speed
@@ -783,21 +788,23 @@ class TestSpeedProfile:
         assert sp.driving_fraction == 1.0
 
     def test_from_stats_no_phase(self) -> None:
-        sp = speed_profile_from_stats({"min_kmh": 10, "max_kmh": 50})
+        sp = speed_profile_from_stats(SpeedStatsSnapshot(min_kmh=10, max_kmh=50))
         assert sp.has_cruise is False
         assert sp.cruise_fraction == 0.0
 
     def test_from_stats_reads_phase_fallbacks_from_nested_phase_maps(self) -> None:
         sp = speed_profile_from_stats(
-            {
-                "min_kmh": 20,
-                "max_kmh": 60,
-                "sample_count": 50,
-            },
-            {
-                "phase_counts": {"acceleration": 5, "cruise": 20},
-                "phase_pcts": {"cruise": 40.0, "idle": 15.0, "speed_unknown": 20.0},
-            },
+            SpeedStatsSnapshot(
+                min_kmh=20,
+                max_kmh=60,
+                sample_count=50,
+            ),
+            PhaseSummarySnapshot.from_dict(
+                {
+                    "phase_counts": {"acceleration": 5, "cruise": 20},
+                    "phase_pcts": {"cruise": 40.0, "idle": 15.0, "speed_unknown": 20.0},
+                }
+            ),
         )
         assert sp.has_cruise is True
         assert sp.has_acceleration is True

--- a/apps/server/tests/domain/test_snapshots.py
+++ b/apps/server/tests/domain/test_snapshots.py
@@ -1,0 +1,206 @@
+"""Tests for domain snapshot value objects.
+
+Covers AnalysisSettingsSnapshot, RunContextSnapshot,
+SpeedStatsSnapshot, and PhaseSummarySnapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import (
+    AnalysisSettingsSnapshot,
+    CarSnapshot,
+    OrderReferenceSpec,
+    PhaseSummarySnapshot,
+    RunContextSnapshot,
+    SpeedStatsSnapshot,
+)
+
+# ── AnalysisSettingsSnapshot ────────────────────────────────────────
+
+
+class TestAnalysisSettingsSnapshotFromDict:
+    """from_dict() constructor tests."""
+
+    def test_empty_dict_never_raises(self) -> None:
+        snap = AnalysisSettingsSnapshot.from_dict({})
+        assert snap.tire_width_mm == 0.0
+        assert snap.tire_deflection_factor == 1.0
+
+    def test_round_trip_fields(self) -> None:
+        data = {
+            "tire_width_mm": 285.0,
+            "tire_aspect_pct": 30.0,
+            "rim_in": 21.0,
+            "final_drive_ratio": 3.08,
+            "current_gear_ratio": 0.64,
+            "wheel_bandwidth_pct": 0.0025,
+            "driveshaft_bandwidth_pct": 0.0025,
+            "engine_bandwidth_pct": 0.0025,
+            "speed_uncertainty_pct": 0.05,
+            "tire_diameter_uncertainty_pct": 0.02,
+            "final_drive_uncertainty_pct": 0.01,
+            "gear_uncertainty_pct": 0.01,
+            "min_abs_band_hz": 1.0,
+            "max_band_half_width_pct": 0.05,
+            "tire_deflection_factor": 0.96,
+        }
+        snap = AnalysisSettingsSnapshot.from_dict(data)
+        assert snap.tire_width_mm == 285.0
+        assert snap.current_gear_ratio == 0.64
+        assert snap.tire_deflection_factor == 0.96
+
+    def test_non_numeric_values_default(self) -> None:
+        snap = AnalysisSettingsSnapshot.from_dict({"tire_width_mm": "not_a_number"})
+        assert snap.tire_width_mm == 0.0
+
+    def test_none_values_default(self) -> None:
+        snap = AnalysisSettingsSnapshot.from_dict({"rim_in": None})
+        assert snap.rim_in == 0.0
+
+    def test_infinity_defaults(self) -> None:
+        snap = AnalysisSettingsSnapshot.from_dict({"tire_width_mm": float("inf")})
+        assert snap.tire_width_mm == 0.0
+
+
+class TestAnalysisSettingsOrderRef:
+    """order_reference_spec property."""
+
+    def test_missing_tire_returns_none(self) -> None:
+        snap = AnalysisSettingsSnapshot()
+        assert snap.order_reference_spec is None
+
+    def test_valid_tire_returns_spec(self) -> None:
+        snap = AnalysisSettingsSnapshot.from_dict(
+            {"tire_width_mm": 285.0, "tire_aspect_pct": 30.0, "rim_in": 21.0}
+        )
+        spec = snap.order_reference_spec
+        assert isinstance(spec, OrderReferenceSpec)
+        assert spec.tire_spec is not None
+        assert spec.tire_spec.width_mm == 285.0
+
+
+# ── RunContextSnapshot ──────────────────────────────────────────────
+
+
+class TestRunContextSnapshotFromDict:
+    """from_dict() constructor tests."""
+
+    def test_empty_dict_never_raises(self) -> None:
+        ctx = RunContextSnapshot.from_dict({})
+        assert ctx.car is None
+        assert ctx.has_car_context is False
+        assert ctx.analysis_settings.tire_width_mm == 0.0
+
+    def test_with_settings_only(self) -> None:
+        ctx = RunContextSnapshot.from_dict({"analysis_settings_snapshot": {"tire_width_mm": 200.0}})
+        assert ctx.analysis_settings.tire_width_mm == 200.0
+        assert ctx.car is None
+
+    def test_with_car_snapshot(self) -> None:
+        ctx = RunContextSnapshot.from_dict(
+            {
+                "analysis_settings_snapshot": {"rim_in": 18.0},
+                "active_car_snapshot": {"name": "Test Car", "uuid": "abc-123"},
+            }
+        )
+        assert ctx.has_car_context is True
+        assert ctx.car is not None
+        assert isinstance(ctx.car, CarSnapshot)
+        assert ctx.car.name == "Test Car"
+
+    def test_order_reference_spec_delegates(self) -> None:
+        ctx = RunContextSnapshot.from_dict(
+            {
+                "analysis_settings_snapshot": {
+                    "tire_width_mm": 285.0,
+                    "tire_aspect_pct": 30.0,
+                    "rim_in": 21.0,
+                }
+            }
+        )
+        assert ctx.order_reference_spec is not None
+
+
+# ── SpeedStatsSnapshot ──────────────────────────────────────────────
+
+
+class TestSpeedStatsSnapshotFromDict:
+    """from_dict() constructor tests."""
+
+    def test_empty_dict_never_raises(self) -> None:
+        snap = SpeedStatsSnapshot.from_dict({})
+        assert snap.min_kmh is None
+        assert snap.steady_speed is False
+        assert snap.sample_count == 0
+
+    def test_round_trip(self) -> None:
+        data = {
+            "min_kmh": 40.0,
+            "max_kmh": 120.0,
+            "mean_kmh": 80.0,
+            "stddev_kmh": 10.5,
+            "range_kmh": 80.0,
+            "steady_speed": True,
+            "sample_count": 500,
+        }
+        snap = SpeedStatsSnapshot.from_dict(data)
+        assert snap.min_kmh == 40.0
+        assert snap.max_kmh == 120.0
+        assert snap.steady_speed is True
+        assert snap.sample_count == 500
+
+    def test_non_numeric_speed_defaults_to_none(self) -> None:
+        snap = SpeedStatsSnapshot.from_dict({"min_kmh": "bad"})
+        assert snap.min_kmh is None
+
+    def test_infinity_speed_defaults_to_none(self) -> None:
+        snap = SpeedStatsSnapshot.from_dict({"mean_kmh": float("inf")})
+        assert snap.mean_kmh is None
+
+
+# ── PhaseSummarySnapshot ────────────────────────────────────────────
+
+
+class TestPhaseSummarySnapshotFromDict:
+    """from_dict() constructor tests."""
+
+    def test_empty_dict_never_raises(self) -> None:
+        snap = PhaseSummarySnapshot.from_dict({})
+        assert snap.total_samples == 0
+        assert snap.has_cruise is False
+        assert dict(snap.phase_counts) == {}
+
+    def test_round_trip(self) -> None:
+        data = {
+            "phase_counts": {"cruise": 100, "accel": 50},
+            "phase_pcts": {"cruise": 0.66, "accel": 0.34},
+            "total_samples": 150,
+            "segment_count": 5,
+            "has_cruise": True,
+            "has_acceleration": True,
+            "cruise_pct": 0.66,
+            "idle_pct": 0.0,
+            "speed_unknown_pct": 0.0,
+        }
+        snap = PhaseSummarySnapshot.from_dict(data)
+        assert snap.total_samples == 150
+        assert snap.has_cruise is True
+        assert snap.phase_counts["cruise"] == 100
+        assert snap.cruise_pct == pytest.approx(0.66)
+
+    def test_invalid_phase_counts_skipped(self) -> None:
+        snap = PhaseSummarySnapshot.from_dict({"phase_counts": {"cruise": "bad", "accel": 10}})
+        assert "cruise" not in snap.phase_counts
+        assert snap.phase_counts["accel"] == 10
+
+    def test_phase_counts_immutable(self) -> None:
+        snap = PhaseSummarySnapshot.from_dict({"phase_counts": {"cruise": 5}})
+        with pytest.raises(TypeError):
+            snap.phase_counts["new"] = 1  # type: ignore[index]
+
+    def test_phase_pcts_immutable(self) -> None:
+        snap = PhaseSummarySnapshot.from_dict({"phase_pcts": {"cruise": 0.5}})
+        with pytest.raises(TypeError):
+            snap.phase_pcts["new"] = 0.1  # type: ignore[index]

--- a/apps/server/tests/domain/test_strength_metrics.py
+++ b/apps/server/tests/domain/test_strength_metrics.py
@@ -1,0 +1,108 @@
+"""Tests for domain strength measurement value objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import StrengthMetrics, StrengthPeak
+
+# ── StrengthPeak ────────────────────────────────────────────────────
+
+
+class TestStrengthPeakFromDict:
+    def test_empty_dict_never_raises(self) -> None:
+        p = StrengthPeak.from_dict({})
+        assert p.hz == 0.0
+        assert p.amp == 0.0
+        assert p.vibration_strength_db == 0.0
+        assert p.strength_bucket is None
+
+    def test_round_trip(self) -> None:
+        data = {
+            "hz": 42.5,
+            "amp": 0.03,
+            "vibration_strength_db": 12.3,
+            "strength_bucket": "moderate",
+        }
+        p = StrengthPeak.from_dict(data)
+        assert p.hz == 42.5
+        assert p.amp == 0.03
+        assert p.vibration_strength_db == pytest.approx(12.3)
+        assert p.strength_bucket == "moderate"
+
+    def test_invalid_hz_defaults(self) -> None:
+        p = StrengthPeak.from_dict({"hz": "bad"})
+        assert p.hz == 0.0
+
+    def test_infinity_defaults(self) -> None:
+        p = StrengthPeak.from_dict({"amp": float("inf")})
+        assert p.amp == 0.0
+
+    def test_empty_bucket_becomes_none(self) -> None:
+        p = StrengthPeak.from_dict({"strength_bucket": ""})
+        assert p.strength_bucket is None
+
+
+# ── StrengthMetrics ─────────────────────────────────────────────────
+
+
+class TestStrengthMetricsFromDict:
+    def test_empty_dict_never_raises(self) -> None:
+        m = StrengthMetrics.from_dict({})
+        assert m.vibration_strength_db == 0.0
+        assert m.peak_amp_g == 0.0
+        assert m.noise_floor_amp_g == 0.0
+        assert m.strength_bucket is None
+        assert m.top_peaks == ()
+
+    def test_round_trip(self) -> None:
+        data = {
+            "vibration_strength_db": 18.5,
+            "peak_amp_g": 0.05,
+            "noise_floor_amp_g": 0.002,
+            "strength_bucket": "strong",
+            "top_peaks": [
+                {
+                    "hz": 42.0,
+                    "amp": 0.05,
+                    "vibration_strength_db": 18.5,
+                    "strength_bucket": "strong",
+                },
+                {
+                    "hz": 84.0,
+                    "amp": 0.02,
+                    "vibration_strength_db": 10.0,
+                    "strength_bucket": "moderate",
+                },
+            ],
+        }
+        m = StrengthMetrics.from_dict(data)
+        assert m.vibration_strength_db == pytest.approx(18.5)
+        assert len(m.top_peaks) == 2
+        assert m.top_peaks[0].hz == 42.0
+        assert m.top_peaks[1].strength_bucket == "moderate"
+
+    def test_non_mapping_peaks_skipped(self) -> None:
+        m = StrengthMetrics.from_dict({"top_peaks": [42, "bad", {"hz": 10.0}]})
+        assert len(m.top_peaks) == 1
+        assert m.top_peaks[0].hz == 10.0
+
+    def test_no_top_peaks_key(self) -> None:
+        m = StrengthMetrics.from_dict({"vibration_strength_db": 5.0})
+        assert m.top_peaks == ()
+
+    def test_from_typed_dict_alias(self) -> None:
+        data = {
+            "vibration_strength_db": 7.0,
+            "peak_amp_g": 0.01,
+            "noise_floor_amp_g": 0.001,
+            "strength_bucket": None,
+            "top_peaks": [],
+        }
+        m = StrengthMetrics.from_typed_dict(data)
+        assert m.vibration_strength_db == 7.0
+        assert m.top_peaks == ()
+
+    def test_top_peaks_immutable(self) -> None:
+        m = StrengthMetrics.from_dict({"top_peaks": [{"hz": 1.0}]})
+        assert isinstance(m.top_peaks, tuple)

--- a/apps/server/tests/hygiene/test_domain_architecture.py
+++ b/apps/server/tests/hygiene/test_domain_architecture.py
@@ -1475,3 +1475,142 @@ def test_lifecycle_mutability_rules() -> None:
         assert dataclasses.is_dataclass(cls), f"{cls.__name__} must be a dataclass"
         frozen = cls.__dataclass_params__.frozen  # type: ignore[attr-defined]
         assert frozen, f"{cls.__name__} must be frozen (immutable once produced)"
+
+
+# ── Domain model type completeness guardrails ───────────────────────────
+
+# Single list of domain-model types that must be importable from vibesensor.domain.
+_EXPECTED_DOMAIN_EXPORTS = [
+    # Aggregates and entities
+    "Car",
+    "DiagnosticCase",
+    "Run",
+    "TestRun",
+    # Value objects — car and context
+    "CarSnapshot",
+    "OrderReferenceSpec",
+    "TireSpec",
+    # Value objects — snapshots
+    "AnalysisSettingsSnapshot",
+    "PhaseSummarySnapshot",
+    "RunContextSnapshot",
+    "SpeedStatsSnapshot",
+    # Value objects — run and capture
+    "ConfigurationSnapshot",
+    "Measurement",
+    "RunCapture",
+    "RunSetup",
+    "VibrationReading",
+    # Value objects — findings and diagnostics
+    "ConfidenceAssessment",
+    "Finding",
+    "FindingEvidence",
+    "FindingKind",
+    "LocationHotspot",
+    "Signature",
+    "StrengthMetrics",
+    "StrengthPeak",
+    "VibrationOrigin",
+    "VibrationSource",
+    # Value objects — run context
+    "DrivingPhase",
+    "DrivingSegment",
+    "RunStatus",
+    "RunSuitability",
+    "Sensor",
+    "SensorPlacement",
+    "SpeedProfile",
+    "SpeedSource",
+    "SpeedSourceKind",
+    "SuitabilityCheck",
+    "Symptom",
+    # Test plan
+    "RecommendedAction",
+    "TestPlan",
+    # Functions
+    "RUN_TRANSITIONS",
+    "plan_test_actions",
+    "speed_band_sort_key",
+    "speed_bin_label",
+    "transition_run",
+]
+
+
+@pytest.mark.parametrize("name", _EXPECTED_DOMAIN_EXPORTS)
+def test_all_domain_model_types_importable(name: str) -> None:
+    """Every domain-model type must be importable from ``vibesensor.domain``."""
+    import importlib
+
+    mod = importlib.import_module("vibesensor.domain")
+    assert hasattr(mod, name), f"{name} must be exported from vibesensor.domain"
+
+
+def test_domain_exports_completeness() -> None:
+    """``__all__`` in vibesensor.domain must cover every expected domain export."""
+    import importlib
+
+    mod = importlib.import_module("vibesensor.domain")
+    all_names = set(getattr(mod, "__all__", []))
+    missing = [n for n in _EXPECTED_DOMAIN_EXPORTS if n not in all_names]
+    assert not missing, f"Missing from domain __all__: {missing}"
+
+
+def test_domain_import_direction() -> None:
+    """Domain modules must NOT import from shared/boundaries/, adapters/, or infra/."""
+    import ast
+
+    from tests._paths import SERVER_ROOT
+
+    domain_dir = SERVER_ROOT / "vibesensor" / "domain"
+    violations: list[str] = []
+    forbidden_prefixes = (
+        "vibesensor.shared.boundaries",
+        "vibesensor.adapters",
+        "vibesensor.infra",
+    )
+    for py_file in domain_dir.glob("*.py"):
+        source = py_file.read_text()
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for prefix in forbidden_prefixes:
+                    if node.module.startswith(prefix):
+                        violations.append(f"{py_file.name} imports from {node.module}")
+    assert not violations, (
+        f"Domain modules must not import from boundary/adapter/infra layers: {violations}"
+    )
+
+
+def test_domain_code_does_not_access_raw_tire_fields() -> None:
+    """Domain-layer code must not read raw tire fields directly from
+    AnalysisSettingsSnapshot — only through order_reference_spec.
+
+    Exceptions: the snapshot's own from_dict() factory, property definitions,
+    and __init__ (dataclass construction).
+    """
+    import ast
+
+    from tests._paths import SERVER_ROOT
+
+    domain_dir = SERVER_ROOT / "vibesensor" / "domain"
+    raw_tire_fields = {"tire_width_mm", "tire_aspect_pct", "rim_in"}
+    violations: list[str] = []
+    for py_file in domain_dir.glob("*.py"):
+        if py_file.name in ("snapshots.py", "car.py"):
+            continue  # snapshots.py defines these fields; car.py uses TireSpec's own fields
+        source = py_file.read_text()
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(node.attr, str):
+                if node.attr in raw_tire_fields:
+                    violations.append(f"{py_file.name}:{node.lineno} accesses .{node.attr}")
+    assert not violations, (
+        f"Domain code must not access raw tire fields on AnalysisSettingsSnapshot "
+        f"(use order_reference_spec instead): {violations}"
+    )

--- a/apps/server/tests/infra/processing/test_sample_builder.py
+++ b/apps/server/tests/infra/processing/test_sample_builder.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vibesensor.domain import AnalysisSettingsSnapshot
 from vibesensor.use_cases.run.sample_builder import (
     build_run_metadata,
     build_sample_records,
@@ -145,7 +146,7 @@ class TestResolveSpeedContext:
         gps.speed_mps = None
         gps.effective_speed_mps = None
         gps.resolve_speed.return_value = MagicMock(source="none")
-        settings = {}
+        settings = AnalysisSettingsSnapshot()
         speed, gps_speed, source, rpm = resolve_speed_context(gps, settings)
         assert speed is None
         assert rpm is None
@@ -155,13 +156,13 @@ class TestResolveSpeedContext:
         gps = MagicMock()
         gps.speed_mps = 10.0
         gps.resolve_speed.return_value = MagicMock(source="gps", speed_mps=10.0)
-        settings = {
-            "tire_width_mm": 205.0,
-            "tire_aspect_pct": 55.0,
-            "rim_in": 16.0,
-            "final_drive_ratio": 3.73,
-            "current_gear_ratio": 1.0,
-        }
+        settings = AnalysisSettingsSnapshot(
+            tire_width_mm=205.0,
+            tire_aspect_pct=55.0,
+            rim_in=16.0,
+            final_drive_ratio=3.73,
+            current_gear_ratio=1.0,
+        )
         speed, gps_speed, source, rpm = resolve_speed_context(gps, settings)
         assert speed == pytest.approx(36.0, rel=0.01)
         assert source == "gps"
@@ -220,7 +221,7 @@ def _default_run_metadata_kwargs(**overrides) -> dict:
     defaults: dict = {
         "run_id": "test-run",
         "start_time_utc": "2026-01-01T00:00:00Z",
-        "analysis_settings_snapshot": {},
+        "analysis_settings_snapshot": AnalysisSettingsSnapshot(),
         "sensor_model": "test",
         "firmware_version": None,
         "default_sample_rate_hz": 800,
@@ -238,11 +239,11 @@ class TestBuildRunMetadata:
             **_default_run_metadata_kwargs(
                 sensor_model="ADXL345",
                 fft_window_size_samples=1024,
-                analysis_settings_snapshot={
-                    "tire_width_mm": 205.0,
-                    "tire_aspect_pct": 55.0,
-                    "rim_in": 16.0,
-                },
+                analysis_settings_snapshot=AnalysisSettingsSnapshot(
+                    tire_width_mm=205.0,
+                    tire_aspect_pct=55.0,
+                    rim_in=16.0,
+                ),
             ),
         )
         assert meta["run_id"] == "test-run"
@@ -291,7 +292,7 @@ class TestBuildSampleRecords:
             registry=reg,
             processor=proc,
             gps_monitor=gps,
-            analysis_settings_snapshot={},
+            analysis_settings_snapshot=AnalysisSettingsSnapshot(),
             default_sample_rate_hz=800,
         )
         assert records == []

--- a/apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py
+++ b/apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py
@@ -1,0 +1,125 @@
+"""Golden-file regression test for boundary reconstruction.
+
+Uses ``examples/sample_complete_run.jsonl`` to verify historical summaries
+reconstruct correctly through ``test_run_from_summary`` → domain objects.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vibesensor.domain.snapshots import PhaseSummarySnapshot, SpeedStatsSnapshot
+from vibesensor.shared.boundaries.diagnostic_case import (
+    speed_profile_from_stats,
+)
+from vibesensor.shared.boundaries.diagnostic_case import (
+    test_run_from_summary as _reconstruct,
+)
+from vibesensor.use_cases.diagnostics import summarize_run_data
+
+_GOLDEN_FILE = Path(__file__).resolve().parents[5] / "examples" / "sample_complete_run.jsonl"
+
+
+@pytest.fixture(scope="module")
+def golden_summary() -> dict:
+    """Load golden JSONL, run through analysis pipeline, return summary."""
+    records: list[dict] = []
+    with _GOLDEN_FILE.open() as f:
+        for line in f:
+            records.append(json.loads(line))
+
+    metadata = records[0]
+    samples = [r for r in records if r.get("record_type") == "sample"]
+    return summarize_run_data(metadata, samples)
+
+
+class TestGoldenFileReconstruction:
+    def test_test_run_from_summary_does_not_raise(self, golden_summary: dict) -> None:
+        test_run = _reconstruct(golden_summary)
+        assert test_run is not None
+        assert test_run.capture.run_id
+
+    def test_speed_profile_reconstructed(self, golden_summary: dict) -> None:
+        test_run = _reconstruct(golden_summary)
+        # The golden file has speed data, so speed_profile should exist
+        if "speed_stats" in golden_summary:
+            assert test_run.speed_profile is not None
+            assert test_run.speed_profile.sample_count >= 0
+
+    def test_findings_reconstructed(self, golden_summary: dict) -> None:
+        test_run = _reconstruct(golden_summary)
+        # Every finding must have a confidence assessment after backfill
+        for f in test_run.findings:
+            assert f.confidence_assessment is not None
+
+    def test_speed_profile_from_typed_snapshots_matches(self, golden_summary: dict) -> None:
+        """Typed snapshot construction produces the same SpeedProfile as
+        the full test_run_from_summary pipeline."""
+        test_run = _reconstruct(golden_summary)
+        raw_speed_stats = golden_summary.get("speed_stats")
+        raw_phase_info = golden_summary.get("phase_info", golden_summary.get("phase_summary"))
+
+        if raw_speed_stats is None:
+            pytest.skip("No speed_stats in golden summary")
+
+        sp = speed_profile_from_stats(
+            SpeedStatsSnapshot.from_dict(raw_speed_stats),
+            PhaseSummarySnapshot.from_dict(raw_phase_info) if raw_phase_info else None,
+        )
+        assert sp == test_run.speed_profile
+
+
+class TestRoundTripParity:
+    """Round-trip parity tests for snapshot from_dict factories."""
+
+    def test_speed_stats_snapshot_from_dict_empty(self) -> None:
+        snap = SpeedStatsSnapshot.from_dict({})
+        assert snap.min_kmh is None
+        assert snap.max_kmh is None
+        assert snap.steady_speed is False
+        assert snap.sample_count == 0
+
+    def test_speed_stats_snapshot_from_dict_partial(self) -> None:
+        snap = SpeedStatsSnapshot.from_dict({"min_kmh": 30, "max_kmh": 80})
+        assert snap.min_kmh == 30.0
+        assert snap.max_kmh == 80.0
+        assert snap.steady_speed is False
+        assert snap.sample_count == 0
+
+    def test_phase_summary_snapshot_from_dict_empty(self) -> None:
+        snap = PhaseSummarySnapshot.from_dict({})
+        assert snap.has_cruise is False
+        assert snap.has_acceleration is False
+        assert snap.cruise_pct == 0.0
+
+    def test_phase_summary_fallback_to_phase_counts(self) -> None:
+        """When top-level has_cruise is missing, fall back to phase_counts."""
+        snap = PhaseSummarySnapshot.from_dict(
+            {
+                "phase_counts": {"cruise": 10, "acceleration": 5},
+            }
+        )
+        assert snap.has_cruise is True
+        assert snap.has_acceleration is True
+
+    def test_phase_summary_fallback_to_phase_pcts(self) -> None:
+        """When top-level cruise_pct is missing, fall back to phase_pcts."""
+        snap = PhaseSummarySnapshot.from_dict(
+            {
+                "phase_pcts": {"cruise": 45.0, "idle": 12.0, "speed_unknown": 8.0},
+            }
+        )
+        assert snap.cruise_pct == pytest.approx(45.0)
+        assert snap.idle_pct == pytest.approx(12.0)
+        assert snap.speed_unknown_pct == pytest.approx(8.0)
+
+    def test_speed_profile_from_stats_with_empty_snapshots(self) -> None:
+        sp = speed_profile_from_stats(SpeedStatsSnapshot())
+        assert sp.min_kmh == 0.0
+        assert sp.max_kmh == 0.0
+        assert sp.steady_speed is False
+        assert sp.sample_count == 0
+        assert sp.cruise_fraction == 0.0

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
@@ -128,12 +128,9 @@ def test_snapshot_returns_copy_of_defaults(tmp_path) -> None:
     db = HistoryDB(tmp_path / "test.db")
     store = SettingsStore(db=db)
     snap = store.analysis_settings_snapshot()
-    assert snap == DEFAULT_ANALYSIS_SETTINGS
-    snap["tire_width_mm"] = 999.0
-    assert (
-        store.analysis_settings_snapshot()["tire_width_mm"]
-        == DEFAULT_ANALYSIS_SETTINGS["tire_width_mm"]
-    )
+    # Frozen dataclass — values match defaults and instance is immutable
+    assert snap.tire_width_mm == DEFAULT_ANALYSIS_SETTINGS["tire_width_mm"]
+    assert snap.rim_in == DEFAULT_ANALYSIS_SETTINGS["rim_in"]
 
 
 def test_update_merges_valid_values(tmp_path) -> None:
@@ -146,8 +143,8 @@ def test_update_merges_valid_values(tmp_path) -> None:
     store.set_active_car(initial["cars"][0]["id"])
     store.update_active_car_aspects({"tire_width_mm": 225.0})
     result = store.analysis_settings_snapshot()
-    assert result["tire_width_mm"] == 225.0
-    assert result["rim_in"] == DEFAULT_ANALYSIS_SETTINGS["rim_in"]
+    assert result.tire_width_mm == 225.0
+    assert result.rim_in == DEFAULT_ANALYSIS_SETTINGS["rim_in"]
 
 
 def test_update_rejects_invalid_and_keeps_old(tmp_path) -> None:
@@ -160,7 +157,7 @@ def test_update_rejects_invalid_and_keeps_old(tmp_path) -> None:
     store.set_active_car(initial["cars"][0]["id"])
     store.update_active_car_aspects({"tire_width_mm": -5.0})
     assert (
-        store.analysis_settings_snapshot()["tire_width_mm"]
+        store.analysis_settings_snapshot().tire_width_mm
         == DEFAULT_ANALYSIS_SETTINGS["tire_width_mm"]
     )
 

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py
@@ -58,13 +58,13 @@ async def test_analysis_settings_endpoint_updates_active_car_aspects(_wiring) ->
 
     await set_analysis(AnalysisSettingsRequest(tire_width_mm=255.0))
     assert settings_store.active_car_aspects()["tire_width_mm"] == 255.0
-    assert settings_store.analysis_settings_snapshot()["tire_width_mm"] == 255.0
+    assert settings_store.analysis_settings_snapshot().tire_width_mm == 255.0
 
     cars = response_payload(
         await add_car(CarUpsertRequest(name="Second", aspects={"tire_width_mm": 225.0})),
     )
     second_id = cars["cars"][1]["id"]
     await set_active(ActiveCarRequest(carId=second_id))
-    assert settings_store.analysis_settings_snapshot()["tire_width_mm"] == 225.0
+    assert settings_store.analysis_settings_snapshot().tire_width_mm == 225.0
     current = response_payload(await get_cars())
     assert current["activeCarId"] == second_id

--- a/apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py
+++ b/apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from test_support.findings import make_finding_payload
 
-from vibesensor.domain import Finding, RunSuitability
+from vibesensor.domain import AnalysisSettingsSnapshot, Finding, RunSuitability
 from vibesensor.shared.boundaries.finding import finding_from_payload
 from vibesensor.use_cases.diagnostics import summarize_run_data
 from vibesensor.use_cases.diagnostics.order_analysis import (
@@ -88,14 +88,13 @@ def _make_run_recorder() -> tuple[RunRecorder, MagicMock]:
     registry.active_client_ids.return_value = []
 
     settings_mock = MagicMock()
-    settings_mock.analysis_settings_snapshot.return_value = {
-        "tire_width_mm": 205,
-        "tire_aspect_pct": 55,
-        "rim_in": 16,
-        "final_drive_ratio": 3.73,
-        "current_gear_ratio": 1.0,
-        "tire_deflection_factor": None,
-    }
+    settings_mock.analysis_settings_snapshot.return_value = AnalysisSettingsSnapshot(
+        tire_width_mm=205,
+        tire_aspect_pct=55,
+        rim_in=16,
+        final_drive_ratio=3.73,
+        current_gear_ratio=1.0,
+    )
 
     logger = RunRecorder(
         RunRecorderConfig(
@@ -613,14 +612,12 @@ class TestResolveSpeedContext:
         gps_mock.resolve_speed.return_value = MagicMock(source="gps", speed_mps=15.0)
         # Remove gear ratio from settings via settings_store mock
         settings_mock = logger._settings_store
-        settings_mock.analysis_settings_snapshot.return_value = {
-            "tire_width_mm": 205,
-            "tire_aspect_pct": 55,
-            "rim_in": 16,
-            "final_drive_ratio": 3.73,
-            "current_gear_ratio": None,  # missing
-            "tire_deflection_factor": None,
-        }
+        settings_mock.analysis_settings_snapshot.return_value = AnalysisSettingsSnapshot(
+            tire_width_mm=205,
+            tire_aspect_pct=55,
+            rim_in=16,
+            final_drive_ratio=3.73,
+        )
         _, _, _, rpm = resolve_speed_context(
             logger.gps_monitor,
             logger._analysis_settings_snapshot(),

--- a/apps/server/tests/use_cases/diagnostics/test_run_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_run_analysis.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 
 from vibesensor.domain import SpeedProfile
+from vibesensor.domain.snapshots import PhaseSummarySnapshot, SpeedStatsSnapshot
 from vibesensor.shared.boundaries.diagnostic_case import speed_profile_from_stats
 from vibesensor.use_cases.diagnostics.helpers import _speed_stats
 from vibesensor.use_cases.diagnostics.summary_builder import (
@@ -84,7 +85,10 @@ class TestPreparedRunDataProperties:
         speed_stats = _speed_stats(prepared.speed_values)
         phase_info = build_phase_summary(prepared.phase_segments)
 
-        assert prepared.speed_profile == speed_profile_from_stats(speed_stats, phase_info)
+        assert prepared.speed_profile == speed_profile_from_stats(
+            SpeedStatsSnapshot.from_dict(speed_stats),
+            PhaseSummarySnapshot.from_dict(phase_info),
+        )
         assert prepared.speed_profile.min_kmh == pytest.approx(speed_stats["min_kmh"])
         assert prepared.speed_profile.max_kmh == pytest.approx(speed_stats["max_kmh"])
         assert prepared.speed_profile.has_acceleration is True

--- a/apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py
+++ b/apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py
@@ -1,13 +1,12 @@
 """Guardrail tests ensuring key definitions have a single source of truth.
 
 These tests prevent regression of the consolidation work by verifying:
-1. DEFAULT_DIAGNOSTIC_SETTINGS is the same object as DEFAULT_ANALYSIS_SETTINGS
-2. Spectrum payloads do not contain dead alias fields
-3. The strength_scoring module does not exist
-4. Metrics log records use canonical field names only
-5. as_float_or_none is the single canonical float converter
-6. percentile is the single canonical percentile implementation
-7. compute_vibration_strength_db output has no dead alias fields
+1. Spectrum payloads do not contain dead alias fields
+2. The strength_scoring module does not exist
+3. Metrics log records use canonical field names only
+4. as_float_or_none is the single canonical float converter
+5. percentile is the single canonical percentile implementation
+6. compute_vibration_strength_db output has no dead alias fields
 """
 
 from __future__ import annotations
@@ -18,19 +17,6 @@ import pytest
 from _paths import REPO_ROOT, SERVER_ROOT
 
 from vibesensor.infra.config.analysis_settings import DEFAULT_ANALYSIS_SETTINGS
-from vibesensor.use_cases.diagnostics.order_bands import DEFAULT_DIAGNOSTIC_SETTINGS
-
-
-def test_diagnostic_settings_is_analysis_settings() -> None:
-    """DEFAULT_DIAGNOSTIC_SETTINGS must be the same object as DEFAULT_ANALYSIS_SETTINGS."""
-    assert DEFAULT_DIAGNOSTIC_SETTINGS is DEFAULT_ANALYSIS_SETTINGS
-
-
-def test_analysis_settings_keys_match() -> None:
-    """Both default dicts have identical keys and values."""
-    assert set(DEFAULT_DIAGNOSTIC_SETTINGS.keys()) == set(DEFAULT_ANALYSIS_SETTINGS.keys())
-    for key in DEFAULT_ANALYSIS_SETTINGS:
-        assert DEFAULT_DIAGNOSTIC_SETTINGS[key] == DEFAULT_ANALYSIS_SETTINGS[key]
 
 
 def test_strength_scoring_module_removed() -> None:

--- a/apps/server/tests/use_cases/run/conftest.py
+++ b/apps/server/tests/use_cases/run/conftest.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import pytest
 
+from vibesensor.domain.car import CarSnapshot
+from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
 # ---------------------------------------------------------------------------
@@ -150,16 +152,16 @@ class _FakeProcessor:
 
 
 class _FakeAnalysisSettings:
-    def analysis_settings_snapshot(self) -> dict[str, float]:
-        return {
-            "tire_width_mm": 285.0,
-            "tire_aspect_pct": 30.0,
-            "rim_in": 21.0,
-            "final_drive_ratio": 3.08,
-            "current_gear_ratio": 0.64,
-        }
+    def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
+        return AnalysisSettingsSnapshot(
+            tire_width_mm=285.0,
+            tire_aspect_pct=30.0,
+            rim_in=21.0,
+            final_drive_ratio=3.08,
+            current_gear_ratio=0.64,
+        )
 
-    def active_car_snapshot(self) -> dict[str, Any] | None:
+    def active_car_snapshot(self) -> CarSnapshot | None:
         return None
 
 
@@ -173,8 +175,8 @@ class _MutableFakeAnalysisSettings(_FakeAnalysisSettings):
             "current_gear_ratio": 0.64,
         }
 
-    def analysis_settings_snapshot(self) -> dict[str, float]:
-        return dict(self.values)
+    def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
+        return AnalysisSettingsSnapshot.from_dict(self.values)
 
 
 class _FakeHistoryDB:

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -9,6 +9,7 @@ import pytest
 from test_support.core import wait_until
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot
 from vibesensor.use_cases.run.post_analysis import PostAnalysisHealthSnapshot
 from vibesensor.use_cases.run.sample_builder import safe_metric
 
@@ -576,25 +577,25 @@ def test_run_metadata_captures_active_car_snapshot(make_logger) -> None:
         "SettingsStoreStub",
         (),
         {
-            "active_car_snapshot": lambda self: {
-                "id": "car-1",
-                "name": "Primary",
-                "type": "sedan",
-                "aspects": {
+            "active_car_snapshot": lambda self: CarSnapshot(
+                car_id="car-1",
+                name="Primary",
+                car_type="sedan",
+                aspects={
                     "tire_width_mm": 255.0,
                     "tire_aspect_pct": 40.0,
                     "rim_in": 19.0,
                     "final_drive_ratio": 3.15,
                     "current_gear_ratio": 0.81,
                 },
-            },
-            "analysis_settings_snapshot": lambda self: {
-                "tire_width_mm": 255.0,
-                "tire_aspect_pct": 40.0,
-                "rim_in": 19.0,
-                "final_drive_ratio": 3.15,
-                "current_gear_ratio": 0.81,
-            },
+            ),
+            "analysis_settings_snapshot": lambda self: AnalysisSettingsSnapshot(
+                tire_width_mm=255.0,
+                tire_aspect_pct=40.0,
+                rim_in=19.0,
+                final_drive_ratio=3.15,
+                current_gear_ratio=0.81,
+            ),
         },
     )()
     logger = make_logger(settings_store=settings_store)

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException
@@ -156,7 +157,7 @@ def create_settings_routes(
 
     @router.get("/api/settings/analysis", response_model=AnalysisSettingsResponse)
     async def get_analysis_settings() -> AnalysisSettingsResponse:
-        return AnalysisSettingsResponse(**settings_store.analysis_settings_snapshot())
+        return AnalysisSettingsResponse(**asdict(settings_store.analysis_settings_snapshot()))
 
     @router.post("/api/settings/analysis", response_model=AnalysisSettingsResponse)
     async def set_analysis_settings(req: AnalysisSettingsRequest) -> AnalysisSettingsResponse:
@@ -164,6 +165,6 @@ def create_settings_routes(
         if changes:
             with domain_errors_to_http(catch_value_error=400):
                 await asyncio.to_thread(settings_store.update_active_car_aspects, changes)
-        return AnalysisSettingsResponse(**settings_store.analysis_settings_snapshot())
+        return AnalysisSettingsResponse(**asdict(settings_store.analysis_settings_snapshot()))
 
     return router

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -34,7 +34,7 @@ RunSuitability
     Whether a run is trustworthy enough for diagnosis.
 """
 
-from .car import Car, TireSpec
+from .car import Car, CarSnapshot, OrderReferenceSpec, TireSpec
 from .confidence_assessment import ConfidenceAssessment
 from .diagnostic_case import DiagnosticCase, Symptom
 from .driving_segment import DrivingPhase, DrivingSegment
@@ -53,50 +53,70 @@ from .run_capture import ConfigurationSnapshot, Measurement, RunCapture, RunSetu
 from .run_status import RUN_TRANSITIONS, RunStatus, transition_run
 from .run_suitability import RunSuitability, SuitabilityCheck
 from .sensor import Sensor, SensorPlacement
+from .snapshots import (
+    AnalysisSettingsSnapshot,
+    PhaseSummarySnapshot,
+    RunContextSnapshot,
+    SpeedStatsSnapshot,
+)
 from .speed_profile import SpeedProfile
 from .speed_source import SpeedSource, SpeedSourceKind
+from .strength_metrics import StrengthMetrics, StrengthPeak
 from .test_plan import RecommendedAction, TestPlan, plan_test_actions
 from .test_run import TestRun
 from .vibration_origin import VibrationOrigin
 
 __all__ = [
-    # Primary domain names (prefer these)
+    # Aggregates and entities
     "Car",
-    "ConfigurationSnapshot",
-    "ConfidenceAssessment",
     "DiagnosticCase",
-    "DrivingSegment",
-    "DrivingPhase",
+    "Run",
+    "TestRun",
+    # Value objects — car and context
+    "CarSnapshot",
+    "OrderReferenceSpec",
+    "TireSpec",
+    # Value objects — snapshots
+    "AnalysisSettingsSnapshot",
+    "PhaseSummarySnapshot",
+    "RunContextSnapshot",
+    "SpeedStatsSnapshot",
+    # Value objects — run and capture
+    "ConfigurationSnapshot",
+    "Measurement",
+    "RunCapture",
+    "RunSetup",
+    "VibrationReading",
+    # Value objects — findings and diagnostics
+    "ConfidenceAssessment",
     "Finding",
     "FindingEvidence",
     "FindingKind",
     "LocationHotspot",
-    "Measurement",
-    "RecommendedAction",
-    "RUN_TRANSITIONS",
-    "Run",
-    "RunCapture",
-    "RunSetup",
+    "Signature",
+    "StrengthMetrics",
+    "StrengthPeak",
+    "VibrationOrigin",
+    "VibrationSource",
+    # Value objects — run context
+    "DrivingPhase",
+    "DrivingSegment",
     "RunStatus",
     "RunSuitability",
     "Sensor",
     "SensorPlacement",
-    "Signature",
     "SpeedProfile",
-    "speed_band_sort_key",
-    "speed_bin_label",
     "SpeedSource",
     "SpeedSourceKind",
-    "Symptom",
     "SuitabilityCheck",
+    "Symptom",
+    # Test plan
+    "RecommendedAction",
     "TestPlan",
-    "TestRun",
-    "TireSpec",
-    "VibrationSource",
-    "VibrationOrigin",
-    "transition_run",
-    # Service functions
+    # Functions
+    "RUN_TRANSITIONS",
     "plan_test_actions",
-    # Existing names
-    "VibrationReading",
+    "speed_band_sort_key",
+    "speed_bin_label",
+    "transition_run",
 ]

--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -1,8 +1,11 @@
-"""The vehicle under test.
+"""The vehicle under test and car-scoped interpretive context.
 
 ``Car`` owns identity, user-facing name, vehicle type, and geometry aspects
 (tire dimensions, gear ratios) that drive order analysis.  ``TireSpec``
 encapsulates the three standard tire dimensions and derived geometry.
+``OrderReferenceSpec`` owns tire geometry and driveline/reference-order
+interpretation.  ``CarSnapshot`` is typed internal car context attached
+to a run.
 Configuration and persistence details remain in ``CarConfig``.
 """
 
@@ -16,6 +19,8 @@ from types import MappingProxyType
 
 __all__ = [
     "Car",
+    "CarSnapshot",
+    "OrderReferenceSpec",
     "TireSpec",
 ]
 
@@ -72,6 +77,147 @@ class TireSpec:
         return self.diameter_mm / 1000.0 * math.pi * self.deflection_factor
 
 
+# ---------------------------------------------------------------------------
+# OrderReferenceSpec — tire geometry + driveline/reference-order interpretation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class OrderReferenceSpec:
+    """Canonical typed owner of tire geometry and driveline/reference-order
+    interpretation within a Car context.
+
+    Owns the data needed to derive wheel, driveshaft, and engine reference
+    frequencies from vehicle speed.
+    """
+
+    tire_spec: TireSpec
+    final_drive_ratio: float
+    current_gear_ratio: float
+    wheel_bandwidth_pct: float
+    driveshaft_bandwidth_pct: float
+    engine_bandwidth_pct: float
+    speed_uncertainty_pct: float
+    tire_diameter_uncertainty_pct: float
+    final_drive_uncertainty_pct: float
+    gear_uncertainty_pct: float
+    min_abs_band_hz: float
+    max_band_half_width_pct: float
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: Mapping[str, float],
+        deflection_factor: float = 1.0,
+    ) -> OrderReferenceSpec | None:
+        """Build from a flat settings mapping.
+
+        Returns ``None`` if tire geometry keys are missing or invalid.
+        """
+        tire = TireSpec.from_aspects(settings, deflection_factor=deflection_factor)
+        if tire is None:
+            return None
+
+        def _f(key: str, default: float = 0.0) -> float:
+            v = settings.get(key)
+            if v is None or not math.isfinite(v):
+                return default
+            return float(v)
+
+        return cls(
+            tire_spec=tire,
+            final_drive_ratio=_f("final_drive_ratio"),
+            current_gear_ratio=_f("current_gear_ratio"),
+            wheel_bandwidth_pct=_f("wheel_bandwidth_pct"),
+            driveshaft_bandwidth_pct=_f("driveshaft_bandwidth_pct"),
+            engine_bandwidth_pct=_f("engine_bandwidth_pct"),
+            speed_uncertainty_pct=_f("speed_uncertainty_pct"),
+            tire_diameter_uncertainty_pct=_f("tire_diameter_uncertainty_pct"),
+            final_drive_uncertainty_pct=_f("final_drive_uncertainty_pct"),
+            gear_uncertainty_pct=_f("gear_uncertainty_pct"),
+            min_abs_band_hz=_f("min_abs_band_hz"),
+            max_band_half_width_pct=_f("max_band_half_width_pct"),
+        )
+
+    # -- queries -----------------------------------------------------------
+
+    @property
+    def tire_circumference_m(self) -> float:
+        """Tire circumference in metres (deflection-adjusted)."""
+        return self.tire_spec.circumference_m
+
+    @property
+    def has_engine_reference(self) -> bool:
+        """Whether gear ratio is set (non-zero) for engine order analysis."""
+        return self.current_gear_ratio != 0.0
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether all required fields are present for order analysis."""
+        return self.final_drive_ratio > 0.0 and self.tire_spec.circumference_m > 0.0
+
+
+# ---------------------------------------------------------------------------
+# CarSnapshot — typed internal car context attached to a run
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CarSnapshot:
+    """Typed internal car context attached to a run.
+
+    Not an aggregate — a supporting typed internal object for run-attached
+    car interpretation context.
+    """
+
+    car_id: str | None = None
+    name: str | None = None
+    car_type: str | None = None
+    variant: str | None = None
+    aspects: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.aspects, MappingProxyType):
+            object.__setattr__(self, "aspects", MappingProxyType(dict(self.aspects)))
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> CarSnapshot:
+        """Parse from a flat mapping. Missing keys default to ``None``/empty."""
+        raw_aspects = d.get("aspects")
+        aspects: dict[str, float] = {}
+        if isinstance(raw_aspects, dict):
+            for k, v in raw_aspects.items():
+                if isinstance(k, str):
+                    try:
+                        aspects[k] = float(v)
+                    except (TypeError, ValueError):
+                        pass
+        return cls(
+            car_id=_str_or_none(d.get("id") or d.get("car_id")),
+            name=_str_or_none(d.get("name")),
+            car_type=_str_or_none(d.get("type") or d.get("car_type")),
+            variant=_str_or_none(d.get("variant")),
+            aspects=aspects,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Project to a persistence-compatible dict."""
+        return {
+            "id": self.car_id,
+            "name": self.name,
+            "type": self.car_type,
+            "variant": self.variant,
+            "aspects": dict(self.aspects),
+        }
+
+
+def _str_or_none(v: object) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s if s else None
+
+
 @dataclass(frozen=True, slots=True)
 class Car:
     """The vehicle under test.
@@ -86,6 +232,7 @@ class Car:
     car_type: str = "sedan"
     aspects: Mapping[str, float] = field(default_factory=dict)
     variant: str | None = None
+    order_reference_spec: OrderReferenceSpec | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if not self.name or not self.name.strip():
@@ -99,6 +246,12 @@ class Car:
                 raise ValueError(
                     f"Car.aspects[{key!r}] must be a positive finite number, got {val}"
                 )
+        # Eagerly derive OrderReferenceSpec from aspects when tire geometry is present.
+        deflection = self.aspects.get("tire_deflection_factor", 1.0)
+        if not isinstance(deflection, (int, float)) or not math.isfinite(deflection):
+            deflection = 1.0
+        spec = OrderReferenceSpec.from_settings(dict(self.aspects), deflection_factor=deflection)
+        object.__setattr__(self, "order_reference_spec", spec)
 
     # -- queries -----------------------------------------------------------
 

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
@@ -131,6 +132,54 @@ class FindingEvidence:
     def is_well_localized(self) -> bool:
         """Evidence is spatially concentrated, not diffuse."""
         return self.spatial_concentration >= self._WELL_LOCALIZED_CONCENTRATION
+
+    @classmethod
+    def from_metrics(cls, d: Mapping[str, object]) -> FindingEvidence:
+        """Construct from a ``FindingEvidenceMetrics`` dict using canonical keys.
+
+        Legacy alias handling (e.g. ``snr_ratio`` → ``snr_db``) is NOT done
+        here — boundary callers must pre-normalize before calling this factory.
+        """
+
+        def _float(key: str) -> float:
+            raw = d.get(key)
+            if raw is None:
+                return 0.0
+            try:
+                return float(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return 0.0
+
+        def _float_or_none(key: str) -> float | None:
+            raw = d.get(key)
+            if raw is None:
+                return None
+            try:
+                return float(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+
+        phase_conf = d.get("per_phase_confidence")
+        phase_items: tuple[tuple[str, float], ...] = ()
+        if isinstance(phase_conf, dict):
+            phase_items = tuple(
+                (str(k), float(v))
+                for k, v in sorted(phase_conf.items())
+                if isinstance(v, (int, float))
+            )
+
+        return cls(
+            match_rate=_float("match_rate"),
+            snr_db=_float_or_none("snr_db"),
+            presence_ratio=_float("presence_ratio"),
+            burstiness=_float("burstiness"),
+            spatial_concentration=_float("spatial_concentration"),
+            frequency_correlation=_float("frequency_correlation"),
+            speed_uniformity=_float("speed_uniformity"),
+            spatial_uniformity=_float("spatial_uniformity"),
+            phase_confidences=phase_items,
+            vibration_strength_db=_float_or_none("vibration_strength_db"),
+        )
 
 
 # ── Signature ─────────────────────────────────────────────────────────────────
@@ -491,3 +540,28 @@ class Finding:
     def is_stronger_than(self, other: Finding) -> bool:
         """Whether this finding ranks higher than *other*."""
         return self.phase_adjusted_score > other.phase_adjusted_score
+
+    def with_confidence_assessment(
+        self,
+        strength_band_key: str,
+        steady_speed: bool,
+        has_reference_gaps: bool,
+        sensor_count: int,
+    ) -> Finding:
+        """Return a copy with a computed :class:`ConfidenceAssessment`.
+
+        Reads ``effective_confidence`` and ``weak_spatial_separation``
+        from *self*, delegates to :meth:`ConfidenceAssessment.assess`,
+        and returns ``replace(self, confidence_assessment=ca)``.
+        """
+        from vibesensor.domain.confidence_assessment import ConfidenceAssessment as CA
+
+        ca = CA.assess(
+            self.effective_confidence,
+            strength_band_key=strength_band_key,
+            steady_speed=steady_speed,
+            has_reference_gaps=has_reference_gaps,
+            weak_spatial=self.weak_spatial_separation,
+            sensor_count=max(sensor_count, 1),
+        )
+        return replace(self, confidence_assessment=ca)

--- a/apps/server/vibesensor/domain/snapshots.py
+++ b/apps/server/vibesensor/domain/snapshots.py
@@ -1,0 +1,306 @@
+"""Typed internal snapshot objects for run-attached interpretation context.
+
+These are canonical internal model concepts — not aggregate roots, not
+boundary payload shapes.
+
+``AnalysisSettingsSnapshot`` — typed analysis-settings context.
+``RunContextSnapshot`` — run-attached interpretive snapshot containing
+settings and optional car context.
+``SpeedStatsSnapshot`` — speed summary for reconstruction/interpretation.
+``PhaseSummarySnapshot`` — phase summary for reconstruction/interpretation.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+from .car import CarSnapshot, OrderReferenceSpec, TireSpec
+
+__all__ = [
+    "AnalysisSettingsSnapshot",
+    "PhaseSummarySnapshot",
+    "RunContextSnapshot",
+    "SpeedStatsSnapshot",
+]
+
+
+def _float_or(d: Mapping[str, object], key: str, default: float = 0.0) -> float:
+    v = d.get(key)
+    if v is None:
+        return default
+    try:
+        f = float(v)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return f if math.isfinite(f) else default
+
+
+def _bool_or(d: Mapping[str, object], key: str, default: bool = False) -> bool:  # noqa: FBT001, FBT002
+    v = d.get(key)
+    if v is None:
+        return default
+    if isinstance(v, bool):
+        return v
+    return default
+
+
+def _int_or(d: Mapping[str, object], key: str, default: int = 0) -> int:
+    v = d.get(key)
+    if v is None:
+        return default
+    try:
+        return int(v)  # type: ignore[call-overload,no-any-return]
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# AnalysisSettingsSnapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisSettingsSnapshot:
+    """Typed internal analysis-settings context used by runtime and
+    use-case logic.
+
+    Raw tire fields (``tire_width_mm``, ``tire_aspect_pct``, ``rim_in``)
+    are construction inputs for ``from_dict()`` persistence compatibility.
+    Behavioral tire geometry access goes through ``order_reference_spec``.
+    """
+
+    tire_width_mm: float = 0.0
+    tire_aspect_pct: float = 0.0
+    rim_in: float = 0.0
+    final_drive_ratio: float = 0.0
+    current_gear_ratio: float = 0.0
+    wheel_bandwidth_pct: float = 0.0
+    driveshaft_bandwidth_pct: float = 0.0
+    engine_bandwidth_pct: float = 0.0
+    speed_uncertainty_pct: float = 0.0
+    tire_diameter_uncertainty_pct: float = 0.0
+    final_drive_uncertainty_pct: float = 0.0
+    gear_uncertainty_pct: float = 0.0
+    min_abs_band_hz: float = 0.0
+    max_band_half_width_pct: float = 0.0
+    tire_deflection_factor: float = 1.0
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> AnalysisSettingsSnapshot:
+        """Parse from flat mapping. Missing keys default to ``0.0``."""
+        return cls(
+            tire_width_mm=_float_or(d, "tire_width_mm"),
+            tire_aspect_pct=_float_or(d, "tire_aspect_pct"),
+            rim_in=_float_or(d, "rim_in"),
+            final_drive_ratio=_float_or(d, "final_drive_ratio"),
+            current_gear_ratio=_float_or(d, "current_gear_ratio"),
+            wheel_bandwidth_pct=_float_or(d, "wheel_bandwidth_pct"),
+            driveshaft_bandwidth_pct=_float_or(d, "driveshaft_bandwidth_pct"),
+            engine_bandwidth_pct=_float_or(d, "engine_bandwidth_pct"),
+            speed_uncertainty_pct=_float_or(d, "speed_uncertainty_pct"),
+            tire_diameter_uncertainty_pct=_float_or(d, "tire_diameter_uncertainty_pct"),
+            final_drive_uncertainty_pct=_float_or(d, "final_drive_uncertainty_pct"),
+            gear_uncertainty_pct=_float_or(d, "gear_uncertainty_pct"),
+            min_abs_band_hz=_float_or(d, "min_abs_band_hz"),
+            max_band_half_width_pct=_float_or(d, "max_band_half_width_pct"),
+            tire_deflection_factor=_float_or(d, "tire_deflection_factor", 1.0),
+        )
+
+    @property
+    def order_reference_spec(self) -> OrderReferenceSpec | None:
+        """Derive ``OrderReferenceSpec`` from these settings.
+
+        Returns ``None`` if tire geometry is missing/invalid.
+        """
+        tire = TireSpec.from_aspects(
+            {
+                "tire_width_mm": self.tire_width_mm,
+                "tire_aspect_pct": self.tire_aspect_pct,
+                "rim_in": self.rim_in,
+            },
+            deflection_factor=self.tire_deflection_factor,
+        )
+        if tire is None:
+            return None
+        return OrderReferenceSpec(
+            tire_spec=tire,
+            final_drive_ratio=self.final_drive_ratio,
+            current_gear_ratio=self.current_gear_ratio,
+            wheel_bandwidth_pct=self.wheel_bandwidth_pct,
+            driveshaft_bandwidth_pct=self.driveshaft_bandwidth_pct,
+            engine_bandwidth_pct=self.engine_bandwidth_pct,
+            speed_uncertainty_pct=self.speed_uncertainty_pct,
+            tire_diameter_uncertainty_pct=self.tire_diameter_uncertainty_pct,
+            final_drive_uncertainty_pct=self.final_drive_uncertainty_pct,
+            gear_uncertainty_pct=self.gear_uncertainty_pct,
+            min_abs_band_hz=self.min_abs_band_hz,
+            max_band_half_width_pct=self.max_band_half_width_pct,
+        )
+
+
+# ---------------------------------------------------------------------------
+# RunContextSnapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RunContextSnapshot:
+    """Run-attached interpretive snapshot containing analysis settings
+    and optional car context.
+    """
+
+    analysis_settings: AnalysisSettingsSnapshot = field(default_factory=AnalysisSettingsSnapshot)
+    car: CarSnapshot | None = None
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> RunContextSnapshot:
+        """Parse from a nested mapping.
+
+        Expects keys ``"analysis_settings_snapshot"`` and optionally
+        ``"active_car_snapshot"``.
+        """
+        raw_settings = d.get("analysis_settings_snapshot")
+        if isinstance(raw_settings, Mapping):
+            settings = AnalysisSettingsSnapshot.from_dict(raw_settings)
+        else:
+            settings = AnalysisSettingsSnapshot()
+
+        raw_car = d.get("active_car_snapshot")
+        car: CarSnapshot | None = None
+        if isinstance(raw_car, Mapping):
+            car = CarSnapshot.from_dict(raw_car)
+
+        return cls(analysis_settings=settings, car=car)
+
+    @property
+    def order_reference_spec(self) -> OrderReferenceSpec | None:
+        """Convenience — delegates to analysis settings."""
+        return self.analysis_settings.order_reference_spec
+
+    @property
+    def has_car_context(self) -> bool:
+        return self.car is not None
+
+
+# ---------------------------------------------------------------------------
+# SpeedStatsSnapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SpeedStatsSnapshot:
+    """Typed internal speed-summary snapshot for reconstruction and
+    interpretation support.
+    """
+
+    min_kmh: float | None = None
+    max_kmh: float | None = None
+    mean_kmh: float | None = None
+    stddev_kmh: float | None = None
+    range_kmh: float | None = None
+    steady_speed: bool = False
+    sample_count: int = 0
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> SpeedStatsSnapshot:
+        """Parse from flat mapping. Missing keys default sensibly."""
+
+        def _opt_float(key: str) -> float | None:
+            v = d.get(key)
+            if v is None:
+                return None
+            try:
+                f = float(v)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+            return f if math.isfinite(f) else None
+
+        return cls(
+            min_kmh=_opt_float("min_kmh"),
+            max_kmh=_opt_float("max_kmh"),
+            mean_kmh=_opt_float("mean_kmh"),
+            stddev_kmh=_opt_float("stddev_kmh"),
+            range_kmh=_opt_float("range_kmh"),
+            steady_speed=_bool_or(d, "steady_speed"),
+            sample_count=_int_or(d, "sample_count"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# PhaseSummarySnapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseSummarySnapshot:
+    """Typed internal phase-summary snapshot for reconstruction and
+    interpretation support.
+    """
+
+    phase_counts: Mapping[str, int] = field(default_factory=dict)
+    phase_pcts: Mapping[str, float] = field(default_factory=dict)
+    total_samples: int = 0
+    segment_count: int = 0
+    has_cruise: bool = False
+    has_acceleration: bool = False
+    cruise_pct: float = 0.0
+    idle_pct: float = 0.0
+    speed_unknown_pct: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.phase_counts, MappingProxyType):
+            object.__setattr__(self, "phase_counts", MappingProxyType(dict(self.phase_counts)))
+        if not isinstance(self.phase_pcts, MappingProxyType):
+            object.__setattr__(self, "phase_pcts", MappingProxyType(dict(self.phase_pcts)))
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> PhaseSummarySnapshot:
+        """Parse from flat mapping. Missing keys default sensibly."""
+        raw_counts = d.get("phase_counts")
+        phase_counts: dict[str, int] = {}
+        if isinstance(raw_counts, dict):
+            for k, v in raw_counts.items():
+                if isinstance(k, str):
+                    try:
+                        phase_counts[k] = int(v)
+                    except (TypeError, ValueError):
+                        pass
+
+        raw_pcts = d.get("phase_pcts")
+        phase_pcts: dict[str, float] = {}
+        if isinstance(raw_pcts, dict):
+            for k, v in raw_pcts.items():
+                if isinstance(k, str):
+                    try:
+                        phase_pcts[k] = float(v)
+                    except (TypeError, ValueError):
+                        pass
+
+        # Fall back to phase_counts/phase_pcts sub-dicts for historical
+        # data that may lack top-level has_*/pct keys.
+        def _flag_fb(key: str, phase_key: str) -> bool:
+            v = d.get(key)
+            if v is not None:
+                return bool(v)
+            return phase_counts.get(phase_key, 0) > 0
+
+        def _pct_fb(key: str, phase_key: str) -> float:
+            v = _float_or(d, key)
+            if v != 0.0 or key in d:
+                return v
+            return phase_pcts.get(phase_key, 0.0)
+
+        return cls(
+            phase_counts=phase_counts,
+            phase_pcts=phase_pcts,
+            total_samples=_int_or(d, "total_samples"),
+            segment_count=_int_or(d, "segment_count"),
+            has_cruise=_flag_fb("has_cruise", "cruise"),
+            has_acceleration=_flag_fb("has_acceleration", "acceleration"),
+            cruise_pct=_pct_fb("cruise_pct", "cruise"),
+            idle_pct=_pct_fb("idle_pct", "idle"),
+            speed_unknown_pct=_pct_fb("speed_unknown_pct", "speed_unknown"),
+        )

--- a/apps/server/vibesensor/domain/strength_metrics.py
+++ b/apps/server/vibesensor/domain/strength_metrics.py
@@ -1,0 +1,105 @@
+"""Domain value objects for vibration strength measurement results.
+
+``StrengthPeak`` — a single identified vibration peak.
+``StrengthMetrics`` — the full strength-measurement summary for one
+    finding or analysis segment.
+
+These are domain-layer interpretations of measurement results.  The
+pipeline-layer ``StrengthPeak`` and ``VibrationStrengthMetrics``
+TypedDicts in ``vibration_strength.py`` remain as hot-path serialization
+shapes.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+__all__ = [
+    "StrengthMetrics",
+    "StrengthPeak",
+]
+
+
+def _float_or(d: Mapping[str, object], key: str, default: float = 0.0) -> float:
+    v = d.get(key)
+    if v is None:
+        return default
+    try:
+        f = float(v)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return f if math.isfinite(f) else default
+
+
+def _str_or_none(d: Mapping[str, object], key: str) -> str | None:
+    v = d.get(key)
+    if isinstance(v, str) and v:
+        return v
+    return None
+
+
+# ---------------------------------------------------------------------------
+# StrengthPeak
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class StrengthPeak:
+    """A single identified vibration peak."""
+
+    hz: float = 0.0
+    amp: float = 0.0
+    vibration_strength_db: float = 0.0
+    strength_bucket: str | None = None
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> StrengthPeak:
+        return cls(
+            hz=_float_or(d, "hz"),
+            amp=_float_or(d, "amp"),
+            vibration_strength_db=_float_or(d, "vibration_strength_db"),
+            strength_bucket=_str_or_none(d, "strength_bucket"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# StrengthMetrics
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class StrengthMetrics:
+    """Full strength-measurement summary for one finding or segment."""
+
+    vibration_strength_db: float = 0.0
+    peak_amp_g: float = 0.0
+    noise_floor_amp_g: float = 0.0
+    strength_bucket: str | None = None
+    top_peaks: tuple[StrengthPeak, ...] = ()
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> StrengthMetrics:
+        raw_peaks = d.get("top_peaks")
+        peaks: tuple[StrengthPeak, ...] = ()
+        if isinstance(raw_peaks, (list, tuple)):
+            parsed: list[StrengthPeak] = []
+            for item in raw_peaks:
+                if isinstance(item, Mapping):
+                    parsed.append(StrengthPeak.from_dict(item))
+            peaks = tuple(parsed)
+
+        return cls(
+            vibration_strength_db=_float_or(d, "vibration_strength_db"),
+            peak_amp_g=_float_or(d, "peak_amp_g"),
+            noise_floor_amp_g=_float_or(d, "noise_floor_amp_g"),
+            strength_bucket=_str_or_none(d, "strength_bucket"),
+            top_peaks=peaks,
+        )
+
+    @classmethod
+    def from_typed_dict(cls, td: Mapping[str, object]) -> StrengthMetrics:
+        """Convenience alias for ``from_dict`` — accepts the pipeline
+        ``VibrationStrengthMetrics`` TypedDict directly."""
+        return cls.from_dict(td)

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -29,12 +29,12 @@ from threading import RLock
 from typing import TYPE_CHECKING, cast, get_args
 
 from vibesensor.adapters.udp.protocol import normalize_sensor_id
-from vibesensor.domain import Car, Sensor, SpeedSource
+from vibesensor.domain import Car, CarSnapshot, Sensor, SpeedSource
+from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.exceptions import PersistenceError as PersistenceError
 from vibesensor.shared.types.backend_types import (
     AnalysisSettingsPayload,
     CarConfig,
-    CarConfigPayload,
     CarConfigUpdatePayload,
     LanguageCode,
     SensorConfig,
@@ -216,10 +216,10 @@ class SettingsStore:
         self._sync_analysis_settings()
         self._sync_speed_source()
 
-    def analysis_settings_snapshot(self) -> dict[str, float]:
-        """Return a thread-safe copy of the current analysis settings."""
+    def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
+        """Return a thread-safe typed snapshot of the current analysis settings."""
         with self._lock:
-            return dict(self._analysis_values)
+            return AnalysisSettingsSnapshot.from_dict(self._analysis_values)
 
     # -- full snapshot ---------------------------------------------------------
 
@@ -274,11 +274,11 @@ class SettingsStore:
             car = car_cfg.to_car()
             return dict(car.aspects)
 
-    def active_car_snapshot(self) -> CarConfigPayload | None:
-        """Return the active car profile as a plain dict snapshot."""
+    def active_car_snapshot(self) -> CarSnapshot | None:
+        """Return the active car profile as a typed domain snapshot."""
         with self._lock:
             car = self._find_car(self._active_car_id)
-            return car.to_dict() if car else None
+            return car.to_car_snapshot() if car else None
 
     def _find_car(self, car_id: str | None) -> CarConfig | None:
         if not car_id:

--- a/apps/server/vibesensor/infra/runtime/rotational_speeds.py
+++ b/apps/server/vibesensor/infra/runtime/rotational_speeds.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from vibesensor.shared.constants import SECONDS_PER_MINUTE
@@ -48,7 +49,7 @@ def build_rotational_speeds_payload(
     *,
     basis_speed_source: str,
     speed_mps: float | None,
-    analysis_settings: dict[str, float],
+    analysis_settings: Mapping[str, object],
 ) -> RotationalSpeedsPayload:
     """Assemble the ``rotational_speeds`` sub-dict for the WS payload."""
     if speed_mps is None or speed_mps <= 0:

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -10,6 +10,7 @@ those are produced by the post-run analysis pipeline and flow through
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 from vibesensor.infra.runtime.processing_loop import STALE_DATA_AGE_S
@@ -101,7 +102,7 @@ class WsBroadcastService:
         payload["rotational_speeds"] = build_rotational_speeds_payload(
             basis_speed_source=basis,
             speed_mps=speed_mps,
-            analysis_settings=analysis_settings_snapshot,
+            analysis_settings=asdict(analysis_settings_snapshot),
         )
         spectra: SpectraPayload | None = None
         if self.include_heavy:

--- a/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
+++ b/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
@@ -7,16 +7,15 @@ Also includes boundary functions for run suitability and speed profile
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import replace
 
 from vibesensor.domain.car import Car
-from vibesensor.domain.confidence_assessment import ConfidenceAssessment
 from vibesensor.domain.diagnostic_case import DiagnosticCase, Symptom
 from vibesensor.domain.driving_segment import DrivingPhase, DrivingSegment
 from vibesensor.domain.finding import Finding
 from vibesensor.domain.run_capture import ConfigurationSnapshot, RunCapture, RunSetup
 from vibesensor.domain.run_suitability import RunSuitability, SuitabilityCheck
 from vibesensor.domain.sensor import Sensor
+from vibesensor.domain.snapshots import PhaseSummarySnapshot, SpeedStatsSnapshot
 from vibesensor.domain.speed_profile import SpeedProfile
 from vibesensor.domain.speed_source import SpeedSource
 from vibesensor.domain.test_plan import RecommendedAction, TestPlan
@@ -28,21 +27,8 @@ from vibesensor.shared.boundaries.finding import (
     step_payloads_from_plan,
 )
 from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_finding
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonObject
-
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
-
-def _as_float(value: object) -> float | None:
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
 
 # ---------------------------------------------------------------------------
 # Run suitability (formerly run_suitability.py)
@@ -124,62 +110,29 @@ def project_analysis_summary(analysis: JsonObject) -> tuple[JsonObject, TestRun 
 
 
 def speed_profile_from_stats(
-    speed_stats: Mapping[str, object],
-    phase_summary: Mapping[str, object] | None = None,
+    speed_stats: SpeedStatsSnapshot,
+    phase_summary: PhaseSummarySnapshot | None = None,
 ) -> SpeedProfile:
-    """Construct a ``SpeedProfile`` from speed-stats and phase-summary dicts."""
-    ps: Mapping[str, object] = phase_summary or {}
+    """Construct a ``SpeedProfile`` from typed speed-stats and phase-summary snapshots."""
+    ps = phase_summary or PhaseSummarySnapshot()
 
-    def _f(d: Mapping[str, object], key: str, default: float = 0.0) -> float:
-        raw = d.get(key)
-        if raw is not None:
-            try:
-                return float(raw)  # type: ignore[arg-type]
-            except (TypeError, ValueError):
-                pass
-        return default
-
-    def _fraction(d: Mapping[str, object], key: str, *, phase_key: str | None = None) -> float:
-        raw = d.get(key)
-        if raw is None and phase_key is not None:
-            phase_pcts = d.get("phase_pcts")
-            if isinstance(phase_pcts, Mapping):
-                raw = phase_pcts.get(phase_key)
-        if raw is None:
-            return 0.0
-        try:
-            pct = float(raw) / 100.0  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return 0.0
-        return min(1.0, max(0.0, pct))
-
-    def _flag(d: Mapping[str, object], key: str, *, phase_key: str | None = None) -> bool:
-        raw = d.get(key)
-        if raw is not None:
-            return bool(raw)
-        if phase_key is None:
-            return False
-        phase_counts = d.get("phase_counts")
-        if not isinstance(phase_counts, Mapping):
-            return False
-        return _f(phase_counts, phase_key, 0.0) > 0.0
+    def _or_zero(v: float | None) -> float:
+        return v if v is not None else 0.0
 
     return SpeedProfile(
-        min_kmh=_f(speed_stats, "min_kmh"),
-        max_kmh=_f(speed_stats, "max_kmh"),
-        mean_kmh=_f(speed_stats, "mean_kmh"),
-        stddev_kmh=_f(speed_stats, "stddev_kmh"),
-        steady_speed=bool(speed_stats.get("steady_speed", False)),
-        has_cruise=_flag(ps, "has_cruise", phase_key="cruise"),
-        has_acceleration=_flag(ps, "has_acceleration", phase_key="acceleration"),
-        cruise_fraction=_fraction(ps, "cruise_pct", phase_key="cruise"),
-        idle_fraction=_fraction(ps, "idle_pct", phase_key="idle"),
-        speed_unknown_fraction=_fraction(
-            ps,
-            "speed_unknown_pct",
-            phase_key="speed_unknown",
+        min_kmh=_or_zero(speed_stats.min_kmh),
+        max_kmh=_or_zero(speed_stats.max_kmh),
+        mean_kmh=_or_zero(speed_stats.mean_kmh),
+        stddev_kmh=_or_zero(speed_stats.stddev_kmh),
+        steady_speed=speed_stats.steady_speed,
+        has_cruise=ps.has_cruise,
+        has_acceleration=ps.has_acceleration,
+        cruise_fraction=min(1.0, max(0.0, ps.cruise_pct / 100.0)) if ps.cruise_pct else 0.0,
+        idle_fraction=min(1.0, max(0.0, ps.idle_pct / 100.0)) if ps.idle_pct else 0.0,
+        speed_unknown_fraction=(
+            min(1.0, max(0.0, ps.speed_unknown_pct / 100.0)) if ps.speed_unknown_pct else 0.0
         ),
-        sample_count=int(_f(speed_stats, "sample_count", 0)),
+        sample_count=speed_stats.sample_count,
     )
 
 
@@ -279,16 +232,16 @@ def test_run_from_summary(summary: Mapping[str, object]) -> TestRun:
                 merged.append(tc)
         findings = tuple(merged)
     actions = _actions_from_steps(summary.get("test_plan"))
-    speed_stats = summary.get("speed_stats")
+    raw_speed_stats = summary.get("speed_stats")
     phase_info = summary.get("phase_info")
     if not isinstance(phase_info, Mapping):
         phase_info = summary.get("phase_summary")
     speed_profile = (
         speed_profile_from_stats(
-            speed_stats,
-            phase_info if isinstance(phase_info, Mapping) else None,
+            SpeedStatsSnapshot.from_dict(raw_speed_stats),
+            PhaseSummarySnapshot.from_dict(phase_info) if isinstance(phase_info, Mapping) else None,
         )
-        if isinstance(speed_stats, Mapping)
+        if isinstance(raw_speed_stats, Mapping)
         else None
     )
     raw_suitability_payload = summary.get("run_suitability")
@@ -316,15 +269,12 @@ def test_run_from_summary(summary: Mapping[str, object]) -> TestRun:
     def _ensure_ca(f: Finding) -> Finding:
         if f.confidence_assessment is not None:
             return f
-        ca = ConfidenceAssessment.assess(
-            f.effective_confidence,
+        return f.with_confidence_assessment(
             strength_band_key=_band_key,
             steady_speed=_steady,
             has_reference_gaps=_has_ref_gaps,
-            weak_spatial=f.weak_spatial_separation,
             sensor_count=max(_sensor_count, 1),
         )
-        return replace(f, confidence_assessment=ca)
 
     findings = tuple(_ensure_ca(f) for f in findings)
     top_causes = tuple(_ensure_ca(f) for f in top_causes)

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -40,49 +40,6 @@ def _has_structured_step_content(steps: object) -> bool:
     return False
 
 
-def finding_evidence_from_metrics(d: dict[str, object]) -> FindingEvidence:
-    """Construct a ``FindingEvidence`` from a ``FindingEvidenceMetrics`` dict."""
-    phase_conf = d.get("per_phase_confidence")
-    phase_items: tuple[tuple[str, float], ...] = ()
-    if isinstance(phase_conf, dict):
-        phase_items = tuple(
-            (str(k), float(v)) for k, v in sorted(phase_conf.items()) if isinstance(v, (int, float))
-        )
-
-    def _float(key: str, *fallbacks: str) -> float:
-        for k in (key, *fallbacks):
-            raw = d.get(k)
-            if raw is not None:
-                try:
-                    return float(raw)  # type: ignore[arg-type]
-                except (TypeError, ValueError):
-                    pass
-        return 0.0
-
-    def _float_or_none(key: str, *fallbacks: str) -> float | None:
-        for k in (key, *fallbacks):
-            raw = d.get(k)
-            if raw is not None:
-                try:
-                    return float(raw)  # type: ignore[arg-type]
-                except (TypeError, ValueError):
-                    pass
-        return None
-
-    return FindingEvidence(
-        match_rate=_float("match_rate"),
-        snr_db=_float_or_none("snr_db", "snr_ratio"),
-        presence_ratio=_float("presence_ratio"),
-        burstiness=_float("burstiness"),
-        spatial_concentration=_float("spatial_concentration"),
-        frequency_correlation=_float("frequency_correlation"),
-        speed_uniformity=_float("speed_uniformity"),
-        spatial_uniformity=_float("spatial_uniformity"),
-        phase_confidences=phase_items,
-        vibration_strength_db=_float_or_none("vibration_strength_db"),
-    )
-
-
 def step_payload_from_action(action: RecommendedAction) -> dict[str, object]:
     """Project one semantic action into the persisted TestStep shape."""
     return {
@@ -189,7 +146,12 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
                 pass
 
     # Build domain value objects from nested dicts when available
-    evidence = finding_evidence_from_metrics(ev_metrics) if isinstance(ev_metrics, dict) else None
+    evidence: FindingEvidence | None = None
+    if isinstance(ev_metrics, dict):
+        # Normalize legacy alias before delegating to domain factory
+        if "snr_ratio" in ev_metrics and "snr_db" not in ev_metrics:
+            ev_metrics = {**ev_metrics, "snr_db": ev_metrics["snr_ratio"]}
+        evidence = FindingEvidence.from_metrics(ev_metrics)
     hotspot_raw = payload.get("location_hotspot")
     location = location_hotspot_from_payload(hotspot_raw) if isinstance(hotspot_raw, dict) else None
 

--- a/apps/server/vibesensor/shared/boundaries/vibration_origin.py
+++ b/apps/server/vibesensor/shared/boundaries/vibration_origin.py
@@ -8,16 +8,8 @@ from typing import TypedDict
 from vibesensor.domain.finding import Finding, VibrationSource
 from vibesensor.domain.location_hotspot import LocationHotspot
 from vibesensor.domain.vibration_origin import VibrationOrigin
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonValue
-
-
-def _as_float(value: object) -> float | None:
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def location_hotspot_from_payload(payload: dict[str, object]) -> LocationHotspot:

--- a/apps/server/vibesensor/shared/run_context.py
+++ b/apps/server/vibesensor/shared/run_context.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from dataclasses import asdict
 from typing import cast
 
+from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot
 from vibesensor.infra.config.analysis_settings import (
-    DEFAULT_ANALYSIS_SETTINGS,
     tire_circumference_m_from_spec,
 )
 from vibesensor.report_i18n import tr as _tr
@@ -15,34 +16,31 @@ from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 from vibesensor.use_cases.diagnostics import i18n_ref
 
-ANALYSIS_SETTINGS_SNAPSHOT_KEYS: tuple[str, ...] = tuple(DEFAULT_ANALYSIS_SETTINGS.keys())
-
 WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE = "reference_context_incomplete"
 WARNING_CODE_CAR_SETTINGS_CHANGED = "car_settings_changed"
 
 
 def build_run_context_snapshot(
     *,
-    analysis_settings_snapshot: Mapping[str, object],
-    active_car_snapshot: Mapping[str, object] | None,
+    analysis_settings_snapshot: AnalysisSettingsSnapshot,
+    active_car_snapshot: CarSnapshot | None,
 ) -> JsonObject:
     """Build a structured run-context snapshot for persisted metadata."""
-    settings_snapshot: JsonObject = {}
-    for key in ANALYSIS_SETTINGS_SNAPSHOT_KEYS:
-        value = _as_float(analysis_settings_snapshot.get(key))
-        if value is not None:
-            settings_snapshot[key] = value
+    settings_dict = asdict(analysis_settings_snapshot)
+    settings_snapshot: JsonObject = {
+        k: v for k, v in settings_dict.items() if isinstance(v, (int, float)) and v == v
+    }
     snapshot: JsonObject = {"analysis_settings_snapshot": settings_snapshot}
     if active_car_snapshot is not None:
-        snapshot["active_car_snapshot"] = _sanitize_car_snapshot(active_car_snapshot)
+        snapshot["active_car_snapshot"] = active_car_snapshot.to_dict()
     return snapshot
 
 
 def apply_run_context_snapshot(
     metadata: JsonObject,
     *,
-    analysis_settings_snapshot: Mapping[str, object],
-    active_car_snapshot: Mapping[str, object] | None,
+    analysis_settings_snapshot: AnalysisSettingsSnapshot,
+    active_car_snapshot: CarSnapshot | None,
 ) -> None:
     """Attach structured run-context snapshot fields to persisted metadata."""
     context_snapshot = build_run_context_snapshot(
@@ -99,7 +97,7 @@ def build_summary_warnings(
 def add_current_context_warnings(
     summary: Mapping[str, JsonValue],
     *,
-    current_active_car_snapshot: Mapping[str, object] | None,
+    current_active_car_snapshot: CarSnapshot | None,
 ) -> JsonObject:
     """Return a summary copy enriched with dynamic current-context warnings."""
     enriched = dict(summary)
@@ -136,10 +134,10 @@ def localize_warning_list(
     return localized
 
 
-def current_car_snapshot_token(current_active_car_snapshot: Mapping[str, object] | None) -> str:
+def current_car_snapshot_token(current_active_car_snapshot: CarSnapshot | None) -> str:
     """Return a stable cache token for current active-car context."""
     return json.dumps(
-        _sanitize_car_snapshot(current_active_car_snapshot) if current_active_car_snapshot else {},
+        current_active_car_snapshot.to_dict() if current_active_car_snapshot else {},
         sort_keys=True,
         ensure_ascii=False,
         default=str,
@@ -149,14 +147,15 @@ def current_car_snapshot_token(current_active_car_snapshot: Mapping[str, object]
 def _build_car_settings_changed_warning(
     metadata: object,
     *,
-    current_active_car_snapshot: Mapping[str, object] | None,
+    current_active_car_snapshot: CarSnapshot | None,
 ) -> JsonObject | None:
     if not is_json_object(metadata) or current_active_car_snapshot is None:
         return None
     recorded_snapshot = metadata.get("active_car_snapshot")
     if not is_json_object(recorded_snapshot):
         return None
-    if _normalized_aspects(recorded_snapshot) == _normalized_aspects(current_active_car_snapshot):
+    current_dict = current_active_car_snapshot.to_dict()
+    if _normalized_aspects(recorded_snapshot) == _normalized_aspects(current_dict):
         return None
     return {
         "code": WARNING_CODE_CAR_SETTINGS_CHANGED,
@@ -166,7 +165,7 @@ def _build_car_settings_changed_warning(
         "detail": i18n_ref(
             "RUN_CONTEXT_WARNING_CAR_SETTINGS_CHANGED_DETAIL",
             run_car=_car_label(recorded_snapshot),
-            current_car=_car_label(current_active_car_snapshot),
+            current_car=_car_label(current_dict),
         ),
     }
 
@@ -177,30 +176,14 @@ def _normalized_warning_list(warnings: object) -> list[JsonObject]:
     return [warning for warning in warnings if is_json_object(warning)]
 
 
-def _sanitize_car_snapshot(snapshot: Mapping[str, object]) -> JsonObject:
-    aspects_raw = snapshot.get("aspects")
-    aspects = aspects_raw if isinstance(aspects_raw, Mapping) else {}
-    return {
-        "id": str(snapshot.get("id") or "").strip() or None,
-        "name": str(snapshot.get("name") or "").strip() or None,
-        "type": str(snapshot.get("type") or "").strip() or None,
-        "variant": str(snapshot.get("variant") or "").strip() or None,
-        "aspects": {
-            key: value
-            for key in ANALYSIS_SETTINGS_SNAPSHOT_KEYS
-            if (value := _as_float(aspects.get(key))) is not None
-        },
-    }
-
-
 def _normalized_aspects(snapshot: Mapping[str, object]) -> tuple[tuple[str, float], ...]:
     aspects_raw = snapshot.get("aspects")
     if not isinstance(aspects_raw, Mapping):
         return ()
     normalized = [
         (key, float(value))
-        for key in ANALYSIS_SETTINGS_SNAPSHOT_KEYS
-        if (value := _as_float(aspects_raw.get(key))) is not None
+        for key, value in aspects_raw.items()
+        if isinstance(key, str) and _as_float(value) is not None
     ]
     return tuple(sorted(normalized))
 

--- a/apps/server/vibesensor/shared/types/backend_types.py
+++ b/apps/server/vibesensor/shared/types/backend_types.py
@@ -18,7 +18,7 @@ from vibesensor.shared.constants import NUMERIC_TYPES
 from vibesensor.shared.types.json_types import JsonObject
 
 if TYPE_CHECKING:
-    from vibesensor.domain import Car, Sensor, SpeedSource
+    from vibesensor.domain import Car, CarSnapshot, Sensor, SpeedSource
 
 _isfinite = math.isfinite
 _LOGGER = logging.getLogger(__name__)
@@ -246,6 +246,18 @@ class CarConfig:
             car_type=self.car_type,
             aspects=dict(self.aspects),
             variant=self.variant,
+        )
+
+    def to_car_snapshot(self) -> CarSnapshot:
+        """Return a lightweight ``CarSnapshot`` for run-context persistence."""
+        from vibesensor.domain import CarSnapshot
+
+        return CarSnapshot(
+            car_id=self.id,
+            name=self.name,
+            car_type=self.car_type,
+            variant=self.variant,
+            aspects=dict(self.aspects),
         )
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/order_bands.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/order_bands.py
@@ -22,8 +22,6 @@ from vibesensor.shared.constants import (
 from vibesensor.shared.json_utils import as_float_or_none
 from vibesensor.shared.types.payload_types import OrderBandPayload
 
-DEFAULT_DIAGNOSTIC_SETTINGS = DEFAULT_ANALYSIS_SETTINGS
-
 
 def build_diagnostic_settings(overrides: Mapping[str, object] | None = None) -> dict[str, float]:
     """Return analysis settings merged with validated *overrides*."""

--- a/apps/server/vibesensor/use_cases/diagnostics/summary_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/summary_builder.py
@@ -32,6 +32,7 @@ from vibesensor.domain import (
 from vibesensor.domain import (
     Finding as DomainFinding,
 )
+from vibesensor.domain.snapshots import PhaseSummarySnapshot, SpeedStatsSnapshot
 from vibesensor.domain.test_plan import plan_test_actions
 from vibesensor.report_i18n import normalize_lang
 from vibesensor.shared.boundaries.diagnostic_case import (
@@ -774,7 +775,10 @@ def prepare_run_data(
         per_sample_phases=per_sample_phases,
         phase_segments=phase_segments,
         run_noise_baseline_g=run_noise_baseline_g,
-        speed_profile=speed_profile_from_stats(speed_stats, phase_info),
+        speed_profile=speed_profile_from_stats(
+            SpeedStatsSnapshot.from_dict(speed_stats),
+            PhaseSummarySnapshot.from_dict(phase_info),
+        ),
         speed_stats_by_phase=_speed_stats_by_phase(samples, per_sample_phases),
         speed_breakdown=speed_breakdown,
         speed_breakdown_skipped_reason=speed_breakdown_skipped_reason,

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -17,10 +17,11 @@ from typing import TYPE_CHECKING, cast
 
 from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+from vibesensor.domain import CarSnapshot
 from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.shared.exceptions import AnalysisNotReadyError, ProcessingError
 from vibesensor.shared.run_context import add_current_context_warnings, current_car_snapshot_token
-from vibesensor.shared.types.backend_types import CarConfigPayload, HistoryRunPayload
+from vibesensor.shared.types.backend_types import HistoryRunPayload
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.use_cases.history.helpers import (
     async_require_run,
@@ -142,7 +143,7 @@ class HistoryReportService:
         run_id: str,
         requested_lang: str,
         *,
-        current_active_car_snapshot: CarConfigPayload | None,
+        current_active_car_snapshot: CarSnapshot | None,
     ) -> ReportPdfCacheKey:
         return (
             run_id,

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -16,13 +16,14 @@ import logging
 import sqlite3
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from threading import RLock
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from vibesensor.adapters.persistence.runlog import utc_now_iso
 from vibesensor.domain import Run
+from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.constants import NUMERIC_TYPES
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.sample_builder import (
@@ -202,12 +203,12 @@ class RunRecorder:
         run = self._current_run
         return run.run_id if run is not None else None
 
-    def _analysis_settings_snapshot(self) -> dict[str, float]:
+    def _analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
         if self._settings_store is not None:
             return self._settings_store.analysis_settings_snapshot()
         from vibesensor.infra.config.analysis_settings import DEFAULT_ANALYSIS_SETTINGS
 
-        return dict(DEFAULT_ANALYSIS_SETTINGS)
+        return AnalysisSettingsSnapshot.from_dict(DEFAULT_ANALYSIS_SETTINGS)
 
     # -----------------------------------------------------------------------
     # Session state
@@ -224,7 +225,7 @@ class RunRecorder:
         with self._lock:
             session = Run(
                 run_id=run_id,
-                analysis_settings=dict(self._analysis_settings_snapshot()),
+                analysis_settings=asdict(self._analysis_settings_snapshot()),
             )
             session.start()
             self._current_run = session

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable, Mapping
+from dataclasses import asdict
 from typing import TYPE_CHECKING, NamedTuple
 
 from vibesensor.adapters.udp.protocol import SensorFrame
+from vibesensor.domain.car import CarSnapshot
+from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.infra.config.analysis_settings import (
     engine_rpm_from_wheel_hz,
     tire_circumference_m_from_spec,
@@ -18,7 +21,6 @@ from vibesensor.infra.config.analysis_settings import (
 )
 from vibesensor.shared.constants import MPS_TO_KMH, NUMERIC_TYPES
 from vibesensor.shared.run_context import (
-    ANALYSIS_SETTINGS_SNAPSHOT_KEYS,
     apply_run_context_snapshot,
     order_reference_context_complete,
 )
@@ -49,15 +51,6 @@ def _parse_peak(raw: object) -> tuple[float, float] | None:
 _VIB_STRENGTH_DB_KEY: str = "vibration_strength_db"
 _STRENGTH_BUCKET_KEY: str = "strength_bucket"
 
-_SPEED_SOURCE_MAP = {
-    "manual": "manual",
-    "gps": "gps",
-    "fallback_manual": "manual",
-    "none": "none",
-}
-
-_SETTINGS_PASSTHROUGH_KEYS = ANALYSIS_SETTINGS_SNAPSHOT_KEYS
-
 
 def _safe_float(d: Mapping[str, object], key: str) -> float | None:
     """Extract a finite float from *d[key]*, or ``None``."""
@@ -69,6 +62,14 @@ def _safe_float(d: Mapping[str, object], key: str) -> float | None:
     except (TypeError, ValueError):
         return None
     return out if _isfinite(out) else None
+
+
+_SPEED_SOURCE_MAP = {
+    "manual": "manual",
+    "gps": "gps",
+    "fallback_manual": "manual",
+    "none": "none",
+}
 
 
 def safe_metric(metrics: dict[str, object], axis: str, key: str) -> float | None:
@@ -157,18 +158,18 @@ class SpeedContext(NamedTuple):
 
 def resolve_speed_context(
     gps_monitor: GPSSpeedMonitor,
-    analysis_settings_snapshot: Mapping[str, object],
+    analysis_settings_snapshot: AnalysisSettingsSnapshot,
 ) -> SpeedContext:
     """Resolve current speed/vehicle state into sample-record values."""
-    settings = analysis_settings_snapshot
+    s = analysis_settings_snapshot
     tire_circumference_m = tire_circumference_m_from_spec(
-        _safe_float(settings, "tire_width_mm"),
-        _safe_float(settings, "tire_aspect_pct"),
-        _safe_float(settings, "rim_in"),
-        deflection_factor=_safe_float(settings, "tire_deflection_factor"),
+        s.tire_width_mm or None,
+        s.tire_aspect_pct or None,
+        s.rim_in or None,
+        deflection_factor=s.tire_deflection_factor or None,
     )
-    final_drive_ratio = _safe_float(settings, "final_drive_ratio")
-    gear_ratio = _safe_float(settings, "current_gear_ratio")
+    final_drive_ratio = s.final_drive_ratio or None
+    gear_ratio = s.current_gear_ratio or None
     gps_speed_mps = gps_monitor.speed_mps
     resolution = gps_monitor.resolve_speed()
     effective_speed_mps = resolution.speed_mps
@@ -231,7 +232,7 @@ def build_sample_records(
     registry: ClientRegistry,
     processor: SignalProcessor,
     gps_monitor: GPSSpeedMonitor,
-    analysis_settings_snapshot: Mapping[str, object],
+    analysis_settings_snapshot: AnalysisSettingsSnapshot,
     default_sample_rate_hz: int,
 ) -> list[dict[str, object]]:
     """Build one batch of sample records from all active clients."""
@@ -241,8 +242,8 @@ def build_sample_records(
         speed_source,
         engine_rpm_estimated,
     ) = resolve_speed_context(gps_monitor, analysis_settings_snapshot)
-    final_drive_ratio = _safe_float(analysis_settings_snapshot, "final_drive_ratio")
-    gear_ratio = _safe_float(analysis_settings_snapshot, "current_gear_ratio")
+    final_drive_ratio = analysis_settings_snapshot.final_drive_ratio or None
+    gear_ratio = analysis_settings_snapshot.current_gear_ratio or None
 
     records: list[dict[str, object]] = []
     active_client_ids = sorted(
@@ -327,20 +328,20 @@ def build_run_metadata(
     *,
     run_id: str,
     start_time_utc: str,
-    analysis_settings_snapshot: Mapping[str, object],
+    analysis_settings_snapshot: AnalysisSettingsSnapshot,
     sensor_model: str,
     firmware_version: str | None,
     default_sample_rate_hz: int,
     metrics_log_hz: int,
     fft_window_size_samples: int,
     accel_scale_g_per_lsb: float | None,
-    active_car_snapshot: Mapping[str, object] | None = None,
+    active_car_snapshot: CarSnapshot | None = None,
     language_provider: Callable[[], str] | None = None,
 ) -> dict[str, object]:
     """Assemble comprehensive run metadata."""
     from vibesensor.adapters.persistence.runlog import create_run_metadata
 
-    settings = analysis_settings_snapshot
+    settings = asdict(analysis_settings_snapshot)
     feature_interval_s = 1.0 / max(1.0, float(metrics_log_hz))
     raw_sample_rate_hz = default_sample_rate_hz if default_sample_rate_hz > 0 else None
     incomplete = raw_sample_rate_hz is None
@@ -355,17 +356,16 @@ def build_run_metadata(
         accel_scale_g_per_lsb=accel_scale_g_per_lsb,
         incomplete_for_order_analysis=incomplete,
     )
-    for _key in _SETTINGS_PASSTHROUGH_KEYS:
-        metadata[_key] = settings.get(_key)
+    metadata.update(settings)
     metadata["tire_circumference_m"] = tire_circumference_m_from_spec(
-        _safe_float(settings, "tire_width_mm"),
-        _safe_float(settings, "tire_aspect_pct"),
-        _safe_float(settings, "rim_in"),
-        deflection_factor=_safe_float(settings, "tire_deflection_factor"),
+        analysis_settings_snapshot.tire_width_mm,
+        analysis_settings_snapshot.tire_aspect_pct,
+        analysis_settings_snapshot.rim_in,
+        deflection_factor=analysis_settings_snapshot.tire_deflection_factor,
     )
     apply_run_context_snapshot(
         metadata,
-        analysis_settings_snapshot=settings,
+        analysis_settings_snapshot=analysis_settings_snapshot,
         active_car_snapshot=active_car_snapshot,
     )
     metadata["incomplete_for_order_analysis"] = not order_reference_context_complete(metadata)

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -43,7 +43,8 @@
 - `domain/`: DDD-aligned domain model package. Primary domain objects
   live under `vibesensor/domain/`; closely related value objects share
   a file with their parent aggregate:
-  `car.py` (Car, TireSpec), `sensor.py` (Sensor, SensorPlacement),
+  `car.py` (Car, TireSpec, OrderReferenceSpec, CarSnapshot),
+  `sensor.py` (Sensor, SensorPlacement),
   `run.py` (Run lifecycle), `test_run.py` (TestRun aggregate),
   `diagnostic_case.py` (DiagnosticCase aggregate, Symptom),
   `run_capture.py` (RunCapture, RunSetup, ConfigurationSnapshot, Measurement, VibrationReading),
@@ -56,7 +57,9 @@
   `location_hotspot.py` (LocationHotspot),
   `speed_profile.py` (SpeedProfile),
   `run_suitability.py` (RunSuitability, SuitabilityCheck),
-  `run_status.py` (RunStatus, RUN_TRANSITIONS).
+  `run_status.py` (RunStatus, RUN_TRANSITIONS),
+  `snapshots.py` (AnalysisSettingsSnapshot, RunContextSnapshot, SpeedStatsSnapshot, PhaseSummarySnapshot),
+  `strength_metrics.py` (StrengthMetrics, StrengthPeak).
   Domain objects own
   classification, ranking, actionability, surfacing, lifecycle, and
   query logic; diagnostics use cases delegate to them. See

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -809,3 +809,17 @@ That does not change the canonical model defined here:
 - `DrivingSegment` is the canonical domain segment concept
 - `Report` is derived from the diagnostic domain and is not a core aggregate
   root
+
+### Closely related sub-exports
+
+The domain package also exports these closely related value objects and
+functions that are conceptually part of a parent aggregate:
+
+- `TireSpec`, `SpeedSourceKind`, `FindingKind`, `Signature`,
+  `VibrationSource`: enum-like or small value-object types
+- `VibrationReading`: raw multi-axis reading attached to `Measurement`;
+  lives in `run_capture.py` alongside `RunCapture`
+- `RunStatus`, `RUN_TRANSITIONS`, `transition_run`: run lifecycle state
+  machine
+- `speed_band_sort_key`, `speed_bin_label`: finding-related classification
+  helpers


### PR DESCRIPTION
## Summary

Replace untyped dict patterns with frozen dataclass domain objects for internal snapshot/context objects flowing through `run_context.py`, `settings_store.py`, `sample_builder.py`, and boundary reconstruction.

## New Domain Types

| Type | File | Purpose |
|------|------|---------|
| `OrderReferenceSpec` | `domain/car.py` | Tire geometry + driveline interpretation |
| `CarSnapshot` | `domain/car.py` | Lightweight car context for run persistence |
| `AnalysisSettingsSnapshot` | `domain/snapshots.py` | Typed analysis configuration |
| `RunContextSnapshot` | `domain/snapshots.py` | Run context with typed car/settings |
| `SpeedStatsSnapshot` | `domain/snapshots.py` | Speed statistics |
| `PhaseSummarySnapshot` | `domain/snapshots.py` | Driving phase summary |
| `StrengthMetrics` | `domain/strength_metrics.py` | Vibration strength metrics (was TypedDict) |
| `StrengthPeak` | `domain/strength_metrics.py` | Individual peak data (was TypedDict) |

## Migration

- `settings_store` returns typed objects (`AnalysisSettingsSnapshot`, `CarSnapshot`)
- `run_context.py` accepts/returns typed snapshots instead of raw dicts
- `sample_builder` accepts `AnalysisSettingsSnapshot`
- Boundary reconstruction (`speed_profile_from_stats`, `test_run_from_summary`) uses typed `SpeedStatsSnapshot`/`PhaseSummarySnapshot`
- `FindingEvidence.from_metrics()` factory on domain object
- `Finding.with_confidence_assessment()` method on domain object
- Dead code cleanup: removed `DEFAULT_DIAGNOSTIC_SETTINGS` alias, consolidated `_as_float` to canonical `as_float_or_none`

## Architecture Guardrails

- 47 parametrized tests for domain exports completeness, import direction (domain must not import from boundary/adapter/infra), and raw tire field access prohibition
- Golden-file regression tests for boundary reconstruction round-trips
- 87 new domain unit tests total

## Validation

- All 5422 tests pass
- `ruff check` clean
- `make typecheck-backend` clean
- Schema exports (`ws` + `http_api`) up to date