### PR TITLE
Extend mypy coverage to updates

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -109,6 +109,7 @@ files = [
   "vibesensor/report_i18n.py",
   "vibesensor/strength_bands.py",
   "vibesensor/coerce.py",
+  "vibesensor/use_cases/updates",
   "vibesensor/use_cases/diagnostics/_types.py",
   "vibesensor/use_cases/diagnostics/helpers.py",
   "vibesensor/use_cases/diagnostics/top_cause_selection.py",

--- a/apps/server/vibesensor/use_cases/updates/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/release_validation.py
@@ -205,7 +205,10 @@ def packaged_static_index_path() -> Path:
             os.environ.pop("VIBESENSOR_DISABLE_AUTO_APP", None)
         else:
             os.environ["VIBESENSOR_DISABLE_AUTO_APP"] = previous_disable_auto_app
-    return Path(app_module.__file__).resolve().parent.parent / "static" / "index.html"
+    module_file = app_module.__file__
+    if module_file is None:
+        raise RuntimeError("vibesensor.app module is missing __file__")
+    return Path(module_file).resolve().parent.parent / "static" / "index.html"
 
 
 def validate_packaged_static_assets() -> Path:


### PR DESCRIPTION
## Summary
- add the full `vibesensor/use_cases/updates` package to the curated backend mypy files list
- fix the one remaining strict-mypy error in `release_validation.py` by guarding the imported module path
- validate with strict mypy on the updates package, `make typecheck-backend`, and the backend CI subset

Closes #836