### PR TITLE
Replace manual WS type mirrors with generated contract aliases

### DIFF
--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -2,38 +2,32 @@ import {
   EXPECTED_SCHEMA_VERSION,
   type StrengthMetricPeak,
   type StrengthMetricsPayload,
+  type WsClientInfo,
   type WsOrderBand,
+  type WsRotationalSpeedValue,
+  type WsRotationalSpeeds,
 } from "./contracts/ws_payload_types";
 import type { SpectrumClientData } from "./app/ui_app_state";
 
 type UnknownRecord = Record<string, unknown>;
 
-export type AdaptedClient = {
-  id: string;
-  name: string;
-  connected: boolean;
-  mac_address: string;
-  location_code: string;
-  last_seen_age_ms: number | null;
-  dropped_frames: number | null;
-  frames_total: number | null;
-  sample_rate_hz: number;
-  firmware_version: string;
-};
+export type AdaptedClient = Pick<
+  WsClientInfo,
+  | "id"
+  | "name"
+  | "connected"
+  | "mac_address"
+  | "location_code"
+  | "last_seen_age_ms"
+  | "dropped_frames"
+  | "frames_total"
+  | "sample_rate_hz"
+  | "firmware_version"
+>;
 
-export type RotationalSpeedValue = {
-  rpm: number | null;
-  mode: string | null;
-  reason: string | null;
-};
+export type RotationalSpeedValue = WsRotationalSpeedValue;
 
-export type RotationalSpeeds = {
-  basis_speed_source: string | null;
-  wheel: RotationalSpeedValue;
-  driveshaft: RotationalSpeedValue;
-  engine: RotationalSpeedValue;
-  order_bands: OrderBand[] | null;
-};
+export type RotationalSpeeds = WsRotationalSpeeds;
 
 export type OrderBand = WsOrderBand;
 
@@ -148,8 +142,8 @@ function parseClient(value: unknown): AdaptedClient | null {
     mac_address: getString(record, "mac_address") ?? "",
     location_code: locationCode,
     last_seen_age_ms: getNumber(record, "last_seen_age_ms"),
-    dropped_frames: getNumber(record, "dropped_frames"),
-    frames_total: getNumber(record, "frames_total"),
+    dropped_frames: getNumber(record, "dropped_frames") ?? 0,
+    frames_total: getNumber(record, "frames_total") ?? 0,
     sample_rate_hz: getNumber(record, "sample_rate_hz") ?? 0,
     firmware_version: getString(record, "firmware_version") ?? "",
   };


### PR DESCRIPTION
## Summary

Replace manually mirrored WebSocket types in `server_payload.ts` with aliases/derivations from the generated contract types in `ws_payload_types.ts`.

## Changes

**Type replacements:**
- `AdaptedClient` → `Pick<WsClientInfo, ...10 fields>` (derived from generated `ClientApiRow`)
- `RotationalSpeedValue` → alias to `WsRotationalSpeedValue` (exact match)
- `RotationalSpeeds` → alias to `WsRotationalSpeeds` (exact match)
- `OrderBand` → was already aliased to `WsOrderBand` (unchanged)

**Parser alignment:**
- `dropped_frames` and `frames_total` in `parseClient()` now default to `0` via `?? 0` to match the non-nullable `number` type in the generated schema (server always sends numbers for these fields)

**What's preserved:**
- All parse functions (`adaptServerPayload`, `parseClient`, `parseSpectra`, etc.) — `unknown` input validation unchanged
- `AdaptedPayload` composite type unchanged
- Runtime behavior unchanged

## Impact

Adding/removing a field in the Python WS schema and running `npm run sync:contracts` now propagates to parsing types automatically — manual mirrors no longer need manual updates.

**Net: 1 file changed, 20 insertions, 26 deletions**

Closes #718