### PR TITLE
Type HTTP settings routes

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -121,6 +121,5 @@ disallow_any_unimported = false
 [[tool.mypy.overrides]]
 module = [
   "vibesensor.adapters.udp.protocol",
-  "vibesensor.adapters.http.settings",
 ]
 ignore_errors = true

--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -13,6 +13,18 @@ def _make_default_snapshot() -> AnalysisSettingsSnapshot:
     return AnalysisSettingsSnapshot(**AnalysisSettingsSnapshot.DEFAULTS)
 
 
+def _make_car_payload(
+    car_id: str = "car-1",
+    name: str = "Test Car",
+) -> dict[str, object]:
+    return {
+        "id": car_id,
+        "name": name,
+        "type": "sedan",
+        "aspects": {"tire_width_mm": 225.0},
+    }
+
+
 def _find_endpoint(router, path: str, method: str = "GET"):
     for route in router.routes:
         if getattr(route, "path", "") == path:
@@ -28,8 +40,8 @@ def _settings_router(fake_state):
 
     fake_state.settings_store.analysis_settings_snapshot.return_value = _make_default_snapshot()
     fake_state.settings_store.get_cars.return_value = {
-        "cars": [{"id": "car-1", "name": "Test Car"}],
-        "activeCar": {"id": "car-1", "name": "Test Car"},
+        "cars": [_make_car_payload()],
+        "activeCarId": "car-1",
     }
     return create_settings_routes(
         fake_state.settings_store,
@@ -74,7 +86,7 @@ class TestDeleteCarEndpoint:
 
         state.settings_store.get_cars.return_value = {
             "cars": [],
-            "activeCar": None,
+            "activeCarId": None,
         }
 
         with pytest.raises(HTTPException) as exc_info:
@@ -88,8 +100,8 @@ class TestDeleteCarEndpoint:
         assert endpoint is not None
 
         state.settings_store.get_cars.return_value = {
-            "cars": [{"id": "car-1", "name": "Test Car"}],
-            "activeCar": {"id": "car-1", "name": "Test Car"},
+            "cars": [_make_car_payload()],
+            "activeCarId": "car-1",
         }
         state.settings_store.delete_car.return_value = {
             "cars": [],
@@ -108,8 +120,8 @@ class TestDeleteCarEndpoint:
         assert endpoint is not None
 
         state.settings_store.get_cars.return_value = {
-            "cars": [{"id": "car-1", "name": "Test Car"}],
-            "activeCar": {"id": "car-1", "name": "Test Car"},
+            "cars": [_make_car_payload()],
+            "activeCarId": "car-1",
         }
         state.settings_store.delete_car.side_effect = ValueError("cannot delete last car")
 
@@ -132,6 +144,118 @@ class TestSetActiveCarEndpoint:
         with pytest.raises(HTTPException) as exc_info:
             await endpoint(req=ActiveCarRequest(carId="no-such-car"))
         assert exc_info.value.status_code == 404
+
+
+class TestCarsEndpoint:
+    @pytest.mark.asyncio
+    async def test_get_cars_response_shape(self, _settings_router) -> None:
+        router, _ = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/cars", "GET")
+        assert endpoint is not None
+
+        result = response_payload(await endpoint())
+
+        assert result["activeCarId"] == "car-1"
+        assert result["cars"][0]["type"] == "sedan"
+        assert result["cars"][0]["aspects"]["tire_width_mm"] == 225.0
+
+    @pytest.mark.asyncio
+    async def test_add_car_passes_only_non_null_fields(self, _settings_router) -> None:
+        router, state = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/cars", "POST")
+        assert endpoint is not None
+
+        from vibesensor.shared.types.api_models import CarUpsertRequest
+
+        state.settings_store.add_car.return_value = {
+            "cars": [_make_car_payload(), _make_car_payload(car_id="car-2", name="Second")],
+            "activeCarId": "car-1",
+        }
+
+        await endpoint(req=CarUpsertRequest(name="Second", variant="Sport"))
+
+        state.settings_store.add_car.assert_called_once_with({"name": "Second", "variant": "Sport"})
+
+
+class TestSpeedSourceEndpoint:
+    @pytest.mark.asyncio
+    async def test_update_speed_source_passes_only_non_null_fields(self, _settings_router) -> None:
+        router, state = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/speed-source", "POST")
+        assert endpoint is not None
+
+        from vibesensor.shared.types.api_models import SpeedSourceRequest
+
+        state.settings_store.update_speed_source.return_value = {
+            "speedSource": "manual",
+            "manualSpeedKph": 42.0,
+            "staleTimeoutS": 15.0,
+        }
+
+        await endpoint(req=SpeedSourceRequest(speedSource="manual", manualSpeedKph=42.0))
+
+        state.settings_store.update_speed_source.assert_called_once_with(
+            {"speedSource": "manual", "manualSpeedKph": 42.0}
+        )
+
+    @pytest.mark.asyncio
+    async def test_speed_source_status_response_shape(self, _settings_router) -> None:
+        router, state = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/speed-source/status", "GET")
+        assert endpoint is not None
+
+        state.gps_monitor.status_dict.return_value = {
+            "gps_enabled": True,
+            "connection_state": "connected",
+            "device": "/dev/ttyUSB0",
+            "fix_mode": 3,
+            "fix_dimension": "3d",
+            "speed_confidence": "high",
+            "epx_m": 1.2,
+            "epy_m": 1.3,
+            "epv_m": 2.4,
+            "last_update_age_s": 0.5,
+            "raw_speed_kmh": 48.2,
+            "effective_speed_kmh": 48.2,
+            "last_error": None,
+            "reconnect_delay_s": None,
+            "fallback_active": False,
+            "speed_source": "gps",
+            "stale_timeout_s": 8.0,
+        }
+
+        result = response_payload(await endpoint())
+
+        assert result["speed_source"] == "gps"
+        assert result["fix_dimension"] == "3d"
+
+
+class TestSensorEndpoint:
+    @pytest.mark.asyncio
+    async def test_update_sensor_passes_normalized_mac_and_non_null_fields(
+        self,
+        _settings_router,
+    ) -> None:
+        router, state = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/sensors/{mac}", "POST")
+        assert endpoint is not None
+
+        from vibesensor.shared.types.api_models import SensorRequest
+
+        normalized_mac = "aabbccddeeff"
+        state.settings_store.get_sensors.return_value = {
+            normalized_mac: {"name": "Wheel sensor", "location_code": "front_left"}
+        }
+
+        await endpoint(
+            mac="AA:BB:CC:DD:EE:FF",
+            req=SensorRequest(name="Wheel sensor", location_code="front_left"),
+        )
+
+        state.settings_store.set_sensor.assert_called_once_with(
+            normalized_mac,
+            {"name": "Wheel sensor", "location_code": "front_left"},
+        )
 
 
 class TestSetAnalysisSettingsEndpoint:
@@ -159,7 +283,9 @@ class TestSetAnalysisSettingsEndpoint:
 
         await endpoint(req=AnalysisSettingsRequest(tire_width_mm=265.0))
 
-        state.settings_store.update_active_car_aspects.assert_called_once()
+        state.settings_store.update_active_car_aspects.assert_called_once_with(
+            {"tire_width_mm": 265.0}
+        )
 
     @pytest.mark.asyncio
     async def test_get_analysis_settings_response_shape(self, _settings_router) -> None:

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -25,6 +25,12 @@ from vibesensor.shared.types.api_models import (
     SpeedUnitRequest,
     SpeedUnitResponse,
 )
+from vibesensor.shared.types.backend_types import (
+    AnalysisSettingsPayload,
+    CarConfigUpdatePayload,
+    SensorConfigUpdatePayload,
+    SpeedSourceUpdatePayload,
+)
 
 if TYPE_CHECKING:
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
@@ -38,60 +44,132 @@ def create_settings_routes(
     """Create and return the device-settings API routes."""
     router = APIRouter()
 
+    def _cars_response(payload: object) -> CarsResponse:
+        return CarsResponse.model_validate(payload)
+
+    def _car_upsert_payload(req: CarUpsertRequest) -> CarConfigUpdatePayload:
+        payload: CarConfigUpdatePayload = {}
+        if req.name is not None:
+            payload["name"] = req.name
+        if req.type is not None:
+            payload["type"] = req.type
+        if req.aspects is not None:
+            payload["aspects"] = req.aspects
+        if req.variant is not None:
+            payload["variant"] = req.variant
+        return payload
+
+    def _speed_source_update_payload(req: SpeedSourceRequest) -> SpeedSourceUpdatePayload:
+        payload: SpeedSourceUpdatePayload = {}
+        if req.speedSource is not None:
+            payload["speedSource"] = req.speedSource
+        if req.manualSpeedKph is not None:
+            payload["manualSpeedKph"] = req.manualSpeedKph
+        if req.staleTimeoutS is not None:
+            payload["staleTimeoutS"] = req.staleTimeoutS
+        return payload
+
+    def _sensor_update_payload(req: SensorRequest) -> SensorConfigUpdatePayload:
+        payload: SensorConfigUpdatePayload = {}
+        if req.name is not None:
+            payload["name"] = req.name
+        if req.location_code is not None:
+            payload["location_code"] = req.location_code
+        return payload
+
+    def _analysis_settings_payload(req: AnalysisSettingsRequest) -> AnalysisSettingsPayload:
+        payload: AnalysisSettingsPayload = {}
+        if req.tire_width_mm is not None:
+            payload["tire_width_mm"] = req.tire_width_mm
+        if req.tire_aspect_pct is not None:
+            payload["tire_aspect_pct"] = req.tire_aspect_pct
+        if req.rim_in is not None:
+            payload["rim_in"] = req.rim_in
+        if req.final_drive_ratio is not None:
+            payload["final_drive_ratio"] = req.final_drive_ratio
+        if req.current_gear_ratio is not None:
+            payload["current_gear_ratio"] = req.current_gear_ratio
+        if req.wheel_bandwidth_pct is not None:
+            payload["wheel_bandwidth_pct"] = req.wheel_bandwidth_pct
+        if req.driveshaft_bandwidth_pct is not None:
+            payload["driveshaft_bandwidth_pct"] = req.driveshaft_bandwidth_pct
+        if req.engine_bandwidth_pct is not None:
+            payload["engine_bandwidth_pct"] = req.engine_bandwidth_pct
+        if req.speed_uncertainty_pct is not None:
+            payload["speed_uncertainty_pct"] = req.speed_uncertainty_pct
+        if req.tire_diameter_uncertainty_pct is not None:
+            payload["tire_diameter_uncertainty_pct"] = req.tire_diameter_uncertainty_pct
+        if req.final_drive_uncertainty_pct is not None:
+            payload["final_drive_uncertainty_pct"] = req.final_drive_uncertainty_pct
+        if req.gear_uncertainty_pct is not None:
+            payload["gear_uncertainty_pct"] = req.gear_uncertainty_pct
+        if req.min_abs_band_hz is not None:
+            payload["min_abs_band_hz"] = req.min_abs_band_hz
+        if req.max_band_half_width_pct is not None:
+            payload["max_band_half_width_pct"] = req.max_band_half_width_pct
+        if req.tire_deflection_factor is not None:
+            payload["tire_deflection_factor"] = req.tire_deflection_factor
+        return payload
+
+    def _analysis_settings_response() -> AnalysisSettingsResponse:
+        return AnalysisSettingsResponse.model_validate(
+            asdict(settings_store.analysis_settings_snapshot())
+        )
+
     # -- cars ------------------------------------------------------------------
 
     @router.get("/api/settings/cars", response_model=CarsResponse)
     async def get_cars() -> CarsResponse:
-        return CarsResponse(**settings_store.get_cars())
+        return _cars_response(settings_store.get_cars())
 
     @router.post("/api/settings/cars", response_model=CarsResponse)
     async def add_car(req: CarUpsertRequest) -> CarsResponse:
-        payload = req.model_dump(exclude_none=True)
+        payload = _car_upsert_payload(req)
         result = await asyncio.to_thread(settings_store.add_car, payload)
-        return CarsResponse(**result)
+        return _cars_response(result)
 
     @router.put("/api/settings/cars/{car_id}", response_model=CarsResponse)
     async def update_car(car_id: str, req: CarUpsertRequest) -> CarsResponse:
-        payload = req.model_dump(exclude_none=True)
+        payload = _car_upsert_payload(req)
         with domain_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(
                 settings_store.update_car,
                 car_id,
                 payload,
             )
-        return CarsResponse(**result)
+        return _cars_response(result)
 
     @router.delete("/api/settings/cars/{car_id}", response_model=CarsResponse)
     async def delete_car(car_id: str) -> CarsResponse:
         # Existence check first so unknown-car yields 404 while business-logic
         # errors (e.g. "cannot delete the last car") propagate as 400.
-        cars_snapshot = await asyncio.to_thread(settings_store.get_cars)
-        if not any(c.get("id") == car_id for c in cars_snapshot.get("cars", [])):
+        cars_snapshot = _cars_response(await asyncio.to_thread(settings_store.get_cars))
+        if not any(car.id == car_id for car in cars_snapshot.cars):
             raise HTTPException(status_code=404, detail=f"Car {car_id!r} not found")
         with domain_errors_to_http(catch_value_error=400):
             result = await asyncio.to_thread(settings_store.delete_car, car_id)
-        return CarsResponse(**result)
+        return _cars_response(result)
 
     @router.post("/api/settings/cars/active", response_model=CarsResponse)
     async def set_active_car(req: ActiveCarRequest) -> CarsResponse:
         car_id = req.carId
         with domain_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(settings_store.set_active_car, car_id)
-        return CarsResponse(**result)
+        return _cars_response(result)
 
     # -- speed source ----------------------------------------------------------
 
     async def _apply_speed_source_update(req: SpeedSourceRequest) -> SpeedSourceResponse:
-        payload = req.model_dump(exclude_none=True)
+        payload = _speed_source_update_payload(req)
         result = await asyncio.to_thread(
             settings_store.update_speed_source,
             payload,
         )
-        return SpeedSourceResponse(**result)
+        return SpeedSourceResponse.model_validate(result)
 
     @router.get("/api/settings/speed-source", response_model=SpeedSourceResponse)
     async def get_speed_source() -> SpeedSourceResponse:
-        return SpeedSourceResponse(**settings_store.get_speed_source())
+        return SpeedSourceResponse.model_validate(settings_store.get_speed_source())
 
     @router.post("/api/settings/speed-source", response_model=SpeedSourceResponse)
     async def update_speed_source(req: SpeedSourceRequest) -> SpeedSourceResponse:
@@ -99,12 +177,12 @@ def create_settings_routes(
 
     @router.get("/api/settings/speed-source/status", response_model=SpeedSourceStatusResponse)
     async def get_speed_source_status() -> SpeedSourceStatusResponse:
-        return SpeedSourceStatusResponse(**gps_monitor.status_dict())
+        return SpeedSourceStatusResponse.model_validate(gps_monitor.status_dict())
 
     # -- sensors ---------------------------------------------------------------
 
     def _sensors_response() -> SensorsResponse:
-        return SensorsResponse(sensorsByMac=settings_store.get_sensors())
+        return SensorsResponse.model_validate({"sensorsByMac": settings_store.get_sensors()})
 
     @router.get("/api/settings/sensors", response_model=SensorsResponse)
     async def get_sensors() -> SensorsResponse:
@@ -113,7 +191,7 @@ def create_settings_routes(
     @router.post("/api/settings/sensors/{mac}", response_model=SensorsResponse)
     async def update_sensor(mac: str, req: SensorRequest) -> SensorsResponse:
         normalized_mac = normalize_mac_or_400(mac)
-        payload = req.model_dump(exclude_none=True)
+        payload = _sensor_update_payload(req)
         with domain_errors_to_http(catch_value_error=400):
             await asyncio.to_thread(
                 settings_store.set_sensor,
@@ -157,14 +235,14 @@ def create_settings_routes(
 
     @router.get("/api/settings/analysis", response_model=AnalysisSettingsResponse)
     async def get_analysis_settings() -> AnalysisSettingsResponse:
-        return AnalysisSettingsResponse(**asdict(settings_store.analysis_settings_snapshot()))
+        return _analysis_settings_response()
 
     @router.post("/api/settings/analysis", response_model=AnalysisSettingsResponse)
     async def set_analysis_settings(req: AnalysisSettingsRequest) -> AnalysisSettingsResponse:
-        changes = req.model_dump(exclude_none=True)
+        changes = _analysis_settings_payload(req)
         if changes:
             with domain_errors_to_http(catch_value_error=400):
                 await asyncio.to_thread(settings_store.update_active_car_aspects, changes)
-        return AnalysisSettingsResponse(**asdict(settings_store.analysis_settings_snapshot()))
+        return _analysis_settings_response()
 
     return router


### PR DESCRIPTION
## Summary
- remove `vibesensor.adapters.http.settings` from the backend mypy denylist in `apps/server/pyproject.toml`
- tighten the settings route boundary by using `model_validate(...)` for strict response models and explicit typed payload builders for store updates
- align the focused settings endpoint tests with the real store contracts and cover the new request/response shaping paths

## Validation
- `.venv/bin/mypy --config-file apps/server/pyproject.toml apps/server/vibesensor/adapters/http/settings.py`
- `make typecheck-backend`
- `.venv/bin/pytest -q apps/server/tests/adapters/http/test_settings_endpoints.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `docker compose build --pull`
- `docker compose up -d`
- live assertions against `/api/settings/cars`, `/api/settings/cars/active`, `/api/settings/cars/{id}`, `/api/settings/speed-source`, `/api/settings/speed-source/status`, `/api/settings/sensors/{mac}`, and `/api/settings/analysis`

Closes #966
