### PR TITLE
refactor: move bounded_sample and create_run_metadata out of persistence (#748)

### DIFF
--- a/apps/server/tests/adapters/persistence/test_runlog.py
+++ b/apps/server/tests/adapters/persistence/test_runlog.py
@@ -7,13 +7,13 @@ import pytest
 
 from vibesensor.adapters.persistence.runlog import (
     RUN_METADATA_TYPE,
-    bounded_sample,
-    create_run_metadata,
     normalize_sample_record,
     read_jsonl_run,
 )
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
+from vibesensor.shared.sampling import bounded_sample
 from vibesensor.shared.time_utils import parse_iso8601, utc_now_iso
+from vibesensor.use_cases.run.sample_builder import create_run_metadata
 
 # -- Helpers -------------------------------------------------------------------
 

--- a/apps/server/tests/integration/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_core_regressions.py
@@ -12,10 +12,10 @@ import time
 
 import pytest
 
-from vibesensor.adapters.persistence.runlog import bounded_sample
 from vibesensor.infra.runtime.registry import _sanitize_name
 from vibesensor.infra.workers.worker_pool import WorkerPool
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
+from vibesensor.shared.sampling import bounded_sample
 from vibesensor.shared.types.backend_types import new_car_id
 from vibesensor.use_cases.diagnostics.order_bands import build_order_bands
 

--- a/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
@@ -20,9 +20,9 @@ import numpy as np
 import pytest
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.adapters.persistence.runlog import bounded_sample as _bounded_sample
 from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.infra.processing import SignalProcessor
+from vibesensor.shared.sampling import bounded_sample as _bounded_sample
 
 # -- shared helpers ----------------------------------------------------------
 

--- a/apps/server/tests/test_support/report_helpers.py
+++ b/apps/server/tests/test_support/report_helpers.py
@@ -8,9 +8,6 @@ from typing import Any
 
 import pytest
 
-from vibesensor.adapters.persistence.runlog import (
-    create_run_metadata,
-)
 from vibesensor.domain import LocationHotspot
 from vibesensor.use_cases.diagnostics import location_analysis as _test_plan_module
 from vibesensor.use_cases.diagnostics import (
@@ -23,6 +20,7 @@ from vibesensor.use_cases.diagnostics.location_analysis import LocationAnalysisR
 from vibesensor.use_cases.diagnostics.order_analysis import (
     _build_order_findings as _findings_build_order_findings,
 )
+from vibesensor.use_cases.run.sample_builder import create_run_metadata
 
 # Canonical run-end record reused across report tests.
 RUN_END = {"record_type": "run_end", "schema_version": "v2-jsonl", "run_id": "run-01"}

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py
@@ -113,7 +113,7 @@ class TestBoundedSampleNoHint:
     """Demonstrate the reactive doubling behavior without total_hint."""
 
     def test_reactive_doubling_wastes_work(self):
-        from vibesensor.adapters.persistence.runlog import bounded_sample
+        from vibesensor.shared.sampling import bounded_sample
 
         items = [{"v": i} for i in range(200)]
         # Without total_hint: starts with stride=1, collects all until overflow

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
@@ -15,7 +15,8 @@ import pytest
 from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.adapters.persistence.runlog import bounded_sample, normalize_sample_record
+from vibesensor.adapters.persistence.runlog import normalize_sample_record
+from vibesensor.shared.sampling import bounded_sample
 from vibesensor.use_cases.diagnostics import build_findings_for_samples, summarize_run_data
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 

--- a/apps/server/vibesensor/adapters/persistence/runlog.py
+++ b/apps/server/vibesensor/adapters/persistence/runlog.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,7 +16,6 @@ from vibesensor.shared.types.backend_types import (
     RUN_END_TYPE,
     RUN_METADATA_TYPE,
     RUN_SAMPLE_TYPE,
-    RunMetadata,
 )
 from vibesensor.shared.types.json_types import JsonObject
 
@@ -27,8 +25,6 @@ __all__ = [
     "RUN_METADATA_TYPE",
     "RUN_SAMPLE_TYPE",
     "RunData",
-    "bounded_sample",
-    "create_run_metadata",
     "normalize_sample_record",
     "read_jsonl_run",
 ]
@@ -43,34 +39,6 @@ class RunData:
     source_path: Path
 
 
-def create_run_metadata(
-    *,
-    run_id: str,
-    start_time_utc: str,
-    sensor_model: str,
-    raw_sample_rate_hz: int | None,
-    feature_interval_s: float | None,
-    fft_window_size_samples: int | None,
-    accel_scale_g_per_lsb: float | None,
-    firmware_version: str | None = None,
-    end_time_utc: str | None = None,
-    incomplete_for_order_analysis: bool = False,
-) -> dict[str, object]:
-    """Build and return a run-metadata dict from the supplied fields."""
-    return RunMetadata.create(
-        run_id=run_id,
-        start_time_utc=start_time_utc,
-        sensor_model=sensor_model,
-        firmware_version=firmware_version,
-        raw_sample_rate_hz=raw_sample_rate_hz,
-        feature_interval_s=feature_interval_s,
-        fft_window_size_samples=fft_window_size_samples,
-        accel_scale_g_per_lsb=accel_scale_g_per_lsb,
-        end_time_utc=end_time_utc,
-        incomplete_for_order_analysis=incomplete_for_order_analysis,
-    ).to_dict()
-
-
 def normalize_sample_record(record: JsonObject) -> JsonObject:
     """Normalize a raw sample dict into canonical form.
 
@@ -81,51 +49,6 @@ def normalize_sample_record(record: JsonObject) -> JsonObject:
     normalized = dict(record)
     normalized.update(frame.to_dict())  # type: ignore[arg-type]  # dict[str, object] → JsonObject
     return normalized
-
-
-def bounded_sample(
-    samples: Iterator[JsonObject],
-    *,
-    max_items: int,
-    total_hint: int = 0,
-) -> tuple[list[JsonObject], int, int]:
-    """Down-sample *samples* to at most *max_items*.
-
-    When *total_hint* is available the stride is computed upfront so
-    that we never over-collect and re-halve.
-
-    Returns
-    -------
-    tuple[list[JsonObject], int, int]
-        ``(kept_samples, total_count, final_stride)`` where
-        *kept_samples* is the down-sampled list, *total_count* is the
-        number of items consumed from the iterator, and *final_stride*
-        is the stride factor that was applied.
-
-    Raises
-    ------
-    ValueError
-        If *max_items* is not a positive integer.
-
-    """
-    if max_items <= 0:
-        raise ValueError(f"bounded_sample: max_items must be >= 1, got {max_items}")
-    stride: int = max(1, -(-total_hint // max_items)) if total_hint > max_items else 1
-    kept: list[JsonObject] = []
-    total = 0
-    for sample in samples:
-        total += 1
-        if (total - 1) % stride != 0:
-            continue
-        kept.append(sample)
-        if len(kept) > max_items:
-            kept = kept[::2]
-            stride *= 2
-    # Final trim: the halving loop can leave len(kept) == max_items + 1
-    # in edge cases (e.g. max_items=1).  Guarantee the contract.
-    if len(kept) > max_items:
-        kept = kept[:max_items]
-    return kept, total, stride
 
 
 def read_jsonl_run(path: Path) -> RunData:

--- a/apps/server/vibesensor/shared/sampling.py
+++ b/apps/server/vibesensor/shared/sampling.py
@@ -1,0 +1,52 @@
+"""Iterator sampling utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from vibesensor.shared.types.json_types import JsonObject
+
+
+def bounded_sample(
+    samples: Iterator[JsonObject],
+    *,
+    max_items: int,
+    total_hint: int = 0,
+) -> tuple[list[JsonObject], int, int]:
+    """Down-sample *samples* to at most *max_items*.
+
+    When *total_hint* is available the stride is computed upfront so
+    that we never over-collect and re-halve.
+
+    Returns
+    -------
+    tuple[list[JsonObject], int, int]
+        ``(kept_samples, total_count, final_stride)`` where
+        *kept_samples* is the down-sampled list, *total_count* is the
+        number of items consumed from the iterator, and *final_stride*
+        is the stride factor that was applied.
+
+    Raises
+    ------
+    ValueError
+        If *max_items* is not a positive integer.
+
+    """
+    if max_items <= 0:
+        raise ValueError(f"bounded_sample: max_items must be >= 1, got {max_items}")
+    stride: int = max(1, -(-total_hint // max_items)) if total_hint > max_items else 1
+    kept: list[JsonObject] = []
+    total = 0
+    for sample in samples:
+        total += 1
+        if (total - 1) % stride != 0:
+            continue
+        kept.append(sample)
+        if len(kept) > max_items:
+            kept = kept[::2]
+            stride *= 2
+    # Final trim: the halving loop can leave len(kept) == max_items + 1
+    # in edge cases (e.g. max_items=1).  Guarantee the contract.
+    if len(kept) > max_items:
+        kept = kept[:max_items]
+    return kept, total, stride

--- a/apps/server/vibesensor/use_cases/run/post_analysis.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from threading import RLock, Thread
 from typing import TYPE_CHECKING, Any
 
-from vibesensor.adapters.persistence.runlog import bounded_sample
+from vibesensor.shared.sampling import bounded_sample
 
 if TYPE_CHECKING:
     from vibesensor.adapters.persistence.history_db import HistoryDB

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -20,6 +20,8 @@ from vibesensor.shared.run_context import (
     apply_run_context_snapshot,
     order_reference_context_complete,
 )
+from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.strength_bands import bucket_for_strength
 
 if TYPE_CHECKING:
@@ -245,6 +247,34 @@ def build_sample_records(
     return records
 
 
+def create_run_metadata(
+    *,
+    run_id: str,
+    start_time_utc: str,
+    sensor_model: str,
+    raw_sample_rate_hz: int | None,
+    feature_interval_s: float | None,
+    fft_window_size_samples: int | None,
+    accel_scale_g_per_lsb: float | None,
+    firmware_version: str | None = None,
+    end_time_utc: str | None = None,
+    incomplete_for_order_analysis: bool = False,
+) -> dict[str, object]:
+    """Build and return a run-metadata dict from the supplied fields."""
+    return RunMetadata.create(
+        run_id=run_id,
+        start_time_utc=start_time_utc,
+        sensor_model=sensor_model,
+        firmware_version=firmware_version,
+        raw_sample_rate_hz=raw_sample_rate_hz,
+        feature_interval_s=feature_interval_s,
+        fft_window_size_samples=fft_window_size_samples,
+        accel_scale_g_per_lsb=accel_scale_g_per_lsb,
+        end_time_utc=end_time_utc,
+        incomplete_for_order_analysis=incomplete_for_order_analysis,
+    ).to_dict()
+
+
 def build_run_metadata(
     *,
     run_id: str,
@@ -260,14 +290,12 @@ def build_run_metadata(
     language_provider: Callable[[], str] | None = None,
 ) -> dict[str, object]:
     """Assemble comprehensive run metadata."""
-    from vibesensor.adapters.persistence.runlog import create_run_metadata
-
     settings = asdict(analysis_settings_snapshot)
     order_reference_spec = analysis_settings_snapshot.order_reference_spec
     feature_interval_s = 1.0 / max(1.0, float(metrics_log_hz))
     raw_sample_rate_hz = default_sample_rate_hz if default_sample_rate_hz > 0 else None
     incomplete = raw_sample_rate_hz is None
-    metadata = create_run_metadata(
+    metadata: JsonObject = create_run_metadata(  # type: ignore[assignment]  # all values are JSON primitives
         run_id=run_id,
         start_time_utc=start_time_utc,
         sensor_model=sensor_model,


### PR DESCRIPTION
## Summary

Moves two misplaced utility functions out of `adapters/persistence/runlog.py`:

- **`bounded_sample`** → `shared/sampling.py` — general iterator downsampling utility with no persistence dependency
- **`create_run_metadata`** → `use_cases/run/sample_builder.py` — metadata factory whose only production consumer is `build_run_metadata` in the same module

## Changes

- **New file**: `apps/server/vibesensor/shared/sampling.py` with `bounded_sample`
- **Modified**: `use_cases/run/sample_builder.py` — added `create_run_metadata` definition
- **Modified**: `adapters/persistence/runlog.py` — removed both functions, cleaned up `__all__` and unused imports (`Iterator`, `RunMetadata`)
- **Updated importers** (1 production + 7 test files):
  - `use_cases/run/post_analysis.py`
  - `tests/adapters/persistence/test_runlog.py`
  - `tests/test_support/report_helpers.py`
  - `tests/integration/test_review_guardrails_core_regressions.py`
  - `tests/integration/test_runtime_quality_pass_regressions.py`
  - `tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py`
  - `tests/use_cases/diagnostics/test_analysis_pipeline_audit.py`

## Testing

All 5427 backend tests pass. Lint and format clean.

Closes #748