### PR TITLE
Add field-parity hygiene tests for StrengthPeak types

### DIFF
--- a/apps/server/tests/hygiene/test_strength_peak_parity.py
+++ b/apps/server/tests/hygiene/test_strength_peak_parity.py
@@ -1,0 +1,60 @@
+"""Hygiene test: field parity between hot-path TypedDicts and domain dataclasses.
+
+The processing pipeline uses ``StrengthPeak`` / ``VibrationStrengthMetrics``
+TypedDicts in ``vibration_strength.py`` for zero-overhead dict construction in
+the real-time FFT loop.  The analysis layer uses frozen dataclass equivalents
+in ``domain/strength_metrics.py``.  Both must share identical field names so
+that ``StrengthMetrics.from_dict()`` can ingest pipeline output without silent
+data loss.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from vibesensor.domain.strength_metrics import (
+    StrengthMetrics as StrengthMetricsDC,
+)
+from vibesensor.domain.strength_metrics import (
+    StrengthPeak as StrengthPeakDC,
+)
+from vibesensor.vibration_strength import (
+    StrengthPeak as StrengthPeakTD,
+)
+from vibesensor.vibration_strength import (
+    VibrationStrengthMetrics as VibrationStrengthMetricsTD,
+)
+
+
+def _dataclass_field_names(cls: type) -> set[str]:
+    return {f.name for f in dataclasses.fields(cls)}
+
+
+def _typeddict_field_names(cls: type) -> set[str]:
+    return set(cls.__required_keys__ | cls.__optional_keys__)
+
+
+class TestStrengthPeakFieldParity:
+    """StrengthPeak TypedDict must have the same fields as the dataclass."""
+
+    def test_field_names_match(self) -> None:
+        dc_fields = _dataclass_field_names(StrengthPeakDC)
+        td_fields = _typeddict_field_names(StrengthPeakTD)
+        assert dc_fields == td_fields, (
+            f"StrengthPeak field drift!\n"
+            f"  dataclass-only: {dc_fields - td_fields}\n"
+            f"  TypedDict-only: {td_fields - dc_fields}"
+        )
+
+
+class TestStrengthMetricsFieldParity:
+    """VibrationStrengthMetrics TypedDict must have the same fields as StrengthMetrics dataclass."""
+
+    def test_field_names_match(self) -> None:
+        dc_fields = _dataclass_field_names(StrengthMetricsDC)
+        td_fields = _typeddict_field_names(VibrationStrengthMetricsTD)
+        assert dc_fields == td_fields, (
+            f"StrengthMetrics field drift!\n"
+            f"  dataclass-only: {dc_fields - td_fields}\n"
+            f"  TypedDict-only: {td_fields - dc_fields}"
+        )


### PR DESCRIPTION
## Summary

Add compile-time sync guarantees between the hot-path TypedDict definitions (`StrengthPeak` / `VibrationStrengthMetrics` in `vibration_strength.py`) and the domain dataclass equivalents (`StrengthPeak` / `StrengthMetrics` in `domain/strength_metrics.py`).

## What changed

New file: `tests/hygiene/test_strength_peak_parity.py`
- `TestStrengthPeakFieldParity` — asserts field-name parity between the TypedDict and dataclass versions of StrengthPeak
- `TestStrengthMetricsFieldParity` — same for VibrationStrengthMetrics TypedDict vs StrengthMetrics dataclass

## Why

The dual TypedDict + dataclass pattern is intentional: TypedDicts give zero-overhead dict construction in the real-time FFT pipeline, while frozen dataclasses provide proper domain objects with behavior (classification, `from_dict()`, etc.) in the analysis layer. However, if either definition gains or loses a field, `StrengthMetrics.from_dict()` silently loses data. These hygiene tests catch any drift immediately.

## Scope decisions

- **No type merge**: The duplication is justified by hot-path performance constraints. A single canonical type would either sacrifice FFT throughput (dataclass overhead) or lose domain behavior (TypedDict limitations).
- **No dead re-export removal**: `payload_types.py` imports `StrengthPeak`/`VibrationStrengthMetrics` for internal use in `CombinedMetrics` and `SpectrumSeriesPayload` type annotations — these are not dead re-exports.

Closes #715