### PR TITLE
Preserve sensor names on location updates

### DIFF
--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -256,8 +256,6 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     }
     const client = state.clients.find((c) => c.id === clientId);
     if (client) {
-      const selected = state.locationOptions.find((loc) => loc.code === locationCode);
-      client.name = selected ? selected.label : "";
       client.location_code = locationCode;
       maybeRenderSensorsSettingsList();
     }

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -35,7 +35,20 @@ test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) 
   await installFakeWebSocket(page, {
     payload: {
       server_time: new Date().toISOString(),
-      clients: [{ id: "001122334455", name: "Front Left", connected: true, sample_rate_hz: 1000, last_seen_age_ms: 10, dropped_frames: 0, frames_total: 100 }],
+      clients: [
+        {
+          id: "001122334455",
+          name: "Front Left",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
       spectra: { clients: { "001122334455": { freq: [1, 2, 3], combined_spectrum_amp_g: [0.1, 0.2, 0.15], strength_metrics: { vibration_strength_db: 12 } } } },
     },
   });

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -23,7 +23,27 @@ test("gps status polling does not override websocket speed readout", async ({ pa
 
 test("spectrum title updates when switching language", async ({ page }) => {
   await installCommonRoutes(page, { settingsHandler: createSettingsHandlerFromMap({ "GET /api/settings/language": { language: "en" }, "POST /api/settings/language": { language: "nl" }, "/api/settings/speed-unit": { speedUnit: "kmh" }, "/api/settings/speed-source/status": gpsStatus({ raw_speed_kmh: 72, effective_speed_kmh: 72 }) }) });
-  await installFakeWebSocket(page, { payload: { server_time: new Date().toISOString(), speed_mps: 20, clients: [{ id: "c1", name: "Front Left", connected: true, frames_total: 100, dropped_frames: 0 }], spectra: { clients: {} } } });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      speed_mps: 20,
+      clients: [
+        {
+          id: "c1",
+          name: "Front Left",
+          connected: true,
+          frames_total: 100,
+          dropped_frames: 0,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          location_code: "",
+          mac_address: "c1",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: { clients: {} },
+    },
+  });
   await page.goto("/");
   await expect(page.locator("#dashboardView [data-i18n='chart.spectrum_title']")).toHaveText("Multi-Sensor Blended Spectrum");
   await page.locator("#languageSelect").selectOption("nl");
@@ -82,4 +102,49 @@ test("analysis bandwidth and uncertainty settings persist through API round-trip
   await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="analysisTab"]').click();
   await expect(page.locator("#wheelBandwidthInput")).toHaveValue("7.5");
+});
+
+test("assigning a sensor location preserves the original sensor name", async ({ page }) => {
+  let locationUpdateCalls = 0;
+
+  await installCommonRoutes(page, {
+    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
+  });
+  await page.route("**/api/clients/**/location", async (route) => {
+    locationUpdateCalls += 1;
+    await fulfillJson(route, {});
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      clients: [
+        {
+          id: "sensor-1",
+          name: "Chassis Sensor A",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "",
+          mac_address: "sensor-1",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: { clients: {} },
+    },
+  });
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="sensorsTab"]').click();
+
+  const row = page.locator('#sensorsSettingsBody tr[data-client-id="sensor-1"]');
+  const locationSelect = row.locator("select.row-location-select");
+
+  await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
+  await locationSelect.selectOption("front_left_wheel");
+  await expect.poll(() => locationUpdateCalls).toBe(1);
+  await expect(locationSelect).toHaveValue("front_left_wheel");
+  await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
 });


### PR DESCRIPTION
## Summary
- keep realtime sensor identity stable when a location assignment succeeds
- derive location display from location_code instead of overwriting client.name
- cover the regression through the settings UI and refresh the WS smoke fixtures to use contract-valid client rows

Closes #898
