### PR TITLE
fix(gitignore): add $MNT/ mount-point directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ apps/ui/test-results/
 .copilot-worktrees/
 tmp/
 .ai-temp/
+
+# Pi image build mount points
+\$MNT/


### PR DESCRIPTION
## Summary

Fixes #736

The `$MNT/` directory at the repo root contains empty Pi image build mount points (`boot/` and `root/`) that should not be tracked by git.

Note: The directory is not currently tracked (empty dirs aren't stored by git), but this gitignore rule prevents any future files placed there from accidentally being committed.

## Changes

- `.gitignore`: Add `\$MNT/` pattern to exclude the mount-point directory