### PR TITLE
refactor: extract spectrogram and FFT from plots.py (#712)

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_persistence_classification.py
+++ b/apps/server/tests/adapters/pdf/test_report_persistence_classification.py
@@ -6,13 +6,13 @@ from test_support.report_helpers import analysis_sample_with_peaks as sample
 
 from vibesensor.use_cases.diagnostics.findings import _classify_peak_type
 from vibesensor.use_cases.diagnostics.plots import (
+    top_peaks_table_rows as _top_peaks_table_rows,
+)
+from vibesensor.use_cases.diagnostics.spectrogram import (
     aggregate_fft_spectrum as _aggregate_fft_spectrum,
 )
-from vibesensor.use_cases.diagnostics.plots import (
+from vibesensor.use_cases.diagnostics.spectrogram import (
     aggregate_fft_spectrum_raw as _aggregate_fft_spectrum_raw,
-)
-from vibesensor.use_cases.diagnostics.plots import (
-    top_peaks_table_rows as _top_peaks_table_rows,
 )
 
 

--- a/apps/server/tests/adapters/pdf/test_report_persistence_summary.py
+++ b/apps/server/tests/adapters/pdf/test_report_persistence_summary.py
@@ -10,13 +10,13 @@ from test_support.report_helpers import (
 
 from vibesensor.use_cases.diagnostics import build_findings_for_samples
 from vibesensor.use_cases.diagnostics.plots import (
+    top_peaks_table_rows as _top_peaks_table_rows,
+)
+from vibesensor.use_cases.diagnostics.spectrogram import (
     spectrogram_from_peaks as _spectrogram_from_peaks,
 )
-from vibesensor.use_cases.diagnostics.plots import (
+from vibesensor.use_cases.diagnostics.spectrogram import (
     spectrogram_from_peaks_raw as _spectrogram_from_peaks_raw,
-)
-from vibesensor.use_cases.diagnostics.plots import (
-    top_peaks_table_rows as _top_peaks_table_rows,
 )
 
 

--- a/apps/server/tests/use_cases/diagnostics/test_plot_data_phase_context.py
+++ b/apps/server/tests/use_cases/diagnostics/test_plot_data_phase_context.py
@@ -180,7 +180,7 @@ def test_aggregate_fft_spectrum_presence_ratio_clamped_to_one() -> None:
     bin (bin_center = 45 Hz). Previously len(amps)=2 / n_samples=1 = 2.0 gave
     a persistence score inflated by 4× relative to a single-peak sample.
     """
-    from vibesensor.use_cases.diagnostics.plots import (
+    from vibesensor.use_cases.diagnostics.spectrogram import (
         aggregate_fft_spectrum as _aggregate_fft_spectrum,
     )
 

--- a/apps/server/vibesensor/use_cases/diagnostics/plots.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/plots.py
@@ -1,24 +1,18 @@
-"""Plot-data builders: spectrum, series, peak tables, and orchestration.
+"""Plot-data builders: series, peak tables, and orchestration.
 
-Consolidates the former ``plot_spectrum``, ``plot_series``,
-``plot_peak_table``, and ``plot_data`` modules into a single file.
-
-This module is **boundary-adjacent**: it transforms raw DSP arrays and
-sample data into rendering-ready data structures (peak tables, spectrum
-rows) consumed by the report template.  It operates on raw numpy/sample
-data, not domain objects, and is intentionally outside the domain layer.
+Spectral computation (FFT spectrum, spectrogram) has been extracted to
+``spectrogram.py``.  This module keeps time-series extraction, peak-table
+ranking, and the top-level ``_plot_data`` orchestrator.
 """
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from math import floor
-from typing import Any, Literal
+from typing import Any
 
 from vibesensor.adapters.pdf.report_types import PeakTableRow
-from vibesensor.domain.finding import speed_bin_label
 from vibesensor.shared.boundaries.analysis_payload import (
     AmpVsPhaseRow,
     FreqVsSpeedByFindingSeries,
@@ -26,7 +20,6 @@ from vibesensor.shared.boundaries.analysis_payload import (
     PhaseBoundary,
     PhaseSegmentOut,
     PlotDataResult,
-    SpectrogramResult,
 )
 from vibesensor.shared.constants import MEMS_NOISE_FLOOR_G
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
@@ -35,294 +28,23 @@ from vibesensor.use_cases.diagnostics.findings import _classify_peak_type
 from vibesensor.use_cases.diagnostics.helpers import (
     _amplitude_weighted_speed_window,
     _effective_baseline_floor,
-    _estimate_strength_floor_amp_g,
-    _location_label,
     _primary_vibration_strength_db,
     _run_noise_baseline_g,
-    _sample_top_peaks,
 )
 from vibesensor.use_cases.diagnostics.phase_segmentation import DrivingPhase, PhaseSegment
 from vibesensor.use_cases.diagnostics.phase_segmentation import (
     segment_run_phases as _segment_run_phases,
 )
+from vibesensor.use_cases.diagnostics.spectrogram import (
+    PeakSampleScan,
+    aggregate_fft_spectrum,
+    aggregate_fft_spectrum_raw,
+    safe_percentile,
+    scan_peak_samples,
+    spectrogram_from_peaks,
+    spectrogram_from_peaks_raw,
+)
 from vibesensor.vibration_strength import compute_db, compute_db_or_none, percentile
-
-# ---------------------------------------------------------------------------
-# Spectrum types & builders (formerly plot_spectrum.py)
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True, slots=True)
-class PeakSampleScanRow:
-    t_s: float | None
-    speed_kmh: float | None
-    peaks: list[tuple[float, float]]
-    floor_amp_g: float | None
-    location: str | None
-    speed_bin: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class PeakSampleScan:
-    sample_count: int
-    rows: list[PeakSampleScanRow]
-    time_values: list[float]
-    speed_values: list[float]
-    total_locations: set[str]
-    total_speed_bin_counts: dict[str, int]
-
-
-def scan_peak_samples(samples: list[Sample]) -> PeakSampleScan:
-    """Scan raw samples once and cache the peak-facing data needed by plot builders."""
-    rows: list[PeakSampleScanRow] = []
-    time_values: list[float] = []
-    speed_values: list[float] = []
-    total_locations: set[str] = set()
-    total_speed_bin_counts: dict[str, int] = defaultdict(int)
-    sample_count = 0
-
-    for sample in samples:
-        if not isinstance(sample, dict):
-            continue
-        sample_count += 1
-        t_s = _as_float(sample.get("t_s"))
-        speed = _as_float(sample.get("speed_kmh"))
-        peaks = [(hz, amp) for hz, amp in _sample_top_peaks(sample) if hz > 0 and amp > 0]
-        floor_amp = _estimate_strength_floor_amp_g(sample)
-        location = _location_label(sample)
-        speed_bin = speed_bin_label(speed) if speed is not None and speed > 0 else None
-
-        if t_s is not None and t_s >= 0:
-            time_values.append(t_s)
-        if speed is not None and speed > 0:
-            speed_values.append(speed)
-        if location:
-            total_locations.add(location)
-        if speed_bin is not None:
-            total_speed_bin_counts[speed_bin] += 1
-
-        rows.append(
-            PeakSampleScanRow(
-                t_s=t_s,
-                speed_kmh=speed,
-                peaks=peaks,
-                floor_amp_g=floor_amp,
-                location=location,
-                speed_bin=speed_bin,
-            ),
-        )
-
-    return PeakSampleScan(
-        sample_count=sample_count,
-        rows=rows,
-        time_values=time_values,
-        speed_values=speed_values,
-        total_locations=total_locations,
-        total_speed_bin_counts=dict(total_speed_bin_counts),
-    )
-
-
-def safe_percentile(sorted_vals: list[float], q: float, *, default: float = 0.0) -> float:
-    """Return ``percentile(sorted_vals, q)`` when possible, else a safe fallback."""
-    if len(sorted_vals) >= 2:
-        return float(percentile(sorted_vals, q))
-    return sorted_vals[-1] if sorted_vals else default
-
-
-def aggregate_fft_spectrum(
-    samples: list[Sample],
-    *,
-    freq_bin_hz: float = 2.0,
-    aggregation: str = "persistence",
-    run_noise_baseline_g: float | None = None,
-    peak_scan: PeakSampleScan | None = None,
-) -> list[tuple[float, float]]:
-    """Return aggregated FFT spectrum for the requested aggregation mode."""
-    if freq_bin_hz <= 0:
-        freq_bin_hz = 2.0
-
-    bin_amps: defaultdict[float, list[float]] = defaultdict(list)
-    resolved_scan = peak_scan or scan_peak_samples(samples)
-    n_samples = resolved_scan.sample_count
-    for row in resolved_scan.rows:
-        for hz, amp in row.peaks:
-            bin_low = floor(hz / freq_bin_hz) * freq_bin_hz
-            bin_center = round(bin_low + (freq_bin_hz / 2.0), 4)
-            bin_amps[bin_center].append(amp)
-    if not bin_amps:
-        return []
-
-    if run_noise_baseline_g is None:
-        run_noise_baseline_g = _run_noise_baseline_g(samples)
-    baseline_floor = _effective_baseline_floor(run_noise_baseline_g)
-
-    result: dict[float, float] = {}
-    for bin_center, amps in bin_amps.items():
-        if aggregation == "max":
-            result[bin_center] = max(amps)
-            continue
-        presence_ratio = min(1.0, len(amps) / max(1, n_samples))
-        p95 = safe_percentile(sorted(amps), 0.95)
-        result[bin_center] = (presence_ratio**2) * (p95 / baseline_floor)
-    return sorted(result.items())
-
-
-def aggregate_fft_spectrum_raw(
-    samples: list[Sample],
-    *,
-    freq_bin_hz: float = 2.0,
-    run_noise_baseline_g: float | None = None,
-    peak_scan: PeakSampleScan | None = None,
-) -> list[tuple[float, float]]:
-    """Return the raw max-amplitude FFT spectrum."""
-    return aggregate_fft_spectrum(
-        samples,
-        freq_bin_hz=freq_bin_hz,
-        aggregation="max",
-        run_noise_baseline_g=run_noise_baseline_g,
-        peak_scan=peak_scan,
-    )
-
-
-def spectrogram_from_peaks(
-    samples: list[Sample],
-    *,
-    aggregation: Literal["persistence", "max"] = "persistence",
-    run_noise_baseline_g: float | None = None,
-    peak_scan: PeakSampleScan | None = None,
-) -> SpectrogramResult:
-    """Build a 2-D spectrogram grid from per-sample peak lists."""
-    resolved_scan = peak_scan or scan_peak_samples(samples)
-    peak_rows: list[tuple[float, float, float, float | None]] = []
-    time_values = resolved_scan.time_values
-    speed_values = resolved_scan.speed_values
-
-    for row in resolved_scan.rows:
-        if not row.peaks:
-            continue
-        for hz, amp in row.peaks:
-            if row.t_s is not None and row.t_s >= 0:
-                peak_rows.append((row.t_s, hz, amp, row.floor_amp_g))
-            elif row.speed_kmh is not None and row.speed_kmh > 0:
-                peak_rows.append((row.speed_kmh, hz, amp, row.floor_amp_g))
-
-    use_time = bool(time_values)
-    empty_result = SpectrogramResult(
-        x_axis="none",
-        x_label_key="TIME_S",
-        x_bins=[],
-        y_bins=[],
-        cells=[],
-        max_amp=0.0,
-    )
-    if not use_time and not speed_values:
-        return empty_result
-
-    x_axis = "time_s" if use_time else "speed_kmh"
-    x_values = time_values if use_time else speed_values
-    x_min = min(x_values)
-    x_max = max(x_values)
-    x_span = max(0.0, x_max - x_min)
-    if x_axis == "time_s":
-        x_bin_width = max(2.0, (x_span / 40.0) if x_span > 0 else 2.0)
-        x_label_key = "TIME_S"
-    else:
-        x_bin_width = max(5.0, (x_span / 30.0) if x_span > 0 else 5.0)
-        x_label_key = "SPEED_KM_H"
-
-    peak_freqs = [hz for _x, hz, _amp, _floor in peak_rows]
-    if not peak_freqs:
-        empty_result["x_axis"] = x_axis
-        empty_result["x_label_key"] = x_label_key
-        return empty_result
-
-    observed_max_hz = max(peak_freqs)
-    freq_cap_hz = min(200.0, max(40.0, observed_max_hz))
-    freq_bin_hz = max(2.0, freq_cap_hz / 45.0)
-
-    cell_by_bin: defaultdict[tuple[float, float], list[tuple[float, float | None]]] = defaultdict(
-        list,
-    )
-    x_sample_counts: defaultdict[float, int] = defaultdict(int)
-    if aggregation == "persistence":
-        for x_val in x_values:
-            x_bin_low = floor((x_val - x_min) / x_bin_width) * x_bin_width + x_min
-            x_sample_counts[x_bin_low] += 1
-
-    for x_val, hz, amp, floor_amp in peak_rows:
-        if hz > freq_cap_hz:
-            continue
-        x_bin_low = floor((x_val - x_min) / x_bin_width) * x_bin_width + x_min
-        y_bin_low = floor(hz / freq_bin_hz) * freq_bin_hz
-        cell_by_bin[(x_bin_low, y_bin_low)].append((amp, floor_amp))
-
-    x_bins = sorted({x for x, _y in cell_by_bin})
-    y_bins = sorted({y for _x, y in cell_by_bin})
-    if not x_bins or not y_bins:
-        empty_result["x_axis"] = x_axis
-        empty_result["x_label_key"] = x_label_key
-        return empty_result
-
-    x_index = {value: idx for idx, value in enumerate(x_bins)}
-    y_index = {value: idx for idx, value in enumerate(y_bins)}
-    cells = [[0.0 for _ in x_bins] for _ in y_bins]
-    max_amp = 0.0
-
-    if run_noise_baseline_g is None:
-        run_noise_baseline_g = _run_noise_baseline_g(samples)
-    baseline_floor = _effective_baseline_floor(run_noise_baseline_g)
-    min_presence_snr = 2.0
-
-    for (x_key, y_key), amp_floor_pairs in cell_by_bin.items():
-        yi = y_index[y_key]
-        xi = x_index[x_key]
-        if aggregation == "persistence":
-            effective_amps: list[float] = []
-            for amp, floor_amp in amp_floor_pairs:
-                local_floor = max(
-                    MEMS_NOISE_FLOOR_G,
-                    floor_amp if floor_amp is not None and floor_amp > 0 else baseline_floor,
-                )
-                snr = amp / local_floor
-                if snr < min_presence_snr:
-                    continue
-                effective_amps.append(amp * min(1.0, snr / 5.0))
-            if not effective_amps:
-                continue
-            p95_amp = safe_percentile(sorted(effective_amps), 0.95)
-            presence_ratio = min(1.0, len(effective_amps) / max(1, x_sample_counts.get(x_key, 1)))
-            val = (presence_ratio**2) * p95_amp
-        else:
-            val = max(amp for amp, _floor in amp_floor_pairs)
-        cells[yi][xi] = val
-        max_amp = max(max_amp, val)
-
-    return SpectrogramResult(
-        x_axis=x_axis,
-        x_label_key=x_label_key,
-        x_bin_width=x_bin_width,
-        y_bin_width=freq_bin_hz,
-        x_bins=[x + (x_bin_width / 2.0) for x in x_bins],
-        y_bins=[y + (freq_bin_hz / 2.0) for y in y_bins],
-        cells=cells,
-        max_amp=max_amp,
-    )
-
-
-def spectrogram_from_peaks_raw(
-    samples: list[Sample],
-    *,
-    run_noise_baseline_g: float | None = None,
-    peak_scan: PeakSampleScan | None = None,
-) -> SpectrogramResult:
-    """Build the raw/max-amplitude spectrogram view."""
-    return spectrogram_from_peaks(
-        samples,
-        aggregation="max",
-        run_noise_baseline_g=run_noise_baseline_g,
-        peak_scan=peak_scan,
-    )
-
 
 # ---------------------------------------------------------------------------
 # Series types & builders (formerly plot_series.py)

--- a/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
@@ -1,0 +1,313 @@
+"""Spectrogram and FFT spectrum builders — extracted from ``plots.py``.
+
+Provides the scan layer (``PeakSampleScan``) that converts raw sample
+dicts into a structured, reusable peak cache, plus the FFT spectrum and
+2-D spectrogram aggregation functions that operate on that cache.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from math import floor
+from typing import Literal
+
+from vibesensor.domain.finding import speed_bin_label
+from vibesensor.shared.boundaries.analysis_payload import SpectrogramResult
+from vibesensor.shared.constants import MEMS_NOISE_FLOOR_G
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics.helpers import (
+    _effective_baseline_floor,
+    _estimate_strength_floor_amp_g,
+    _location_label,
+    _run_noise_baseline_g,
+    _sample_top_peaks,
+)
+from vibesensor.vibration_strength import percentile
+
+# ---------------------------------------------------------------------------
+# Peak-sample scan layer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PeakSampleScanRow:
+    t_s: float | None
+    speed_kmh: float | None
+    peaks: list[tuple[float, float]]
+    floor_amp_g: float | None
+    location: str | None
+    speed_bin: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PeakSampleScan:
+    sample_count: int
+    rows: list[PeakSampleScanRow]
+    time_values: list[float]
+    speed_values: list[float]
+    total_locations: set[str]
+    total_speed_bin_counts: dict[str, int]
+
+
+def scan_peak_samples(samples: list[Sample]) -> PeakSampleScan:
+    """Scan raw samples once and cache the peak-facing data needed by plot builders."""
+    rows: list[PeakSampleScanRow] = []
+    time_values: list[float] = []
+    speed_values: list[float] = []
+    total_locations: set[str] = set()
+    total_speed_bin_counts: dict[str, int] = defaultdict(int)
+    sample_count = 0
+
+    for sample in samples:
+        if not isinstance(sample, dict):
+            continue
+        sample_count += 1
+        t_s = _as_float(sample.get("t_s"))
+        speed = _as_float(sample.get("speed_kmh"))
+        peaks = [(hz, amp) for hz, amp in _sample_top_peaks(sample) if hz > 0 and amp > 0]
+        floor_amp = _estimate_strength_floor_amp_g(sample)
+        location = _location_label(sample)
+        speed_bin = speed_bin_label(speed) if speed is not None and speed > 0 else None
+
+        if t_s is not None and t_s >= 0:
+            time_values.append(t_s)
+        if speed is not None and speed > 0:
+            speed_values.append(speed)
+        if location:
+            total_locations.add(location)
+        if speed_bin is not None:
+            total_speed_bin_counts[speed_bin] += 1
+
+        rows.append(
+            PeakSampleScanRow(
+                t_s=t_s,
+                speed_kmh=speed,
+                peaks=peaks,
+                floor_amp_g=floor_amp,
+                location=location,
+                speed_bin=speed_bin,
+            ),
+        )
+
+    return PeakSampleScan(
+        sample_count=sample_count,
+        rows=rows,
+        time_values=time_values,
+        speed_values=speed_values,
+        total_locations=total_locations,
+        total_speed_bin_counts=dict(total_speed_bin_counts),
+    )
+
+
+def safe_percentile(sorted_vals: list[float], q: float, *, default: float = 0.0) -> float:
+    """Return ``percentile(sorted_vals, q)`` when possible, else a safe fallback."""
+    if len(sorted_vals) >= 2:
+        return float(percentile(sorted_vals, q))
+    return sorted_vals[-1] if sorted_vals else default
+
+
+# ---------------------------------------------------------------------------
+# FFT spectrum
+# ---------------------------------------------------------------------------
+
+
+def aggregate_fft_spectrum(
+    samples: list[Sample],
+    *,
+    freq_bin_hz: float = 2.0,
+    aggregation: str = "persistence",
+    run_noise_baseline_g: float | None = None,
+    peak_scan: PeakSampleScan | None = None,
+) -> list[tuple[float, float]]:
+    """Return aggregated FFT spectrum for the requested aggregation mode."""
+    if freq_bin_hz <= 0:
+        freq_bin_hz = 2.0
+
+    bin_amps: defaultdict[float, list[float]] = defaultdict(list)
+    resolved_scan = peak_scan or scan_peak_samples(samples)
+    n_samples = resolved_scan.sample_count
+    for row in resolved_scan.rows:
+        for hz, amp in row.peaks:
+            bin_low = floor(hz / freq_bin_hz) * freq_bin_hz
+            bin_center = round(bin_low + (freq_bin_hz / 2.0), 4)
+            bin_amps[bin_center].append(amp)
+    if not bin_amps:
+        return []
+
+    if run_noise_baseline_g is None:
+        run_noise_baseline_g = _run_noise_baseline_g(samples)
+    baseline_floor = _effective_baseline_floor(run_noise_baseline_g)
+
+    result: dict[float, float] = {}
+    for bin_center, amps in bin_amps.items():
+        if aggregation == "max":
+            result[bin_center] = max(amps)
+            continue
+        presence_ratio = min(1.0, len(amps) / max(1, n_samples))
+        p95 = safe_percentile(sorted(amps), 0.95)
+        result[bin_center] = (presence_ratio**2) * (p95 / baseline_floor)
+    return sorted(result.items())
+
+
+def aggregate_fft_spectrum_raw(
+    samples: list[Sample],
+    *,
+    freq_bin_hz: float = 2.0,
+    run_noise_baseline_g: float | None = None,
+    peak_scan: PeakSampleScan | None = None,
+) -> list[tuple[float, float]]:
+    """Return the raw max-amplitude FFT spectrum."""
+    return aggregate_fft_spectrum(
+        samples,
+        freq_bin_hz=freq_bin_hz,
+        aggregation="max",
+        run_noise_baseline_g=run_noise_baseline_g,
+        peak_scan=peak_scan,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spectrogram
+# ---------------------------------------------------------------------------
+
+
+def spectrogram_from_peaks(
+    samples: list[Sample],
+    *,
+    aggregation: Literal["persistence", "max"] = "persistence",
+    run_noise_baseline_g: float | None = None,
+    peak_scan: PeakSampleScan | None = None,
+) -> SpectrogramResult:
+    """Build a 2-D spectrogram grid from per-sample peak lists."""
+    resolved_scan = peak_scan or scan_peak_samples(samples)
+    peak_rows: list[tuple[float, float, float, float | None]] = []
+    time_values = resolved_scan.time_values
+    speed_values = resolved_scan.speed_values
+
+    for row in resolved_scan.rows:
+        if not row.peaks:
+            continue
+        for hz, amp in row.peaks:
+            if row.t_s is not None and row.t_s >= 0:
+                peak_rows.append((row.t_s, hz, amp, row.floor_amp_g))
+            elif row.speed_kmh is not None and row.speed_kmh > 0:
+                peak_rows.append((row.speed_kmh, hz, amp, row.floor_amp_g))
+
+    use_time = bool(time_values)
+    empty_result = SpectrogramResult(
+        x_axis="none",
+        x_label_key="TIME_S",
+        x_bins=[],
+        y_bins=[],
+        cells=[],
+        max_amp=0.0,
+    )
+    if not use_time and not speed_values:
+        return empty_result
+
+    x_axis = "time_s" if use_time else "speed_kmh"
+    x_values = time_values if use_time else speed_values
+    x_min = min(x_values)
+    x_max = max(x_values)
+    x_span = max(0.0, x_max - x_min)
+    if x_axis == "time_s":
+        x_bin_width = max(2.0, (x_span / 40.0) if x_span > 0 else 2.0)
+        x_label_key = "TIME_S"
+    else:
+        x_bin_width = max(5.0, (x_span / 30.0) if x_span > 0 else 5.0)
+        x_label_key = "SPEED_KM_H"
+
+    peak_freqs = [hz for _x, hz, _amp, _floor in peak_rows]
+    if not peak_freqs:
+        empty_result["x_axis"] = x_axis
+        empty_result["x_label_key"] = x_label_key
+        return empty_result
+
+    observed_max_hz = max(peak_freqs)
+    freq_cap_hz = min(200.0, max(40.0, observed_max_hz))
+    freq_bin_hz = max(2.0, freq_cap_hz / 45.0)
+
+    cell_by_bin: defaultdict[tuple[float, float], list[tuple[float, float | None]]] = defaultdict(
+        list,
+    )
+    x_sample_counts: defaultdict[float, int] = defaultdict(int)
+    if aggregation == "persistence":
+        for x_val in x_values:
+            x_bin_low = floor((x_val - x_min) / x_bin_width) * x_bin_width + x_min
+            x_sample_counts[x_bin_low] += 1
+
+    for x_val, hz, amp, floor_amp in peak_rows:
+        if hz > freq_cap_hz:
+            continue
+        x_bin_low = floor((x_val - x_min) / x_bin_width) * x_bin_width + x_min
+        y_bin_low = floor(hz / freq_bin_hz) * freq_bin_hz
+        cell_by_bin[(x_bin_low, y_bin_low)].append((amp, floor_amp))
+
+    x_bins = sorted({x for x, _y in cell_by_bin})
+    y_bins = sorted({y for _x, y in cell_by_bin})
+    if not x_bins or not y_bins:
+        empty_result["x_axis"] = x_axis
+        empty_result["x_label_key"] = x_label_key
+        return empty_result
+
+    x_index = {value: idx for idx, value in enumerate(x_bins)}
+    y_index = {value: idx for idx, value in enumerate(y_bins)}
+    cells = [[0.0 for _ in x_bins] for _ in y_bins]
+    max_amp = 0.0
+
+    if run_noise_baseline_g is None:
+        run_noise_baseline_g = _run_noise_baseline_g(samples)
+    baseline_floor = _effective_baseline_floor(run_noise_baseline_g)
+    min_presence_snr = 2.0
+
+    for (x_key, y_key), amp_floor_pairs in cell_by_bin.items():
+        yi = y_index[y_key]
+        xi = x_index[x_key]
+        if aggregation == "persistence":
+            effective_amps: list[float] = []
+            for amp, floor_amp in amp_floor_pairs:
+                local_floor = max(
+                    MEMS_NOISE_FLOOR_G,
+                    floor_amp if floor_amp is not None and floor_amp > 0 else baseline_floor,
+                )
+                snr = amp / local_floor
+                if snr < min_presence_snr:
+                    continue
+                effective_amps.append(amp * min(1.0, snr / 5.0))
+            if not effective_amps:
+                continue
+            p95_amp = safe_percentile(sorted(effective_amps), 0.95)
+            presence_ratio = min(1.0, len(effective_amps) / max(1, x_sample_counts.get(x_key, 1)))
+            val = (presence_ratio**2) * p95_amp
+        else:
+            val = max(amp for amp, _floor in amp_floor_pairs)
+        cells[yi][xi] = val
+        max_amp = max(max_amp, val)
+
+    return SpectrogramResult(
+        x_axis=x_axis,
+        x_label_key=x_label_key,
+        x_bin_width=x_bin_width,
+        y_bin_width=freq_bin_hz,
+        x_bins=[x + (x_bin_width / 2.0) for x in x_bins],
+        y_bins=[y + (freq_bin_hz / 2.0) for y in y_bins],
+        cells=cells,
+        max_amp=max_amp,
+    )
+
+
+def spectrogram_from_peaks_raw(
+    samples: list[Sample],
+    *,
+    run_noise_baseline_g: float | None = None,
+    peak_scan: PeakSampleScan | None = None,
+) -> SpectrogramResult:
+    """Build the raw/max-amplitude spectrogram view."""
+    return spectrogram_from_peaks(
+        samples,
+        aggregation="max",
+        run_noise_baseline_g=run_noise_baseline_g,
+        peak_scan=peak_scan,
+    )


### PR DESCRIPTION
## Summary

Extracts spectrogram and FFT spectrum computation from `plots.py` (752 → 474 lines) into a new `diagnostics/spectrogram.py` (313 lines).

## Changes

**New file: `apps/server/vibesensor/use_cases/diagnostics/spectrogram.py`**
- `PeakSampleScanRow`, `PeakSampleScan`, `scan_peak_samples` — scan layer that pre-processes raw samples into a reusable peak cache
- `safe_percentile` — statistical helper
- `aggregate_fft_spectrum`, `aggregate_fft_spectrum_raw` — FFT spectrum aggregation
- `spectrogram_from_peaks`, `spectrogram_from_peaks_raw` — 2-D spectrogram grid builders

**Modified: `apps/server/vibesensor/use_cases/diagnostics/plots.py`**
- Imports scan/FFT/spectrogram symbols from `spectrogram.py`
- Retains: `build_plot_series`, `top_peaks_table_rows`, `_plot_data` orchestrator, amp_vs_phase, steady_speed_distribution

**Updated test imports:**
- `test_report_persistence_summary.py` — spectrogram imports from `spectrogram.py`
- `test_report_persistence_classification.py` — FFT imports from `spectrogram.py`
- `test_plot_data_phase_context.py` — FFT import from `spectrogram.py`

## Acceptance criteria
- [x] `plots.py` is under 600 lines (474)
- [x] Spectrogram computation is independently importable and testable
- [x] All 5441 backend tests pass, mypy clean, ruff clean

Closes #712