### PR TITLE
Eliminate CarConfig, store domain Car directly in SettingsStore

### DIFF
--- a/apps/server/tests/adapters/persistence/test_car_variants.py
+++ b/apps/server/tests/adapters/persistence/test_car_variants.py
@@ -12,7 +12,8 @@ from vibesensor.adapters.persistence.car_library import (
     get_variants_for_model,
     resolve_variant,
 )
-from vibesensor.shared.types.backend_types import CarConfig
+from vibesensor.domain import Car
+from vibesensor.shared.types.backend_types import car_to_persistence_dict
 
 
 def _variant_label(entry: dict, variant: dict) -> str:
@@ -179,36 +180,36 @@ def test_car_library_variant_entry_requires_drivetrain() -> None:
 
 
 # ---------------------------------------------------------------------------
-# CarConfig domain model tests
+# Car persistence (from_persisted_dict) tests
 # ---------------------------------------------------------------------------
 
 
-def test_car_config_from_dict_without_variant() -> None:
-    """CarConfig.from_dict without variant sets variant to None."""
-    car = CarConfig.from_dict({"name": "Old Car", "type": "sedan"})
+def test_car_from_persisted_dict_without_variant() -> None:
+    """Car.from_persisted_dict without variant sets variant to None."""
+    car = Car.from_persisted_dict({"name": "Old Car", "type": "sedan"})
     assert car.variant is None
-    d = car.to_dict()
+    d = car_to_persistence_dict(car)
     assert "variant" not in d
 
 
-def test_car_config_from_dict_with_variant() -> None:
-    """CarConfig.from_dict with variant preserves it."""
-    car = CarConfig.from_dict({"name": "BMW 320i", "type": "Sedan", "variant": "320i"})
+def test_car_from_persisted_dict_with_variant() -> None:
+    """Car.from_persisted_dict with variant preserves it."""
+    car = Car.from_persisted_dict({"name": "BMW 320i", "type": "Sedan", "variant": "320i"})
     assert car.variant == "320i"
-    d = car.to_dict()
+    d = car_to_persistence_dict(car)
     assert d["variant"] == "320i"
 
 
-def test_car_config_from_dict_empty_variant() -> None:
+def test_car_from_persisted_dict_empty_variant() -> None:
     """Empty string variant is treated as None."""
-    car = CarConfig.from_dict({"name": "Car", "type": "sedan", "variant": ""})
+    car = Car.from_persisted_dict({"name": "Car", "type": "sedan", "variant": ""})
     assert car.variant is None
 
 
-def test_car_config_variant_truncated() -> None:
+def test_car_from_persisted_dict_variant_truncated() -> None:
     """Very long variant names are truncated to 64 chars."""
     long_name = "x" * 100
-    car = CarConfig.from_dict({"name": "Car", "type": "sedan", "variant": long_name})
+    car = Car.from_persisted_dict({"name": "Car", "type": "sedan", "variant": long_name})
     assert len(car.variant) == 64  # type: ignore[arg-type]
 
 

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -5,15 +5,16 @@ from pathlib import Path
 import pytest
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.domain import Car
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.infra.config.settings_store import (
     PersistenceError,
     SettingsStore,
 )
 from vibesensor.shared.types.backend_types import (
-    CarConfig,
     SensorConfig,
     _parse_manual_speed,
+    car_to_persistence_dict,
 )
 
 DEFAULT_CAR_ASPECTS = AnalysisSettingsSnapshot.DEFAULTS
@@ -35,7 +36,7 @@ def _sabotaged_store(tmp_path: Path) -> SettingsStore:
 
 
 def test_validate_car_fills_defaults() -> None:
-    car = CarConfig.from_dict({}).to_dict()
+    car = car_to_persistence_dict(Car.from_persisted_dict({}))
     assert car["name"] == "Unnamed Car"
     assert car["type"] == "sedan"
     assert car["id"]
@@ -43,13 +44,13 @@ def test_validate_car_fills_defaults() -> None:
 
 
 def test_validate_car_preserves_aspects() -> None:
-    car = CarConfig.from_dict({"aspects": {"tire_width_mm": 245.0}}).to_dict()
+    car = car_to_persistence_dict(Car.from_persisted_dict({"aspects": {"tire_width_mm": 245.0}}))
     assert car["aspects"]["tire_width_mm"] == 245.0
     assert car["aspects"]["rim_in"] == DEFAULT_CAR_ASPECTS["rim_in"]
 
 
 def test_validate_car_truncates_name() -> None:
-    car = CarConfig.from_dict({"name": "x" * 100}).to_dict()
+    car = car_to_persistence_dict(Car.from_persisted_dict({"name": "x" * 100}))
     assert len(car["name"]) <= 64
 
 

--- a/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
+++ b/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
@@ -25,6 +25,7 @@ from pydantic import ValidationError
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.infra.config.settings_store import SettingsStore
+from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.shared.json_utils import sanitize_for_json
 from vibesensor.shared.types.api_models import CarUpsertRequest, SensorRequest, SpeedSourceRequest
 from vibesensor.use_cases.diagnostics.helpers import _corr_abs
@@ -177,16 +178,16 @@ class TestHistoryDbCorruptedSchemaVersion:
 
 
 # ------------------------------------------------------------------
-# 6. settings_store — dict rollback safety
+# 6. settings_store — car rollback safety
 # ------------------------------------------------------------------
 
 
 class TestSettingsStoreRollbackSafety:
-    """Car aspects rollback must use clear/update, not reassignment."""
+    """Car aspects rollback must restore original state on persist failure."""
 
     def test_rollback_preserves_dict_identity(self) -> None:
-        """After a failed persist, the car.aspects dict object
-        should still be the same object (not replaced).
+        """After a failed persist, the car should be restored
+        to its original state (same content).
         """
         store = SettingsStore(db=None)
         car_data = store.add_car({"name": "TestCar", "type": "sedan"})
@@ -195,22 +196,22 @@ class TestSettingsStoreRollbackSafety:
         # Set as active so _find_car works
         store.set_active_car(car_id)
 
-        # Get the aspects dict reference before update
+        # Get the aspects content before update
         with store._lock:
             car = store._find_car(car_id)
-            original_aspects_id = id(car.aspects)
+            original_aspects = dict(car.aspects)
 
-        # Force persist to fail
+        # Force persist to fail with PersistenceError (triggers rollback)
         with (
-            patch.object(store, "_persist", side_effect=Exception("disk full")),
-            contextlib.suppress(Exception),
+            patch.object(store, "_persist", side_effect=PersistenceError("disk full")),
+            contextlib.suppress(PersistenceError),
         ):
             store.update_car(car_id, {"aspects": {"wheel": 1.0, "driveshaft": 0.5}})
 
-        # The aspects dict should still be the SAME object
+        # The aspects content should be unchanged
         with store._lock:
             car = store._find_car(car_id)
-            assert id(car.aspects) == original_aspects_id
+            assert dict(car.aspects) == original_aspects
 
 
 # ------------------------------------------------------------------

--- a/apps/server/tests/shared/types/test_domain_models.py
+++ b/apps/server/tests/shared/types/test_domain_models.py
@@ -1,4 +1,4 @@
-"""Tests for domain_models module: CarConfig, SensorConfig, SpeedSourceConfig,
+"""Tests for domain_models module: Car persistence, SensorConfig, SpeedSourceConfig,
 RunMetadata, and SensorFrame parsing/serialization.
 """
 
@@ -9,12 +9,13 @@ from typing import Any
 import pytest
 
 from vibesensor.adapters.udp.protocol import SensorFrame
+from vibesensor.domain import Car
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
 from vibesensor.shared.types.backend_types import (
-    CarConfig,
     RunMetadata,
     SensorConfig,
     SpeedSourceConfig,
+    car_to_persistence_dict,
 )
 
 # ---------------------------------------------------------------------------
@@ -56,42 +57,41 @@ class TestAsIntOrNone:
 
 
 # ---------------------------------------------------------------------------
-# CarConfig
+# Car persistence (from_persisted_dict / car_to_persistence_dict)
 # ---------------------------------------------------------------------------
 
 
-class TestCarConfig:
+class TestCarPersistedDict:
     def test_from_dict_basic(self) -> None:
-        car = CarConfig.from_dict({"id": "c1", "name": "MyCar", "type": "sedan"})
+        car = Car.from_persisted_dict({"id": "c1", "name": "MyCar", "type": "sedan"})
         assert car.id == "c1"
         assert car.name == "MyCar"
         assert car.car_type == "sedan"
-        assert isinstance(car.aspects, dict)
 
     def test_from_dict_defaults(self) -> None:
-        car = CarConfig.from_dict({})
+        car = Car.from_persisted_dict({})
         assert car.name == "Unnamed Car"
         assert car.car_type == "sedan"
 
     def test_name_truncated_at_64(self) -> None:
         long = "A" * 100
-        car = CarConfig.from_dict({"name": long})
+        car = Car.from_persisted_dict({"name": long})
         assert len(car.name) <= 64
 
     @pytest.mark.smoke
     def test_roundtrip(self) -> None:
-        car = CarConfig.from_dict({"id": "x", "name": "Test", "type": "suv"})
-        d = car.to_dict()
+        car = Car.from_persisted_dict({"id": "x", "name": "Test", "type": "suv"})
+        d = car_to_persistence_dict(car)
         assert d["id"] == "x"
         assert d["name"] == "Test"
 
     def test_missing_id_gets_generated(self) -> None:
-        car = CarConfig.from_dict({"name": "Generated"})
+        car = Car.from_persisted_dict({"name": "Generated"})
         assert car.name == "Generated"
         assert car.id  # non-empty UUID
 
     def test_aspects_sanitized(self) -> None:
-        car = CarConfig.from_dict({"aspects": {"tire_width_mm": "not_a_number"}})
+        car = Car.from_persisted_dict({"aspects": {"tire_width_mm": "not_a_number"}})
         # Invalid aspect should be overridden by default
         assert isinstance(car.aspects.get("tire_width_mm"), (int, float))
 
@@ -110,7 +110,7 @@ class TestCarConfig:
         field: str,
         fallback: str,
     ) -> None:
-        car = CarConfig.from_dict(data)
+        car = Car.from_persisted_dict(data)
         assert getattr(car, field) == fallback
 
 

--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -6,7 +6,6 @@ encapsulates the three standard tire dimensions and derived geometry.
 ``OrderReferenceSpec`` owns tire geometry and driveline/reference-order
 interpretation.  ``CarSnapshot`` is typed internal car context attached
 to a run.
-Configuration and persistence details remain in ``CarConfig``.
 """
 
 from __future__ import annotations
@@ -406,7 +405,6 @@ class Car:
 
     Owns identity, user-facing name, vehicle type, and geometry aspects
     (tire dimensions, gear ratios) that drive order analysis.
-    Configuration and persistence details remain in ``CarConfig``.
     """
 
     id: str = field(default_factory=lambda: uuid.uuid4().hex)
@@ -449,6 +447,35 @@ class Car:
         if spec is not None:
             normalized_aspects = spec.to_settings_dict()
         object.__setattr__(self, "_aspects", MappingProxyType(normalized_aspects))
+
+    @classmethod
+    def from_persisted_dict(cls, data: Mapping[str, object]) -> Car:
+        """Construct a ``Car`` from a raw persisted dict (e.g., loaded from JSON).
+
+        Fills missing aspects from ``AnalysisSettingsSnapshot.DEFAULTS`` and
+        sanitises input values.
+        """
+        # Lazy import — snapshots.py imports from this module.
+        from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
+
+        car_id = str(data.get("id") or str(uuid.uuid4()))
+        name = str(data.get("name") or "Unnamed Car").strip()[:64] or "Unnamed Car"
+        car_type = str(data.get("type") or "sedan").strip()[:32] or "sedan"
+        raw_aspects = data.get("aspects") or {}
+        aspects: dict[str, float] = dict(AnalysisSettingsSnapshot.DEFAULTS)
+        if isinstance(raw_aspects, dict):
+            aspects.update(AnalysisSettingsSnapshot.sanitize(raw_aspects))
+        raw_variant = data.get("variant")
+        variant = (
+            str(raw_variant).strip()[:64] if isinstance(raw_variant, str) and raw_variant else None
+        )
+        return cls(
+            id=car_id,
+            name=name,
+            car_type=car_type,
+            aspects=aspects,
+            variant=variant or None,
+        )
 
     @property
     def aspects(self) -> Mapping[str, float]:

--- a/apps/server/vibesensor/infra/config/car_settings.py
+++ b/apps/server/vibesensor/infra/config/car_settings.py
@@ -15,8 +15,8 @@ from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.shared.types.backend_types import (
     AnalysisSettingsPayload,
-    CarConfig,
     CarConfigUpdatePayload,
+    car_to_persistence_dict,
     new_car_id,
 )
 
@@ -42,7 +42,7 @@ class CarSettingsMixin:
     # Declared for type-checker visibility; actual attributes live on SettingsStore.
     if TYPE_CHECKING:
         _lock: RLock
-        _cars: list[CarConfig]
+        _cars: list[Car]
         _active_car_id: str | None
         _sanitize_analysis: staticmethod
 
@@ -54,23 +54,14 @@ class CarSettingsMixin:
     def active_car(self) -> Car | None:
         """Return the active car as a domain ``Car`` value object."""
         with self._lock:
-            car_cfg = self._find_car(self._active_car_id)
-            if car_cfg is None:
-                return None
-            return Car(
-                id=car_cfg.id,
-                name=car_cfg.name,
-                car_type=car_cfg.car_type,
-                aspects=dict(car_cfg.aspects),
-                variant=car_cfg.variant,
-            )
+            return self._find_car(self._active_car_id)
 
     # -- car operations --------------------------------------------------------
 
     def get_cars(self) -> dict[str, object]:
         with self._lock:
             return {
-                "cars": [c.to_dict() for c in self._cars],
+                "cars": [car_to_persistence_dict(c) for c in self._cars],
                 "activeCarId": self._active_car_id,
             }
 
@@ -81,33 +72,26 @@ class CarSettingsMixin:
         (rejecting zero and negative values) fires on the hot path.
         """
         with self._lock:
-            car_cfg = self._find_car(self._active_car_id)
-            if car_cfg is None:
+            car = self._find_car(self._active_car_id)
+            if car is None:
                 return None
-            car = Car(
-                id=car_cfg.id,
-                name=car_cfg.name,
-                car_type=car_cfg.car_type,
-                aspects=dict(car_cfg.aspects),
-                variant=car_cfg.variant,
-            )
             return dict(car.aspects)
 
     def active_car_snapshot(self) -> CarSnapshot | None:
         """Return the active car profile as a typed domain snapshot."""
         with self._lock:
-            car_cfg = self._find_car(self._active_car_id)
-            if car_cfg is None:
+            car = self._find_car(self._active_car_id)
+            if car is None:
                 return None
             return CarSnapshot(
-                car_id=car_cfg.id,
-                name=car_cfg.name,
-                car_type=car_cfg.car_type,
-                variant=car_cfg.variant,
-                aspects=dict(car_cfg.aspects),
+                car_id=car.id,
+                name=car.name,
+                car_type=car.car_type,
+                variant=car.variant,
+                aspects=dict(car.aspects),
             )
 
-    def _find_car(self, car_id: str | None) -> CarConfig | None:
+    def _find_car(self, car_id: str | None) -> Car | None:
         if not car_id:
             return None
         return next((c for c in self._cars if c.id == car_id), None)
@@ -131,7 +115,7 @@ class CarSettingsMixin:
         with self._lock:
             payload: dict[str, object] = dict(car_data)
             payload["id"] = new_car_id()
-            car = CarConfig.from_dict(payload)
+            car = Car.from_persisted_dict(payload)
             self._cars.append(car)
             try:
                 self._persist()
@@ -146,34 +130,41 @@ class CarSettingsMixin:
             car = self._find_car(car_id)
             if car is None:
                 raise ValueError(f"Unknown car id: {car_id}")
-            # Snapshot for rollback
-            old_name, old_type = car.name, car.car_type
-            old_aspects = dict(car.aspects)
-            old_variant = car.variant
+            idx = next(i for i, c in enumerate(self._cars) if c.id == car_id)
+            # Build updated fields via reconstruction
+            new_name = car.name
             if "name" in car_data:
                 raw_name = car_data["name"]
                 if isinstance(raw_name, str):
-                    name = _clamp_str(raw_name, 64)
-                    if name:
-                        car.name = name
+                    clamped = _clamp_str(raw_name, 64)
+                    if clamped:
+                        new_name = clamped
+            new_car_type = car.car_type
             if "type" in car_data:
                 raw_type = car_data["type"]
                 if isinstance(raw_type, str):
-                    car_type = _clamp_str(raw_type, 32)
-                    if car_type:
-                        car.car_type = car_type
+                    clamped = _clamp_str(raw_type, 32)
+                    if clamped:
+                        new_car_type = clamped
+            new_aspects = dict(car.aspects)
             if "aspects" in car_data and isinstance(car_data["aspects"], dict):
-                car.aspects.update(AnalysisSettingsSnapshot.sanitize(car_data["aspects"]))
+                new_aspects.update(AnalysisSettingsSnapshot.sanitize(car_data["aspects"]))
+            new_variant = car.variant
             if "variant" in car_data:
                 raw = car_data["variant"]
-                car.variant = _clamp_str(raw, 64) or None if isinstance(raw, str) and raw else None
+                new_variant = _clamp_str(raw, 64) or None if isinstance(raw, str) and raw else None
+            updated = Car(
+                id=car.id,
+                name=new_name,
+                car_type=new_car_type,
+                aspects=new_aspects,
+                variant=new_variant,
+            )
+            self._cars[idx] = updated
             try:
                 self._persist()
             except PersistenceError:
-                car.name, car.car_type = old_name, old_type
-                car.aspects.clear()
-                car.aspects.update(old_aspects)
-                car.variant = old_variant
+                self._cars[idx] = car  # rollback
                 raise
             self._sync_analysis_settings()
             return self.get_cars()
@@ -186,16 +177,23 @@ class CarSettingsMixin:
             car = self._find_car(self._active_car_id)
             if car is None:
                 raise ValueError("No active car configured")
-            old_aspects = dict(car.aspects)
-            car.aspects.update(AnalysisSettingsSnapshot.sanitize(aspects))
+            idx = next(i for i, c in enumerate(self._cars) if c.id == car.id)
+            new_aspects = {**car.aspects, **AnalysisSettingsSnapshot.sanitize(aspects)}
+            updated = Car(
+                id=car.id,
+                name=car.name,
+                car_type=car.car_type,
+                aspects=new_aspects,
+                variant=car.variant,
+            )
+            self._cars[idx] = updated
             try:
                 self._persist()
             except PersistenceError:
-                car.aspects.clear()
-                car.aspects.update(old_aspects)
+                self._cars[idx] = car  # rollback
                 raise
             self._sync_analysis_settings()
-            return dict(car.aspects)
+            return dict(updated.aspects)
 
     def delete_car(self, car_id: str) -> dict[str, object]:
         with self._lock:

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -29,6 +29,7 @@ from threading import RLock
 from typing import TYPE_CHECKING, cast, get_args
 
 from vibesensor.domain import (
+    Car,
     Sensor,
     SensorPlacement,
     SpeedSource,
@@ -39,7 +40,6 @@ from vibesensor.infra.config.car_settings import CarSettingsMixin
 from vibesensor.infra.config.car_settings import _clamp_str as _clamp_str
 from vibesensor.shared.exceptions import PersistenceError as PersistenceError
 from vibesensor.shared.types.backend_types import (
-    CarConfig,
     LanguageCode,
     SensorConfig,
     SensorConfigUpdatePayload,
@@ -49,6 +49,7 @@ from vibesensor.shared.types.backend_types import (
     SpeedSourcePayload,
     SpeedSourceUpdatePayload,
     SpeedUnitCode,
+    car_to_persistence_dict,
 )
 from vibesensor.shared.types.json_types import JsonObject
 
@@ -118,7 +119,7 @@ class SettingsStore(CarSettingsMixin):
         self._sanitize_analysis = AnalysisSettingsSnapshot.sanitize
         self._analysis_values: dict[str, float] = dict(AnalysisSettingsSnapshot.DEFAULTS)
 
-        self._cars: list[CarConfig] = []
+        self._cars: list[Car] = []
         self._active_car_id: str | None = None
         self._speed_cfg = SpeedSourceConfig.default()
         self._language: LanguageCode = "en"
@@ -140,7 +141,7 @@ class SettingsStore(CarSettingsMixin):
             # Cars
             raw_cars = raw.get("cars")
             if isinstance(raw_cars, list) and raw_cars:
-                self._cars = [CarConfig.from_dict(c) for c in raw_cars if isinstance(c, dict)]
+                self._cars = [Car.from_persisted_dict(c) for c in raw_cars if isinstance(c, dict)]
 
             active_id = str(raw.get("activeCarId") or "")
             car_ids = {c.id for c in self._cars}
@@ -218,7 +219,7 @@ class SettingsStore(CarSettingsMixin):
     def snapshot(self) -> SettingsSnapshotPayload:
         with self._lock:
             return {
-                "cars": [c.to_dict() for c in self._cars],
+                "cars": [car_to_persistence_dict(c) for c in self._cars],
                 "activeCarId": self._active_car_id,
                 **self._speed_cfg.to_dict(),
                 "language": self._language,

--- a/apps/server/vibesensor/shared/types/backend_types.py
+++ b/apps/server/vibesensor/shared/types/backend_types.py
@@ -11,18 +11,16 @@ from typing import TYPE_CHECKING, Final, Literal, TypeAlias
 
 from typing_extensions import NotRequired, TypedDict  # noqa: UP035 (Pydantic on Python 3.11)
 
-from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.domain.speed_source import SpeedSourceKind as SpeedSourceKind
 from vibesensor.shared.constants import NUMERIC_TYPES
 
 if TYPE_CHECKING:
-    from vibesensor.domain import SpeedSource
+    from vibesensor.domain import Car, SpeedSource
 
 _isfinite = math.isfinite
 _LOGGER = logging.getLogger(__name__)
 
 __all__ = [
-    "CarConfig",
     "CarConfigPayload",
     "CarConfigUpdatePayload",
     "RUN_END_TYPE",
@@ -38,6 +36,7 @@ __all__ = [
     "SpeedSourcePayload",
     "SpeedSourceUpdatePayload",
     "VALID_SPEED_SOURCES",
+    "car_to_persistence_dict",
     "new_car_id",
 ]
 
@@ -151,53 +150,21 @@ def new_car_id() -> str:
 
 
 # ---------------------------------------------------------------------------
-# CarConfig
+# Persistence boundary helper
 # ---------------------------------------------------------------------------
 
 
-@dataclass(slots=True)
-class CarConfig:
-    """Persisted vehicle profile (ID, name, type, geometry aspects, variant)."""
-
-    id: str
-    name: str
-    car_type: str
-    aspects: dict[str, float]
-    variant: str | None
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, object]) -> CarConfig:
-        """Construct a :class:`CarConfig` from a raw dict (e.g., loaded from JSON)."""
-        car_id = str(data.get("id") or new_car_id())
-        name = str(data.get("name") or "Unnamed Car").strip()[:64] or "Unnamed Car"
-        car_type = str(data.get("type") or "sedan").strip()[:32] or "sedan"
-        raw_aspects = data.get("aspects") or {}
-        aspects = dict(AnalysisSettingsSnapshot.DEFAULTS)
-        if isinstance(raw_aspects, dict):
-            aspects.update(AnalysisSettingsSnapshot.sanitize(raw_aspects))
-        raw_variant = data.get("variant")
-        variant = (
-            str(raw_variant).strip()[:64] if isinstance(raw_variant, str) and raw_variant else None
-        )
-        return cls(
-            id=car_id,
-            name=name,
-            car_type=car_type,
-            aspects=aspects,
-            variant=variant or None,
-        )
-
-    def to_dict(self) -> CarConfigPayload:
-        """Serialise this car config to a plain dict for JSON persistence."""
-        d: CarConfigPayload = {
-            "id": self.id,
-            "name": self.name,
-            "type": self.car_type,
-            "aspects": dict(self.aspects),
-        }
-        if self.variant:
-            d["variant"] = self.variant
-        return d
+def car_to_persistence_dict(car: Car) -> CarConfigPayload:
+    """Serialise a domain ``Car`` to a plain dict for JSON persistence."""
+    d: CarConfigPayload = {
+        "id": car.id,
+        "name": car.name,
+        "type": car.car_type,
+        "aspects": dict(car.aspects),
+    }
+    if car.variant:
+        d["variant"] = car.variant
+    return d
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Eliminate the `CarConfig` dataclass and store domain `Car` objects directly in `SettingsStore`. This removes a redundant parallel representation that duplicated all fields from `Car` with zero additional value.

## Changes

**domain/car.py:**
- Add `Car.from_persisted_dict(data)` classmethod absorbing `CarConfig.from_dict()` logic (ID generation, name/type clamping, aspect default-fill + sanitization, variant parsing)
- Uses lazy import of `AnalysisSettingsSnapshot` to avoid circular import with `snapshots.py`

**backend_types.py:**
- Add `car_to_persistence_dict(car: Car) -> CarConfigPayload` boundary function
- Delete `CarConfig` dataclass entirely
- `CarConfigPayload` and `CarConfigUpdatePayload` TypedDicts retained (API boundary types)

**car_settings.py / settings_store.py:**
- `list[CarConfig]` → `list[Car]`
- `active_car()` returns stored Car directly (no more on-demand `CarConfig→Car` conversion)
- `active_car_aspects()` returns `dict(car.aspects)` directly
- `update_car()` and `update_active_car_aspects()` use frozen-object reconstruction instead of mutable dict operations
- Rollback on `PersistenceError` swaps the old Car back (`self._cars[idx] = old_car`)
- `add_car()` uses `Car.from_persisted_dict()` instead of `CarConfig.from_dict()`

**Tests:**
- Migrated `TestCarConfig` → `TestCarPersistedDict` (tests `Car.from_persisted_dict` + `car_to_persistence_dict`)
- Migrated car variant persistence tests to use new API
- Updated rollback safety test to verify content restoration (not dict identity, since Car is frozen)

**Net: 8 files, 143 insertions, 147 deletions**

Closes #742