### PR TITLE
refactor: inject config into hotspot self_heal adapter

### DIFF
--- a/apps/server/vibesensor/adapters/hotspot/self_heal.py
+++ b/apps/server/vibesensor/adapters/hotspot/self_heal.py
@@ -11,6 +11,7 @@ import logging
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from vibesensor.adapters.hotspot.parsers import (
     HealStateStore,
@@ -23,7 +24,9 @@ from vibesensor.adapters.hotspot.parsers import (
     parse_port53_conflict,
     parse_rfkill_blocked,
 )
-from vibesensor.app.settings import APConfig, APSelfHealConfig, load_config
+
+if TYPE_CHECKING:
+    from vibesensor.app.settings import APConfig, APSelfHealConfig
 
 LOGGER = logging.getLogger("vibesensor.adapters.hotspot.selfheal")
 
@@ -548,11 +551,8 @@ def run_self_heal_once(
     return 0
 
 
-def run_self_heal(config_path: Path, diagnostics_only: bool = False) -> int:
-    """Load configuration from *config_path* and run one self-heal cycle."""
-    cfg = load_config(config_path)
-    ap = cfg.ap
-    self_heal = cfg.ap.self_heal
+def run_self_heal(ap: APConfig, self_heal: APSelfHealConfig, diagnostics_only: bool = False) -> int:
+    """Run one self-heal cycle with the given configuration."""
     runner = CommandRunner()
     store = HealStateStore(self_heal.state_file)
     return run_self_heal_once(ap, self_heal, runner, store, diagnostics_only=diagnostics_only)
@@ -580,7 +580,11 @@ def main() -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    raise SystemExit(run_self_heal(args.config, diagnostics_only=args.mode == "diagnostics"))
+    from vibesensor.app.settings import load_config
+
+    cfg = load_config(args.config)
+    diag_only = args.mode == "diagnostics"
+    raise SystemExit(run_self_heal(cfg.ap, cfg.ap.self_heal, diagnostics_only=diag_only))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Injects config into the hotspot self_heal adapter instead of having it import from `app/settings`.

## Problem

`adapters/hotspot/self_heal.py` imported `APConfig`, `APSelfHealConfig`, and `load_config` directly from `app/settings` — the adapter layer should not depend on the app layer (the composition root).

## Changes

- `run_self_heal()` now accepts `APConfig` and `APSelfHealConfig` as parameters instead of a config file path
- `load_config` call moved to `main()` (the CLI composition root, which is the appropriate place for app-layer imports)
- `APConfig`/`APSelfHealConfig` type imports moved under `TYPE_CHECKING` (possible because `from __future__ import annotations` is present)

All 48 hotspot tests and import boundary hygiene tests pass.

Closes #739