### PR TITLE
Split PDF mapping helpers

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
@@ -5,7 +5,21 @@ from __future__ import annotations
 import pytest
 
 from vibesensor.adapters.pdf.pattern_parts import parts_for_pattern, why_parts_listed
-from vibesensor.adapters.pdf.presentation import strength_label, strength_text
+from vibesensor.adapters.pdf.peak_table import (
+    build_peak_row,
+    build_peak_rows_from_plots,
+    peak_row_system_label,
+)
+from vibesensor.adapters.pdf.presentation import (
+    order_label_human,
+    peak_classification_text,
+    strength_label,
+    strength_text,
+)
+from vibesensor.adapters.pdf.report_sections import (
+    build_data_trust_from_summary,
+    build_next_steps_from_summary,
+)
 from vibesensor.domain.confidence_assessment import ConfidenceAssessment
 
 
@@ -45,6 +59,30 @@ def test_strength_text_value() -> None:
     txt = strength_text(22.0, lang="en")
     assert "Moderate" in txt
     assert "22.0 dB" in txt
+
+
+def test_order_label_human_localizes_order_names() -> None:
+    assert order_label_human("en", "1x wheel") == "1x wheel order"
+    assert order_label_human("nl", "2x engine") == "2x motororde"
+
+
+def test_peak_classification_text_uses_translations() -> None:
+    translated = peak_classification_text(
+        "persistent",
+        tr=lambda key, **_kw: {
+            "CLASSIFICATION_PERSISTENT": "Persistent",
+            "UNKNOWN": "Unknown",
+        }[key],
+    )
+    assert translated == "Persistent"
+
+
+def test_extracted_pdf_builders_are_importable() -> None:
+    assert callable(build_peak_rows_from_plots)
+    assert callable(build_peak_row)
+    assert callable(peak_row_system_label)
+    assert callable(build_next_steps_from_summary)
+    assert callable(build_data_trust_from_summary)
 
 
 @pytest.mark.parametrize(

--- a/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 
 from vibesensor.adapters.pdf.mapping import map_summary
-from vibesensor.adapters.pdf.mapping import peak_classification_text as _peak_classification_text
+from vibesensor.adapters.pdf.presentation import (
+    peak_classification_text as _peak_classification_text,
+)
 from vibesensor.report_i18n import tr
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/hygiene/test_domain_architecture.py
+++ b/apps/server/tests/hygiene/test_domain_architecture.py
@@ -1074,12 +1074,12 @@ def test_next_steps_domain_path_is_primary() -> None:
     """
     from tests._paths import SERVER_ROOT
 
-    mapping_path = SERVER_ROOT / "vibesensor" / "adapters" / "pdf" / "mapping.py"
-    source = mapping_path.read_text()
+    sections_path = SERVER_ROOT / "vibesensor" / "adapters" / "pdf" / "report_sections.py"
+    source = sections_path.read_text()
 
     # Find the function body
     func_start = source.find("def build_next_steps_from_summary(")
-    assert func_start != -1, "build_next_steps_from_summary not found in mapping.py"
+    assert func_start != -1, "build_next_steps_from_summary not found in report_sections.py"
 
     # Find end of function (next top-level def or end of file)
     next_def = source.find("\ndef ", func_start + 1)

--- a/apps/server/tests/integration/test_multi_domain_regressions.py
+++ b/apps/server/tests/integration/test_multi_domain_regressions.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vibesensor.adapters.pdf.mapping import order_label_human
+from vibesensor.adapters.pdf.presentation import order_label_human
 from vibesensor.domain import Finding, SpeedSourceKind
 from vibesensor.domain.finding import speed_bin_label
 from vibesensor.report_i18n import resolve_i18n as resolve_i18n_impl

--- a/apps/server/vibesensor/adapters/pdf/__init__.py
+++ b/apps/server/vibesensor/adapters/pdf/__init__.py
@@ -9,6 +9,7 @@ Import analysis symbols from ``vibesensor.use_cases.diagnostics`` directly.
 Module topology
 ---------------
 - **Data layer**: ``report_data.py`` (dataclasses).
+- **Mapping helpers**: ``peak_table.py`` (peak rows), ``report_sections.py`` (report sections), ``presentation.py`` (render-only labels), ``pattern_parts.py`` (parts suggestions).
 - **Engine**: ``pdf_engine.py`` (public entry, page orchestration, pagination).
 - **Pages**: ``pdf_page1.py``, ``pdf_page2.py``.
 - **Diagrams**: ``pdf_diagram_render.py`` (layout planning, drawing).

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -12,29 +12,28 @@ from typing import Any
 
 from vibesensor import __version__
 from vibesensor.adapters.pdf.pattern_parts import parts_for_pattern, why_parts_listed
-from vibesensor.adapters.pdf.presentation import strength_label, strength_text
+from vibesensor.adapters.pdf.peak_table import build_peak_rows_from_plots
+from vibesensor.adapters.pdf.presentation import order_label_human, strength_label, strength_text
 from vibesensor.adapters.pdf.report_data import (
-    DataTrustItem,
-    NextStep,
     PartSuggestion,
     PatternEvidence,
-    PeakRow,
     ReportTemplateData,
     SystemFindingCard,
 )
-from vibesensor.adapters.pdf.report_types import PeakTableRow
+from vibesensor.adapters.pdf.report_sections import (
+    build_data_trust_from_summary,
+    build_next_steps_from_summary,
+)
 from vibesensor.coerce import coerce_float
 from vibesensor.domain import (
     ConfidenceAssessment,
     Finding,
     TestRun,
     VibrationOrigin,
-    VibrationSource,
 )
-from vibesensor.report_i18n import human_source, is_i18n_ref, normalize_lang, resolve_i18n
+from vibesensor.report_i18n import human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
-from vibesensor.shared.boundaries.diagnostic_case import run_suitability_payload
 from vibesensor.shared.boundaries.vibration_origin import (
     build_origin_explanation,
     vibration_origin_from_payload,
@@ -178,51 +177,6 @@ class PrimaryCandidateContext:
     tier: str
 
 
-# ---------------------------------------------------------------------------
-# Shared i18n and value-resolution helpers
-# ---------------------------------------------------------------------------
-
-_ORDER_LABEL_NAMES_NL: dict[str, str] = {
-    "wheel": "wielorde",
-    "engine": "motororde",
-    "driveshaft": "aandrijfasorde",
-}
-_ORDER_LABEL_NAMES_DEFAULT: dict[str, str] = {
-    "wheel": "wheel order",
-    "engine": "engine order",
-    "driveshaft": "driveshaft order",
-}
-
-_CLASSIFICATION_I18N_KEYS: dict[str, str] = {
-    "patterned": "CLASSIFICATION_PATTERNED",
-    "persistent": "CLASSIFICATION_PERSISTENT",
-    "transient": "CLASSIFICATION_TRANSIENT",
-    "baseline_noise": "CLASSIFICATION_BASELINE_NOISE",
-}
-
-
-def order_label_human(lang: str, label: str) -> str:
-    """Translate a language-neutral order label like ``1x wheel``."""
-    names = _ORDER_LABEL_NAMES_NL if lang == "nl" else _ORDER_LABEL_NAMES_DEFAULT
-    parts = label.strip().split(" ", 1)
-    if len(parts) == 2:
-        multiplier, base = parts
-        localized = names.get(base.lower(), base)
-        return f"{multiplier} {localized}"
-    return label
-
-
-def peak_classification_text(value: object, tr: Callable[..., str]) -> str:
-    """Map a peak classification code to report text."""
-    normalized = str(value or "").strip().lower()
-    i18n_key = _CLASSIFICATION_I18N_KEYS.get(normalized)
-    if i18n_key:
-        return tr(i18n_key)
-    if not normalized:
-        return tr("UNKNOWN")
-    return str(value).replace("_", " ").title()
-
-
 def _origin_from_aggregate(
     aggregate: TestRun | None,
     fallback: Mapping[str, Any] | None,
@@ -287,70 +241,6 @@ def normalized_origin_location(origin: VibrationOrigin | None) -> str:
     return "" if raw.lower() == "unknown" else raw
 
 
-# ---------------------------------------------------------------------------
-# Peak-row and location-hotspot shaping
-# ---------------------------------------------------------------------------
-
-
-def build_peak_rows_from_plots(
-    summary: AnalysisSummary,
-    *,
-    lang: str,
-    tr: Callable,
-) -> list[PeakRow]:
-    """Build peak-table rows from the plots section."""
-    plots = summary.get("plots")
-    if plots is None:
-        return []
-    raw_peaks = [row for row in (plots.get("peaks_table", []) or []) if isinstance(row, dict)]
-    above_noise = [row for row in raw_peaks if (_as_float(row.get("strength_db")) or 0.0) > 0]
-    ranked = above_noise or raw_peaks
-    return [build_peak_row(row, lang=lang, tr=tr) for row in ranked[:8]]
-
-
-def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable) -> PeakRow:
-    """Build one report peak row from a plot peak-table row."""
-    rank_val = _as_float(row.get("rank"))
-    rank = str(int(rank_val)) if rank_val is not None else "—"
-    freq_val = _as_float(row.get("frequency_hz"))
-    freq = f"{freq_val:.1f}" if freq_val is not None else "—"
-    classification = peak_classification_text(row.get("peak_classification"), tr=tr)
-    order_label_raw = str(row.get("order_label") or "").strip()
-    order = order_label_human(lang, order_label_raw) if order_label_raw else classification
-    peak_db_val = _as_float(row.get("p95_intensity_db"))
-    peak_db = f"{peak_db_val:.1f}" if peak_db_val is not None else "—"
-    strength_db_val = _as_float(row.get("strength_db"))
-    strength_db = f"{strength_db_val:.1f}" if strength_db_val is not None else "—"
-    speed = str(row.get("typical_speed_band") or "—")
-    presence = _as_float(row.get("presence_ratio")) or 0.0
-    score = _as_float(row.get("persistence_score")) or 0.0
-    return PeakRow(
-        rank=rank,
-        system=peak_row_system_label(row, tr=tr),
-        freq_hz=freq,
-        order=order,
-        peak_db=peak_db,
-        strength_db=strength_db,
-        speed_band=speed,
-        relevance=f"{classification} · {presence:.0%} {tr('PRESENCE')} · {tr('SCORE')} {score:.2f}",
-    )
-
-
-def peak_row_system_label(row: PeakTableRow, *, tr: Callable[..., str]) -> str:
-    """Resolve the system label shown for one peak row."""
-    source_hint = str(row.get("suspected_source") or "").strip().lower()
-    _SOURCE_MAP: dict[str, str] = {
-        VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
-        VibrationSource.ENGINE: "SOURCE_ENGINE",
-        VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
-        VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
-    }
-    i18n_key = _SOURCE_MAP.get(source_hint)
-    if i18n_key:
-        return str(tr(i18n_key))
-    return "\u2014"
-
-
 def compute_location_hotspot_rows(sensor_intensity: list[dict]) -> list[dict]:
     """Pre-compute location hotspot rows from sensor intensity data."""
     if not sensor_intensity:
@@ -388,124 +278,6 @@ def collect_location_intensity(sensor_intensity: list[dict]) -> dict[str, list[f
         if location and p95 is not None and p95 > 0:
             amp_by_location[location].append(p95)
     return amp_by_location
-
-
-# ---------------------------------------------------------------------------
-# Action and trust-list builders
-# ---------------------------------------------------------------------------
-
-
-def build_next_steps_from_summary(
-    summary: AnalysisSummary,
-    *,
-    aggregate: TestRun | None,
-    tier: str,
-    cert_reason: str,
-    lang: str,
-    tr: Callable,
-) -> list[NextStep]:
-    """Build next-step actions from a run summary dict."""
-    if tier == "A":
-        return [
-            NextStep(action=action, why=cert_reason)
-            for action in (
-                tr("TIER_A_CAPTURE_WIDER_SPEED"),
-                tr("TIER_A_CAPTURE_MORE_SENSORS"),
-                tr("TIER_A_CAPTURE_REFERENCE_DATA"),
-            )
-        ]
-
-    next_steps: list[NextStep] = []
-    if aggregate is not None and aggregate.recommended_actions:
-        for action in aggregate.recommended_actions:
-            next_steps.append(
-                NextStep(
-                    action=_resolve_step_value(action.instruction, lang=lang, tr=tr),
-                    why=_resolve_optional_step_value(action.rationale, lang=lang, tr=tr),
-                    confirm=_resolve_optional_step_value(
-                        action.confirmation_signal,
-                        lang=lang,
-                        tr=tr,
-                    ),
-                    falsify=_resolve_optional_step_value(
-                        action.falsification_signal,
-                        lang=lang,
-                        tr=tr,
-                    ),
-                    eta=action.estimated_duration,
-                ),
-            )
-    return next_steps
-
-
-def _resolve_step_value(value: object, *, lang: str, tr: Callable) -> str:
-    """Resolve a required step field into report text."""
-    if isinstance(value, str) and value.isupper() and "_" in value:
-        translated = str(tr(value))
-        if translated and translated != value:
-            return translated
-    return resolve_i18n(lang, value, tr=tr) if is_i18n_ref(value) else str(value or "")
-
-
-def _resolve_optional_step_value(
-    value: object,
-    *,
-    lang: str,
-    tr: Callable,
-) -> str | None:
-    """Resolve an optional step field into report text or ``None``."""
-    resolved = _resolve_step_value(value, lang=lang, tr=tr).strip()
-    return resolved or None
-
-
-def build_data_trust_from_summary(
-    summary: AnalysisSummary,
-    *,
-    aggregate: TestRun | None,
-    lang: str,
-    tr: Callable,
-) -> list[DataTrustItem]:
-    """Build the data-trust checklist from run_suitability items."""
-    data_trust: list[DataTrustItem] = []
-    if aggregate is not None and aggregate.suitability is not None:
-        projected = run_suitability_payload(
-            aggregate.suitability,
-        )
-        for proj in projected:
-            data_trust.append(
-                DataTrustItem(
-                    check=_resolve_check_text(proj.get("check_key"), lang=lang, tr=tr),
-                    state=str(proj.get("state") or "warn"),
-                    detail=_resolve_detail_text(proj.get("explanation"), lang=lang, tr=tr),
-                ),
-            )
-    for warning in summary["warnings"]:
-        data_trust.append(
-            DataTrustItem(
-                check=_resolve_detail_text(warning.get("title"), lang=lang, tr=tr) or "",
-                state=str(warning.get("severity") or "warn"),
-                detail=_resolve_detail_text(warning.get("detail"), lang=lang, tr=tr),
-            ),
-        )
-    return data_trust
-
-
-def _resolve_check_text(value: object, *, lang: str, tr: Callable[..., str]) -> str:
-    """Resolve the checklist label text."""
-    if is_i18n_ref(value):
-        return resolve_i18n(lang, value, tr=tr)
-    if isinstance(value, str) and value.startswith("SUITABILITY_CHECK_"):
-        return str(tr(value))
-    return str(value or "")
-
-
-def _resolve_detail_text(value: object, *, lang: str, tr: Callable) -> str | None:
-    """Resolve the checklist detail text."""
-    if is_i18n_ref(value) or isinstance(value, list):
-        resolved = resolve_i18n(lang, value, tr=tr).strip()
-    else:
-        resolved = str(value or "").strip()
-    return resolved or None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/vibesensor/adapters/pdf/peak_table.py
+++ b/apps/server/vibesensor/adapters/pdf/peak_table.py
@@ -1,0 +1,77 @@
+"""Peak-table builders extracted from the PDF report mapper."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vibesensor.adapters.pdf.presentation import order_label_human, peak_classification_text
+from vibesensor.adapters.pdf.report_data import PeakRow
+from vibesensor.adapters.pdf.report_types import PeakTableRow
+from vibesensor.domain import VibrationSource
+from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
+
+__all__ = [
+    "build_peak_row",
+    "build_peak_rows_from_plots",
+    "peak_row_system_label",
+]
+
+
+def build_peak_rows_from_plots(
+    summary: AnalysisSummary,
+    *,
+    lang: str,
+    tr: Callable[..., str],
+) -> list[PeakRow]:
+    """Build peak-table rows from the plots section."""
+    plots = summary.get("plots")
+    if plots is None:
+        return []
+    raw_peaks = [row for row in (plots.get("peaks_table", []) or []) if isinstance(row, dict)]
+    above_noise = [row for row in raw_peaks if (_as_float(row.get("strength_db")) or 0.0) > 0]
+    ranked = above_noise or raw_peaks
+    return [build_peak_row(row, lang=lang, tr=tr) for row in ranked[:8]]
+
+
+def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> PeakRow:
+    """Build one report peak row from a plot peak-table row."""
+    rank_val = _as_float(row.get("rank"))
+    rank = str(int(rank_val)) if rank_val is not None else "—"
+    freq_val = _as_float(row.get("frequency_hz"))
+    freq = f"{freq_val:.1f}" if freq_val is not None else "—"
+    classification = peak_classification_text(row.get("peak_classification"), tr=tr)
+    order_label_raw = str(row.get("order_label") or "").strip()
+    order = order_label_human(lang, order_label_raw) if order_label_raw else classification
+    peak_db_val = _as_float(row.get("p95_intensity_db"))
+    peak_db = f"{peak_db_val:.1f}" if peak_db_val is not None else "—"
+    strength_db_val = _as_float(row.get("strength_db"))
+    strength_db = f"{strength_db_val:.1f}" if strength_db_val is not None else "—"
+    speed = str(row.get("typical_speed_band") or "—")
+    presence = _as_float(row.get("presence_ratio")) or 0.0
+    score = _as_float(row.get("persistence_score")) or 0.0
+    return PeakRow(
+        rank=rank,
+        system=peak_row_system_label(row, tr=tr),
+        freq_hz=freq,
+        order=order,
+        peak_db=peak_db,
+        strength_db=strength_db,
+        speed_band=speed,
+        relevance=f"{classification} · {presence:.0%} {tr('PRESENCE')} · {tr('SCORE')} {score:.2f}",
+    )
+
+
+def peak_row_system_label(row: PeakTableRow, *, tr: Callable[..., str]) -> str:
+    """Resolve the system label shown for one peak row."""
+    source_hint = str(row.get("suspected_source") or "").strip().lower()
+    source_map: dict[str, str] = {
+        VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
+        VibrationSource.ENGINE: "SOURCE_ENGINE",
+        VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
+        VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
+    }
+    i18n_key = source_map.get(source_hint)
+    if i18n_key:
+        return str(tr(i18n_key))
+    return "—"

--- a/apps/server/vibesensor/adapters/pdf/presentation.py
+++ b/apps/server/vibesensor/adapters/pdf/presentation.py
@@ -1,12 +1,18 @@
-"""Presentation-only strength labeling helpers for PDF/report rendering."""
+"""Presentation-only labeling helpers for PDF/report rendering."""
 
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 
 from vibesensor.strength_bands import BANDS
 
-__all__ = ["strength_label", "strength_text"]
+__all__ = [
+    "order_label_human",
+    "peak_classification_text",
+    "strength_label",
+    "strength_text",
+]
 
 _isfinite = math.isfinite
 
@@ -26,6 +32,46 @@ _STRENGTH_THRESHOLDS: tuple[tuple[float, str, str, str], ...] = tuple(
     )
     for band in BANDS
 )
+
+_ORDER_LABEL_NAMES_NL: dict[str, str] = {
+    "wheel": "wielorde",
+    "engine": "motororde",
+    "driveshaft": "aandrijfasorde",
+}
+_ORDER_LABEL_NAMES_DEFAULT: dict[str, str] = {
+    "wheel": "wheel order",
+    "engine": "engine order",
+    "driveshaft": "driveshaft order",
+}
+
+_CLASSIFICATION_I18N_KEYS: dict[str, str] = {
+    "patterned": "CLASSIFICATION_PATTERNED",
+    "persistent": "CLASSIFICATION_PERSISTENT",
+    "transient": "CLASSIFICATION_TRANSIENT",
+    "baseline_noise": "CLASSIFICATION_BASELINE_NOISE",
+}
+
+
+def order_label_human(lang: str, label: str) -> str:
+    """Translate a language-neutral order label like ``1x wheel``."""
+    names = _ORDER_LABEL_NAMES_NL if lang == "nl" else _ORDER_LABEL_NAMES_DEFAULT
+    parts = label.strip().split(" ", 1)
+    if len(parts) == 2:
+        multiplier, base = parts
+        localized = names.get(base.lower(), base)
+        return f"{multiplier} {localized}"
+    return label
+
+
+def peak_classification_text(value: object, tr: Callable[..., str]) -> str:
+    """Map a peak classification code to report text."""
+    normalized = str(value or "").strip().lower()
+    i18n_key = _CLASSIFICATION_I18N_KEYS.get(normalized)
+    if i18n_key:
+        return tr(i18n_key)
+    if not normalized:
+        return tr("UNKNOWN")
+    return str(value).replace("_", " ").title()
 
 
 def strength_label(db_value: float | None, *, lang: str = "en") -> tuple[str, str]:

--- a/apps/server/vibesensor/adapters/pdf/report_sections.py
+++ b/apps/server/vibesensor/adapters/pdf/report_sections.py
@@ -1,0 +1,127 @@
+"""Section builders extracted from the PDF report mapper."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vibesensor.adapters.pdf.report_data import DataTrustItem, NextStep
+from vibesensor.domain import TestRun
+from vibesensor.report_i18n import is_i18n_ref, resolve_i18n
+from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.boundaries.diagnostic_case import run_suitability_payload
+
+__all__ = [
+    "build_data_trust_from_summary",
+    "build_next_steps_from_summary",
+]
+
+
+def build_next_steps_from_summary(
+    summary: AnalysisSummary,
+    *,
+    aggregate: TestRun | None,
+    tier: str,
+    cert_reason: str,
+    lang: str,
+    tr: Callable[..., str],
+) -> list[NextStep]:
+    """Build next-step actions from a run summary dict."""
+    if tier == "A":
+        return [
+            NextStep(action=action, why=cert_reason)
+            for action in (
+                tr("TIER_A_CAPTURE_WIDER_SPEED"),
+                tr("TIER_A_CAPTURE_MORE_SENSORS"),
+                tr("TIER_A_CAPTURE_REFERENCE_DATA"),
+            )
+        ]
+
+    next_steps: list[NextStep] = []
+    if aggregate is not None and aggregate.recommended_actions:
+        for action in aggregate.recommended_actions:
+            next_steps.append(
+                NextStep(
+                    action=_resolve_step_value(action.instruction, lang=lang, tr=tr),
+                    why=_resolve_optional_step_value(action.rationale, lang=lang, tr=tr),
+                    confirm=_resolve_optional_step_value(
+                        action.confirmation_signal,
+                        lang=lang,
+                        tr=tr,
+                    ),
+                    falsify=_resolve_optional_step_value(
+                        action.falsification_signal,
+                        lang=lang,
+                        tr=tr,
+                    ),
+                    eta=action.estimated_duration,
+                ),
+            )
+    return next_steps
+
+
+def _resolve_step_value(value: object, *, lang: str, tr: Callable[..., str]) -> str:
+    """Resolve a required step field into report text."""
+    if isinstance(value, str) and value.isupper() and "_" in value:
+        translated = str(tr(value))
+        if translated and translated != value:
+            return translated
+    return resolve_i18n(lang, value, tr=tr) if is_i18n_ref(value) else str(value or "")
+
+
+def _resolve_optional_step_value(
+    value: object,
+    *,
+    lang: str,
+    tr: Callable[..., str],
+) -> str | None:
+    """Resolve an optional step field into report text or ``None``."""
+    resolved = _resolve_step_value(value, lang=lang, tr=tr).strip()
+    return resolved or None
+
+
+def build_data_trust_from_summary(
+    summary: AnalysisSummary,
+    *,
+    aggregate: TestRun | None,
+    lang: str,
+    tr: Callable[..., str],
+) -> list[DataTrustItem]:
+    """Build the data-trust checklist from run-suitability items."""
+    data_trust: list[DataTrustItem] = []
+    if aggregate is not None and aggregate.suitability is not None:
+        projected = run_suitability_payload(aggregate.suitability)
+        for proj in projected:
+            data_trust.append(
+                DataTrustItem(
+                    check=_resolve_check_text(proj.get("check_key"), lang=lang, tr=tr),
+                    state=str(proj.get("state") or "warn"),
+                    detail=_resolve_detail_text(proj.get("explanation"), lang=lang, tr=tr),
+                ),
+            )
+    for warning in summary["warnings"]:
+        data_trust.append(
+            DataTrustItem(
+                check=_resolve_detail_text(warning.get("title"), lang=lang, tr=tr) or "",
+                state=str(warning.get("severity") or "warn"),
+                detail=_resolve_detail_text(warning.get("detail"), lang=lang, tr=tr),
+            ),
+        )
+    return data_trust
+
+
+def _resolve_check_text(value: object, *, lang: str, tr: Callable[..., str]) -> str:
+    """Resolve the checklist label text."""
+    if is_i18n_ref(value):
+        return resolve_i18n(lang, value, tr=tr)
+    if isinstance(value, str) and value.startswith("SUITABILITY_CHECK_"):
+        return str(tr(value))
+    return str(value or "")
+
+
+def _resolve_detail_text(value: object, *, lang: str, tr: Callable[..., str]) -> str | None:
+    """Resolve the checklist detail text."""
+    if is_i18n_ref(value) or isinstance(value, list):
+        resolved = resolve_i18n(lang, value, tr=tr).strip()
+    else:
+        resolved = str(value or "").strip()
+    return resolved or None

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -17,7 +17,7 @@ Recording stops
       → summary_builder.py (phases, suitability, payload assembly)
       → findings.py, peak_binning.py, signal_aggregation.py, ranking.py, top_cause_selection.py, plots.py
     → map_summary() [vibesensor.adapters.pdf.mapping]
-      → mapping.py (actions, peaks, systems)
+      → mapping.py + peak_table.py + report_sections.py (report shaping + orchestration)
     → store_analysis() [vibesensor.adapters.persistence.history_db]
 
 GET /api/history/{run_id}/report.pdf [vibesensor.adapters.http.history]
@@ -46,6 +46,10 @@ The `vibesensor.adapters.pdf` package contains **only** rendering code:
 | `pdf_drawing.py`, `pdf_text.py` | Shared drawing and text helpers |
 | `pdf_diagram_render.py` | Diagram planning, drawing, and location canonicalisation |
 | `report_data.py` | Dataclass definitions (pure data) |
+| `presentation.py` | Rendering-only label helpers (strength/order/classification text) |
+| `peak_table.py` | Peak-row builders for the report evidence table |
+| `report_sections.py` | Next-step and data-trust section builders |
+| `pattern_parts.py` | Pattern-to-parts suggestion helpers |
 
 **Rule:** Report modules must not import from `vibesensor.use_cases.diagnostics` at
 module level.  A guardrail test (`test_report_analysis_separation.py`)


### PR DESCRIPTION
## Summary
- extract peak-table builders into adapters/pdf/peak_table.py
- extract next-step and data-trust section builders into adapters/pdf/report_sections.py
- move order/classification label helpers into presentation.py so mapping.py stays orchestration-focused and now measures 794 lines

## Validation
- focused PDF/report pytest suite covering mapping, context, regression, i18n, and separation paths
- follow-up pytest suite for the broader ownership/regression tests touched by the extraction
- make typecheck-backend
- ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #711