### PR TITLE
Extend mypy coverage to diagnostics helpers

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -116,6 +116,8 @@ files = [
   "vibesensor/use_cases/diagnostics/plots.py",
   "vibesensor/use_cases/diagnostics/location_analysis.py",
   "vibesensor/use_cases/diagnostics/phase_segmentation.py",
+  "vibesensor/use_cases/diagnostics/rotational_physics.py",
+  "vibesensor/use_cases/diagnostics/spectrogram.py",
   "vibesensor/use_cases/diagnostics/findings.py",
   "vibesensor/use_cases/diagnostics/order_analysis.py",
   "vibesensor/use_cases/diagnostics/summary_builder.py",


### PR DESCRIPTION
## Summary
- add `rotational_physics.py` and `spectrogram.py` to the curated backend mypy file list
- confirm both diagnostics helper modules already type-check cleanly under the existing strict settings

## Testing
- PATH="$PWD/.venv/bin:$PATH" python -m mypy --config-file apps/server/pyproject.toml apps/server/vibesensor/use_cases/diagnostics/rotational_physics.py apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
- PATH="$PWD/.venv/bin:$PATH" make typecheck-backend
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #834