### PR TITLE
typing: add findings.py and order_analysis.py to mypy enforcement

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -113,6 +113,8 @@ files = [
   "vibesensor/use_cases/diagnostics/plots.py",
   "vibesensor/use_cases/diagnostics/location_analysis.py",
   "vibesensor/use_cases/diagnostics/phase_segmentation.py",
+  "vibesensor/use_cases/diagnostics/findings.py",
+  "vibesensor/use_cases/diagnostics/order_analysis.py",
   "vibesensor/adapters/websocket/hub.py",
   "vibesensor/adapters/persistence/history_db",
   "vibesensor/adapters/pdf/pdf_engine.py",

--- a/apps/server/vibesensor/use_cases/diagnostics/findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/findings.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from vibesensor.domain import Finding as DomainFinding
 from vibesensor.domain.finding import (
     FindingKind,
+    VibrationSource,
 )
 from vibesensor.shared.constants import ORDER_SUPPRESS_PERSISTENT_MIN_CONF, SPEED_COVERAGE_MIN_PCT
 from vibesensor.shared.types.json_types import JsonObject
@@ -97,7 +98,7 @@ _MIN_DIAGNOSTIC_SAMPLES = 5
 def _reference_missing_finding(
     *,
     finding_id: str,
-    suspected_source: str,
+    suspected_source: VibrationSource,
     kind: FindingKind = FindingKind.REFERENCE,
 ) -> DomainFinding:
     return DomainFinding(
@@ -122,7 +123,7 @@ def build_reference_findings(
         findings.append(
             _reference_missing_finding(
                 finding_id="REF_SPEED",
-                suspected_source="unknown",
+                suspected_source=VibrationSource.UNKNOWN,
             ),
         )
 
@@ -130,7 +131,7 @@ def build_reference_findings(
         findings.append(
             _reference_missing_finding(
                 finding_id="REF_WHEEL",
-                suspected_source="wheel/tire",
+                suspected_source=VibrationSource.WHEEL_TIRE,
             ),
         )
 
@@ -143,7 +144,7 @@ def build_reference_findings(
         findings.append(
             _reference_missing_finding(
                 finding_id="REF_ENGINE",
-                suspected_source="engine",
+                suspected_source=VibrationSource.ENGINE,
             ),
         )
 
@@ -151,7 +152,7 @@ def build_reference_findings(
         findings.append(
             _reference_missing_finding(
                 finding_id="REF_SAMPLE_RATE",
-                suspected_source="unknown",
+                suspected_source=VibrationSource.UNKNOWN,
             ),
         )
     return findings, engine_ref_sufficient

--- a/apps/server/vibesensor/use_cases/diagnostics/order_analysis.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/order_analysis.py
@@ -124,7 +124,7 @@ def _order_label(order: int, base: str) -> str:
 @dataclass(slots=True, frozen=True)
 class OrderHypothesis:
     key: str
-    suspected_source: str
+    suspected_source: VibrationSource
     order_label_base: str
     order: int
     # Path compliance factor: models how much the mechanical transmission
@@ -436,7 +436,8 @@ def _mean(values: list[float]) -> float:
 
 
 def _normalized_source(finding: DomainFinding) -> str:
-    return finding.source_normalized
+    src: str = finding.source_normalized
+    return src
 
 
 def detect_diffuse_excitation(
@@ -890,6 +891,8 @@ def assemble_order_finding(
         focused_speed_band=context.focused_speed_band,
         hotspot_speed_band=hotspot_speed_band,
     )
+    phases_raw = phase_evidence.get("phases_detected")
+    phases_detected = tuple(phases_raw) if isinstance(phases_raw, list) else ()
     finding = DomainFinding(
         finding_id="F_ORDER",
         finding_key=hypothesis.key,
@@ -905,8 +908,8 @@ def assemble_order_finding(
         diffuse_excitation=diffuse_excitation,
         weak_spatial_separation=weak_spatial_separation,
         vibration_strength_db=absolute_strength_db,
-        cruise_fraction=phase_evidence["cruise_fraction"],
-        phases_detected=tuple(phase_evidence.get("phases_detected") or ()),
+        cruise_fraction=_as_float(phase_evidence["cruise_fraction"]) or 0.0,
+        phases_detected=phases_detected,
         matched_points=tuple(match.matched_points),
         evidence=FindingEvidence(
             match_rate=context.effective_match_rate,


### PR DESCRIPTION
Closes #747

## Changes
- Add `vibesensor/use_cases/diagnostics/findings.py` and `vibesensor/use_cases/diagnostics/order_analysis.py` to mypy enforcement (~1630 lines combined)
- Fix `OrderHypothesis.suspected_source`: `str` → `VibrationSource` (type-safe enum)
- Fix `_reference_missing_finding` parameter and all call sites to use `VibrationSource` enum members
- Fix `cruise_fraction` boundary: use `_as_float()` for `dict[str, object]` access
- Fix `phases_detected`: `isinstance(list)` narrowing for `tuple()` conversion
- Fix `_normalized_source`: typed local for StrEnum property return

## Validation
- `make typecheck-backend` passes (80 source files, zero errors)
- `make lint` passes
- All diagnostics + domain tests pass (2156 passed)
- Zero new `# type: ignore` lines