### PR TITLE
feat: add all domain model files to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -90,9 +90,7 @@ select = ["E", "F", "I", "UP", "B"]
 python_version = "3.11"
 files = [
   "vibesensor/app",
-  "vibesensor/domain/snapshots.py",
-  "vibesensor/domain/strength_metrics.py",
-  "vibesensor/domain/car.py",
+  "vibesensor/domain",
   "vibesensor/shared/types/api_models.py",
   "vibesensor/shared/types/backend_types.py",
   "vibesensor/adapters/gps/gps_speed.py",
@@ -104,6 +102,8 @@ files = [
   "vibesensor/shared/run_context.py",
   "vibesensor/infra/config/settings_store.py",
   "vibesensor/report_i18n.py",
+  "vibesensor/strength_bands.py",
+  "vibesensor/coerce.py",
 ]
 follow_imports = "skip"
 check_untyped_defs = true

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -189,14 +189,10 @@ class FindingEvidence:
             mean_relative_error=_float_or_none("mean_relative_error"),
             mean_noise_floor_db=_float_or_none("mean_noise_floor_db"),
             possible_samples=(
-                int(d["possible_samples"])
-                if isinstance(d.get("possible_samples"), (int, float))
-                else None
+                int(ps) if isinstance((ps := d.get("possible_samples")), (int, float)) else None
             ),
             matched_samples=(
-                int(d["matched_samples"])
-                if isinstance(d.get("matched_samples"), (int, float))
-                else None
+                int(ms) if isinstance((ms := d.get("matched_samples")), (int, float)) else None
             ),
             snr_db=_float_or_none("snr_db"),
             presence_ratio=_float("presence_ratio"),
@@ -206,8 +202,8 @@ class FindingEvidence:
             speed_uniformity=_float("speed_uniformity"),
             spatial_uniformity=_float("spatial_uniformity"),
             phases_with_evidence=(
-                int(d["phases_with_evidence"])
-                if isinstance(d.get("phases_with_evidence"), (int, float))
+                int(pwe)
+                if isinstance((pwe := d.get("phases_with_evidence")), (int, float))
                 else None
             ),
             phase_confidences=phase_items,

--- a/apps/server/vibesensor/domain/location_hotspot.py
+++ b/apps/server/vibesensor/domain/location_hotspot.py
@@ -243,6 +243,8 @@ class LocationIntensitySummary:
             v = raw.get(key)
             if v is None:
                 return None
+            if not isinstance(v, (int, float, str)):
+                return None
             try:
                 f = coerce_float(v)
             except (TypeError, ValueError):

--- a/apps/server/vibesensor/shared/run_context.py
+++ b/apps/server/vibesensor/shared/run_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from typing import cast
 
 from vibesensor.domain import (
     AnalysisSettingsSnapshot,
@@ -43,7 +44,7 @@ def apply_run_context_snapshot(
         analysis_settings_snapshot=analysis_settings_snapshot,
         active_car_snapshot=active_car_snapshot,
     )
-    metadata.update(context_snapshot.to_metadata_dict())
+    metadata.update(cast(JsonObject, context_snapshot.to_metadata_dict()))
     if context_snapshot.has_car_context:
         metadata["active_car_id"] = context_snapshot.active_car_id
         metadata["car_name"] = context_snapshot.car_name


### PR DESCRIPTION
## Summary

Replace 3 individual domain file entries with the `vibesensor/domain` directory in `pyproject.toml` mypy config. All 20 domain model files are now type-checked.

## Changes

**pyproject.toml** — Replace individual domain file entries with directory-level enforcement:
- `vibesensor/domain/car.py`, `vibesensor/domain/snapshots.py`, `vibesensor/domain/finding.py` → `vibesensor/domain`
- Add `vibesensor/strength_bands.py` to mypy files (fixes `no-any-return` in `run_capture.py`)

**Fix 7 mypy errors surfaced by expanded coverage:**

| File | Error | Fix |
|------|-------|-----|
| `location_hotspot.py` | `call-overload` on `int()`/`float()` with `object` args | `isinstance` narrowing guards |
| `finding.py` (3 errors) | `call-overload` on `int()` with `object` args | Walrus-operator `isinstance` pattern |
| `run_capture.py` | `no-any-return` from `bucket_for_strength` | Added `strength_bands.py` to mypy enforcement |
| `run_context.py` | `arg-type` mismatch `dict[str, object]` vs `JsonObject` | `cast()` for domain→shared boundary |

## Testing

- `make typecheck-backend`: 43 source files, 0 errors
- `python -m pytest -xq apps/server/tests/`: 5440 passed

Closes #726