### PR TITLE
refactor(domain): remove dependency on shared/locations.py for domain isolation

### DIFF
--- a/apps/server/tests/hygiene/test_location_codes_sync.py
+++ b/apps/server/tests/hygiene/test_location_codes_sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 from tests._paths import REPO_ROOT
+from vibesensor.domain.sensor import _LOCATION_CODES as DOMAIN_LOCATION_CODES
 from vibesensor.shared.locations import LOCATION_CODES
 
 _CONSTANTS_TS = REPO_ROOT / "apps" / "ui" / "src" / "constants.ts"
@@ -19,4 +20,11 @@ def test_frontend_location_codes_match_backend() -> None:
         f"Frontend/backend location code mismatch.\n"
         f"  Backend:  {backend_codes}\n"
         f"  Frontend: {frontend_codes}"
+    )
+
+
+def test_domain_location_codes_match_shared() -> None:
+    """Domain-internal _LOCATION_CODES must stay in sync with shared/locations."""
+    assert DOMAIN_LOCATION_CODES == LOCATION_CODES, (
+        "domain/sensor.py _LOCATION_CODES drifted from shared/locations.py LOCATION_CODES"
     )

--- a/apps/server/vibesensor/domain/sensor.py
+++ b/apps/server/vibesensor/domain/sensor.py
@@ -10,11 +10,32 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Final
 
 __all__ = [
     "Sensor",
     "SensorPlacement",
 ]
+
+# Domain-internal location code registry.  The canonical external-facing
+# copy lives in ``shared/locations.py``; a hygiene test guards parity.
+_LOCATION_CODES: Final[dict[str, str]] = {
+    "front_left_wheel": "Front Left Wheel",
+    "front_right_wheel": "Front Right Wheel",
+    "rear_left_wheel": "Rear Left Wheel",
+    "rear_right_wheel": "Rear Right Wheel",
+    "transmission": "Transmission",
+    "driveshaft_tunnel": "Driveshaft Tunnel",
+    "engine_bay": "Engine Bay",
+    "front_subframe": "Front Subframe",
+    "rear_subframe": "Rear Subframe",
+    "driver_seat": "Driver Seat",
+    "front_passenger_seat": "Front Passenger Seat",
+    "rear_left_seat": "Rear Left Seat",
+    "rear_center_seat": "Rear Center Seat",
+    "rear_right_seat": "Rear Right Seat",
+    "trunk": "Trunk",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,13 +64,11 @@ class SensorPlacement:
     def from_code(cls, code: str) -> SensorPlacement:
         """Create a placement from a canonical location code.
 
-        Resolves the human-readable label from the location code registry
-        (``vibesensor.shared.locations.LOCATION_CODES``).  Falls back to a
-        title-cased version of the code if the code is not found.
+        Resolves the human-readable label from the domain-internal location
+        code registry.  Falls back to a title-cased version of the code if
+        the code is not found.
         """
-        from vibesensor.shared.locations import LOCATION_CODES
-
-        label = LOCATION_CODES.get(code, code.replace("_", " ").title())
+        label = _LOCATION_CODES.get(code, code.replace("_", " ").title())
         return cls(code=code, label=label)
 
 


### PR DESCRIPTION
## Summary

Fixes #701

The domain layer (`vibesensor/domain/`) should have zero outward dependencies to remain independently testable and truly innermost. Previously, `domain/sensor.py` had a lazy import of `LOCATION_CODES` from `shared/locations.py` — the only domain→shared violation.

## Changes

- **`domain/sensor.py`**: Inline a domain-internal `_LOCATION_CODES` constant (15 entries), removing the lazy import from `shared/locations`
- **`tests/hygiene/test_location_codes_sync.py`**: Add `test_domain_location_codes_match_shared()` to guard parity between the domain copy and `shared/locations.py`

## Verification

- `domain/` has zero imports from `shared/`, `infra/`, `adapters/`, `app/`, or `use_cases/`
- All 249 hygiene tests pass
- Lint and format checks pass