### PR TITLE
refactor: move normalize_sensor_id from UDP adapter to domain/sensor

### DIFF
--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from fastapi import HTTPException
 
-from vibesensor.adapters.udp.protocol import normalize_sensor_id
+from vibesensor.domain import normalize_sensor_id
 from vibesensor.shared.exceptions import (
     AnalysisNotReadyError,
     DataCorruptError,

--- a/apps/server/vibesensor/adapters/http/websocket.py
+++ b/apps/server/vibesensor/adapters/http/websocket.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
-from vibesensor.adapters.udp.protocol import normalize_sensor_id
+from vibesensor.domain import normalize_sensor_id
 
 if TYPE_CHECKING:
     from vibesensor.adapters.websocket.hub import WebSocketHub

--- a/apps/server/vibesensor/adapters/udp/protocol.py
+++ b/apps/server/vibesensor/adapters/udp/protocol.py
@@ -41,7 +41,6 @@ __all__ = [
     "parse_data",
     "parse_data_ack",
     "parse_hello",
-    "normalize_sensor_id",
     "SensorFrame",
 ]
 
@@ -394,13 +393,8 @@ def pack_data_ack(client_id: bytes, last_seq_received: int) -> bytes:
 
 
 # ---------------------------------------------------------------------------
-# Sensor ID normalisation & JSONL SensorFrame
+# JSONL SensorFrame
 # ---------------------------------------------------------------------------
-
-
-def normalize_sensor_id(sensor_id: str) -> str:
-    """Normalize a sensor MAC / hex string to canonical lowercase hex."""
-    return str(parse_client_id(str(sensor_id)).hex())
 
 
 _VSD_KEY: str = "vibration_strength_db"

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -53,7 +53,7 @@ from .run import Run
 from .run_capture import ConfigurationSnapshot, Measurement, RunCapture, RunSetup, VibrationReading
 from .run_status import RUN_TRANSITIONS, RunStatus, is_run_deletable, transition_run
 from .run_suitability import RunSuitability, SuitabilityCheck
-from .sensor import Sensor, SensorPlacement
+from .sensor import Sensor, SensorPlacement, normalize_sensor_id
 from .snapshots import (
     AnalysisSettingsSnapshot,
     DrivingPhaseSummary,
@@ -123,6 +123,7 @@ __all__ = [
     # Functions
     "RUN_TRANSITIONS",
     "is_run_deletable",
+    "normalize_sensor_id",
     "plan_test_actions",
     "speed_band_sort_key",
     "speed_bin_label",

--- a/apps/server/vibesensor/domain/sensor.py
+++ b/apps/server/vibesensor/domain/sensor.py
@@ -15,6 +15,7 @@ from typing import Final
 __all__ = [
     "Sensor",
     "SensorPlacement",
+    "normalize_sensor_id",
 ]
 
 # Domain-internal location code registry.  The canonical external-facing
@@ -114,3 +115,24 @@ class Sensor:
             )
             for code in location_codes
         )
+
+
+# ---------------------------------------------------------------------------
+# Sensor ID normalisation
+# ---------------------------------------------------------------------------
+
+_SENSOR_ID_HEX_LEN: Final[int] = 12
+
+
+def normalize_sensor_id(sensor_id: str) -> str:
+    """Normalize a sensor MAC / hex string to canonical 12-char lowercase hex.
+
+    Accepts raw hex (``"AABBCCDDEEFF"``) or colon-separated
+    (``"AA:BB:CC:DD:EE:FF"``) formats.
+    """
+    compact = sensor_id.replace(":", "").strip().lower()
+    if len(compact) != _SENSOR_ID_HEX_LEN:
+        raise ValueError("sensor_id must be 12 hex chars")
+    # Validate hex by attempting conversion.
+    bytes.fromhex(compact)
+    return compact

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -28,8 +28,14 @@ import sqlite3
 from threading import RLock
 from typing import TYPE_CHECKING, cast, get_args
 
-from vibesensor.adapters.udp.protocol import normalize_sensor_id
-from vibesensor.domain import Car, CarSnapshot, Sensor, SensorPlacement, SpeedSource
+from vibesensor.domain import (
+    Car,
+    CarSnapshot,
+    Sensor,
+    SensorPlacement,
+    SpeedSource,
+    normalize_sensor_id,
+)
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.exceptions import PersistenceError as PersistenceError
 from vibesensor.shared.types.backend_types import (

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -20,7 +20,7 @@ from vibesensor.adapters.udp.protocol import (
     client_id_hex,
     client_id_mac,
 )
-from vibesensor.adapters.udp.protocol import normalize_sensor_id as _normalize_client_id
+from vibesensor.domain import normalize_sensor_id as _normalize_client_id
 from vibesensor.infra.processing.models import ClientMetrics
 from vibesensor.shared.types.payload_types import ClientApiRow
 


### PR DESCRIPTION
## Summary

Moves `normalize_sensor_id` from the UDP protocol adapter to `domain/sensor.py`, fixing layer violations where infra and HTTP modules imported from a transport adapter for a generic utility.

## Problem

`normalize_sensor_id` is a sensor identity concern (MAC hex normalization) that has nothing to do with UDP transport. Four modules imported it from `adapters/udp/protocol`:
- `infra/config/settings_store.py` — infra → adapter violation
- `infra/runtime/registry.py` — infra → adapter violation
- `adapters/http/_helpers.py` — HTTP adapter reaching into UDP adapter
- `adapters/http/websocket.py` — HTTP adapter reaching into UDP adapter

## Changes

- Added self-contained `normalize_sensor_id()` to `domain/sensor.py` (no protocol dependency)
- Exported via `domain/__init__.py` and `__all__`
- Updated all 4 importers to use `vibesensor.domain`
- Removed the function and its `__all__` entry from `protocol.py` (no-backward-compat policy)

All 5425 tests pass, including import boundary and architecture hygiene tests.

Closes #740