### PR TITLE
Split RuntimeState dependency groups

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -19,8 +19,8 @@ ESP32 nodes -> adapters/udp/ -> infra/processing/ + use_cases/diagnostics/
 
 Backend ownership boundaries:
 
-- `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), app-owned `RuntimeState` (`runtime_state.py`), and YAML settings/config loading (`settings.py`).
-- `adapters/http/` and `adapters/websocket/`: HTTP route groups and live WebSocket delivery.
+- `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), a lifecycle-focused `RuntimeState` plus top-level `AppRuntime` bundle (`runtime_state.py`), and YAML settings/config loading (`settings.py`).
+- `adapters/http/` and `adapters/websocket/`: HTTP route groups and live WebSocket delivery. `adapters/http/dependencies.py` owns the grouped router dependency dataclasses consumed by `adapters/http/__init__.py`.
 - `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination.
 - `infra/processing/`: signal processing pipeline.
 - `infra/config/`: runtime settings stores used by recording and runtime services.

--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -12,6 +12,13 @@ from fastapi import FastAPI, WebSocketDisconnect
 from test_support import response_payload as _response_payload
 
 from vibesensor.adapters.http import create_router
+from vibesensor.adapters.http.dependencies import (
+    HistoryDeps,
+    RouterDeps,
+    SettingsDeps,
+    TelemetryDeps,
+    UpdateDeps,
+)
 from vibesensor.infra.runtime import RuntimeHealthState
 from vibesensor.use_cases.diagnostics import summarize_run_data
 from vibesensor.use_cases.history.exports import HistoryExportService
@@ -266,6 +273,49 @@ class FakeState:
             self.history_db, self.settings_store, pdf_renderer=pdf_renderer
         )
         self.export_service = HistoryExportService(self.history_db)
+
+    @property
+    def telemetry(self) -> TelemetryDeps:
+        return TelemetryDeps(
+            processing_loop_state=self.processing_loop_state,
+            health_state=self.health_state,
+            processor=self.processor,
+            registry=self.registry,
+            control_plane=self.control_plane,
+            run_recorder=self.run_recorder,
+            ws_hub=self.ws_hub,
+        )
+
+    @property
+    def settings(self) -> SettingsDeps:
+        return SettingsDeps(
+            settings_store=self.settings_store,
+            gps_monitor=self.gps_monitor,
+        )
+
+    @property
+    def history(self) -> HistoryDeps:
+        return HistoryDeps(
+            run_service=self.run_service,
+            report_service=self.report_service,
+            export_service=self.export_service,
+        )
+
+    @property
+    def updates(self) -> UpdateDeps:
+        return UpdateDeps(
+            update_manager=self.update_manager,
+            esp_flash_manager=self.esp_flash_manager,
+        )
+
+    @property
+    def router(self) -> RouterDeps:
+        return RouterDeps(
+            telemetry=self.telemetry,
+            settings=self.settings,
+            history=self.history,
+            updates=self.updates,
+        )
 
 
 def make_router_and_state(

--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -171,9 +171,6 @@ def _make_state(
         settings_store=settings_store,
         gps_monitor=gps_monitor,
         history_db=_SENTINEL,
-        run_service=_SENTINEL,
-        report_service=_SENTINEL,
-        export_service=_SENTINEL,
         processing_loop_state=processing_state,
         health_state=health_state,
         processing_loop=ProcessingLoop(

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -13,6 +13,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vibesensor.adapters.http.dependencies import (
+    HistoryDeps,
+    RouterDeps,
+    SettingsDeps,
+    TelemetryDeps,
+    UpdateDeps,
+)
 from vibesensor.infra.runtime import ProcessingLoopState, RuntimeHealthState
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.reports import HistoryReportService
@@ -25,11 +32,10 @@ from vibesensor.use_cases.history.runs import HistoryRunService
 
 @dataclass
 class FakeState:
-    """Minimal stand-in for RuntimeState used by ``create_router``.
+    """Minimal stand-in for router assembly tests.
 
-    Provides the same flat fields as the production ``RuntimeState``
-    so that shape drift between test fixtures and production code is
-    caught at construction time rather than via obscure test failures.
+    Keeps the convenient flat fields used throughout tests while exposing the
+    grouped dependency attributes consumed by ``create_router``.
     """
 
     config: object = field(default_factory=MagicMock)
@@ -64,6 +70,49 @@ class FakeState:
             )
         if self.export_service is None:
             self.export_service = HistoryExportService(self.history_db)
+
+    @property
+    def telemetry(self) -> TelemetryDeps:
+        return TelemetryDeps(
+            processing_loop_state=self.processing_loop_state,
+            health_state=self.health_state,
+            processor=self.processor,
+            registry=self.registry,
+            control_plane=self.control_plane,
+            run_recorder=self.run_recorder,
+            ws_hub=self.ws_hub,
+        )
+
+    @property
+    def settings(self) -> SettingsDeps:
+        return SettingsDeps(
+            settings_store=self.settings_store,
+            gps_monitor=self.gps_monitor,
+        )
+
+    @property
+    def history(self) -> HistoryDeps:
+        return HistoryDeps(
+            run_service=self.run_service,
+            report_service=self.report_service,
+            export_service=self.export_service,
+        )
+
+    @property
+    def updates(self) -> UpdateDeps:
+        return UpdateDeps(
+            update_manager=self.update_manager,
+            esp_flash_manager=self.esp_flash_manager,
+        )
+
+    @property
+    def router(self) -> RouterDeps:
+        return RouterDeps(
+            telemetry=self.telemetry,
+            settings=self.settings,
+            history=self.history,
+            updates=self.updates,
+        )
 
 
 @pytest.fixture

--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -35,24 +35,45 @@ def install_pi_text() -> str:
 @pytest.mark.smoke
 def test_smoke_health_route_registered() -> None:
     state = MagicMock()
-    state.registry = MagicMock()
-    state.processor = MagicMock()
-    state.control_plane = MagicMock()
-    state.worker_pool = MagicMock()
-    state.settings_store = MagicMock()
-    state.gps_monitor = MagicMock()
-    state.run_recorder = MagicMock()
-    state.history_db = MagicMock()
-    state.run_service = MagicMock()
-    state.report_service = MagicMock()
-    state.export_service = MagicMock()
-    state.ws_hub = MagicMock()
-    state.ws_broadcast = MagicMock()
-    state.processing_loop_state = MagicMock()
-    state.health_state = MagicMock()
-    state.processing_loop = MagicMock()
-    state.update_manager = MagicMock()
-    state.esp_flash_manager = MagicMock()
+    placeholder = MagicMock()
+    state.telemetry = type(
+        "Telemetry",
+        (),
+        {
+            "control_plane": placeholder,
+            "health_state": placeholder,
+            "processing_loop_state": placeholder,
+            "processor": placeholder,
+            "registry": placeholder,
+            "run_recorder": placeholder,
+            "ws_hub": placeholder,
+        },
+    )()
+    state.settings = type(
+        "Settings",
+        (),
+        {
+            "gps_monitor": placeholder,
+            "settings_store": placeholder,
+        },
+    )()
+    state.history = type(
+        "History",
+        (),
+        {
+            "export_service": placeholder,
+            "report_service": placeholder,
+            "run_service": placeholder,
+        },
+    )()
+    state.updates = type(
+        "Updates",
+        (),
+        {
+            "esp_flash_manager": placeholder,
+            "update_manager": placeholder,
+        },
+    )()
     router = create_router(state)
     routes = {r.path: r.methods for r in router.routes if hasattr(r, "methods")}
     assert "/api/health" in routes, "Missing /api/health route"

--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -110,10 +110,9 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         ("infra/runtime/registry.py", "vibesensor.adapters.persistence.history_db"),
         ("infra/runtime/rotational_speeds.py", "vibesensor.adapters.gps.gps_speed"),
         ("infra/runtime/ws_broadcast.py", "vibesensor.adapters.gps.gps_speed"),
-        # adapters/infra → app
-        # RuntimeState now lives in app/, but router/lifecycle still consume the
-        # flat app-owned runtime bag until issue #752 splits those dependency groups.
-        ("adapters/http/__init__.py", "vibesensor.app.runtime_state"),
+        # infra → app
+        # RuntimeState is now lifecycle-focused, but LifecycleManager still consumes
+        # the app-owned runtime bag directly.
         ("infra/runtime/lifecycle.py", "vibesensor.app.runtime_state"),
         # adapters → app
         ("adapters/hotspot/self_heal.py", "vibesensor.app.settings"),

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -137,9 +137,6 @@ def _make_runtime(**overrides: Any):
     settings_store = overrides.pop("settings_store", MagicMock())
     gps_monitor = overrides.pop("gps_monitor", MagicMock())
     history_db = overrides.pop("history_db", MagicMock())
-    run_service = overrides.pop("run_service", MagicMock())
-    report_service = overrides.pop("report_service", MagicMock())
-    export_service = overrides.pop("export_service", MagicMock())
     diagnostics = overrides.pop("run_recorder", MagicMock())
     update_manager = overrides.pop("update_manager", MagicMock())
     esp_flash_manager = overrides.pop("esp_flash_manager", MagicMock())
@@ -154,9 +151,6 @@ def _make_runtime(**overrides: Any):
         settings_store=settings_store,
         gps_monitor=gps_monitor,
         history_db=history_db,
-        run_service=run_service,
-        report_service=report_service,
-        export_service=export_service,
         processing_loop_state=processing_state,
         health_state=health_state,
         processing_loop=ProcessingLoop(

--- a/apps/server/tests/use_cases/updates/test_update_manager_api.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_api.py
@@ -5,6 +5,13 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
+from vibesensor.adapters.http.dependencies import (
+    HistoryDeps,
+    RouterDeps,
+    SettingsDeps,
+    TelemetryDeps,
+    UpdateDeps,
+)
 from vibesensor.use_cases.updates.manager import UpdateManager
 
 
@@ -12,9 +19,31 @@ class TestUpdateApiEndpoints:
     def test_status_endpoint_exists(self) -> None:
         from vibesensor.adapters.http import create_router
 
-        state = MagicMock()
-        state.update_manager = UpdateManager()
-        state.esp_flash_manager = MagicMock()
+        placeholder = MagicMock()
+        state = RouterDeps(
+            telemetry=TelemetryDeps(
+                processing_loop_state=placeholder,
+                health_state=placeholder,
+                processor=placeholder,
+                registry=placeholder,
+                control_plane=placeholder,
+                run_recorder=placeholder,
+                ws_hub=placeholder,
+            ),
+            settings=SettingsDeps(
+                settings_store=placeholder,
+                gps_monitor=placeholder,
+            ),
+            history=HistoryDeps(
+                run_service=placeholder,
+                report_service=placeholder,
+                export_service=placeholder,
+            ),
+            updates=UpdateDeps(
+                update_manager=UpdateManager(),
+                esp_flash_manager=MagicMock(),
+            ),
+        )
         router = create_router(state)
         paths = [route.path for route in router.routes]
         assert "/api/update/status" in paths

--- a/apps/server/vibesensor/adapters/http/__init__.py
+++ b/apps/server/vibesensor/adapters/http/__init__.py
@@ -7,19 +7,17 @@ combines them so that ``app.py`` only needs::
     from vibesensor.adapters.http import create_router
 
 Route modules receive only the specific services they need. The package-level
-assembler still accepts the app-owned runtime state, but immediately fans that
-out into explicit per-route dependencies.
+assembler accepts focused dependency groups instead of the full app runtime bag.
 """
 
 from __future__ import annotations
-
-from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
 
 from vibesensor.adapters.http.car_library import create_car_library_routes
 from vibesensor.adapters.http.clients import create_client_routes
 from vibesensor.adapters.http.debug import create_debug_routes
+from vibesensor.adapters.http.dependencies import RouterDeps
 from vibesensor.adapters.http.health import create_health_routes
 from vibesensor.adapters.http.history import create_history_routes
 from vibesensor.adapters.http.recording import create_recording_routes
@@ -27,55 +25,52 @@ from vibesensor.adapters.http.settings import create_settings_routes
 from vibesensor.adapters.http.updates import create_update_routes
 from vibesensor.adapters.http.websocket import create_websocket_routes
 
-if TYPE_CHECKING:
-    from vibesensor.app.runtime_state import RuntimeState
 
-
-def create_router(services: RuntimeState) -> APIRouter:
+def create_router(services: RouterDeps) -> APIRouter:
     """Assemble all domain-specific route groups into one router."""
     router = APIRouter()
     router.include_router(
         create_health_routes(
-            services.processing_loop_state,
-            services.health_state,
-            services.processor,
-            services.registry,
-            services.run_recorder,
+            services.telemetry.processing_loop_state,
+            services.telemetry.health_state,
+            services.telemetry.processor,
+            services.telemetry.registry,
+            services.telemetry.run_recorder,
         ),
     )
     router.include_router(
         create_settings_routes(
-            services.settings_store,
-            services.gps_monitor,
+            services.settings.settings_store,
+            services.settings.gps_monitor,
         ),
     )
     router.include_router(
         create_client_routes(
-            services.registry,
-            services.control_plane,
-            services.settings_store,
-            services.processor,
+            services.telemetry.registry,
+            services.telemetry.control_plane,
+            services.settings.settings_store,
+            services.telemetry.processor,
         ),
     )
     router.include_router(
         create_recording_routes(
-            services.run_recorder,
+            services.telemetry.run_recorder,
         ),
     )
     router.include_router(
         create_history_routes(
-            run_service=services.run_service,
-            report_service=services.report_service,
-            export_service=services.export_service,
+            run_service=services.history.run_service,
+            report_service=services.history.report_service,
+            export_service=services.history.export_service,
         ),
     )
-    router.include_router(create_websocket_routes(services.ws_hub))
+    router.include_router(create_websocket_routes(services.telemetry.ws_hub))
     router.include_router(
         create_update_routes(
-            services.update_manager,
-            services.esp_flash_manager,
+            services.updates.update_manager,
+            services.updates.esp_flash_manager,
         ),
     )
     router.include_router(create_car_library_routes())
-    router.include_router(create_debug_routes(services.processor))
+    router.include_router(create_debug_routes(services.telemetry.processor))
     return router

--- a/apps/server/vibesensor/adapters/http/dependencies.py
+++ b/apps/server/vibesensor/adapters/http/dependencies.py
@@ -1,0 +1,61 @@
+"""Typed dependency groups for assembling HTTP route groups."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from vibesensor.infra.config.settings_store import SettingsStore
+from vibesensor.infra.processing import SignalProcessor
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
+from vibesensor.infra.runtime.registry import ClientRegistry
+from vibesensor.use_cases.history.exports import HistoryExportService
+from vibesensor.use_cases.history.reports import HistoryReportService
+from vibesensor.use_cases.history.runs import HistoryRunService
+from vibesensor.use_cases.run import RunRecorder
+from vibesensor.use_cases.updates.esp_flash_manager import EspFlashManager
+from vibesensor.use_cases.updates.manager import UpdateManager
+
+if TYPE_CHECKING:
+    from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+    from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
+    from vibesensor.adapters.websocket.hub import WebSocketHub
+
+
+@dataclass(slots=True)
+class TelemetryDeps:
+    processing_loop_state: ProcessingLoopState
+    health_state: RuntimeHealthState
+    processor: SignalProcessor
+    registry: ClientRegistry
+    control_plane: UDPControlPlane
+    run_recorder: RunRecorder
+    ws_hub: WebSocketHub
+
+
+@dataclass(slots=True)
+class SettingsDeps:
+    settings_store: SettingsStore
+    gps_monitor: GPSSpeedMonitor
+
+
+@dataclass(slots=True)
+class HistoryDeps:
+    run_service: HistoryRunService
+    report_service: HistoryReportService
+    export_service: HistoryExportService
+
+
+@dataclass(slots=True)
+class UpdateDeps:
+    update_manager: UpdateManager
+    esp_flash_manager: EspFlashManager
+
+
+@dataclass(slots=True)
+class RouterDeps:
+    telemetry: TelemetryDeps
+    settings: SettingsDeps
+    history: HistoryDeps
+    updates: UpdateDeps

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -23,7 +23,7 @@ from fastapi.staticfiles import StaticFiles
 from vibesensor.adapters.http import create_router
 from vibesensor.adapters.udp.udp_data_rx import start_udp_data_receiver
 from vibesensor.app.container import build_runtime
-from vibesensor.app.runtime_state import RuntimeState
+from vibesensor.app.runtime_state import AppRuntime
 from vibesensor.app.settings import load_config
 from vibesensor.infra.runtime.lifecycle import LifecycleManager
 
@@ -71,7 +71,10 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     config = load_config(config_path)
     _setup_file_logging(config.logging.app_log_path)
     runtime = build_runtime(config)
-    lifecycle = LifecycleManager(runtime=runtime, start_udp_receiver=start_udp_data_receiver)
+    lifecycle = LifecycleManager(
+        runtime=runtime.lifecycle,
+        start_udp_receiver=start_udp_data_receiver,
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -91,7 +94,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     app = FastAPI(title="VibeSensor", lifespan=lifespan)
     app.state.runtime = runtime
-    app.include_router(create_router(runtime))
+    app.include_router(create_router(runtime.router))
     if os.getenv("VIBESENSOR_SERVE_STATIC", "1") == "1":
         static_dir = _PACKAGE_DIR / "static"
         if not (static_dir / "index.html").exists():
@@ -124,7 +127,7 @@ def main() -> None:
     args = parser.parse_args()
 
     runtime_app = create_app(config_path=args.config)
-    runtime: RuntimeState = runtime_app.state.runtime
+    runtime: AppRuntime = runtime_app.state.runtime
     host = runtime.config.server.host
     port = runtime.config.server.port
     try:

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -4,10 +4,17 @@ import logging
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+from vibesensor.adapters.http.dependencies import (
+    HistoryDeps,
+    RouterDeps,
+    SettingsDeps,
+    TelemetryDeps,
+    UpdateDeps,
+)
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 from vibesensor.adapters.websocket.hub import WebSocketHub
-from vibesensor.app.runtime_state import RuntimeState
+from vibesensor.app.runtime_state import AppRuntime, RuntimeState
 from vibesensor.app.settings import AppConfig
 from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.infra.processing import SignalProcessor
@@ -70,8 +77,8 @@ def create_history_db(config: AppConfig) -> HistoryDB:
     return history_db
 
 
-def build_runtime(config: AppConfig) -> RuntimeState:
-    """Construct all services and return a wired RuntimeState."""
+def build_runtime(config: AppConfig) -> AppRuntime:
+    """Construct all services and return the app runtime bundle."""
     accel_scale_g_per_lsb = resolve_accel_scale_g_per_lsb(config)
 
     # DB + settings
@@ -167,7 +174,9 @@ def build_runtime(config: AppConfig) -> RuntimeState:
         rollback_dir=str(config.update.rollback_dir),
     )
 
-    runtime = RuntimeState(
+    esp_flash_manager = EspFlashManager()
+
+    lifecycle = RuntimeState(
         config=config,
         registry=registry,
         processor=processor,
@@ -176,9 +185,6 @@ def build_runtime(config: AppConfig) -> RuntimeState:
         settings_store=settings_store,
         gps_monitor=gps_monitor,
         history_db=history_db,
-        run_service=run_service,
-        report_service=report_service,
-        export_service=export_service,
         processing_loop_state=processing_loop_state,
         health_state=health_state,
         processing_loop=processing_loop,
@@ -186,7 +192,31 @@ def build_runtime(config: AppConfig) -> RuntimeState:
         ws_broadcast=ws_broadcast,
         run_recorder=run_recorder,
         update_manager=update_manager,
-        esp_flash_manager=EspFlashManager(),
+        esp_flash_manager=esp_flash_manager,
+    )
+    router = RouterDeps(
+        telemetry=TelemetryDeps(
+            processing_loop_state=processing_loop_state,
+            health_state=health_state,
+            processor=processor,
+            registry=registry,
+            control_plane=control_plane,
+            run_recorder=run_recorder,
+            ws_hub=ws_hub,
+        ),
+        settings=SettingsDeps(
+            settings_store=settings_store,
+            gps_monitor=gps_monitor,
+        ),
+        history=HistoryDeps(
+            run_service=run_service,
+            report_service=report_service,
+            export_service=export_service,
+        ),
+        updates=UpdateDeps(
+            update_manager=update_manager,
+            esp_flash_manager=esp_flash_manager,
+        ),
     )
     settings_store.sync_all()
-    return runtime
+    return AppRuntime(lifecycle=lifecycle, router=router)

--- a/apps/server/vibesensor/app/runtime_state.py
+++ b/apps/server/vibesensor/app/runtime_state.py
@@ -1,10 +1,11 @@
-"""App-owned runtime assembly for the fully wired service graph."""
+"""App-owned runtime assembly for lifecycle and router dependency bundles."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from vibesensor.adapters.http.dependencies import RouterDeps
 from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
@@ -12,9 +13,6 @@ from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingL
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.workers.worker_pool import WorkerPool
-from vibesensor.use_cases.history.exports import HistoryExportService
-from vibesensor.use_cases.history.reports import HistoryReportService
-from vibesensor.use_cases.history.runs import HistoryRunService
 from vibesensor.use_cases.run import RunRecorder
 from vibesensor.use_cases.updates.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.manager import UpdateManager
@@ -29,30 +27,33 @@ if TYPE_CHECKING:
 
 @dataclass(slots=True)
 class RuntimeState:
-    """Top-level runtime with flat field access."""
+    """Lifecycle-focused runtime dependencies."""
 
     config: AppConfig
-    # ingress
     registry: ClientRegistry
     processor: SignalProcessor
     control_plane: UDPControlPlane
     worker_pool: WorkerPool
-    # settings
     settings_store: SettingsStore
     gps_monitor: GPSSpeedMonitor
-    # persistence
     history_db: HistoryDB
-    run_service: HistoryRunService
-    report_service: HistoryReportService
-    export_service: HistoryExportService
-    # processing
     processing_loop_state: ProcessingLoopState
     health_state: RuntimeHealthState
     processing_loop: ProcessingLoop
-    # websocket
     ws_hub: WebSocketHub
     ws_broadcast: WsBroadcastService
-    # top-level
     run_recorder: RunRecorder
     update_manager: UpdateManager
     esp_flash_manager: EspFlashManager
+
+
+@dataclass(slots=True)
+class AppRuntime:
+    """Top-level app runtime bundle used by bootstrap and CLI entrypoints."""
+
+    lifecycle: RuntimeState
+    router: RouterDeps
+
+    @property
+    def config(self) -> AppConfig:
+        return self.lifecycle.config

--- a/apps/server/vibesensor/cli/http_api_schema_export.py
+++ b/apps/server/vibesensor/cli/http_api_schema_export.py
@@ -12,12 +12,18 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 from fastapi import FastAPI
 
 from vibesensor.adapters.http import create_router
+from vibesensor.adapters.http.dependencies import (
+    HistoryDeps,
+    RouterDeps,
+    SettingsDeps,
+    TelemetryDeps,
+    UpdateDeps,
+)
 
 _DEFAULT_OUT = (
     Path(__file__).resolve().parents[4]
@@ -30,29 +36,33 @@ _DEFAULT_OUT = (
 
 
 def _build_openapi_app() -> FastAPI:
-    placeholder = object()
-    services = SimpleNamespace(
-        registry=placeholder,
-        processor=placeholder,
-        control_plane=placeholder,
-        settings_store=placeholder,
-        gps_monitor=placeholder,
-        analysis_settings=placeholder,
-        apply_car_settings=placeholder,
-        apply_speed_source_settings=placeholder,
-        run_recorder=placeholder,
-        history_db=placeholder,
-        run_service=placeholder,
-        report_service=placeholder,
-        export_service=placeholder,
-        ws_hub=placeholder,
-        update_manager=placeholder,
-        esp_flash_manager=placeholder,
-        processing_loop_state=placeholder,
-        health_state=placeholder,
+    placeholder: Any = object()
+    services = RouterDeps(
+        telemetry=TelemetryDeps(
+            processing_loop_state=placeholder,
+            health_state=placeholder,
+            processor=placeholder,
+            registry=placeholder,
+            control_plane=placeholder,
+            run_recorder=placeholder,
+            ws_hub=placeholder,
+        ),
+        settings=SettingsDeps(
+            settings_store=placeholder,
+            gps_monitor=placeholder,
+        ),
+        history=HistoryDeps(
+            run_service=placeholder,
+            report_service=placeholder,
+            export_service=placeholder,
+        ),
+        updates=UpdateDeps(
+            update_manager=placeholder,
+            esp_flash_manager=placeholder,
+        ),
     )
     app = FastAPI(title="VibeSensor HTTP API")
-    app.include_router(create_router(cast(Any, services)))
+    app.include_router(create_router(services))
     return app
 
 

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -27,8 +27,8 @@ Scope: single source of truth for detailed file layout, entry points, package st
 
 ## Backend package layout
 
-- `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds the flat app-owned `RuntimeState`, `runtime_state.py` owns that fully wired service graph, and `settings.py` owns YAML config loading and validation.
-- `adapters/http/`: health, clients, settings, recording, history, websocket, updates, car library, and debug route groups; `adapters/http/__init__.py` assembles the router.
+- `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds a lifecycle-focused `RuntimeState` plus the top-level `AppRuntime` bundle, `runtime_state.py` owns those app-facing runtime bundles, and `settings.py` owns YAML config loading and validation.
+- `adapters/http/`: health, clients, settings, recording, history, websocket, updates, car library, and debug route groups; `adapters/http/dependencies.py` owns the grouped router dependency dataclasses and `adapters/http/__init__.py` assembles the router from them.
 - `adapters/websocket/hub.py`: live WebSocket connection fan-out and payload delivery.
 - `adapters/persistence/`: SQLite history DB (`history_db/` keeps `HistoryDB` as the public facade and splits internals across `_run_lifecycle.py`, `_sample_io.py`, `_queries.py`, `_schema.py`, and `_samples.py`) and the static car library loader (`car_library.py`).
 - `adapters/pdf/`: PDF/report rendering pipeline and report mapping entrypoints.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,7 +43,7 @@ apps/server/tests/
 | `vibesensor/analysis/*` | `apps/server/tests/analysis/` |
 | `vibesensor/report/*`, `report_i18n.py` | `apps/server/tests/report/` |
 | `vibesensor/routes/*` | `apps/server/tests/api/` |
-| `vibesensor/app/runtime_state.py`, `vibesensor/infra/runtime/*`, `worker_pool.py` | `apps/server/tests/infra/runtime/` |
+| `vibesensor/app/runtime_state.py`, `vibesensor/adapters/http/dependencies.py`, `vibesensor/infra/runtime/*`, `worker_pool.py` | `apps/server/tests/infra/runtime/` and `apps/server/tests/adapters/http/` |
 | `vibesensor/adapters/persistence/history_db/*`, `vibesensor/use_cases/history/*` | `apps/server/tests/adapters/persistence/history_db/` and `apps/server/tests/use_cases/history/` |
 | `vibesensor/update/*` | `apps/server/tests/update/` |
 | `vibesensor/processing/*` | `apps/server/tests/processing/` |


### PR DESCRIPTION
## Summary
- reduce RuntimeState to the fields LifecycleManager actually uses and introduce a small AppRuntime bundle for bootstrap wiring
- add grouped HTTP router dependencies so create_router no longer consumes the full runtime bag
- update runtime/router tests and docs, and remove the temporary router-to-app layer-boundary allowance from the hygiene guard

## Validation
- pytest -q apps/server/tests/infra/runtime/ apps/server/tests/adapters/http/test_route_registration.py apps/server/tests/adapters/http/test_health_endpoint.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py apps/server/tests/use_cases/updates/test_update_manager_api.py apps/server/tests/hygiene/test_ai_smoke.py apps/server/tests/adapters/websocket/test_build_ws_payload.py
- make typecheck-backend
- make docs-lint
- ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #752