### PR TITLE
refactor(shared): extract time utilities from runlog.py to shared/time_utils.py (#699)

### DIFF
--- a/apps/server/tests/adapters/persistence/test_runlog.py
+++ b/apps/server/tests/adapters/persistence/test_runlog.py
@@ -10,11 +10,10 @@ from vibesensor.adapters.persistence.runlog import (
     bounded_sample,
     create_run_metadata,
     normalize_sample_record,
-    parse_iso8601,
     read_jsonl_run,
-    utc_now_iso,
 )
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
+from vibesensor.shared.time_utils import parse_iso8601, utc_now_iso
 
 # -- Helpers -------------------------------------------------------------------
 

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -294,7 +294,7 @@ def test_store_language_roundtrip() -> None:
 def test_store_corrupted_snapshot_falls_back_to_defaults(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     # Write invalid JSON directly into the settings_snapshot table
-    from vibesensor.adapters.persistence.runlog import utc_now_iso
+    from vibesensor.shared.time_utils import utc_now_iso
 
     with db._cursor() as cur:
         cur.execute(

--- a/apps/server/tests/integration/test_multi_domain_regressions.py
+++ b/apps/server/tests/integration/test_multi_domain_regressions.py
@@ -15,11 +15,11 @@ import pytest
 
 from vibesensor.adapters.pdf.mapping import order_label_human
 from vibesensor.adapters.pdf.mapping import resolve_i18n as resolve_i18n_impl
-from vibesensor.adapters.persistence.runlog import parse_iso8601
 from vibesensor.domain import Finding, SpeedSourceKind
 from vibesensor.domain.finding import speed_bin_label
 from vibesensor.report_i18n import tr
 from vibesensor.shared.json_utils import as_float_or_none as runlog_as_float_or_none
+from vibesensor.shared.time_utils import parse_iso8601
 from vibesensor.use_cases.diagnostics.findings import _sensor_intensity_by_location
 from vibesensor.use_cases.diagnostics.helpers import _format_duration
 from vibesensor.use_cases.diagnostics.location_analysis import _weighted_speed_window_label

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -23,7 +23,6 @@ from vibesensor.adapters.pdf.report_data import (
     SystemFindingCard,
 )
 from vibesensor.adapters.pdf.report_types import PeakTableRow
-from vibesensor.adapters.persistence.runlog import utc_now_iso
 from vibesensor.domain import (
     ConfidenceAssessment,
     Finding,
@@ -40,6 +39,7 @@ from vibesensor.shared.boundaries.vibration_origin import (
 )
 from vibesensor.shared.constants import PHASE_I18N_KEYS
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
 __all__ = ["Report", "map_summary"]

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -31,7 +31,6 @@ from vibesensor.adapters.persistence.history_db._schema import (
     SCHEMA_SQL,
     SCHEMA_VERSION,
 )
-from vibesensor.adapters.persistence.runlog import utc_now_iso
 from vibesensor.adapters.udp.protocol import SensorFrame
 from vibesensor.domain.run_status import (
     RunStatus,
@@ -39,6 +38,7 @@ from vibesensor.domain.run_status import (
     transition_run,
 )
 from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
+from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 
 # Re-export for public API.

--- a/apps/server/vibesensor/adapters/persistence/runlog.py
+++ b/apps/server/vibesensor/adapters/persistence/runlog.py
@@ -2,7 +2,6 @@
 
 Provides helpers for reading metric run files in JSONL format,
 plus normalisation helpers for canonical field name handling.
-``utc_now_iso()`` is canonically defined in this module.
 """
 
 from __future__ import annotations
@@ -11,7 +10,6 @@ import json
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 
 from vibesensor.adapters.udp.protocol import SensorFrame
@@ -32,9 +30,7 @@ __all__ = [
     "bounded_sample",
     "create_run_metadata",
     "normalize_sample_record",
-    "parse_iso8601",
     "read_jsonl_run",
-    "utc_now_iso",
 ]
 
 
@@ -45,25 +41,6 @@ class RunData:
     metadata: JsonObject
     samples: list[JsonObject]
     source_path: Path
-
-
-def utc_now_iso() -> str:
-    """Return the current UTC time as an ISO 8601 string."""
-    return datetime.now(UTC).isoformat()
-
-
-def parse_iso8601(value: object) -> datetime | None:
-    """Parse an ISO 8601 string into an aware ``datetime``, or return ``None``."""
-    if not isinstance(value, str) or not value.strip():
-        return None
-    try:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        # Ensure timezone-aware: assume UTC for naive timestamps
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=UTC)
-        return dt
-    except ValueError:
-        return None
 
 
 def create_run_metadata(

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-from vibesensor.adapters.persistence.runlog import utc_now_iso
+from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.payload_types import SCHEMA_VERSION, LiveWsPayload, SpectraPayload
 
 

--- a/apps/server/vibesensor/shared/time_utils.py
+++ b/apps/server/vibesensor/shared/time_utils.py
@@ -1,0 +1,24 @@
+"""Cross-cutting time utilities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO 8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def parse_iso8601(value: object) -> datetime | None:
+    """Parse an ISO 8601 string into an aware ``datetime``, or return ``None``."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        # Ensure timezone-aware: assume UTC for naive timestamps
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    except ValueError:
+        return None

--- a/apps/server/vibesensor/use_cases/diagnostics/summary_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/summary_builder.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from statistics import median as _median
 from typing import Any
 
-from vibesensor.adapters.persistence.runlog import parse_iso8601, utc_now_iso
 from vibesensor.domain import (
     ConfigurationSnapshot,
     DiagnosticCase,
@@ -59,6 +58,7 @@ from vibesensor.shared.constants import (
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.run_context import build_summary_warnings, order_reference_context_complete
+from vibesensor.shared.time_utils import parse_iso8601, utc_now_iso
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.strength_bands import bucket_for_strength
 from vibesensor.use_cases.diagnostics._types import (

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -21,10 +21,10 @@ from threading import RLock
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from vibesensor.adapters.persistence.runlog import utc_now_iso
 from vibesensor.domain import Run
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.constants import NUMERIC_TYPES
+from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.sample_builder import (
     build_run_metadata,

--- a/apps/server/vibesensor/use_cases/updates/firmware_cache.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware_cache.py
@@ -539,7 +539,7 @@ class FirmwareCache:
             validate_bundle(extract_dir)
 
             # Write metadata
-            from vibesensor.adapters.persistence.runlog import utc_now_iso
+            from vibesensor.shared.time_utils import utc_now_iso
 
             meta = BundleMeta(
                 tag=tag,


### PR DESCRIPTION
## Summary

Extracts `utc_now_iso()` and `parse_iso8601()` from `adapters/persistence/runlog.py` into a new `shared/time_utils.py` module.

## Motivation

These are general-purpose time utilities used by 7+ modules across `use_cases/`, `infra/`, and `adapters/` layers. Embedding them in the persistence adapter created false coupling — touching `runlog.py` for persistence reasons risked breaking unrelated time consumers.

## Changes

- **New**: `vibesensor/shared/time_utils.py` — canonical home for `utc_now_iso()` and `parse_iso8601()`
- **Removed**: Both functions from `adapters/persistence/runlog.py` (no compatibility aliases per repo convention)
- **Updated importers (6 production)**:
  - `use_cases/diagnostics/summary_builder.py`
  - `use_cases/run/logger.py`
  - `use_cases/updates/firmware_cache.py`
  - `adapters/persistence/history_db/__init__.py`
  - `adapters/pdf/mapping.py`
  - `infra/runtime/ws_broadcast.py`
- **Updated importers (3 tests)**:
  - `tests/adapters/persistence/test_runlog.py`
  - `tests/integration/test_multi_domain_regressions.py`
  - `tests/infra/config/test_settings_store.py`

Closes #699