### PR TITLE
Extract client snapshot presenter

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -21,7 +21,7 @@ Backend ownership boundaries:
 
 - `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), a lifecycle-focused `RuntimeState` plus top-level `AppRuntime` bundle (`runtime_state.py`), and YAML settings/config loading (`settings.py`).
 - `adapters/http/` and `adapters/websocket/`: HTTP route groups and live WebSocket delivery. `adapters/http/dependencies.py` owns the grouped router dependency dataclasses consumed by `adapters/http/__init__.py`.
-- `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination.
+- `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination. `registry.py` now owns raw client tracking plus `client_snapshots()`, while `client_snapshot.py` owns the API/WS client-row presenter reused by both the HTTP clients route and live WebSocket broadcasting.
 - `infra/processing/`: signal processing pipeline.
 - `infra/config/`: runtime settings stores used by recording and runtime services.
 - `use_cases/diagnostics/`: post-stop analysis/findings logic; `order_analysis.py` now keeps the core matching/scoring/assembly primitives, `order_pipeline.py` owns the order-finding orchestration/session flow above those primitives, `order_heuristics.py` owns the pure scoring/filter heuristics, and the package-level API still re-exports shared vehicle-order helpers used by live telemetry.

--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -215,6 +215,9 @@ class FakeState:
             (),
             {
                 "snapshot_for_api": lambda self: [],
+                "client_snapshots": (
+                    lambda self, now=None, now_mono=None, metrics_by_client=None: []
+                ),
                 "data_loss_snapshot": lambda self: {
                     "tracked_clients": 0,
                     "affected_clients": 0,

--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from vibesensor.domain import AnalysisSettingsSnapshot
+from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 
 if TYPE_CHECKING:
     from vibesensor.app.runtime_state import RuntimeState
@@ -25,16 +26,33 @@ class _StubRegistry:
     def active_client_ids(self) -> list[str]:
         return [c["id"] for c in self._clients if "id" in c]
 
-    def snapshot_for_api(
+    def client_snapshots(
         self,
         now: float | None = None,
         *,
         now_mono: float | None = None,
         metrics_by_client: dict[str, Any] | None = None,
-        include_metrics: bool = True,
-    ) -> list[dict[str, Any]]:
+    ) -> list[ClientSnapshot]:
+        del now, now_mono, metrics_by_client
         self.snapshot_calls += 1
-        return list(self._clients)
+        return [
+            ClientSnapshot(
+                client_id=str(client["id"]),
+                name=str(client.get("name", "")),
+                connected=bool(client.get("connected", False)),
+                location_code=str(client.get("location_code", "")),
+                firmware_version=str(client.get("firmware_version", "")),
+                sample_rate_hz=int(client.get("sample_rate_hz", 0)),
+                frame_samples=int(client.get("frame_samples", 0)),
+                last_seen_age_ms=client.get("last_seen_age_ms"),
+                frames_total=int(client.get("frames_total", 0)),
+                dropped_frames=int(client.get("dropped_frames", 0)),
+                latest_metrics=client.get("latest_metrics"),
+                reset_count=int(client.get("reset_count", 0)),
+                last_reset_time=client.get("last_reset_time"),
+            )
+            for client in self._clients
+        ]
 
 
 class _StubProcessor:
@@ -203,8 +221,8 @@ def _make_state(
 # ---------------------------------------------------------------------------
 
 _TWO_CLIENTS = [
-    {"id": "aaa", "name": "front-left"},
-    {"id": "bbb", "name": "rear-right"},
+    {"id": "aaaaaaaaaaaa", "name": "front-left"},
+    {"id": "bbbbbbbbbbbb", "name": "rear-right"},
 ]
 
 _ROTATIONAL_KEYS = ("wheel", "driveshaft", "engine")
@@ -232,7 +250,7 @@ def _assert_rotational(
 
 def test_build_ws_payload_returns_required_keys() -> None:
     state = _make_state(clients=_TWO_CLIENTS, ws_include_heavy=True)
-    payload = state.ws_broadcast.build_payload(selected_client="aaa")
+    payload = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
 
     # Always-present keys
     for key in ("server_time", "speed_mps", "clients", "selected_client_id", "rotational_speeds"):
@@ -242,14 +260,14 @@ def test_build_ws_payload_returns_required_keys() -> None:
     assert "spectra" in payload, "missing heavy key: spectra"
 
     assert payload["speed_mps"] == 12.5
-    assert payload["selected_client_id"] == "aaa"
+    assert payload["selected_client_id"] == "aaaaaaaaaaaa"
     assert len(payload["clients"]) == 2
     _assert_rotational(payload["rotational_speeds"], rpm_positive=True)
 
 
 def test_build_ws_payload_light_tick_omits_spectra_and_selected() -> None:
     state = _make_state(clients=_TWO_CLIENTS, ws_include_heavy=False)
-    payload = state.ws_broadcast.build_payload(selected_client="aaa")
+    payload = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
 
     assert "spectra" not in payload
 
@@ -258,7 +276,7 @@ def test_build_ws_payload_auto_selects_first_client() -> None:
     state = _make_state(clients=_TWO_CLIENTS, ws_include_heavy=True)
     payload = state.ws_broadcast.build_payload(selected_client=None)
 
-    assert payload["selected_client_id"] == "aaa"
+    assert payload["selected_client_id"] == "aaaaaaaaaaaa"
 
 
 def test_build_ws_payload_no_clients() -> None:
@@ -281,11 +299,11 @@ def test_build_ws_payload_reuses_shared_payload_per_tick() -> None:
     assert isinstance(settings_store, _StubSettingsStore)
 
     state.ws_broadcast.tick = 77
-    payload_aaa = state.ws_broadcast.build_payload(selected_client="aaa")
-    payload_bbb = state.ws_broadcast.build_payload(selected_client="bbb")
+    payload_aaa = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
+    payload_bbb = state.ws_broadcast.build_payload(selected_client="bbbbbbbbbbbb")
 
-    assert payload_aaa["selected_client_id"] == "aaa"
-    assert payload_bbb["selected_client_id"] == "bbb"
+    assert payload_aaa["selected_client_id"] == "aaaaaaaaaaaa"
+    assert payload_bbb["selected_client_id"] == "bbbbbbbbbbbb"
     assert payload_aaa["server_time"] == payload_bbb["server_time"]
     assert payload_aaa["clients"] == payload_bbb["clients"]
     assert registry.snapshot_calls == 1
@@ -316,5 +334,5 @@ def test_build_ws_payload_rotational_speeds_include_reason_when_speed_unavailabl
     assert isinstance(gps, _StubGPS)
     gps.effective_speed_mps = None
 
-    payload = state.ws_broadcast.build_payload(selected_client="aaa")
+    payload = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
     _assert_rotational(payload["rotational_speeds"], reason="speed_unavailable")

--- a/apps/server/tests/adapters/websocket/test_ws_models.py
+++ b/apps/server/tests/adapters/websocket/test_ws_models.py
@@ -45,10 +45,10 @@ def _make_state(**kwargs: Any) -> Any:
 
 def test_build_ws_payload_includes_schema_version() -> None:
     state = _make_state(
-        clients=[{"id": "aaa", "name": "front"}],
+        clients=[{"id": "aaaaaaaaaaaa", "name": "front"}],
         ws_include_heavy=True,
     )
-    payload = state.ws_broadcast.build_payload(selected_client="aaa")
+    payload = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
     assert "schema_version" in payload
     assert payload["schema_version"] == SCHEMA_VERSION
 

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage
+from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
 from vibesensor.infra.runtime.registry import ClientRegistry
 
 
@@ -29,7 +30,7 @@ def test_registry_sequence_gap(tmp_path: Path) -> None:
     registry.update_from_data(msg0, ("10.4.0.2", 50000), now=2.0)
     registry.update_from_data(msg1, ("10.4.0.2", 50000), now=3.0)
 
-    row = registry.snapshot_for_api(now=3.0)[0]
+    row = snapshot_for_api(registry, now=3.0)[0]
     assert row["frames_total"] == 2
     assert row["dropped_frames"] == 1
     assert row["mac_address"] == "aa:bb:cc:dd:ee:ff"
@@ -51,7 +52,7 @@ def test_registry_rename_persist(tmp_path: Path) -> None:
     )
     registry2.update_from_hello(hello, ("10.4.0.3", 9011), now=5.0)
 
-    row = registry2.snapshot_for_api(now=5.0)[0]
+    row = snapshot_for_api(registry2, now=5.0)[0]
     assert row["name"] == "rear"
 
 
@@ -64,7 +65,7 @@ def test_registry_rename_normalizes_client_id(tmp_path: Path) -> None:
     registry.set_name(lower_id, "rear")
     registry.set_name(upper_id, "rear-updated")
 
-    rows = registry.snapshot_for_api(now=1.0)
+    rows = snapshot_for_api(registry, now=1.0)
     assert len(rows) == 1
     assert rows[0]["id"] == lower_id
     assert rows[0]["name"] == "rear-updated"
@@ -77,7 +78,7 @@ def test_registry_snapshot_includes_persisted_offline_clients(tmp_path: Path) ->
     registry.set_name(offline_id, "rear-right-wheel")
 
     registry2 = ClientRegistry(db=db)
-    rows = {row["id"]: row for row in registry2.snapshot_for_api(now=10.0)}
+    rows = {row["id"]: row for row in snapshot_for_api(registry2, now=10.0)}
     assert rows[offline_id]["name"] == "rear-right-wheel"
     assert rows[offline_id]["connected"] is False
     assert rows[offline_id]["mac_address"] == "00:11:22:33:44:55"
@@ -113,7 +114,7 @@ def test_registry_persist_keeps_offline_names(tmp_path: Path) -> None:
         now=4.0,
     )
 
-    rows = {row["id"]: row for row in registry2.snapshot_for_api(now=4.0)}
+    rows = {row["id"]: row for row in snapshot_for_api(registry2, now=4.0)}
     assert rows[offline_id]["name"] == "offline-node"
 
 
@@ -134,7 +135,7 @@ def test_registry_hello_uses_advertised_control_port(tmp_path: Path) -> None:
     assert record is not None
     assert record.control_addr == ("10.4.0.2", 9010)
 
-    row = registry.snapshot_for_api(now=1.0)[0]
+    row = snapshot_for_api(registry, now=1.0)[0]
     assert row["frame_samples"] == 200
 
 
@@ -189,7 +190,9 @@ def test_registry_staleness_uses_monotonic_clock_when_now_not_provided(
     now["mono"] = 105.0
 
     assert registry.active_client_ids() == ["001122334455"]
-    row = registry.snapshot_for_api()[0]
+    row = snapshot_for_api(
+        registry,
+    )[0]
     assert row["connected"] is True
 
     now["mono"] = 120.1
@@ -206,7 +209,7 @@ def test_registry_remove_client_clears_persisted_entry(tmp_path: Path) -> None:
     assert registry.remove_client(client_id) is False
 
     registry2 = ClientRegistry(db=db)
-    rows = registry2.snapshot_for_api(now=1.0)
+    rows = snapshot_for_api(registry2, now=1.0)
     assert rows == []
 
 
@@ -245,7 +248,7 @@ def test_registry_detects_sensor_reset_on_large_sequence_backstep(tmp_path: Path
         ("10.4.0.2", 50000),
         now=3.0,
     )
-    row = registry.snapshot_for_api(now=3.0)[0]
+    row = snapshot_for_api(registry, now=3.0)[0]
     assert row["reset_count"] == 1
     assert row["dropped_frames"] == 0
 
@@ -297,7 +300,7 @@ def test_registry_clear_name_reverts_to_default(tmp_path: Path) -> None:
 
     # Verify persistence: the cleared name should NOT come back after reload
     registry2 = ClientRegistry(db=db)
-    rows = registry2.snapshot_for_api(now=1.0)
+    rows = snapshot_for_api(registry2, now=1.0)
     names = [r["name"] for r in rows if r["id"] == client_id]
     # After clearing, the client may or may not appear in snapshot (depending on
     # whether it's currently connected). If it appears, it should have the default name.
@@ -337,7 +340,7 @@ def test_set_location_populates_client_record(tmp_path: Path) -> None:
 
     hex_id = "aabbccddeeff"
     # Before assignment: location should be empty
-    row_before = registry.snapshot_for_api(now=1.0)[0]
+    row_before = snapshot_for_api(registry, now=1.0)[0]
     assert row_before["location_code"] == ""
 
     # Assign location
@@ -345,7 +348,7 @@ def test_set_location_populates_client_record(tmp_path: Path) -> None:
     assert record.location_code == "front_left_wheel"
 
     # After assignment: snapshot must expose the location
-    row_after = registry.snapshot_for_api(now=2.0)[0]
+    row_after = snapshot_for_api(registry, now=2.0)[0]
     assert row_after["location_code"] == "front_left_wheel"
 
 
@@ -354,7 +357,7 @@ def test_set_location_trims_whitespace(tmp_path: Path) -> None:
     registry = ClientRegistry(db=db)
     hex_id = "001122334455"
     registry.set_location(hex_id, "  rear_axle  ")
-    row = registry.snapshot_for_api(now=1.0)[0]
+    row = snapshot_for_api(registry, now=1.0)[0]
     assert row["location_code"] == "rear_axle"
 
 
@@ -407,7 +410,7 @@ def test_duplicate_seq_is_detected(tmp_path: Path) -> None:
     r2 = registry.update_from_data(msg, ("10.4.0.2", 50000), now=3.0)
     assert r2.is_duplicate is True
 
-    row = registry.snapshot_for_api(now=3.0)[0]
+    row = snapshot_for_api(registry, now=3.0)[0]
     assert row["frames_total"] == 1
     assert registry.get(client_id.hex()).duplicates_received == 1
 
@@ -425,7 +428,7 @@ def test_duplicate_does_not_inflate_frames_total(tmp_path: Path) -> None:
         msg = _data_msg(client_id, seq, seq * 10000)
         registry.update_from_data(msg, ("10.4.0.2", 50000), now=10.0 + seq)
 
-    row = registry.snapshot_for_api(now=15.0)[0]
+    row = snapshot_for_api(registry, now=15.0)[0]
     assert row["frames_total"] == 5
     assert registry.get(client_id.hex()).duplicates_received == 2
     assert row["dropped_frames"] == 0
@@ -444,7 +447,7 @@ def test_out_of_order_not_flagged_as_duplicate(tmp_path: Path) -> None:
     r = registry.update_from_data(msg1, ("10.4.0.2", 50000), now=5.0)
     assert r.is_duplicate is False
 
-    row = registry.snapshot_for_api(now=5.0)[0]
+    row = snapshot_for_api(registry, now=5.0)[0]
     assert row["frames_total"] == 3
     assert registry.get(client_id.hex()).duplicates_received == 0
 
@@ -468,7 +471,7 @@ def test_reset_clears_seen_seqs(tmp_path: Path) -> None:
     r2 = registry.update_from_data(msg_1, ("10.4.0.2", 50000), now=4.0)
     assert r2.is_duplicate is False
 
-    row = registry.snapshot_for_api(now=4.0)[0]
+    row = snapshot_for_api(registry, now=4.0)[0]
     assert row["frames_total"] == 3
     assert registry.get(client_id.hex()).duplicates_received == 0
 
@@ -486,7 +489,7 @@ def test_short_session_restart_not_flagged_as_duplicate(tmp_path: Path) -> None:
         msg = _data_msg(client_id, seq, seq * 10000)
         registry.update_from_data(msg, ("10.4.0.2", 50000), now=2.0 + seq * 0.01)
 
-    row = registry.snapshot_for_api(now=3.0)[0]
+    row = snapshot_for_api(registry, now=3.0)[0]
     assert row["frames_total"] == 50
     assert registry.get(client_id.hex()).duplicates_received == 0
 
@@ -496,6 +499,6 @@ def test_short_session_restart_not_flagged_as_duplicate(tmp_path: Path) -> None:
         r = registry.update_from_data(msg, ("10.4.0.2", 50000), now=5.0 + seq * 0.01)
         assert r.is_duplicate is False, f"seq={seq} wrongly flagged as duplicate"
 
-    row2 = registry.snapshot_for_api(now=6.0)[0]
+    row2 = snapshot_for_api(registry, now=6.0)[0]
     assert row2["frames_total"] == 100
     assert registry.get(client_id.hex()).duplicates_received == 0

--- a/apps/server/tests/infra/runtime/test_registry_location_cap.py
+++ b/apps/server/tests/infra/runtime/test_registry_location_cap.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
 from vibesensor.infra.runtime.registry import ClientRegistry
 
 _CLIENT_ID = "aabbccddeeff"
@@ -86,7 +87,7 @@ def test_set_location_visible_on_snapshot(tmp_path: Path) -> None:
     """The location is visible in the registry snapshot after set_location."""
     registry = _make_registry(tmp_path)
     registry.set_location(_CLIENT_ID, "rear-right")
-    snapshot = registry.snapshot_for_api(now=1.0)
+    snapshot = snapshot_for_api(registry, now=1.0)
     matched = [s for s in snapshot if s.get("id") == _CLIENT_ID]
     assert matched, "client_id not found in snapshot"
     assert matched[0].get("location_code") == "rear-right"

--- a/apps/server/tests/integration/test_refactor_contract_regressions.py
+++ b/apps/server/tests/integration/test_refactor_contract_regressions.py
@@ -17,11 +17,15 @@ import pytest
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage
 from vibesensor.domain import RunStatus
+from vibesensor.infra.runtime.client_snapshot import (
+    ClientSnapshot,
+    build_client_api_row,
+    snapshot_for_api,
+)
 from vibesensor.infra.runtime.registry import (
     _JITTER_EMA_ALPHA,
     _RESTART_SEQ_GAP,
     ClientRegistry,
-    ClientSnapshot,
 )
 from vibesensor.use_cases.updates.firmware_cache import FirmwareCacheConfig, GitHubReleaseFetcher
 from vibesensor.use_cases.updates.release_fetcher import (
@@ -211,7 +215,7 @@ class TestGitHubAPIClient:
 
 
 # ---------------------------------------------------------------------------
-# Fix 6: _client_api_row helper
+# Fix 6: client snapshot presenter helper
 # ---------------------------------------------------------------------------
 
 
@@ -234,23 +238,21 @@ _EXPECTED_ROW_KEYS = {
 
 
 class TestClientApiRow:
-    """Verify the extracted _client_api_row helper produces correct dicts."""
+    """Verify the extracted client snapshot presenter produces correct dicts."""
 
     def test_disconnected_row_has_all_keys(self) -> None:
-        row = ClientRegistry._client_api_row(
-            "aabbccddeeff",
-            ClientSnapshot(name="test-client", connected=False),
+        row = build_client_api_row(
+            ClientSnapshot(client_id="aabbccddeeff", name="test-client", connected=False),
         )
         assert set(row.keys()) == _EXPECTED_ROW_KEYS
 
     def test_connected_row_has_same_keys(self) -> None:
-        disconnected = ClientRegistry._client_api_row(
-            "aabbccddeeff",
-            ClientSnapshot(name="a", connected=False),
+        disconnected = build_client_api_row(
+            ClientSnapshot(client_id="aabbccddeeff", name="a", connected=False),
         )
-        connected = ClientRegistry._client_api_row(
-            "aabbccddeeff",
+        connected = build_client_api_row(
             ClientSnapshot(
+                client_id="aabbccddeeff",
                 name="b",
                 connected=True,
                 location_code="front-left",
@@ -262,9 +264,8 @@ class TestClientApiRow:
 
     def test_defaults_match_old_disconnected_shape(self) -> None:
         """Disconnected client row defaults match the original inline dict."""
-        row = ClientRegistry._client_api_row(
-            "aabbccddeeff",
-            ClientSnapshot(name="test", connected=False),
+        row = build_client_api_row(
+            ClientSnapshot(client_id="aabbccddeeff", name="test", connected=False),
         )
         assert row["connected"] is False
         assert row["location_code"] == ""
@@ -274,13 +275,12 @@ class TestClientApiRow:
         assert row["latest_metrics"] == {}
 
     def test_snapshot_uses_helper(self, registry: ClientRegistry) -> None:
-        """Verify snapshot_for_api returns rows with the same keys as _client_api_row."""
+        """Verify snapshot_for_api returns rows with the same keys as build_client_api_row."""
         registry.set_name("aabbccddeeff", "my-sensor")
-        rows = registry.snapshot_for_api(now=1.0, now_mono=1.0)
+        rows = snapshot_for_api(registry, now=1.0, now_mono=1.0)
         assert len(rows) == 1
-        helper_row = ClientRegistry._client_api_row(
-            "aabbccddeeff",
-            ClientSnapshot(name="my-sensor", connected=False),
+        helper_row = build_client_api_row(
+            ClientSnapshot(client_id="aabbccddeeff", name="my-sensor", connected=False),
         )
         assert set(rows[0].keys()) == set(helper_row.keys())
 

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException
 
 from vibesensor.adapters.http._helpers import normalize_client_id_or_400
 from vibesensor.adapters.udp.protocol import client_id_mac
+from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
 from vibesensor.shared.locations import all_locations, label_for_code
 from vibesensor.shared.types.api_models import (
     ClientLocationsResponse,
@@ -40,7 +41,7 @@ def create_client_routes(
     async def get_clients() -> ClientsResponse:
         active_ids = registry.active_client_ids()
         metrics = processor.all_latest_metrics(active_ids)
-        return ClientsResponse(clients=registry.snapshot_for_api(metrics_by_client=metrics))
+        return ClientsResponse(clients=snapshot_for_api(registry, metrics_by_client=metrics))
 
     @router.get("/api/client-locations", response_model=ClientLocationsResponse)
     async def get_client_locations() -> ClientLocationsResponse:

--- a/apps/server/vibesensor/infra/runtime/client_snapshot.py
+++ b/apps/server/vibesensor/infra/runtime/client_snapshot.py
@@ -1,0 +1,92 @@
+"""Client snapshot model and API/WS presenter helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from vibesensor.domain import normalize_sensor_id
+from vibesensor.shared.types.payload_types import ClientApiRow, ClientMetrics
+
+if TYPE_CHECKING:
+    from vibesensor.infra.runtime.registry import ClientRegistry
+
+
+@dataclass(slots=True)
+class ClientSnapshot:
+    """Raw client snapshot assembled from registry runtime state."""
+
+    client_id: str
+    name: str
+    connected: bool
+    location_code: str = ""
+    firmware_version: str = ""
+    sample_rate_hz: int = 0
+    frame_samples: int = 0
+    last_seen_age_ms: int | None = None
+    frames_total: int = 0
+    dropped_frames: int = 0
+    latest_metrics: ClientMetrics | None = None
+    reset_count: int = 0
+    last_reset_time: float | None = None
+
+
+def build_client_api_row(
+    snapshot: ClientSnapshot,
+    *,
+    include_metrics: bool = True,
+) -> ClientApiRow:
+    """Build a single client row for HTTP and WebSocket payloads."""
+    normalized_client_id = normalize_sensor_id(snapshot.client_id)
+    row: ClientApiRow = {
+        "id": normalized_client_id,
+        "mac_address": ":".join(
+            normalized_client_id[idx : idx + 2] for idx in range(0, len(normalized_client_id), 2)
+        ),
+        "name": snapshot.name,
+        "connected": snapshot.connected,
+        "location_code": snapshot.location_code,
+        "firmware_version": snapshot.firmware_version,
+        "sample_rate_hz": snapshot.sample_rate_hz,
+        "last_seen_age_ms": snapshot.last_seen_age_ms,
+        "frames_total": snapshot.frames_total,
+        "dropped_frames": snapshot.dropped_frames,
+    }
+    if include_metrics:
+        row["frame_samples"] = snapshot.frame_samples
+        row["latest_metrics"] = (
+            snapshot.latest_metrics if snapshot.latest_metrics is not None else ClientMetrics()
+        )
+        row["reset_count"] = snapshot.reset_count
+        row["last_reset_time"] = snapshot.last_reset_time
+    return row
+
+
+def build_client_api_rows(
+    snapshots: list[ClientSnapshot],
+    *,
+    include_metrics: bool = True,
+) -> list[ClientApiRow]:
+    """Project registry snapshots into the existing API/WS payload rows."""
+    return [
+        build_client_api_row(snapshot, include_metrics=include_metrics) for snapshot in snapshots
+    ]
+
+
+def snapshot_for_api(
+    registry: ClientRegistry,
+    now: float | None = None,
+    *,
+    now_mono: float | None = None,
+    metrics_by_client: dict[str, ClientMetrics] | None = None,
+    include_metrics: bool = True,
+) -> list[ClientApiRow]:
+    """Convenience presenter from registry snapshots to API rows."""
+    return build_client_api_rows(
+        registry.client_snapshots(
+            now=now,
+            now_mono=now_mono,
+            metrics_by_client=metrics_by_client,
+        ),
+        include_metrics=include_metrics,
+    )

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -1,7 +1,7 @@
 """Client registry — tracks active ESP32 sensor clients.
 
 Maintains per-client state (sequence numbers, dedup windows, last-seen
-timestamps) and exposes a snapshot API for connected clients.
+timestamps) and exposes raw client snapshots for transport presenters.
 """
 
 from __future__ import annotations
@@ -18,11 +18,10 @@ from vibesensor.adapters.udp.protocol import (
     DataMessage,
     HelloMessage,
     client_id_hex,
-    client_id_mac,
 )
 from vibesensor.domain import normalize_sensor_id as _normalize_client_id
-from vibesensor.infra.processing.models import ClientMetrics
-from vibesensor.shared.types.payload_types import ClientApiRow
+from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
+from vibesensor.shared.types.payload_types import ClientMetrics
 
 if TYPE_CHECKING:
     from vibesensor.adapters.persistence.history_db import HistoryDB
@@ -82,30 +81,6 @@ class DataUpdateResult:
     is_duplicate: bool = False
 
 
-@dataclass
-class ClientSnapshot:
-    """Flattened view of a single client for the API snapshot response.
-
-    Collected by :meth:`ClientRegistry.snapshot_for_api` from a
-    :class:`ClientRecord` and passed to :meth:`ClientRegistry._client_api_row`
-    so that the row-builder receives a single structured argument instead of
-    many keyword parameters.
-    """
-
-    name: str
-    connected: bool
-    location_code: str = ""
-    firmware_version: str = ""
-    sample_rate_hz: int = 0
-    frame_samples: int = 0
-    last_seen_age_ms: int | None = None
-    frames_total: int = 0
-    dropped_frames: int = 0
-    latest_metrics: ClientMetrics | None = None
-    reset_count: int = 0
-    last_reset_time: float | None = None
-
-
 @dataclass(slots=True)
 class ClientRecord:
     """Per-client state: last-seen timestamps, dedup window, hello/firmware metadata."""
@@ -161,7 +136,7 @@ class ClientRecord:
 
 
 class ClientRegistry:
-    """Thread-safe registry of connected ESP32 clients with snapshot and snapshot helpers."""
+    """Thread-safe registry of connected ESP32 clients with raw snapshot helpers."""
 
     def __init__(
         self,
@@ -528,63 +503,27 @@ class ClientRegistry:
             record.last_ack_cmd_seq = cmd_seq
             record.last_ack_status = None
 
-    @staticmethod
-    def _client_api_row(
-        client_id: str,
-        snapshot: ClientSnapshot,
-        *,
-        include_metrics: bool = True,
-    ) -> ClientApiRow:
-        """Build a single client row for the API snapshot.
-
-        Centralises the dict shape so both connected and disconnected
-        branches produce identical key sets.
-        """
-        row: ClientApiRow = {
-            "id": client_id,
-            "mac_address": client_id_mac(client_id),
-            "name": snapshot.name,
-            "connected": snapshot.connected,
-            "location_code": snapshot.location_code,
-            "firmware_version": snapshot.firmware_version,
-            "sample_rate_hz": snapshot.sample_rate_hz,
-            "last_seen_age_ms": snapshot.last_seen_age_ms,
-            "frames_total": snapshot.frames_total,
-            "dropped_frames": snapshot.dropped_frames,
-        }
-        if include_metrics:
-            row["frame_samples"] = snapshot.frame_samples
-            row["latest_metrics"] = (
-                snapshot.latest_metrics if snapshot.latest_metrics is not None else ClientMetrics()
-            )
-            row["reset_count"] = snapshot.reset_count
-            row["last_reset_time"] = snapshot.last_reset_time
-        return row
-
-    def snapshot_for_api(
+    def client_snapshots(
         self,
         now: float | None = None,
         *,
         now_mono: float | None = None,
         metrics_by_client: dict[str, ClientMetrics] | None = None,
-        include_metrics: bool = True,
-    ) -> list[ClientApiRow]:
+    ) -> list[ClientSnapshot]:
+        """Return raw per-client snapshots for transport presenters."""
         with self._lock:
             now_ts = self._resolve_now_wall(now)
             mono_now = self._resolve_now_mono(now_mono)
-            rows: list[ClientApiRow] = []
+            snapshots: list[ClientSnapshot] = []
             all_client_ids = sorted(set(self._clients) | set(self._user_names))
             for client_id in all_client_ids:
                 record = self._clients.get(client_id)
                 if record is None:
-                    rows.append(
-                        self._client_api_row(
-                            client_id,
-                            ClientSnapshot(
-                                name=self._user_names.get(client_id, f"client-{client_id[-4:]}"),
-                                connected=False,
-                            ),
-                            include_metrics=include_metrics,
+                    snapshots.append(
+                        ClientSnapshot(
+                            client_id=client_id,
+                            name=self._user_names.get(client_id, f"client-{client_id[-4:]}"),
+                            connected=False,
                         ),
                     )
                     continue
@@ -595,28 +534,25 @@ class ClientRegistry:
                     record.last_seen_mono
                     and (mono_now - record.last_seen_mono) <= self._stale_ttl_seconds,
                 )
-                rows.append(
-                    self._client_api_row(
-                        record.client_id,
-                        ClientSnapshot(
-                            name=record.name,
-                            connected=connected,
-                            location_code=record.location_code,
-                            firmware_version=record.firmware_version,
-                            sample_rate_hz=record.sample_rate_hz,
-                            frame_samples=record.frame_samples,
-                            last_seen_age_ms=age_ms,
-                            frames_total=record.frames_total,
-                            dropped_frames=record.frames_dropped,
-                            latest_metrics=(
-                                metrics_by_client.get(record.client_id, {})
-                                if metrics_by_client is not None
-                                else {}
-                            ),
-                            reset_count=record.reset_count,
-                            last_reset_time=record.last_reset_time,
+                snapshots.append(
+                    ClientSnapshot(
+                        client_id=record.client_id,
+                        name=record.name,
+                        connected=connected,
+                        location_code=record.location_code,
+                        firmware_version=record.firmware_version,
+                        sample_rate_hz=record.sample_rate_hz,
+                        frame_samples=record.frame_samples,
+                        last_seen_age_ms=age_ms,
+                        frames_total=record.frames_total,
+                        dropped_frames=record.frames_dropped,
+                        latest_metrics=(
+                            metrics_by_client.get(record.client_id)
+                            if metrics_by_client is not None
+                            else None
                         ),
-                        include_metrics=include_metrics,
+                        reset_count=record.reset_count,
+                        last_reset_time=record.last_reset_time,
                     ),
                 )
-            return rows
+            return snapshots

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
+from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
 from vibesensor.infra.runtime.processing_loop import STALE_DATA_AGE_S
 from vibesensor.infra.runtime.rotational_speeds import (
     build_rotational_speeds_payload,
@@ -78,7 +79,7 @@ class WsBroadcastService:
         self.include_heavy = (self.tick % heavy_every) == 0
 
     def _build_shared_payload(self) -> LiveWsPayload:
-        clients = self._registry.snapshot_for_api(include_metrics=False)
+        clients = snapshot_for_api(self._registry, include_metrics=False)
         client_ids = [c["id"] for c in clients]
         fresh_ids = self._processor.clients_with_recent_data(
             client_ids,

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -33,7 +33,7 @@ Scope: single source of truth for detailed file layout, entry points, package st
 - `adapters/persistence/`: SQLite history DB (`history_db/` keeps `HistoryDB` as the public facade and splits internals across `_run_lifecycle.py`, `_sample_io.py`, `_queries.py`, `_schema.py`, and `_samples.py`) and the static car library loader (`car_library.py`).
 - `adapters/pdf/`: PDF/report rendering pipeline and report mapping entrypoints.
 - `adapters/udp/`, `adapters/gps/`, `adapters/simulator/`, `adapters/hotspot/`: UDP protocol transport, GPS speed ingestion, simulator tooling, and hotspot/AP operational adapters.
-- `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination.
+- `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination. `registry.py` owns raw `ClientRegistry` state tracking plus `client_snapshots()`, while `client_snapshot.py` owns the client-row presenter reused by `/api/clients` and `ws_broadcast.py`.
 - `infra/processing/`: signal processing pipeline (buffers, FFT, payload shaping, and processor facade).
 - `infra/config/`: runtime settings store (single `SettingsStore` owns both analysis and device settings) used by runtime wiring and exposed to use-cases through focused shared read ports.
 - `infra/workers/`: worker-pool infrastructure.


### PR DESCRIPTION
Summary
- move client row formatting out of ClientRegistry into infra/runtime/client_snapshot.py
- make ClientRegistry expose raw client_snapshots() and update HTTP plus WS callers to use the presenter
- update runtime regression tests and runtime ownership docs to match the new seam

Testing
- ruff check apps/server/vibesensor/infra/runtime/client_snapshot.py apps/server/vibesensor/infra/runtime/registry.py apps/server/vibesensor/infra/runtime/ws_broadcast.py apps/server/vibesensor/adapters/http/clients.py apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/adapters/http/_history_endpoint_helpers.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/integration/test_refactor_contract_regressions.py
- pytest -q apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/integration/test_refactor_contract_regressions.py
- pytest -q apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/integration/test_refactor_contract_regressions.py
- make docs-lint
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #828
