### PR TITLE
Decouple run and diagnostics from adapters

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -26,7 +26,7 @@ Backend ownership boundaries:
 - `infra/config/`: runtime settings stores used by recording and runtime services.
 - `use_cases/diagnostics/`: post-stop analysis/findings logic.
 - `use_cases/run/`: recording orchestration and post-analysis queue.
-- `adapters/persistence/` and `use_cases/history/`: SQLite persistence, runlog I/O, car library loading, and history/report/export services.
+- `adapters/persistence/`, `shared/boundaries/`, and `use_cases/history/`: SQLite persistence, shared run-log decoding/normalization, car library loading, and history/report/export services.
 - `adapters/pdf/`: PDF/report rendering pipeline.
 - `use_cases/updates/`: wheel-based update flow.
 - `adapters/hotspot/`: Wi-Fi AP monitoring, parsing, and self-heal infrastructure.

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -135,7 +135,7 @@ def test_v4_db_rejected(tmp_path: Path) -> None:
 
 
 def test_v2_sensor_frame_objects(tmp_path: Path) -> None:
-    from vibesensor.adapters.udp.protocol import SensorFrame
+    from vibesensor.shared.types.sensor_frame import SensorFrame
 
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-sf", "2026-01-01T00:00:00Z", {"source": "test"})

--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -87,7 +87,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         ("domain/strength_metrics.py", "vibesensor.coerce"),
         # shared → adapters
         # use_cases → adapters
-        ("use_cases/diagnostics/helpers.py", "vibesensor.adapters.persistence.runlog"),
         ("use_cases/history/exports.py", "vibesensor.adapters.persistence.history_db"),
         ("use_cases/history/helpers.py", "vibesensor.adapters.persistence.history_db"),
         ("use_cases/history/reports.py", "vibesensor.adapters.persistence.history_db"),
@@ -95,8 +94,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         ("use_cases/run/logger.py", "vibesensor.adapters.gps.gps_speed"),
         ("use_cases/run/logger.py", "vibesensor.adapters.persistence.history_db"),
         ("use_cases/run/post_analysis.py", "vibesensor.adapters.persistence.history_db"),
-        ("use_cases/run/sample_builder.py", "vibesensor.adapters.udp.protocol"),
-        ("use_cases/run/sample_builder.py", "vibesensor.adapters.gps.gps_speed"),
         # use_cases → infra
         ("use_cases/history/reports.py", "vibesensor.infra.config.settings_store"),
         ("use_cases/history/runs.py", "vibesensor.infra.config.settings_store"),

--- a/apps/server/tests/hygiene/test_sample_column_alignment.py
+++ b/apps/server/tests/hygiene/test_sample_column_alignment.py
@@ -3,7 +3,7 @@
 The same sample field set is defined independently in:
 - Schema DDL (``_schema.py`` ``samples_v2`` table)
 - Insertion columns (``_samples.py`` ``_V2_COLUMNS``)
-- Domain model (``domain_models.py`` ``SensorFrame``)
+- Shared typed sample schema (``shared/types/sensor_frame.py`` ``SensorFrame``)
 - CSV export (``exports.py`` ``EXPORT_CSV_COLUMNS``)
 
 A typo or omission in any of these produces silent NULL insertion or missing
@@ -17,7 +17,7 @@ import dataclasses
 
 from vibesensor.adapters.persistence.history_db._samples import _V2_COLUMNS
 from vibesensor.adapters.persistence.history_db._schema import SCHEMA_SQL
-from vibesensor.adapters.udp.protocol import SensorFrame
+from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.history.exports import EXPORT_CSV_COLUMNS
 
 # Known source-specific columns that are intentionally absent from other sources.

--- a/apps/server/tests/infra/processing/test_sample_builder.py
+++ b/apps/server/tests/infra/processing/test_sample_builder.py
@@ -13,6 +13,7 @@ import pytest
 
 from vibesensor.domain import AnalysisSettingsSnapshot, StrengthMetrics
 from vibesensor.use_cases.run.sample_builder import (
+    SpeedContext,
     build_run_metadata,
     build_sample_records,
     dominant_hz_from_strength,
@@ -205,10 +206,6 @@ class TestBuildSampleRecords:
     def test_no_active_clients(self) -> None:
         reg = MagicMock()
         proc = MagicMock()
-        gps = MagicMock()
-        gps.speed_mps = None
-        gps.effective_speed_mps = None
-        gps.resolve_speed.return_value = MagicMock(source="none")
         proc.clients_with_recent_data.return_value = []
         records = build_sample_records(
             run_id="r1",
@@ -216,7 +213,7 @@ class TestBuildSampleRecords:
             timestamp_utc="2026-01-01T00:00:00Z",
             registry=reg,
             processor=proc,
-            gps_monitor=gps,
+            speed_context=SpeedContext(None, None, "none", None),
             analysis_settings_snapshot=AnalysisSettingsSnapshot(),
             default_sample_rate_hz=800,
         )
@@ -263,17 +260,13 @@ class TestBuildSampleRecords:
         proc.latest_sample_xyz.return_value = (0.1, 0.2, 0.3)
         proc.latest_sample_rate_hz.return_value = 400
 
-        gps = MagicMock()
-        gps.speed_mps = None
-        gps.resolve_speed.return_value = MagicMock(source="none", speed_mps=None)
-
         records = build_sample_records(
             run_id="r1",
             t_s=1.25,
             timestamp_utc="2026-01-01T00:00:00Z",
             registry=reg,
             processor=proc,
-            gps_monitor=gps,
+            speed_context=SpeedContext(None, None, "none", None),
             analysis_settings_snapshot=AnalysisSettingsSnapshot(),
             default_sample_rate_hz=800,
         )

--- a/apps/server/tests/shared/boundaries/test_run_log.py
+++ b/apps/server/tests/shared/boundaries/test_run_log.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from vibesensor.adapters.persistence.runlog import (
+from vibesensor.shared.boundaries.run_log import (
     RUN_METADATA_TYPE,
     normalize_sample_record,
     read_jsonl_run,
@@ -266,7 +266,7 @@ def test_read_jsonl_run_logs_warning_for_corrupt_lines(
     path.write_text("\n".join(lines) + "\n")
     import logging
 
-    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.persistence.runlog"):
+    with caplog.at_level(logging.WARNING, logger="vibesensor.shared.boundaries.run_log"):
         run_data = read_jsonl_run(path)
     assert len(run_data.samples) == 1
     assert "Skipping corrupt JSONL line 2" in caplog.text
@@ -327,7 +327,7 @@ def test_read_jsonl_run_warns_on_duplicate_metadata(
 
     import logging
 
-    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.persistence.runlog"):
+    with caplog.at_level(logging.WARNING, logger="vibesensor.shared.boundaries.run_log"):
         run_data = read_jsonl_run(path)
 
     # First metadata wins
@@ -356,7 +356,7 @@ def test_read_jsonl_run_end_record_without_end_time_utc_leaves_metadata_unchange
 
     import logging
 
-    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.persistence.runlog"):
+    with caplog.at_level(logging.WARNING, logger="vibesensor.shared.boundaries.run_log"):
         run_data = read_jsonl_run(path)
 
     # end_time_utc must NOT be set to None

--- a/apps/server/tests/shared/types/test_domain_models.py
+++ b/apps/server/tests/shared/types/test_domain_models.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import pytest
 
-from vibesensor.adapters.udp.protocol import SensorFrame
 from vibesensor.domain import Car
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
 from vibesensor.shared.types.backend_types import (
@@ -17,6 +16,7 @@ from vibesensor.shared.types.backend_types import (
     SpeedSourceConfig,
     car_to_persistence_dict,
 )
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 # ---------------------------------------------------------------------------
 # Helper parsers

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
@@ -15,7 +15,7 @@ import pytest
 from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.adapters.persistence.runlog import normalize_sample_record
+from vibesensor.shared.boundaries.run_log import normalize_sample_record
 from vibesensor.shared.sampling import bounded_sample
 from vibesensor.use_cases.diagnostics import build_findings_for_samples, summarize_run_data
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig

--- a/apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py
+++ b/apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py
@@ -681,12 +681,19 @@ class TestExtractStrengthData:
 class TestResolveSpeedContext:
     """Tests for _resolve_speed_context via a minimal RunRecorder setup."""
 
+    @staticmethod
+    def _resolve_from_logger(logger) -> tuple[float | None, float | None, str, float | None]:
+        resolution = logger.gps_monitor.resolve_speed()
+        return resolve_speed_context(
+            gps_speed_mps=logger.gps_monitor.speed_mps,
+            resolved_speed_mps=resolution.speed_mps,
+            resolved_speed_source=resolution.source,
+            analysis_settings_snapshot=logger._analysis_settings_snapshot(),
+        )
+
     def test_no_speed_available(self) -> None:
         logger, _ = _make_run_recorder()
-        speed_kmh, gps_speed, source, rpm = resolve_speed_context(
-            logger.gps_monitor,
-            logger._analysis_settings_snapshot(),
-        )
+        speed_kmh, gps_speed, source, rpm = self._resolve_from_logger(logger)
         assert speed_kmh is None
         assert rpm is None
 
@@ -694,10 +701,7 @@ class TestResolveSpeedContext:
         logger, gps_mock = _make_run_recorder()
         gps_mock.speed_mps = 10.0  # 36 km/h
         gps_mock.resolve_speed.return_value = MagicMock(source="gps", speed_mps=10.0)
-        speed_kmh, gps_speed, source, rpm = resolve_speed_context(
-            logger.gps_monitor,
-            logger._analysis_settings_snapshot(),
-        )
+        speed_kmh, gps_speed, source, rpm = self._resolve_from_logger(logger)
         assert speed_kmh == pytest.approx(36.0, rel=0.01)
         assert gps_speed == pytest.approx(36.0, rel=0.01)
         assert source == "gps"
@@ -707,10 +711,7 @@ class TestResolveSpeedContext:
         logger, gps_mock = _make_run_recorder()
         gps_mock.override_speed_mps = 20.0  # 72 km/h
         gps_mock.resolve_speed.return_value = MagicMock(source="manual", speed_mps=20.0)
-        speed_kmh, _, source, _ = resolve_speed_context(
-            logger.gps_monitor,
-            logger._analysis_settings_snapshot(),
-        )
+        speed_kmh, _, source, _ = self._resolve_from_logger(logger)
         assert speed_kmh == pytest.approx(72.0, rel=0.01)
         assert source == "manual"
 
@@ -725,10 +726,7 @@ class TestResolveSpeedContext:
             rim_in=16,
             final_drive_ratio=3.73,
         )
-        _, _, _, rpm = resolve_speed_context(
-            logger.gps_monitor,
-            logger._analysis_settings_snapshot(),
-        )
+        _, _, _, rpm = self._resolve_from_logger(logger)
         assert rpm is None, "Without gear_ratio, RPM should not be estimated"
 
     def test_uses_order_reference_spec_for_engine_rpm(
@@ -748,10 +746,7 @@ class TestResolveSpeedContext:
         gps_mock.speed_mps = 10.0
         gps_mock.resolve_speed.return_value = MagicMock(source="gps", speed_mps=10.0)
 
-        speed, _, _, rpm = resolve_speed_context(
-            logger.gps_monitor,
-            logger._analysis_settings_snapshot(),
-        )
+        speed, _, _, rpm = self._resolve_from_logger(logger)
 
         assert speed == pytest.approx(36.0, rel=0.01)
         assert rpm == 1234.5

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -31,7 +31,6 @@ from vibesensor.adapters.persistence.history_db._schema import (
     SCHEMA_SQL,
     SCHEMA_VERSION,
 )
-from vibesensor.adapters.udp.protocol import SensorFrame
 from vibesensor.domain.run_status import (
     RunStatus,
     is_run_deletable,
@@ -40,6 +39,7 @@ from vibesensor.domain.run_status import (
 from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 # Re-export for public API.
 __all__ = ["HistoryDB"]

--- a/apps/server/vibesensor/adapters/persistence/history_db/_samples.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_samples.py
@@ -1,7 +1,7 @@
 """Sample serialisation helpers for the ``samples_v2`` table.
 
 Pure functions and schema constants that convert between in-memory sample
-dicts / :class:`~vibesensor.domain_models.SensorFrame` objects and flat
+dicts / :class:`~vibesensor.shared.types.sensor_frame.SensorFrame` objects and flat
 SQLite row tuples.  Extracted from :mod:`vibesensor.adapters.persistence.history_db` to keep the
 schema-specific column definitions and conversion logic in one place.
 """
@@ -12,9 +12,9 @@ import logging
 import math
 from typing import TypeGuard
 
-from vibesensor.adapters.udp.protocol import SensorFrame
 from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_array, is_json_object
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 LOGGER = logging.getLogger(__name__)
 

--- a/apps/server/vibesensor/adapters/udp/protocol.py
+++ b/apps/server/vibesensor/adapters/udp/protocol.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import struct
-from collections.abc import Mapping
 from dataclasses import dataclass
 
 import numpy as np
@@ -41,7 +40,6 @@ __all__ = [
     "parse_data",
     "parse_data_ack",
     "parse_hello",
-    "SensorFrame",
 ]
 
 VERSION = 1
@@ -390,151 +388,3 @@ def parse_data_ack(data: bytes) -> DataAckMessage:
 def pack_data_ack(client_id: bytes, last_seq_received: int) -> bytes:
     """Encode a DATA_ACK message as bytes."""
     return DATA_ACK_STRUCT.pack(MSG_DATA_ACK, VERSION, client_id, last_seq_received & 0xFFFFFFFF)
-
-
-# ---------------------------------------------------------------------------
-# JSONL SensorFrame
-# ---------------------------------------------------------------------------
-
-
-_VSD_KEY: str = "vibration_strength_db"
-_BUCKET_KEY: str = "strength_bucket"
-
-
-def _normalize_peak_list(peaks_raw: object, *, max_items: int) -> list[dict[str, object]]:
-    """Validate and normalise a raw peak list into canonical form."""
-    from vibesensor.shared.json_utils import as_float_or_none
-
-    normalized: list[dict[str, object]] = []
-    if not isinstance(peaks_raw, list):
-        return normalized
-    for peak in peaks_raw[:max_items]:
-        if not isinstance(peak, dict):
-            continue
-        hz = as_float_or_none(peak.get("hz"))
-        amp = as_float_or_none(peak.get("amp"))
-        if hz is None or amp is None or hz <= 0 or amp <= 0:
-            continue
-        normalized_peak: dict[str, object] = {"hz": hz, "amp": amp}
-        peak_db = as_float_or_none(peak.get(_VSD_KEY))
-        if peak_db is not None:
-            normalized_peak[_VSD_KEY] = peak_db
-        peak_bucket = peak.get(_BUCKET_KEY)
-        if peak_bucket not in (None, ""):
-            normalized_peak[_BUCKET_KEY] = str(peak_bucket)
-        normalized.append(normalized_peak)
-    return normalized
-
-
-@dataclass(slots=True)
-class SensorFrame:
-    """A single sample/data record from a JSONL run file."""
-
-    run_id: str
-    timestamp_utc: str
-    t_s: float | None
-    client_id: str
-    client_name: str
-    location: str
-    sample_rate_hz: int | None
-    speed_kmh: float | None
-    gps_speed_kmh: float | None
-    speed_source: str
-    engine_rpm: float | None
-    engine_rpm_source: str
-    gear: float | None
-    final_drive_ratio: float | None
-    accel_x_g: float | None
-    accel_y_g: float | None
-    accel_z_g: float | None
-    dominant_freq_hz: float | None
-    dominant_axis: str
-    top_peaks: list[dict[str, object]]
-    vibration_strength_db: float | None
-    strength_bucket: str | None
-    strength_peak_amp_g: float | None
-    strength_floor_amp_g: float | None
-    frames_dropped_total: int
-    queue_overflow_drops: int
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "run_id": self.run_id,
-            "timestamp_utc": self.timestamp_utc,
-            "t_s": self.t_s,
-            "client_id": self.client_id,
-            "client_name": self.client_name,
-            "location": self.location,
-            "sample_rate_hz": self.sample_rate_hz,
-            "speed_kmh": self.speed_kmh,
-            "gps_speed_kmh": self.gps_speed_kmh,
-            "speed_source": self.speed_source,
-            "engine_rpm": self.engine_rpm,
-            "engine_rpm_source": self.engine_rpm_source,
-            "gear": self.gear,
-            "final_drive_ratio": self.final_drive_ratio,
-            "accel_x_g": self.accel_x_g,
-            "accel_y_g": self.accel_y_g,
-            "accel_z_g": self.accel_z_g,
-            "dominant_freq_hz": self.dominant_freq_hz,
-            "dominant_axis": self.dominant_axis,
-            "top_peaks": list(self.top_peaks),
-            _VSD_KEY: self.vibration_strength_db,
-            _BUCKET_KEY: self.strength_bucket,
-            "strength_peak_amp_g": self.strength_peak_amp_g,
-            "strength_floor_amp_g": self.strength_floor_amp_g,
-            "frames_dropped_total": self.frames_dropped_total,
-            "queue_overflow_drops": self.queue_overflow_drops,
-        }
-
-    @classmethod
-    def from_dict(cls, record: Mapping[str, object]) -> SensorFrame:
-        """Normalize a raw sample dict (e.g. from JSONL or DB) into a SensorFrame."""
-        from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
-
-        t_s = as_float_or_none(record.get("t_s"))
-        speed_kmh = as_float_or_none(record.get("speed_kmh"))
-        gps_speed_kmh = as_float_or_none(record.get("gps_speed_kmh"))
-        accel_x_g = as_float_or_none(record.get("accel_x_g"))
-        accel_y_g = as_float_or_none(record.get("accel_y_g"))
-        accel_z_g = as_float_or_none(record.get("accel_z_g"))
-        engine_rpm = as_float_or_none(record.get("engine_rpm"))
-        gear = as_float_or_none(record.get("gear"))
-        dominant_freq_hz = as_float_or_none(record.get("dominant_freq_hz"))
-        vibration_strength_db = as_float_or_none(record.get(_VSD_KEY))
-        raw_bucket = record.get(_BUCKET_KEY)
-        strength_bucket = str(raw_bucket) if raw_bucket not in (None, "") else None
-        strength_peak_amp_g = as_float_or_none(record.get("strength_peak_amp_g"))
-        strength_floor_amp_g = as_float_or_none(record.get("strength_floor_amp_g"))
-        sample_rate_hz = as_int_or_none(record.get("sample_rate_hz"))
-
-        normalized_peaks = _normalize_peak_list(record.get("top_peaks"), max_items=10)
-
-        return cls(
-            run_id=str(record.get("run_id", "")),
-            timestamp_utc=str(record.get("timestamp_utc", "")),
-            t_s=t_s,
-            client_id=str(record.get("client_id", "")),
-            client_name=str(record.get("client_name", "")),
-            location=str(record.get("location", "")),
-            sample_rate_hz=sample_rate_hz,
-            speed_kmh=speed_kmh,
-            gps_speed_kmh=gps_speed_kmh,
-            speed_source=str(record.get("speed_source", "")),
-            engine_rpm=engine_rpm,
-            engine_rpm_source=str(record.get("engine_rpm_source", "")),
-            gear=gear,
-            final_drive_ratio=as_float_or_none(record.get("final_drive_ratio")),
-            accel_x_g=accel_x_g,
-            accel_y_g=accel_y_g,
-            accel_z_g=accel_z_g,
-            dominant_freq_hz=dominant_freq_hz,
-            dominant_axis=str(record.get("dominant_axis", "")),
-            top_peaks=normalized_peaks,
-            vibration_strength_db=vibration_strength_db,
-            strength_bucket=strength_bucket,
-            strength_peak_amp_g=strength_peak_amp_g,
-            strength_floor_amp_g=strength_floor_amp_g,
-            frames_dropped_total=as_int_or_none(record.get("frames_dropped_total")) or 0,
-            queue_overflow_drops=as_int_or_none(record.get("queue_overflow_drops")) or 0,
-        )

--- a/apps/server/vibesensor/shared/boundaries/run_log.py
+++ b/apps/server/vibesensor/shared/boundaries/run_log.py
@@ -1,8 +1,4 @@
-"""Run-log I/O — reading and normalising JSONL run files.
-
-Provides helpers for reading metric run files in JSONL format,
-plus normalisation helpers for canonical field name handling.
-"""
+"""Shared JSONL run-log boundary decoder used by diagnostics and persistence."""
 
 from __future__ import annotations
 
@@ -12,15 +8,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
-from vibesensor.adapters.udp.protocol import SensorFrame
 from vibesensor.shared.types.backend_types import (
     RUN_END_TYPE,
     RUN_METADATA_TYPE,
     RUN_SAMPLE_TYPE,
 )
 from vibesensor.shared.types.json_types import JsonObject
-
-LOGGER = logging.getLogger(__name__)
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 __all__ = [
     "RUN_METADATA_TYPE",
@@ -29,6 +23,8 @@ __all__ = [
     "normalize_sample_record",
     "read_jsonl_run",
 ]
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -41,11 +37,7 @@ class RunData:
 
 
 def normalize_sample_record(record: JsonObject) -> JsonObject:
-    """Normalize a raw sample dict into canonical form.
-
-    Delegates to :class:`SensorFrame` for field parsing.  Extra keys present
-    in *record* but not part of the SensorFrame schema are preserved.
-    """
+    """Normalize a raw sample dict into canonical form."""
     frame = SensorFrame.from_dict(record)
     normalized = dict(record)
     normalized.update(cast(JsonObject, frame.to_dict()))

--- a/apps/server/vibesensor/shared/types/sensor_frame.py
+++ b/apps/server/vibesensor/shared/types/sensor_frame.py
@@ -1,0 +1,150 @@
+"""Canonical typed sample record shared across recording and persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+__all__ = ["SensorFrame"]
+
+_VSD_KEY: str = "vibration_strength_db"
+_BUCKET_KEY: str = "strength_bucket"
+
+
+def _normalize_peak_list(peaks_raw: object, *, max_items: int) -> list[dict[str, object]]:
+    """Validate and normalize a raw peak list into canonical form."""
+    from vibesensor.shared.json_utils import as_float_or_none
+
+    normalized: list[dict[str, object]] = []
+    if not isinstance(peaks_raw, list):
+        return normalized
+    for peak in peaks_raw[:max_items]:
+        if not isinstance(peak, dict):
+            continue
+        hz = as_float_or_none(peak.get("hz"))
+        amp = as_float_or_none(peak.get("amp"))
+        if hz is None or amp is None or hz <= 0 or amp <= 0:
+            continue
+        normalized_peak: dict[str, object] = {"hz": hz, "amp": amp}
+        peak_db = as_float_or_none(peak.get(_VSD_KEY))
+        if peak_db is not None:
+            normalized_peak[_VSD_KEY] = peak_db
+        peak_bucket = peak.get(_BUCKET_KEY)
+        if peak_bucket not in (None, ""):
+            normalized_peak[_BUCKET_KEY] = str(peak_bucket)
+        normalized.append(normalized_peak)
+    return normalized
+
+
+@dataclass(slots=True)
+class SensorFrame:
+    """A single sample record shared by run recording and persistence."""
+
+    run_id: str
+    timestamp_utc: str
+    t_s: float | None
+    client_id: str
+    client_name: str
+    location: str
+    sample_rate_hz: int | None
+    speed_kmh: float | None
+    gps_speed_kmh: float | None
+    speed_source: str
+    engine_rpm: float | None
+    engine_rpm_source: str
+    gear: float | None
+    final_drive_ratio: float | None
+    accel_x_g: float | None
+    accel_y_g: float | None
+    accel_z_g: float | None
+    dominant_freq_hz: float | None
+    dominant_axis: str
+    top_peaks: list[dict[str, object]]
+    vibration_strength_db: float | None
+    strength_bucket: str | None
+    strength_peak_amp_g: float | None
+    strength_floor_amp_g: float | None
+    frames_dropped_total: int
+    queue_overflow_drops: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "timestamp_utc": self.timestamp_utc,
+            "t_s": self.t_s,
+            "client_id": self.client_id,
+            "client_name": self.client_name,
+            "location": self.location,
+            "sample_rate_hz": self.sample_rate_hz,
+            "speed_kmh": self.speed_kmh,
+            "gps_speed_kmh": self.gps_speed_kmh,
+            "speed_source": self.speed_source,
+            "engine_rpm": self.engine_rpm,
+            "engine_rpm_source": self.engine_rpm_source,
+            "gear": self.gear,
+            "final_drive_ratio": self.final_drive_ratio,
+            "accel_x_g": self.accel_x_g,
+            "accel_y_g": self.accel_y_g,
+            "accel_z_g": self.accel_z_g,
+            "dominant_freq_hz": self.dominant_freq_hz,
+            "dominant_axis": self.dominant_axis,
+            "top_peaks": list(self.top_peaks),
+            _VSD_KEY: self.vibration_strength_db,
+            _BUCKET_KEY: self.strength_bucket,
+            "strength_peak_amp_g": self.strength_peak_amp_g,
+            "strength_floor_amp_g": self.strength_floor_amp_g,
+            "frames_dropped_total": self.frames_dropped_total,
+            "queue_overflow_drops": self.queue_overflow_drops,
+        }
+
+    @classmethod
+    def from_dict(cls, record: Mapping[str, object]) -> SensorFrame:
+        """Normalize a raw sample dict (for example from JSONL or DB) into a SensorFrame."""
+        from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
+
+        t_s = as_float_or_none(record.get("t_s"))
+        speed_kmh = as_float_or_none(record.get("speed_kmh"))
+        gps_speed_kmh = as_float_or_none(record.get("gps_speed_kmh"))
+        accel_x_g = as_float_or_none(record.get("accel_x_g"))
+        accel_y_g = as_float_or_none(record.get("accel_y_g"))
+        accel_z_g = as_float_or_none(record.get("accel_z_g"))
+        engine_rpm = as_float_or_none(record.get("engine_rpm"))
+        gear = as_float_or_none(record.get("gear"))
+        dominant_freq_hz = as_float_or_none(record.get("dominant_freq_hz"))
+        vibration_strength_db = as_float_or_none(record.get(_VSD_KEY))
+        raw_bucket = record.get(_BUCKET_KEY)
+        strength_bucket = str(raw_bucket) if raw_bucket not in (None, "") else None
+        strength_peak_amp_g = as_float_or_none(record.get("strength_peak_amp_g"))
+        strength_floor_amp_g = as_float_or_none(record.get("strength_floor_amp_g"))
+        sample_rate_hz = as_int_or_none(record.get("sample_rate_hz"))
+
+        normalized_peaks = _normalize_peak_list(record.get("top_peaks"), max_items=10)
+
+        return cls(
+            run_id=str(record.get("run_id", "")),
+            timestamp_utc=str(record.get("timestamp_utc", "")),
+            t_s=t_s,
+            client_id=str(record.get("client_id", "")),
+            client_name=str(record.get("client_name", "")),
+            location=str(record.get("location", "")),
+            sample_rate_hz=sample_rate_hz,
+            speed_kmh=speed_kmh,
+            gps_speed_kmh=gps_speed_kmh,
+            speed_source=str(record.get("speed_source", "")),
+            engine_rpm=engine_rpm,
+            engine_rpm_source=str(record.get("engine_rpm_source", "")),
+            gear=gear,
+            final_drive_ratio=as_float_or_none(record.get("final_drive_ratio")),
+            accel_x_g=accel_x_g,
+            accel_y_g=accel_y_g,
+            accel_z_g=accel_z_g,
+            dominant_freq_hz=dominant_freq_hz,
+            dominant_axis=str(record.get("dominant_axis", "")),
+            top_peaks=normalized_peaks,
+            vibration_strength_db=vibration_strength_db,
+            strength_bucket=strength_bucket,
+            strength_peak_amp_g=strength_peak_amp_g,
+            strength_floor_amp_g=strength_floor_amp_g,
+            frames_dropped_total=as_int_or_none(record.get("frames_dropped_total")) or 0,
+            queue_overflow_drops=as_int_or_none(record.get("queue_overflow_drops")) or 0,
+        )

--- a/apps/server/vibesensor/use_cases/diagnostics/helpers.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/helpers.py
@@ -8,9 +8,9 @@ from math import isfinite, sqrt
 from pathlib import Path
 from typing import TypedDict
 
-from vibesensor.adapters.persistence.runlog import read_jsonl_run
 from vibesensor.domain import OrderReferenceSpec, SpeedProfileSummary, TireSpec
 from vibesensor.domain.finding import speed_band_sort_key, speed_bin_label
+from vibesensor.shared.boundaries.run_log import read_jsonl_run
 from vibesensor.shared.constants import (
     KMH_TO_MPS,
     MEMS_NOISE_FLOOR_G,

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -31,6 +31,7 @@ from vibesensor.use_cases.run.sample_builder import (
     build_run_metadata,
     build_sample_records,
     firmware_version_for_run,
+    resolve_speed_context,
 )
 
 if TYPE_CHECKING:
@@ -718,14 +719,21 @@ class RunRecorder:
         t_s: float,
         timestamp_utc: str,
     ) -> list[dict[str, object]]:
+        analysis_settings_snapshot = self._analysis_settings_snapshot()
+        speed_resolution = self.gps_monitor.resolve_speed()
         return build_sample_records(
             run_id=run_id,
             t_s=t_s,
             timestamp_utc=timestamp_utc,
             registry=self.registry,
             processor=self.processor,
-            gps_monitor=self.gps_monitor,
-            analysis_settings_snapshot=self._analysis_settings_snapshot(),
+            speed_context=resolve_speed_context(
+                gps_speed_mps=self.gps_monitor.speed_mps,
+                resolved_speed_mps=speed_resolution.speed_mps,
+                resolved_speed_source=speed_resolution.source,
+                analysis_settings_snapshot=analysis_settings_snapshot,
+            ),
+            analysis_settings_snapshot=analysis_settings_snapshot,
             default_sample_rate_hz=self.default_sample_rate_hz,
         )
 

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -11,7 +11,6 @@ from collections.abc import Callable, Mapping
 from dataclasses import asdict
 from typing import TYPE_CHECKING, NamedTuple, cast
 
-from vibesensor.adapters.udp.protocol import SensorFrame
 from vibesensor.coerce import coerce_float
 from vibesensor.domain.car import CarSnapshot
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
@@ -23,10 +22,10 @@ from vibesensor.shared.run_context import (
 )
 from vibesensor.shared.types.backend_types import RunMetadata
 from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.strength_bands import bucket_for_strength
 
 if TYPE_CHECKING:
-    from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
     from vibesensor.infra.processing import SignalProcessor
     from vibesensor.infra.runtime.registry import ClientRegistry
 
@@ -98,23 +97,23 @@ class SpeedContext(NamedTuple):
 
 
 def resolve_speed_context(
-    gps_monitor: GPSSpeedMonitor,
+    *,
+    gps_speed_mps: float | None,
+    resolved_speed_mps: float | None,
+    resolved_speed_source: str,
     analysis_settings_snapshot: AnalysisSettingsSnapshot,
 ) -> SpeedContext:
-    """Resolve current speed/vehicle state into sample-record values."""
+    """Resolve a concrete speed snapshot into sample-record values."""
     order_reference_spec = analysis_settings_snapshot.order_reference_spec
-    gps_speed_mps = gps_monitor.speed_mps
-    resolution = gps_monitor.resolve_speed()
-    effective_speed_mps = resolution.speed_mps
     gps_speed_kmh = (
         (float(gps_speed_mps) * MPS_TO_KMH) if isinstance(gps_speed_mps, NUMERIC_TYPES) else None
     )
     speed_kmh = (
-        (float(effective_speed_mps) * MPS_TO_KMH)
-        if isinstance(effective_speed_mps, NUMERIC_TYPES)
+        (float(resolved_speed_mps) * MPS_TO_KMH)
+        if isinstance(resolved_speed_mps, NUMERIC_TYPES)
         else None
     )
-    speed_source = _SPEED_SOURCE_MAP.get(resolution.source, "none")
+    speed_source = _SPEED_SOURCE_MAP.get(resolved_speed_source, "none")
     engine_rpm_estimated = None
     if speed_kmh is not None and order_reference_spec is not None:
         engine_rpm_estimated = order_reference_spec.engine_rpm_from_speed_kmh(speed_kmh)
@@ -154,7 +153,7 @@ def build_sample_records(
     timestamp_utc: str,
     registry: ClientRegistry,
     processor: SignalProcessor,
-    gps_monitor: GPSSpeedMonitor,
+    speed_context: SpeedContext,
     analysis_settings_snapshot: AnalysisSettingsSnapshot,
     default_sample_rate_hz: int,
 ) -> list[dict[str, object]]:
@@ -164,7 +163,7 @@ def build_sample_records(
         gps_speed_kmh,
         speed_source,
         engine_rpm_estimated,
-    ) = resolve_speed_context(gps_monitor, analysis_settings_snapshot)
+    ) = speed_context
     order_reference_spec = analysis_settings_snapshot.order_reference_spec
     final_drive_ratio = (
         order_reference_spec.final_drive_ratio if order_reference_spec is not None else None

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -30,7 +30,7 @@ Scope: single source of truth for detailed file layout, entry points, package st
 - `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds the flat `RuntimeState`, and `settings.py` owns YAML config loading and validation.
 - `adapters/http/`: health, clients, settings, recording, history, websocket, updates, car library, and debug route groups; `adapters/http/__init__.py` assembles the router.
 - `adapters/websocket/hub.py`: live WebSocket connection fan-out and payload delivery.
-- `adapters/persistence/`: SQLite history DB (`history_db/`), JSONL runlog I/O (`runlog.py`), and the static car library loader (`car_library.py`).
+- `adapters/persistence/`: SQLite history DB (`history_db/`) and the static car library loader (`car_library.py`).
 - `adapters/pdf/`: PDF/report rendering pipeline and report mapping entrypoints.
 - `adapters/udp/`, `adapters/gps/`, `adapters/simulator/`, `adapters/hotspot/`: UDP protocol transport, GPS speed ingestion, simulator tooling, and hotspot/AP operational adapters.
 - `infra/runtime/`: flat `RuntimeState`, lifecycle management, processing loop, health snapshots, and WebSocket broadcast coordination.
@@ -41,7 +41,7 @@ Scope: single source of truth for detailed file layout, entry points, package st
 - `use_cases/history/`: run query/delete, PDF report generation, CSV/ZIP exports, and history-facing helper orchestration above persistence. `helpers.py` owns the local `HistoryRecord` TypedDict used only inside history workflows.
 - `use_cases/run/`: recording pipeline orchestration; `logger.py` owns `RunRecorder`, `post_analysis.py` owns the background analysis queue, and `sample_builder.py` owns pure sample-building helpers.
 - `use_cases/updates/`: wheel-based updater workflow orchestration, firmware cache, ESP flashing, release discovery, install, rollback, runner, Wi-Fi, and status tracking.
-- `shared/`: cross-cutting typed payloads (`shared/types/`), boundary serializers/decoders (`shared/boundaries/`), exceptions (`shared/exceptions.py`), JSON helpers (`shared/json_utils.py`), location identifiers (`shared/locations.py`), and run-context helpers. `shared/boundaries/diagnostic_case.py` owns summary projection, typed speed/suitability decoding, and shared metadata-to-case reconstruction (`case_context_from_metadata`).
+- `shared/`: cross-cutting typed payloads (`shared/types/`), boundary serializers/decoders (`shared/boundaries/`), exceptions (`shared/exceptions.py`), JSON helpers (`shared/json_utils.py`), location identifiers (`shared/locations.py`), and run-context helpers. `shared/types/sensor_frame.py` owns the canonical typed sample-record shape used by recording and persistence, while `shared/boundaries/run_log.py` owns JSONL run-log decoding/normalization shared by diagnostics and persistence. `shared/boundaries/diagnostic_case.py` owns summary projection, typed speed/suitability decoding, and shared metadata-to-case reconstruction (`case_context_from_metadata`).
 - `domain/`: DDD-aligned domain model package. Primary domain objects
   live under `vibesensor/domain/`; closely related value objects share
   a file with their parent aggregate:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,13 +44,14 @@ apps/server/tests/
 | `vibesensor/report/*`, `report_i18n.py` | `apps/server/tests/report/` |
 | `vibesensor/routes/*` | `apps/server/tests/api/` |
 | `vibesensor/app.py`, `runtime/*`, `worker_pool.py` | `apps/server/tests/app/` |
-| `vibesensor/history_db/*`, `history_services/*`, `runlog.py` | `apps/server/tests/history/` |
+| `vibesensor/history_db/*`, `history_services/*` | `apps/server/tests/history/` |
 | `vibesensor/update/*` | `apps/server/tests/update/` |
 | `vibesensor/processing/*` | `apps/server/tests/processing/` |
 | `vibesensor/ws_hub.py`, `ws_schema_export.py` | `apps/server/tests/websocket/` |
 | `vibesensor/config.py`, `settings_store.py`, `constants.py` | `apps/server/tests/config/` |
 | `vibesensor/analysis/order_bands.py` | `apps/server/tests/diagnostics/` |
 | `vibesensor/domain/*`, `vibesensor/boundaries/*`, `backend_types.py`, `json_utils.py`, `registry.py` | `apps/server/tests/domain/` |
+| `vibesensor/shared/boundaries/*`, `vibesensor/shared/types/sensor_frame.py` | `apps/server/tests/shared/` |
 | `vibesensor/gps_speed.py` | `apps/server/tests/gps/` |
 | `vibesensor/protocol.py`, `udp_*.py` | `apps/server/tests/protocol/` |
 | `vibesensor/metrics_log/*` | `apps/server/tests/metrics_log/` |


### PR DESCRIPTION
## Summary
- move `SensorFrame` into `shared/types` so `use_cases/run/sample_builder.py` no longer imports an adapter-owned transport type
- move reusable JSONL run-log decoding/normalization into `shared/boundaries/run_log.py` so diagnostics no longer imports from `adapters.persistence`
- refactor `sample_builder.py` to consume a pure `SpeedContext`, then update tests, docs, and the resolved layer-boundary allowlist entries

Closes #704

## Validation
- `cd apps/server && pytest -q tests/shared/boundaries/test_run_log.py tests/shared/types/test_domain_models.py tests/infra/processing/test_sample_builder.py tests/use_cases/run/test_metrics_log_helpers.py tests/use_cases/diagnostics/test_analysis_persistence.py tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py tests/hygiene/test_layer_boundaries.py tests/hygiene/test_sample_column_alignment.py tests/adapters/persistence/history_db/test_history_db_structured_storage.py`
- `make typecheck-backend`
- `export PATH="$PWD/.venv/bin:$PATH" && ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests`
