### PR TITLE
Promote HTTP adapters to mypy coverage

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -164,14 +164,8 @@ disallow_any_unimported = false
 [[tool.mypy.overrides]]
 module = [
   "vibesensor.adapters.udp.protocol",
-  "vibesensor.adapters.http.updates",
-  "vibesensor.adapters.http.car_library",
-  "vibesensor.adapters.http.debug",
   "vibesensor.adapters.http.settings",
-  "vibesensor.adapters.http.clients",
   "vibesensor.adapters.http.history",
-  "vibesensor.adapters.http.recording",
-  "vibesensor.adapters.http.health",
   "vibesensor.adapters.pdf.pdf_page2",
   "vibesensor.infra.runtime.health_snapshot",
 ]

--- a/apps/server/vibesensor/adapters/http/car_library.py
+++ b/apps/server/vibesensor/adapters/http/car_library.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from vibesensor.shared.types.api_models import (
     CarLibraryBrandsResponse,
+    CarLibraryModelEntry,
     CarLibraryModelsResponse,
     CarLibraryTypesResponse,
 )
@@ -48,6 +49,11 @@ def create_car_library_routes() -> APIRouter:
                 status_code=404,
                 detail=f"Unknown type {car_type!r} for brand {brand!r}",
             )
-        return CarLibraryModelsResponse(models=get_models_for_brand_type(brand, car_type))
+        return CarLibraryModelsResponse(
+            models=[
+                CarLibraryModelEntry.model_validate(model)
+                for model in get_models_for_brand_type(brand, car_type)
+            ]
+        )
 
     return router

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -16,6 +16,7 @@ from vibesensor.shared.types.api_models import (
     ClientsResponse,
     IdentifyRequest,
     IdentifyResponse,
+    LocationOptionResponse,
     RemoveClientResponse,
     SetClientLocationResponse,
     SetLocationRequest,
@@ -45,7 +46,11 @@ def create_client_routes(
 
     @router.get("/api/client-locations", response_model=ClientLocationsResponse)
     async def get_client_locations() -> ClientLocationsResponse:
-        return ClientLocationsResponse(locations=all_locations())
+        return ClientLocationsResponse(
+            locations=[
+                LocationOptionResponse.model_validate(location) for location in all_locations()
+            ]
+        )
 
     @router.post("/api/clients/{client_id}/identify", response_model=IdentifyResponse)
     async def identify_client(client_id: str, req: IdentifyRequest) -> IdentifyResponse:
@@ -90,7 +95,7 @@ def create_client_routes(
             registry.clear_name(normalized_client_id)
 
         updated = registry.get(normalized_client_id)
-        name = updated.name if updated else None
+        name = updated.name if updated and updated.name is not None else ""
         mac = client_id_mac(normalized_client_id)
         await asyncio.to_thread(settings_store.set_sensor, mac, {"location_code": code})
         return SetClientLocationResponse(

--- a/apps/server/vibesensor/adapters/http/debug.py
+++ b/apps/server/vibesensor/adapters/http/debug.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeGuard
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
 
 __all__ = ["create_debug_routes"]
+
+
+def _is_raw_samples_error_payload(
+    payload: RawSamplesPayload | RawSamplesErrorPayload,
+) -> TypeGuard[RawSamplesErrorPayload]:
+    return "error" in payload
 
 
 def create_debug_routes(processor: SignalProcessor) -> APIRouter:
@@ -46,7 +52,7 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
         """Raw time-domain samples in g for offline analysis."""
         normalized = normalize_client_id_or_400(client_id)
         result = processor.raw_samples(normalized, n_samples=n)
-        if isinstance(result, dict) and "error" in result:
+        if _is_raw_samples_error_payload(result):
             raise HTTPException(
                 status_code=404,
                 detail=result["error"],

--- a/apps/server/vibesensor/adapters/http/health.py
+++ b/apps/server/vibesensor/adapters/http/health.py
@@ -29,8 +29,8 @@ def create_health_routes(
 
     @router.get("/api/health", response_model=HealthResponse)
     async def health() -> HealthResponse:
-        return HealthResponse(
-            **build_health_snapshot(loop_state, health_state, processor, registry, run_recorder)
+        return HealthResponse.model_validate(
+            build_health_snapshot(loop_state, health_state, processor, registry, run_recorder)
         )
 
     return router

--- a/apps/server/vibesensor/adapters/http/health_snapshot.py
+++ b/apps/server/vibesensor/adapters/http/health_snapshot.py
@@ -23,6 +23,10 @@ def build_health_snapshot(
     run_recorder: RunRecorder,
 ) -> HealthSnapshotData:
     """Build the health snapshot dict."""
+
+    def _coerce_duration(value: float | None) -> float:
+        return value if value is not None else 0.0
+
     failures = loop_state.processing_failure_count
     data_loss = registry.data_loss_snapshot()
     persistence = run_recorder.health_snapshot()
@@ -90,9 +94,9 @@ def build_health_snapshot(
         "data_loss": data_loss,
         "persistence": persistence,
         "intake_stats": processor.intake_stats(),
-        "tick_duration_s": loop_state.last_tick_duration_s,
-        "max_tick_duration_s": loop_state.max_tick_duration_s,
+        "tick_duration_s": _coerce_duration(loop_state.last_tick_duration_s),
+        "max_tick_duration_s": _coerce_duration(loop_state.max_tick_duration_s),
         "tick_count": loop_state.tick_count,
-        "db_last_write_duration_s": run_recorder.last_write_duration_s,
-        "db_max_write_duration_s": run_recorder.max_write_duration_s,
+        "db_last_write_duration_s": _coerce_duration(run_recorder.last_write_duration_s),
+        "db_max_write_duration_s": _coerce_duration(run_recorder.max_write_duration_s),
     }

--- a/apps/server/vibesensor/adapters/http/recording.py
+++ b/apps/server/vibesensor/adapters/http/recording.py
@@ -22,14 +22,14 @@ def create_recording_routes(
 
     @router.get("/api/recording/status", response_model=RecordingStatusResponse)
     async def get_logging_status() -> RecordingStatusResponse:
-        return RecordingStatusResponse(**run_recorder.status())
+        return RecordingStatusResponse.model_validate(run_recorder.status())
 
     @router.post("/api/recording/start", response_model=RecordingStatusResponse)
     async def start_logging() -> RecordingStatusResponse:
-        return RecordingStatusResponse(**run_recorder.start_recording())
+        return RecordingStatusResponse.model_validate(run_recorder.start_recording())
 
     @router.post("/api/recording/stop", response_model=RecordingStatusResponse)
     async def stop_logging() -> RecordingStatusResponse:
-        return RecordingStatusResponse(**run_recorder.stop_recording())
+        return RecordingStatusResponse.model_validate(run_recorder.stop_recording())
 
     return router

--- a/apps/server/vibesensor/adapters/http/updates.py
+++ b/apps/server/vibesensor/adapters/http/updates.py
@@ -39,7 +39,7 @@ def create_update_routes(
 
     @router.get("/api/update/status", response_model=UpdateStatusResponse)
     async def get_update_status() -> UpdateStatusResponse:
-        return UpdateStatusResponse(**update_manager.status.to_dict())
+        return UpdateStatusResponse.model_validate(update_manager.status.to_dict())
 
     @router.post("/api/update/start", response_model=UpdateStartResponse)
     async def start_update(req: UpdateStartRequest) -> UpdateStartResponse:
@@ -56,7 +56,7 @@ def create_update_routes(
     @router.get("/api/esp-flash/ports", response_model=EspFlashPortsResponse)
     async def list_esp_flash_ports() -> EspFlashPortsResponse:
         ports = await esp_flash_manager.list_ports()
-        return EspFlashPortsResponse(ports=ports)
+        return EspFlashPortsResponse.model_validate({"ports": ports})
 
     @router.post("/api/esp-flash/start", response_model=EspFlashStartResponse)
     async def start_esp_flash(req: EspFlashStartRequest) -> EspFlashStartResponse:
@@ -66,11 +66,11 @@ def create_update_routes(
 
     @router.get("/api/esp-flash/status", response_model=EspFlashStatusResponse)
     async def get_esp_flash_status() -> EspFlashStatusResponse:
-        return EspFlashStatusResponse(**esp_flash_manager.status.to_dict())
+        return EspFlashStatusResponse.model_validate(esp_flash_manager.status.to_dict())
 
     @router.get("/api/esp-flash/logs", response_model=EspFlashLogsResponse)
     async def get_esp_flash_logs(after: int = Query(default=0, ge=0)) -> EspFlashLogsResponse:
-        return EspFlashLogsResponse(**esp_flash_manager.logs_since(after))
+        return EspFlashLogsResponse.model_validate(esp_flash_manager.logs_since(after))
 
     @router.post("/api/esp-flash/cancel", response_model=EspFlashCancelResponse)
     async def cancel_esp_flash() -> EspFlashCancelResponse:
@@ -78,6 +78,6 @@ def create_update_routes(
 
     @router.get("/api/esp-flash/history", response_model=EspFlashHistoryResponse)
     async def get_esp_flash_history() -> EspFlashHistoryResponse:
-        return EspFlashHistoryResponse(attempts=esp_flash_manager.history())
+        return EspFlashHistoryResponse.model_validate({"attempts": esp_flash_manager.history()})
 
     return router


### PR DESCRIPTION
## Summary
- remove six HTTP adapter modules from the backend mypy ignore_errors override
- fix their surfaced typing issues by validating raw payloads at the HTTP boundary and tightening a few adapter return paths
- validate with unsuppressed mypy on the promoted slice, `make typecheck-backend`, and the backend CI subset

Closes #840