### PR TITLE
Remove stale chunk docs index entry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,6 @@ Every documentation file in the repository and a short description of what it co
 | `.github/instructions/frontend.instructions.md` | Frontend-specific rules and deltas for AI work. |
 | `.github/instructions/tests.instructions.md` | Test-specific conventions and commands for AI work. |
 | `AGENTS.md` | Routes readers to `.github/copilot-instructions.md`. |
-| `docs/ai/chunk*.md` | Supporting task-planning context for multi-step AI work. |
 
 ## Architecture & Design
 


### PR DESCRIPTION
## Summary
- remove the stale docs/ai/chunk*.md row from docs/README.md

## Validation
- make docs-lint
- rg -n "docs/ai/chunk\*\.md|chunk\*\.md|docs/ai/chunk" docs README.md .github AGENTS.md CONTRIBUTING.md

Closes #847
