### PR TITLE
typing: add location_analysis.py and phase_segmentation.py to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -111,6 +111,8 @@ files = [
   "vibesensor/use_cases/diagnostics/top_cause_selection.py",
   "vibesensor/use_cases/diagnostics/order_bands.py",
   "vibesensor/use_cases/diagnostics/plots.py",
+  "vibesensor/use_cases/diagnostics/location_analysis.py",
+  "vibesensor/use_cases/diagnostics/phase_segmentation.py",
   "vibesensor/adapters/websocket/hub.py",
 ]
 follow_imports = "skip"

--- a/apps/server/vibesensor/use_cases/diagnostics/location_analysis.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/location_analysis.py
@@ -68,11 +68,12 @@ def _localization_confidence(
     location_count: int,
     total_samples: int,
 ) -> float:
-    return LocationHotspot.compute_confidence(
+    confidence: float = LocationHotspot.compute_confidence(
         dominance_ratio=dominance_ratio,
         location_count=location_count,
         total_samples=total_samples,
     )
+    return confidence
 
 
 def _score_locations_in_bin(


### PR DESCRIPTION
Closes #724

## Changes
- Add `vibesensor/use_cases/diagnostics/location_analysis.py` and `vibesensor/use_cases/diagnostics/phase_segmentation.py` to the mypy enforced file list in pyproject.toml
- Fix one `no-any-return` error in `_localization_confidence` (typed local variable to bridge the `follow_imports=skip` boundary)
- `phase_segmentation.py` was already fully typed — no changes needed

## Validation
- `make typecheck-backend` passes (66 source files, zero errors)
- `make lint` passes
- All domain + use_cases tests pass (2156 passed)
- Zero new `# type: ignore` lines