### PR TITLE
Validate WS payloads with AJV

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -66,14 +66,10 @@ and chart behavior.
 
 - `src/contracts/ws_payload_schema.json` is the canonical JSON Schema for live WS payloads.
 - `src/contracts/ws_payload_types.ts` is generated from that schema by `npm run sync:contracts`.
-- `src/server_payload.ts` is not just a type wrapper today: it also applies runtime normalization such as schema-version warnings, shared-`freq` fallback, partial `strength_metrics` defaults, and malformed-entry dropping before the rest of the UI sees a payload.
+- `src/ws_payload_validator.ts` compiles AJV against `ws_payload_schema.json` and validates the normalized live payload at runtime.
+- `src/server_payload.ts` now keeps the compatibility layer thin: it normalizes the small set of supported legacy `strength_metrics` quirks before validation, then adapts the validated `LiveWsPayload` with schema-version warnings and shared-`freq` fallback.
 
-Investigation summary for schema-generated runtime decoders:
-
-- Tested `ajv` directly against `src/contracts/ws_payload_schema.json`. The schema compiled successfully and correctly accepted a fully populated `LiveWsPayload` sample while rejecting bad field types.
-- The same AJV spike rejected payload shapes that the UI currently accepts and normalizes in `server_payload.ts`, especially spectra entries with partial `strength_metrics` objects that rely on UI-side defaulting.
-- Recommendation: prefer an AJV-backed boundary validator because the repo already has JSON Schema as the WS source of truth; keep a thin adapter layer after validation for shared-`freq` fallback, backwards-compatible defaults, and warning/log behavior instead of trying to replace `server_payload.ts` with a pure generated decoder in one step.
-- Effort estimate: **Medium**. A follow-up implementation needs to add and wire the validator, decide which legacy payload shapes remain supported, update WS fixtures/tests, and only then simplify the remaining manual adaptation logic.
+AJV-backed runtime validation now sits at the WebSocket boundary. The UI still preserves the intentionally supported compatibility behavior called out in the original investigation—partial `strength_metrics` defaults, malformed peak dropping, shared-`freq` fallback, and schema-version warning logging—but the rest of the payload now has to satisfy the canonical JSON Schema before the app state adapter accepts it.
 
 ## Visual Tests
 

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vibesensor-ui",
       "version": "0.1.0",
       "dependencies": {
+        "ajv": "^8.18.0",
         "uplot": "^1.6.31"
       },
       "devDependencies": {
@@ -876,6 +877,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -945,6 +961,11 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -960,6 +981,21 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -1068,6 +1104,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1254,6 +1295,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -19,6 +19,7 @@
     "snapshot:update": "node update-snapshots.mjs"
   },
   "dependencies": {
+    "ajv": "^8.18.0",
     "uplot": "^1.6.31"
   },
   "devDependencies": {

--- a/apps/ui/src/contracts/ws_payload_schema.generated.ts
+++ b/apps/ui/src/contracts/ws_payload_schema.generated.ts
@@ -1,0 +1,536 @@
+// Generated from apps/ui/src/contracts/ws_payload_schema.json
+// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs
+
+export const wsPayloadSchema = {
+  "$defs": {
+    "AlignmentInfoPayload": {
+      "properties": {
+        "aligned": {
+          "title": "Aligned",
+          "type": "boolean"
+        },
+        "clock_synced": {
+          "title": "Clock Synced",
+          "type": "boolean"
+        },
+        "overlap_ratio": {
+          "title": "Overlap Ratio",
+          "type": "number"
+        },
+        "sensor_count": {
+          "title": "Sensor Count",
+          "type": "integer"
+        },
+        "shared_window_s": {
+          "title": "Shared Window S",
+          "type": "number"
+        }
+      },
+      "required": [
+        "overlap_ratio",
+        "aligned",
+        "shared_window_s",
+        "sensor_count",
+        "clock_synced"
+      ],
+      "title": "AlignmentInfoPayload",
+      "type": "object"
+    },
+    "AxisMetrics": {
+      "properties": {
+        "p2p": {
+          "title": "P2P",
+          "type": "number"
+        },
+        "peaks": {
+          "items": {
+            "$ref": "#/$defs/AxisPeak"
+          },
+          "title": "Peaks",
+          "type": "array"
+        },
+        "rms": {
+          "title": "Rms",
+          "type": "number"
+        }
+      },
+      "required": [
+        "rms",
+        "p2p",
+        "peaks"
+      ],
+      "title": "AxisMetrics",
+      "type": "object"
+    },
+    "AxisPeak": {
+      "properties": {
+        "amp": {
+          "title": "Amp",
+          "type": "number"
+        },
+        "hz": {
+          "title": "Hz",
+          "type": "number"
+        },
+        "snr_ratio": {
+          "title": "Snr Ratio",
+          "type": "number"
+        }
+      },
+      "title": "AxisPeak",
+      "type": "object"
+    },
+    "ClientApiRow": {
+      "properties": {
+        "connected": {
+          "title": "Connected",
+          "type": "boolean"
+        },
+        "dropped_frames": {
+          "title": "Dropped Frames",
+          "type": "integer"
+        },
+        "firmware_version": {
+          "title": "Firmware Version",
+          "type": "string"
+        },
+        "frame_samples": {
+          "title": "Frame Samples",
+          "type": "integer"
+        },
+        "frames_total": {
+          "title": "Frames Total",
+          "type": "integer"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "last_reset_time": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Last Reset Time"
+        },
+        "last_seen_age_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Last Seen Age Ms"
+        },
+        "latest_metrics": {
+          "$ref": "#/$defs/ClientMetrics"
+        },
+        "location_code": {
+          "title": "Location Code",
+          "type": "string"
+        },
+        "mac_address": {
+          "title": "Mac Address",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "reset_count": {
+          "title": "Reset Count",
+          "type": "integer"
+        },
+        "sample_rate_hz": {
+          "title": "Sample Rate Hz",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id",
+        "mac_address",
+        "name",
+        "connected",
+        "location_code",
+        "firmware_version",
+        "sample_rate_hz",
+        "last_seen_age_ms",
+        "frames_total",
+        "dropped_frames"
+      ],
+      "title": "ClientApiRow",
+      "type": "object"
+    },
+    "ClientMetrics": {
+      "properties": {
+        "combined": {
+          "$ref": "#/$defs/CombinedMetrics"
+        },
+        "x": {
+          "$ref": "#/$defs/AxisMetrics"
+        },
+        "y": {
+          "$ref": "#/$defs/AxisMetrics"
+        },
+        "z": {
+          "$ref": "#/$defs/AxisMetrics"
+        }
+      },
+      "title": "ClientMetrics",
+      "type": "object"
+    },
+    "CombinedMetrics": {
+      "properties": {
+        "peaks": {
+          "items": {
+            "$ref": "#/$defs/StrengthPeak"
+          },
+          "title": "Peaks",
+          "type": "array"
+        },
+        "strength_metrics": {
+          "$ref": "#/$defs/VibrationStrengthMetrics"
+        },
+        "vib_mag_p2p": {
+          "title": "Vib Mag P2P",
+          "type": "number"
+        },
+        "vib_mag_rms": {
+          "title": "Vib Mag Rms",
+          "type": "number"
+        }
+      },
+      "title": "CombinedMetrics",
+      "type": "object"
+    },
+    "FrequencyWarningPayload": {
+      "properties": {
+        "client_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Client Ids",
+          "type": "array"
+        },
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message",
+        "client_ids"
+      ],
+      "title": "FrequencyWarningPayload",
+      "type": "object"
+    },
+    "OrderBandPayload": {
+      "properties": {
+        "center_hz": {
+          "title": "Center Hz",
+          "type": "number"
+        },
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "tolerance": {
+          "title": "Tolerance",
+          "type": "number"
+        }
+      },
+      "required": [
+        "key",
+        "center_hz",
+        "tolerance"
+      ],
+      "title": "OrderBandPayload",
+      "type": "object"
+    },
+    "RotationalSpeedValuePayload": {
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Mode"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reason"
+        },
+        "rpm": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Rpm"
+        }
+      },
+      "required": [
+        "rpm",
+        "mode",
+        "reason"
+      ],
+      "title": "RotationalSpeedValuePayload",
+      "type": "object"
+    },
+    "RotationalSpeedsPayload": {
+      "properties": {
+        "basis_speed_source": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Basis Speed Source"
+        },
+        "driveshaft": {
+          "$ref": "#/$defs/RotationalSpeedValuePayload"
+        },
+        "engine": {
+          "$ref": "#/$defs/RotationalSpeedValuePayload"
+        },
+        "order_bands": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/OrderBandPayload"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Order Bands"
+        },
+        "wheel": {
+          "$ref": "#/$defs/RotationalSpeedValuePayload"
+        }
+      },
+      "required": [
+        "basis_speed_source",
+        "wheel",
+        "driveshaft",
+        "engine",
+        "order_bands"
+      ],
+      "title": "RotationalSpeedsPayload",
+      "type": "object"
+    },
+    "SpectraPayload": {
+      "properties": {
+        "alignment": {
+          "$ref": "#/$defs/AlignmentInfoPayload"
+        },
+        "clients": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SpectrumSeriesPayload"
+          },
+          "title": "Clients",
+          "type": "object"
+        },
+        "freq": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Freq",
+          "type": "array"
+        },
+        "warning": {
+          "$ref": "#/$defs/FrequencyWarningPayload"
+        }
+      },
+      "title": "SpectraPayload",
+      "type": "object"
+    },
+    "SpectrumSeriesPayload": {
+      "properties": {
+        "combined_spectrum_amp_g": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Combined Spectrum Amp G",
+          "type": "array"
+        },
+        "freq": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Freq",
+          "type": "array"
+        },
+        "strength_metrics": {
+          "$ref": "#/$defs/VibrationStrengthMetrics"
+        }
+      },
+      "title": "SpectrumSeriesPayload",
+      "type": "object"
+    },
+    "StrengthPeak": {
+      "properties": {
+        "amp": {
+          "title": "Amp",
+          "type": "number"
+        },
+        "hz": {
+          "title": "Hz",
+          "type": "number"
+        },
+        "strength_bucket": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Strength Bucket"
+        },
+        "vibration_strength_db": {
+          "title": "Vibration Strength Db",
+          "type": "number"
+        }
+      },
+      "required": [
+        "hz",
+        "amp",
+        "vibration_strength_db",
+        "strength_bucket"
+      ],
+      "title": "StrengthPeak",
+      "type": "object"
+    },
+    "VibrationStrengthMetrics": {
+      "properties": {
+        "noise_floor_amp_g": {
+          "title": "Noise Floor Amp G",
+          "type": "number"
+        },
+        "peak_amp_g": {
+          "title": "Peak Amp G",
+          "type": "number"
+        },
+        "strength_bucket": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Strength Bucket"
+        },
+        "top_peaks": {
+          "items": {
+            "$ref": "#/$defs/StrengthPeak"
+          },
+          "title": "Top Peaks",
+          "type": "array"
+        },
+        "vibration_strength_db": {
+          "title": "Vibration Strength Db",
+          "type": "number"
+        }
+      },
+      "required": [
+        "vibration_strength_db",
+        "peak_amp_g",
+        "noise_floor_amp_g",
+        "strength_bucket",
+        "top_peaks"
+      ],
+      "title": "VibrationStrengthMetrics",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "clients": {
+      "items": {
+        "$ref": "#/$defs/ClientApiRow"
+      },
+      "title": "Clients",
+      "type": "array"
+    },
+    "rotational_speeds": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RotationalSpeedsPayload"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "schema_version": {
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "selected_client_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Selected Client Id"
+    },
+    "server_time": {
+      "title": "Server Time",
+      "type": "string"
+    },
+    "spectra": {
+      "$ref": "#/$defs/SpectraPayload"
+    },
+    "speed_mps": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Speed Mps"
+    }
+  },
+  "title": "LiveWsPayload",
+  "type": "object"
+} as const;
+
+export default wsPayloadSchema;

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -1,5 +1,6 @@
 import {
   EXPECTED_SCHEMA_VERSION,
+  type LiveWsPayload,
   type StrengthMetricPeak,
   type StrengthMetricsPayload,
   type WsClientInfo,
@@ -8,6 +9,7 @@ import {
   type WsRotationalSpeeds,
 } from "./contracts/ws_payload_types";
 import type { SpectrumClientData } from "./app/ui_app_state";
+import { validateLiveWsPayload } from "./ws_payload_validator";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -57,9 +59,9 @@ function getBoolean(record: UnknownRecord, key: string): boolean {
   return Boolean(record[key]);
 }
 
-function asNumberArray(value: unknown): number[] {
+function asFiniteNumberArray(value: unknown): number[] {
   return Array.isArray(value)
-    ? value.map((v) => Number(v)).filter((v) => Number.isFinite(v))
+    ? value.filter((entry): entry is number => typeof entry === "number" && Number.isFinite(entry))
     : [];
 }
 
@@ -88,9 +90,9 @@ function parseStrengthMetricPeak(value: unknown): StrengthMetricPeak | null {
   };
 }
 
-function parseStrengthMetrics(value: unknown): StrengthMetricsPayload | null {
+function normalizeStrengthMetrics(value: unknown): StrengthMetricsPayload | undefined {
   const record = asRecord(value);
-  if (!record) return null;
+  if (!record) return undefined;
   const defaults = emptyStrengthMetrics();
   const topPeaks = Array.isArray(record.top_peaks)
     ? record.top_peaks
@@ -106,64 +108,93 @@ function parseStrengthMetrics(value: unknown): StrengthMetricsPayload | null {
   };
 }
 
-function parseRotationalSpeedValue(value: unknown): RotationalSpeedValue {
-  const record = asRecord(value);
-  if (!record) {
-    return { rpm: null, mode: null, reason: null };
+function normalizePayloadForValidation(payload: UnknownRecord): LiveWsPayload {
+  const spectraRecord = asRecord(payload.spectra);
+  if (!spectraRecord) {
+    return payload as LiveWsPayload;
   }
-  return {
-    rpm: getNumber(record, "rpm"),
-    mode: getString(record, "mode"),
-    reason: getString(record, "reason"),
-  };
-}
 
-function parseOrderBand(value: unknown): OrderBand | null {
-  const record = asRecord(value);
-  if (!record) return null;
-  const key = getString(record, "key");
-  const centerHz = getNumber(record, "center_hz");
-  const tolerance = getNumber(record, "tolerance");
-  if (key === null || centerHz === null || tolerance === null) return null;
-  return { key, center_hz: centerHz, tolerance };
-}
+  const clientsRecord = asRecord(spectraRecord.clients);
+  if (!clientsRecord) {
+    return {
+      ...payload,
+      spectra: spectraRecord as LiveWsPayload["spectra"],
+    } as LiveWsPayload;
+  }
 
-function parseClient(value: unknown): AdaptedClient | null {
-  const record = asRecord(value);
-  if (!record) return null;
-  const id = getString(record, "id");
-  const name = getString(record, "name");
-  if (id === null || name === null) return null;
-  const locationCode = getString(record, "location_code") ?? "";
-  return {
-    id,
-    name,
-    connected: getBoolean(record, "connected"),
-    mac_address: getString(record, "mac_address") ?? "",
-    location_code: locationCode,
-    last_seen_age_ms: getNumber(record, "last_seen_age_ms"),
-    dropped_frames: getNumber(record, "dropped_frames") ?? 0,
-    frames_total: getNumber(record, "frames_total") ?? 0,
-    sample_rate_hz: getNumber(record, "sample_rate_hz") ?? 0,
-    firmware_version: getString(record, "firmware_version") ?? "",
-  };
-}
-
-function parseSpectra(value: unknown): AdaptedPayload["spectra"] | null {
-  const record = asRecord(value);
-  if (!record) return null;
-  const sharedFreq = asNumberArray(record.freq);
-  const clientsRecord = asRecord(record.clients);
-  if (!clientsRecord) return null;
-
-  const adaptedClients: Record<string, SpectrumClientData> = {};
+  const normalizedSpectraClients: Record<string, UnknownRecord> = {};
   for (const [clientId, spectrum] of Object.entries(clientsRecord)) {
     const spectrumRecord = asRecord(spectrum);
-    if (!spectrumRecord) continue;
-    const rawPerClientFreq = asNumberArray(spectrumRecord.freq);
+    if (!spectrumRecord) {
+      normalizedSpectraClients[clientId] = { value: spectrum };
+      continue;
+    }
+    const normalizedSpectrum: UnknownRecord = {
+      ...spectrumRecord,
+      ...(Array.isArray(spectrumRecord.freq) ? { freq: asFiniteNumberArray(spectrumRecord.freq) } : {}),
+      ...(Array.isArray(spectrumRecord.combined_spectrum_amp_g)
+        ? { combined_spectrum_amp_g: asFiniteNumberArray(spectrumRecord.combined_spectrum_amp_g) }
+        : {}),
+    };
+    const normalizedStrengthMetrics = normalizeStrengthMetrics(spectrumRecord.strength_metrics);
+    if (normalizedStrengthMetrics) {
+      normalizedSpectrum.strength_metrics = normalizedStrengthMetrics;
+    } else {
+      delete normalizedSpectrum.strength_metrics;
+    }
+    normalizedSpectraClients[clientId] = normalizedSpectrum;
+  }
+
+  return {
+    ...payload,
+    spectra: {
+      ...spectraRecord,
+      ...(Array.isArray(spectraRecord.freq) ? { freq: asFiniteNumberArray(spectraRecord.freq) } : {}),
+      clients: normalizedSpectraClients,
+    },
+  } as LiveWsPayload;
+}
+
+function adaptClient(client: WsClientInfo): AdaptedClient {
+  return {
+    id: client.id,
+    name: client.name,
+    connected: client.connected,
+    mac_address: client.mac_address,
+    location_code: client.location_code,
+    last_seen_age_ms: client.last_seen_age_ms,
+    dropped_frames: client.dropped_frames,
+    frames_total: client.frames_total,
+    sample_rate_hz: client.sample_rate_hz,
+    firmware_version: client.firmware_version,
+  };
+}
+
+function adaptRotationalSpeeds(
+  rotationalSpeeds: LiveWsPayload["rotational_speeds"],
+): RotationalSpeeds | null {
+  if (!rotationalSpeeds) {
+    return null;
+  }
+  return {
+    basis_speed_source: rotationalSpeeds.basis_speed_source,
+    wheel: rotationalSpeeds.wheel,
+    driveshaft: rotationalSpeeds.driveshaft,
+    engine: rotationalSpeeds.engine,
+    order_bands: rotationalSpeeds.order_bands?.map((band: WsOrderBand): OrderBand => band) ?? null,
+  };
+}
+
+function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectra"] | null {
+  if (!spectra?.clients) return null;
+  const sharedFreq = spectra.freq ?? [];
+
+  const adaptedClients: Record<string, SpectrumClientData> = {};
+  for (const [clientId, spectrum] of Object.entries(spectra.clients)) {
+    const rawPerClientFreq = spectrum.freq ?? [];
     const freq = rawPerClientFreq.length > 0 ? rawPerClientFreq : sharedFreq;
-    const combined = asNumberArray(spectrumRecord.combined_spectrum_amp_g);
-    const strengthMetrics = parseStrengthMetrics(spectrumRecord.strength_metrics);
+    const combined = spectrum.combined_spectrum_amp_g ?? [];
+    const strengthMetrics = spectrum.strength_metrics ?? null;
     if (!freq.length || !combined.length || strengthMetrics === null) continue;
     adaptedClients[clientId] = {
       freq,
@@ -183,7 +214,9 @@ export function adaptServerPayload(payload: unknown): AdaptedPayload {
     throw new Error("Missing websocket payload.");
   }
 
-  const schemaVersion = getString(payloadRecord, "schema_version");
+  const validatedPayload = validateLiveWsPayload(normalizePayloadForValidation(payloadRecord));
+
+  const schemaVersion = validatedPayload.schema_version ?? null;
   if (
     schemaVersion !== null &&
     schemaVersion !== EXPECTED_SCHEMA_VERSION &&
@@ -197,31 +230,10 @@ export function adaptServerPayload(payload: unknown): AdaptedPayload {
     );
   }
 
-  const clients = Array.isArray(payloadRecord.clients)
-    ? payloadRecord.clients
-        .map((client) => parseClient(client))
-        .filter((client): client is AdaptedClient => client !== null)
-    : [];
-
-  const rotationalRecord = asRecord(payloadRecord.rotational_speeds);
-  const rotationalSpeeds: RotationalSpeeds | null = rotationalRecord
-    ? {
-        basis_speed_source: getString(rotationalRecord, "basis_speed_source"),
-        wheel: parseRotationalSpeedValue(rotationalRecord.wheel),
-        driveshaft: parseRotationalSpeedValue(rotationalRecord.driveshaft),
-        engine: parseRotationalSpeedValue(rotationalRecord.engine),
-        order_bands: Array.isArray(rotationalRecord.order_bands)
-          ? rotationalRecord.order_bands
-              .map((band) => parseOrderBand(band))
-              .filter((band): band is OrderBand => band !== null)
-          : null,
-      }
-    : null;
-
   return {
-    clients,
-    speed_mps: getNumber(payloadRecord, "speed_mps"),
-    rotational_speeds: rotationalSpeeds,
-    spectra: parseSpectra(payloadRecord.spectra),
+    clients: validatedPayload.clients?.map(adaptClient) ?? [],
+    speed_mps: validatedPayload.speed_mps ?? null,
+    rotational_speeds: adaptRotationalSpeeds(validatedPayload.rotational_speeds),
+    spectra: adaptSpectra(validatedPayload.spectra),
   };
 }

--- a/apps/ui/src/ws_payload_validator.ts
+++ b/apps/ui/src/ws_payload_validator.ts
@@ -1,0 +1,31 @@
+import Ajv2020, { type ErrorObject } from "ajv/dist/2020.js";
+import type { ValidateFunction } from "ajv";
+import wsPayloadSchema from "./contracts/ws_payload_schema.generated";
+import type { LiveWsPayload } from "./contracts/ws_payload_types";
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  strict: false,
+});
+
+const liveWsPayloadValidator = ajv.compile(wsPayloadSchema) as ValidateFunction<LiveWsPayload>;
+
+function formatValidationErrors(errors: readonly ErrorObject[] | null | undefined): string {
+  if (!errors?.length) {
+    return "unknown schema violation";
+  }
+  return errors
+    .slice(0, 3)
+    .map((error) => {
+      const path = error.instancePath || "/";
+      return `${path} ${error.message ?? "is invalid"}`;
+    })
+    .join("; ");
+}
+
+export function validateLiveWsPayload(payload: unknown): LiveWsPayload {
+  if (liveWsPayloadValidator(payload)) {
+    return payload;
+  }
+  throw new Error(`Invalid websocket payload: ${formatValidationErrors(liveWsPayloadValidator.errors)}`);
+}

--- a/apps/ui/tests/cycle2_fixes.spec.ts
+++ b/apps/ui/tests/cycle2_fixes.spec.ts
@@ -13,7 +13,7 @@
 
 import { expect, test } from "@playwright/test";
 import { adaptServerPayload } from "../src/server_payload";
-import { applySpectrumTick } from "../src/app/state/ui_app_state";
+import { applySpectrumTick } from "../src/app/ui_app_state";
 import { areHeavyFramesCompatible, interpolateHeavyFrame } from "../src/app/spectrum_animation";
 
 // ---------------------------------------------------------------------------

--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -42,6 +42,15 @@ test.describe("schema_version handling", () => {
     expect(adapted).toBeDefined();
   });
 
+  test("rejects invalid field types via AJV validation", () => {
+    expect(() =>
+      adaptServerPayload({
+        ...basePayload,
+        speed_mps: "10",
+      }),
+    ).toThrow(/Invalid websocket payload/);
+  });
+
   test("EXPECTED_SCHEMA_VERSION is string '1'", () => {
     expect(EXPECTED_SCHEMA_VERSION).toBe("1");
   });
@@ -71,6 +80,9 @@ test.describe("shared freq optimization", () => {
     expect(adapted.spectra).not.toBeNull();
     expect(adapted.spectra!.clients.sensor1.freq).toEqual([10, 20, 30]);
     expect(adapted.spectra!.clients.sensor2.freq).toEqual([10, 20, 30]);
+    expect(adapted.spectra!.clients.sensor1.strength_metrics.peak_amp_g).toBe(0);
+    expect(adapted.spectra!.clients.sensor1.strength_metrics.noise_floor_amp_g).toBe(0);
+    expect(adapted.spectra!.clients.sensor1.strength_metrics.top_peaks).toEqual([]);
   });
 
   test("prefers per-client freq over shared when both present", () => {
@@ -151,5 +163,32 @@ test.describe("shared freq optimization", () => {
     expect(adapted.spectra!.clients.sensor1.freq).toEqual([10, 20, 30]);
     // sensor2 uses its own per-client freq
     expect(adapted.spectra!.clients.sensor2.freq).toEqual([15, 25, 35]);
+  });
+
+  test("drops malformed strength metric peaks before validation", () => {
+    const adapted = adaptServerPayload({
+      ...basePayload,
+      spectra: {
+        freq: [10, 20, 30],
+        clients: {
+          sensor1: {
+            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
+            strength_metrics: {
+              vibration_strength_db: 12,
+              peak_amp_g: 0.2,
+              noise_floor_amp_g: 0.01,
+              top_peaks: [
+                { hz: 10, amp: 0.1, vibration_strength_db: 12, strength_bucket: "l2" },
+                { hz: 20, amp: 0.2 },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(adapted.spectra).not.toBeNull();
+    expect(adapted.spectra!.clients.sensor1.strength_metrics.top_peaks).toEqual([
+      { hz: 10, amp: 0.1, vibration_strength_db: 12, strength_bucket: "l2" },
+    ]);
   });
 });

--- a/tools/config/sync_shared_contracts_to_ui.mjs
+++ b/tools/config/sync_shared_contracts_to_ui.mjs
@@ -12,6 +12,7 @@ const requireFromUi = createRequire(resolve(root, 'apps/ui/package.json'));
 const httpSchemaSrc = resolve(root, 'apps/ui/src/contracts/http_api_schema.json');
 const httpTypesDst = resolve(root, 'apps/ui/src/generated/http_api_contracts.ts');
 const wsSchemaSrc = resolve(root, 'apps/ui/src/contracts/ws_payload_schema.json');
+const wsSchemaTsDst = resolve(root, 'apps/ui/src/contracts/ws_payload_schema.generated.ts');
 const wsTypesDst = resolve(root, 'apps/ui/src/contracts/ws_payload_types.ts');
 
 function writeGenerated(filePath, content, checkMode) {
@@ -119,6 +120,18 @@ async function generateWsTypes() {
 	);
 }
 
+function generateWsSchemaModule() {
+	const wsSchema = JSON.parse(readFileSync(wsSchemaSrc, 'utf8'));
+	return (
+		'// Generated from apps/ui/src/contracts/ws_payload_schema.json\n'
+		+ '// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs\n\n'
+		+ 'export const wsPayloadSchema = '
+		+ `${JSON.stringify(wsSchema, null, 2)}`
+		+ ' as const;\n\n'
+		+ 'export default wsPayloadSchema;\n'
+	);
+}
+
 async function main() {
 	const checkMode = process.argv.includes('--check');
 
@@ -128,6 +141,9 @@ async function main() {
 	const wsGenerated = await generateWsTypes();
 	writeGenerated(wsTypesDst, wsGenerated, checkMode);
 
+	const wsSchemaModule = generateWsSchemaModule();
+	writeGenerated(wsSchemaTsDst, wsSchemaModule, checkMode);
+
 	if (checkMode) {
 		console.log('Generated UI contract files are up to date.');
 		return;
@@ -135,6 +151,7 @@ async function main() {
 
 	console.log(`Generated ${httpSchemaSrc} -> ${httpTypesDst}`);
 	console.log(`Generated ${wsSchemaSrc} -> ${wsTypesDst}`);
+	console.log(`Generated ${wsSchemaSrc} -> ${wsSchemaTsDst}`);
 }
 
 await main();


### PR DESCRIPTION
## Summary
- validate live WebSocket payloads with AJV against the canonical WS schema at the UI boundary
- preserve the supported compatibility behavior by normalizing legacy `strength_metrics` quirks before validation and keeping a thin post-validation adapter for schema-version/shared-freq handling
- generate a TS-exported WS schema artifact from the existing sync script so both Vite and the Node-based Playwright runner can consume the same source-of-truth schema

## Validation
- cd apps/ui && npm run sync:contracts && npm run typecheck && npm run build
- cd apps/ui && npx playwright test tests/ws_contract.spec.ts tests/cycle2_fixes.spec.ts --workers=1

Closes #870
