### PR TITLE
Remove dead current_file from recording status contract and UI

### DIFF
--- a/apps/server/tests/adapters/http/test_recording_endpoints.py
+++ b/apps/server/tests/adapters/http/test_recording_endpoints.py
@@ -7,7 +7,6 @@ from test_support import response_payload
 
 _RECORDING_STATUS_DICT = {
     "enabled": True,
-    "current_file": None,
     "run_id": "run-abc",
     "write_error": None,
     "analysis_in_progress": False,
@@ -19,7 +18,6 @@ _RECORDING_STATUS_DICT = {
 
 _IDLE_STATUS_DICT = {
     "enabled": False,
-    "current_file": None,
     "run_id": None,
     "write_error": None,
     "analysis_in_progress": False,
@@ -63,6 +61,7 @@ class TestRecordingStatusEndpoint:
         assert "samples_written" in result
         assert "samples_dropped" in result
         assert "last_completed_run_id" in result
+        assert "current_file" not in result
 
     @pytest.mark.asyncio
     async def test_status_idle_enabled_false(self, _recording_router) -> None:

--- a/apps/server/vibesensor/shared/types/api_models/recording.py
+++ b/apps/server/vibesensor/shared/types/api_models/recording.py
@@ -9,7 +9,6 @@ class RecordingStatusResponse(BaseModel):
     """Response body with the current recording (run-logging) status."""
 
     enabled: bool
-    current_file: str | None
     run_id: str | None
     write_error: str | None
     analysis_in_progress: bool

--- a/apps/server/vibesensor/use_cases/run/status_reporting.py
+++ b/apps/server/vibesensor/use_cases/run/status_reporting.py
@@ -28,7 +28,6 @@ def build_run_recorder_status(
     persist = persistence.status_snapshot()
     return {
         "enabled": enabled,
-        "current_file": None,
         "run_id": run_id,
         "write_error": persist.write_error,
         "analysis_in_progress": post_analysis.is_active,

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -74,7 +74,6 @@
               <button id="startLoggingBtn" class="btn" data-i18n="dashboard.start_recording">Start Recording</button>
               <button id="stopLoggingBtn" class="btn" data-i18n="dashboard.stop_recording">Stop Recording</button>
             </div>
-            <div id="currentLogFile" class="card__subtle">Current file: --</div>
           </div>
 
         </div>

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -145,7 +145,6 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     } else {
       setPillState(els.loggingStatus, on ? "ok" : "muted", on ? t("status.running") : t("status.stopped"));
     }
-    if (els.currentLogFile) els.currentLogFile.textContent = t("status.current_file", { value: status.current_file || "--" });
     if (els.startLoggingBtn) els.startLoggingBtn.disabled = on || !hasActiveClients;
     if (els.stopLoggingBtn) els.stopLoggingBtn.disabled = !on;
   }

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -138,7 +138,6 @@ export function createAppState(): AppState {
     runDetailsById: {},
     loggingStatus: {
       enabled: false,
-      current_file: null,
       run_id: null,
       write_error: null,
       analysis_in_progress: false,

--- a/apps/ui/src/app/ui_dom_registry.ts
+++ b/apps/ui/src/app/ui_dom_registry.ts
@@ -18,7 +18,6 @@ export interface UiDomElements {
   rotationalEngineValue: HTMLElement | null;
   rotationalEngineMode: HTMLElement | null;
   loggingStatus: HTMLElement | null;
-  currentLogFile: HTMLElement | null;
   startLoggingBtn: HTMLButtonElement | null;
   stopLoggingBtn: HTMLButtonElement | null;
   refreshHistoryBtn: HTMLButtonElement | null;
@@ -122,7 +121,6 @@ export function createUiDomRegistry(): UiDomElements {
     rotationalEngineValue: el("rotationalEngineValue"),
     rotationalEngineMode: el("rotationalEngineMode"),
     loggingStatus: el("loggingStatus"),
-    currentLogFile: el("currentLogFile"),
     startLoggingBtn: btnEl("startLoggingBtn"),
     stopLoggingBtn: btnEl("stopLoggingBtn"),
     refreshHistoryBtn: btnEl("refreshHistoryBtn"),

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -4118,17 +4118,6 @@
             "title": "Analysis In Progress",
             "type": "boolean"
           },
-          "current_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Current File"
-          },
           "enabled": {
             "title": "Enabled",
             "type": "boolean"
@@ -4190,7 +4179,6 @@
         },
         "required": [
           "enabled",
-          "current_file",
           "run_id",
           "write_error",
           "analysis_in_progress"

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -1511,8 +1511,6 @@ export interface components {
     RecordingStatusResponse: {
       /** Analysis In Progress */
       analysis_in_progress: boolean;
-      /** Current File */
-      current_file: string | null;
       /** Enabled */
       enabled: boolean;
       /** Last Completed Run Error */

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -181,7 +181,6 @@
   "status.running": "Running",
   "status.stopped": "Stopped",
   "status.unavailable": "Unavailable",
-  "status.current_file": "Current file: {value}",
   "speed.gps": "Speed: {value} {unit} (GPS)",
   "speed.override": "Speed: {value} {unit} (Override)",
   "speed.none": "Speed: -- {unit}",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -181,7 +181,6 @@
   "status.running": "Lopend",
   "status.stopped": "Gestopt",
   "status.unavailable": "Niet beschikbaar",
-  "status.current_file": "Huidig bestand: {value}",
   "speed.gps": "Snelheid: {value} {unit} (GPS)",
   "speed.override": "Snelheid: {value} {unit} (Handmatig)",
   "speed.none": "Snelheid: -- {unit}",

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -25,11 +25,11 @@ test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) 
   });
   await page.route("**/api/recording/start", async (route) => {
     startCalls += 1;
-    await fulfillJson(route, { enabled: true, current_file: "run-001.jsonl" });
+    await fulfillJson(route, { enabled: true, run_id: "run-001" });
   });
   await page.route("**/api/recording/stop", async (route) => {
     stopCalls += 1;
-    await fulfillJson(route, { enabled: false, current_file: null });
+    await fulfillJson(route, { enabled: false, run_id: null });
   });
 
   await installFakeWebSocket(page, {

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -63,7 +63,7 @@ export async function fulfillJson(route: Route, body: unknown): Promise<void> {
 
 export async function installCommonRoutes(page: Page, options: CommonRouteOptions = {}): Promise<void> {
   await page.route("**/api/recording/status", async (route) => {
-    await fulfillJson(route, { enabled: false, current_file: null });
+    await fulfillJson(route, { enabled: false, run_id: null });
   });
   await page.route("**/api/history**", async (route) => {
     if (!requestPath(route).startsWith("/api/history")) {


### PR DESCRIPTION
## Summary
- remove the dead current_file field from the backend recording-status contract and builder
- remove the meaningless dashboard Current file placeholder and related UI wiring
- regenerate HTTP contracts and update smoke fixtures so they stop inventing file names

## Testing
- .venv/bin/pytest -q apps/server/tests/adapters/http/test_recording_endpoints.py apps/server/tests/adapters/http/test_http_api_schema_export.py
- make typecheck-backend
- make lint with the repo .venv/bin tools on PATH
- cd apps/ui && npm run typecheck && npm run build && npx playwright test --config=playwright.config.ts tests/smoke.bootstrap.spec.ts --project=laptop-light --workers=1
- docker compose build --pull
- docker compose up -d
- .venv/bin/python -m vibesensor.adapters.simulator.sim_sender --count 2 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server
- curl-based assertions against /api/recording/status, /api/recording/start, /api/recording/stop, and /

Closes #952