### PR TITLE
docs: create documentation index mapping every doc to scope and authority

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Use this file as the human-facing source of truth for day-to-day development wor
 
 Primary references:
 
+- Documentation index: [docs/README.md](docs/README.md)
 - Repo structure: [docs/ai/repo-map.md](docs/ai/repo-map.md)
 - Server setup and deployment: [apps/server/README.md](apps/server/README.md)
 - Testing layout and commands: [docs/testing.md](docs/testing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,91 @@
+# Documentation Index
+
+Every documentation file in the repository, its scope, intended audience, and authority level.
+
+**Authority levels:**
+- **Source of truth** — canonical reference for its topic; other files should defer to it.
+- **Pointer** — routes to the source of truth; contains no unique content.
+- **Supplementary** — adds context but defers to the source of truth on conflicts.
+
+## AI Guidance
+
+| File | Scope | Audience | Authority |
+|------|-------|----------|-----------|
+| `.github/copilot-instructions.md` | High-level orientation, behavioral rules, common commands | AI | Source of truth for AI behavioral rules |
+| `docs/ai/repo-map.md` | Detailed file layout, entry points, module ownership | AI + human | Source of truth for repo structure and file ownership |
+| `.github/instructions/general.instructions.md` | Shared workflow, validation, execution guardrails | AI | Source of truth for agent execution rules |
+| `.github/instructions/backend.instructions.md` | Backend-specific behavioral rules and deltas | AI | Source of truth for backend coding rules |
+| `.github/instructions/frontend.instructions.md` | Frontend-specific rules | AI | Source of truth for frontend coding rules |
+| `.github/instructions/tests.instructions.md` | Test-specific conventions and commands | AI | Source of truth for test conventions |
+| `AGENTS.md` | Agent guidance router | AI | Pointer → `.github/copilot-instructions.md` |
+| `docs/ai/chunk*.md` | Task planning context for multi-step AI work | AI | Supplementary |
+
+## Architecture & Design
+
+| File | Scope | Audience | Authority |
+|------|-------|----------|-----------|
+| `docs/domain-model.md` | Domain object graph, modeling rules, adapter inventory | Both | Source of truth for domain model |
+| `docs/analysis_pipeline.md` | Post-stop diagnostics pipeline: steps, modules, data flow | Both | Source of truth for analysis pipeline |
+| `docs/report_pipeline.md` | Report generation flow from analysis to PDF | Both | Source of truth for report pipeline |
+| `docs/design_language.md` | Visual design decisions (report layout, UI) | Both | Source of truth for design choices |
+| `docs/metrics.md` | Vibration metrics definitions and units | Both | Source of truth for metric definitions |
+| `docs/metrics_to_report_mapping.md` | How metrics map to report sections | Both | Source of truth for metric→report mapping |
+| `docs/protocol.md` | UDP/WebSocket protocol between ESP32 and server | Both | Source of truth for wire protocol |
+
+## Infrastructure & Operations
+
+| File | Scope | Audience | Authority |
+|------|-------|----------|-----------|
+| `docs/operational-runbooks.md` | Troubleshooting and operational procedures | Human | Source of truth for ops procedures |
+| `docs/history_db_schema.md` | SQLite history database schema | Both | Source of truth for DB schema |
+| `docs/run_schema_v2.md` | Run data persistence schema v2 | Both | Source of truth for run schema |
+| `docs/intake_buffering.md` | Sample intake and buffering strategy | Both | Source of truth for intake design |
+| `docs/time_alignment.md` | Multi-sensor time alignment approach | Both | Source of truth for time alignment |
+| `docs/multithreading_performance.md` | Threading model and performance considerations | Both | Source of truth for threading design |
+| `docs/ssh-root-cause.md` | SSH connectivity root-cause analysis | Human | Supplementary |
+
+## Testing
+
+| File | Scope | Audience | Authority |
+|------|-------|----------|-----------|
+| `docs/testing.md` | Test layout, commands, CI parity, conventions | Both | Source of truth for testing |
+
+## READMEs (setup and orientation)
+
+| File | Scope | Audience | Authority |
+|------|-------|----------|-----------|
+| `README.md` | Project overview and quickstart | Human | Source of truth for project intro |
+| `CONTRIBUTING.md` | Development workflow and setup paths | Human | Source of truth for contributor workflow |
+| `CHANGELOG.md` | Release history | Human | Source of truth for changelog |
+| `apps/server/README.md` | Backend setup, deployment, CLI | Human | Source of truth for server setup |
+| `apps/ui/README.md` | Frontend setup and build | Human | Source of truth for UI setup |
+| `firmware/esp/README.md` | ESP32 firmware setup and flashing | Human | Source of truth for firmware |
+| `firmware/esp/HARDENING.md` | Firmware security hardening notes | Human | Supplementary |
+| `hardware/README.md` | Hardware components and wiring | Human | Source of truth for hardware |
+| `infra/ci/README.md` | CI pipeline overview | Human | Source of truth for CI |
+| `infra/pi-image/pi-gen/README.md` | Raspberry Pi image build | Human | Source of truth for Pi image |
+
+## Data & reference
+
+| File | Scope | Audience | Authority |
+|------|-------|----------|-----------|
+| `apps/server/data/CAR_VARIANT_SOURCES.md` | Car variant data sourcing notes | Human | Supplementary |
+
+## Topic → source-of-truth quick reference
+
+| Topic | Authoritative file |
+|-------|-------------------|
+| Repo structure / file ownership | `docs/ai/repo-map.md` |
+| Domain model | `docs/domain-model.md` |
+| Analysis pipeline | `docs/analysis_pipeline.md` |
+| Report pipeline | `docs/report_pipeline.md` |
+| Metrics & units | `docs/metrics.md` |
+| Wire protocol | `docs/protocol.md` |
+| DB schema | `docs/history_db_schema.md` |
+| Testing conventions | `docs/testing.md` |
+| AI behavioral rules | `.github/copilot-instructions.md` |
+| Backend coding rules | `.github/instructions/backend.instructions.md` |
+| Frontend coding rules | `.github/instructions/frontend.instructions.md` |
+| Contributor workflow | `CONTRIBUTING.md` |
+| Server setup | `apps/server/README.md` |
+| Design language | `docs/design_language.md` |


### PR DESCRIPTION
## Summary

Creates `docs/README.md` as a comprehensive documentation index mapping every doc file in the repository to its scope, intended audience (human/AI/both), and authority level (source of truth/pointer/supplementary).

## Contents

- **AI Guidance** section: copilot-instructions, repo-map, instruction files, AGENTS.md
- **Architecture & Design** section: domain model, analysis pipeline, report pipeline, etc.
- **Infrastructure & Operations** section: runbooks, DB schema, threading, etc.
- **Testing** section
- **READMEs** section: all component READMEs
- **Quick reference table**: topic → authoritative file for fast lookups

## Changes

- New file: `docs/README.md`
- Modified: `CONTRIBUTING.md` — added link to docs index in Primary References

## Acceptance Criteria
- [x] Clear documentation index exists
- [x] Every doc file in the repo is listed
- [x] Source-of-truth for each topic is unambiguous
- [x] Index is linked from CONTRIBUTING.md

Closes #749