### PR TITLE
Generate UI shared constants from backend

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ Instruction sources
 Architectural constraints
 - Offline-first hotspot boot: hotspot provisioning must not depend on internet connectivity. Required packages are baked into the image build stage.
 - Deterministic image outputs: custom pi-gen stage must export uniquely suffixed artifacts and self-validate rootfs contents.
-- Internal shared logic belongs in the server package (`vibesensor/vibration_strength.py`, `vibesensor/strength_bands.py`), not in separate packages. Shared TS constants live directly in `apps/ui/src/constants.ts`.
+- Internal shared logic belongs in the server package (`vibesensor/vibration_strength.py`, `vibesensor/strength_bands.py`), not in separate packages. Generated shared TS constants are emitted to `apps/ui/src/constants.ts` from backend sources under `vibesensor.shared.*`.
 - Do not create runtime file-loading mechanisms for static configuration data. Use Python constants for values that don't change between deployments.
 
 Domain model (scope: behavioral rules only; see `docs/domain-model.md` for the full domain object catalog and relationship map)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,13 +131,13 @@ Then edit `config.yaml` as needed. The file is gitignored, so your local changes
 
 The contract-sync flow lives in
 [apps/ui/README.md#contract-sync](apps/ui/README.md#contract-sync). Use that
-section for what `npm run sync:contracts` regenerates, what it intentionally
-does not touch (`apps/ui/src/constants.ts`), and what to do when CI reports
-frontend contract drift.
+section for what `npm run sync:contracts` regenerates (including
+`apps/ui/src/constants.ts`) and what to do when CI reports frontend contract
+drift.
 
 ## Common failure cases
 
 - Hook warning about missing `privacy_guard.py`: this is non-blocking; run the documented validation commands directly.
 - Port confusion: production-style access is usually `http://127.0.0.1`, while native dev often uses `http://127.0.0.1:8000`.
-- UI contract drift: follow [apps/ui/README.md#contract-sync](apps/ui/README.md#contract-sync) for the generated HTTP/WS contract flow and the backend hygiene guard for `apps/ui/src/constants.ts`.
+- UI contract drift: follow [apps/ui/README.md#contract-sync](apps/ui/README.md#contract-sync) for the generated HTTP/WS/constants sync flow and rerun `npm run sync:contracts`.
 - Slow or failing end-to-end runs: check Docker status and the operational runbook before debugging application logic.

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -2,11 +2,16 @@ FROM node:22.14-slim AS ui-build
 
 WORKDIR /app/apps/ui
 
+RUN apt-get update && apt-get install -y --no-install-recommends python3 && rm -rf /var/lib/apt/lists/*
+
 COPY apps/ui/package*.json ./
 RUN npm ci
 
-RUN mkdir -p /app/tools/config
+RUN mkdir -p /app/tools/config /app/apps/server/vibesensor/shared
 COPY tools/config/sync_shared_contracts_to_ui.mjs /app/tools/config/sync_shared_contracts_to_ui.mjs
+COPY tools/config/generate_ui_shared_constants.py /app/tools/config/generate_ui_shared_constants.py
+COPY apps/server/vibesensor/shared/locations.py /app/apps/server/vibesensor/shared/locations.py
+COPY apps/server/vibesensor/shared/strength_fields.py /app/apps/server/vibesensor/shared/strength_fields.py
 COPY apps/ui/ ./
 RUN npm run build
 

--- a/apps/server/tests/hygiene/test_frontend_metric_fields_sync.py
+++ b/apps/server/tests/hygiene/test_frontend_metric_fields_sync.py
@@ -1,55 +1,30 @@
-"""Guard: frontend METRIC_FIELDS stays in sync with backend strength payload fields."""
+"""Guard: shared metric field names stay aligned with backend strength payload fields."""
 
 from __future__ import annotations
 
-import re
-
-from tests._paths import REPO_ROOT
+from vibesensor.shared.strength_fields import METRIC_FIELDS
 from vibesensor.vibration_strength import StrengthPeak as StrengthPeakTD
 from vibesensor.vibration_strength import VibrationStrengthMetrics as VibrationStrengthMetricsTD
-
-_CONSTANTS_TS = REPO_ROOT / "apps" / "ui" / "src" / "constants.ts"
-_EXPECTED_METRIC_FIELDS = {
-    "vibration_strength_db": "vibration_strength_db",
-    "strength_bucket": "strength_bucket",
-}
 
 
 def _typeddict_field_names(cls: type) -> set[str]:
     return set(cls.__required_keys__ | cls.__optional_keys__)
 
 
-def _frontend_metric_fields() -> dict[str, str]:
-    text = _CONSTANTS_TS.read_text()
-    match = re.search(
-        r"export const METRIC_FIELDS = \{(?P<body>.*?)\} as const;",
-        text,
-        flags=re.DOTALL,
-    )
-    assert match is not None, "METRIC_FIELDS missing from apps/ui/src/constants.ts"
-    return dict(re.findall(r'([a-z_]+):\s*"([a-z_]+)"', match.group("body")))
-
-
-def test_frontend_metric_fields_match_backend_strength_fields() -> None:
-    """Frontend METRIC_FIELDS must stay aligned with canonical backend strength field names."""
+def test_backend_metric_fields_match_strength_payload_fields() -> None:
+    """Shared METRIC_FIELDS must stay aligned with backend strength payload fields."""
     backend_peak_fields = _typeddict_field_names(StrengthPeakTD)
     backend_metrics_fields = _typeddict_field_names(VibrationStrengthMetricsTD)
-    expected_metric_fields = set(_EXPECTED_METRIC_FIELDS.values())
+    expected_metric_fields = set(METRIC_FIELDS.values())
 
+    assert expected_metric_fields, "METRIC_FIELDS must not be empty."
     assert expected_metric_fields <= backend_peak_fields, (
-        "StrengthPeak TypedDict drifted from the canonical frontend metric fields.\n"
+        "StrengthPeak TypedDict drifted from the shared frontend metric fields.\n"
         f"  TypedDict fields: {sorted(backend_peak_fields)}\n"
         f"  Expected:       {sorted(expected_metric_fields)}"
     )
     assert expected_metric_fields <= backend_metrics_fields, (
-        "VibrationStrengthMetrics TypedDict drifted from the canonical frontend metric fields.\n"
+        "VibrationStrengthMetrics TypedDict drifted from the shared frontend metric fields.\n"
         f"  TypedDict fields: {sorted(backend_metrics_fields)}\n"
         f"  Expected:       {sorted(expected_metric_fields)}"
-    )
-
-    frontend_fields = _frontend_metric_fields()
-    assert frontend_fields == _EXPECTED_METRIC_FIELDS, (
-        "Frontend/backend METRIC_FIELDS drifted.\n"
-        f"  Backend:  {_EXPECTED_METRIC_FIELDS}\n"
-        f"  Frontend: {frontend_fields}"
     )

--- a/apps/server/tests/hygiene/test_location_codes_sync.py
+++ b/apps/server/tests/hygiene/test_location_codes_sync.py
@@ -2,24 +2,34 @@
 
 from __future__ import annotations
 
-import re
+import subprocess
+import sys
 
 from tests._paths import REPO_ROOT
 from vibesensor.domain.sensor import _LOCATION_CODES as DOMAIN_LOCATION_CODES
 from vibesensor.shared.locations import LOCATION_CODES
 
 _CONSTANTS_TS = REPO_ROOT / "apps" / "ui" / "src" / "constants.ts"
+_GENERATOR = REPO_ROOT / "tools" / "config" / "generate_ui_shared_constants.py"
 
 
-def test_frontend_location_codes_match_backend() -> None:
-    """Frontend constants.ts LOCATION_CODES must match backend keys."""
-    text = _CONSTANTS_TS.read_text()
-    frontend_codes = re.findall(r'"([a-z_]+)"', text.split("LOCATION_CODES")[1].split("]")[0])
-    backend_codes = list(LOCATION_CODES.keys())
-    assert frontend_codes == backend_codes, (
-        f"Frontend/backend location code mismatch.\n"
-        f"  Backend:  {backend_codes}\n"
-        f"  Frontend: {frontend_codes}"
+def _generated_constants_ts() -> str:
+    result = subprocess.run(
+        [sys.executable, str(_GENERATOR)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def test_generated_ui_constants_are_current() -> None:
+    """Generated apps/ui/src/constants.ts must stay in sync with backend sources."""
+    expected = _generated_constants_ts()
+    actual = _CONSTANTS_TS.read_text()
+    assert actual == expected, (
+        "apps/ui/src/constants.ts is stale.\n"
+        "Run `npm run sync:contracts` to regenerate the shared UI constants."
     )
 
 

--- a/apps/server/vibesensor/shared/strength_fields.py
+++ b/apps/server/vibesensor/shared/strength_fields.py
@@ -1,0 +1,12 @@
+"""Shared vibration-strength field names for generated frontend constants."""
+
+from __future__ import annotations
+
+from typing import Final
+
+METRIC_FIELDS: Final[dict[str, str]] = {
+    "vibration_strength_db": "vibration_strength_db",
+    "strength_bucket": "strength_bucket",
+}
+
+__all__ = ["METRIC_FIELDS"]

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -28,16 +28,16 @@ in one step.
 
 ## Contract sync
 
-Use `npm run sync:contracts` to refresh the generated frontend contracts.
+Use `npm run sync:contracts` to refresh the generated frontend contracts and shared constants.
 
 It regenerates:
 
 - `src/generated/http_api_contracts.ts`
 - `src/contracts/ws_payload_types.ts`
 - `src/contracts/ws_payload_schema.generated.ts`
+- `src/constants.ts`
 
-It does **not** rewrite `src/constants.ts`; backend hygiene tests guard drift
-for `LOCATION_CODES` and `METRIC_FIELDS` there.
+`npm run check:contracts` fails if any of those generated files are stale.
 
 ## Source Modules
 
@@ -61,7 +61,7 @@ for `LOCATION_CODES` and `METRIC_FIELDS` there.
 | `diagnostics.ts` | Strength band normalization and vibration matrix helpers |
 | `vehicle_math.ts` | Tire diameter, order tolerance, and uncertainty calculations |
 | `format.ts` | Number, byte, and timestamp formatting utilities |
-| `constants.ts` | Sensor location codes and shared strength field names, with backend hygiene tests guarding drift |
+| `constants.ts` | Generated sensor location codes and shared strength field names from backend sources |
 | `theme.ts` | Chart color palette and order band fill colors |
 | `styles/app.css` | Full CSS with light/dark theme tokens |
 

--- a/apps/ui/src/constants.ts
+++ b/apps/ui/src/constants.ts
@@ -1,6 +1,9 @@
+// Generated from apps/server/vibesensor/shared/locations.py and apps/server/vibesensor/shared/strength_fields.py
+// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs
+
 export const METRIC_FIELDS = {
-  vibration_strength_db: "vibration_strength_db",
-  strength_bucket: "strength_bucket",
+  "vibration_strength_db": "vibration_strength_db",
+  "strength_bucket": "strength_bucket"
 } as const;
 
 export const LOCATION_CODES = [
@@ -18,7 +21,7 @@ export const LOCATION_CODES = [
   "rear_left_seat",
   "rear_center_seat",
   "rear_right_seat",
-  "trunk",
+  "trunk"
 ] as const;
 
 export const defaultLocationCodes = LOCATION_CODES;

--- a/tools/config/generate_ui_shared_constants.py
+++ b/tools/config/generate_ui_shared_constants.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SHARED_ROOT = ROOT / "apps" / "server" / "vibesensor" / "shared"
+LOCATIONS_PATH = SHARED_ROOT / "locations.py"
+STRENGTH_FIELDS_PATH = SHARED_ROOT / "strength_fields.py"
+
+
+def _load_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]:
+    tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+    for node in tree.body:
+        value_node: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign):
+            target = node.target
+            if (
+                isinstance(target, ast.Name)
+                and target.id == constant_name
+                and node.value is not None
+            ):
+                value_node = node.value
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == constant_name:
+                    value_node = node.value
+                    break
+        if value_node is None:
+            continue
+        value = ast.literal_eval(value_node)
+        if not isinstance(value, dict) or not all(
+            isinstance(key, str) and isinstance(item, str)
+            for key, item in value.items()
+        ):
+            msg = f"{module_path}::{constant_name} must be a dict[str, str] literal"
+            raise ValueError(msg)
+        return dict(value)
+    msg = f"Could not find {constant_name} in {module_path}"
+    raise ValueError(msg)
+
+
+def render_ui_shared_constants_module() -> str:
+    location_codes = _load_dict_constant(LOCATIONS_PATH, "LOCATION_CODES")
+    metric_fields = _load_dict_constant(STRENGTH_FIELDS_PATH, "METRIC_FIELDS")
+    return (
+        "// Generated from apps/server/vibesensor/shared/locations.py and "
+        "apps/server/vibesensor/shared/strength_fields.py\n"
+        "// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs\n\n"
+        f"export const METRIC_FIELDS = {json.dumps(metric_fields, indent=2)} as const;\n\n"
+        f"export const LOCATION_CODES = {json.dumps(list(location_codes.keys()), indent=2)} as const;\n\n"
+        "export const defaultLocationCodes = LOCATION_CODES;\n"
+    )
+
+
+def main() -> None:
+    sys.stdout.write(render_ui_shared_constants_module())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/config/sync_shared_contracts_to_ui.mjs
+++ b/tools/config/sync_shared_contracts_to_ui.mjs
@@ -11,6 +11,8 @@ const root = resolve(__dirname, '../..');
 const requireFromUi = createRequire(resolve(root, 'apps/ui/package.json'));
 const httpSchemaSrc = resolve(root, 'apps/ui/src/contracts/http_api_schema.json');
 const httpTypesDst = resolve(root, 'apps/ui/src/generated/http_api_contracts.ts');
+const constantsGeneratorSrc = resolve(root, 'tools/config/generate_ui_shared_constants.py');
+const constantsDst = resolve(root, 'apps/ui/src/constants.ts');
 const wsSchemaSrc = resolve(root, 'apps/ui/src/contracts/ws_payload_schema.json');
 const wsSchemaTsDst = resolve(root, 'apps/ui/src/contracts/ws_payload_schema.generated.ts');
 const wsTypesDst = resolve(root, 'apps/ui/src/contracts/ws_payload_types.ts');
@@ -132,6 +134,21 @@ function generateWsSchemaModule() {
 	);
 }
 
+function generateSharedConstants() {
+	const pythonCmd = process.env.PYTHON || 'python3';
+	const result = spawnSync(pythonCmd, [constantsGeneratorSrc], {
+		cwd: root,
+		encoding: 'utf8',
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		throw new Error(result.stderr || result.stdout || 'Shared constants generation failed');
+	}
+	return result.stdout;
+}
+
 async function main() {
 	const checkMode = process.argv.includes('--check');
 
@@ -144,6 +161,9 @@ async function main() {
 	const wsSchemaModule = generateWsSchemaModule();
 	writeGenerated(wsSchemaTsDst, wsSchemaModule, checkMode);
 
+	const sharedConstants = generateSharedConstants();
+	writeGenerated(constantsDst, sharedConstants, checkMode);
+
 	if (checkMode) {
 		console.log('Generated UI contract files are up to date.');
 		return;
@@ -152,6 +172,7 @@ async function main() {
 	console.log(`Generated ${httpSchemaSrc} -> ${httpTypesDst}`);
 	console.log(`Generated ${wsSchemaSrc} -> ${wsTypesDst}`);
 	console.log(`Generated ${wsSchemaSrc} -> ${wsSchemaTsDst}`);
+	console.log(`Generated ${constantsGeneratorSrc} -> ${constantsDst}`);
 }
 
 await main();


### PR DESCRIPTION
## Summary
- generate `apps/ui/src/constants.ts` through the existing `sync_shared_contracts_to_ui.mjs` flow instead of keeping it handwritten
- promote shared metric field names into a backend-owned constant and update hygiene tests to validate generated output/back-end alignment
- update docs and Docker UI builds so constants generation is part of the normal contract-sync/runtime path

## Validation
- .venv/bin/pytest -q apps/server/tests/hygiene/test_location_codes_sync.py apps/server/tests/hygiene/test_frontend_metric_fields_sync.py
- make typecheck-backend
- PATH="$PWD/.venv/bin:$PATH" make lint
- cd apps/ui && npm run check:contracts && npm run typecheck && npm run build
- docker compose --progress=plain build --pull
- docker compose up -d
- served UI Playwright load check plus simulator traffic producing /api/clients rows

Closes #964