### PR TITLE
Guard canonical finding evidence keys

### DIFF
--- a/apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py
+++ b/apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from vibesensor.domain.finding import VibrationSource
-from vibesensor.shared.boundaries.finding import finding_from_payload
+from vibesensor.domain.finding import Finding, FindingEvidence, VibrationSource
+from vibesensor.shared.boundaries.finding import finding_from_payload, finding_payload_from_domain
 
 
 class TestLegacySourceAlias:
@@ -44,3 +44,17 @@ class TestLegacySnrRatioAlias:
         # snr_db should be None because the normalization was removed
         assert finding.evidence is not None
         assert finding.evidence.snr_db is None
+
+    def test_projection_uses_only_canonical_snr_db_key(self) -> None:
+        finding = Finding(
+            finding_id="F-snr",
+            suspected_source=VibrationSource.DRIVELINE,
+            evidence=FindingEvidence(snr_db=12.5),
+        )
+
+        payload = finding_payload_from_domain(finding)
+
+        evidence_metrics = payload["evidence_metrics"]
+        assert isinstance(evidence_metrics, dict)
+        assert evidence_metrics["snr_db"] == 12.5
+        assert "snr_ratio" not in evidence_metrics


### PR DESCRIPTION
## Summary
- confirm the finding boundary alias cleanup is already live by guarding the canonical `snr_db` evidence key on write
- keep the existing read-side regression proving `snr_ratio` no longer hydrates domain finding evidence

## Testing
- PATH="$PWD/.venv/bin:$PATH" pytest -q apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/shared/boundaries/test_enrich_findings_equivalence.py
- PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #837