### PR TITLE
feat: add shared/boundaries/ modules to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -102,6 +102,7 @@ files = [
   "vibesensor/shared/types/payload_types.py",
   "vibesensor/infra/runtime/registry.py",
   "vibesensor/shared/run_context.py",
+  "vibesensor/shared/boundaries",
   "vibesensor/infra/config/settings_store.py",
   "vibesensor/report_i18n.py",
 ]

--- a/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
+++ b/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
@@ -7,6 +7,7 @@ Also includes boundary functions for run suitability and speed profile
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from typing import cast
 
 from vibesensor.domain.car import Car, OrderReferenceSpec
 from vibesensor.domain.diagnostic_case import DiagnosticCase, Symptom
@@ -79,7 +80,9 @@ def project_analysis_summary(analysis: JsonObject) -> tuple[JsonObject, TestRun]
     serialized from the domain ``TestRun``.
     """
     test_run = test_run_from_summary(analysis)
-    projected: JsonObject = dict(analysis)
+    # Work with dict[str, object] to match boundary function return types;
+    # cast to JsonObject at the return boundary.
+    projected: dict[str, object] = dict(analysis)
     projected["findings"] = [finding_payload_from_domain(f) for f in test_run.findings]
     projected["top_causes"] = [
         finding_payload_from_domain(f) for f in test_run.effective_top_causes()
@@ -101,7 +104,7 @@ def project_analysis_summary(analysis: JsonObject) -> tuple[JsonObject, TestRun]
     if not _has_structured_step_content(analysis.get("test_plan")):
         projected["test_plan"] = step_payloads_from_plan(test_run.test_plan)
     projected["run_suitability"] = run_suitability_payload(test_run.suitability)
-    return projected, test_run
+    return cast(JsonObject, projected), test_run
 
 
 def case_context_from_metadata(


### PR DESCRIPTION
## Summary

Add `vibesensor/shared/boundaries` directory to the mypy enforced file list. All 4 boundary modules are now type-checked.

## Changes

**pyproject.toml** — Add `vibesensor/shared/boundaries` to mypy files list

**diagnostic_case.py** — Fix 5 mypy errors in `project_analysis_summary`:
- Boundary serializers (`finding_payload_from_domain`, `step_payloads_from_plan`, `run_suitability_payload`) return `dict[str, object]`, not `dict[str, JsonValue]`
- Changed working variable from `JsonObject` to `dict[str, object]` and cast at the return boundary (1 cast vs 5)

## Result
- 0 `# type: ignore` suppressions in boundary files
- `make typecheck-backend`: 30 source files, 0 errors
- `pytest -xq apps/server/tests/`: 5441 passed

Closes #727