### PR TITLE
refactor: extract i18n resolution from pdf/mapping to report_i18n (#702)

### DIFF
--- a/apps/server/tests/adapters/pdf/test_i18n_separation.py
+++ b/apps/server/tests/adapters/pdf/test_i18n_separation.py
@@ -17,9 +17,9 @@ from pathlib import Path
 import pytest
 from _paths import SERVER_ROOT
 
-from vibesensor.adapters.pdf.mapping import is_i18n_ref, map_summary
-from vibesensor.adapters.pdf.mapping import resolve_i18n as resolve_i18n_impl
-from vibesensor.report_i18n import tr
+from vibesensor.adapters.pdf.mapping import map_summary
+from vibesensor.report_i18n import is_i18n_ref, tr
+from vibesensor.report_i18n import resolve_i18n as resolve_i18n_impl
 from vibesensor.use_cases.diagnostics import summarize_run_data
 
 _SERVER_PKG = SERVER_ROOT / "vibesensor"

--- a/apps/server/tests/integration/test_multi_domain_regressions.py
+++ b/apps/server/tests/integration/test_multi_domain_regressions.py
@@ -14,9 +14,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibesensor.adapters.pdf.mapping import order_label_human
-from vibesensor.adapters.pdf.mapping import resolve_i18n as resolve_i18n_impl
 from vibesensor.domain import Finding, SpeedSourceKind
 from vibesensor.domain.finding import speed_bin_label
+from vibesensor.report_i18n import resolve_i18n as resolve_i18n_impl
 from vibesensor.report_i18n import tr
 from vibesensor.shared.json_utils import as_float_or_none as runlog_as_float_or_none
 from vibesensor.shared.time_utils import parse_iso8601

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -30,17 +30,16 @@ from vibesensor.domain import (
     VibrationOrigin,
     VibrationSource,
 )
-from vibesensor.report_i18n import normalize_lang
+from vibesensor.report_i18n import human_source, is_i18n_ref, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.diagnostic_case import run_suitability_payload
 from vibesensor.shared.boundaries.vibration_origin import (
     build_origin_explanation,
     vibration_origin_from_payload,
 )
-from vibesensor.shared.constants import PHASE_I18N_KEYS
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import JsonObject
 
 __all__ = ["Report", "map_summary"]
 
@@ -198,64 +197,6 @@ _CLASSIFICATION_I18N_KEYS: dict[str, str] = {
     "transient": "CLASSIFICATION_TRANSIENT",
     "baseline_noise": "CLASSIFICATION_BASELINE_NOISE",
 }
-
-
-def is_i18n_ref(value: object) -> bool:
-    """Check whether *value* is a language-neutral i18n reference dict."""
-    return isinstance(value, dict) and "_i18n_key" in value
-
-
-def human_source(source: object, *, tr: Callable[[str], str]) -> str:
-    """Resolve a source code to its user-facing label."""
-    raw = str(source or "").strip().lower()
-    mapping: dict[VibrationSource, str] = {
-        VibrationSource.WHEEL_TIRE: tr("SOURCE_WHEEL_TIRE"),
-        VibrationSource.DRIVELINE: tr("SOURCE_DRIVELINE"),
-        VibrationSource.ENGINE: tr("SOURCE_ENGINE"),
-        VibrationSource.BODY_RESONANCE: tr("SOURCE_BODY_RESONANCE"),
-        VibrationSource.TRANSIENT_IMPACT: tr("SOURCE_TRANSIENT_IMPACT"),
-        VibrationSource.BASELINE_NOISE: tr("SOURCE_BASELINE_NOISE"),
-        VibrationSource.UNKNOWN_RESONANCE: tr("SOURCE_UNKNOWN_RESONANCE"),
-        VibrationSource.UNKNOWN: tr("UNKNOWN"),
-    }
-    try:
-        key = VibrationSource(raw)
-    except ValueError:
-        logger.warning(
-            "Unrecognized vibration source %r; falling back to titlecase",
-            raw,
-        )
-        return raw.replace("_", " ").title() if raw else tr("UNKNOWN")
-    return mapping.get(key, tr("UNKNOWN"))
-
-
-def resolve_i18n(
-    lang: str,
-    value: object,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    """Resolve plain strings, i18n refs, or lists of i18n refs to text."""
-    if isinstance(value, list):
-        return " ".join(resolve_i18n(lang, item, tr=tr) for item in value if item)
-    if not isinstance(value, dict) or "_i18n_key" not in value:
-        return str(value) if value is not None else ""
-    key = str(value["_i18n_key"])
-    suffix = str(value.get("_suffix", ""))
-    params = {k: v for k, v in value.items() if k not in ("_i18n_key", "_suffix")}
-    resolved_params: dict[str, JsonValue] = {}
-    for param_key, param_value in params.items():
-        if is_i18n_ref(param_value):
-            resolved_params[param_key] = resolve_i18n(lang, param_value, tr=tr)
-        elif param_key == "source" and isinstance(param_value, str):
-            resolved_params[param_key] = human_source(param_value, tr=tr)
-        elif param_key == "phase" and isinstance(param_value, str):
-            i18n_key = PHASE_I18N_KEYS.get(param_value)
-            resolved_params[param_key] = tr(i18n_key) if i18n_key else param_value
-        else:
-            resolved_params[param_key] = param_value
-    result = tr(key, **resolved_params)
-    return result + suffix if suffix else result
 
 
 def order_label_human(lang: str, label: str) -> str:

--- a/apps/server/vibesensor/report_i18n.py
+++ b/apps/server/vibesensor/report_i18n.py
@@ -6,9 +6,15 @@ Translation data is loaded from ``apps/server/data/report_i18n.json``.
 from __future__ import annotations
 
 import json
+import logging
+from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+
+from vibesensor.domain.finding import VibrationSource
+from vibesensor.shared.constants import PHASE_I18N_KEYS
+from vibesensor.shared.types.json_types import JsonValue
 
 _DATA_FILE = Path(__file__).resolve().parent.parent / "data" / "report_i18n.json"
 
@@ -44,3 +50,64 @@ def tr(lang: object, key: str, **kwargs: Any) -> str:
         return template.format(**kwargs)
     except (KeyError, IndexError):
         return template
+
+
+_logger = logging.getLogger(__name__)
+
+
+def is_i18n_ref(value: object) -> bool:
+    """Check whether *value* is a language-neutral i18n reference dict."""
+    return isinstance(value, dict) and "_i18n_key" in value
+
+
+def human_source(source: object, *, tr: Callable[[str], str]) -> str:
+    """Resolve a source code to its user-facing label."""
+    raw = str(source or "").strip().lower()
+    mapping: dict[VibrationSource, str] = {
+        VibrationSource.WHEEL_TIRE: tr("SOURCE_WHEEL_TIRE"),
+        VibrationSource.DRIVELINE: tr("SOURCE_DRIVELINE"),
+        VibrationSource.ENGINE: tr("SOURCE_ENGINE"),
+        VibrationSource.BODY_RESONANCE: tr("SOURCE_BODY_RESONANCE"),
+        VibrationSource.TRANSIENT_IMPACT: tr("SOURCE_TRANSIENT_IMPACT"),
+        VibrationSource.BASELINE_NOISE: tr("SOURCE_BASELINE_NOISE"),
+        VibrationSource.UNKNOWN_RESONANCE: tr("SOURCE_UNKNOWN_RESONANCE"),
+        VibrationSource.UNKNOWN: tr("UNKNOWN"),
+    }
+    try:
+        key = VibrationSource(raw)
+    except ValueError:
+        _logger.warning(
+            "Unrecognized vibration source %r; falling back to titlecase",
+            raw,
+        )
+        return raw.replace("_", " ").title() if raw else tr("UNKNOWN")
+    return mapping.get(key, tr("UNKNOWN"))
+
+
+def resolve_i18n(
+    lang: str,
+    value: object,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    """Resolve plain strings, i18n refs, or lists of i18n refs to text."""
+    if isinstance(value, list):
+        return " ".join(resolve_i18n(lang, item, tr=tr) for item in value if item)
+    if not isinstance(value, dict) or "_i18n_key" not in value:
+        return str(value) if value is not None else ""
+    key = str(value["_i18n_key"])
+    suffix = str(value.get("_suffix", ""))
+    params = {k: v for k, v in value.items() if k not in ("_i18n_key", "_suffix")}
+    resolved_params: dict[str, JsonValue] = {}
+    for param_key, param_value in params.items():
+        if is_i18n_ref(param_value):
+            resolved_params[param_key] = resolve_i18n(lang, param_value, tr=tr)
+        elif param_key == "source" and isinstance(param_value, str):
+            resolved_params[param_key] = human_source(param_value, tr=tr)
+        elif param_key == "phase" and isinstance(param_value, str):
+            i18n_key = PHASE_I18N_KEYS.get(param_value)
+            resolved_params[param_key] = tr(i18n_key) if i18n_key else param_value
+        else:
+            resolved_params[param_key] = param_value
+    result = tr(key, **resolved_params)
+    return result + suffix if suffix else result

--- a/apps/server/vibesensor/shared/run_context.py
+++ b/apps/server/vibesensor/shared/run_context.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import cast
 
 from vibesensor.domain import (
     AnalysisSettingsSnapshot,
@@ -205,6 +204,6 @@ def _resolve_optional_i18n(lang: str, value: object) -> str | None:
 def _resolve_i18n(lang: str, value: object) -> str:
     from functools import partial
 
-    from vibesensor.adapters.pdf.mapping import resolve_i18n
+    from vibesensor.report_i18n import resolve_i18n
 
-    return cast("str", resolve_i18n(lang, value, tr=partial(_tr, lang)))
+    return resolve_i18n(lang, value, tr=partial(_tr, lang))


### PR DESCRIPTION
## Summary

Extracts `is_i18n_ref`, `human_source`, and `resolve_i18n` from `adapters/pdf/mapping.py` to `report_i18n.py` — their natural home alongside `tr()` and `normalize_lang()`.

## Problem

`shared/run_context.py` had a deferred import from `adapters/pdf/mapping` to access `resolve_i18n`, creating a shared→adapter boundary violation. The i18n resolution functions have no PDF-adapter dependencies — they only depend on domain types (`VibrationSource`) and shared constants (`PHASE_I18N_KEYS`).

## Changes

- **`report_i18n.py`**: Added `is_i18n_ref`, `human_source`, `resolve_i18n` with necessary imports
- **`adapters/pdf/mapping.py`**: Removed the three functions, now imports them from `report_i18n`
- **`shared/run_context.py`**: Import `resolve_i18n` from `report_i18n` instead of `adapters/pdf/mapping`; removed now-redundant `cast()` and unused `cast` import
- **2 test files**: Updated imports to point to `report_i18n`

## Testing

All 5427 backend tests pass. Lint, format, and typecheck clean.

Closes #702