### PR TITLE
fix(contracts): sync UI analysis settings defaults with backend

### DIFF
--- a/apps/server/tests/hygiene/test_analysis_settings_sync.py
+++ b/apps/server/tests/hygiene/test_analysis_settings_sync.py
@@ -1,0 +1,72 @@
+"""Guard: UI and backend analysis-settings defaults stay in sync."""
+
+from __future__ import annotations
+
+import re
+
+from tests._paths import REPO_ROOT
+from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
+
+_UI_APP_STATE_TS = REPO_ROOT / "apps" / "ui" / "src" / "app" / "ui_app_state.ts"
+_SETTINGS_FEATURE_TS = (
+    REPO_ROOT / "apps" / "ui" / "src" / "app" / "features" / "settings_feature.ts"
+)
+
+
+def _parse_ui_vehicle_defaults() -> dict[str, float]:
+    """Extract vehicleSettings defaults from ui_app_state.ts."""
+    text = _UI_APP_STATE_TS.read_text()
+    match = re.search(
+        r"vehicleSettings:\s*\{([^}]+)\}",
+        text,
+        re.DOTALL,
+    )
+    assert match, "Could not find vehicleSettings block in ui_app_state.ts"
+    block = match.group(1)
+    pairs: dict[str, float] = {}
+    for line_match in re.finditer(r"(\w+):\s*([0-9.]+)", block):
+        pairs[line_match.group(1)] = float(line_match.group(2))
+    return pairs
+
+
+def _parse_ui_setting_keys() -> list[str]:
+    """Extract ANALYSIS_SETTING_KEYS from settings_feature.ts."""
+    text = _SETTINGS_FEATURE_TS.read_text()
+    match = re.search(
+        r"ANALYSIS_SETTING_KEYS\s*=\s*\[([^\]]+)\]",
+        text,
+        re.DOTALL,
+    )
+    assert match, "Could not find ANALYSIS_SETTING_KEYS in settings_feature.ts"
+    return re.findall(r'"(\w+)"', match.group(1))
+
+
+def test_ui_defaults_match_backend() -> None:
+    """Every backend DEFAULTS key must appear in UI vehicleSettings with the
+    same value."""
+    backend = AnalysisSettingsSnapshot.DEFAULTS
+    frontend = _parse_ui_vehicle_defaults()
+
+    missing = set(backend) - set(frontend)
+    assert not missing, f"UI vehicleSettings is missing keys: {sorted(missing)}"
+
+    mismatched: list[str] = []
+    for key, be_val in backend.items():
+        fe_val = frontend[key]
+        if abs(fe_val - be_val) > 1e-9:
+            mismatched.append(f"  {key}: UI={fe_val}, backend={be_val}")
+    assert not mismatched, "UI/backend analysis-settings default mismatch:\n" + "\n".join(
+        mismatched
+    )
+
+
+def test_ui_setting_keys_match_backend() -> None:
+    """ANALYSIS_SETTING_KEYS must list every backend DEFAULTS key."""
+    backend_keys = set(AnalysisSettingsSnapshot.DEFAULTS)
+    frontend_keys = set(_parse_ui_setting_keys())
+
+    missing = backend_keys - frontend_keys
+    assert not missing, f"ANALYSIS_SETTING_KEYS missing: {sorted(missing)}"
+
+    extra = frontend_keys - backend_keys
+    assert not extra, f"ANALYSIS_SETTING_KEYS has extra keys: {sorted(extra)}"

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -61,6 +61,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     "gear_uncertainty_pct",
     "min_abs_band_hz",
     "max_band_half_width_pct",
+    "tire_deflection_factor",
   ] as const satisfies readonly (keyof AnalysisSettingsPayload)[];
 
   const GPS_POLL_FAST = 2_000;
@@ -140,22 +141,10 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   }
 
   async function syncAnalysisSettingsToServer(): Promise<void> {
-    const payload: Record<string, number> = {
-      tire_width_mm: state.vehicleSettings.tire_width_mm,
-      tire_aspect_pct: state.vehicleSettings.tire_aspect_pct,
-      rim_in: state.vehicleSettings.rim_in,
-      final_drive_ratio: state.vehicleSettings.final_drive_ratio,
-      current_gear_ratio: state.vehicleSettings.current_gear_ratio,
-      wheel_bandwidth_pct: state.vehicleSettings.wheel_bandwidth_pct,
-      driveshaft_bandwidth_pct: state.vehicleSettings.driveshaft_bandwidth_pct,
-      engine_bandwidth_pct: state.vehicleSettings.engine_bandwidth_pct,
-      speed_uncertainty_pct: state.vehicleSettings.speed_uncertainty_pct,
-      tire_diameter_uncertainty_pct: state.vehicleSettings.tire_diameter_uncertainty_pct,
-      final_drive_uncertainty_pct: state.vehicleSettings.final_drive_uncertainty_pct,
-      gear_uncertainty_pct: state.vehicleSettings.gear_uncertainty_pct,
-      min_abs_band_hz: state.vehicleSettings.min_abs_band_hz,
-      max_band_half_width_pct: state.vehicleSettings.max_band_half_width_pct,
-    };
+    const payload: Record<string, number> = {};
+    for (const key of ANALYSIS_SETTING_KEYS) {
+      payload[key] = state.vehicleSettings[key];
+    }
     try {
       await setAnalysisSettings(payload);
     } catch (_err) {

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -26,6 +26,7 @@ export interface VehicleSettings {
   gear_uncertainty_pct: number;
   min_abs_band_hz: number;
   max_band_half_width_pct: number;
+  tire_deflection_factor: number;
   [key: string]: number;
 }
 
@@ -143,20 +144,21 @@ export function createAppState(): AppState {
     },
     locationOptions: [],
     vehicleSettings: {
-      tire_width_mm: 285,
-      tire_aspect_pct: 30,
-      rim_in: 21,
+      tire_width_mm: 285.0,
+      tire_aspect_pct: 30.0,
+      rim_in: 21.0,
       final_drive_ratio: 3.08,
       current_gear_ratio: 0.64,
-      wheel_bandwidth_pct: 6.0,
-      driveshaft_bandwidth_pct: 5.6,
-      engine_bandwidth_pct: 6.2,
-      speed_uncertainty_pct: 0.6,
-      tire_diameter_uncertainty_pct: 1.2,
-      final_drive_uncertainty_pct: 0.2,
-      gear_uncertainty_pct: 0.5,
-      min_abs_band_hz: 0.4,
-      max_band_half_width_pct: 8.0,
+      wheel_bandwidth_pct: 5.0,
+      driveshaft_bandwidth_pct: 4.5,
+      engine_bandwidth_pct: 5.2,
+      speed_uncertainty_pct: 1.0,
+      tire_diameter_uncertainty_pct: 1.0,
+      final_drive_uncertainty_pct: 0.1,
+      gear_uncertainty_pct: 0.2,
+      min_abs_band_hz: 0.2,
+      max_band_half_width_pct: 6.0,
+      tire_deflection_factor: 0.97,
     },
     cars: [],
     activeCarId: null,


### PR DESCRIPTION
## Summary

Fix 9 divergent default values between UI and backend analysis settings, add missing `tire_deflection_factor` field, and add a hygiene test to prevent future drift.

## Changes

- **ui_app_state.ts**: Update all 9 divergent defaults to match `AnalysisSettingsSnapshot.DEFAULTS`. Add `tire_deflection_factor` to `VehicleSettings` interface and defaults.
- **settings_feature.ts**: Add `tire_deflection_factor` to `ANALYSIS_SETTING_KEYS`. Refactor `syncAnalysisSettingsToServer()` to loop over `ANALYSIS_SETTING_KEYS` instead of manually listing fields (DRY, prevents future drift).
- **test_analysis_settings_sync.py**: New hygiene test that verifies UI defaults and setting keys match backend `AnalysisSettingsSnapshot.DEFAULTS`.

Closes #717