### PR TITLE
Expose finding schemas in HTTP contract

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -56,3 +56,31 @@ def test_export_schema_contains_typed_history_list_entry(schema_dict: dict[str, 
     assert history_response["properties"]["runs"]["items"] == {
         "$ref": "#/components/schemas/HistoryListEntryResponse",
     }
+
+
+def test_export_schema_contains_finding_components_for_history_insights(
+    schema_dict: dict[str, Any],
+) -> None:
+    history_insights = schema_dict["components"]["schemas"]["HistoryInsightsResponse"]
+    finding_payload = schema_dict["components"]["schemas"]["FindingPayload"]
+
+    assert history_insights["properties"]["findings"]["items"] == {
+        "$ref": "#/components/schemas/FindingPayload",
+    }
+    assert history_insights["properties"]["top_causes"]["items"] == {
+        "$ref": "#/components/schemas/FindingPayload",
+    }
+    assert {
+        "finding_id",
+        "suspected_source",
+        "amplitude_metric",
+        "evidence_metrics",
+        "matched_points",
+    }.issubset(finding_payload["properties"])
+    assert finding_payload["properties"]["evidence_metrics"]["anyOf"] == [
+        {"$ref": "#/components/schemas/FindingEvidenceMetrics"},
+        {"type": "null"},
+    ]
+    assert finding_payload["properties"]["matched_points"]["items"] == {
+        "$ref": "#/components/schemas/MatchedPoint",
+    }

--- a/apps/server/vibesensor/shared/types/api_models.py
+++ b/apps/server/vibesensor/shared/types/api_models.py
@@ -55,7 +55,13 @@ __all__ = [
     "HistoryListResponse",
     "HistoryRunResponse",
     "HistoryInsightWarningResponse",
+    "AmplitudeMetric",
+    "FindingEvidenceMetrics",
+    "FindingPayload",
     "HistoryInsightsResponse",
+    "LocationHotspotPayload",
+    "MatchedPoint",
+    "PhaseEvidence",
     "DeleteHistoryRunResponse",
     "UpdateRuntimeResponse",
     "UpdateIssueResponse",
@@ -78,6 +84,9 @@ __all__ = [
     "CarLibraryModelEntry",
     "CarLibraryModelsResponse",
 ]
+
+ApiPayloadObject: TypeAlias = dict[str, object]
+ApiPayloadValue: TypeAlias = None | bool | int | float | str | list[object] | ApiPayloadObject
 
 # ---------------------------------------------------------------------------
 # Shared base classes
@@ -454,12 +463,133 @@ class HistoryInsightWarningResponse(BaseModel):
     detail: str | None = None
 
 
+class MatchedPoint(_ExtraAllowBase):
+    """HTTP contract for one serialized finding matched-point observation."""
+
+    t_s: float | None = None
+    speed_kmh: float | None = None
+    predicted_hz: float | None = None
+    matched_hz: float | None = None
+    rel_error: float | None = None
+    amp: float | None = None
+    location: str | None = None
+    phase: str | None = None
+
+
+class PhaseEvidence(_ExtraAllowBase):
+    """HTTP contract for optional driving-phase evidence attached to a finding."""
+
+    cruise_fraction: float | None = None
+    phases_detected: list[str] = Field(default_factory=list)
+
+
+class AmplitudeMetric(_ExtraAllowBase):
+    """HTTP contract for finding amplitude/strength metadata.
+
+    The runtime payload currently emits both a compact
+    ``{"vibration_strength_db": ...}`` shape and richer
+    ``{"name", "value", "units", "definition"}`` objects in tests/report helpers,
+    so the schema keeps both representations legal without changing runtime behavior.
+    """
+
+    name: str | None = None
+    value: float | None = None
+    units: str | None = None
+    definition: ApiPayloadValue = None
+    vibration_strength_db: float | None = None
+
+
+class LocationHotspotPayload(_ExtraAllowBase):
+    """HTTP contract for serialized location-hotspot evidence."""
+
+    dominance_ratio: float | None = None
+    location_count: int | None = None
+    top_location: str | None = None
+    second_location: str | None = None
+    ambiguous_location: bool | None = None
+    ambiguous_locations: list[str] = Field(default_factory=list)
+    localization_confidence: float | None = None
+    weak_spatial_separation: bool | None = None
+
+
+class FindingEvidenceMetrics(_ExtraAllowBase):
+    """HTTP contract for serialized evidence metrics attached to a finding."""
+
+    match_rate: float | None = None
+    global_match_rate: float | None = None
+    focused_speed_band: str | None = None
+    mean_relative_error: float | None = None
+    mean_noise_floor_db: float | None = None
+    vibration_strength_db: float | None = None
+    possible_samples: int | None = None
+    matched_samples: int | None = None
+    frequency_correlation: float | None = None
+    per_phase_confidence: dict[str, float] | None = None
+    phases_with_evidence: int | None = None
+    presence_ratio: float | None = None
+    median_intensity_db: float | None = None
+    p95_intensity_db: float | None = None
+    max_intensity_db: float | None = None
+    burstiness: float | None = None
+    run_noise_baseline_db: float | None = None
+    median_relative_to_run_noise: float | None = None
+    p95_relative_to_run_noise: float | None = None
+    sample_count: int | None = None
+    total_samples: int | None = None
+    spatial_concentration: float | None = None
+    spatial_uniformity: float | None = None
+    speed_uniformity: float | None = None
+
+
+class FindingPayload(_ExtraAllowBase):
+    """HTTP contract for one serialized finding in analysis history payloads."""
+
+    finding_id: str
+    suspected_source: str
+    evidence_summary: ApiPayloadValue
+    frequency_hz_or_order: ApiPayloadValue
+    amplitude_metric: AmplitudeMetric
+    confidence: float | None
+    quick_checks: list[ApiPayloadValue]
+    finding_kind: str | None = None
+    finding_key: str | None = None
+    severity: str | None = None
+    confidence_label_key: str | None = None
+    confidence_tone: str | None = None
+    confidence_pct: str | None = None
+    matched_points: list[MatchedPoint] = Field(default_factory=list)
+    location_hotspot: LocationHotspotPayload | None = None
+    strongest_location: str | None = None
+    strongest_speed_band: str | None = None
+    dominant_phase: str | None = None
+    peak_speed_kmh: float | None = None
+    speed_window_kmh: list[float] | None = None
+    dominance_ratio: float | None = None
+    localization_confidence: float | None = None
+    weak_spatial_separation: bool | None = None
+    corroborating_locations: int | None = None
+    diffuse_excitation: bool | None = None
+    phase_evidence: PhaseEvidence | None = None
+    evidence_metrics: FindingEvidenceMetrics | None = None
+    next_sensor_move: ApiPayloadValue = None
+    actions: list[ApiPayloadObject] = Field(default_factory=list)
+    ranking_score: float | None = None
+    peak_classification: str | None = None
+    phase_presence: dict[str, float] | None = None
+    signatures_observed: list[str] = Field(default_factory=list)
+    grouped_count: int | None = None
+    order: str | None = None
+    diagnostic_caveat: ApiPayloadValue = None
+
+
 class HistoryInsightsResponse(_ExtraAllowBase):
     """Response body with aggregated diagnostic insights for a run."""
 
     run_id: str | None = None
     status: str | None = None
     warnings: list[HistoryInsightWarningResponse] = Field(default_factory=list)
+    findings: list[FindingPayload] = Field(default_factory=list)
+    top_causes: list[FindingPayload] = Field(default_factory=list)
 
 
 class DeleteHistoryRunResponse(BaseModel):
@@ -653,6 +783,3 @@ class CarLibraryModelsResponse(BaseModel):
     """Response body listing car library model entries."""
 
     models: list[CarLibraryModelEntry]
-
-
-ApiPayloadObject: TypeAlias = dict[str, object]

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -16,6 +16,86 @@
         "title": "ActiveCarRequest",
         "type": "object"
       },
+      "AmplitudeMetric": {
+        "additionalProperties": true,
+        "description": "HTTP contract for finding amplitude/strength metadata.\n\nThe runtime payload currently emits both a compact\n``{\"vibration_strength_db\": ...}`` shape and richer\n``{\"name\", \"value\", \"units\", \"definition\"}`` objects in tests/report helpers,\nso the schema keeps both representations legal without changing runtime behavior.",
+        "properties": {
+          "definition": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Definition"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "units": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Units"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          },
+          "vibration_strength_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibration Strength Db"
+          }
+        },
+        "title": "AmplitudeMetric",
+        "type": "object"
+      },
       "AnalysisSettingsRequest": {
         "description": "Request body for updating vehicle analysis settings (tire geometry, gear ratios, etc.).",
         "properties": {
@@ -1455,6 +1535,752 @@
         "title": "EspSerialPortResponse",
         "type": "object"
       },
+      "FindingEvidenceMetrics": {
+        "additionalProperties": true,
+        "description": "HTTP contract for serialized evidence metrics attached to a finding.",
+        "properties": {
+          "burstiness": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Burstiness"
+          },
+          "focused_speed_band": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focused Speed Band"
+          },
+          "frequency_correlation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Correlation"
+          },
+          "global_match_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Global Match Rate"
+          },
+          "match_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match Rate"
+          },
+          "matched_samples": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Samples"
+          },
+          "max_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Intensity Db"
+          },
+          "mean_noise_floor_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Noise Floor Db"
+          },
+          "mean_relative_error": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Relative Error"
+          },
+          "median_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Median Intensity Db"
+          },
+          "median_relative_to_run_noise": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Median Relative To Run Noise"
+          },
+          "p95_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "P95 Intensity Db"
+          },
+          "p95_relative_to_run_noise": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "P95 Relative To Run Noise"
+          },
+          "per_phase_confidence": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Per Phase Confidence"
+          },
+          "phases_with_evidence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phases With Evidence"
+          },
+          "possible_samples": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Possible Samples"
+          },
+          "presence_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Presence Ratio"
+          },
+          "run_noise_baseline_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Noise Baseline Db"
+          },
+          "sample_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sample Count"
+          },
+          "spatial_concentration": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spatial Concentration"
+          },
+          "spatial_uniformity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spatial Uniformity"
+          },
+          "speed_uniformity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Uniformity"
+          },
+          "total_samples": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Samples"
+          },
+          "vibration_strength_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vibration Strength Db"
+          }
+        },
+        "title": "FindingEvidenceMetrics",
+        "type": "object"
+      },
+      "FindingPayload": {
+        "additionalProperties": true,
+        "description": "HTTP contract for one serialized finding in analysis history payloads.",
+        "properties": {
+          "actions": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "amplitude_metric": {
+            "$ref": "#/components/schemas/AmplitudeMetric"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "confidence_label_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Label Key"
+          },
+          "confidence_pct": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Pct"
+          },
+          "confidence_tone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Tone"
+          },
+          "corroborating_locations": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corroborating Locations"
+          },
+          "diagnostic_caveat": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diagnostic Caveat"
+          },
+          "diffuse_excitation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diffuse Excitation"
+          },
+          "dominance_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominance Ratio"
+          },
+          "dominant_phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominant Phase"
+          },
+          "evidence_metrics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FindingEvidenceMetrics"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "evidence_summary": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence Summary"
+          },
+          "finding_id": {
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "finding_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finding Key"
+          },
+          "finding_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finding Kind"
+          },
+          "frequency_hz_or_order": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Hz Or Order"
+          },
+          "grouped_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grouped Count"
+          },
+          "localization_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Localization Confidence"
+          },
+          "location_hotspot": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LocationHotspotPayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "matched_points": {
+            "items": {
+              "$ref": "#/components/schemas/MatchedPoint"
+            },
+            "title": "Matched Points",
+            "type": "array"
+          },
+          "next_sensor_move": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Sensor Move"
+          },
+          "order": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order"
+          },
+          "peak_classification": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peak Classification"
+          },
+          "peak_speed_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peak Speed Kmh"
+          },
+          "phase_evidence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PhaseEvidence"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "phase_presence": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Presence"
+          },
+          "quick_checks": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {},
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": "Quick Checks",
+            "type": "array"
+          },
+          "ranking_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ranking Score"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "signatures_observed": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Signatures Observed",
+            "type": "array"
+          },
+          "speed_window_kmh": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Window Kmh"
+          },
+          "strongest_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strongest Location"
+          },
+          "strongest_speed_band": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strongest Speed Band"
+          },
+          "suspected_source": {
+            "title": "Suspected Source",
+            "type": "string"
+          },
+          "weak_spatial_separation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weak Spatial Separation"
+          }
+        },
+        "required": [
+          "finding_id",
+          "suspected_source",
+          "evidence_summary",
+          "frequency_hz_or_order",
+          "amplitude_metric",
+          "confidence",
+          "quick_checks"
+        ],
+        "title": "FindingPayload",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -1859,6 +2685,13 @@
         "additionalProperties": true,
         "description": "Response body with aggregated diagnostic insights for a run.",
         "properties": {
+          "findings": {
+            "items": {
+              "$ref": "#/components/schemas/FindingPayload"
+            },
+            "title": "Findings",
+            "type": "array"
+          },
           "run_id": {
             "anyOf": [
               {
@@ -1880,6 +2713,13 @@
               }
             ],
             "title": "Status"
+          },
+          "top_causes": {
+            "items": {
+              "$ref": "#/components/schemas/FindingPayload"
+            },
+            "title": "Top Causes",
+            "type": "array"
           },
           "warnings": {
             "items": {
@@ -2073,6 +2913,98 @@
         "title": "LanguageResponse",
         "type": "object"
       },
+      "LocationHotspotPayload": {
+        "additionalProperties": true,
+        "description": "HTTP contract for serialized location-hotspot evidence.",
+        "properties": {
+          "ambiguous_location": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ambiguous Location"
+          },
+          "ambiguous_locations": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Ambiguous Locations",
+            "type": "array"
+          },
+          "dominance_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominance Ratio"
+          },
+          "localization_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Localization Confidence"
+          },
+          "location_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Count"
+          },
+          "second_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Second Location"
+          },
+          "top_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Location"
+          },
+          "weak_spatial_separation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weak Spatial Separation"
+          }
+        },
+        "title": "LocationHotspotPayload",
+        "type": "object"
+      },
       "LocationOptionResponse": {
         "description": "A single sensor-location option (code + human-readable label).",
         "properties": {
@@ -2090,6 +3022,128 @@
           "label"
         ],
         "title": "LocationOptionResponse",
+        "type": "object"
+      },
+      "MatchedPoint": {
+        "additionalProperties": true,
+        "description": "HTTP contract for one serialized finding matched-point observation.",
+        "properties": {
+          "amp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amp"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "matched_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Hz"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase"
+          },
+          "predicted_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicted Hz"
+          },
+          "rel_error": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rel Error"
+          },
+          "speed_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Kmh"
+          },
+          "t_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "T S"
+          }
+        },
+        "title": "MatchedPoint",
+        "type": "object"
+      },
+      "PhaseEvidence": {
+        "additionalProperties": true,
+        "description": "HTTP contract for optional driving-phase evidence attached to a finding.",
+        "properties": {
+          "cruise_fraction": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cruise Fraction"
+          },
+          "phases_detected": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Phases Detected",
+            "type": "array"
+          }
+        },
+        "title": "PhaseEvidence",
         "type": "object"
       },
       "RawSamplesErrorPayload": {

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -206,6 +206,30 @@ export interface components {
       carId: string;
     };
     /**
+     * AmplitudeMetric
+     * @description HTTP contract for finding amplitude/strength metadata.
+     *
+     * The runtime payload currently emits both a compact
+     * ``{"vibration_strength_db": ...}`` shape and richer
+     * ``{"name", "value", "units", "definition"}`` objects in tests/report helpers,
+     * so the schema keeps both representations legal without changing runtime behavior.
+     */
+    AmplitudeMetric: {
+      /** Definition */
+      definition?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Name */
+      name?: string | null;
+      /** Units */
+      units?: string | null;
+      /** Value */
+      value?: number | null;
+      /** Vibration Strength Db */
+      vibration_strength_db?: number | null;
+      [key: string]: unknown;
+    };
+    /**
      * AnalysisSettingsRequest
      * @description Request body for updating vehicle analysis settings (tire geometry, gear ratios, etc.).
      */
@@ -709,6 +733,152 @@ export interface components {
       /** Vid */
       vid?: number | null;
     };
+    /**
+     * FindingEvidenceMetrics
+     * @description HTTP contract for serialized evidence metrics attached to a finding.
+     */
+    FindingEvidenceMetrics: {
+      /** Burstiness */
+      burstiness?: number | null;
+      /** Focused Speed Band */
+      focused_speed_band?: string | null;
+      /** Frequency Correlation */
+      frequency_correlation?: number | null;
+      /** Global Match Rate */
+      global_match_rate?: number | null;
+      /** Match Rate */
+      match_rate?: number | null;
+      /** Matched Samples */
+      matched_samples?: number | null;
+      /** Max Intensity Db */
+      max_intensity_db?: number | null;
+      /** Mean Noise Floor Db */
+      mean_noise_floor_db?: number | null;
+      /** Mean Relative Error */
+      mean_relative_error?: number | null;
+      /** Median Intensity Db */
+      median_intensity_db?: number | null;
+      /** Median Relative To Run Noise */
+      median_relative_to_run_noise?: number | null;
+      /** P95 Intensity Db */
+      p95_intensity_db?: number | null;
+      /** P95 Relative To Run Noise */
+      p95_relative_to_run_noise?: number | null;
+      /** Per Phase Confidence */
+      per_phase_confidence?: {
+        [key: string]: number;
+      } | null;
+      /** Phases With Evidence */
+      phases_with_evidence?: number | null;
+      /** Possible Samples */
+      possible_samples?: number | null;
+      /** Presence Ratio */
+      presence_ratio?: number | null;
+      /** Run Noise Baseline Db */
+      run_noise_baseline_db?: number | null;
+      /** Sample Count */
+      sample_count?: number | null;
+      /** Spatial Concentration */
+      spatial_concentration?: number | null;
+      /** Spatial Uniformity */
+      spatial_uniformity?: number | null;
+      /** Speed Uniformity */
+      speed_uniformity?: number | null;
+      /** Total Samples */
+      total_samples?: number | null;
+      /** Vibration Strength Db */
+      vibration_strength_db?: number | null;
+      [key: string]: unknown;
+    };
+    /**
+     * FindingPayload
+     * @description HTTP contract for one serialized finding in analysis history payloads.
+     */
+    FindingPayload: {
+      /** Actions */
+      actions?: {
+          [key: string]: unknown;
+        }[];
+      amplitude_metric: components["schemas"]["AmplitudeMetric"];
+      /** Confidence */
+      confidence: number | null;
+      /** Confidence Label Key */
+      confidence_label_key?: string | null;
+      /** Confidence Pct */
+      confidence_pct?: string | null;
+      /** Confidence Tone */
+      confidence_tone?: string | null;
+      /** Corroborating Locations */
+      corroborating_locations?: number | null;
+      /** Diagnostic Caveat */
+      diagnostic_caveat?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Diffuse Excitation */
+      diffuse_excitation?: boolean | null;
+      /** Dominance Ratio */
+      dominance_ratio?: number | null;
+      /** Dominant Phase */
+      dominant_phase?: string | null;
+      evidence_metrics?: components["schemas"]["FindingEvidenceMetrics"] | null;
+      /** Evidence Summary */
+      evidence_summary: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Finding Id */
+      finding_id: string;
+      /** Finding Key */
+      finding_key?: string | null;
+      /** Finding Kind */
+      finding_kind?: string | null;
+      /** Frequency Hz Or Order */
+      frequency_hz_or_order: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Grouped Count */
+      grouped_count?: number | null;
+      /** Localization Confidence */
+      localization_confidence?: number | null;
+      location_hotspot?: components["schemas"]["LocationHotspotPayload"] | null;
+      /** Matched Points */
+      matched_points?: components["schemas"]["MatchedPoint"][];
+      /** Next Sensor Move */
+      next_sensor_move?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Order */
+      order?: string | null;
+      /** Peak Classification */
+      peak_classification?: string | null;
+      /** Peak Speed Kmh */
+      peak_speed_kmh?: number | null;
+      phase_evidence?: components["schemas"]["PhaseEvidence"] | null;
+      /** Phase Presence */
+      phase_presence?: {
+        [key: string]: number;
+      } | null;
+      /** Quick Checks */
+      quick_checks: (boolean | number | string | unknown[] | {
+          [key: string]: unknown;
+        } | null)[];
+      /** Ranking Score */
+      ranking_score?: number | null;
+      /** Severity */
+      severity?: string | null;
+      /** Signatures Observed */
+      signatures_observed?: string[];
+      /** Speed Window Kmh */
+      speed_window_kmh?: number[] | null;
+      /** Strongest Location */
+      strongest_location?: string | null;
+      /** Strongest Speed Band */
+      strongest_speed_band?: string | null;
+      /** Suspected Source */
+      suspected_source: string;
+      /** Weak Spatial Separation */
+      weak_spatial_separation?: boolean | null;
+      [key: string]: unknown;
+    };
     /** HTTPValidationError */
     HTTPValidationError: {
       /** Detail */
@@ -891,10 +1061,14 @@ export interface components {
      * @description Response body with aggregated diagnostic insights for a run.
      */
     HistoryInsightsResponse: {
+      /** Findings */
+      findings?: components["schemas"]["FindingPayload"][];
       /** Run Id */
       run_id?: string | null;
       /** Status */
       status?: string | null;
+      /** Top Causes */
+      top_causes?: components["schemas"]["FindingPayload"][];
       /** Warnings */
       warnings?: components["schemas"]["HistoryInsightWarningResponse"][];
       [key: string]: unknown;
@@ -987,6 +1161,29 @@ export interface components {
       language: string;
     };
     /**
+     * LocationHotspotPayload
+     * @description HTTP contract for serialized location-hotspot evidence.
+     */
+    LocationHotspotPayload: {
+      /** Ambiguous Location */
+      ambiguous_location?: boolean | null;
+      /** Ambiguous Locations */
+      ambiguous_locations?: string[];
+      /** Dominance Ratio */
+      dominance_ratio?: number | null;
+      /** Localization Confidence */
+      localization_confidence?: number | null;
+      /** Location Count */
+      location_count?: number | null;
+      /** Second Location */
+      second_location?: string | null;
+      /** Top Location */
+      top_location?: string | null;
+      /** Weak Spatial Separation */
+      weak_spatial_separation?: boolean | null;
+      [key: string]: unknown;
+    };
+    /**
      * LocationOptionResponse
      * @description A single sensor-location option (code + human-readable label).
      */
@@ -995,6 +1192,40 @@ export interface components {
       code: string;
       /** Label */
       label: string;
+    };
+    /**
+     * MatchedPoint
+     * @description HTTP contract for one serialized finding matched-point observation.
+     */
+    MatchedPoint: {
+      /** Amp */
+      amp?: number | null;
+      /** Location */
+      location?: string | null;
+      /** Matched Hz */
+      matched_hz?: number | null;
+      /** Phase */
+      phase?: string | null;
+      /** Predicted Hz */
+      predicted_hz?: number | null;
+      /** Rel Error */
+      rel_error?: number | null;
+      /** Speed Kmh */
+      speed_kmh?: number | null;
+      /** T S */
+      t_s?: number | null;
+      [key: string]: unknown;
+    };
+    /**
+     * PhaseEvidence
+     * @description HTTP contract for optional driving-phase evidence attached to a finding.
+     */
+    PhaseEvidence: {
+      /** Cruise Fraction */
+      cruise_fraction?: number | null;
+      /** Phases Detected */
+      phases_detected?: string[];
+      [key: string]: unknown;
     };
     /** RawSamplesErrorPayload */
     RawSamplesErrorPayload: {


### PR DESCRIPTION
## Summary
- add explicit finding-focused HTTP response models and wire `HistoryInsightsResponse` to expose `findings`/`top_causes`
- regenerate the exported HTTP OpenAPI schema and generated UI HTTP contract types so findings become named components
- add schema-export regression coverage for the insights response contract

## Testing
- `PATH="$PWD/.venv/bin:$PATH" ruff check apps/server/vibesensor/shared/types/api_models.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `PATH="$PWD/.venv/bin:$PATH" ruff format --check apps/server/vibesensor/shared/types/api_models.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python -m pytest -q apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `cd apps/ui && npm run typecheck`
- `PATH="$PWD/.venv/bin:$PATH" make docs-lint`
- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests`

Closes #829
