### PR TITLE
Type remaining AnalysisSummaryResponse sub-objects

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -70,6 +70,12 @@ def test_export_schema_contains_finding_components_for_history_insights(
     assert history_insights["properties"]["top_causes"]["items"] == {
         "$ref": "#/components/schemas/FindingPayload",
     }
+    assert history_insights["properties"]["warnings"]["items"] == {
+        "$ref": "#/components/schemas/HistoryInsightWarningResponse",
+    }
+    assert history_insights["properties"]["sensor_intensity_by_location"]["items"] == {
+        "$ref": "#/components/schemas/LocationIntensitySummaryResponse",
+    }
     assert {
         "finding_id",
         "suspected_source",
@@ -120,6 +126,33 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     }
     assert analysis_summary["properties"]["phase_speed_breakdown"]["items"] == {
         "$ref": "#/components/schemas/PhaseSpeedBreakdownRow",
+    }
+    assert analysis_summary["properties"]["warnings"]["items"] == {
+        "$ref": "#/components/schemas/SummaryWarningResponse",
+    }
+    assert analysis_summary["properties"]["phase_segments"]["items"] == {
+        "$ref": "#/components/schemas/PhaseSegmentSummaryResponse",
+    }
+    assert analysis_summary["properties"]["test_plan"]["items"] == {
+        "$ref": "#/components/schemas/TestPlanStepResponse",
+    }
+    assert analysis_summary["properties"]["phase_timeline"]["items"] == {
+        "$ref": "#/components/schemas/PhaseTimelineEntryResponse",
+    }
+    assert analysis_summary["properties"]["speed_stats"] == {
+        "$ref": "#/components/schemas/SpeedStatsResponse",
+    }
+    assert analysis_summary["properties"]["speed_stats_by_phase"]["additionalProperties"] == {
+        "$ref": "#/components/schemas/SpeedStatsResponse",
+    }
+    assert analysis_summary["properties"]["phase_info"] == {
+        "$ref": "#/components/schemas/PhaseInfoResponse",
+    }
+    assert analysis_summary["properties"]["sensor_intensity_by_location"]["items"] == {
+        "$ref": "#/components/schemas/LocationIntensitySummaryResponse",
+    }
+    assert analysis_summary["properties"]["data_quality"] == {
+        "$ref": "#/components/schemas/DataQualityResponse",
     }
     assert analysis_summary["properties"]["run_suitability"]["items"] == {
         "$ref": "#/components/schemas/RunSuitabilityCheck",

--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -8,7 +8,7 @@ for serialization into ``FindingPayload`` and similar boundary payloads.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NotRequired, Required, TypedDict
+from typing import TYPE_CHECKING, Literal, NotRequired, Required, TypedDict
 
 from vibesensor.domain import OrderMatchObservation
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
@@ -158,6 +158,146 @@ class RunSuitabilityCheck(TypedDict):
     check_key: str
     state: str
     explanation: JsonValue
+
+
+class SummaryWarningPayload(TypedDict):
+    code: str
+    severity: Literal["warn", "error"]
+    applies_to: str
+    title: JsonValue
+    detail: JsonValue
+
+
+class TestPlanStepPayload(TypedDict):
+    action_id: str
+    what: str
+    why: str | None
+    confirm: str | None
+    falsify: str | None
+    eta: str | None
+
+
+class PhaseTimelineEntryPayload(TypedDict):
+    phase: str
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    has_fault_evidence: bool
+
+
+class PhaseSegmentSummaryPayload(TypedDict):
+    phase: str
+    start_idx: int
+    end_idx: int
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    sample_count: int
+
+
+class SpeedStatsPayload(TypedDict):
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    range_kmh: float | None
+    steady_speed: bool
+    sample_count: int
+
+
+class PhaseInfoPayload(TypedDict):
+    phase_counts: dict[str, int]
+    phase_pcts: dict[str, float]
+    total_samples: int
+    segment_count: int
+    has_cruise: bool
+    has_acceleration: bool
+    cruise_pct: float
+    idle_pct: float
+    speed_unknown_pct: float
+
+
+class OutlierSummaryPayload(TypedDict):
+    count: int
+    outlier_count: int
+    outlier_pct: float
+    lower_bound: float | None
+    upper_bound: float | None
+
+
+class DataQualityRequiredMissingPctPayload(TypedDict):
+    t_s: float
+    speed_kmh: float
+    accel_x: float
+    accel_y: float
+    accel_z: float
+
+
+class DataQualitySpeedCoveragePayload(TypedDict):
+    non_null_pct: float
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    count_non_null: int
+
+
+class DataQualityAccelSanityPayload(TypedDict):
+    x_mean: float | None
+    x_variance: float | None
+    y_mean: float | None
+    y_variance: float | None
+    z_mean: float | None
+    z_variance: float | None
+    sensor_limit: float | None
+    saturation_count: int | None
+
+
+class DataQualityOutliersPayload(TypedDict):
+    accel_magnitude: OutlierSummaryPayload
+    amplitude_metric: OutlierSummaryPayload
+
+
+class DataQualityPayload(TypedDict):
+    required_missing_pct: DataQualityRequiredMissingPctPayload
+    speed_coverage: DataQualitySpeedCoveragePayload
+    accel_sanity: DataQualityAccelSanityPayload
+    outliers: DataQualityOutliersPayload
+
+
+class StrengthBucketDistributionPayload(TypedDict):
+    total: int
+    counts: dict[str, int]
+    percent_time_l0: float
+    percent_time_l1: float
+    percent_time_l2: float
+    percent_time_l3: float
+    percent_time_l4: float
+    percent_time_l5: float
+
+
+class PhaseIntensityStatsPayload(TypedDict):
+    count: int
+    mean_intensity_db: float | None
+    max_intensity_db: float | None
+
+
+class LocationIntensitySummaryPayload(TypedDict):
+    location: str
+    partial_coverage: bool
+    sample_count: int
+    sample_coverage_ratio: float
+    sample_coverage_warning: bool
+    mean_intensity_db: float | None
+    p50_intensity_db: float | None
+    p95_intensity_db: float | None
+    max_intensity_db: float | None
+    dropped_frames_delta: float | None
+    queue_overflow_drops_delta: float | None
+    strength_bucket_distribution: StrengthBucketDistributionPayload
+    phase_intensity: dict[str, PhaseIntensityStatsPayload] | None
 
 
 # ---------------------------------------------------------------------------
@@ -321,26 +461,26 @@ class AnalysisSummary(TypedDict):
     accel_scale_g_per_lsb: float | None
     incomplete_for_order_analysis: bool
     metadata: JsonObject
-    warnings: list[JsonObject]
+    warnings: list[SummaryWarningPayload]
     speed_breakdown: list[SpeedBreakdownRow]
     phase_speed_breakdown: list[PhaseSpeedBreakdownRow]
-    phase_segments: list[JsonObject]
+    phase_segments: list[PhaseSegmentSummaryPayload]
     run_noise_baseline_db: float | None
     speed_breakdown_skipped_reason: JsonObject | None
     findings: list[FindingPayload]
     top_causes: list[FindingPayload]
     most_likely_origin: SuspectedVibrationOrigin
-    test_plan: list[JsonObject]
-    phase_timeline: list[JsonObject]
-    speed_stats: JsonObject
-    speed_stats_by_phase: dict[str, JsonObject]
-    phase_info: JsonObject
+    test_plan: list[TestPlanStepPayload]
+    phase_timeline: list[PhaseTimelineEntryPayload]
+    speed_stats: SpeedStatsPayload
+    speed_stats_by_phase: dict[str, SpeedStatsPayload]
+    phase_info: PhaseInfoPayload
     sensor_locations: list[str]
     sensor_locations_connected_throughout: list[str]
     sensor_count_used: int
-    sensor_intensity_by_location: list[JsonObject]
+    sensor_intensity_by_location: list[LocationIntensitySummaryPayload]
     run_suitability: list[RunSuitabilityCheck]
-    data_quality: JsonObject
+    data_quality: DataQualityPayload
     samples: NotRequired[list[JsonObject]]
     plots: NotRequired[PlotDataResult]
     analysis_metadata: NotRequired[JsonObject]

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -16,7 +16,10 @@ from vibesensor.coerce import coerce_float
 from vibesensor.domain import Finding, FindingEvidence, Signature, VibrationSource
 from vibesensor.domain.order_match import OrderMatchObservation
 from vibesensor.domain.test_plan import RecommendedAction, TestPlan
-from vibesensor.shared.boundaries.analysis_payload import matched_point_from_observation
+from vibesensor.shared.boundaries.analysis_payload import (
+    TestPlanStepPayload,
+    matched_point_from_observation,
+)
 from vibesensor.shared.boundaries.vibration_origin import (
     location_hotspot_from_payload,
     vibration_origin_from_payload,
@@ -44,7 +47,7 @@ def _has_structured_step_content(steps: object) -> bool:
     return False
 
 
-def step_payload_from_action(action: RecommendedAction) -> dict[str, object]:
+def step_payload_from_action(action: RecommendedAction) -> TestPlanStepPayload:
     """Project one semantic action into the persisted TestStep shape."""
     return {
         "action_id": action.action_id,
@@ -56,7 +59,7 @@ def step_payload_from_action(action: RecommendedAction) -> dict[str, object]:
     }
 
 
-def step_payloads_from_plan(test_plan: TestPlan) -> list[dict[str, object]]:
+def step_payloads_from_plan(test_plan: TestPlan) -> list[TestPlanStepPayload]:
     """Project a semantic TestPlan into the persisted TestStep payload list."""
     return [step_payload_from_action(action) for action in test_plan.prioritized_actions]
 

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_plots.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_plots.py
@@ -12,12 +12,12 @@ from vibesensor.shared.boundaries.analysis_payload import (
     PeakTableRow,
     PhaseBoundary,
     PhaseSegmentOut,
+    PhaseSegmentSummaryPayload,
     PhaseSpeedBreakdownRow,
     PlotDataResult,
     SpectrogramResult,
     SpeedBreakdownRow,
 )
-from vibesensor.shared.types.json_types import JsonObject
 
 from ._contracts import (
     PeakTableRowLike,
@@ -29,7 +29,9 @@ from ._contracts import (
 )
 
 
-def serialize_phase_segments(phase_segments: Sequence[PhaseSegmentLike]) -> list[JsonObject]:
+def serialize_phase_segments(
+    phase_segments: Sequence[PhaseSegmentLike],
+) -> list[PhaseSegmentSummaryPayload]:
     """Serialize phase segments to JSON-safe dicts."""
     return [
         {

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -12,7 +12,16 @@ from vibesensor.domain import (
 )
 from vibesensor.domain.snapshots import DrivingPhaseSummary, SpeedProfileSummary
 from vibesensor.domain.vibration_origin import VibrationOrigin
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.boundaries.analysis_payload import (
+    AnalysisSummary,
+    DataQualityPayload,
+    LocationIntensitySummaryPayload,
+    OutlierSummaryPayload,
+    PhaseInfoPayload,
+    PhaseTimelineEntryPayload,
+    SpeedStatsPayload,
+    TestPlanStepPayload,
+)
 from vibesensor.shared.boundaries.diagnostic_case import run_suitability_payload
 from vibesensor.shared.boundaries.vibration_origin import (
     SuspectedVibrationOrigin,
@@ -70,7 +79,7 @@ def build_data_quality_dict(
     speed_non_null_pct: float,
     accel_stats: AccelStatisticsLike,
     amp_metric_values: list[float],
-) -> JsonObject:
+) -> DataQualityPayload:
     """Build the ``data_quality`` sub-dict for the persisted run summary."""
     sample_rows = list(samples)
     return {
@@ -100,8 +109,14 @@ def build_data_quality_dict(
             "saturation_count": _int_value(accel_stats, "sat_count"),
         },
         "outliers": {
-            "accel_magnitude": _json_outlier_summary(_float_list(accel_stats, "accel_mag_vals")),
-            "amplitude_metric": _json_outlier_summary(amp_metric_values),
+            "accel_magnitude": cast(
+                OutlierSummaryPayload,
+                _json_outlier_summary(_float_list(accel_stats, "accel_mag_vals")),
+            ),
+            "amplitude_metric": cast(
+                OutlierSummaryPayload,
+                _json_outlier_summary(amp_metric_values),
+            ),
         },
     }
 
@@ -163,7 +178,7 @@ def build_summary_payload(
     findings: tuple[DomainFinding, ...],
     top_causes: tuple[DomainFinding, ...],
     most_likely_origin: VibrationOrigin | None,
-    test_plan: list[JsonObject],
+    test_plan: list[TestPlanStepPayload],
     phase_timeline: list[DrivingPhaseInterval],
     speed_stats: SpeedProfileSummary,
     speed_stats_by_phase: dict[str, SpeedProfileSummary],
@@ -178,6 +193,17 @@ def build_summary_payload(
     amp_metric_values: list[float],
 ) -> AnalysisSummary:
     """Assemble the final summary payload from already-computed artifacts."""
+    phase_timeline_payload: list[PhaseTimelineEntryPayload] = [
+        {
+            "phase": entry.phase.value,
+            "start_t_s": entry.start_t_s,
+            "end_t_s": entry.end_t_s,
+            "speed_min_kmh": entry.speed_min_kmh,
+            "speed_max_kmh": entry.speed_max_kmh,
+            "has_fault_evidence": entry.has_fault_evidence,
+        }
+        for entry in phase_timeline
+    ]
     return {
         "file_name": file_name,
         "run_id": run_id,
@@ -208,26 +234,19 @@ def build_summary_payload(
         "top_causes": serialize_findings(top_causes),
         "most_likely_origin": serialize_origin_summary(most_likely_origin),
         "test_plan": test_plan,
-        "phase_timeline": [
-            {
-                "phase": entry.phase.value,
-                "start_t_s": entry.start_t_s,
-                "end_t_s": entry.end_t_s,
-                "speed_min_kmh": entry.speed_min_kmh,
-                "speed_max_kmh": entry.speed_max_kmh,
-                "has_fault_evidence": entry.has_fault_evidence,
-            }
-            for entry in phase_timeline
-        ],
-        "speed_stats": cast(JsonObject, speed_stats.to_dict()),
+        "phase_timeline": phase_timeline_payload,
+        "speed_stats": cast(SpeedStatsPayload, speed_stats.to_dict()),
         "speed_stats_by_phase": {
-            k: cast(JsonObject, v.to_dict()) for k, v in speed_stats_by_phase.items()
+            k: cast(SpeedStatsPayload, v.to_dict()) for k, v in speed_stats_by_phase.items()
         },
-        "phase_info": cast(JsonObject, phase_info.to_dict()),
+        "phase_info": cast(PhaseInfoPayload, phase_info.to_dict()),
         "sensor_locations": sensor_locations,
         "sensor_locations_connected_throughout": sorted(connected_locations),
         "sensor_count_used": len(sensor_locations),
-        "sensor_intensity_by_location": [asdict(row) for row in sensor_intensity_by_location],
+        "sensor_intensity_by_location": [
+            cast(LocationIntensitySummaryPayload, asdict(row))
+            for row in sensor_intensity_by_location
+        ],
         "run_suitability": run_suitability_payload(run_suitability),
         "samples": samples,
         "data_quality": build_data_quality_dict(

--- a/apps/server/vibesensor/shared/run_context.py
+++ b/apps/server/vibesensor/shared/run_context.py
@@ -13,6 +13,7 @@ from vibesensor.domain import (
     RunContextSnapshot,
 )
 from vibesensor.report_i18n import tr as _tr
+from vibesensor.shared.boundaries.analysis_payload import SummaryWarningPayload
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
@@ -75,9 +76,9 @@ def build_summary_warnings(
     metadata: Mapping[str, object],
     *,
     reference_complete: bool,
-) -> list[JsonObject]:
+) -> list[SummaryWarningPayload]:
     """Build language-neutral trust warnings stored with the analysis summary."""
-    warnings: list[JsonObject] = []
+    warnings: list[SummaryWarningPayload] = []
     if not reference_complete or bool(metadata.get("incomplete_for_order_analysis")):
         warnings.append(
             {

--- a/apps/server/vibesensor/shared/types/api_models/history.py
+++ b/apps/server/vibesensor/shared/types/api_models/history.py
@@ -47,6 +47,163 @@ class HistoryInsightWarningResponse(BaseModel):
     detail: str | None = None
 
 
+class SummaryWarningResponse(BaseModel):
+    """Response body for a persisted summary warning before localization."""
+
+    code: str
+    severity: Literal["warn", "error"]
+    applies_to: str
+    title: ApiPayloadValue
+    detail: ApiPayloadValue = None
+
+
+class TestPlanStepResponse(BaseModel):
+    """Response body for one recommended next-step action."""
+
+    action_id: str
+    what: str
+    why: str | None
+    confirm: str | None
+    falsify: str | None
+    eta: str | None
+
+
+class PhaseTimelineEntryResponse(BaseModel):
+    """Response body for one summarized phase-timeline interval."""
+
+    phase: str
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    has_fault_evidence: bool
+
+
+class SpeedStatsResponse(BaseModel):
+    """Response body for one summarized speed-profile snapshot."""
+
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    range_kmh: float | None
+    steady_speed: bool
+    sample_count: int
+
+
+class PhaseInfoResponse(BaseModel):
+    """Response body for aggregate driving-phase coverage metrics."""
+
+    phase_counts: dict[str, int]
+    phase_pcts: dict[str, float]
+    total_samples: int
+    segment_count: int
+    has_cruise: bool
+    has_acceleration: bool
+    cruise_pct: float
+    idle_pct: float
+    speed_unknown_pct: float
+
+
+class OutlierSummaryResponse(BaseModel):
+    """Response body for an outlier-summary bucket."""
+
+    count: int
+    outlier_count: int
+    outlier_pct: float
+    lower_bound: float | None
+    upper_bound: float | None
+
+
+class DataQualityRequiredMissingPctResponse(BaseModel):
+    """Response body for required-field missing percentages."""
+
+    t_s: float
+    speed_kmh: float
+    accel_x: float
+    accel_y: float
+    accel_z: float
+
+
+class DataQualitySpeedCoverageResponse(BaseModel):
+    """Response body for summarized speed-coverage statistics."""
+
+    non_null_pct: float
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    count_non_null: int
+
+
+class DataQualityAccelSanityResponse(BaseModel):
+    """Response body for acceleration sanity diagnostics."""
+
+    x_mean: float | None
+    x_variance: float | None
+    y_mean: float | None
+    y_variance: float | None
+    z_mean: float | None
+    z_variance: float | None
+    sensor_limit: float | None
+    saturation_count: int | None
+
+
+class DataQualityOutliersResponse(BaseModel):
+    """Response body for grouped outlier summaries."""
+
+    accel_magnitude: OutlierSummaryResponse
+    amplitude_metric: OutlierSummaryResponse
+
+
+class DataQualityResponse(BaseModel):
+    """Response body for run-level data-quality diagnostics."""
+
+    required_missing_pct: DataQualityRequiredMissingPctResponse
+    speed_coverage: DataQualitySpeedCoverageResponse
+    accel_sanity: DataQualityAccelSanityResponse
+    outliers: DataQualityOutliersResponse
+
+
+class StrengthBucketDistributionResponse(BaseModel):
+    """Response body for per-location strength-bucket coverage."""
+
+    total: int
+    counts: dict[str, int]
+    percent_time_l0: float
+    percent_time_l1: float
+    percent_time_l2: float
+    percent_time_l3: float
+    percent_time_l4: float
+    percent_time_l5: float
+
+
+class PhaseIntensityStatsResponse(BaseModel):
+    """Response body for per-phase intensity aggregates at one location."""
+
+    count: int
+    mean_intensity_db: float | None
+    max_intensity_db: float | None
+
+
+class LocationIntensitySummaryResponse(BaseModel):
+    """Response body for one sensor-location intensity summary row."""
+
+    location: str
+    partial_coverage: bool
+    sample_count: int
+    sample_coverage_ratio: float
+    sample_coverage_warning: bool
+    mean_intensity_db: float | None
+    p50_intensity_db: float | None
+    p95_intensity_db: float | None
+    max_intensity_db: float | None
+    dropped_frames_delta: float | None
+    queue_overflow_drops_delta: float | None
+    strength_bucket_distribution: StrengthBucketDistributionResponse
+    phase_intensity: dict[str, PhaseIntensityStatsResponse] | None = None
+
+
 class MatchedPoint(_ExtraAllowBase):
     """HTTP contract for one serialized finding matched-point observation."""
 
@@ -239,6 +396,19 @@ class PhaseSegmentOut(BaseModel):
     end_t_s: float | None
 
 
+class PhaseSegmentSummaryResponse(BaseModel):
+    """Typed HTTP contract for a summarized driving-phase segment."""
+
+    phase: str
+    start_idx: int
+    end_idx: int
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    sample_count: int
+
+
 class PhaseBoundary(BaseModel):
     """Typed HTTP contract for a phase-boundary marker."""
 
@@ -292,8 +462,8 @@ class SuspectedVibrationOriginPayload(_ExtraAllowBase):
     explanation: ApiPayloadValue = None
 
 
-class AnalysisSummaryResponse(_ExtraAllowBase):
-    """Typed HTTP contract for the persisted analysis summary on one history run."""
+class _AnalysisSummaryCoreResponse(_ExtraAllowBase):
+    """Shared typed HTTP contract fields used by history-run analysis payloads."""
 
     file_name: str
     run_id: str
@@ -314,39 +484,41 @@ class AnalysisSummaryResponse(_ExtraAllowBase):
     accel_scale_g_per_lsb: float | None
     incomplete_for_order_analysis: bool
     metadata: ApiPayloadObject
-    warnings: list[ApiPayloadObject]
     speed_breakdown: list[SpeedBreakdownRow]
     phase_speed_breakdown: list[PhaseSpeedBreakdownRow]
-    phase_segments: list[ApiPayloadObject]
+    phase_segments: list[PhaseSegmentSummaryResponse]
     run_noise_baseline_db: float | None
     speed_breakdown_skipped_reason: ApiPayloadObject | None
     findings: list[FindingPayload]
     top_causes: list[FindingPayload]
     most_likely_origin: SuspectedVibrationOriginPayload
-    test_plan: list[ApiPayloadObject]
-    phase_timeline: list[ApiPayloadObject]
-    speed_stats: ApiPayloadObject
-    speed_stats_by_phase: dict[str, ApiPayloadObject]
-    phase_info: ApiPayloadObject
+    test_plan: list[TestPlanStepResponse]
+    phase_timeline: list[PhaseTimelineEntryResponse]
+    speed_stats: SpeedStatsResponse
+    speed_stats_by_phase: dict[str, SpeedStatsResponse]
+    phase_info: PhaseInfoResponse
     sensor_locations: list[str]
     sensor_locations_connected_throughout: list[str]
     sensor_count_used: int
-    sensor_intensity_by_location: list[ApiPayloadObject]
+    sensor_intensity_by_location: list[LocationIntensitySummaryResponse]
     run_suitability: list[RunSuitabilityCheck]
-    data_quality: ApiPayloadObject
+    data_quality: DataQualityResponse
     samples: list[ApiPayloadObject] = Field(default_factory=list)
     plots: PlotDataResult | None = None
     analysis_metadata: ApiPayloadObject = Field(default_factory=dict)
 
 
-class HistoryInsightsResponse(_ExtraAllowBase):
-    """Response body with aggregated diagnostic insights for a run."""
+class AnalysisSummaryResponse(_AnalysisSummaryCoreResponse):
+    """Typed HTTP contract for the persisted analysis summary on one history run."""
 
-    run_id: str | None = None
+    warnings: list[SummaryWarningResponse]
+
+
+class HistoryInsightsResponse(_AnalysisSummaryCoreResponse):
+    """Response body for the localized history insights endpoint payload."""
+
     status: str | None = None
     warnings: list[HistoryInsightWarningResponse] = Field(default_factory=list)
-    findings: list[FindingPayload] = Field(default_factory=list)
-    top_causes: list[FindingPayload] = Field(default_factory=list)
 
 
 class DeleteHistoryRunResponse(BaseModel):

--- a/apps/server/vibesensor/use_cases/diagnostics/_summary_result.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_summary_result.py
@@ -106,7 +106,7 @@ def build_analysis_result(
     summary_speed_stats = _speed_stats(prepared.speed_values)
     summary_phase_info = build_phase_summary(prepared.phase_segments)
     domain_test_plan = plan_test_actions(domain_findings)
-    summary_test_plan = cast(list[JsonObject], step_payloads_from_plan(domain_test_plan))
+    summary_test_plan = step_payloads_from_plan(domain_test_plan)
 
     test_run = TestRun(
         capture=RunCapture(

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -7,20 +7,7 @@ import type {
 import type { RunDetail } from "../ui_app_state";
 import { heatColor, normalizeUnit } from "../features/heat_utils";
 
-interface LocationIntensityRow {
-  location?: string | null;
-  p50_intensity_db?: number | null;
-  p95_intensity_db?: number | null;
-  mean_intensity_db?: number | null;
-  max_intensity_db?: number | null;
-  p50?: number | null;
-  p95?: number | null;
-  dropped_frames_delta?: number | null;
-  frames_dropped_delta?: number | null;
-  queue_overflow_drops_delta?: number | null;
-  sample_count?: number | null;
-  samples?: number | null;
-}
+type LocationIntensityRow = HistoryInsightsPayload["sensor_intensity_by_location"][number];
 
 const EMPTY_RUN_DETAIL: RunDetail = {
   preview: null,
@@ -66,12 +53,7 @@ function summarizeFindings(summary: HistoryInsightsPayload | null): FindingPaylo
 }
 
 function summarizeWarnings(payload: HistoryInsightsPayload | null): HistoryInsightWarningPayload[] {
-  const warnings = Array.isArray(payload?.warnings) ? payload.warnings : [];
-  return warnings.filter((warning): warning is HistoryInsightWarningPayload => {
-    return typeof warning?.code === "string"
-      && typeof warning?.severity === "string"
-      && typeof warning?.title === "string";
-  });
+  return payload?.warnings ?? [];
 }
 
 function normalizeLogLocationKey(location: unknown): string {
@@ -92,19 +74,12 @@ function normalizeLogLocationKey(location: unknown): string {
   return raw;
 }
 
-function isLocationIntensityRow(value: unknown): value is LocationIntensityRow {
-  return typeof value === "object" && value !== null;
-}
-
 function sensorIntensityRows(summary: HistoryInsightsPayload | null): LocationIntensityRow[] {
-  if (!Array.isArray(summary?.sensor_intensity_by_location)) {
-    return [];
-  }
-  return summary.sensor_intensity_by_location.filter(isLocationIntensityRow);
+  return summary?.sensor_intensity_by_location ?? [];
 }
 
 function metricFromLocationStat(row: LocationIntensityRow): number | null {
-  const value = Number(row.p95_intensity_db ?? row.p95 ?? row.mean_intensity_db ?? row.max_intensity_db);
+  const value = Number(row.p95_intensity_db ?? row.mean_intensity_db ?? row.max_intensity_db);
   return Number.isFinite(value) ? value : null;
 }
 
@@ -161,17 +136,17 @@ function renderPreviewStats(
   }
   const body = rows
     .map((row) => {
-      const dropped = row?.dropped_frames_delta ?? row?.frames_dropped_delta;
-      const overflow = row?.queue_overflow_drops_delta;
+      const dropped = row.dropped_frames_delta;
+      const overflow = row.queue_overflow_drops_delta;
       return `
           <tr>
             <td>${escapeHtml(row.location || "--")}</td>
-            <td class="numeric">${fmt(Number(row.p50_intensity_db ?? row.p50), 1)}</td>
-            <td class="numeric">${fmt(Number(row.p95_intensity_db ?? row.p95), 1)}</td>
+            <td class="numeric">${fmt(Number(row.p50_intensity_db), 1)}</td>
+            <td class="numeric">${fmt(Number(row.p95_intensity_db), 1)}</td>
             <td class="numeric">${fmt(Number(row.max_intensity_db), 1)}</td>
             <td class="numeric">${typeof dropped === "number" ? formatInt(dropped) : "--"}</td>
             <td class="numeric">${typeof overflow === "number" ? formatInt(overflow) : "--"}</td>
-            <td class="numeric">${formatInt(Number(row.sample_count ?? row.samples))}</td>
+            <td class="numeric">${formatInt(Number(row.sample_count))}</td>
           </tr>`;
     })
     .join("");

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -426,9 +426,7 @@
             "type": "object"
           },
           "data_quality": {
-            "additionalProperties": true,
-            "title": "Data Quality",
-            "type": "object"
+            "$ref": "#/components/schemas/DataQualityResponse"
           },
           "duration_s": {
             "title": "Duration S",
@@ -613,14 +611,11 @@
             "title": "Peak Picker Method"
           },
           "phase_info": {
-            "additionalProperties": true,
-            "title": "Phase Info",
-            "type": "object"
+            "$ref": "#/components/schemas/PhaseInfoResponse"
           },
           "phase_segments": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/PhaseSegmentSummaryResponse"
             },
             "title": "Phase Segments",
             "type": "array"
@@ -634,8 +629,7 @@
           },
           "phase_timeline": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/PhaseTimelineEntryResponse"
             },
             "title": "Phase Timeline",
             "type": "array"
@@ -733,8 +727,7 @@
           },
           "sensor_intensity_by_location": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/LocationIntensitySummaryResponse"
             },
             "title": "Sensor Intensity By Location",
             "type": "array"
@@ -801,14 +794,11 @@
             "title": "Speed Breakdown Skipped Reason"
           },
           "speed_stats": {
-            "additionalProperties": true,
-            "title": "Speed Stats",
-            "type": "object"
+            "$ref": "#/components/schemas/SpeedStatsResponse"
           },
           "speed_stats_by_phase": {
             "additionalProperties": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/SpeedStatsResponse"
             },
             "title": "Speed Stats By Phase",
             "type": "object"
@@ -843,8 +833,7 @@
           },
           "test_plan": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/TestPlanStepResponse"
             },
             "title": "Test Plan",
             "type": "array"
@@ -858,8 +847,7 @@
           },
           "warnings": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/SummaryWarningResponse"
             },
             "title": "Warnings",
             "type": "array"
@@ -877,7 +865,6 @@
           "accel_scale_g_per_lsb",
           "incomplete_for_order_analysis",
           "metadata",
-          "warnings",
           "speed_breakdown",
           "phase_speed_breakdown",
           "phase_segments",
@@ -896,7 +883,8 @@
           "sensor_count_used",
           "sensor_intensity_by_location",
           "run_suitability",
-          "data_quality"
+          "data_quality",
+          "warnings"
         ],
         "title": "AnalysisSummaryResponse",
         "type": "object"
@@ -1520,6 +1508,254 @@
           }
         },
         "title": "CombinedMetrics",
+        "type": "object"
+      },
+      "DataQualityAccelSanityResponse": {
+        "description": "Response body for acceleration sanity diagnostics.",
+        "properties": {
+          "saturation_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Saturation Count"
+          },
+          "sensor_limit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sensor Limit"
+          },
+          "x_mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Mean"
+          },
+          "x_variance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Variance"
+          },
+          "y_mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Mean"
+          },
+          "y_variance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Variance"
+          },
+          "z_mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Z Mean"
+          },
+          "z_variance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Z Variance"
+          }
+        },
+        "required": [
+          "x_mean",
+          "x_variance",
+          "y_mean",
+          "y_variance",
+          "z_mean",
+          "z_variance",
+          "sensor_limit",
+          "saturation_count"
+        ],
+        "title": "DataQualityAccelSanityResponse",
+        "type": "object"
+      },
+      "DataQualityOutliersResponse": {
+        "description": "Response body for grouped outlier summaries.",
+        "properties": {
+          "accel_magnitude": {
+            "$ref": "#/components/schemas/OutlierSummaryResponse"
+          },
+          "amplitude_metric": {
+            "$ref": "#/components/schemas/OutlierSummaryResponse"
+          }
+        },
+        "required": [
+          "accel_magnitude",
+          "amplitude_metric"
+        ],
+        "title": "DataQualityOutliersResponse",
+        "type": "object"
+      },
+      "DataQualityRequiredMissingPctResponse": {
+        "description": "Response body for required-field missing percentages.",
+        "properties": {
+          "accel_x": {
+            "title": "Accel X",
+            "type": "number"
+          },
+          "accel_y": {
+            "title": "Accel Y",
+            "type": "number"
+          },
+          "accel_z": {
+            "title": "Accel Z",
+            "type": "number"
+          },
+          "speed_kmh": {
+            "title": "Speed Kmh",
+            "type": "number"
+          },
+          "t_s": {
+            "title": "T S",
+            "type": "number"
+          }
+        },
+        "required": [
+          "t_s",
+          "speed_kmh",
+          "accel_x",
+          "accel_y",
+          "accel_z"
+        ],
+        "title": "DataQualityRequiredMissingPctResponse",
+        "type": "object"
+      },
+      "DataQualityResponse": {
+        "description": "Response body for run-level data-quality diagnostics.",
+        "properties": {
+          "accel_sanity": {
+            "$ref": "#/components/schemas/DataQualityAccelSanityResponse"
+          },
+          "outliers": {
+            "$ref": "#/components/schemas/DataQualityOutliersResponse"
+          },
+          "required_missing_pct": {
+            "$ref": "#/components/schemas/DataQualityRequiredMissingPctResponse"
+          },
+          "speed_coverage": {
+            "$ref": "#/components/schemas/DataQualitySpeedCoverageResponse"
+          }
+        },
+        "required": [
+          "required_missing_pct",
+          "speed_coverage",
+          "accel_sanity",
+          "outliers"
+        ],
+        "title": "DataQualityResponse",
+        "type": "object"
+      },
+      "DataQualitySpeedCoverageResponse": {
+        "description": "Response body for summarized speed-coverage statistics.",
+        "properties": {
+          "count_non_null": {
+            "title": "Count Non Null",
+            "type": "integer"
+          },
+          "max_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Kmh"
+          },
+          "mean_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Kmh"
+          },
+          "min_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Kmh"
+          },
+          "non_null_pct": {
+            "title": "Non Null Pct",
+            "type": "number"
+          },
+          "stddev_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stddev Kmh"
+          }
+        },
+        "required": [
+          "non_null_pct",
+          "min_kmh",
+          "max_kmh",
+          "mean_kmh",
+          "stddev_kmh",
+          "count_non_null"
+        ],
+        "title": "DataQualitySpeedCoverageResponse",
         "type": "object"
       },
       "DebugSpectrumErrorPayload": {
@@ -3098,8 +3334,130 @@
       },
       "HistoryInsightsResponse": {
         "additionalProperties": true,
-        "description": "Response body with aggregated diagnostic insights for a run.",
+        "description": "Response body for the localized history insights endpoint payload.",
         "properties": {
+          "accel_scale_g_per_lsb": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accel Scale G Per Lsb"
+          },
+          "analysis_metadata": {
+            "additionalProperties": true,
+            "title": "Analysis Metadata",
+            "type": "object"
+          },
+          "data_quality": {
+            "$ref": "#/components/schemas/DataQualityResponse"
+          },
+          "duration_s": {
+            "title": "Duration S",
+            "type": "number"
+          },
+          "end_time_utc": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time Utc"
+          },
+          "feature_interval_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Interval S"
+          },
+          "fft_window_size_samples": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fft Window Size Samples"
+          },
+          "fft_window_type": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fft Window Type"
+          },
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
           "findings": {
             "items": {
               "$ref": "#/components/schemas/FindingPayload"
@@ -3107,16 +3465,298 @@
             "title": "Findings",
             "type": "array"
           },
-          "run_id": {
+          "firmware_version": {
             "anyOf": [
               {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
                 "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Run Id"
+            "title": "Firmware Version"
+          },
+          "incomplete_for_order_analysis": {
+            "title": "Incomplete For Order Analysis",
+            "type": "boolean"
+          },
+          "lang": {
+            "title": "Lang",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          },
+          "most_likely_origin": {
+            "$ref": "#/components/schemas/SuspectedVibrationOriginPayload"
+          },
+          "peak_picker_method": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peak Picker Method"
+          },
+          "phase_info": {
+            "$ref": "#/components/schemas/PhaseInfoResponse"
+          },
+          "phase_segments": {
+            "items": {
+              "$ref": "#/components/schemas/PhaseSegmentSummaryResponse"
+            },
+            "title": "Phase Segments",
+            "type": "array"
+          },
+          "phase_speed_breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/PhaseSpeedBreakdownRow"
+            },
+            "title": "Phase Speed Breakdown",
+            "type": "array"
+          },
+          "phase_timeline": {
+            "items": {
+              "$ref": "#/components/schemas/PhaseTimelineEntryResponse"
+            },
+            "title": "Phase Timeline",
+            "type": "array"
+          },
+          "plots": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PlotDataResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "raw_sample_rate_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Sample Rate Hz"
+          },
+          "record_length": {
+            "title": "Record Length",
+            "type": "string"
+          },
+          "report_date": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Report Date"
+          },
+          "rows": {
+            "title": "Rows",
+            "type": "integer"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "string"
+          },
+          "run_noise_baseline_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Noise Baseline Db"
+          },
+          "run_suitability": {
+            "items": {
+              "$ref": "#/components/schemas/RunSuitabilityCheck"
+            },
+            "title": "Run Suitability",
+            "type": "array"
+          },
+          "samples": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Samples",
+            "type": "array"
+          },
+          "sensor_count_used": {
+            "title": "Sensor Count Used",
+            "type": "integer"
+          },
+          "sensor_intensity_by_location": {
+            "items": {
+              "$ref": "#/components/schemas/LocationIntensitySummaryResponse"
+            },
+            "title": "Sensor Intensity By Location",
+            "type": "array"
+          },
+          "sensor_locations": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Sensor Locations",
+            "type": "array"
+          },
+          "sensor_locations_connected_throughout": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Sensor Locations Connected Throughout",
+            "type": "array"
+          },
+          "sensor_model": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sensor Model"
+          },
+          "speed_breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/SpeedBreakdownRow"
+            },
+            "title": "Speed Breakdown",
+            "type": "array"
+          },
+          "speed_breakdown_skipped_reason": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Breakdown Skipped Reason"
+          },
+          "speed_stats": {
+            "$ref": "#/components/schemas/SpeedStatsResponse"
+          },
+          "speed_stats_by_phase": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SpeedStatsResponse"
+            },
+            "title": "Speed Stats By Phase",
+            "type": "object"
+          },
+          "start_time_utc": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time Utc"
           },
           "status": {
             "anyOf": [
@@ -3128,6 +3768,13 @@
               }
             ],
             "title": "Status"
+          },
+          "test_plan": {
+            "items": {
+              "$ref": "#/components/schemas/TestPlanStepResponse"
+            },
+            "title": "Test Plan",
+            "type": "array"
           },
           "top_causes": {
             "items": {
@@ -3144,6 +3791,38 @@
             "type": "array"
           }
         },
+        "required": [
+          "file_name",
+          "run_id",
+          "rows",
+          "duration_s",
+          "record_length",
+          "lang",
+          "raw_sample_rate_hz",
+          "feature_interval_s",
+          "accel_scale_g_per_lsb",
+          "incomplete_for_order_analysis",
+          "metadata",
+          "speed_breakdown",
+          "phase_speed_breakdown",
+          "phase_segments",
+          "run_noise_baseline_db",
+          "speed_breakdown_skipped_reason",
+          "findings",
+          "top_causes",
+          "most_likely_origin",
+          "test_plan",
+          "phase_timeline",
+          "speed_stats",
+          "speed_stats_by_phase",
+          "phase_info",
+          "sensor_locations",
+          "sensor_locations_connected_throughout",
+          "sensor_count_used",
+          "sensor_intensity_by_location",
+          "run_suitability",
+          "data_quality"
+        ],
         "title": "HistoryInsightsResponse",
         "type": "object"
       },
@@ -3419,6 +4098,130 @@
         "title": "LocationHotspotPayload",
         "type": "object"
       },
+      "LocationIntensitySummaryResponse": {
+        "description": "Response body for one sensor-location intensity summary row.",
+        "properties": {
+          "dropped_frames_delta": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dropped Frames Delta"
+          },
+          "location": {
+            "title": "Location",
+            "type": "string"
+          },
+          "max_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Intensity Db"
+          },
+          "mean_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Intensity Db"
+          },
+          "p50_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "P50 Intensity Db"
+          },
+          "p95_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "P95 Intensity Db"
+          },
+          "partial_coverage": {
+            "title": "Partial Coverage",
+            "type": "boolean"
+          },
+          "phase_intensity": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/PhaseIntensityStatsResponse"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Intensity"
+          },
+          "queue_overflow_drops_delta": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Queue Overflow Drops Delta"
+          },
+          "sample_count": {
+            "title": "Sample Count",
+            "type": "integer"
+          },
+          "sample_coverage_ratio": {
+            "title": "Sample Coverage Ratio",
+            "type": "number"
+          },
+          "sample_coverage_warning": {
+            "title": "Sample Coverage Warning",
+            "type": "boolean"
+          },
+          "strength_bucket_distribution": {
+            "$ref": "#/components/schemas/StrengthBucketDistributionResponse"
+          }
+        },
+        "required": [
+          "location",
+          "partial_coverage",
+          "sample_count",
+          "sample_coverage_ratio",
+          "sample_coverage_warning",
+          "mean_intensity_db",
+          "p50_intensity_db",
+          "p95_intensity_db",
+          "max_intensity_db",
+          "dropped_frames_delta",
+          "queue_overflow_drops_delta",
+          "strength_bucket_distribution"
+        ],
+        "title": "LocationIntensitySummaryResponse",
+        "type": "object"
+      },
       "LocationOptionResponse": {
         "description": "A single sensor-location option (code + human-readable label).",
         "properties": {
@@ -3564,6 +4367,54 @@
           }
         },
         "title": "MatchedPoint",
+        "type": "object"
+      },
+      "OutlierSummaryResponse": {
+        "description": "Response body for an outlier-summary bucket.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "lower_bound": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lower Bound"
+          },
+          "outlier_count": {
+            "title": "Outlier Count",
+            "type": "integer"
+          },
+          "outlier_pct": {
+            "title": "Outlier Pct",
+            "type": "number"
+          },
+          "upper_bound": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upper Bound"
+          }
+        },
+        "required": [
+          "count",
+          "outlier_count",
+          "outlier_pct",
+          "lower_bound",
+          "upper_bound"
+        ],
+        "title": "OutlierSummaryResponse",
         "type": "object"
       },
       "PeakTableRow": {
@@ -3767,6 +4618,104 @@
         "title": "PhaseEvidence",
         "type": "object"
       },
+      "PhaseInfoResponse": {
+        "description": "Response body for aggregate driving-phase coverage metrics.",
+        "properties": {
+          "cruise_pct": {
+            "title": "Cruise Pct",
+            "type": "number"
+          },
+          "has_acceleration": {
+            "title": "Has Acceleration",
+            "type": "boolean"
+          },
+          "has_cruise": {
+            "title": "Has Cruise",
+            "type": "boolean"
+          },
+          "idle_pct": {
+            "title": "Idle Pct",
+            "type": "number"
+          },
+          "phase_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Phase Counts",
+            "type": "object"
+          },
+          "phase_pcts": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Phase Pcts",
+            "type": "object"
+          },
+          "segment_count": {
+            "title": "Segment Count",
+            "type": "integer"
+          },
+          "speed_unknown_pct": {
+            "title": "Speed Unknown Pct",
+            "type": "number"
+          },
+          "total_samples": {
+            "title": "Total Samples",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "phase_counts",
+          "phase_pcts",
+          "total_samples",
+          "segment_count",
+          "has_cruise",
+          "has_acceleration",
+          "cruise_pct",
+          "idle_pct",
+          "speed_unknown_pct"
+        ],
+        "title": "PhaseInfoResponse",
+        "type": "object"
+      },
+      "PhaseIntensityStatsResponse": {
+        "description": "Response body for per-phase intensity aggregates at one location.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "max_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Intensity Db"
+          },
+          "mean_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Intensity Db"
+          }
+        },
+        "required": [
+          "count",
+          "mean_intensity_db",
+          "max_intensity_db"
+        ],
+        "title": "PhaseIntensityStatsResponse",
+        "type": "object"
+      },
       "PhaseSegmentOut": {
         "description": "Typed HTTP contract for a serialized driving-phase segment.",
         "properties": {
@@ -3803,6 +4752,83 @@
           "end_t_s"
         ],
         "title": "PhaseSegmentOut",
+        "type": "object"
+      },
+      "PhaseSegmentSummaryResponse": {
+        "description": "Typed HTTP contract for a summarized driving-phase segment.",
+        "properties": {
+          "end_idx": {
+            "title": "End Idx",
+            "type": "integer"
+          },
+          "end_t_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End T S"
+          },
+          "phase": {
+            "title": "Phase",
+            "type": "string"
+          },
+          "sample_count": {
+            "title": "Sample Count",
+            "type": "integer"
+          },
+          "speed_max_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Max Kmh"
+          },
+          "speed_min_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Min Kmh"
+          },
+          "start_idx": {
+            "title": "Start Idx",
+            "type": "integer"
+          },
+          "start_t_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start T S"
+          }
+        },
+        "required": [
+          "phase",
+          "start_idx",
+          "end_idx",
+          "start_t_s",
+          "end_t_s",
+          "speed_min_kmh",
+          "speed_max_kmh",
+          "sample_count"
+        ],
+        "title": "PhaseSegmentSummaryResponse",
         "type": "object"
       },
       "PhaseSpeedBreakdownRow": {
@@ -3870,6 +4896,73 @@
           "max_vibration_strength_db"
         ],
         "title": "PhaseSpeedBreakdownRow",
+        "type": "object"
+      },
+      "PhaseTimelineEntryResponse": {
+        "description": "Response body for one summarized phase-timeline interval.",
+        "properties": {
+          "end_t_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End T S"
+          },
+          "has_fault_evidence": {
+            "title": "Has Fault Evidence",
+            "type": "boolean"
+          },
+          "phase": {
+            "title": "Phase",
+            "type": "string"
+          },
+          "speed_max_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Max Kmh"
+          },
+          "speed_min_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Min Kmh"
+          },
+          "start_t_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start T S"
+          }
+        },
+        "required": [
+          "phase",
+          "start_t_s",
+          "end_t_s",
+          "speed_min_kmh",
+          "speed_max_kmh",
+          "has_fault_evidence"
+        ],
+        "title": "PhaseTimelineEntryResponse",
         "type": "object"
       },
       "PlotDataResult": {
@@ -4751,6 +5844,85 @@
         "title": "SpeedSourceStatusResponse",
         "type": "object"
       },
+      "SpeedStatsResponse": {
+        "description": "Response body for one summarized speed-profile snapshot.",
+        "properties": {
+          "max_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Kmh"
+          },
+          "mean_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Kmh"
+          },
+          "min_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Kmh"
+          },
+          "range_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Range Kmh"
+          },
+          "sample_count": {
+            "title": "Sample Count",
+            "type": "integer"
+          },
+          "stddev_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stddev Kmh"
+          },
+          "steady_speed": {
+            "title": "Steady Speed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "min_kmh",
+          "max_kmh",
+          "mean_kmh",
+          "stddev_kmh",
+          "range_kmh",
+          "steady_speed",
+          "sample_count"
+        ],
+        "title": "SpeedStatsResponse",
+        "type": "object"
+      },
       "SpeedUnitRequest": {
         "description": "Request body for changing the displayed speed unit.",
         "properties": {
@@ -4781,6 +5953,58 @@
           "speedUnit"
         ],
         "title": "SpeedUnitResponse",
+        "type": "object"
+      },
+      "StrengthBucketDistributionResponse": {
+        "description": "Response body for per-location strength-bucket coverage.",
+        "properties": {
+          "counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Counts",
+            "type": "object"
+          },
+          "percent_time_l0": {
+            "title": "Percent Time L0",
+            "type": "number"
+          },
+          "percent_time_l1": {
+            "title": "Percent Time L1",
+            "type": "number"
+          },
+          "percent_time_l2": {
+            "title": "Percent Time L2",
+            "type": "number"
+          },
+          "percent_time_l3": {
+            "title": "Percent Time L3",
+            "type": "number"
+          },
+          "percent_time_l4": {
+            "title": "Percent Time L4",
+            "type": "number"
+          },
+          "percent_time_l5": {
+            "title": "Percent Time L5",
+            "type": "number"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "counts",
+          "percent_time_l0",
+          "percent_time_l1",
+          "percent_time_l2",
+          "percent_time_l3",
+          "percent_time_l4",
+          "percent_time_l5"
+        ],
+        "title": "StrengthBucketDistributionResponse",
         "type": "object"
       },
       "StrengthPeak": {
@@ -4816,6 +6040,91 @@
           "strength_bucket"
         ],
         "title": "StrengthPeak",
+        "type": "object"
+      },
+      "SummaryWarningResponse": {
+        "description": "Response body for a persisted summary warning before localization.",
+        "properties": {
+          "applies_to": {
+            "title": "Applies To",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "severity": {
+            "enum": [
+              "warn",
+              "error"
+            ],
+            "title": "Severity",
+            "type": "string"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "required": [
+          "code",
+          "severity",
+          "applies_to",
+          "title"
+        ],
+        "title": "SummaryWarningResponse",
         "type": "object"
       },
       "SuspectedVibrationOriginPayload": {
@@ -4925,6 +6234,73 @@
           }
         },
         "title": "SuspectedVibrationOriginPayload",
+        "type": "object"
+      },
+      "TestPlanStepResponse": {
+        "description": "Response body for one recommended next-step action.",
+        "properties": {
+          "action_id": {
+            "title": "Action Id",
+            "type": "string"
+          },
+          "confirm": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirm"
+          },
+          "eta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eta"
+          },
+          "falsify": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Falsify"
+          },
+          "what": {
+            "title": "What",
+            "type": "string"
+          },
+          "why": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Why"
+          }
+        },
+        "required": [
+          "action_id",
+          "what",
+          "why",
+          "confirm",
+          "falsify",
+          "eta"
+        ],
+        "title": "TestPlanStepResponse",
         "type": "object"
       },
       "UpdateCancelResponse": {

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -321,10 +321,7 @@ export interface components {
       analysis_metadata?: {
         [key: string]: unknown;
       };
-      /** Data Quality */
-      data_quality: {
-        [key: string]: unknown;
-      };
+      data_quality: components["schemas"]["DataQualityResponse"];
       /** Duration S */
       duration_s: number;
       /** End Time Utc */
@@ -362,20 +359,13 @@ export interface components {
       peak_picker_method?: boolean | number | string | unknown[] | {
         [key: string]: unknown;
       } | null;
-      /** Phase Info */
-      phase_info: {
-        [key: string]: unknown;
-      };
+      phase_info: components["schemas"]["PhaseInfoResponse"];
       /** Phase Segments */
-      phase_segments: {
-          [key: string]: unknown;
-        }[];
+      phase_segments: components["schemas"]["PhaseSegmentSummaryResponse"][];
       /** Phase Speed Breakdown */
       phase_speed_breakdown: components["schemas"]["PhaseSpeedBreakdownRow"][];
       /** Phase Timeline */
-      phase_timeline: {
-          [key: string]: unknown;
-        }[];
+      phase_timeline: components["schemas"]["PhaseTimelineEntryResponse"][];
       plots?: components["schemas"]["PlotDataResult"] | null;
       /** Raw Sample Rate Hz */
       raw_sample_rate_hz: number | null;
@@ -400,9 +390,7 @@ export interface components {
       /** Sensor Count Used */
       sensor_count_used: number;
       /** Sensor Intensity By Location */
-      sensor_intensity_by_location: {
-          [key: string]: unknown;
-        }[];
+      sensor_intensity_by_location: components["schemas"]["LocationIntensitySummaryResponse"][];
       /** Sensor Locations */
       sensor_locations: string[];
       /** Sensor Locations Connected Throughout */
@@ -417,30 +405,21 @@ export interface components {
       speed_breakdown_skipped_reason: {
         [key: string]: unknown;
       } | null;
-      /** Speed Stats */
-      speed_stats: {
-        [key: string]: unknown;
-      };
+      speed_stats: components["schemas"]["SpeedStatsResponse"];
       /** Speed Stats By Phase */
       speed_stats_by_phase: {
-        [key: string]: {
-          [key: string]: unknown;
-        };
+        [key: string]: components["schemas"]["SpeedStatsResponse"];
       };
       /** Start Time Utc */
       start_time_utc?: boolean | number | string | unknown[] | {
         [key: string]: unknown;
       } | null;
       /** Test Plan */
-      test_plan: {
-          [key: string]: unknown;
-        }[];
+      test_plan: components["schemas"]["TestPlanStepResponse"][];
       /** Top Causes */
       top_causes: components["schemas"]["FindingPayload"][];
       /** Warnings */
-      warnings: {
-          [key: string]: unknown;
-        }[];
+      warnings: components["schemas"]["SummaryWarningResponse"][];
       [key: string]: unknown;
     };
     /** AxisMetrics */
@@ -670,6 +649,80 @@ export interface components {
       vib_mag_p2p?: number;
       /** Vib Mag Rms */
       vib_mag_rms?: number;
+    };
+    /**
+     * DataQualityAccelSanityResponse
+     * @description Response body for acceleration sanity diagnostics.
+     */
+    DataQualityAccelSanityResponse: {
+      /** Saturation Count */
+      saturation_count: number | null;
+      /** Sensor Limit */
+      sensor_limit: number | null;
+      /** X Mean */
+      x_mean: number | null;
+      /** X Variance */
+      x_variance: number | null;
+      /** Y Mean */
+      y_mean: number | null;
+      /** Y Variance */
+      y_variance: number | null;
+      /** Z Mean */
+      z_mean: number | null;
+      /** Z Variance */
+      z_variance: number | null;
+    };
+    /**
+     * DataQualityOutliersResponse
+     * @description Response body for grouped outlier summaries.
+     */
+    DataQualityOutliersResponse: {
+      accel_magnitude: components["schemas"]["OutlierSummaryResponse"];
+      amplitude_metric: components["schemas"]["OutlierSummaryResponse"];
+    };
+    /**
+     * DataQualityRequiredMissingPctResponse
+     * @description Response body for required-field missing percentages.
+     */
+    DataQualityRequiredMissingPctResponse: {
+      /** Accel X */
+      accel_x: number;
+      /** Accel Y */
+      accel_y: number;
+      /** Accel Z */
+      accel_z: number;
+      /** Speed Kmh */
+      speed_kmh: number;
+      /** T S */
+      t_s: number;
+    };
+    /**
+     * DataQualityResponse
+     * @description Response body for run-level data-quality diagnostics.
+     */
+    DataQualityResponse: {
+      accel_sanity: components["schemas"]["DataQualityAccelSanityResponse"];
+      outliers: components["schemas"]["DataQualityOutliersResponse"];
+      required_missing_pct: components["schemas"]["DataQualityRequiredMissingPctResponse"];
+      speed_coverage: components["schemas"]["DataQualitySpeedCoverageResponse"];
+    };
+    /**
+     * DataQualitySpeedCoverageResponse
+     * @description Response body for summarized speed-coverage statistics.
+     */
+    DataQualitySpeedCoverageResponse: {
+      /** Count Non Null */
+      count_non_null: number;
+      /** Max Kmh */
+      max_kmh: number | null;
+      /** Mean Kmh */
+      mean_kmh: number | null;
+      /** Min Kmh */
+      min_kmh: number | null;
+      /** Non Null Pct */
+      non_null_pct: number;
+      /** Stddev Kmh */
+      stddev_kmh: number | null;
     };
     /** DebugSpectrumErrorPayload */
     DebugSpectrumErrorPayload: {
@@ -1187,17 +1240,114 @@ export interface components {
     };
     /**
      * HistoryInsightsResponse
-     * @description Response body with aggregated diagnostic insights for a run.
+     * @description Response body for the localized history insights endpoint payload.
      */
     HistoryInsightsResponse: {
+      /** Accel Scale G Per Lsb */
+      accel_scale_g_per_lsb: number | null;
+      /** Analysis Metadata */
+      analysis_metadata?: {
+        [key: string]: unknown;
+      };
+      data_quality: components["schemas"]["DataQualityResponse"];
+      /** Duration S */
+      duration_s: number;
+      /** End Time Utc */
+      end_time_utc?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Feature Interval S */
+      feature_interval_s: number | null;
+      /** Fft Window Size Samples */
+      fft_window_size_samples?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Fft Window Type */
+      fft_window_type?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** File Name */
+      file_name: string;
       /** Findings */
-      findings?: components["schemas"]["FindingPayload"][];
+      findings: components["schemas"]["FindingPayload"][];
+      /** Firmware Version */
+      firmware_version?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Incomplete For Order Analysis */
+      incomplete_for_order_analysis: boolean;
+      /** Lang */
+      lang: string;
+      /** Metadata */
+      metadata: {
+        [key: string]: unknown;
+      };
+      most_likely_origin: components["schemas"]["SuspectedVibrationOriginPayload"];
+      /** Peak Picker Method */
+      peak_picker_method?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      phase_info: components["schemas"]["PhaseInfoResponse"];
+      /** Phase Segments */
+      phase_segments: components["schemas"]["PhaseSegmentSummaryResponse"][];
+      /** Phase Speed Breakdown */
+      phase_speed_breakdown: components["schemas"]["PhaseSpeedBreakdownRow"][];
+      /** Phase Timeline */
+      phase_timeline: components["schemas"]["PhaseTimelineEntryResponse"][];
+      plots?: components["schemas"]["PlotDataResult"] | null;
+      /** Raw Sample Rate Hz */
+      raw_sample_rate_hz: number | null;
+      /** Record Length */
+      record_length: string;
+      /** Report Date */
+      report_date?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Rows */
+      rows: number;
       /** Run Id */
-      run_id?: string | null;
+      run_id: string;
+      /** Run Noise Baseline Db */
+      run_noise_baseline_db: number | null;
+      /** Run Suitability */
+      run_suitability: components["schemas"]["RunSuitabilityCheck"][];
+      /** Samples */
+      samples?: {
+          [key: string]: unknown;
+        }[];
+      /** Sensor Count Used */
+      sensor_count_used: number;
+      /** Sensor Intensity By Location */
+      sensor_intensity_by_location: components["schemas"]["LocationIntensitySummaryResponse"][];
+      /** Sensor Locations */
+      sensor_locations: string[];
+      /** Sensor Locations Connected Throughout */
+      sensor_locations_connected_throughout: string[];
+      /** Sensor Model */
+      sensor_model?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /** Speed Breakdown */
+      speed_breakdown: components["schemas"]["SpeedBreakdownRow"][];
+      /** Speed Breakdown Skipped Reason */
+      speed_breakdown_skipped_reason: {
+        [key: string]: unknown;
+      } | null;
+      speed_stats: components["schemas"]["SpeedStatsResponse"];
+      /** Speed Stats By Phase */
+      speed_stats_by_phase: {
+        [key: string]: components["schemas"]["SpeedStatsResponse"];
+      };
+      /** Start Time Utc */
+      start_time_utc?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
       /** Status */
       status?: string | null;
+      /** Test Plan */
+      test_plan: components["schemas"]["TestPlanStepResponse"][];
       /** Top Causes */
-      top_causes?: components["schemas"]["FindingPayload"][];
+      top_causes: components["schemas"]["FindingPayload"][];
       /** Warnings */
       warnings?: components["schemas"]["HistoryInsightWarningResponse"][];
       [key: string]: unknown;
@@ -1311,6 +1461,39 @@ export interface components {
       [key: string]: unknown;
     };
     /**
+     * LocationIntensitySummaryResponse
+     * @description Response body for one sensor-location intensity summary row.
+     */
+    LocationIntensitySummaryResponse: {
+      /** Dropped Frames Delta */
+      dropped_frames_delta: number | null;
+      /** Location */
+      location: string;
+      /** Max Intensity Db */
+      max_intensity_db: number | null;
+      /** Mean Intensity Db */
+      mean_intensity_db: number | null;
+      /** P50 Intensity Db */
+      p50_intensity_db: number | null;
+      /** P95 Intensity Db */
+      p95_intensity_db: number | null;
+      /** Partial Coverage */
+      partial_coverage: boolean;
+      /** Phase Intensity */
+      phase_intensity?: {
+        [key: string]: components["schemas"]["PhaseIntensityStatsResponse"];
+      } | null;
+      /** Queue Overflow Drops Delta */
+      queue_overflow_drops_delta: number | null;
+      /** Sample Count */
+      sample_count: number;
+      /** Sample Coverage Ratio */
+      sample_coverage_ratio: number;
+      /** Sample Coverage Warning */
+      sample_coverage_warning: boolean;
+      strength_bucket_distribution: components["schemas"]["StrengthBucketDistributionResponse"];
+    };
+    /**
      * LocationOptionResponse
      * @description A single sensor-location option (code + human-readable label).
      */
@@ -1352,6 +1535,22 @@ export interface components {
       /** T S */
       t_s?: number | null;
       [key: string]: unknown;
+    };
+    /**
+     * OutlierSummaryResponse
+     * @description Response body for an outlier-summary bucket.
+     */
+    OutlierSummaryResponse: {
+      /** Count */
+      count: number;
+      /** Lower Bound */
+      lower_bound: number | null;
+      /** Outlier Count */
+      outlier_count: number;
+      /** Outlier Pct */
+      outlier_pct: number;
+      /** Upper Bound */
+      upper_bound: number | null;
     };
     /**
      * PeakTableRow
@@ -1418,6 +1617,46 @@ export interface components {
       [key: string]: unknown;
     };
     /**
+     * PhaseInfoResponse
+     * @description Response body for aggregate driving-phase coverage metrics.
+     */
+    PhaseInfoResponse: {
+      /** Cruise Pct */
+      cruise_pct: number;
+      /** Has Acceleration */
+      has_acceleration: boolean;
+      /** Has Cruise */
+      has_cruise: boolean;
+      /** Idle Pct */
+      idle_pct: number;
+      /** Phase Counts */
+      phase_counts: {
+        [key: string]: number;
+      };
+      /** Phase Pcts */
+      phase_pcts: {
+        [key: string]: number;
+      };
+      /** Segment Count */
+      segment_count: number;
+      /** Speed Unknown Pct */
+      speed_unknown_pct: number;
+      /** Total Samples */
+      total_samples: number;
+    };
+    /**
+     * PhaseIntensityStatsResponse
+     * @description Response body for per-phase intensity aggregates at one location.
+     */
+    PhaseIntensityStatsResponse: {
+      /** Count */
+      count: number;
+      /** Max Intensity Db */
+      max_intensity_db: number | null;
+      /** Mean Intensity Db */
+      mean_intensity_db: number | null;
+    };
+    /**
      * PhaseSegmentOut
      * @description Typed HTTP contract for a serialized driving-phase segment.
      */
@@ -1426,6 +1665,28 @@ export interface components {
       end_t_s: number | null;
       /** Phase */
       phase: string;
+      /** Start T S */
+      start_t_s: number | null;
+    };
+    /**
+     * PhaseSegmentSummaryResponse
+     * @description Typed HTTP contract for a summarized driving-phase segment.
+     */
+    PhaseSegmentSummaryResponse: {
+      /** End Idx */
+      end_idx: number;
+      /** End T S */
+      end_t_s: number | null;
+      /** Phase */
+      phase: string;
+      /** Sample Count */
+      sample_count: number;
+      /** Speed Max Kmh */
+      speed_max_kmh: number | null;
+      /** Speed Min Kmh */
+      speed_min_kmh: number | null;
+      /** Start Idx */
+      start_idx: number;
       /** Start T S */
       start_t_s: number | null;
     };
@@ -1446,6 +1707,24 @@ export interface components {
       mean_vibration_strength_db: number | null;
       /** Phase */
       phase: string;
+    };
+    /**
+     * PhaseTimelineEntryResponse
+     * @description Response body for one summarized phase-timeline interval.
+     */
+    PhaseTimelineEntryResponse: {
+      /** End T S */
+      end_t_s: number | null;
+      /** Has Fault Evidence */
+      has_fault_evidence: boolean;
+      /** Phase */
+      phase: string;
+      /** Speed Max Kmh */
+      speed_max_kmh: number | null;
+      /** Speed Min Kmh */
+      speed_min_kmh: number | null;
+      /** Start T S */
+      start_t_s: number | null;
     };
     /**
      * PlotDataResult
@@ -1726,6 +2005,26 @@ export interface components {
       stale_timeout_s: number;
     };
     /**
+     * SpeedStatsResponse
+     * @description Response body for one summarized speed-profile snapshot.
+     */
+    SpeedStatsResponse: {
+      /** Max Kmh */
+      max_kmh: number | null;
+      /** Mean Kmh */
+      mean_kmh: number | null;
+      /** Min Kmh */
+      min_kmh: number | null;
+      /** Range Kmh */
+      range_kmh: number | null;
+      /** Sample Count */
+      sample_count: number;
+      /** Stddev Kmh */
+      stddev_kmh: number | null;
+      /** Steady Speed */
+      steady_speed: boolean;
+    };
+    /**
      * SpeedUnitRequest
      * @description Request body for changing the displayed speed unit.
      */
@@ -1744,6 +2043,30 @@ export interface components {
       /** Speedunit */
       speedUnit: string;
     };
+    /**
+     * StrengthBucketDistributionResponse
+     * @description Response body for per-location strength-bucket coverage.
+     */
+    StrengthBucketDistributionResponse: {
+      /** Counts */
+      counts: {
+        [key: string]: number;
+      };
+      /** Percent Time L0 */
+      percent_time_l0: number;
+      /** Percent Time L1 */
+      percent_time_l1: number;
+      /** Percent Time L2 */
+      percent_time_l2: number;
+      /** Percent Time L3 */
+      percent_time_l3: number;
+      /** Percent Time L4 */
+      percent_time_l4: number;
+      /** Percent Time L5 */
+      percent_time_l5: number;
+      /** Total */
+      total: number;
+    };
     /** StrengthPeak */
     StrengthPeak: {
       /** Amp */
@@ -1754,6 +2077,29 @@ export interface components {
       strength_bucket: string | null;
       /** Vibration Strength Db */
       vibration_strength_db: number;
+    };
+    /**
+     * SummaryWarningResponse
+     * @description Response body for a persisted summary warning before localization.
+     */
+    SummaryWarningResponse: {
+      /** Applies To */
+      applies_to: string;
+      /** Code */
+      code: string;
+      /** Detail */
+      detail?: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * Severity
+       * @enum {string}
+       */
+      severity: "warn" | "error";
+      /** Title */
+      title: boolean | number | string | unknown[] | {
+        [key: string]: unknown;
+      } | null;
     };
     /**
      * SuspectedVibrationOriginPayload
@@ -1779,6 +2125,24 @@ export interface components {
       /** Weak Spatial Separation */
       weak_spatial_separation?: boolean | null;
       [key: string]: unknown;
+    };
+    /**
+     * TestPlanStepResponse
+     * @description Response body for one recommended next-step action.
+     */
+    TestPlanStepResponse: {
+      /** Action Id */
+      action_id: string;
+      /** Confirm */
+      confirm: string | null;
+      /** Eta */
+      eta: string | null;
+      /** Falsify */
+      falsify: string | null;
+      /** What */
+      what: string;
+      /** Why */
+      why: string | null;
     };
     /**
      * UpdateCancelResponse


### PR DESCRIPTION
## Summary
- type the remaining stable AnalysisSummaryResponse sub-objects instead of exposing generic maps
- split top-level summary phase segments from plot phase segments so each surface exposes the right shape
- regenerate HTTP contracts and simplify the history table view to consume the generated sensor-intensity types directly

## Validation
- .venv/bin/pytest -q apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/adapters/http/test_api_history_route_state.py
- make typecheck-backend
- PATH="$PWD/.venv/bin:$PATH" make lint
- cd apps/ui && npm run typecheck && npm run build && npx playwright test --config=playwright.config.ts tests/smoke.history.spec.ts --project=laptop-light --workers=1
- docker compose build --pull
- docker compose up -d
- repo-local simulator run plus /api/history/{run_id}/insights key assertions

Closes #961