### PR TITLE
typing: audit and fix semantically incorrect cast() usages

### DIFF
--- a/apps/server/vibesensor/adapters/http/debug.py
+++ b/apps/server/vibesensor/adapters/http/debug.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -34,7 +34,7 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
         if isinstance(result, dict) and "error" in result:
             raise HTTPException(
                 status_code=404,
-                detail=cast("DebugSpectrumErrorPayload", result)["error"],
+                detail=result["error"],
             )
         return result
 
@@ -49,7 +49,7 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
         if isinstance(result, dict) and "error" in result:
             raise HTTPException(
                 status_code=404,
-                detail=cast("RawSamplesErrorPayload", result)["error"],
+                detail=result["error"],
             )
         return result
 

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -11,7 +11,7 @@ import sqlite3
 import time
 from dataclasses import dataclass, field
 from threading import RLock
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from vibesensor.adapters.udp.protocol import (
     AckMessage,
@@ -555,9 +555,7 @@ class ClientRegistry:
         if include_metrics:
             row["frame_samples"] = snapshot.frame_samples
             row["latest_metrics"] = (
-                snapshot.latest_metrics
-                if snapshot.latest_metrics is not None
-                else cast("ClientMetrics", {})
+                snapshot.latest_metrics if snapshot.latest_metrics is not None else ClientMetrics()
             )
             row["reset_count"] = snapshot.reset_count
             row["last_reset_time"] = snapshot.last_reset_time

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -13,7 +13,7 @@ import logging
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
@@ -129,7 +129,8 @@ class HistoryReportService:
             analysis_summary,
             test_run=test_run,
         )
-        return cast("bytes", build_report_pdf(mapped_summary))
+        pdf: bytes = build_report_pdf(mapped_summary)
+        return pdf
 
     @staticmethod
     def _metadata_cache_token(metadata: object) -> str:


### PR DESCRIPTION
## Summary

Audits all `cast()` usages across the backend and fixes 4 semantically incorrect or unnecessary ones.

## Changes

- **reports.py**: Replaced `cast('bytes', build_report_pdf(...))` with a typed local variable — `build_report_pdf` already returns `bytes`, the cast was masking the function signature due to `follow_imports = 'skip'`
- **registry.py**: Replaced `cast('ClientMetrics', {})` with `ClientMetrics()` — the proper TypedDict constructor instead of casting an empty dict
- **debug.py**: Replaced `cast('DebugSpectrumErrorPayload', result)['error']` and `cast('RawSamplesErrorPayload', result)['error']` with direct `result['error']` access, since the `'error' in result` guard already established the key exists

## Remaining casts (all legitimate)

| Cast | File | Rationale |
|------|------|-----------|
| `asyncio.DatagramTransport` (×4) | sim_sender.py, udp_control_tx.py, udp_data_rx.py | Known asyncio pattern — `connection_made` receives `BaseTransport` |
| `JsonObject` (×3) | processor.py, settings_store.py, diagnostic_case.py | Structural boundary casts from TypedDicts/dicts to JSON-compatible shapes |
| `HistoryRecord` (×1) | helpers.py | Narrowing from validated `JsonObject` after null + shape guard |

## Validation

- `make typecheck-backend` passes
- `make lint` passes
- All targeted tests pass (494 passed, 1 skipped)

Closes #731