### PR TITLE
Type RuntimeState against shared ports

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -19,7 +19,7 @@ ESP32 nodes -> adapters/udp/ -> infra/processing/ + use_cases/diagnostics/
 
 Backend ownership boundaries:
 
-- `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), a lifecycle-focused `RuntimeState` plus top-level `AppRuntime` bundle (`runtime_state.py`), and YAML settings/config loading (`settings.py`).
+- `app/`: FastAPI app factory (`bootstrap.py`), runtime container wiring (`container.py`), a lifecycle-focused `RuntimeState` plus top-level `AppRuntime` bundle (`runtime_state.py`), and YAML settings/config loading (`settings.py`). `runtime_state.py` now types read-side runtime fields against the existing shared ports where they already fit lifecycle consumers, while `container.py` remains the concrete composition root.
 - `adapters/http/` and `adapters/websocket/`: HTTP route groups and live WebSocket delivery. `adapters/http/dependencies.py` owns the grouped router dependency dataclasses consumed by `adapters/http/__init__.py`.
 - `infra/runtime/`: lifecycle management, processing loop, runtime health state, and WebSocket broadcast coordination. `registry.py` now owns raw client tracking plus `client_snapshots()`, while `client_snapshot.py` owns the API/WS client-row presenter reused by both the HTTP clients route and live WebSocket broadcasting.
 - `infra/processing/`: signal processing pipeline.

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, get_type_hints
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -398,3 +398,32 @@ def test_runtime_state_has_public_attribute(attr: str) -> None:
     from vibesensor.app.runtime_state import RuntimeState
 
     assert hasattr(RuntimeState, attr), f"RuntimeState missing {attr}"
+
+
+def test_runtime_state_uses_focused_ports_for_read_side_runtime_fields() -> None:
+    """RuntimeState should expose existing shared ports for read-side services."""
+    from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
+    from vibesensor.adapters.websocket.hub import WebSocketHub
+    from vibesensor.app import runtime_state as runtime_state_module
+    from vibesensor.app.runtime_state import RuntimeState
+    from vibesensor.app.settings import AppConfig
+    from vibesensor.shared.types.client_tracker import ClientTracker
+    from vibesensor.shared.types.settings_reader import SettingsReader
+    from vibesensor.shared.types.signal_source import SignalSource
+
+    hints = get_type_hints(
+        RuntimeState,
+        globalns={
+            **vars(runtime_state_module),
+            "AppConfig": AppConfig,
+            "GPSSpeedMonitor": GPSSpeedMonitor,
+            "HistoryDB": HistoryDB,
+            "UDPControlPlane": UDPControlPlane,
+            "WebSocketHub": WebSocketHub,
+        },
+    )
+    assert hints["registry"] is ClientTracker
+    assert hints["processor"] is SignalSource
+    assert hints["settings_store"] is SettingsReader

--- a/apps/server/vibesensor/app/runtime_state.py
+++ b/apps/server/vibesensor/app/runtime_state.py
@@ -1,4 +1,9 @@
-"""App-owned runtime assembly for lifecycle and router dependency bundles."""
+"""App-owned runtime assembly for lifecycle and router dependency bundles.
+
+The lifecycle runtime bag prefers focused shared ports where the existing
+protocols already match what downstream consumers need. ``container.py``
+remains the concrete composition root that instantiates the real adapters.
+"""
 
 from __future__ import annotations
 
@@ -6,13 +11,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.http.dependencies import RouterDeps
-from vibesensor.infra.config.settings_store import SettingsStore
-from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingLoopState
-from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.workers.worker_pool import WorkerPool
+from vibesensor.shared.types.client_tracker import ClientTracker
+from vibesensor.shared.types.settings_reader import SettingsReader
+from vibesensor.shared.types.signal_source import SignalSource
 from vibesensor.use_cases.run import RunRecorder
 from vibesensor.use_cases.updates.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.manager import UpdateManager
@@ -30,11 +35,11 @@ class RuntimeState:
     """Lifecycle-focused runtime dependencies."""
 
     config: AppConfig
-    registry: ClientRegistry
-    processor: SignalProcessor
+    registry: ClientTracker
+    processor: SignalSource
     control_plane: UDPControlPlane
     worker_pool: WorkerPool
-    settings_store: SettingsStore
+    settings_store: SettingsReader
     gps_monitor: GPSSpeedMonitor
     history_db: HistoryDB
     processing_loop_state: ProcessingLoopState

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -27,7 +27,7 @@ Scope: single source of truth for detailed file layout, entry points, package st
 
 ## Backend package layout
 
-- `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds a lifecycle-focused `RuntimeState` plus the top-level `AppRuntime` bundle, `runtime_state.py` owns those app-facing runtime bundles, and `settings.py` owns YAML config loading and validation.
+- `app/`: startup and wiring. `bootstrap.py` creates the FastAPI app, `container.py` builds a lifecycle-focused `RuntimeState` plus the top-level `AppRuntime` bundle, `runtime_state.py` owns those app-facing runtime bundles and types eligible read-side runtime fields to the existing shared ports, and `settings.py` owns YAML config loading and validation.
 - `adapters/http/`: health, clients, settings, recording, history, websocket, updates, car library, and debug route groups; `adapters/http/dependencies.py` owns the grouped router dependency dataclasses and `adapters/http/__init__.py` assembles the router from them.
 - `adapters/websocket/hub.py`: live WebSocket connection fan-out and payload delivery.
 - `adapters/persistence/`: SQLite history DB (`history_db/` keeps `HistoryDB` as the public facade and splits internals across `_run_lifecycle.py`, `_sample_io.py`, `_queries.py`, `_schema.py`, and `_samples.py`) and the static car library loader (`car_library.py`).


### PR DESCRIPTION
## Summary
- type eligible RuntimeState fields against the existing shared ports instead of concrete adapters
- add a focused runtime test that guards the public RuntimeState type hints
- update backend architecture docs to describe the lifecycle runtime bag boundary

Fixes #812