### PR TITLE
docs: deduplicate layout details between copilot-instructions and repo-map

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,8 @@
-Repository overview
-- VibeSensor has a Python backend in `apps/server/`, a TypeScript/Vite dashboard in `apps/ui/`, simulator tooling in `apps/server/vibesensor/adapters/simulator/`, and device/firmware assets under `firmware/esp/`, `hardware/`, and `infra/pi-image/`.
-- Backend architecture is package-based: `app/bootstrap.py` creates the FastAPI app, `app/container.py` wires services into a flat RuntimeState, `adapters/http/` owns HTTP/WebSocket route groups, `infra/runtime/` owns runtime coordination, `adapters/persistence/history_db/` owns SQLite persistence, `adapters/pdf/` owns PDF rendering, and `use_cases/updates/` owns wheel-based update workflows.
-- Key runtime artifacts are `docker-compose.yml` at repo root and `apps/server/pyproject.toml` for backend packaging and CLI entry points.
+Repository overview (scope: high-level orientation and behavioral rules; see `docs/ai/repo-map.md` for detailed layout, entry points, and file ownership)
+- VibeSensor: Python backend (`apps/server/`), TypeScript/Vite dashboard (`apps/ui/`), ESP32 firmware (`firmware/esp/`), Pi image build (`infra/pi-image/`).
+- Key runtime artifacts: `docker-compose.yml` (local stack), `apps/server/pyproject.toml` (backend packaging and CLI entry points).
 - Units policy: raw ingest/sample acceleration values may use g, but post-stop analysis outputs (persisted summaries, findings, report-template artifacts) must expose vibration strength or intensity in dB only.
 - Canonical dB definition: `vibesensor/vibration_strength.py::vibration_strength_db_scalar()` (`20*log10((peak+eps)/(floor+eps))`, `eps=max(1e-9, floor*0.05)`).
-- Domain file map highlights: `car.py` owns `Car`, `TireSpec`, `OrderReferenceSpec`, and `CarSnapshot`; `snapshots.py` owns `AnalysisSettingsSnapshot`, `RunContextSnapshot`, `RunMetadataSnapshot`, `SpeedProfileSummary`, and `DrivingPhaseSummary`; `order_match.py` owns `OrderMatchObservation`; `driving_segment.py` owns `DrivingSegment`, `DrivingPhase`, `DrivingPhaseInterval`, and `DrivingPhaseSegment`; `location_hotspot.py` owns `LocationHotspot` and `LocationIntensitySummary`; `strength_metrics.py` owns `StrengthMetrics` and `StrengthPeak`.
 
 Source-of-truth note
 - This file is the canonical short AI guide; `AGENTS.md` should remain a pointer to this file to prevent drift.
@@ -21,12 +19,10 @@ Architectural constraints
 - Internal shared logic belongs in the server package (`vibesensor/vibration_strength.py`, `vibesensor/strength_bands.py`), not in separate packages. Shared TS constants live directly in `apps/ui/src/constants.ts`.
 - Do not create runtime file-loading mechanisms for static configuration data. Use Python constants for values that don't change between deployments.
 
-Domain model
-- Domain objects own behavior (classification, ranking, lifecycle, computation).  Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
-- Each primary domain object lives under `vibesensor/domain/`; closely related value objects may share a file with their parent aggregate.  Consumers import from `vibesensor.domain`, not from individual module files.
-- The core diagnostic aggregates are `DiagnosticCase` and `TestRun`; boundary consumers reconstruct domain views via `shared/boundaries/diagnostic_case.py::test_run_from_summary()` and re-serialize via individual boundary serializers (`finding_payload_from_domain`, `origin_payload_from_finding`, etc.).
+Domain model (scope: behavioral rules only; see `docs/ai/repo-map.md` for file listings and `docs/domain-model.md` for the full relationship map)
+- Domain objects own behavior (classification, ranking, lifecycle, computation). Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
+- Consumers import from `vibesensor.domain`, not from individual module files.
 - Boundary decoders/serializers live under `apps/server/vibesensor/shared/boundaries/`; do not rebuild payload-driven business logic in report/history/runtime consumers.
-- See `docs/domain-model.md` for the full relationship map, adapter inventory, and modeling rules.
 
 Common commands
 - `python -m pip install -e "./apps/server[dev]"`

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,24 +1,12 @@
 ---
 applyTo: "apps/server/**"
 ---
-Backend (python `apps/server/`)
+Backend (scope: backend-specific behavioral rules and deltas; see `docs/ai/repo-map.md` for full package layout and entry points)
 - Shared workflow/validation rules live in `.github/instructions/general.instructions.md`; this file only captures backend-specific deltas.
-- Backend ownership boundaries:
-	- `apps/server/vibesensor/app/bootstrap.py`: FastAPI app factory and CLI-facing startup entry.
-	- `apps/server/vibesensor/app/container.py`: `build_runtime()` constructs the flat `RuntimeState`.
-	- `apps/server/vibesensor/adapters/http/`: HTTP and WebSocket route groups, assembled by `adapters/http/__init__.py`.
-	- `apps/server/vibesensor/infra/runtime/`: subsystem ownership, lifecycle coordination, processing loop, and websocket broadcast state; routes receive `RuntimeState` directly.
-	- `apps/server/vibesensor/adapters/persistence/history_db/`: SQLite-backed history and settings persistence.
-	- `apps/server/vibesensor/adapters/pdf/pdf_engine.py`: public PDF renderer entrypoint and page orchestration.
-	- `apps/server/vibesensor/domain/`: DDD-aligned domain model package. Primary domain objects live under `vibesensor/domain/`; closely related value objects may share a file with their parent aggregate. Includes `FindingKind` enum, `RunStatus` state machine, and all domain queries. Key domain files and types:
-		- `car.py`: Car, TireSpec, OrderReferenceSpec, CarSnapshot
-		- `snapshots.py`: AnalysisSettingsSnapshot, RunContextSnapshot, SpeedProfileSummary, DrivingPhaseSummary
-		- `strength_metrics.py`: StrengthMetrics, StrengthPeak
-		- `finding.py`: Finding, FindingEvidence (with `from_metrics()` factory and `with_confidence_assessment()` method)
-		- See `docs/domain-model.md` for the full relationship map and file layout.
+- Backend ownership boundaries: see `docs/ai/repo-map.md` § "Backend package layout" for the full module map and `docs/domain-model.md` for the domain object graph.
 - Domain-first modeling rules:
 	- Domain objects own behavior (classification, ranking, lifecycle, computation). Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
-	- Each primary domain object lives under `vibesensor/domain/`; closely related value objects may share a file with their parent aggregate. Consumers import from `vibesensor.domain`, not from individual module files.
+	- Consumers import from `vibesensor.domain`, not from individual module files.
 	- Analysis pipeline adapters delegate classification and ranking to domain `Finding`.
 	- Keep pure math, DSP, FFT, and signal-processing transforms functional; do not wrap them in classes unless a domain reason exists.
 	- Do not introduce forward-looking infrastructure types until their persistence and delivery requirements exist. Domain types that produce outputs consumed by no production code path are phantom infrastructure.

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -1,5 +1,7 @@
 # Repo map
 
+Scope: single source of truth for detailed file layout, entry points, package structure, and module ownership. Behavioral rules live in `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md`.
+
 ## Primary entry points
 
 - Backend app: `apps/server/vibesensor/app/bootstrap.py`


### PR DESCRIPTION
## Summary

Makes `docs/ai/repo-map.md` the single source of truth for detailed file layout, entry points, and module ownership. Reduces `.github/copilot-instructions.md` and `.github/instructions/backend.instructions.md` to high-level orientation and behavioral rules only, with pointers to repo-map.md.

## Changes

- **copilot-instructions.md**: Removed detailed backend architecture paragraph and domain type file map from Repository overview. Removed detailed Domain model file listings; kept behavioral rules only with pointer to repo-map.md and domain-model.md. Added scope headers.
- **backend.instructions.md**: Replaced 12-line ownership boundary list with pointer to repo-map.md. Kept all domain-first modeling rules and behavioral guidance. Added scope header.
- **repo-map.md**: Added scope header clarifying it's the single source of truth for layout details.

## Acceptance criteria
- [x] Domain model details appear in exactly one location (repo-map.md)
- [x] Backend package layout appears in exactly one location (repo-map.md)
- [x] copilot-instructions references repo-map for details instead of duplicating
- [x] Each doc has a clear scope statement

Closes #738