### PR TITLE
typing: add PDF adapter orchestration modules to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -115,6 +115,15 @@ files = [
   "vibesensor/use_cases/diagnostics/phase_segmentation.py",
   "vibesensor/adapters/websocket/hub.py",
   "vibesensor/adapters/persistence/history_db",
+  "vibesensor/adapters/pdf/pdf_engine.py",
+  "vibesensor/adapters/pdf/report_data.py",
+  "vibesensor/adapters/pdf/report_types.py",
+  "vibesensor/adapters/pdf/presentation.py",
+  "vibesensor/adapters/pdf/pattern_parts.py",
+  "vibesensor/adapters/pdf/pdf_style.py",
+  "vibesensor/adapters/pdf/pdf_drawing.py",
+  "vibesensor/adapters/pdf/pdf_text.py",
+  "vibesensor/adapters/pdf/mapping.py",
 ]
 follow_imports = "skip"
 check_untyped_defs = true

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -274,7 +274,8 @@ class PdfRenderContext:
         lang = data.lang
 
         def default_tr(key: str, **kw: object) -> str:
-            return _tr(lang, key, **kw)
+            result: str = _tr(lang, key, **kw)
+            return result
 
         def default_text(en: str, nl: str) -> str:
             return nl if lang == "nl" else en

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -13,11 +13,12 @@ import logging
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.domain import CarSnapshot
+from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.shared.exceptions import AnalysisNotReadyError, ProcessingError
 from vibesensor.shared.run_context import add_current_context_warnings, current_car_snapshot_token
@@ -125,8 +126,12 @@ class HistoryReportService:
         *,
         test_run: TestRun | None = None,
     ) -> bytes:
+        # analysis_summary comes from persistence as JsonObject but
+        # map_summary expects the AnalysisSummary TypedDict shape.
+        # The data has been validated upstream; cast at the boundary.
+        summary = cast(AnalysisSummary, analysis_summary)
         mapped_summary = map_summary(
-            analysis_summary,
+            summary,
             test_run=test_run,
         )
         pdf: bytes = build_report_pdf(mapped_summary)


### PR DESCRIPTION
Closes #730

## Changes
- Add 8 PDF adapter modules to mypy enforcement: `pdf_engine.py`, `report_data.py`, `report_types.py`, `presentation.py`, `pattern_parts.py`, `pdf_style.py`, `pdf_drawing.py`, `pdf_text.py`, `mapping.py`
- Fix `no-any-return` in `pdf_style.py` (typed local for `_tr` boundary)
- Fix `arg-type` in `reports.py` (`cast(AnalysisSummary, ...)` at persistence boundary)
- Remaining `Any` usage in `pdf_diagram_render.py` (11 usages) is for untyped reportlab drawing objects — left for a follow-up per issue scope

## Validation
- `make typecheck-backend` passes (78 source files, zero errors)
- `make lint` passes
- All adapter + use_cases tests pass (2887 passed)
- Zero new `# type: ignore` lines