### PR TITLE
Fix settings divergence after failed saves

### DIFF
--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -114,26 +114,32 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     if (els.maxBandHalfWidthInput) els.maxBandHalfWidthInput.value = String(state.vehicleSettings.max_band_half_width_pct);
   }
 
-  async function syncSpeedSourceToServer(): Promise<void> {
+  function showSettingsSaveError(error: unknown): void {
+    window.alert(error instanceof Error ? error.message : t("settings.save_failed"));
+  }
+
+  function applySpeedSourcePayload(payload: SpeedSourcePayload): void {
+    state.speedSource = payload.speedSource;
+    state.manualSpeedKph = payload.manualSpeedKph;
+    if (els.staleTimeoutInput) els.staleTimeoutInput.value = String(payload.staleTimeoutS);
+    syncSpeedSourceInputs();
+    ctx.renderSpeedReadout();
+  }
+
+  async function syncSpeedSourceToServer(payload: SpeedSourceRequest): Promise<void> {
     try {
-      const payload: SpeedSourceRequest = {
-        speedSource: state.speedSource,
-        manualSpeedKph: state.manualSpeedKph,
-      };
-      const staleVal = Number(els.staleTimeoutInput?.value);
-      if (staleVal >= 3 && staleVal <= 120) payload.staleTimeoutS = staleVal;
-      await updateSettingsSpeedSource(payload);
-    } catch (_err) { /* ignore */ }
+      const saved = await updateSettingsSpeedSource(payload);
+      applySpeedSourcePayload(saved);
+    } catch (error) {
+      void loadSpeedSourceFromServer();
+      showSettingsSaveError(error);
+    }
   }
 
   async function loadSpeedSourceFromServer(): Promise<void> {
     try {
       const payload: SpeedSourcePayload = await getSettingsSpeedSource();
-      state.speedSource = payload.speedSource;
-      state.manualSpeedKph = payload.manualSpeedKph;
-      if (els.staleTimeoutInput) els.staleTimeoutInput.value = String(payload.staleTimeoutS);
-      syncSpeedSourceInputs();
-      ctx.renderSpeedReadout();
+      applySpeedSourcePayload(payload);
     } catch (_err) { /* ignore */ }
   }
 
@@ -149,15 +155,22 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     }
   }
 
-  async function syncAnalysisSettingsToServer(): Promise<void> {
-    const payload: AnalysisSettingsRequest = {};
+  function applyAnalysisSettingsPayload(serverSettings: AnalysisSettingsPayload): void {
     for (const key of ANALYSIS_SETTING_KEYS) {
-      payload[key] = state.vehicleSettings[key];
+      const value = serverSettings[key];
+      if (typeof value === "number") state.vehicleSettings[key] = value;
     }
+    syncSettingsInputs();
+    ctx.renderSpectrum();
+  }
+
+  async function syncAnalysisSettingsToServer(payload: AnalysisSettingsRequest): Promise<void> {
     try {
-      await setAnalysisSettings(payload);
-    } catch (_err) {
-      console.warn("Failed to save analysis settings", _err);
+      const saved = await setAnalysisSettings(payload);
+      applyAnalysisSettingsPayload(saved);
+    } catch (error) {
+      syncSettingsInputs();
+      showSettingsSaveError(error);
     }
   }
 
@@ -165,12 +178,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     try {
       const serverSettings = await getAnalysisSettings();
       if (serverSettings) {
-        for (const key of ANALYSIS_SETTING_KEYS) {
-          const value = serverSettings[key];
-          if (typeof value === "number") state.vehicleSettings[key] = value;
-        }
-        syncSettingsInputs();
-        ctx.renderSpectrum();
+        applyAnalysisSettingsPayload(serverSettings);
       }
     } catch (_err) { /* ignore */ }
   }
@@ -271,17 +279,23 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
       window.alert(t("settings.validation_error"));
       return;
     }
-    state.vehicleSettings.wheel_bandwidth_pct = wheelBandwidth;
-    state.vehicleSettings.driveshaft_bandwidth_pct = driveshaftBandwidth;
-    state.vehicleSettings.engine_bandwidth_pct = engineBandwidth;
-    state.vehicleSettings.speed_uncertainty_pct = speedUncertainty;
-    state.vehicleSettings.tire_diameter_uncertainty_pct = tireDiameterUncertainty;
-    state.vehicleSettings.final_drive_uncertainty_pct = finalDriveUncertainty;
-    state.vehicleSettings.gear_uncertainty_pct = gearUncertainty;
-    state.vehicleSettings.min_abs_band_hz = minAbsBandHz;
-    state.vehicleSettings.max_band_half_width_pct = maxBandHalfWidth;
-    void syncAnalysisSettingsToServer();
-    ctx.renderSpectrum();
+    const payload: AnalysisSettingsRequest = {
+      wheel_bandwidth_pct: wheelBandwidth,
+      driveshaft_bandwidth_pct: driveshaftBandwidth,
+      engine_bandwidth_pct: engineBandwidth,
+      speed_uncertainty_pct: speedUncertainty,
+      tire_diameter_uncertainty_pct: tireDiameterUncertainty,
+      final_drive_uncertainty_pct: finalDriveUncertainty,
+      gear_uncertainty_pct: gearUncertainty,
+      min_abs_band_hz: minAbsBandHz,
+      max_band_half_width_pct: maxBandHalfWidth,
+    };
+    for (const key of ANALYSIS_SETTING_KEYS) {
+      if (!(key in payload)) {
+        payload[key] = state.vehicleSettings[key];
+      }
+    }
+    void syncAnalysisSettingsToServer(payload);
   }
 
   function saveSpeedSourceFromInputs(): void {
@@ -291,19 +305,24 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
       if (r.checked && isSpeedSourceKind(r.value)) src = r.value;
     });
     const manual = Number(els.manualSpeedInput?.value);
-    state.speedSource = src;
-    state.manualSpeedKph = Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null;
-    void syncSpeedSourceToServer();
-    ctx.renderSpeedReadout();
+    const payload: SpeedSourceRequest = {
+      speedSource: src,
+      manualSpeedKph: Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null,
+    };
+    const staleVal = Number(els.staleTimeoutInput?.value);
+    if (staleVal >= 3 && staleVal <= 120) payload.staleTimeoutS = staleVal;
+    void syncSpeedSourceToServer(payload);
   }
 
   function saveHeaderManualSpeedFromInput(): void {
     const manual = Number(els.headerManualSpeedInput?.value);
-    state.speedSource = "manual";
-    state.manualSpeedKph = Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null;
-    syncSpeedSourceInputs();
-    void syncSpeedSourceToServer();
-    ctx.renderSpeedReadout();
+    const payload: SpeedSourceRequest = {
+      speedSource: "manual",
+      manualSpeedKph: Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null,
+    };
+    const staleVal = Number(els.staleTimeoutInput?.value);
+    if (staleVal >= 3 && staleVal <= 120) payload.staleTimeoutS = staleVal;
+    void syncSpeedSourceToServer(payload);
   }
 
   function setActiveSettingsTab(tabId: string): void {

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -241,14 +241,40 @@ export class UiShellController {
     return raw === "mps" ? "mps" : "kmh";
   }
 
-  private saveLanguage(lang: string): void {
-    this.state.lang = I18N.normalizeLang(lang);
-    void setSettingsLanguage(this.state.lang).catch(() => {});
+  private async saveLanguage(lang: string): Promise<void> {
+    const previousLang = this.state.lang;
+    const nextLang = I18N.normalizeLang(lang);
+    try {
+      const payload = await setSettingsLanguage(nextLang);
+      this.state.lang = I18N.normalizeLang(payload?.language || nextLang);
+      if (this.els.languageSelect) {
+        this.els.languageSelect.value = this.state.lang;
+      }
+      this.applyLanguage(true);
+    } catch (error) {
+      if (this.els.languageSelect) {
+        this.els.languageSelect.value = previousLang;
+      }
+      window.alert(error instanceof Error ? error.message : this.t("settings.save_failed"));
+    }
   }
 
-  private saveSpeedUnit(unit: string): void {
-    this.state.speedUnit = this.normalizeSpeedUnit(unit);
-    void setSettingsSpeedUnit(this.state.speedUnit).catch(() => {});
+  private async saveSpeedUnit(unit: string): Promise<void> {
+    const previousUnit = this.state.speedUnit;
+    const nextUnit = this.normalizeSpeedUnit(unit);
+    try {
+      const payload = await setSettingsSpeedUnit(nextUnit);
+      this.state.speedUnit = this.normalizeSpeedUnit(payload?.speedUnit || nextUnit);
+      if (this.els.speedUnitSelect) {
+        this.els.speedUnitSelect.value = this.state.speedUnit;
+      }
+      this.renderSpeedReadout();
+    } catch (error) {
+      if (this.els.speedUnitSelect) {
+        this.els.speedUnitSelect.value = previousUnit;
+      }
+      window.alert(error instanceof Error ? error.message : this.t("settings.save_failed"));
+    }
   }
 
   private speedValueInSelectedUnit(speedMps: number | null): number | null {
@@ -357,15 +383,13 @@ export class UiShellController {
     if (this.els.languageSelect) {
       this.els.languageSelect.value = this.state.lang;
       this.els.languageSelect.addEventListener("change", () => {
-        this.saveLanguage(this.els.languageSelect!.value);
-        this.applyLanguage(true);
+        void this.saveLanguage(this.els.languageSelect!.value);
       });
     }
     if (this.els.speedUnitSelect) {
       this.els.speedUnitSelect.value = this.state.speedUnit;
       this.els.speedUnitSelect.addEventListener("change", () => {
-        this.saveSpeedUnit(this.els.speedUnitSelect!.value);
-        this.renderSpeedReadout();
+        void this.saveSpeedUnit(this.els.speedUnitSelect!.value);
       });
     }
   }

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -103,6 +103,7 @@
   "settings.car.delete_failed": "Failed to delete car.",
   "settings.car.activate_failed": "Failed to activate car.",
   "settings.car.save_failed": "Failed to save settings.",
+  "settings.save_failed": "Failed to save settings.",
   "settings.car.step_brand": "Select Brand",
   "settings.car.step_type": "Select Type",
   "settings.car.step_model": "Select Model",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -103,6 +103,7 @@
   "settings.car.delete_failed": "Kan auto niet verwijderen.",
   "settings.car.activate_failed": "Kan auto niet activeren.",
   "settings.car.save_failed": "Instellingen opslaan mislukt.",
+  "settings.save_failed": "Instellingen opslaan mislukt.",
   "settings.car.step_brand": "Selecteer merk",
   "settings.car.step_type": "Selecteer type",
   "settings.car.step_model": "Selecteer model",

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -148,3 +148,69 @@ test("assigning a sensor location preserves the original sensor name", async ({ 
   await expect(locationSelect).toHaveValue("front_left_wheel");
   await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
 });
+
+test("failed speed-source save reverts the UI and shows an error", async ({ page }) => {
+  let dialogMessage = "";
+  page.on("dialog", async (dialog) => {
+    dialogMessage = dialog.message();
+    await dialog.accept();
+  });
+
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/language": { language: "en" },
+      "GET /api/settings/speed-unit": { speedUnit: "kmh" },
+      "GET /api/settings/speed-source": { speedSource: "gps", manualSpeedKph: null, staleTimeoutS: 5 },
+      "POST /api/settings/speed-source": async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Speed source save failed" }),
+        });
+      },
+    }),
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await page.locator('input[name="speedSourceRadio"][value="manual"]').check();
+  await page.locator("#manualSpeedInput").fill("45");
+  await page.locator("#saveSpeedSourceBtn").click();
+
+  await expect.poll(() => dialogMessage).toContain("Speed source save failed");
+  await expect(page.locator('input[name="speedSourceRadio"][value="gps"]')).toBeChecked();
+  await expect(page.locator('input[name="speedSourceRadio"][value="manual"]')).not.toBeChecked();
+  await expect(page.locator("#manualSpeedInput")).toHaveValue("");
+});
+
+test("failed language save reverts the selector and shows an error", async ({ page }) => {
+  let dialogMessage = "";
+  page.on("dialog", async (dialog) => {
+    dialogMessage = dialog.message();
+    await dialog.accept();
+  });
+
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/language": { language: "en" },
+      "POST /api/settings/language": async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Language save failed" }),
+        });
+      },
+      "GET /api/settings/speed-unit": { speedUnit: "kmh" },
+    }),
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#languageSelect").selectOption("nl");
+
+  await expect.poll(() => dialogMessage).toContain("Language save failed");
+  await expect(page.locator("#languageSelect")).toHaveValue("en");
+  await expect(page.locator("#tab-settings")).toContainText("Settings");
+});


### PR DESCRIPTION
## Summary
- keep language, speed-unit, speed-source, and analysis settings UI state pessimistic until persistence succeeds
- revert visible controls and show an alert when a settings save fails instead of silently diverging from the server
- add smoke coverage for failed speed-source and language saves

## Validation
- cd apps/ui && npm run typecheck
- cd apps/ui && npm run build
- cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --workers=1

Closes #899