### PR TITLE
Clarify the FindingPayload boundary

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -77,6 +77,18 @@ def test_export_schema_contains_finding_components_for_history_insights(
         "evidence_metrics",
         "matched_points",
     }.issubset(finding_payload["properties"])
+    assert {
+        "quick_checks",
+        "peak_speed_kmh",
+        "speed_window_kmh",
+        "localization_confidence",
+        "corroborating_locations",
+        "next_sensor_move",
+        "actions",
+        "phase_presence",
+        "grouped_count",
+        "diagnostic_caveat",
+    }.isdisjoint(finding_payload["properties"])
     assert finding_payload["properties"]["evidence_metrics"]["anyOf"] == [
         {"$ref": "#/components/schemas/FindingEvidenceMetrics"},
         {"type": "null"},

--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -229,7 +229,7 @@ class TestFindingDomainObject:
             "peak_classification": "harmonic",
             # Extra payload-only fields should be ignored
             "evidence_summary": "some evidence",
-            "quick_checks": [],
+            "legacy_unused_field": [],
         }
         f = finding_from_payload(payload)
         assert f.finding_id == "F001"

--- a/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from vibesensor.domain import Finding, VibrationSource
+from vibesensor.shared.boundaries.finding import finding_payload_from_domain
+
+
+def test_projection_emits_canonical_amplitude_metric_shape() -> None:
+    payload = finding_payload_from_domain(
+        Finding(
+            finding_id="F001",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            vibration_strength_db=22.3,
+        )
+    )
+
+    assert payload["amplitude_metric"] == {
+        "name": "vibration_strength_db",
+        "value": 22.3,
+        "units": "dB",
+        "definition": {"_i18n_key": "METRIC_VIBRATION_STRENGTH_DB"},
+    }
+    assert payload["evidence_metrics"] == {"vibration_strength_db": 22.3}
+
+
+def test_projection_omits_removed_dead_contract_fields() -> None:
+    payload = finding_payload_from_domain(
+        Finding(
+            finding_id="F001",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            vibration_strength_db=22.3,
+        )
+    )
+
+    assert {
+        "quick_checks",
+        "peak_speed_kmh",
+        "speed_window_kmh",
+        "localization_confidence",
+        "corroborating_locations",
+        "next_sensor_move",
+        "actions",
+        "phase_presence",
+        "grouped_count",
+        "diagnostic_caveat",
+    }.isdisjoint(payload)

--- a/apps/server/tests/test_support/findings.py
+++ b/apps/server/tests/test_support/findings.py
@@ -55,7 +55,6 @@ def make_finding_payload(
             "definition": {"_i18n_key": "METRIC"},
         },
         "confidence": confidence,
-        "quick_checks": [],
         "ranking_score": ranking_score,
     }
     if severity != "diagnostic":

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -58,12 +58,23 @@ def test_finding_typed_dict_exposes_core_contract() -> None:
         "frequency_hz_or_order",
         "amplitude_metric",
         "confidence",
-        "quick_checks",
         "evidence_metrics",
         "phase_evidence",
     }.issubset(hints)
     assert hints["amplitude_metric"] == AmplitudeMetric
     assert hints["matched_points"] == list[MatchedPoint]
+    assert {
+        "quick_checks",
+        "peak_speed_kmh",
+        "speed_window_kmh",
+        "localization_confidence",
+        "corroborating_locations",
+        "next_sensor_move",
+        "actions",
+        "phase_presence",
+        "grouped_count",
+        "diagnostic_caveat",
+    }.isdisjoint(hints)
 
 
 # -- speed_profile tests ------------------------------------------------------

--- a/apps/server/vibesensor/domain/finding.py
+++ b/apps/server/vibesensor/domain/finding.py
@@ -259,7 +259,8 @@ class Finding:
     """One diagnostic conclusion or cause candidate from analysis.
 
     This is the first-class domain object for a finding.
-    ``FindingPayload`` (the TypedDict in ``analysis._types``) remains as
+    ``FindingPayload`` (the TypedDict in
+    ``vibesensor.shared.boundaries.analysis_payload``) remains as
     the serialization/payload shape; use
     :func:`~vibesensor.shared.boundaries.finding.finding_from_payload` to create
     a domain ``Finding`` from a payload dict.

--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -91,6 +91,8 @@ class PhaseEvidence(TypedDict, total=False):
 
 
 class AmplitudeMetric(TypedDict):
+    """Presentation-only vibration-strength summary attached to a finding payload."""
+
     name: str
     value: float | None
     units: str
@@ -164,42 +166,51 @@ class RunSuitabilityCheck(TypedDict):
 
 
 class FindingPayload(TypedDict, total=False):
+    """Serialized finding payload used at transport and persistence boundaries.
+
+    This payload intentionally remains a superset of the domain
+    :class:`~vibesensor.domain.Finding`:
+
+    * direct domain fields are copied across unchanged,
+    * ``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,
+      and the confidence label fields are presentation-oriented projections
+      computed during ``finding_payload_from_domain()``,
+    * ``matched_points``, ``phase_evidence``, ``evidence_metrics``,
+      ``location_hotspot``, and ``signatures_observed`` are boundary mirrors
+      of richer domain sub-objects.
+    """
+
+    # Direct domain-owned finding state.
     finding_id: Required[str]
-    suspected_source: Required[str]
-    evidence_summary: Required[JsonValue]
-    frequency_hz_or_order: Required[JsonValue]
-    amplitude_metric: Required[AmplitudeMetric]
-    confidence: Required[float | None]
-    quick_checks: Required[list[JsonValue]]
-    finding_kind: str
     finding_key: str
+    suspected_source: Required[str]
+    confidence: Required[float | None]
+    finding_kind: str
     severity: str
-    confidence_label_key: str
-    confidence_tone: str
-    confidence_pct: str
-    matched_points: list[MatchedPoint]
-    location_hotspot: LocationHotspotPayload | None
     strongest_location: str | None
     strongest_speed_band: str | None
     dominant_phase: str | None
-    peak_speed_kmh: float | None
-    speed_window_kmh: list[float] | None
     dominance_ratio: float | None
-    localization_confidence: float
     weak_spatial_separation: bool
-    corroborating_locations: int
     diffuse_excitation: bool
-    phase_evidence: PhaseEvidence | None
-    evidence_metrics: FindingEvidenceMetrics
-    next_sensor_move: JsonValue
-    actions: list[JsonObject]
     ranking_score: float
     peak_classification: str
-    phase_presence: dict[str, float] | None
-    signatures_observed: list[str]
-    grouped_count: int
     order: str
-    diagnostic_caveat: JsonValue
+
+    # Presentation-only projections computed from domain-owned data.
+    evidence_summary: Required[JsonValue]
+    frequency_hz_or_order: Required[JsonValue]
+    amplitude_metric: Required[AmplitudeMetric]
+    confidence_label_key: str
+    confidence_tone: str
+    confidence_pct: str
+
+    # Boundary mirrors of richer nested domain objects.
+    matched_points: list[MatchedPoint]
+    location_hotspot: LocationHotspotPayload | None
+    phase_evidence: PhaseEvidence | None
+    evidence_metrics: FindingEvidenceMetrics
+    signatures_observed: list[str]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -21,6 +21,7 @@ from vibesensor.shared.boundaries.vibration_origin import (
     location_hotspot_from_payload,
     vibration_origin_from_payload,
 )
+from vibesensor.shared.json_utils import i18n_ref
 
 _MAX_SIGNATURES_PER_FINDING: int = 3
 
@@ -58,6 +59,16 @@ def step_payload_from_action(action: RecommendedAction) -> dict[str, object]:
 def step_payloads_from_plan(test_plan: TestPlan) -> list[dict[str, object]]:
     """Project a semantic TestPlan into the persisted TestStep payload list."""
     return [step_payload_from_action(action) for action in test_plan.prioritized_actions]
+
+
+def _amplitude_metric_payload(finding: Finding) -> dict[str, object]:
+    """Project the canonical presentation-only amplitude summary for a finding."""
+    return {
+        "name": "vibration_strength_db",
+        "value": finding.vibration_strength_db,
+        "units": "dB",
+        "definition": i18n_ref("METRIC_VIBRATION_STRENGTH_DB"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -230,10 +241,10 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
 def finding_payload_from_domain(
     finding: Finding,
 ) -> dict[str, object]:
-    """Project a domain Finding to a complete payload dict.
+    """Project a domain Finding to the current persisted/public payload dict.
 
-    Produces all FindingPayload fields from domain objects alone,
-    without pass-through shortcuts to original payload dicts.
+    Produces the documented ``FindingPayload`` contract from domain objects
+    alone, without pass-through shortcuts to original payload dicts.
     """
     payload: dict[str, object] = {
         "finding_id": finding.finding_id,
@@ -252,8 +263,7 @@ def finding_payload_from_domain(
         "frequency_hz_or_order": (
             finding.frequency_hz if finding.frequency_hz is not None else finding.order or ""
         ),
-        "amplitude_metric": {"vibration_strength_db": finding.vibration_strength_db},
-        "quick_checks": [],
+        "amplitude_metric": _amplitude_metric_payload(finding),
     }
     if finding.severity:
         payload["severity"] = finding.severity

--- a/apps/server/vibesensor/shared/types/api_models.py
+++ b/apps/server/vibesensor/shared/types/api_models.py
@@ -542,17 +542,22 @@ class FindingEvidenceMetrics(_ExtraAllowBase):
 
 
 class FindingPayload(_ExtraAllowBase):
-    """HTTP contract for one serialized finding in analysis history payloads."""
+    """HTTP contract for one serialized finding in analysis history payloads.
+
+    This schema mirrors ``shared.boundaries.analysis_payload.FindingPayload``.
+    It intentionally includes a few presentation-oriented projections
+    (``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,
+    and the confidence label fields) alongside the domain-owned finding data.
+    """
 
     finding_id: str
+    finding_key: str | None = None
     suspected_source: str
     evidence_summary: ApiPayloadValue
     frequency_hz_or_order: ApiPayloadValue
     amplitude_metric: AmplitudeMetric
     confidence: float | None
-    quick_checks: list[ApiPayloadValue]
     finding_kind: str | None = None
-    finding_key: str | None = None
     severity: str | None = None
     confidence_label_key: str | None = None
     confidence_tone: str | None = None
@@ -562,24 +567,15 @@ class FindingPayload(_ExtraAllowBase):
     strongest_location: str | None = None
     strongest_speed_band: str | None = None
     dominant_phase: str | None = None
-    peak_speed_kmh: float | None = None
-    speed_window_kmh: list[float] | None = None
     dominance_ratio: float | None = None
-    localization_confidence: float | None = None
     weak_spatial_separation: bool | None = None
-    corroborating_locations: int | None = None
     diffuse_excitation: bool | None = None
     phase_evidence: PhaseEvidence | None = None
     evidence_metrics: FindingEvidenceMetrics | None = None
-    next_sensor_move: ApiPayloadValue = None
-    actions: list[ApiPayloadObject] = Field(default_factory=list)
     ranking_score: float | None = None
     peak_classification: str | None = None
-    phase_presence: dict[str, float] | None = None
     signatures_observed: list[str] = Field(default_factory=list)
-    grouped_count: int | None = None
     order: str | None = None
-    diagnostic_caveat: ApiPayloadValue = None
 
 
 class HistoryInsightsResponse(_ExtraAllowBase):

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -1812,16 +1812,8 @@
       },
       "FindingPayload": {
         "additionalProperties": true,
-        "description": "HTTP contract for one serialized finding in analysis history payloads.",
+        "description": "HTTP contract for one serialized finding in analysis history payloads.\n\nThis schema mirrors ``shared.boundaries.analysis_payload.FindingPayload``.\nIt intentionally includes a few presentation-oriented projections\n(``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,\nand the confidence label fields) alongside the domain-owned finding data.",
         "properties": {
-          "actions": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Actions",
-            "type": "array"
-          },
           "amplitude_metric": {
             "$ref": "#/components/schemas/AmplitudeMetric"
           },
@@ -1868,45 +1860,6 @@
               }
             ],
             "title": "Confidence Tone"
-          },
-          "corroborating_locations": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corroborating Locations"
-          },
-          "diagnostic_caveat": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Diagnostic Caveat"
           },
           "diffuse_excitation": {
             "anyOf": [
@@ -2033,28 +1986,6 @@
             ],
             "title": "Frequency Hz Or Order"
           },
-          "grouped_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grouped Count"
-          },
-          "localization_confidence": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Localization Confidence"
-          },
           "location_hotspot": {
             "anyOf": [
               {
@@ -2071,34 +2002,6 @@
             },
             "title": "Matched Points",
             "type": "array"
-          },
-          "next_sensor_move": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Sensor Move"
           },
           "order": {
             "anyOf": [
@@ -2122,17 +2025,6 @@
             ],
             "title": "Peak Classification"
           },
-          "peak_speed_kmh": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Peak Speed Kmh"
-          },
           "phase_evidence": {
             "anyOf": [
               {
@@ -2142,51 +2034,6 @@
                 "type": "null"
               }
             ]
-          },
-          "phase_presence": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "type": "number"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Phase Presence"
-          },
-          "quick_checks": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "items": {},
-                  "type": "array"
-                },
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "title": "Quick Checks",
-            "type": "array"
           },
           "ranking_score": {
             "anyOf": [
@@ -2216,20 +2063,6 @@
             },
             "title": "Signatures Observed",
             "type": "array"
-          },
-          "speed_window_kmh": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "number"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Speed Window Kmh"
           },
           "strongest_location": {
             "anyOf": [
@@ -2275,8 +2108,7 @@
           "evidence_summary",
           "frequency_hz_or_order",
           "amplitude_metric",
-          "confidence",
-          "quick_checks"
+          "confidence"
         ],
         "title": "FindingPayload",
         "type": "object"

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -793,12 +793,13 @@ export interface components {
     /**
      * FindingPayload
      * @description HTTP contract for one serialized finding in analysis history payloads.
+     *
+     * This schema mirrors ``shared.boundaries.analysis_payload.FindingPayload``.
+     * It intentionally includes a few presentation-oriented projections
+     * (``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,
+     * and the confidence label fields) alongside the domain-owned finding data.
      */
     FindingPayload: {
-      /** Actions */
-      actions?: {
-          [key: string]: unknown;
-        }[];
       amplitude_metric: components["schemas"]["AmplitudeMetric"];
       /** Confidence */
       confidence: number | null;
@@ -808,12 +809,6 @@ export interface components {
       confidence_pct?: string | null;
       /** Confidence Tone */
       confidence_tone?: string | null;
-      /** Corroborating Locations */
-      corroborating_locations?: number | null;
-      /** Diagnostic Caveat */
-      diagnostic_caveat?: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
       /** Diffuse Excitation */
       diffuse_excitation?: boolean | null;
       /** Dominance Ratio */
@@ -835,40 +830,20 @@ export interface components {
       frequency_hz_or_order: boolean | number | string | unknown[] | {
         [key: string]: unknown;
       } | null;
-      /** Grouped Count */
-      grouped_count?: number | null;
-      /** Localization Confidence */
-      localization_confidence?: number | null;
       location_hotspot?: components["schemas"]["LocationHotspotPayload"] | null;
       /** Matched Points */
       matched_points?: components["schemas"]["MatchedPoint"][];
-      /** Next Sensor Move */
-      next_sensor_move?: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
       /** Order */
       order?: string | null;
       /** Peak Classification */
       peak_classification?: string | null;
-      /** Peak Speed Kmh */
-      peak_speed_kmh?: number | null;
       phase_evidence?: components["schemas"]["PhaseEvidence"] | null;
-      /** Phase Presence */
-      phase_presence?: {
-        [key: string]: number;
-      } | null;
-      /** Quick Checks */
-      quick_checks: (boolean | number | string | unknown[] | {
-          [key: string]: unknown;
-        } | null)[];
       /** Ranking Score */
       ranking_score?: number | null;
       /** Severity */
       severity?: string | null;
       /** Signatures Observed */
       signatures_observed?: string[];
-      /** Speed Window Kmh */
-      speed_window_kmh?: number[] | null;
       /** Strongest Location */
       strongest_location?: string | null;
       /** Strongest Speed Band */


### PR DESCRIPTION
## Summary
- document which serialized finding fields are intentional presentation-only projections versus domain mirrors
- remove dead FindingPayload contract keys from the backend model and generated HTTP schema/types
- normalize projected amplitude metrics and add focused regression coverage for the finding boundary

## Testing
- PATH="$PWD/.venv/bin:$PATH" pytest -q apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/shared/boundaries/test_enrich_findings_equivalence.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_test_plan.py apps/server/tests/domain/test_domain_objects.py apps/server/tests/adapters/http/test_http_api_schema_export.py
- PATH="$PWD/.venv/bin:$PATH" make typecheck-backend
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests
- cd apps/ui && npm run typecheck && npm run build

Closes #835