### PR TITLE
typing: add websocket/hub.py to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -111,6 +111,7 @@ files = [
   "vibesensor/use_cases/diagnostics/top_cause_selection.py",
   "vibesensor/use_cases/diagnostics/order_bands.py",
   "vibesensor/use_cases/diagnostics/plots.py",
+  "vibesensor/adapters/websocket/hub.py",
 ]
 follow_imports = "skip"
 check_untyped_defs = true


### PR DESCRIPTION
## Summary

Adds `vibesensor/adapters/websocket/hub.py` (~368 lines) to the mypy enforced file list. The module was already well-typed — no type errors needed fixing.

## Changes

- Added `vibesensor/adapters/websocket/hub.py` to the `files` list in `[tool.mypy]` section of `pyproject.toml`

## Validation

- `make typecheck-backend` passes cleanly (0 errors)
- All WebSocket/broadcast tests pass (56 passed, 2 skipped)

Closes #751