### PR TITLE
Reject misaligned spectrum payloads

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -67,9 +67,9 @@ and chart behavior.
 - `src/contracts/ws_payload_schema.json` is the canonical JSON Schema for live WS payloads.
 - `src/contracts/ws_payload_types.ts` is generated from that schema by `npm run sync:contracts`.
 - `src/ws_payload_validator.ts` compiles AJV against `ws_payload_schema.json` and validates the normalized live payload at runtime.
-- `src/server_payload.ts` now keeps the compatibility layer thin: it normalizes the small set of supported legacy `strength_metrics` quirks before validation, then adapts the validated `LiveWsPayload` with schema-version warnings and shared-`freq` fallback.
+- `src/server_payload.ts` now keeps the compatibility layer thin: it normalizes the small set of supported legacy `strength_metrics` quirks before validation, then adapts the validated `LiveWsPayload` with schema-version warnings, shared-`freq` fallback, and malformed/misaligned spectrum rejection.
 
-AJV-backed runtime validation now sits at the WebSocket boundary. The UI still preserves the intentionally supported compatibility behavior called out in the original investigation—partial `strength_metrics` defaults, malformed peak dropping, shared-`freq` fallback, and schema-version warning logging—but the rest of the payload now has to satisfy the canonical JSON Schema before the app state adapter accepts it.
+AJV-backed runtime validation now sits at the WebSocket boundary. The UI still preserves the intentionally supported compatibility behavior called out in the original investigation—partial `strength_metrics` defaults, malformed peak dropping, shared-`freq` fallback, schema-version warning logging, and dropping malformed spectrum series before they can misalign bins—but the rest of the payload now has to satisfy the canonical JSON Schema before the app state adapter accepts it.
 
 ## Visual Tests
 

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -59,10 +59,18 @@ function getBoolean(record: UnknownRecord, key: string): boolean {
   return Boolean(record[key]);
 }
 
-function asFiniteNumberArray(value: unknown): number[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is number => typeof entry === "number" && Number.isFinite(entry))
-    : [];
+function parseFiniteNumberArray(value: unknown): number[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const numbers: number[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "number" || !Number.isFinite(entry)) {
+      return null;
+    }
+    numbers.push(entry);
+  }
+  return numbers;
 }
 
 function emptyStrengthMetrics(): StrengthMetricsPayload {
@@ -129,11 +137,23 @@ function normalizePayloadForValidation(payload: UnknownRecord): LiveWsPayload {
       normalizedSpectraClients[clientId] = { value: spectrum };
       continue;
     }
+    const normalizedFreq = Array.isArray(spectrumRecord.freq)
+      ? parseFiniteNumberArray(spectrumRecord.freq)
+      : undefined;
+    if (Array.isArray(spectrumRecord.freq) && normalizedFreq === null) {
+      continue;
+    }
+    const normalizedCombinedSpectrum = Array.isArray(spectrumRecord.combined_spectrum_amp_g)
+      ? parseFiniteNumberArray(spectrumRecord.combined_spectrum_amp_g)
+      : undefined;
+    if (Array.isArray(spectrumRecord.combined_spectrum_amp_g) && normalizedCombinedSpectrum === null) {
+      continue;
+    }
     const normalizedSpectrum: UnknownRecord = {
       ...spectrumRecord,
-      ...(Array.isArray(spectrumRecord.freq) ? { freq: asFiniteNumberArray(spectrumRecord.freq) } : {}),
-      ...(Array.isArray(spectrumRecord.combined_spectrum_amp_g)
-        ? { combined_spectrum_amp_g: asFiniteNumberArray(spectrumRecord.combined_spectrum_amp_g) }
+      ...(normalizedFreq ? { freq: normalizedFreq } : {}),
+      ...(normalizedCombinedSpectrum
+        ? { combined_spectrum_amp_g: normalizedCombinedSpectrum }
         : {}),
     };
     const normalizedStrengthMetrics = normalizeStrengthMetrics(spectrumRecord.strength_metrics);
@@ -145,11 +165,15 @@ function normalizePayloadForValidation(payload: UnknownRecord): LiveWsPayload {
     normalizedSpectraClients[clientId] = normalizedSpectrum;
   }
 
+  const normalizedSharedFreq = Array.isArray(spectraRecord.freq)
+    ? parseFiniteNumberArray(spectraRecord.freq)
+    : undefined;
+
   return {
     ...payload,
     spectra: {
       ...spectraRecord,
-      ...(Array.isArray(spectraRecord.freq) ? { freq: asFiniteNumberArray(spectraRecord.freq) } : {}),
+      ...(normalizedSharedFreq ? { freq: normalizedSharedFreq } : {}),
       clients: normalizedSpectraClients,
     },
   } as LiveWsPayload;
@@ -195,7 +219,9 @@ function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectr
     const freq = rawPerClientFreq.length > 0 ? rawPerClientFreq : sharedFreq;
     const combined = spectrum.combined_spectrum_amp_g ?? [];
     const strengthMetrics = spectrum.strength_metrics ?? null;
-    if (!freq.length || !combined.length || strengthMetrics === null) continue;
+    if (!freq.length || !combined.length || strengthMetrics === null || freq.length !== combined.length) {
+      continue;
+    }
     adaptedClients[clientId] = {
       freq,
       combined,

--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -140,6 +140,40 @@ test.describe("shared freq optimization", () => {
     expect(Object.keys(adapted.spectra!.clients)).toHaveLength(0);
   });
 
+  test("skips client when per-client freq contains malformed numeric elements", () => {
+    const adapted = adaptServerPayload({
+      ...basePayload,
+      spectra: {
+        clients: {
+          sensor1: {
+            freq: [10, "bad", 30],
+            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
+            strength_metrics: { vibration_strength_db: 12 },
+          },
+        },
+      },
+    });
+    expect(adapted.spectra).not.toBeNull();
+    expect(Object.keys(adapted.spectra!.clients)).toHaveLength(0);
+  });
+
+  test("skips client when freq and amplitude bin counts differ", () => {
+    const adapted = adaptServerPayload({
+      ...basePayload,
+      spectra: {
+        clients: {
+          sensor1: {
+            freq: [10, 20],
+            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
+            strength_metrics: { vibration_strength_db: 12 },
+          },
+        },
+      },
+    });
+    expect(adapted.spectra).not.toBeNull();
+    expect(Object.keys(adapted.spectra!.clients)).toHaveLength(0);
+  });
+
   test("handles mixed: some clients with per-client freq, some without", () => {
     const adapted = adaptServerPayload({
       ...basePayload,


### PR DESCRIPTION
## Summary
- reject malformed spectrum arrays instead of filtering and silently reindexing bins
- skip adapted spectra whose frequency and amplitude vectors do not have matching lengths
- add regression coverage for malformed and misaligned spectrum payloads

Fixes #895