### PR TITLE
Relax documentation sync mandates

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -22,4 +22,4 @@ Backend (scope: backend-specific behavioral rules and deltas; see `docs/ai/repo-
 - Treat `Any` as a design smell by default: prefer `object` for untrusted inputs, shared JSON aliases for persisted payloads, `ParamSpec` for callable wrappers, and focused `TypedDict`/protocol contracts for nested state.
 - For live processing / WebSocket payloads, prefer shared contracts in `apps/server/vibesensor/shared/types/payload_types.py` and `vibesensor.vibration_strength` over ad-hoc `dict[str, Any]` bags.
 - i18n: Add/modify keys in `apps/server/data/report_i18n.json` when changing user-facing strings.
-- Documentation maintenance: when backend structure, commands, route ownership, persistence layout, report flow, or update flow changes, update `apps/server/README.md`, `docs/testing.md`, and the relevant `docs/ai/*.md` and `.github/*.instructions.md` files in the same change set.
+- Common backend documentation touchpoints include `apps/server/README.md`, `docs/testing.md`, and the relevant `docs/ai/*.md` or `.github/*.instructions.md` files.

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -50,8 +50,7 @@ Complexity hygiene
 - Do not duplicate utility functions across modules. Maintain a single canonical implementation and import from it. Exception: standalone tooling scripts (e.g. ``tools/build_ui_static.py``) that must run without the server package installed may carry a local copy; mark it with a comment pointing at the canonical source.
 
 Documentation maintenance (always required)
-- After every meaningful code change, check whether docs, repo maps, runbooks, READMEs, and instruction files that reference the touched area are now stale.
-- Update stale documentation in the same change set; do not leave documentation drift for later unless the user explicitly asks you not to touch docs.
+- Before merging, review whether docs, repo maps, runbooks, READMEs, and instruction files that reference the touched area have gone stale, and update the relevant ones unless the user explicitly asks you not to touch docs.
 - Remove or rewrite obsolete guidance instead of layering caveats on top of it.
 - Keep human-facing docs and AI-facing guidance aligned with the live code, paths, commands, and ownership boundaries.
 
@@ -75,7 +74,6 @@ Docs (`docs/`)
 - For any user-visible text changes, update `apps/server/data/report_i18n.json` and mention new keys in docs.
 - Rewrite or remove stale sections aggressively; do not keep contradictory historical guidance in place.
 - Prefer direct pointers to current source-of-truth files over long prose that will drift.
-- When architecture, file ownership, commands, or workflows change, update the matching repo maps, runbooks, READMEs, and instruction files in the same change set.
 
 Infra / Docker / CI (`docker-compose.yml`, `.github/workflows/`)
 - CI: `.github/workflows/ci.yml` is authoritative for blocking job commands (`backend-quality`, `backend-typecheck`, `frontend-typecheck`, `ui-smoke`, `backend-tests`, `e2e`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,6 @@ When a single shard fails in CI, run the corresponding focused suite locally fir
 ## Pull requests and merge expectations
 
 - Work on a branch, not directly on `main`.
-- Keep docs in sync with meaningful code changes.
 - Before asking for merge, run the relevant local validation plus the smallest broader suite that matches your change.
 - After opening or updating a PR, monitor checks until they are green:
 
@@ -123,7 +122,7 @@ python3 tools/watch_pr_checks.py --pr <PR_NUMBER> --interval 30 --repo Skamba/Vi
 
 ## Documentation expectations
 
-When you change ownership boundaries, commands, or workflows, update the matching docs in the same change set. Common touchpoints are:
+When you change ownership boundaries, commands, or workflows, review the matching docs before merging and update any that became stale. Common touchpoints are:
 
 - [README.md](README.md)
 - [apps/server/README.md](apps/server/README.md)

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -95,8 +95,6 @@ Current route groups:
 - `car_library.py`
 - `debug.py`
 
-When route ownership changes, update this README and the AI repo maps in the same change set.
-
 ## Reports
 
 Generate a PDF from a saved run:

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -60,8 +60,7 @@ in one step.
 
 The runtime layer is intentionally split so `ui_app_runtime.ts` stays a
 composition root instead of becoming a single-file owner for transport, shell,
-and chart behavior. If you change startup wiring or long-lived UI ownership,
-update this README and the AI repo maps in the same change set.
+and chart behavior.
 
 ## WebSocket contract boundary
 

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -76,7 +76,3 @@ Scope: single source of truth for detailed file layout, entry points, package st
 - Regression tests live in the feature directory they primarily test, or in `integration/` for cross-cutting regressions.
 - Shared test support lives at the test root (`conftest.py`, `_paths.py`, focused helper modules, and the `test_support/` package including `findings.py` for canonical finding-payload factories).
 - Full map: `docs/testing.md`.
-
-## Source-of-truth rule
-
-When code movement changes this map, update `docs/ai/repo-map.md`, `.github/copilot-instructions.md`, and the affected README or instruction file in the same change set.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -215,7 +215,6 @@ The default CI-parity suite now mirrors these blocking GitHub checks:
 2. Keep files focused on one behavior, scenario family, or maintenance boundary.
 3. Reuse shared helpers only when multiple files need the same setup or assertions.
 4. Import `SERVER_ROOT` and `REPO_ROOT` from `_paths.py` instead of using fragile parent traversals.
-5. If a refactor changes test placement or ownership boundaries, update this file in the same change set.
 
 ## Markers
 


### PR DESCRIPTION
## Summary
- keep one lighter documentation-maintenance rule in general.instructions.md and one human-facing reminder in CONTRIBUTING.md
- remove duplicated same-change-set doc-sync mandates from the repo map, testing doc, and server/UI READMEs
- keep backend guidance as touchpoint references instead of another hard synchronization obligation

## Validation
- make docs-lint
- rg -n "same change set|same change-set|same-change-set" .github docs apps/server/README.md apps/ui/README.md CONTRIBUTING.md

Closes #842
