### PR TITLE
Replace manual WS payload reshaping with generated-type-driven parsing

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -41,7 +41,8 @@ in one step.
 | `ws.ts` | WebSocket client with auto-reconnect and stale detection |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |
 | `spectrum.ts` | uPlot chart wrapper for interactive spectrum visualization |
-| `server_payload.ts` | Runtime WebSocket payload adaptation, normalization, and schema-version guardrails around the generated WS types |
+| `server_payload.ts` | Runtime WebSocket payload adaptation and schema-version guardrails around the generated WS types |
+| `ws_payload_normalization.ts` | Small pre-AJV compatibility shim for legacy spectra and `strength_metrics` payload quirks |
 | `diagnostics.ts` | Strength band normalization and vibration matrix helpers |
 | `vehicle_math.ts` | Tire diameter, order tolerance, and uncertainty calculations |
 | `format.ts` | Number, byte, and timestamp formatting utilities |
@@ -66,8 +67,9 @@ and chart behavior.
 
 - `src/contracts/ws_payload_schema.json` is the canonical JSON Schema for live WS payloads.
 - `src/contracts/ws_payload_types.ts` is generated from that schema by `npm run sync:contracts`.
-- `src/ws_payload_validator.ts` compiles AJV against `ws_payload_schema.json` and validates the normalized live payload at runtime.
-- `src/server_payload.ts` now keeps the compatibility layer thin: it normalizes the small set of supported legacy `strength_metrics` quirks before validation, then adapts the validated `LiveWsPayload` with schema-version warnings, shared-`freq` fallback, and malformed/misaligned spectrum rejection.
+- `src/ws_payload_normalization.ts` keeps the pre-validation compatibility shim small: it only normalizes the supported legacy `strength_metrics` and malformed-spectra quirks before AJV runs.
+- `src/ws_payload_validator.ts` compiles AJV against `ws_payload_schema.json` and validates that normalized live payload at runtime.
+- `src/server_payload.ts` then adapts the validated `LiveWsPayload` with schema-version warnings, shared-`freq` fallback, and malformed/misaligned spectrum rejection.
 
 AJV-backed runtime validation now sits at the WebSocket boundary. The UI still preserves the intentionally supported compatibility behavior called out in the original investigation—partial `strength_metrics` defaults, malformed peak dropping, shared-`freq` fallback, schema-version warning logging, and dropping malformed spectrum series before they can misalign bins—but the rest of the payload now has to satisfy the canonical JSON Schema before the app state adapter accepts it.
 

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -1,8 +1,6 @@
 import {
   EXPECTED_SCHEMA_VERSION,
   type LiveWsPayload,
-  type StrengthMetricPeak,
-  type StrengthMetricsPayload,
   type WsClientInfo,
   type WsOrderBand,
   type WsRotationalSpeedValue,
@@ -10,8 +8,7 @@ import {
 } from "./contracts/ws_payload_types";
 import type { SpectrumClientData } from "./app/ui_app_state";
 import { validateLiveWsPayload } from "./ws_payload_validator";
-
-type UnknownRecord = Record<string, unknown>;
+import { normalizePayloadForValidation } from "./ws_payload_normalization";
 
 export type AdaptedClient = Pick<
   WsClientInfo,
@@ -42,173 +39,6 @@ export type AdaptedPayload = {
   } | null;
 };
 
-function asRecord(value: unknown): UnknownRecord | null {
-  return value && typeof value === "object" ? (value as UnknownRecord) : null;
-}
-
-function getString(record: UnknownRecord, key: string): string | null {
-  return typeof record[key] === "string" ? String(record[key]) : null;
-}
-
-function getNumber(record: UnknownRecord, key: string): number | null {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function getBoolean(record: UnknownRecord, key: string): boolean {
-  return Boolean(record[key]);
-}
-
-function parseFiniteNumberArray(value: unknown): number[] | null {
-  if (!Array.isArray(value)) {
-    return null;
-  }
-  const numbers: number[] = [];
-  for (const entry of value) {
-    if (typeof entry !== "number" || !Number.isFinite(entry)) {
-      return null;
-    }
-    numbers.push(entry);
-  }
-  return numbers;
-}
-
-function emptyStrengthMetrics(): StrengthMetricsPayload {
-  return {
-    vibration_strength_db: 0,
-    peak_amp_g: 0,
-    noise_floor_amp_g: 0,
-    strength_bucket: null,
-    top_peaks: [],
-  };
-}
-
-function parseStrengthMetricPeak(value: unknown): StrengthMetricPeak | null {
-  const record = asRecord(value);
-  if (!record) return null;
-  const hz = getNumber(record, "hz");
-  const amp = getNumber(record, "amp");
-  const vibrationStrengthDb = getNumber(record, "vibration_strength_db");
-  if (hz === null || amp === null || vibrationStrengthDb === null) return null;
-  return {
-    hz,
-    amp,
-    vibration_strength_db: vibrationStrengthDb,
-    strength_bucket: getString(record, "strength_bucket"),
-  };
-}
-
-function normalizeStrengthMetrics(value: unknown): StrengthMetricsPayload | undefined {
-  const record = asRecord(value);
-  if (!record) return undefined;
-  const defaults = emptyStrengthMetrics();
-  const topPeaks = Array.isArray(record.top_peaks)
-    ? record.top_peaks
-        .map((peak) => parseStrengthMetricPeak(peak))
-        .filter((peak): peak is StrengthMetricPeak => peak !== null)
-    : [];
-  return {
-    vibration_strength_db: getNumber(record, "vibration_strength_db") ?? defaults.vibration_strength_db,
-    peak_amp_g: getNumber(record, "peak_amp_g") ?? defaults.peak_amp_g,
-    noise_floor_amp_g: getNumber(record, "noise_floor_amp_g") ?? defaults.noise_floor_amp_g,
-    strength_bucket: getString(record, "strength_bucket") ?? defaults.strength_bucket,
-    top_peaks: topPeaks,
-  };
-}
-
-function normalizePayloadForValidation(payload: UnknownRecord): LiveWsPayload {
-  const spectraRecord = asRecord(payload.spectra);
-  if (!spectraRecord) {
-    return payload as LiveWsPayload;
-  }
-
-  const clientsRecord = asRecord(spectraRecord.clients);
-  if (!clientsRecord) {
-    return {
-      ...payload,
-      spectra: spectraRecord as LiveWsPayload["spectra"],
-    } as LiveWsPayload;
-  }
-
-  const normalizedSpectraClients: Record<string, UnknownRecord> = {};
-  for (const [clientId, spectrum] of Object.entries(clientsRecord)) {
-    const spectrumRecord = asRecord(spectrum);
-    if (!spectrumRecord) {
-      normalizedSpectraClients[clientId] = { value: spectrum };
-      continue;
-    }
-    const normalizedFreq = Array.isArray(spectrumRecord.freq)
-      ? parseFiniteNumberArray(spectrumRecord.freq)
-      : undefined;
-    if (Array.isArray(spectrumRecord.freq) && normalizedFreq === null) {
-      continue;
-    }
-    const normalizedCombinedSpectrum = Array.isArray(spectrumRecord.combined_spectrum_amp_g)
-      ? parseFiniteNumberArray(spectrumRecord.combined_spectrum_amp_g)
-      : undefined;
-    if (Array.isArray(spectrumRecord.combined_spectrum_amp_g) && normalizedCombinedSpectrum === null) {
-      continue;
-    }
-    const normalizedSpectrum: UnknownRecord = {
-      ...spectrumRecord,
-      ...(normalizedFreq ? { freq: normalizedFreq } : {}),
-      ...(normalizedCombinedSpectrum
-        ? { combined_spectrum_amp_g: normalizedCombinedSpectrum }
-        : {}),
-    };
-    const normalizedStrengthMetrics = normalizeStrengthMetrics(spectrumRecord.strength_metrics);
-    if (normalizedStrengthMetrics) {
-      normalizedSpectrum.strength_metrics = normalizedStrengthMetrics;
-    } else {
-      delete normalizedSpectrum.strength_metrics;
-    }
-    normalizedSpectraClients[clientId] = normalizedSpectrum;
-  }
-
-  const normalizedSharedFreq = Array.isArray(spectraRecord.freq)
-    ? parseFiniteNumberArray(spectraRecord.freq)
-    : undefined;
-
-  return {
-    ...payload,
-    spectra: {
-      ...spectraRecord,
-      ...(normalizedSharedFreq ? { freq: normalizedSharedFreq } : {}),
-      clients: normalizedSpectraClients,
-    },
-  } as LiveWsPayload;
-}
-
-function adaptClient(client: WsClientInfo): AdaptedClient {
-  return {
-    id: client.id,
-    name: client.name,
-    connected: client.connected,
-    mac_address: client.mac_address,
-    location_code: client.location_code,
-    last_seen_age_ms: client.last_seen_age_ms,
-    dropped_frames: client.dropped_frames,
-    frames_total: client.frames_total,
-    sample_rate_hz: client.sample_rate_hz,
-    firmware_version: client.firmware_version,
-  };
-}
-
-function adaptRotationalSpeeds(
-  rotationalSpeeds: LiveWsPayload["rotational_speeds"],
-): RotationalSpeeds | null {
-  if (!rotationalSpeeds) {
-    return null;
-  }
-  return {
-    basis_speed_source: rotationalSpeeds.basis_speed_source,
-    wheel: rotationalSpeeds.wheel,
-    driveshaft: rotationalSpeeds.driveshaft,
-    engine: rotationalSpeeds.engine,
-    order_bands: rotationalSpeeds.order_bands?.map((band: WsOrderBand): OrderBand => band) ?? null,
-  };
-}
-
 function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectra"] | null {
   if (!spectra?.clients) return null;
   const sharedFreq = spectra.freq ?? [];
@@ -234,15 +64,7 @@ function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectr
 
 let schemaWarningLogged = false;
 
-export function adaptServerPayload(payload: unknown): AdaptedPayload {
-  const payloadRecord = asRecord(payload);
-  if (!payloadRecord) {
-    throw new Error("Missing websocket payload.");
-  }
-
-  const validatedPayload = validateLiveWsPayload(normalizePayloadForValidation(payloadRecord));
-
-  const schemaVersion = validatedPayload.schema_version ?? null;
+function warnOnUnknownSchemaVersion(schemaVersion: string | null): void {
   if (
     schemaVersion !== null &&
     schemaVersion !== EXPECTED_SCHEMA_VERSION &&
@@ -255,11 +77,22 @@ export function adaptServerPayload(payload: unknown): AdaptedPayload {
       "Update the UI to match the server version.",
     );
   }
+}
+
+export function adaptServerPayload(payload: unknown): AdaptedPayload {
+  if (payload === null || typeof payload !== "object") {
+    throw new Error("Missing websocket payload.");
+  }
+
+  const validatedPayload = validateLiveWsPayload(
+    normalizePayloadForValidation(payload as Record<string, unknown>),
+  );
+  warnOnUnknownSchemaVersion(validatedPayload.schema_version ?? null);
 
   return {
-    clients: validatedPayload.clients?.map(adaptClient) ?? [],
+    clients: validatedPayload.clients ?? [],
     speed_mps: validatedPayload.speed_mps ?? null,
-    rotational_speeds: adaptRotationalSpeeds(validatedPayload.rotational_speeds),
+    rotational_speeds: validatedPayload.rotational_speeds ?? null,
     spectra: adaptSpectra(validatedPayload.spectra),
   };
 }

--- a/apps/ui/src/ws_payload_normalization.ts
+++ b/apps/ui/src/ws_payload_normalization.ts
@@ -1,0 +1,119 @@
+import type { StrengthMetricPeak, StrengthMetricsPayload } from "./contracts/ws_payload_types";
+
+const EMPTY_STRENGTH_METRICS: StrengthMetricsPayload = {
+  vibration_strength_db: 0,
+  peak_amp_g: 0,
+  noise_floor_amp_g: 0,
+  strength_bucket: null,
+  top_peaks: [],
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function normalizeStrengthMetricPeak(value: unknown): StrengthMetricPeak | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const { hz, amp, vibration_strength_db, strength_bucket } = value as Record<string, unknown>;
+  if (!isFiniteNumber(hz) || !isFiniteNumber(amp) || !isFiniteNumber(vibration_strength_db)) {
+    return null;
+  }
+  return {
+    hz,
+    amp,
+    vibration_strength_db,
+    strength_bucket: typeof strength_bucket === "string" || strength_bucket === null
+      ? strength_bucket
+      : null,
+  };
+}
+
+function normalizeStrengthMetrics(value: unknown): StrengthMetricsPayload | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const {
+    vibration_strength_db,
+    peak_amp_g,
+    noise_floor_amp_g,
+    strength_bucket,
+    top_peaks,
+  } = value as Record<string, unknown>;
+  return {
+    vibration_strength_db: isFiniteNumber(vibration_strength_db)
+      ? vibration_strength_db
+      : EMPTY_STRENGTH_METRICS.vibration_strength_db,
+    peak_amp_g: isFiniteNumber(peak_amp_g) ? peak_amp_g : EMPTY_STRENGTH_METRICS.peak_amp_g,
+    noise_floor_amp_g: isFiniteNumber(noise_floor_amp_g)
+      ? noise_floor_amp_g
+      : EMPTY_STRENGTH_METRICS.noise_floor_amp_g,
+    strength_bucket: typeof strength_bucket === "string" || strength_bucket === null
+      ? strength_bucket
+      : EMPTY_STRENGTH_METRICS.strength_bucket,
+    top_peaks: Array.isArray(top_peaks)
+      ? top_peaks
+          .map((peak) => normalizeStrengthMetricPeak(peak))
+          .filter((peak): peak is StrengthMetricPeak => peak !== null)
+      : EMPTY_STRENGTH_METRICS.top_peaks,
+  };
+}
+
+function normalizeSpectrumSeries(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return { value };
+  }
+
+  const normalizedSpectrum = { ...(value as Record<string, unknown>) };
+  if (Array.isArray(normalizedSpectrum.freq) && !normalizedSpectrum.freq.every(isFiniteNumber)) {
+    return { value };
+  }
+  if (
+    Array.isArray(normalizedSpectrum.combined_spectrum_amp_g) &&
+    !normalizedSpectrum.combined_spectrum_amp_g.every(isFiniteNumber)
+  ) {
+    return { value };
+  }
+
+  const strengthMetrics = normalizeStrengthMetrics(normalizedSpectrum.strength_metrics);
+  if (strengthMetrics) {
+    normalizedSpectrum.strength_metrics = strengthMetrics;
+  } else {
+    delete normalizedSpectrum.strength_metrics;
+  }
+  return normalizedSpectrum;
+}
+
+export function normalizePayloadForValidation(payload: Record<string, unknown>): Record<string, unknown> {
+  const spectra = payload.spectra;
+  if (spectra === null || typeof spectra !== "object" || Array.isArray(spectra)) {
+    return payload;
+  }
+
+  const normalizedSpectra = { ...(spectra as Record<string, unknown>) };
+  const clients = normalizedSpectra.clients;
+  if (clients === null || typeof clients !== "object" || Array.isArray(clients)) {
+    return {
+      ...payload,
+      spectra: normalizedSpectra,
+    };
+  }
+
+  if (Array.isArray(normalizedSpectra.freq) && !normalizedSpectra.freq.every(isFiniteNumber)) {
+    delete normalizedSpectra.freq;
+  }
+
+  const normalizedClients: Record<string, Record<string, unknown>> = {};
+  for (const [clientId, spectrum] of Object.entries(clients)) {
+    normalizedClients[clientId] = normalizeSpectrumSeries(spectrum);
+  }
+
+  return {
+    ...payload,
+    spectra: {
+      ...normalizedSpectra,
+      clients: normalizedClients,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- move the legacy spectra/strength-metric compatibility normalization into a narrow pre-AJV helper
- slim `server_payload.ts` to a generated-type-driven adapter that trusts validated `LiveWsPayload` values for clients and rotational speeds
- update the UI README WebSocket contract-boundary docs to reflect the new normalization → validation → adaptation split

Closes #943

## Validation
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `cd apps/ui && npm run check:contracts && npm run typecheck && npm run build`
- `cd apps/ui && npx playwright test tests/ws_contract.spec.ts tests/cycle2_fixes.spec.ts --project=laptop-light --workers=1`
- `docker compose build --pull && docker compose up -d` + browser/simulator smoke against `http://127.0.0.1:8000` (`UI_LIVE_CONNECTED`; `intake_stats.total_ingested_samples` stabilized at `9600` after simulator stop)
