### PR TITLE
refactor: decouple use_cases from adapters/pdf (#703)

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -15,8 +15,20 @@ from vibesensor.adapters.http import create_router
 from vibesensor.infra.runtime import RuntimeHealthState
 from vibesensor.use_cases.diagnostics import summarize_run_data
 from vibesensor.use_cases.history.exports import HistoryExportService
-from vibesensor.use_cases.history.reports import HistoryReportService
+from vibesensor.use_cases.history.reports import HistoryReportService, PdfRendererFn
 from vibesensor.use_cases.history.runs import HistoryRunService
+
+
+def _real_pdf_renderer(analysis_summary: dict, test_run: object | None) -> bytes:
+    """Default test renderer wiring the real adapter pipeline."""
+    from typing import cast
+
+    from vibesensor.adapters.pdf.mapping import map_summary
+    from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+    from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+
+    summary = cast(AnalysisSummary, analysis_summary)
+    return build_report_pdf(map_summary(summary, test_run=test_run))
 
 
 def make_metadata(**overrides: Any) -> dict[str, Any]:
@@ -138,7 +150,13 @@ class FakeWs:
 
 
 class FakeState:
-    def __init__(self, history_db: FakeHistoryDB, ws_hub: FakeWsHub) -> None:
+    def __init__(
+        self,
+        history_db: FakeHistoryDB,
+        ws_hub: FakeWsHub,
+        *,
+        pdf_renderer: PdfRendererFn = _real_pdf_renderer,
+    ) -> None:
         self.history_db = history_db
         self.ws_hub = ws_hub
         self.settings_store = type(
@@ -244,7 +262,9 @@ class FakeState:
         self.update_manager = MagicMock()
         self.esp_flash_manager = MagicMock()
         self.run_service = HistoryRunService(self.history_db, self.settings_store)
-        self.report_service = HistoryReportService(self.history_db, self.settings_store)
+        self.report_service = HistoryReportService(
+            self.history_db, self.settings_store, pdf_renderer=pdf_renderer
+        )
         self.export_service = HistoryExportService(self.history_db)
 
 
@@ -255,6 +275,7 @@ def make_router_and_state(
     metadata: dict[str, Any] | None = None,
     samples: list[dict[str, Any]] | None = None,
     analysis: dict[str, Any] | None = None,
+    pdf_renderer: PdfRendererFn = _real_pdf_renderer,
 ):
     metadata = metadata or make_metadata(language=language)
     samples = samples or [sample(i) for i in range(sample_count)]
@@ -264,7 +285,9 @@ def make_router_and_state(
         lang=language,
         include_samples=False,
     )
-    state = FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub())
+    state = FakeState(
+        FakeHistoryDB(metadata, samples, analysis), FakeWsHub(), pdf_renderer=pdf_renderer
+    )
     app = FastAPI()
     router = create_router(state)
     app.include_router(router)

--- a/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from io import BytesIO
-from unittest.mock import patch
 
 import pytest
 from _history_endpoint_helpers import (
     FakeHistoryDB,
     FakeState,
     FakeWsHub,
+    _real_pdf_renderer,
     make_metadata,
     make_router_and_state,
     make_status_router,
@@ -76,22 +76,25 @@ async def test_report_pdf_lang_override_when_template_data_persisted() -> None:
     analysis = summarize_run_data(metadata, samples, lang="nl", include_samples=False)
     analysis["_report_template_data"] = {"lang": "nl", "title": "legacy"}
 
+    render_count = 0
+    real_renderer = _real_pdf_renderer
+
+    def counting_renderer(summary: dict, test_run: object | None) -> bytes:
+        nonlocal render_count
+        render_count += 1
+        return real_renderer(summary, test_run)
+
     db = FakeHistoryDB(metadata, samples, analysis)
-    state = FakeState(db, FakeWsHub())
+    state = FakeState(db, FakeWsHub(), pdf_renderer=counting_renderer)
     app = FastAPI()
     router = create_router(state)
     app.include_router(router)
     endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
 
-    with patch("vibesensor.use_cases.history.reports.map_summary") as patched_map_summary:
-        patched_map_summary.side_effect = lambda summary, **kwargs: __import__(
-            "vibesensor.adapters.pdf.mapping",
-            fromlist=["map_summary"],
-        ).map_summary(summary, **kwargs)
-        nl = await endpoint("run-1", "nl")
-        en = await endpoint("run-1", "en")
+    nl = await endpoint("run-1", "nl")
+    en = await endpoint("run-1", "en")
 
-    assert patched_map_summary.call_count == 1
+    assert render_count == 1
 
     assert nl.body.startswith(b"%PDF")
     assert en.body.startswith(b"%PDF")
@@ -108,18 +111,18 @@ async def test_report_pdf_lang_override_when_template_data_persisted() -> None:
 
 @pytest.mark.asyncio
 async def test_report_pdf_reuses_cached_pdf_for_same_run_lang_and_analysis() -> None:
-    router, _ = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
     call_count = 0
 
-    def fake_pdf(_summary: dict[str, object]) -> bytes:
+    def fake_renderer(_summary: dict, _test_run: object | None) -> bytes:
         nonlocal call_count
         call_count += 1
         return b"%PDF-cached"
 
-    with patch("vibesensor.use_cases.history.reports.build_report_pdf", side_effect=fake_pdf):
-        first = await endpoint("run-1", "en")
-        second = await endpoint("run-1", "en")
+    router, _ = make_router_and_state(language="en", pdf_renderer=fake_renderer)
+    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+
+    first = await endpoint("run-1", "en")
+    second = await endpoint("run-1", "en")
 
     assert call_count == 1
     assert first.body == second.body == b"%PDF-cached"
@@ -127,19 +130,19 @@ async def test_report_pdf_reuses_cached_pdf_for_same_run_lang_and_analysis() -> 
 
 @pytest.mark.asyncio
 async def test_report_pdf_reuses_cached_pdf_across_lang_when_template_is_persisted() -> None:
-    router, state = make_router_and_state(language="nl")
-    state.history_db.analysis["_report_template_data"] = {"lang": "nl", "title": "legacy"}
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
     call_count = 0
 
-    def fake_pdf(_data) -> bytes:
+    def fake_renderer(_summary: dict, _test_run: object | None) -> bytes:
         nonlocal call_count
         call_count += 1
         return b"%PDF-cached-cross-lang"
 
-    with patch("vibesensor.use_cases.history.reports.build_report_pdf", side_effect=fake_pdf):
-        first = await endpoint("run-1", "en")
-        second = await endpoint("run-1", "nl")
+    router, state = make_router_and_state(language="nl", pdf_renderer=fake_renderer)
+    state.history_db.analysis["_report_template_data"] = {"lang": "nl", "title": "legacy"}
+    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+
+    first = await endpoint("run-1", "en")
+    second = await endpoint("run-1", "nl")
 
     assert call_count == 1
     assert first.body == second.body == b"%PDF-cached-cross-lang"
@@ -168,19 +171,21 @@ async def test_report_pdf_cache_invalidates_when_analysis_completed_at_changes()
             result["analysis_completed_at"] = ts
             return result
 
-    state = FakeState(TimestampFlipDB(metadata, samples, analysis), FakeWsHub())
-    router = create_router(state)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
     call_count = 0
 
-    def fake_pdf(_summary: dict[str, object]) -> bytes:
+    def fake_renderer(_summary: dict, _test_run: object | None) -> bytes:
         nonlocal call_count
         call_count += 1
         return b"%PDF-versioned"
 
-    with patch("vibesensor.use_cases.history.reports.build_report_pdf", side_effect=fake_pdf):
-        await endpoint("run-1", "en")
-        await endpoint("run-1", "en")
+    state = FakeState(
+        TimestampFlipDB(metadata, samples, analysis), FakeWsHub(), pdf_renderer=fake_renderer
+    )
+    router = create_router(state)
+    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+
+    await endpoint("run-1", "en")
+    await endpoint("run-1", "en")
 
     assert call_count == 2
 

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -57,7 +57,11 @@ class FakeState:
         if self.run_service is None:
             self.run_service = HistoryRunService(self.history_db, self.settings_store)
         if self.report_service is None:
-            self.report_service = HistoryReportService(self.history_db, self.settings_store)
+            self.report_service = HistoryReportService(
+                self.history_db,
+                self.settings_store,
+                pdf_renderer=lambda _summary, _test_run: b"%PDF-stub",
+            )
         if self.export_service is None:
             self.export_service = HistoryExportService(self.history_db)
 

--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -86,14 +86,10 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         ("domain/snapshots.py", "vibesensor.coerce"),
         ("domain/strength_metrics.py", "vibesensor.coerce"),
         # shared → adapters
-        ("shared/boundaries/analysis_payload.py", "vibesensor.adapters.pdf.report_types"),
         # use_cases → adapters
         ("use_cases/diagnostics/helpers.py", "vibesensor.adapters.persistence.runlog"),
-        ("use_cases/diagnostics/plots.py", "vibesensor.adapters.pdf.report_types"),
         ("use_cases/history/exports.py", "vibesensor.adapters.persistence.history_db"),
         ("use_cases/history/helpers.py", "vibesensor.adapters.persistence.history_db"),
-        ("use_cases/history/reports.py", "vibesensor.adapters.pdf.mapping"),
-        ("use_cases/history/reports.py", "vibesensor.adapters.pdf.pdf_engine"),
         ("use_cases/history/reports.py", "vibesensor.adapters.persistence.history_db"),
         ("use_cases/history/runs.py", "vibesensor.adapters.persistence.history_db"),
         ("use_cases/run/logger.py", "vibesensor.adapters.gps.gps_speed"),

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -61,6 +61,7 @@ async def test_report_service_load_report_request_uses_persisted_language() -> N
                 "analysis": {"lang": "nl", "findings": [], "title": "X"},
             },
         ),
+        pdf_renderer=lambda _s, _t: b"%PDF-stub",
     )
 
     request = await service.load_report_request("run-1", "en")

--- a/apps/server/vibesensor/adapters/pdf/report_types.py
+++ b/apps/server/vibesensor/adapters/pdf/report_types.py
@@ -2,28 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from vibesensor.shared.boundaries.analysis_payload import PeakTableRow
 
 __all__ = ["PeakTableRow"]
-
-
-class PeakTableRow(TypedDict):
-    """Shape of a single row in the ranked peak table."""
-
-    rank: int
-    frequency_hz: float
-    order_label: str
-    max_intensity_db: float | None
-    median_intensity_db: float | None
-    p95_intensity_db: float | None
-    run_noise_baseline_db: float | None
-    median_vs_run_noise_ratio: float
-    p95_vs_run_noise_ratio: float
-    strength_floor_db: float | None
-    strength_db: float | None
-    presence_ratio: float
-    burstiness: float
-    persistence_score: float
-    suspected_source: str
-    peak_classification: str
-    typical_speed_band: str

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.persistence.history_db import HistoryDB
@@ -16,6 +17,9 @@ from vibesensor.infra.runtime.state import RuntimeState
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.workers.worker_pool import WorkerPool
 from vibesensor.sensor_units import ADXL345_SCALE_G_PER_LSB, SENSOR_MODEL
+
+if TYPE_CHECKING:
+    from vibesensor.domain import TestRun
 from vibesensor.shared.constants import (
     FFT_N,
     FFT_UPDATE_HZ,
@@ -33,6 +37,19 @@ from vibesensor.use_cases.updates.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.manager import UpdateManager
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _build_pdf_bytes(analysis_summary: dict, test_run: TestRun | None) -> bytes:
+    """Compose adapters/pdf pipeline into a single callable for injection."""
+    from typing import cast
+
+    from vibesensor.adapters.pdf.mapping import map_summary
+    from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+    from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+
+    summary = cast(AnalysisSummary, analysis_summary)
+    mapped = map_summary(summary, test_run=test_run)
+    return build_report_pdf(mapped)
 
 
 def resolve_accel_scale_g_per_lsb(config: AppConfig) -> float:
@@ -67,7 +84,7 @@ def build_runtime(config: AppConfig) -> RuntimeState:
 
     # persistence services
     run_service = HistoryRunService(history_db, settings_store)
-    report_service = HistoryReportService(history_db, settings_store)
+    report_service = HistoryReportService(history_db, settings_store, pdf_renderer=_build_pdf_bytes)
     export_service = HistoryExportService(history_db)
 
     # ingress

--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -14,7 +14,6 @@ from vibesensor.domain import OrderMatchObservation
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
 if TYPE_CHECKING:
-    from vibesensor.adapters.pdf.report_types import PeakTableRow
     from vibesensor.shared.boundaries.vibration_origin import SuspectedVibrationOrigin
 
 __all__ = [
@@ -27,6 +26,7 @@ __all__ = [
     "LocationHotspotPayload",
     "MatchedAmpVsSpeedSeries",
     "MatchedPoint",
+    "PeakTableRow",
     "PhaseBoundary",
     "PhaseEvidence",
     "PhaseSegmentOut",
@@ -42,6 +42,28 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Small leaf shapes (no forward-references)
 # ---------------------------------------------------------------------------
+
+
+class PeakTableRow(TypedDict):
+    """Shape of a single row in the ranked peak table."""
+
+    rank: int
+    frequency_hz: float
+    order_label: str
+    max_intensity_db: float | None
+    median_intensity_db: float | None
+    p95_intensity_db: float | None
+    run_noise_baseline_db: float | None
+    median_vs_run_noise_ratio: float
+    p95_vs_run_noise_ratio: float
+    strength_floor_db: float | None
+    strength_db: float | None
+    presence_ratio: float
+    burstiness: float
+    persistence_score: float
+    suspected_source: str
+    peak_classification: str
+    typical_speed_band: str
 
 
 class MatchedPoint(TypedDict, total=False):

--- a/apps/server/vibesensor/use_cases/diagnostics/plots.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/plots.py
@@ -12,11 +12,11 @@ from dataclasses import dataclass, field
 from math import floor
 from typing import Any
 
-from vibesensor.adapters.pdf.report_types import PeakTableRow
 from vibesensor.shared.boundaries.analysis_payload import (
     AmpVsPhaseRow,
     FreqVsSpeedByFindingSeries,
     MatchedAmpVsSpeedSeries,
+    PeakTableRow,
     PhaseBoundary,
     PhaseSegmentOut,
     PlotDataResult,

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -13,12 +13,9 @@ import logging
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-from vibesensor.adapters.pdf.mapping import map_summary
-from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.domain import CarSnapshot
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.shared.exceptions import AnalysisNotReadyError, ProcessingError
 from vibesensor.shared.run_context import add_current_context_warnings, current_car_snapshot_token
@@ -35,6 +32,10 @@ if TYPE_CHECKING:
     from vibesensor.adapters.persistence.history_db import HistoryDB
     from vibesensor.domain import TestRun
     from vibesensor.infra.config.settings_store import SettingsStore
+
+#: Callable that turns a persisted analysis dict into PDF bytes.
+#: Signature: ``(analysis_summary, test_run) -> bytes``.
+PdfRendererFn = Callable[[dict, "TestRun | None"], bytes]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,11 +64,18 @@ class HistoryReportRequest:
 class HistoryReportService:
     """Load persisted report data and coordinate cached PDF generation."""
 
-    __slots__ = ("_history_db", "_pdf_cache", "_settings_store")
+    __slots__ = ("_history_db", "_pdf_cache", "_pdf_renderer", "_settings_store")
 
-    def __init__(self, history_db: HistoryDB, settings_store: SettingsStore | None = None) -> None:
+    def __init__(
+        self,
+        history_db: HistoryDB,
+        settings_store: SettingsStore | None = None,
+        *,
+        pdf_renderer: PdfRendererFn,
+    ) -> None:
         self._history_db = history_db
         self._pdf_cache = HistoryReportPdfCache()
+        self._pdf_renderer = pdf_renderer
         self._settings_store = settings_store
 
     async def build_pdf(self, run_id: str, requested_lang: str | None) -> HistoryReportPdf:
@@ -78,9 +86,9 @@ class HistoryReportService:
 
         pdf = await self._pdf_cache.get_or_build(
             request.cache_key,
-            lambda: self._build_pdf_bytes(
+            lambda: self._pdf_renderer(
                 request.analysis_summary,
-                test_run=request.domain_test_run,
+                request.domain_test_run,
             ),
             run_id=run_id,
         )
@@ -119,23 +127,6 @@ class HistoryReportService:
             analysis_summary=analysis_summary,
             domain_test_run=domain_test_run,
         )
-
-    @staticmethod
-    def _build_pdf_bytes(
-        analysis_summary: JsonObject,
-        *,
-        test_run: TestRun | None = None,
-    ) -> bytes:
-        # analysis_summary comes from persistence as JsonObject but
-        # map_summary expects the AnalysisSummary TypedDict shape.
-        # The data has been validated upstream; cast at the boundary.
-        summary = cast(AnalysisSummary, analysis_summary)
-        mapped_summary = map_summary(
-            summary,
-            test_run=test_run,
-        )
-        pdf: bytes = build_report_pdf(mapped_summary)
-        return pdf
 
     @staticmethod
     def _metadata_cache_token(metadata: object) -> str:


### PR DESCRIPTION
Closes #703

## Summary

Removes the `use_cases → adapters/pdf` dependency by:

1. **Moving `PeakTableRow`** from `adapters/pdf/report_types.py` to `shared/boundaries/analysis_payload.py` — it's a data-shape contract used by analysis, not a rendering concern.

2. **Injecting `pdf_renderer` callable** into `HistoryReportService` instead of importing `map_summary`/`build_report_pdf` at module level. The real adapter pipeline is wired in `container.py` via `_build_pdf_bytes`.

3. **Removing 4 entries** from the layer-boundary violation allowlist (`shared→adapters.pdf.report_types`, `use_cases/diagnostics/plots→adapters.pdf.report_types`, `use_cases/history/reports→adapters.pdf.mapping`, `use_cases/history/reports→adapters.pdf.pdf_engine`).

## Changes

| File | Change |
|------|--------|
| `shared/boundaries/analysis_payload.py` | Added `PeakTableRow` TypedDict definition |
| `adapters/pdf/report_types.py` | Re-exports `PeakTableRow` from shared (backward compat for adapters) |
| `use_cases/diagnostics/plots.py` | Import `PeakTableRow` from shared instead of adapters |
| `use_cases/history/reports.py` | Accept `pdf_renderer: PdfRendererFn` via constructor; removed `map_summary`/`build_report_pdf` imports |
| `app/container.py` | Added `_build_pdf_bytes` wiring function; pass to `HistoryReportService` |
| `tests/hygiene/test_layer_boundaries.py` | Removed 4 solved violation entries |
| Test files | Updated `HistoryReportService` construction sites and replaced `patch()` calls with injected renderers |