### PR TITLE
Extend mypy coverage to vibration strength

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -109,6 +109,7 @@ files = [
   "vibesensor/report_i18n.py",
   "vibesensor/strength_bands.py",
   "vibesensor/coerce.py",
+  "vibesensor/vibration_strength.py",
   "vibesensor/use_cases/updates",
   "vibesensor/use_cases/diagnostics/_types.py",
   "vibesensor/use_cases/diagnostics/helpers.py",


### PR DESCRIPTION
## Summary
- add `vibesensor/vibration_strength.py` to the curated backend mypy files list
- verify the module already passes strict mypy without code changes
- validate with direct mypy on the module, `make typecheck-backend`, and the backend CI subset

Closes #839