### PR TITLE
Tighten live client staleness semantics

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -54,6 +54,12 @@ The local development configs default the HTTP listener to port `8000`.
 
 Configuration is YAML-based. Run `vibesensor-config-preflight --dump-defaults` to see all available keys with defaults. Use `apps/server/config.dev.yaml` or `apps/server/config.docker.yaml` for local overrides.
 
+For live sensor presence, `processing.client_live_ttl_seconds` controls how long
+`/api/clients` and `/ws` keep reporting `connected: true` after the last
+packet. `processing.client_ttl_seconds` is the longer retention/eviction window
+for keeping stale clients and their metadata available after they stop sending
+traffic.
+
 Common runtime files under `apps/server/data/` include:
 
 - `history.db`: persisted run history and settings.

--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -115,3 +116,57 @@ async def test_identify_client_200_when_sensor_reachable() -> None:
         await endpoint("aa:bb:cc:dd:ee:ff", type("Req", (), {"duration_ms": 1000})()),
     )
     assert resp == {"status": "sent", "cmd_seq": 7}
+
+
+@pytest.mark.asyncio
+async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from vibesensor.adapters.http.clients import create_client_routes
+    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.udp.protocol import HelloMessage
+    from vibesensor.infra.runtime.registry import ClientRegistry
+
+    db = HistoryDB(tmp_path / "history.db")
+    registry = ClientRegistry(db=db, live_ttl_seconds=5.0, retention_ttl_seconds=30.0)
+    hello = HelloMessage(
+        client_id=bytes.fromhex("001122334455"),
+        control_port=9010,
+        sample_rate_hz=800,
+        name="sensor",
+        firmware_version="fw",
+    )
+    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
+
+    now = {"wall": 9.0, "mono": 9.0}
+    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
+    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: now["mono"])
+
+    control_plane = MagicMock()
+    settings_store = MagicMock()
+    processor = MagicMock()
+    processor.all_latest_metrics.return_value = {}
+    router = create_client_routes(registry, control_plane, settings_store, processor)
+    endpoint = route_endpoint(router, "/api/clients")
+
+    resp = response_payload(await endpoint())
+    assert processor.all_latest_metrics.call_args.args == ([],)
+    assert resp["clients"] == [
+        {
+            "id": "001122334455",
+            "mac_address": "00:11:22:33:44:55",
+            "name": "sensor",
+            "connected": False,
+            "location_code": "",
+            "firmware_version": "fw",
+            "sample_rate_hz": 800,
+            "frame_samples": 0,
+            "last_seen_age_ms": 8000,
+            "frames_total": 0,
+            "dropped_frames": 0,
+            "latest_metrics": {},
+            "reset_count": 0,
+            "last_reset_time": None,
+        },
+    ]

--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -141,6 +141,7 @@ class _StubProcessingConfig:
     fft_update_hz: int = 4
     fft_n: int = 2048
     spectrum_max_hz: int = 200
+    client_live_ttl_seconds: int = 10
     client_ttl_seconds: int = 120
     accel_scale_g_per_lsb: float | None = None
 
@@ -336,3 +337,41 @@ def test_build_ws_payload_rotational_speeds_include_reason_when_speed_unavailabl
 
     payload = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
     _assert_rotational(payload["rotational_speeds"], reason="speed_unavailable")
+
+
+def test_build_ws_payload_marks_retained_stale_clients_disconnected(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.udp.protocol import HelloMessage
+    from vibesensor.infra.runtime.registry import ClientRegistry
+    from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
+
+    db = HistoryDB(tmp_path / "history.db")
+    registry = ClientRegistry(db=db, live_ttl_seconds=5.0, retention_ttl_seconds=30.0)
+    hello = HelloMessage(
+        client_id=bytes.fromhex("001122334455"),
+        control_port=9010,
+        sample_rate_hz=800,
+        name="sensor",
+        firmware_version="fw",
+    )
+    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
+
+    now = {"wall": 9.0, "mono": 9.0}
+    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
+    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: now["mono"])
+
+    ws_broadcast = WsBroadcastService(
+        ui_push_hz=10,
+        ui_heavy_push_hz=4,
+        registry=registry,
+        processor=_StubProcessor(),
+        gps_monitor=_StubGPS(),
+        settings_store=_StubSettingsStore(),
+    )
+    payload = ws_broadcast.build_payload(selected_client=None)
+    assert len(payload["clients"]) == 1
+    assert payload["clients"][0]["connected"] is False
+    assert payload["clients"][0]["last_seen_age_ms"] == 8000

--- a/apps/server/tests/app/test_config_validation.py
+++ b/apps/server/tests/app/test_config_validation.py
@@ -35,6 +35,7 @@ def _make_processing(**overrides: float | None) -> ProcessingConfig:
     defaults: dict[str, float | None] = {
         "sample_rate_hz": 800,
         "waveform_seconds": 8,
+        "client_live_ttl_seconds": 10,
         "client_ttl_seconds": 120,
         "accel_scale_g_per_lsb": None,
     }
@@ -50,6 +51,7 @@ class TestPositiveIntegerClamping:
         [
             "sample_rate_hz",
             "waveform_seconds",
+            "client_live_ttl_seconds",
             "client_ttl_seconds",
         ],
     )
@@ -63,6 +65,7 @@ class TestPositiveIntegerClamping:
         [
             "sample_rate_hz",
             "waveform_seconds",
+            "client_live_ttl_seconds",
             "client_ttl_seconds",
         ],
     )
@@ -91,6 +94,13 @@ class TestLoadConfigValidation:
         cfg = load_config(config_path)
         assert cfg.processing.sample_rate_hz == 800
         assert cfg.processing.waveform_seconds == 8
+        assert cfg.processing.client_live_ttl_seconds == 10
+        assert cfg.processing.client_ttl_seconds == 120
+
+    def test_retention_ttl_is_clamped_to_live_ttl(self) -> None:
+        cfg = _make_processing(client_live_ttl_seconds=15, client_ttl_seconds=5)
+        assert cfg.client_live_ttl_seconds == 15
+        assert cfg.client_ttl_seconds == 15
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -141,7 +141,7 @@ def test_registry_hello_uses_advertised_control_port(tmp_path: Path) -> None:
 
 def test_registry_evicts_stale_clients(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db, stale_ttl_seconds=2.0)
+    registry = ClientRegistry(db=db, live_ttl_seconds=2.0, retention_ttl_seconds=2.0)
 
     fresh = HelloMessage(
         client_id=bytes.fromhex("001122334455"),
@@ -171,7 +171,7 @@ def test_registry_staleness_uses_monotonic_clock_when_now_not_provided(
     monkeypatch,
 ) -> None:
     db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db, stale_ttl_seconds=10.0)
+    registry = ClientRegistry(db=db, live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
     now = {"wall": 1_000.0, "mono": 100.0}
 
     monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
@@ -197,6 +197,32 @@ def test_registry_staleness_uses_monotonic_clock_when_now_not_provided(
 
     now["mono"] = 120.1
     assert registry.active_client_ids() == []
+    stale_row = snapshot_for_api(registry)[0]
+    assert stale_row["connected"] is False
+    assert stale_row["last_seen_age_ms"] is not None
+
+
+def test_registry_retains_stale_client_until_retention_ttl(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    registry = ClientRegistry(db=db, live_ttl_seconds=5.0, retention_ttl_seconds=30.0)
+    hello = HelloMessage(
+        client_id=bytes.fromhex("001122334455"),
+        control_port=9010,
+        sample_rate_hz=800,
+        name="sensor",
+        firmware_version="fw",
+    )
+    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
+
+    assert registry.active_client_ids(now_mono=4.0) == ["001122334455"]
+    stale_row = snapshot_for_api(registry, now=9.0, now_mono=9.0)[0]
+    assert stale_row["connected"] is False
+    assert stale_row["last_seen_age_ms"] == 8000
+    assert registry.active_client_ids(now_mono=9.0) == []
+    assert registry.evict_stale(now_mono=9.0) == []
+
+    assert registry.evict_stale(now_mono=32.0) == ["001122334455"]
+    assert registry.get("001122334455") is None
 
 
 def test_registry_remove_client_clears_persisted_entry(tmp_path: Path) -> None:

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -33,6 +33,7 @@ class _StubProcessingConfig:
     waveform_seconds: int = 8
     waveform_display_hz: int = 120
     spectrum_max_hz: int = 200
+    client_live_ttl_seconds: int = 10
     client_ttl_seconds: int = 120
     accel_scale_g_per_lsb: float | None = None
     spectrum_min_hz: int = 5

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -110,7 +110,8 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     # ingress
     registry = ClientRegistry(
         db=history_db,
-        stale_ttl_seconds=config.processing.client_ttl_seconds,
+        live_ttl_seconds=config.processing.client_live_ttl_seconds,
+        retention_ttl_seconds=config.processing.client_ttl_seconds,
     )
     worker_pool = WorkerPool(max_workers=4, thread_name_prefix="vibesensor-fft")
     processor = SignalProcessor(

--- a/apps/server/vibesensor/app/settings.py
+++ b/apps/server/vibesensor/app/settings.py
@@ -65,6 +65,7 @@ DEFAULT_CONFIG: JsonObject = {
     "processing": {
         "sample_rate_hz": 800,
         "waveform_seconds": 8,
+        "client_live_ttl_seconds": 10,
         "client_ttl_seconds": 120,
         "accel_scale_g_per_lsb": None,
     },
@@ -118,6 +119,7 @@ LOGGER = logging.getLogger(__name__)
 _PROCESSING_POS_FIELDS: tuple[str, ...] = (
     "sample_rate_hz",
     "waveform_seconds",
+    "client_live_ttl_seconds",
     "client_ttl_seconds",
 )
 _PROCESSING_POS_MIN: int = 1
@@ -217,10 +219,11 @@ class UDPConfig:
 
 @dataclass(slots=True)
 class ProcessingConfig:
-    """Signal processing parameters (sample rate, buffer size, client TTL)."""
+    """Signal processing parameters plus live-vs-retained client timing."""
 
     sample_rate_hz: int
     waveform_seconds: int
+    client_live_ttl_seconds: int
     client_ttl_seconds: int
     accel_scale_g_per_lsb: float | None
 
@@ -252,6 +255,16 @@ class ProcessingConfig:
                 clamped_seconds,
             )
             object.__setattr__(self, "waveform_seconds", clamped_seconds)
+
+        if self.client_ttl_seconds < self.client_live_ttl_seconds:
+            LOGGER.warning(
+                "processing.client_ttl_seconds=%s is below "
+                "processing.client_live_ttl_seconds=%s — clamping retention TTL to %s",
+                self.client_ttl_seconds,
+                self.client_live_ttl_seconds,
+                self.client_live_ttl_seconds,
+            )
+            object.__setattr__(self, "client_ttl_seconds", self.client_live_ttl_seconds)
 
 
 @dataclass(slots=True)
@@ -441,6 +454,10 @@ def load_config(config_path: Path | None = None) -> AppConfig:
             waveform_seconds=_coerce_int(
                 processing_cfg["waveform_seconds"],
                 "processing.waveform_seconds",
+            ),
+            client_live_ttl_seconds=_coerce_int(
+                processing_cfg["client_live_ttl_seconds"],
+                "processing.client_live_ttl_seconds",
             ),
             client_ttl_seconds=_coerce_int(
                 processing_cfg["client_ttl_seconds"],

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -102,15 +102,17 @@ class ClientRecord:
 
 
 class ClientRegistry:
-    """Thread-safe registry of connected ESP32 clients with raw snapshot helpers."""
+    """Thread-safe registry of live and recently-retained ESP32 clients."""
 
     def __init__(
         self,
         db: HistoryDB | None = None,
-        stale_ttl_seconds: float = 120.0,
+        live_ttl_seconds: float = 10.0,
+        retention_ttl_seconds: float = 120.0,
     ):
         self._lock = RLock()
-        self._stale_ttl_seconds = max(1.0, stale_ttl_seconds)
+        self._live_ttl_seconds = max(1.0, live_ttl_seconds)
+        self._retention_ttl_seconds = max(self._live_ttl_seconds, retention_ttl_seconds)
         self._clients: dict[str, ClientRecord] = {}
         self._metadata = ClientMetadataManager(
             lock=self._lock,
@@ -122,6 +124,17 @@ class ClientRegistry:
             delete_client_name=(lambda client_id: db.delete_client_name(client_id))
             if db is not None
             else None,
+        )
+
+    def _is_live_unlocked(self, record: ClientRecord, mono_now: float) -> bool:
+        return bool(
+            record.last_seen_mono and (mono_now - record.last_seen_mono) <= self._live_ttl_seconds,
+        )
+
+    def _is_retained_unlocked(self, record: ClientRecord, mono_now: float) -> bool:
+        return bool(
+            record.last_seen_mono
+            and (mono_now - record.last_seen_mono) <= self._retention_ttl_seconds,
         )
 
     def _get_or_create(self, client_id: str) -> ClientRecord:
@@ -295,8 +308,7 @@ class ClientRegistry:
             return [
                 record.client_id
                 for record in self._clients.values()
-                if record.last_seen_mono
-                and (mono_now - record.last_seen_mono) <= self._stale_ttl_seconds
+                if self._is_live_unlocked(record, mono_now)
             ]
 
     def data_loss_snapshot(self) -> dict[str, int]:
@@ -329,8 +341,7 @@ class ClientRegistry:
             stale_ids = [
                 client_id
                 for client_id, record in self._clients.items()
-                if record.last_seen_mono
-                and (mono_now - record.last_seen_mono) > self._stale_ttl_seconds
+                if record.last_seen_mono and not self._is_retained_unlocked(record, mono_now)
             ]
             for client_id in stale_ids:
                 self._clients.pop(client_id, None)
@@ -369,10 +380,7 @@ class ClientRegistry:
                 age_ms = (
                     int(max(0.0, now_ts - record.last_seen) * 1000) if record.last_seen else None
                 )
-                connected = bool(
-                    record.last_seen_mono
-                    and (mono_now - record.last_seen_mono) <= self._stale_ttl_seconds,
-                )
+                connected = self._is_live_unlocked(record, mono_now)
                 snapshots.append(
                     ClientSnapshot(
                         client_id=record.client_id,

--- a/apps/server/vibesensor/shared/types/api_models/clients.py
+++ b/apps/server/vibesensor/shared/types/api_models/clients.py
@@ -22,7 +22,7 @@ class SetLocationRequest(_FrozenBase):
 
 
 class ClientsResponse(BaseModel):
-    """Response body listing all currently-connected sensor clients."""
+    """Response body listing known sensor clients and their live connection state."""
 
     clients: list[ClientApiRow]
 

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -1482,7 +1482,7 @@
         "type": "object"
       },
       "ClientsResponse": {
-        "description": "Response body listing all currently-connected sensor clients.",
+        "description": "Response body listing known sensor clients and their live connection state.",
         "properties": {
           "clients": {
             "items": {

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -655,7 +655,7 @@ export interface components {
     };
     /**
      * ClientsResponse
-     * @description Response body listing all currently-connected sensor clients.
+     * @description Response body listing known sensor clients and their live connection state.
      */
     ClientsResponse: {
       /** Clients */


### PR DESCRIPTION
## Summary
- split short-window client liveness from longer registry retention so /api/clients and /ws stop treating retained stale sensors as live
- add focused registry, HTTP, and websocket coverage for disconnect transitions and retained stale clients
- update backend config/docs/schema wording to document the live-vs-retained distinction and sync the HTTP contract snapshot

## Validation
- .venv/bin/pytest -q apps/server/tests/infra/runtime/test_registry.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/app/test_config_validation.py
- .venv/bin/python -m vibesensor.cli.http_api_schema_export
- cd apps/ui && npm run sync:contracts && npm run check:contracts && npm run typecheck
- make typecheck-backend
- make lint
- docker compose build --pull
- docker compose up -d
- .venv/bin/python -m vibesensor.adapters.simulator.sim_sender --count 3 --duration 12 --server-host 127.0.0.1 --no-auto-server
- .venv/bin/python -m vibesensor.adapters.simulator.ws_smoke --uri ws://127.0.0.1:8000/ws --min-clients 1 --timeout 20
- verified post-stop /api/clients and /ws retained 3 clients but reported connected=false after the live TTL elapsed

Closes #951