### PR TITLE
Type settings API payloads

### DIFF
--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -1,6 +1,8 @@
 import { apiJson } from "./http";
 import type {
+  AnalysisSettingsRequest,
   AnalysisSettingsPayload,
+  CarUpsertRequest,
   CarsPayload,
   EspFlashCancelPayload,
   EspFlashHistoryPayload,
@@ -10,6 +12,7 @@ import type {
   EspFlashStatusPayload,
   HealthStatusPayload,
   LanguagePayload,
+  SpeedSourceRequest,
   SpeedSourcePayload,
   SpeedSourceStatusPayload,
   SpeedUnitPayload,
@@ -48,7 +51,7 @@ export async function getAnalysisSettings(): Promise<AnalysisSettingsPayload> {
   return apiJson("/api/settings/analysis");
 }
 
-export async function setAnalysisSettings(payload: Record<string, number>): Promise<AnalysisSettingsPayload> {
+export async function setAnalysisSettings(payload: AnalysisSettingsRequest): Promise<AnalysisSettingsPayload> {
   return apiJson("/api/settings/analysis", {
     method: "POST",
     headers: JSON_HEADERS,
@@ -60,7 +63,7 @@ export async function getSettingsCars(): Promise<CarsPayload> {
   return apiJson("/api/settings/cars");
 }
 
-export async function addSettingsCar(car: Record<string, unknown>): Promise<CarsPayload> {
+export async function addSettingsCar(car: CarUpsertRequest): Promise<CarsPayload> {
   return apiJson("/api/settings/cars", {
     method: "POST",
     headers: JSON_HEADERS,
@@ -68,7 +71,7 @@ export async function addSettingsCar(car: Record<string, unknown>): Promise<Cars
   });
 }
 
-export async function updateSettingsCar(carId: string, car: Record<string, unknown>): Promise<CarsPayload> {
+export async function updateSettingsCar(carId: string, car: CarUpsertRequest): Promise<CarsPayload> {
   return apiJson(`/api/settings/cars/${encodeURIComponent(carId)}`, {
     method: "PUT",
     headers: JSON_HEADERS,
@@ -94,7 +97,7 @@ export async function getSettingsSpeedSource(): Promise<SpeedSourcePayload> {
   return apiJson("/api/settings/speed-source");
 }
 
-export async function updateSettingsSpeedSource(data: Record<string, unknown>): Promise<SpeedSourcePayload> {
+export async function updateSettingsSpeedSource(data: SpeedSourceRequest): Promise<SpeedSourcePayload> {
   return apiJson("/api/settings/speed-source", {
     method: "POST",
     headers: JSON_HEADERS,

--- a/apps/ui/src/api/types.ts
+++ b/apps/ui/src/api/types.ts
@@ -2,6 +2,7 @@ import type { components } from "../generated/http_api_contracts";
 
 type Schema<Name extends keyof components["schemas"]> = components["schemas"][Name];
 
+export type AnalysisSettingsRequest = Schema<"AnalysisSettingsRequest">;
 export type AnalysisSettingsPayload = Schema<"AnalysisSettingsResponse">;
 export type CarLibraryBrandsPayload = Schema<"CarLibraryBrandsResponse">;
 export type CarLibraryGearbox = Schema<"CarLibraryGearboxEntry">;
@@ -10,6 +11,7 @@ export type CarLibraryModelsPayload = Schema<"CarLibraryModelsResponse">;
 export type CarLibraryTireOption = Schema<"CarLibraryTireOptionEntry">;
 export type CarLibraryTypesPayload = Schema<"CarLibraryTypesResponse">;
 export type CarLibraryVariant = Schema<"CarLibraryVariantEntry">;
+export type CarUpsertRequest = Schema<"CarUpsertRequest">;
 export type CarRecord = Schema<"CarResponse">;
 export type CarsPayload = Schema<"CarsResponse">;
 export type ClientLocationsResponse = Schema<"ClientLocationsResponse">;
@@ -34,6 +36,8 @@ export type HistoryRunPayload = Schema<"HistoryRunResponse">;
 export type LanguagePayload = Schema<"LanguageResponse">;
 export type LocationOption = Schema<"LocationOptionResponse">;
 export type LoggingStatusPayload = Schema<"RecordingStatusResponse">;
+export type SpeedSourceKind = Schema<"SpeedSourceKind">;
+export type SpeedSourceRequest = Schema<"SpeedSourceRequest">;
 export type SpeedSourcePayload = Schema<"SpeedSourceResponse">;
 export type SpeedSourceStatusPayload = Schema<"SpeedSourceStatusResponse">;
 export type SpeedUnitPayload = Schema<"SpeedUnitResponse">;

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -2,8 +2,12 @@ import type { FeatureDepsBase } from "../feature_deps_base";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { AppState } from "../ui_app_state";
 import type {
+  AnalysisSettingsRequest,
   AnalysisSettingsPayload,
+  CarUpsertRequest,
   CarsPayload,
+  SpeedSourceKind,
+  SpeedSourceRequest,
   SpeedSourcePayload,
   SpeedSourceStatusPayload,
 } from "../../api/types";
@@ -66,7 +70,12 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
 
   const GPS_POLL_FAST = 2_000;
   const GPS_POLL_SLOW = 10_000;
+  const SPEED_SOURCE_KINDS = ["gps", "manual", "obd2"] as const satisfies readonly SpeedSourceKind[];
   let gpsPollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function isSpeedSourceKind(value: string): value is SpeedSourceKind {
+    return SPEED_SOURCE_KINDS.some((kind) => kind === value);
+  }
 
   function hasValidActiveCar(): boolean {
     return Boolean(state.activeCarId && state.cars.some((c) => c.id === state.activeCarId));
@@ -107,7 +116,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
 
   async function syncSpeedSourceToServer(): Promise<void> {
     try {
-      const payload: Record<string, unknown> = {
+      const payload: SpeedSourceRequest = {
         speedSource: state.speedSource,
         manualSpeedKph: state.manualSpeedKph,
       };
@@ -141,7 +150,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   }
 
   async function syncAnalysisSettingsToServer(): Promise<void> {
-    const payload: Record<string, number> = {};
+    const payload: AnalysisSettingsRequest = {};
     for (const key of ANALYSIS_SETTING_KEYS) {
       payload[key] = state.vehicleSettings[key];
     }
@@ -277,8 +286,10 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
 
   function saveSpeedSourceFromInputs(): void {
     const radios = document.querySelectorAll<HTMLInputElement>('input[name="speedSourceRadio"]');
-    let src = "gps";
-    radios.forEach((r) => { if (r.checked) src = r.value; });
+    let src: SpeedSourceKind = "gps";
+    radios.forEach((r) => {
+      if (r.checked && isSpeedSourceKind(r.value)) src = r.value;
+    });
     const manual = Number(els.manualSpeedInput?.value);
     state.speedSource = src;
     state.manualSpeedKph = Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null;
@@ -336,7 +347,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   async function addCarFromWizard(name: string, carType: string, aspects: Record<string, number>, variant?: string): Promise<void> {
     try {
       const fullAspects = { ...state.vehicleSettings, ...aspects };
-      const payload: Record<string, unknown> = { name, type: carType, aspects: fullAspects };
+      const payload: CarUpsertRequest = { name, type: carType, aspects: fullAspects };
       if (variant) payload.variant = variant;
       const result = await addSettingsCar(payload);
       if (Array.isArray(result.cars)) {

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -9,6 +9,7 @@ import type {
   HistoryInsightsPayload,
   LocationOption,
   LoggingStatusPayload,
+  SpeedSourceKind,
 } from "../api/types";
 
 export interface VehicleSettings {
@@ -103,7 +104,7 @@ export interface AppState {
   vehicleSettings: VehicleSettings;
   cars: CarRecord[];
   activeCarId: string | null;
-  speedSource: string;
+  speedSource: SpeedSourceKind;
   manualSpeedKph: number | null;
   gpsFallbackActive: boolean;
   chartBands: ChartBand[];


### PR DESCRIPTION
## Summary
- use generated request contract types for settings write endpoints instead of untyped Record payloads
- type the matching settings feature payload builders and tighten speed-source state typing to the generated union
- validate with `cd apps/ui && npm run typecheck && npm run build`

Closes #838