### PR TITLE
Deduplicate AI instruction guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,8 @@ Domain model (scope: behavioral rules only; see `docs/ai/repo-map.md` for file l
 - Consumers import from `vibesensor.domain`, not from individual module files.
 - Boundary decoders/serializers live under `apps/server/vibesensor/shared/boundaries/`; do not rebuild payload-driven business logic in report/history/runtime consumers.
 
-Common commands
+Canonical commands
+- This is the single source of truth for recurring local and CI command invocations; other AI guidance should reference this list instead of repeating it.
 - `python -m pip install -e "./apps/server[dev]"`
 - `make lint`
 - `make typecheck-backend`

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -2,7 +2,6 @@
 applyTo: "apps/server/**"
 ---
 Backend (scope: backend-specific behavioral rules and deltas; see `docs/ai/repo-map.md` for full package layout and entry points)
-- Shared workflow/validation rules live in `.github/instructions/general.instructions.md`; this file only captures backend-specific deltas.
 - Backend ownership boundaries: see `docs/ai/repo-map.md` § "Backend package layout" for the full module map and `docs/domain-model.md` for the domain object graph.
 - Domain-first modeling rules:
 	- Domain objects own behavior (classification, ranking, lifecycle, computation). Adapters at persistence/transport/rendering boundaries bridge to/from domain objects but do not duplicate domain logic.
@@ -18,12 +17,9 @@ Backend (scope: backend-specific behavioral rules and deltas; see `docs/ai/repo-
 	- Validate report-facing output (rendered/report API/PDF text and ordering), not just internal helper outputs.
 	- When user-facing report text changes, update `apps/server/data/report_i18n.json`.
 	- `apps/server/vibesensor/use_cases/updates/`: wheel-based updater package; `manager.py` is the public facade with workflow orchestration and validation; other modules handle Wi-Fi, releases, ESP flash, firmware cache, release validation, install and rollback, and status. Do not add backward-compatibility shims, static method passthroughs, or module-level aliases in `use_cases/updates/`; when methods move to sub-modules, update callers directly.
-- Install: `python -m pip install -e "./apps/server[dev]"` (used by CI).
-- Backend type gate: `make typecheck-backend` runs the enforced mypy slice for the reorganized `app/`, `shared/`, `domain/`, `infra/`, `use_cases/`, and `adapters/` packages.
+- Use the canonical backend command list in `.github/copilot-instructions.md`; its backend type gate is the enforced mypy slice for the reorganized `app/`, `shared/`, `domain/`, `infra/`, `use_cases/`, and `adapters/` packages, and `docs/testing.md` covers backend test placement and command details.
 - Prefer explicit payload contracts (`TypedDict`, dataclass, protocol, `JsonValue`/`JsonObject` aliases) over broad `Any` when shaping analysis, report, and persistence data.
 - Treat `Any` as a design smell by default: prefer `object` for untrusted inputs, shared JSON aliases for persisted payloads, `ParamSpec` for callable wrappers, and focused `TypedDict`/protocol contracts for nested state.
 - For live processing / WebSocket payloads, prefer shared contracts in `apps/server/vibesensor/shared/types/payload_types.py` and `vibesensor.vibration_strength` over ad-hoc `dict[str, Any]` bags.
-- Tests: add tests in the matching `tests/<module>/` subdirectory (see `docs/testing.md`); use `tests/integration/` for cross-cutting scenarios and regressions. Run a single area with `pytest -q apps/server/tests/<module>/`.
 - i18n: Add/modify keys in `apps/server/data/report_i18n.json` when changing user-facing strings.
-- Styling/lint: `ruff` is enforced in CI; follow existing `ruff` conventions.
 - Documentation maintenance: when backend structure, commands, route ownership, persistence layout, report flow, or update flow changes, update `apps/server/README.md`, `docs/testing.md`, and the relevant `docs/ai/*.md` and `.github/*.instructions.md` files in the same change set.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -2,9 +2,7 @@
 applyTo: "apps/ui/**"
 ---
 Frontend (`apps/ui`)
-- Commands: `cd apps/ui && npm ci`, `cd apps/ui && npm run build`, `cd apps/ui && npm run typecheck`.
 - Shared contract sync is canonicalized through `npm run sync:contracts` (which calls `tools/config/sync_shared_contracts_to_ui.mjs` for generated HTTP API and WS payload contracts); do not introduce a second sync path.
 - Keep frontend changes focused when practical; larger cross-cutting and breaking UI changes are allowed.
 - Keep `apps/ui/src/` free of `any`/`as any`; prefer explicit interfaces, unions, and narrowing helpers when wiring server payloads and DOM state.
 - For server/WebSocket inputs, keep raw data as `unknown` until a decoder proves the shape; avoid treating inbound payloads as generic record bags up front.
-- Prefer updating `apps/ui/src/` components and running `npm run build` locally before pushing.

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -62,25 +62,11 @@ Updater deployment policy
 
 Validation (always required)
 - Pull request default mode: after opening or updating a PR, check CI/review status, fix all blocking issues, push updates, and keep monitoring until required checks are green.
-- For every PR, use `python3 tools/watch_pr_checks.py --pr <PR_NUMBER> --interval 30 --repo Skamba/VibeSensor` as the default monitor.
+- Use the canonical command list in `.github/copilot-instructions.md` for PR check watching, lint/type checks, CI-parity runs, single-area pytest runs, and local Docker bring-up; use `docs/testing.md` for test layout, CI limitations, and the optional `act` wrapper, and follow targeted → broader → local-GitHub-workflow validation before finalizing any task.
 - Treat watcher exit `RESULT=NON_GREEN` as immediate action: inspect the latest failing run promptly, determine root cause, implement the smallest complete maintainable fix, push, and restart the watcher.
 - Treat watcher exit `RESULT=ALL_GREEN` as the merge-ready gate for CI checks.
-- Test in this order: targeted tests first, then broader relevant suites.
-- CI-parity suite for fast iteration: `make test-all` (`python3 tools/tests/run_ci_parallel.py`). Mirrors all CI jobs including Docker-backed e2e; use `--job` flags to run a subset without Docker.
-- Required pre-finalization CI gate: `act -W .github/workflows/ci.yml` runs the real GitHub workflow locally in Docker. All supported jobs must pass before finalizing any task. See `docs/testing.md` for known limitations and the optional wrapper at `tools/tests/run_ci_with_act.sh`.
-- Optional focused CI subset for faster loops: `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests`.
-- Run a single feature area: `pytest -q apps/server/tests/<module>/` (e.g., `tests/analysis/`, `tests/report/`).
-- Test layout: feature-based subdirectories mirror source modules; see `docs/testing.md`.
 - If an intentional refactor changes function-level seams or helper boundaries, refactor the affected tests in the same change set so they validate current behavior instead of pinning obsolete internals.
-- Run lint (`ruff check`) and backend type checks (`make typecheck-backend`) before pushing changes.
-- After any backend or frontend change, rebuild and test via Docker before considering the work done:
-  1. `docker compose build --pull`
-  2. `docker compose up -d`
-  3. `docker compose ps`
-  4. `vibesensor-sim --count 5 --duration 10 --no-interactive`
-  5. confirm `http://127.0.0.1` updates live while the simulator runs (`:80` default; if `:80` is not serving in the current config, try `http://127.0.0.1:8000` as the backup/dev port),
-  6. verify updates stop after the simulator stops (no stale-data artifacts),
-  7. check `docker compose logs --tail 50` if needed.
+- After any backend or frontend change, exercise the local Docker stack with the canonical commands, confirm `http://127.0.0.1` updates live while `vibesensor-sim --count 5 --duration 10 --no-interactive` runs (`:8000` fallback if `:80` is not serving), then verify updates stop once the simulator stops; inspect `docker compose logs --tail 50` if needed.
 - Breaking changes are allowed when intentional.
 - No-backward-compatibility policy: we own the full codebase end to end. Do not add or preserve backward-compatibility layers (deprecated paths, adapters, fallbacks, shims, version-bridging logic, or legacy schema support) unless explicitly asked. Remove them when encountered. Standardize on the current contract, schema, config, and runtime path. Do not add new compatibility code "just in case". If compatibility seems necessary, flag it explicitly rather than implementing it silently.
 
@@ -92,8 +78,6 @@ Docs (`docs/`)
 - When architecture, file ownership, commands, or workflows change, update the matching repo maps, runbooks, READMEs, and instruction files in the same change set.
 
 Infra / Docker / CI (`docker-compose.yml`, `.github/workflows/`)
-- Local dev: `docker compose build --pull` then `docker compose up -d`.
 - CI: `.github/workflows/ci.yml` is authoritative for blocking job commands (`backend-quality`, `backend-typecheck`, `frontend-typecheck`, `ui-smoke`, `backend-tests`, `e2e`).
-- Local CI-parity run: `make test-all` (runs `python3 tools/tests/run_ci_parallel.py`, which mirrors those CI job command groups in parallel).
 - Keep CI steps maintainable; larger CI/workflow updates are allowed when needed. If adding new test dependencies, update `apps/server/pyproject.toml` so CI installs them via the editable install.
 - Avoid embedding secrets in workflow files; use repository secrets for tokens.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -2,22 +2,13 @@
 applyTo: "apps/server/tests/**"
 ---
 Tests
-- Shared workflow/validation rules live in `.github/instructions/general.instructions.md`; this file only captures test-specific deltas.
-- Test layout: feature-based subdirectories under `apps/server/tests/` mirror source modules. See `docs/testing.md` for the full map.
-- Mapping rule: if you change `vibesensor/<module>/`, the tests live in `tests/<module>/`.
-- Cross-cutting directories: `integration/` (scenarios and cross-cutting regressions), `hygiene/` (guards).
-- Shared helpers: `conftest.py` (fixtures, available to all subdirs), `_paths.py` (use `SERVER_ROOT`/`REPO_ROOT` instead of `Path(__file__).parents[N]`), and the focused `test_support/` modules for synthetic data generators and assertions.
+- Detailed test layout, placement rules, shared root helpers, and CI command usage live in `docs/testing.md`; this file only captures test-specific deltas, so use the matching `tests/<module>/` directory from that map, reserve `integration/` for cross-cutting regressions, and use `hygiene/` for guards.
 - Import style: use `from test_support.X import Y` (short form). The `tests/` directory is on `sys.path` via `testpaths` in `pyproject.toml`. Do not use `from tests.test_support` or manipulate `sys.path` for test imports.
 - Use `test_support/findings.py` factories (`make_finding_payload`, `make_ref_finding`, `make_info_finding`) for constructing finding dicts in tests. Do not create local finding factories in individual test files.
 - Test helper re-exports that only alias another module's symbol should be replaced with direct imports. Keep test helper modules for functions that add real logic.
 - Use `test_support/sample_scenarios.py` builders as the single source for synthetic sample/phase construction. Do not duplicate sample-generation logic in other helpers.
-- New tests: place in the matching `tests/<module>/` subdirectory; use `tests/integration/` for cross-cutting scenarios and multi-subsystem regressions. Do not add new tests to existing large omnibus regression files — prefer a new focused test module in the matching feature-area directory.
-- When an intentional refactor changes function-level seams or helper boundaries, update or replace tightly coupled tests so they validate current behavior and contracts instead of preserving obsolete internals.
+- Do not add new tests to existing large omnibus regression files — prefer a new focused test module in the matching feature-area directory.
 - Do not use `inspect.getsource` or `ast.parse` on production code in tests. These create brittle source-string-matching assertions that break on any refactor. Instead, test the observable behavior: call the function with representative inputs and assert on outputs, side-effects, or raised exceptions.
 - Do not create local `FakeState` or fake runtime classes in individual test files. Use the shared `FakeState` from `conftest.py` and customise it via constructor arguments.
 - Do not add private bridge/shim methods to production classes solely for test access. Test sub-components directly (e.g. `proc._store._get_or_create_unlocked`, `proc._metrics.fft_params`) instead of adding pass-through wrappers on the outer class.
-- Default CI-aligned test suite for fast iteration (non-containerized): `make test-all` (runs `python3 tools/tests/run_ci_parallel.py` to mirror CI `backend-quality`, `backend-typecheck`, `frontend-typecheck`, `ui-smoke`, `backend-tests`, and `e2e` job groups in parallel).
-- Required pre-finalization CI gate: `act -W .github/workflows/ci.yml` runs the real GitHub workflow locally in Docker. All supported jobs must pass before finalizing. See `docs/testing.md` for full usage, known limitations, and the optional wrapper at `tools/tests/run_ci_with_act.sh`.
-- Optional CI job subset for faster local iteration: `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests`.
-- Run a single feature area: `pytest -q apps/server/tests/analysis/` (or any subdirectory).
 - Optional focused backend pytest run (for faster iteration, not a CI substitute): `python3 tools/tests/pytest_progress.py --show-test-names apps/server/tests`.


### PR DESCRIPTION
## Summary
- make .github/copilot-instructions.md the explicit canonical command list
- replace duplicated command bullets in the general, backend, and frontend instruction files with source-of-truth references
- collapse repeated test layout and CI guidance in tests.instructions.md down to references plus test-only deltas

## Validation
- make docs-lint

Closes #841
