### PR TITLE
typing: add history_db persistence module to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -114,6 +114,7 @@ files = [
   "vibesensor/use_cases/diagnostics/location_analysis.py",
   "vibesensor/use_cases/diagnostics/phase_segmentation.py",
   "vibesensor/adapters/websocket/hub.py",
+  "vibesensor/adapters/persistence/history_db",
 ]
 follow_imports = "skip"
 check_untyped_defs = true

--- a/apps/server/vibesensor/adapters/persistence/history_db/_samples.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_samples.py
@@ -117,7 +117,7 @@ def v2_row_to_dict(row: tuple[object, ...]) -> JsonObject:
         val = row[_V2_COL_OFFSET + i]
         if col in _json_cols:
             if val:
-                parsed = safe_json_loads(val, context=f"column {col}")  # type: ignore[arg-type]
+                parsed = safe_json_loads(str(val), context=f"column {col}")
                 if is_json_array(parsed):
                     d[col] = parsed
                 else:

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -25,6 +25,7 @@ from vibesensor.domain import Run
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.constants import NUMERIC_TYPES
 from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.sample_builder import (
     build_run_metadata,
@@ -691,7 +692,7 @@ class RunRecorder:
             self.schedule_post_analysis(run_id_to_analyze)
         return result
 
-    def _run_metadata_record(self, run_id: str, start_time_utc: str) -> dict[str, object]:
+    def _run_metadata_record(self, run_id: str, start_time_utc: str) -> JsonObject:
         return build_run_metadata(
             run_id=run_id,
             start_time_utc=start_time_utc,

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -289,7 +289,7 @@ def build_run_metadata(
     accel_scale_g_per_lsb: float | None,
     active_car_snapshot: CarSnapshot | None = None,
     language_provider: Callable[[], str] | None = None,
-) -> dict[str, object]:
+) -> JsonObject:
     """Assemble comprehensive run metadata."""
     settings = asdict(analysis_settings_snapshot)
     order_reference_spec = analysis_settings_snapshot.order_reference_spec


### PR DESCRIPTION
Closes #733

## Changes
- Add `vibesensor/adapters/persistence/history_db` (3 modules) to the mypy enforced file list
- Remove unused `type: ignore[arg-type]` in `_samples.py` — replaced with `str()` narrowing
- Fix type boundary: `build_run_metadata` and `_run_metadata_record` now return `JsonObject` instead of `dict[str, object]`, resolving arg-type errors at the `HistoryDB.create_run` and `finalize_run` call sites

## Validation
- `make typecheck-backend` passes (69 source files, zero errors)
- `make lint` passes
- All adapter + use_cases + infra tests pass (3300 passed)
- Zero new `# type: ignore` lines