### PR TITLE
Extend mypy coverage to PDF renderers

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -134,6 +134,9 @@ files = [
   "vibesensor/adapters/pdf/report_types.py",
   "vibesensor/adapters/pdf/presentation.py",
   "vibesensor/adapters/pdf/pattern_parts.py",
+  "vibesensor/adapters/pdf/pdf_page1.py",
+  "vibesensor/adapters/pdf/pdf_page2.py",
+  "vibesensor/adapters/pdf/pdf_diagram_render.py",
   "vibesensor/adapters/pdf/pdf_style.py",
   "vibesensor/adapters/pdf/pdf_drawing.py",
   "vibesensor/adapters/pdf/pdf_text.py",
@@ -166,7 +169,6 @@ module = [
   "vibesensor.adapters.udp.protocol",
   "vibesensor.adapters.http.settings",
   "vibesensor.adapters.http.history",
-  "vibesensor.adapters.pdf.pdf_page2",
   "vibesensor.infra.runtime.health_snapshot",
 ]
 ignore_errors = true

--- a/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -354,7 +354,7 @@ def _extract_amp_by_location(
     return connected_locations, amp_by_location
 
 
-def _highlight_map(top_findings: list[Finding | Mapping[str, object]]) -> dict[str, str]:
+def _highlight_map(top_findings: Sequence[Finding | Mapping[str, object]]) -> dict[str, str]:
     highlight: dict[str, str] = {}
     for finding in top_findings[:3]:
         if isinstance(finding, Mapping):
@@ -569,7 +569,7 @@ def _draw_source_legend(
 
 
 def car_location_diagram(
-    top_findings: list[Finding | Mapping[str, object]],
+    top_findings: Sequence[Finding | Mapping[str, object]],
     summary: dict[str, object],
     location_rows: list[dict[str, object]],
     *,


### PR DESCRIPTION
## Summary
- add pdf_page1.py, pdf_page2.py, and pdf_diagram_render.py to the enforced backend mypy slice
- remove vibesensor.adapters.pdf.pdf_page2 from the mypy ignore_errors override
- make the PDF diagram boundary accept a covariant Sequence so pdf_page2.py can pass list[Finding] without an invariant list mismatch

## Validation
- cd apps/server && python3 -m mypy --config-file pyproject.toml vibesensor/adapters/pdf/pdf_page1.py vibesensor/adapters/pdf/pdf_page2.py vibesensor/adapters/pdf/pdf_diagram_render.py
- make typecheck-backend
- PATH="<repo-root>/.venv/bin:$PATH" python3 tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests

Closes #843
