### PR TITLE
refactor: move PlotDataResult and plot TypedDicts to shared/boundaries/

### DIFF
--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -14,19 +14,26 @@ from vibesensor.domain import OrderMatchObservation
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
 if TYPE_CHECKING:
+    from vibesensor.adapters.pdf.report_types import PeakTableRow
     from vibesensor.shared.boundaries.vibration_origin import SuspectedVibrationOrigin
-    from vibesensor.use_cases.diagnostics.plots import PlotDataResult
 
 __all__ = [
+    "AmpVsPhaseRow",
     "AmplitudeMetric",
     "AnalysisSummary",
     "FindingEvidenceMetrics",
     "FindingPayload",
+    "FreqVsSpeedByFindingSeries",
     "LocationHotspotPayload",
+    "MatchedAmpVsSpeedSeries",
     "MatchedPoint",
+    "PhaseBoundary",
     "PhaseEvidence",
+    "PhaseSegmentOut",
     "PhaseSpeedBreakdownRow",
+    "PlotDataResult",
     "RunSuitabilityCheck",
+    "SpectrogramResult",
     "SpeedBreakdownRow",
     "matched_point_from_observation",
 ]
@@ -181,6 +188,84 @@ class FindingPayload(TypedDict, total=False):
     grouped_count: int
     order: str
     diagnostic_caveat: JsonValue
+
+
+# ---------------------------------------------------------------------------
+# Plot-data boundary shapes (moved from use_cases/diagnostics/plots.py)
+# ---------------------------------------------------------------------------
+
+
+class SpectrogramResult(TypedDict, total=False):
+    """Shape returned by spectrogram builders."""
+
+    x_axis: Required[str]
+    x_label_key: Required[str]
+    x_bins: Required[list[float]]
+    y_bins: Required[list[float]]
+    cells: Required[list[list[float]]]
+    max_amp: Required[float]
+    x_bin_width: float
+    y_bin_width: float
+
+
+class MatchedAmpVsSpeedSeries(TypedDict):
+    """Per-finding matched-point series for amp-vs-speed."""
+
+    label: str
+    points: list[tuple[float, float]]
+
+
+class FreqVsSpeedByFindingSeries(TypedDict):
+    """Per-finding frequency-vs-speed series with predicted overlay."""
+
+    label: str
+    matched: list[tuple[float, float]]
+    predicted: list[tuple[float, float]]
+
+
+class AmpVsPhaseRow(TypedDict):
+    """A single phase-grouped vibration row."""
+
+    phase: str
+    count: int
+    mean_vib_db: float
+    max_vib_db: float | None
+    mean_speed_kmh: float | None
+
+
+class PhaseSegmentOut(TypedDict):
+    """Serialised driving-phase segment for plot consumers."""
+
+    phase: str
+    start_t_s: float | None
+    end_t_s: float | None
+
+
+class PhaseBoundary(TypedDict):
+    """Phase boundary marker for plot overlay."""
+
+    phase: str
+    t_s: float | None
+    end_t_s: float | None
+
+
+class PlotDataResult(TypedDict):
+    """Shape returned by the plot-data orchestration layer."""
+
+    vib_magnitude: list[tuple[float, float, str]]
+    dominant_freq: list[tuple[float, float]]
+    amp_vs_speed: list[tuple[float, float]]
+    amp_vs_phase: list[AmpVsPhaseRow]
+    matched_amp_vs_speed: list[MatchedAmpVsSpeedSeries]
+    freq_vs_speed_by_finding: list[FreqVsSpeedByFindingSeries]
+    steady_speed_distribution: dict[str, float] | None
+    fft_spectrum: list[tuple[float, float]]
+    fft_spectrum_raw: list[tuple[float, float]]
+    peaks_spectrogram: SpectrogramResult
+    peaks_spectrogram_raw: SpectrogramResult
+    peaks_table: list[PeakTableRow]
+    phase_segments: list[PhaseSegmentOut]
+    phase_boundaries: list[PhaseBoundary]
 
 
 class AnalysisSummary(TypedDict):

--- a/apps/server/vibesensor/use_cases/diagnostics/plots.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/plots.py
@@ -15,10 +15,19 @@ from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from math import floor
-from typing import Any, Literal, Required, TypedDict
+from typing import Any, Literal
 
 from vibesensor.adapters.pdf.report_types import PeakTableRow
 from vibesensor.domain.finding import speed_bin_label
+from vibesensor.shared.boundaries.analysis_payload import (
+    AmpVsPhaseRow,
+    FreqVsSpeedByFindingSeries,
+    MatchedAmpVsSpeedSeries,
+    PhaseBoundary,
+    PhaseSegmentOut,
+    PlotDataResult,
+    SpectrogramResult,
+)
 from vibesensor.shared.constants import MEMS_NOISE_FLOOR_G
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.use_cases.diagnostics._types import Sample
@@ -41,23 +50,6 @@ from vibesensor.vibration_strength import compute_db, compute_db_or_none, percen
 # ---------------------------------------------------------------------------
 # Spectrum types & builders (formerly plot_spectrum.py)
 # ---------------------------------------------------------------------------
-
-
-class SpectrogramResult(TypedDict, total=False):
-    """Shape returned by spectrogram builders.
-
-    Required fields are always present; ``x_bin_width`` and ``y_bin_width``
-    are only set in non-empty results.
-    """
-
-    x_axis: Required[str]
-    x_label_key: Required[str]
-    x_bins: Required[list[float]]
-    y_bins: Required[list[float]]
-    cells: Required[list[list[float]]]
-    max_amp: Required[float]
-    x_bin_width: float
-    y_bin_width: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -335,47 +327,6 @@ def spectrogram_from_peaks_raw(
 # ---------------------------------------------------------------------------
 # Series types & builders (formerly plot_series.py)
 # ---------------------------------------------------------------------------
-
-
-class MatchedAmpVsSpeedSeries(TypedDict):
-    """Per-finding matched-point series for amp-vs-speed."""
-
-    label: str
-    points: list[tuple[float, float]]
-
-
-class FreqVsSpeedByFindingSeries(TypedDict):
-    """Per-finding frequency-vs-speed series with predicted overlay."""
-
-    label: str
-    matched: list[tuple[float, float]]
-    predicted: list[tuple[float, float]]
-
-
-class AmpVsPhaseRow(TypedDict):
-    """A single phase-grouped vibration row."""
-
-    phase: str
-    count: int
-    mean_vib_db: float
-    max_vib_db: float | None
-    mean_speed_kmh: float | None
-
-
-class PhaseSegmentOut(TypedDict):
-    """Serialised driving-phase segment for plot consumers."""
-
-    phase: str
-    start_t_s: float | None
-    end_t_s: float | None
-
-
-class PhaseBoundary(TypedDict):
-    """Phase boundary marker for plot overlay."""
-
-    phase: str
-    t_s: float | None
-    end_t_s: float | None
 
 
 @dataclass(frozen=True)
@@ -735,25 +686,6 @@ def top_peaks_table_rows(
 # ---------------------------------------------------------------------------
 # Plot-data orchestration (formerly plot_data.py)
 # ---------------------------------------------------------------------------
-
-
-class PlotDataResult(TypedDict):
-    """Shape returned by the plot-data orchestration layer."""
-
-    vib_magnitude: list[tuple[float, float, str]]
-    dominant_freq: list[tuple[float, float]]
-    amp_vs_speed: list[tuple[float, float]]
-    amp_vs_phase: list[AmpVsPhaseRow]
-    matched_amp_vs_speed: list[MatchedAmpVsSpeedSeries]
-    freq_vs_speed_by_finding: list[FreqVsSpeedByFindingSeries]
-    steady_speed_distribution: dict[str, float] | None
-    fft_spectrum: list[tuple[float, float]]
-    fft_spectrum_raw: list[tuple[float, float]]
-    peaks_spectrogram: SpectrogramResult
-    peaks_spectrogram_raw: SpectrogramResult
-    peaks_table: list[PeakTableRow]
-    phase_segments: list[PhaseSegmentOut]
-    phase_boundaries: list[PhaseBoundary]
 
 
 def _plot_data(


### PR DESCRIPTION
## Summary

Moves `PlotDataResult` and 6 related plot TypedDicts from `use_cases/diagnostics/plots.py` to `shared/boundaries/analysis_payload.py` to fix a reverse dependency.

## Problem

`shared/boundaries/analysis_payload.py` had a `TYPE_CHECKING`-only import from `use_cases/diagnostics/plots` for `PlotDataResult` — the shared boundary layer referencing a use-case module. While not a runtime dependency, this is a structural layer violation.

## Changes

Moved these 7 TypedDicts to `shared/boundaries/analysis_payload.py`:
- `SpectrogramResult`
- `MatchedAmpVsSpeedSeries`
- `FreqVsSpeedByFindingSeries`
- `AmpVsPhaseRow`
- `PhaseSegmentOut`
- `PhaseBoundary`
- `PlotDataResult`

Updated `plots.py` to import them from the boundary module. Removed the reverse `TYPE_CHECKING` import. All 5425 tests pass.

Closes #745