### PR TITLE
cleanup(boundaries): remove 10 dead fields from LocationHotspotPayload (#721)

### DIFF
--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -76,24 +76,14 @@ class AmplitudeMetric(TypedDict):
 
 
 class LocationHotspotPayload(TypedDict, total=False):
-    speed_range: str
-    location: str
-    mean_amp: float
     dominance_ratio: float | None
     location_count: int
     top_location: str
     second_location: str | None
-    top_location_samples: int
-    second_location_samples: int
-    corroborated_by_n_sensors: int
-    total_samples: int
     ambiguous_location: bool
     ambiguous_locations: list[str]
-    partial_coverage: bool
     localization_confidence: float
     weak_spatial_separation: bool
-    no_wheel_sensors: bool
-    per_bin_results: list[LocationHotspotPayload]
 
 
 class FindingEvidenceMetrics(TypedDict, total=False):


### PR DESCRIPTION
## Summary

Removes 10 dead fields from `LocationHotspotPayload` in `shared/boundaries/analysis_payload.py`. These fields were declared in the TypedDict but never written by the serializer (`finding_payload_from_domain()`) and never consumed by the deserializer (`location_hotspot_from_payload()`).

## Removed fields

| Field | Reason dead |
|---|---|
| `speed_range` | Never serialized |
| `location` | Legacy alias; only read as fallback for `top_location` (which is always written) |
| `mean_amp` | Never serialized |
| `top_location_samples` | Never serialized |
| `second_location_samples` | Never serialized |
| `corroborated_by_n_sensors` | Never serialized |
| `total_samples` | Never serialized |
| `partial_coverage` | Never serialized |
| `no_wheel_sensors` | Never serialized |
| `per_bin_results` | Never serialized |

## Kept fields (8)

`dominance_ratio`, `location_count`, `top_location`, `second_location` (legacy fallback, NotRequired), `ambiguous_location`, `ambiguous_locations`, `localization_confidence`, `weak_spatial_separation`

## Backward compatibility

The deserializer uses `.get()` throughout, so persisted history runs containing the old fields continue to deserialize correctly — extras are simply ignored.

Closes #721