### PR TITLE
Break infra/use_cases import cycle

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -19,14 +19,14 @@ ESP32 nodes -> adapters/udp/ -> infra/processing/ + use_cases/diagnostics/
 
 Backend ownership boundaries:
 
-- `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), and YAML settings/config loading (`settings.py`).
+- `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), app-owned `RuntimeState` (`runtime_state.py`), and YAML settings/config loading (`settings.py`).
 - `adapters/http/` and `adapters/websocket/`: HTTP route groups and live WebSocket delivery.
-- `infra/runtime/`: flat `RuntimeState`, lifecycle management, processing loop, health snapshots, and WebSocket broadcast coordination.
+- `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination.
 - `infra/processing/`: signal processing pipeline.
 - `infra/config/`: runtime settings stores used by recording and runtime services.
-- `use_cases/diagnostics/`: post-stop analysis/findings logic.
+- `use_cases/diagnostics/`: post-stop analysis/findings logic; the package-level API still re-exports shared vehicle-order helpers used by live telemetry.
 - `use_cases/run/`: recording orchestration and post-analysis queue.
-- `adapters/persistence/`, `shared/boundaries/`, and `use_cases/history/`: SQLite persistence, shared run-log decoding/normalization, car library loading, and history/report/export services.
+- `adapters/persistence/`, `shared/`, and `use_cases/history/`: SQLite persistence, shared typed contracts/pure helpers (including run-log decoding and vehicle-order math), car library loading, and history/report/export services.
 - `adapters/pdf/`: PDF/report rendering pipeline.
 - `use_cases/updates/`: wheel-based update flow.
 - `adapters/hotspot/`: Wi-Fi AP monitoring, parsing, and self-heal infrastructure.

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -109,7 +109,7 @@ files = [
   "vibesensor/use_cases/diagnostics/_types.py",
   "vibesensor/use_cases/diagnostics/helpers.py",
   "vibesensor/use_cases/diagnostics/top_cause_selection.py",
-  "vibesensor/use_cases/diagnostics/order_bands.py",
+  "vibesensor/shared/order_bands.py",
   "vibesensor/use_cases/diagnostics/plots.py",
   "vibesensor/use_cases/diagnostics/location_analysis.py",
   "vibesensor/use_cases/diagnostics/phase_segmentation.py",

--- a/apps/server/tests/adapters/http/test_health_snapshot.py
+++ b/apps/server/tests/adapters/http/test_health_snapshot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from vibesensor.infra.runtime.health_snapshot import build_health_snapshot
+from vibesensor.adapters.http.health_snapshot import build_health_snapshot
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingHealth, ProcessingLoopState
 

--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from vibesensor.domain import AnalysisSettingsSnapshot
 
 if TYPE_CHECKING:
-    from vibesensor.infra.runtime import RuntimeState
+    from vibesensor.app.runtime_state import RuntimeState
 
 # ---------------------------------------------------------------------------
 # Minimal stubs – only implement methods called by build_ws_payload / on_ws_broadcast_tick
@@ -145,7 +145,8 @@ def _make_state(
     ui_push_hz: int = 10,
     ui_heavy_push_hz: int = 4,
 ) -> RuntimeState:
-    import vibesensor.infra.runtime as runtime_module
+    from vibesensor.app.runtime_state import RuntimeState
+    from vibesensor.infra.runtime import RuntimeHealthState
     from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingLoopState
     from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 
@@ -154,14 +155,14 @@ def _make_state(
     gps_monitor = _StubGPS()
     settings_store = _StubSettingsStore()
     processing_state = ProcessingLoopState()
-    health_state = runtime_module.RuntimeHealthState()
+    health_state = RuntimeHealthState()
     config = _StubConfig(
         processing=_StubProcessingConfig(
             ui_push_hz=ui_push_hz,
             ui_heavy_push_hz=ui_heavy_push_hz,
         ),
     )
-    state = runtime_module.RuntimeState(
+    state = RuntimeState(
         config=config,
         registry=registry,
         processor=processor,

--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -6,7 +6,7 @@ respect the layer dependency DAG:
     domain → (nothing)
     shared → {domain}
     use_cases → {domain, shared}
-    infra → {domain, shared, use_cases}
+    infra → {domain, shared}
     adapters → {domain, shared, infra, use_cases}
     app → (everything)
 
@@ -34,7 +34,7 @@ _ALLOWED_IMPORTS: dict[str, frozenset[str]] = {
     "domain": frozenset(),
     "shared": frozenset({"domain"}),
     "use_cases": frozenset({"domain", "shared"}),
-    "infra": frozenset({"domain", "shared", "use_cases"}),
+    "infra": frozenset({"domain", "shared"}),
     "adapters": frozenset({"domain", "shared", "infra", "use_cases"}),
     "app": frozenset({"domain", "shared", "use_cases", "infra", "adapters"}),
 }
@@ -109,13 +109,12 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         ("infra/runtime/registry.py", "vibesensor.adapters.udp.protocol"),
         ("infra/runtime/registry.py", "vibesensor.adapters.persistence.history_db"),
         ("infra/runtime/rotational_speeds.py", "vibesensor.adapters.gps.gps_speed"),
-        ("infra/runtime/state.py", "vibesensor.adapters.gps.gps_speed"),
-        ("infra/runtime/state.py", "vibesensor.adapters.persistence.history_db"),
-        ("infra/runtime/state.py", "vibesensor.adapters.udp.udp_control_tx"),
-        ("infra/runtime/state.py", "vibesensor.adapters.websocket.hub"),
         ("infra/runtime/ws_broadcast.py", "vibesensor.adapters.gps.gps_speed"),
-        # infra → app
-        ("infra/runtime/state.py", "vibesensor.app.settings"),
+        # adapters/infra → app
+        # RuntimeState now lives in app/, but router/lifecycle still consume the
+        # flat app-owned runtime bag until issue #752 splits those dependency groups.
+        ("adapters/http/__init__.py", "vibesensor.app.runtime_state"),
+        ("infra/runtime/lifecycle.py", "vibesensor.app.runtime_state"),
         # adapters → app
         ("adapters/hotspot/self_heal.py", "vibesensor.app.settings"),
     }

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -119,6 +119,7 @@ class _StubProcessor:
 def _make_runtime(**overrides: Any):
     """Build a RuntimeState with stubs for lifecycle testing."""
     import vibesensor.infra.runtime as runtime_module
+    from vibesensor.app.runtime_state import RuntimeState
     from vibesensor.infra.runtime.lifecycle import LifecycleManager
     from vibesensor.infra.runtime.processing_loop import (
         ProcessingLoop,
@@ -144,7 +145,7 @@ def _make_runtime(**overrides: Any):
     esp_flash_manager = overrides.pop("esp_flash_manager", MagicMock())
     processing_state = ProcessingLoopState()
     health_state = runtime_module.RuntimeHealthState()
-    rt = runtime_module.RuntimeState(
+    rt = RuntimeState(
         config=config,
         registry=registry,
         processor=processor,
@@ -400,6 +401,6 @@ async def test_stop_cancels_tasks_and_closes_resources(monkeypatch) -> None:
 @pytest.mark.parametrize("attr", ["settings_store", "processing_loop", "ws_broadcast"])
 def test_runtime_state_has_public_attribute(attr: str) -> None:
     """Canonical import path should expose key public attributes."""
-    from vibesensor.infra.runtime import RuntimeState
+    from vibesensor.app.runtime_state import RuntimeState
 
     assert hasattr(RuntimeState, attr), f"RuntimeState missing {attr}"

--- a/apps/server/tests/integration/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_core_regressions.py
@@ -15,9 +15,9 @@ import pytest
 from vibesensor.infra.runtime.registry import _sanitize_name
 from vibesensor.infra.workers.worker_pool import WorkerPool
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
+from vibesensor.shared.order_bands import build_order_bands
 from vibesensor.shared.sampling import bounded_sample
 from vibesensor.shared.types.backend_types import new_car_id
-from vibesensor.use_cases.diagnostics.order_bands import build_order_bands
 
 # ---------------------------------------------------------------------------
 # Item 1 + 2: Public API naming in domain_models
@@ -50,7 +50,7 @@ class TestDomainModelsPublicAPI:
 
 
 # ---------------------------------------------------------------------------
-# Item 4: build_order_bands lives in order_bands
+# Item 4: build_order_bands lives in shared.order_bands
 # ---------------------------------------------------------------------------
 
 

--- a/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
@@ -28,7 +28,7 @@ from vibesensor.infra.config.settings_store import PersistenceError, SettingsSto
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.infra.workers.worker_pool import WorkerPool
 from vibesensor.shared.locations import is_wheel_location
-from vibesensor.use_cases.diagnostics.order_bands import (
+from vibesensor.shared.order_bands import (
     as_float_or_none as order_bands_as_float_or_none,
 )
 

--- a/apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py
+++ b/apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py
@@ -5,7 +5,7 @@ from math import pi
 import pytest
 
 from vibesensor.shared.constants import KMH_TO_MPS
-from vibesensor.use_cases.diagnostics.order_bands import (
+from vibesensor.shared.order_bands import (
     build_diagnostic_settings,
     vehicle_orders_hz,
 )

--- a/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from math import inf, nan
 
-from vibesensor.use_cases.diagnostics.order_bands import (
+from vibesensor.shared.order_bands import (
     build_diagnostic_settings,
     tolerance_for_order,
     vehicle_orders_hz,

--- a/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py
@@ -4,13 +4,13 @@ import pytest
 
 from vibesensor.domain import OrderReferenceSpec
 from vibesensor.shared.json_utils import as_float_or_none
-from vibesensor.use_cases.diagnostics.helpers import _effective_engine_rpm
-from vibesensor.use_cases.diagnostics.order_bands import (
+from vibesensor.shared.order_bands import (
     build_diagnostic_settings,
     combined_relative_uncertainty,
     tolerance_for_order,
     vehicle_orders_hz,
 )
+from vibesensor.use_cases.diagnostics.helpers import _effective_engine_rpm
 
 # -- _as_float NaN/edge cases -------------------------------------------------
 

--- a/apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py
+++ b/apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py
@@ -61,7 +61,7 @@ def test_as_float_single_source_of_truth() -> None:
     from runlog, not a local re-definition.
     """
     from vibesensor.shared.json_utils import as_float_or_none
-    from vibesensor.use_cases.diagnostics.order_bands import as_float_or_none as ob_as_float
+    from vibesensor.shared.order_bands import as_float_or_none as ob_as_float
 
     assert ob_as_float is as_float_or_none, (
         "order_bands.as_float_or_none must be imported from runlog.as_float_or_none"

--- a/apps/server/vibesensor/adapters/http/__init__.py
+++ b/apps/server/vibesensor/adapters/http/__init__.py
@@ -7,8 +7,8 @@ combines them so that ``app.py`` only needs::
     from vibesensor.adapters.http import create_router
 
 Route modules receive only the specific services they need. The package-level
-assembler now depends on explicit route services instead of a broad runtime
-facade.
+assembler still accepts the app-owned runtime state, but immediately fans that
+out into explicit per-route dependencies.
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ from vibesensor.adapters.http.updates import create_update_routes
 from vibesensor.adapters.http.websocket import create_websocket_routes
 
 if TYPE_CHECKING:
-    from vibesensor.infra.runtime import RuntimeState
+    from vibesensor.app.runtime_state import RuntimeState
 
 
 def create_router(services: RuntimeState) -> APIRouter:

--- a/apps/server/vibesensor/adapters/http/health.py
+++ b/apps/server/vibesensor/adapters/http/health.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
 
-from vibesensor.infra.runtime.health_snapshot import build_health_snapshot
+from vibesensor.adapters.http.health_snapshot import build_health_snapshot
 from vibesensor.shared.types.api_models import HealthResponse
 
 if TYPE_CHECKING:

--- a/apps/server/vibesensor/adapters/http/health_snapshot.py
+++ b/apps/server/vibesensor/adapters/http/health_snapshot.py
@@ -1,11 +1,11 @@
-"""Health snapshot builder — pure business logic, no HTTP concerns."""
+"""Health snapshot payload builder for the HTTP health endpoint."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING, Literal
 
 from vibesensor.infra.runtime.processing_loop import ProcessingHealth
-from vibesensor.use_cases.run.logger import RunRecorderHealthSnapshot
+from vibesensor.shared.types.health_snapshot import HealthSnapshotData
 
 if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
@@ -13,32 +13,6 @@ if TYPE_CHECKING:
     from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
     from vibesensor.infra.runtime.registry import ClientRegistry
     from vibesensor.use_cases.run import RunRecorder
-
-
-class HealthSnapshotData(TypedDict):
-    """Typed snapshot returned by :func:`build_health_snapshot`."""
-
-    status: Literal["ok", "warn", "degraded"]
-    startup_state: str
-    startup_phase: str
-    startup_error: str | None
-    startup_warnings: list[str]
-    background_task_failures: dict[str, str]
-    processing_state: str
-    processing_failures: int
-    processing_failure_categories: dict[str, int]
-    processing_last_failure: str | None
-    sample_rate_mismatch_count: int
-    frame_size_mismatch_count: int
-    degradation_reasons: list[str]
-    data_loss: dict[str, int]
-    persistence: RunRecorderHealthSnapshot
-    intake_stats: dict[str, object]
-    tick_duration_s: float | None
-    max_tick_duration_s: float | None
-    tick_count: int
-    db_last_write_duration_s: float | None
-    db_max_write_duration_s: float | None
 
 
 def build_health_snapshot(
@@ -96,10 +70,9 @@ def build_health_snapshot(
         degradation_reasons.append("analyzing_runs_present")
     if persistence["last_completed_run_error"]:
         degradation_reasons.append("last_analysis_failed")
+    status: Literal["ok", "warn", "degraded"] = "ok"
     if degradation_reasons:
         status = "degraded" if has_error else "warn"
-    else:
-        status = "ok"
     return {
         "status": status,
         "startup_state": health_state.startup_state,

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -23,8 +23,8 @@ from fastapi.staticfiles import StaticFiles
 from vibesensor.adapters.http import create_router
 from vibesensor.adapters.udp.udp_data_rx import start_udp_data_receiver
 from vibesensor.app.container import build_runtime
+from vibesensor.app.runtime_state import RuntimeState
 from vibesensor.app.settings import load_config
-from vibesensor.infra.runtime import RuntimeState
 from vibesensor.infra.runtime.lifecycle import LifecycleManager
 
 __all__ = ["create_app", "main"]

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -7,13 +7,13 @@ from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 from vibesensor.adapters.websocket.hub import WebSocketHub
+from vibesensor.app.runtime_state import RuntimeState
 from vibesensor.app.settings import AppConfig
 from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingLoopState
 from vibesensor.infra.runtime.registry import ClientRegistry
-from vibesensor.infra.runtime.state import RuntimeState
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.workers.worker_pool import WorkerPool
 from vibesensor.sensor_units import ADXL345_SCALE_G_PER_LSB, SENSOR_MODEL

--- a/apps/server/vibesensor/app/runtime_state.py
+++ b/apps/server/vibesensor/app/runtime_state.py
@@ -1,4 +1,4 @@
-"""RuntimeState – top-level runtime assembly."""
+"""App-owned runtime assembly for the fully wired service graph."""
 
 from __future__ import annotations
 

--- a/apps/server/vibesensor/infra/runtime/__init__.py
+++ b/apps/server/vibesensor/infra/runtime/__init__.py
@@ -2,7 +2,6 @@
 
 Submodules
 ----------
-- ``state``: top-level runtime assembly (RuntimeState)
 - ``builders``: focused service builders
 - ``processing_loop``: ProcessingLoop (async tick loop + failure tracking)
 - ``ws_broadcast``: WsBroadcastService (payload assembly + cache)
@@ -12,10 +11,8 @@ Submodules
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
-from vibesensor.infra.runtime.state import RuntimeState
 
 __all__ = [
     "ProcessingLoopState",
     "RuntimeHealthState",
-    "RuntimeState",
 ]

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from vibesensor.shared.constants import UI_PUSH_HZ
 
 if TYPE_CHECKING:
-    from vibesensor.infra.runtime.state import RuntimeState
+    from vibesensor.app.runtime_state import RuntimeState
 
     StartUdpReceiver = Callable[
         ...,

--- a/apps/server/vibesensor/infra/runtime/rotational_speeds.py
+++ b/apps/server/vibesensor/infra/runtime/rotational_speeds.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING
 
 from vibesensor.domain.speed_source import SpeedSource
 from vibesensor.shared.constants import SECONDS_PER_MINUTE
+from vibesensor.shared.order_bands import build_order_bands, vehicle_orders_hz
 from vibesensor.shared.types.payload_types import (
     RotationalSpeedsPayload,
     RotationalSpeedValuePayload,
 )
-from vibesensor.use_cases.diagnostics import build_order_bands, vehicle_orders_hz
 
 if TYPE_CHECKING:
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor

--- a/apps/server/vibesensor/shared/order_bands.py
+++ b/apps/server/vibesensor/shared/order_bands.py
@@ -1,8 +1,4 @@
-"""Order-band math and diagnostic settings.
-
-Computes vehicle-order frequencies (wheel, driveshaft, engine) and tolerance
-bands from speed and car-specification analysis settings.
-"""
+"""Shared vehicle-order math for live telemetry and diagnostics."""
 
 from __future__ import annotations
 
@@ -18,6 +14,16 @@ from vibesensor.shared.constants import (
 )
 from vibesensor.shared.json_utils import as_float_or_none
 from vibesensor.shared.types.payload_types import OrderBandPayload
+
+__all__ = [
+    "as_float_or_none",
+    "build_diagnostic_settings",
+    "build_order_bands",
+    "combined_relative_uncertainty",
+    "order_tolerances",
+    "tolerance_for_order",
+    "vehicle_orders_hz",
+]
 
 
 def build_diagnostic_settings(overrides: Mapping[str, object] | None = None) -> dict[str, float]:
@@ -63,12 +69,7 @@ def order_tolerances(
     orders_hz: dict[str, float],
     order_reference_spec: OrderReferenceSpec,
 ) -> tuple[float, float, float]:
-    """Compute (wheel_tol, drive_tol, engine_tol) for the given order frequencies.
-
-    Both callers (build_order_bands and classify_peak_hz) need
-    the same trio of tolerance values.  Centralising the computation here avoids
-    repeating the five-parameter call pattern three times per site.
-    """
+    """Compute (wheel_tol, drive_tol, engine_tol) for the given order frequencies."""
     common = {
         "min_abs_band_hz": order_reference_spec.min_abs_band_hz,
         "max_band_half_width_pct": order_reference_spec.max_band_half_width_pct,
@@ -98,11 +99,7 @@ def build_order_bands(
     orders_hz: dict[str, float],
     analysis_settings: Mapping[str, object],
 ) -> list[OrderBandPayload]:
-    """Pre-compute order tolerance bands so the frontend doesn't duplicate this math.
-
-    This is a pure function that depends only on the order frequencies and
-    analysis settings — no runtime state required.
-    """
+    """Pre-compute order tolerance bands so the frontend doesn't duplicate this math."""
     resolved = build_diagnostic_settings(analysis_settings)
     order_reference_spec = OrderReferenceSpec.from_settings(resolved)
     if order_reference_spec is None:
@@ -141,10 +138,7 @@ def vehicle_orders_hz(
     speed_mps: float | None,
     settings: Mapping[str, object],
 ) -> dict[str, float] | None:
-    """Return per-order frequencies in Hz for the given speed and settings.
-
-    Returns ``None`` when *speed_mps* is unavailable or non-positive.
-    """
+    """Return per-order frequencies in Hz for the given speed and settings."""
     if speed_mps is None or not isfinite(speed_mps) or speed_mps <= 0:
         return None
     spec_settings = build_diagnostic_settings(settings)

--- a/apps/server/vibesensor/shared/types/health_snapshot.py
+++ b/apps/server/vibesensor/shared/types/health_snapshot.py
@@ -1,0 +1,52 @@
+"""Shared typed contracts for runtime and persistence health snapshots."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from vibesensor.shared.types.json_types import JsonObject
+
+
+class RunRecorderHealthSnapshot(TypedDict):
+    """Health snapshot dict returned by ``RunRecorder.health_snapshot()``."""
+
+    write_error: str | None
+    analysis_in_progress: bool
+    analysis_queue_depth: int
+    analysis_queue_max_depth: int
+    analysis_active_run_id: str | None
+    analysis_started_at: float | None
+    analysis_elapsed_s: float | None
+    analysis_queue_oldest_age_s: float | None
+    analyzing_run_count: int
+    analyzing_oldest_age_s: float | None
+    samples_written: int
+    samples_dropped: int
+    last_completed_run_id: str | None
+    last_completed_run_error: str | None
+
+
+class HealthSnapshotData(TypedDict):
+    """Typed snapshot returned by the health-snapshot builder."""
+
+    status: Literal["ok", "warn", "degraded"]
+    startup_state: str
+    startup_phase: str
+    startup_error: str | None
+    startup_warnings: list[str]
+    background_task_failures: dict[str, str]
+    processing_state: str
+    processing_failures: int
+    processing_failure_categories: dict[str, int]
+    processing_last_failure: str | None
+    sample_rate_mismatch_count: int
+    frame_size_mismatch_count: int
+    degradation_reasons: list[str]
+    data_loss: dict[str, int]
+    persistence: RunRecorderHealthSnapshot
+    intake_stats: JsonObject
+    tick_duration_s: float | None
+    max_tick_duration_s: float | None
+    tick_count: int
+    db_last_write_duration_s: float | None
+    db_max_write_duration_s: float | None

--- a/apps/server/vibesensor/use_cases/diagnostics/__init__.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/__init__.py
@@ -11,7 +11,7 @@ High-level analysis entry points are re-exported here so callers can use
 findings.  The domain ``Finding`` lives in ``vibesensor.domain``.
 """
 
-from vibesensor.use_cases.diagnostics.order_bands import build_order_bands, vehicle_orders_hz
+from vibesensor.shared.order_bands import build_order_bands, vehicle_orders_hz
 from vibesensor.use_cases.diagnostics.summary_builder import (
     AnalysisResult,
     RunAnalysis,

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -18,13 +18,14 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from threading import RLock
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from vibesensor.domain import Run
 from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.shared.constants import NUMERIC_TYPES
 from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.health_snapshot import RunRecorderHealthSnapshot
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.sample_builder import (
@@ -108,25 +109,6 @@ class RecorderShutdownReport:
     analysis_in_progress: bool
     write_error: str | None
     final_status: dict[str, object]
-
-
-class RunRecorderHealthSnapshot(TypedDict):
-    """Health snapshot dict returned by :meth:`RunRecorder.health_snapshot`."""
-
-    write_error: str | None
-    analysis_in_progress: bool
-    analysis_queue_depth: int
-    analysis_queue_max_depth: int
-    analysis_active_run_id: str | None
-    analysis_started_at: float | None
-    analysis_elapsed_s: float | None
-    analysis_queue_oldest_age_s: float | None
-    analyzing_run_count: int
-    analyzing_oldest_age_s: float | None
-    samples_written: int
-    samples_dropped: int
-    last_completed_run_id: str | None
-    last_completed_run_error: str | None
 
 
 class RunRecorder:

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -27,13 +27,13 @@ Scope: single source of truth for detailed file layout, entry points, package st
 
 ## Backend package layout
 
-- `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds the flat `RuntimeState`, and `settings.py` owns YAML config loading and validation.
+- `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds the flat app-owned `RuntimeState`, `runtime_state.py` owns that fully wired service graph, and `settings.py` owns YAML config loading and validation.
 - `adapters/http/`: health, clients, settings, recording, history, websocket, updates, car library, and debug route groups; `adapters/http/__init__.py` assembles the router.
 - `adapters/websocket/hub.py`: live WebSocket connection fan-out and payload delivery.
 - `adapters/persistence/`: SQLite history DB (`history_db/`) and the static car library loader (`car_library.py`).
 - `adapters/pdf/`: PDF/report rendering pipeline and report mapping entrypoints.
 - `adapters/udp/`, `adapters/gps/`, `adapters/simulator/`, `adapters/hotspot/`: UDP protocol transport, GPS speed ingestion, simulator tooling, and hotspot/AP operational adapters.
-- `infra/runtime/`: flat `RuntimeState`, lifecycle management, processing loop, health snapshots, and WebSocket broadcast coordination.
+- `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination.
 - `infra/processing/`: signal processing pipeline (buffers, FFT, payload shaping, and processor facade).
 - `infra/config/`: runtime settings store (single `SettingsStore` owns both analysis and device settings) used by runtime wiring and recording flows.
 - `infra/workers/`: worker-pool infrastructure.
@@ -41,7 +41,7 @@ Scope: single source of truth for detailed file layout, entry points, package st
 - `use_cases/history/`: run query/delete, PDF report generation, CSV/ZIP exports, and history-facing helper orchestration above persistence. `helpers.py` owns the local `HistoryRecord` TypedDict used only inside history workflows.
 - `use_cases/run/`: recording pipeline orchestration; `logger.py` owns `RunRecorder`, `post_analysis.py` owns the background analysis queue, and `sample_builder.py` owns pure sample-building helpers.
 - `use_cases/updates/`: wheel-based updater workflow orchestration, firmware cache, ESP flashing, release discovery, install, rollback, runner, Wi-Fi, and status tracking.
-- `shared/`: cross-cutting typed payloads (`shared/types/`), boundary serializers/decoders (`shared/boundaries/`), exceptions (`shared/exceptions.py`), JSON helpers (`shared/json_utils.py`), location identifiers (`shared/locations.py`), and run-context helpers. `shared/types/sensor_frame.py` owns the canonical typed sample-record shape used by recording and persistence, while `shared/boundaries/run_log.py` owns JSONL run-log decoding/normalization shared by diagnostics and persistence. `shared/boundaries/diagnostic_case.py` owns summary projection, typed speed/suitability decoding, and shared metadata-to-case reconstruction (`case_context_from_metadata`).
+- `shared/`: cross-cutting typed payloads (`shared/types/`), boundary serializers/decoders (`shared/boundaries/`), exceptions (`shared/exceptions.py`), JSON helpers (`shared/json_utils.py`), location identifiers (`shared/locations.py`), run-context helpers, and shared pure vehicle-order math (`shared/order_bands.py`). `shared/types/sensor_frame.py` owns the canonical typed sample-record shape used by recording and persistence, `shared/types/health_snapshot.py` owns runtime/persistence health snapshot TypedDicts shared by recording and HTTP health reporting, `shared/boundaries/run_log.py` owns JSONL run-log decoding/normalization shared by diagnostics and persistence, and `shared/boundaries/diagnostic_case.py` owns summary projection, typed speed/suitability decoding, and shared metadata-to-case reconstruction (`case_context_from_metadata`).
 - `domain/`: DDD-aligned domain model package. Primary domain objects
   live under `vibesensor/domain/`; closely related value objects share
   a file with their parent aggregate:

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -7,13 +7,17 @@ Scope: architecture and data flow for the post-stop diagnostics pipeline in
 
 1. **Analysis runs only once** — after a recording is stopped.
    Report rendering and API endpoints use persisted results.
-2. **Single package** — all analysis logic lives in
-   `apps/server/vibesensor/use_cases/diagnostics/`. No analysis helpers elsewhere.
+2. **Diagnostics-first package** — diagnostic orchestration, ranking, and
+   post-stop reasoning live in `apps/server/vibesensor/use_cases/diagnostics/`.
+   The shared vehicle-order frequency math used by both diagnostics and live
+   telemetry lives in `apps/server/vibesensor/shared/order_bands.py`.
 3. **Single entrypoint** — `RunAnalysis(...).summarize()` (or the procedural
    wrapper `summarize_run_data()`) is the pipeline entrypoint.
 4. **Public API** — external code imports from `vibesensor.use_cases.diagnostics`:
    `summarize_run_data()`, `build_findings_for_samples()`, `summarize_log()`,
    `RunAnalysis`, `AnalysisResult`, `build_order_bands()`, `vehicle_orders_hz()`.
+   The diagnostics package re-exports the order-band helpers from
+   `vibesensor.shared.order_bands`.
 5. **Renderer-only report package** — `vibesensor.adapters.pdf` must not
    import from `vibesensor.use_cases.diagnostics` (enforced by tests).
 6. **No circular coupling** — the live signal-processing layer
@@ -72,7 +76,7 @@ in order. Each step runs exactly once per analysis invocation.
 
 | Module | LOC | Responsibility |
 |--------|-----|---------------|
-| `__init__.py` | ~50 | Public API re-exports |
+| `__init__.py` | ~50 | Public API re-exports, including shared order-band helpers |
 | `_types.py` | ~50 | Local type aliases (`PhaseEvidence`, `FindingPayload`, `AnalysisSummary`) |
 | `summary_builder.py` | ~1100 | Top-level pipeline orchestration: `RunAnalysis`, `PreparedRunData`, `AnalysisResult`, `build_summary_payload` |
 | `findings.py` | ~400 | Finding construction and enrichment: `PeakFindingAnalyzer`, `finalize_findings`, `build_reference_findings`, `prepare_analysis_samples` |
@@ -82,7 +86,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `phase_segmentation.py` | ~300 | Driving-phase classification (IDLE → COAST_DOWN) |
 | `location_analysis.py` | ~300 | Per-sensor-location vibration intensity and spatial analysis |
 | `top_cause_selection.py` | ~80 | Phase-adjusted finding ranking and grouping |
-| `order_bands.py` | ~150 | Tire/driveline order-frequency band computation |
+| `shared/order_bands.py` | ~150 | Shared tire/driveline order-frequency band computation for diagnostics and live telemetry |
 | `helpers.py` | ~500 | Shared formatting, axis helpers, statistics utilities |
 | `plots.py` | ~700 | Chart data shaping: FFT, spectrogram, time-series, peak table |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,13 +43,13 @@ apps/server/tests/
 | `vibesensor/analysis/*` | `apps/server/tests/analysis/` |
 | `vibesensor/report/*`, `report_i18n.py` | `apps/server/tests/report/` |
 | `vibesensor/routes/*` | `apps/server/tests/api/` |
-| `vibesensor/app.py`, `runtime/*`, `worker_pool.py` | `apps/server/tests/app/` |
+| `vibesensor/app/runtime_state.py`, `vibesensor/infra/runtime/*`, `worker_pool.py` | `apps/server/tests/infra/runtime/` |
 | `vibesensor/history_db/*`, `history_services/*` | `apps/server/tests/history/` |
 | `vibesensor/update/*` | `apps/server/tests/update/` |
 | `vibesensor/processing/*` | `apps/server/tests/processing/` |
 | `vibesensor/ws_hub.py`, `ws_schema_export.py` | `apps/server/tests/websocket/` |
 | `vibesensor/config.py`, `settings_store.py`, `constants.py` | `apps/server/tests/config/` |
-| `vibesensor/analysis/order_bands.py` | `apps/server/tests/diagnostics/` |
+| `vibesensor/shared/order_bands.py` | `apps/server/tests/use_cases/diagnostics/` |
 | `vibesensor/domain/*`, `vibesensor/boundaries/*`, `backend_types.py`, `json_utils.py`, `registry.py` | `apps/server/tests/domain/` |
 | `vibesensor/shared/boundaries/*`, `vibesensor/shared/types/sensor_frame.py` | `apps/server/tests/shared/` |
 | `vibesensor/gps_speed.py` | `apps/server/tests/gps/` |


### PR DESCRIPTION
## Summary
- move the flat RuntimeState into app/ so infra no longer owns use-case service wiring
- move shared order-band math into shared/ while keeping the diagnostics package API re-exporting it
- move the health snapshot builder/contracts out of the infra↔use_cases boundary and tighten the infra layer guard

## Validation
- focused pytest suite covering the touched runtime, HTTP, websocket, diagnostics, integration, and hygiene paths
- make typecheck-backend
- ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #706