### PR TITLE
Replace 23 float()/int() type:ignore suppressions with typed coercion helpers

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -23,6 +23,7 @@ from vibesensor.adapters.pdf.report_data import (
     SystemFindingCard,
 )
 from vibesensor.adapters.pdf.report_types import PeakTableRow
+from vibesensor.coerce import coerce_float
 from vibesensor.domain import (
     ConfidenceAssessment,
     Finding,
@@ -927,7 +928,7 @@ def build_report_from_summary(summary: dict[str, object]) -> Report:
     duration_s: float | None = None
     if duration_s_raw is not None:
         try:
-            duration_s = float(duration_s_raw)  # type: ignore[arg-type]
+            duration_s = coerce_float(duration_s_raw)
         except (TypeError, ValueError):
             pass
 

--- a/apps/server/vibesensor/coerce.py
+++ b/apps/server/vibesensor/coerce.py
@@ -1,0 +1,31 @@
+"""Type-safe numeric coercion for boundary deserialization.
+
+``coerce_float`` and ``coerce_int`` accept ``object`` input and narrow
+via ``isinstance`` so mypy validates the call without ``type: ignore``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["coerce_float", "coerce_int"]
+
+
+def coerce_float(value: object) -> float:
+    """Coerce an untrusted ``object`` to ``float`` without ``type: ignore``.
+
+    Narrows via ``isinstance`` so the call is statically valid for mypy.
+    Raises ``TypeError`` or ``ValueError`` on non-numeric input — callers
+    must handle those when the source is untrusted.
+    """
+    if isinstance(value, (int, float, str, bytes)):
+        return float(value)
+    raise TypeError(f"Cannot coerce {type(value).__name__} to float")
+
+
+def coerce_int(value: object) -> int:
+    """Coerce an untrusted ``object`` to ``int`` without ``type: ignore``.
+
+    Uses ``round()`` on the float conversion for fractional values.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return round(coerce_float(value))

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 
+from vibesensor.coerce import coerce_float
+
 if TYPE_CHECKING:
     from vibesensor.domain.confidence_assessment import ConfidenceAssessment
     from vibesensor.domain.location_hotspot import LocationHotspot
@@ -154,7 +156,7 @@ class FindingEvidence:
             if raw is None:
                 return 0.0
             try:
-                return float(raw)  # type: ignore[arg-type]
+                return coerce_float(raw)
             except (TypeError, ValueError):
                 return 0.0
 
@@ -163,7 +165,7 @@ class FindingEvidence:
             if raw is None:
                 return None
             try:
-                return float(raw)  # type: ignore[arg-type]
+                return coerce_float(raw)
             except (TypeError, ValueError):
                 return None
 

--- a/apps/server/vibesensor/domain/location_hotspot.py
+++ b/apps/server/vibesensor/domain/location_hotspot.py
@@ -12,6 +12,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import ClassVar
 
+from vibesensor.coerce import coerce_float, coerce_int
+
 __all__ = ["LocationHotspot", "LocationIntensitySummary"]
 
 
@@ -242,20 +244,20 @@ class LocationIntensitySummary:
             if v is None:
                 return None
             try:
-                f = float(v)  # type: ignore[arg-type]
+                f = coerce_float(v)
             except (TypeError, ValueError):
                 return None
             return f
 
         sc = raw.get("sample_count", raw.get("samples", 0))
         try:
-            sample_count = int(sc)  # type: ignore[arg-type]
+            sample_count = coerce_int(sc)
         except (TypeError, ValueError):
             sample_count = 0
 
         scr = raw.get("sample_coverage_ratio", 0.0)
         try:
-            sample_coverage_ratio = float(scr)  # type: ignore[arg-type]
+            sample_coverage_ratio = coerce_float(scr)
         except (TypeError, ValueError):
             sample_coverage_ratio = 0.0
 

--- a/apps/server/vibesensor/domain/order_match.py
+++ b/apps/server/vibesensor/domain/order_match.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from vibesensor.coerce import coerce_float
+
 __all__ = ["OrderMatchObservation"]
 
 _CLOSE_MATCH_THRESHOLD = 0.05  # 5% relative error
@@ -52,7 +54,7 @@ class OrderMatchObservation:
             if v is None:
                 return None
             try:
-                return float(v)  # type: ignore[arg-type]
+                return coerce_float(v)
             except (TypeError, ValueError):
                 return None
 
@@ -61,7 +63,7 @@ class OrderMatchObservation:
             if v is None:
                 return default
             try:
-                return float(v)  # type: ignore[arg-type]
+                return coerce_float(v)
             except (TypeError, ValueError):
                 return default
 

--- a/apps/server/vibesensor/domain/snapshots.py
+++ b/apps/server/vibesensor/domain/snapshots.py
@@ -19,6 +19,8 @@ from dataclasses import asdict, dataclass, field
 from types import MappingProxyType
 from typing import ClassVar
 
+from vibesensor.coerce import coerce_float
+
 from .car import CarSnapshot, OrderReferenceSpec
 from .driving_segment import DrivingPhaseSegment
 
@@ -38,7 +40,7 @@ def _float_or(d: Mapping[str, object], key: str, default: float = 0.0) -> float:
     if v is None:
         return default
     try:
-        f = float(v)  # type: ignore[arg-type]
+        f = coerce_float(v)
     except (TypeError, ValueError):
         return default
     return f if math.isfinite(f) else default
@@ -193,7 +195,7 @@ class AnalysisSettingsSnapshot:
             if raw is None:
                 continue
             try:
-                value = float(raw)  # type: ignore[arg-type]
+                value = coerce_float(raw)
             except (TypeError, ValueError):
                 _LOGGER.debug("Dropping non-numeric analysis setting %s=%r", key, raw)
                 continue
@@ -336,7 +338,7 @@ class SpeedProfileSummary:
             if v is None:
                 return None
             try:
-                f = float(v)  # type: ignore[arg-type]
+                f = coerce_float(v)
             except (TypeError, ValueError):
                 return None
             return f if math.isfinite(f) else None
@@ -480,7 +482,7 @@ def _opt_float_raw(d: Mapping[str, object], key: str) -> float | None:
     if v is None:
         return None
     try:
-        f = float(v)  # type: ignore[arg-type]
+        f = coerce_float(v)
     except (TypeError, ValueError):
         return None
     return f if math.isfinite(f) else None

--- a/apps/server/vibesensor/domain/strength_metrics.py
+++ b/apps/server/vibesensor/domain/strength_metrics.py
@@ -16,6 +16,8 @@ import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from vibesensor.coerce import coerce_float
+
 __all__ = [
     "StrengthMetrics",
     "StrengthPeak",
@@ -27,7 +29,7 @@ def _float_or(d: Mapping[str, object], key: str, default: float = 0.0) -> float:
     if v is None:
         return default
     try:
-        f = float(v)  # type: ignore[arg-type]
+        f = coerce_float(v)
     except (TypeError, ValueError):
         return default
     return f if math.isfinite(f) else default
@@ -38,7 +40,7 @@ def _float_or_none(d: Mapping[str, object], key: str) -> float | None:
     if v is None:
         return None
     try:
-        f = float(v)  # type: ignore[arg-type]
+        f = coerce_float(v)
     except (TypeError, ValueError):
         return None
     return f if math.isfinite(f) else None

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from vibesensor.coerce import coerce_float
 from vibesensor.domain.finding import Finding, FindingEvidence, Signature, VibrationSource
 from vibesensor.domain.order_match import OrderMatchObservation
 from vibesensor.domain.test_plan import RecommendedAction, TestPlan
@@ -87,7 +88,7 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     confidence: float | None = None
     if conf_raw is not None:
         try:
-            confidence = float(conf_raw)  # type: ignore[arg-type]
+            confidence = coerce_float(conf_raw)
         except (TypeError, ValueError):
             pass
 
@@ -96,7 +97,7 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     freq_or_order_label: str = ""
     if freq_raw is not None:
         try:
-            frequency_hz = float(freq_raw)  # type: ignore[arg-type]
+            frequency_hz = coerce_float(freq_raw)
         except (TypeError, ValueError):
             # Non-numeric value like "1x wheel" — preserve as order label
             freq_or_order_label = str(freq_raw).strip()
@@ -109,7 +110,7 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     ranking_score = 0.0
     if ranking_raw is not None:
         try:
-            ranking_score = float(ranking_raw)  # type: ignore[arg-type]
+            ranking_score = coerce_float(ranking_raw)
         except (TypeError, ValueError):
             pass
 
@@ -117,7 +118,7 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     dominance_ratio: float | None = None
     if dominance_raw is not None:
         try:
-            dominance_ratio = float(dominance_raw)  # type: ignore[arg-type]
+            dominance_ratio = coerce_float(dominance_raw)
         except (TypeError, ValueError):
             pass
 

--- a/apps/server/vibesensor/shared/boundaries/vibration_origin.py
+++ b/apps/server/vibesensor/shared/boundaries/vibration_origin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TypedDict
 
+from vibesensor.coerce import coerce_float, coerce_int
 from vibesensor.domain.finding import Finding, VibrationSource
 from vibesensor.domain.location_hotspot import LocationHotspot
 from vibesensor.domain.vibration_origin import VibrationOrigin
@@ -30,7 +31,7 @@ def location_hotspot_from_payload(payload: dict[str, object]) -> LocationHotspot
     dominance_ratio: float | None = None
     if dom_raw is not None:
         try:
-            dominance_ratio = float(dom_raw)  # type: ignore[arg-type]
+            dominance_ratio = coerce_float(dom_raw)
         except (TypeError, ValueError):
             pass
 
@@ -38,7 +39,7 @@ def location_hotspot_from_payload(payload: dict[str, object]) -> LocationHotspot
     localization_confidence: float | None = None
     if loc_conf_raw is not None:
         try:
-            localization_confidence = float(loc_conf_raw)  # type: ignore[arg-type]
+            localization_confidence = coerce_float(loc_conf_raw)
         except (TypeError, ValueError):
             pass
 
@@ -46,7 +47,7 @@ def location_hotspot_from_payload(payload: dict[str, object]) -> LocationHotspot
     loc_count: int | None = None
     if loc_count_raw is not None:
         try:
-            loc_count = int(loc_count_raw)  # type: ignore[arg-type]
+            loc_count = coerce_int(loc_count_raw)
         except (TypeError, ValueError):
             pass
 

--- a/apps/server/vibesensor/shared/json_utils.py
+++ b/apps/server/vibesensor/shared/json_utils.py
@@ -10,6 +10,7 @@ import json
 import logging
 import math
 
+from vibesensor.coerce import coerce_float
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 
 __all__ = [
@@ -31,7 +32,7 @@ def as_float_or_none(value: object) -> float | None:
     if value in (None, "") or isinstance(value, bool):
         return None
     try:
-        out = float(value)  # type: ignore[arg-type]
+        out = coerce_float(value)
     except (TypeError, ValueError):
         return None
     if not _isfinite(out):

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -12,6 +12,7 @@ from dataclasses import asdict
 from typing import TYPE_CHECKING, NamedTuple
 
 from vibesensor.adapters.udp.protocol import SensorFrame
+from vibesensor.coerce import coerce_float
 from vibesensor.domain.car import CarSnapshot
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.domain.strength_metrics import StrengthMetrics
@@ -38,7 +39,7 @@ def _safe_float(d: Mapping[str, object], key: str) -> float | None:
     if raw is None:
         return None
     try:
-        out = float(raw)  # type: ignore[arg-type]
+        out = coerce_float(raw)
     except (TypeError, ValueError):
         return None
     return out if _isfinite(out) else None


### PR DESCRIPTION
## Summary

Replace all 23 `float(v) # type: ignore[arg-type]` and `int(v) # type: ignore[arg-type]` suppressions with typed coercion helpers that mypy validates statically.

## What changed

**New file:** `vibesensor/coerce.py`
- `coerce_float(value: object) -> float` — narrows via `isinstance` for `int`, `float`, `str`, `bytes`
- `coerce_int(value: object) -> int` — non-bool int passthrough, else `round(coerce_float(v))`

Placed at top-level `vibesensor/` (not `shared/`) because domain files must not import from `vibesensor.shared.*`.

**21 `float()` + 2 `int()` suppressions replaced** across 10 files:
- `domain/strength_metrics.py` (2)
- `domain/snapshots.py` (4)
- `domain/location_hotspot.py` (3, including 1 int)
- `domain/order_match.py` (2)
- `domain/finding.py` (2)
- `shared/boundaries/finding.py` (4)
- `shared/boundaries/vibration_origin.py` (3, including 1 int)
- `shared/json_utils.py` (1, in `as_float_or_none`)
- `use_cases/run/sample_builder.py` (1)
- `adapters/pdf/mapping.py` (1)

## Verification
- `ruff check` + `ruff format --check` — pass
- `make typecheck-backend` — 0 issues
- `pytest -xq apps/server/tests/` — 5430 passed

Closes #728