### PR TITLE
Ignore runtime app logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ __pycache__/
 # Runtime data
 apps/server/data/*.csv
 apps/server/data/*.jsonl
+apps/server/data/*.log
 apps/server/data/*.db
 apps/server/data/*.db-shm
 apps/server/data/*.db-wal

--- a/apps/server/data/app.log
+++ b/apps/server/data/app.log
@@ -1,8 +1,0 @@
-2026-03-18 20:15:53,531 ERROR    vibesensor.app.container: Failed during early startup DB operations; closing DB.
-Traceback (most recent call last):
-  File "/home/psewu/repos/VibeSensor/apps/server/vibesensor/app/container.py", line 46, in create_history_db
-    recovered_runs = history_db.recover_stale_recording_runs()
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/psewu/repos/VibeSensor/apps/server/vibesensor/adapters/persistence/history_db/__init__.py", line 450, in recover_stale_recording_runs
-    cur.execute(
-sqlite3.OperationalError: attempt to write a readonly database


### PR DESCRIPTION
## Summary
- stop tracking the committed runtime log at `apps/server/data/app.log`
- ignore future `apps/server/data/*.log` files while keeping `.gitkeep` in place

## Validation
- git ls-files --error-unmatch apps/server/data/.gitkeep
- verify `apps/server/data/app.log` is no longer tracked
- git check-ignore -v --no-index apps/server/data/app.log

Closes #849
