### PR TITLE
Remove legacy artifact alias fallback

### DIFF
--- a/apps/server/tests/hygiene/test_pi_gen_artifact_selection.py
+++ b/apps/server/tests/hygiene/test_pi_gen_artifact_selection.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+from _paths import REPO_ROOT
+
+_ARTIFACTS_SH = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "artifacts.sh"
+_IMG_SUFFIX = "-vibesensor-lite"
+
+
+def _choose_final_artifact(base_dir: Path) -> subprocess.CompletedProcess[str]:
+    script = "\n".join(
+        (
+            "set -euo pipefail",
+            f"IMG_SUFFIX={shlex.quote(_IMG_SUFFIX)}",
+            f"source {shlex.quote(str(_ARTIFACTS_SH))}",
+            f"choose_final_artifact {shlex.quote(str(base_dir))}",
+        )
+    )
+    return subprocess.run(
+        ["bash", "-lc", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_choose_final_artifact_prefers_current_image_priority(tmp_path: Path) -> None:
+    (tmp_path / f"image_2026-03-21{_IMG_SUFFIX}.zip").write_text("", encoding="utf-8")
+    (tmp_path / f"image_2026-03-21{_IMG_SUFFIX}.img.xz").write_text("", encoding="utf-8")
+    (tmp_path / f"image_2026-03-21{_IMG_SUFFIX}.img").write_text("", encoding="utf-8")
+
+    result = _choose_final_artifact(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).name == f"image_2026-03-21{_IMG_SUFFIX}.img"
+
+
+def test_choose_final_artifact_prefers_image_prefixed_zip_over_legacy_name(tmp_path: Path) -> None:
+    (tmp_path / f"legacy-build{_IMG_SUFFIX}.zip").write_text("", encoding="utf-8")
+    (tmp_path / f"image_2026-03-21{_IMG_SUFFIX}.zip").write_text("", encoding="utf-8")
+
+    result = _choose_final_artifact(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).name == f"image_2026-03-21{_IMG_SUFFIX}.zip"
+
+
+def test_choose_final_artifact_rejects_legacy_non_image_zip_names(tmp_path: Path) -> None:
+    (tmp_path / f"legacy-build{_IMG_SUFFIX}.zip").write_text("", encoding="utf-8")
+
+    result = _choose_final_artifact(tmp_path)
+
+    assert result.returncode != 0
+    assert result.stdout == ""

--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -37,7 +37,7 @@ BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh
 Standalone validation against an existing image artifact:
 
 ```bash
-# validate the latest artifact in infra/pi-image/pi-gen/out/
+# validate the current artifact in infra/pi-image/pi-gen/out/
 ./infra/pi-image/pi-gen/validate-image.sh
 
 # or validate a specific .img / .img.xz / .zip artifact

--- a/infra/pi-image/pi-gen/lib/artifacts.sh
+++ b/infra/pi-image/pi-gen/lib/artifacts.sh
@@ -20,12 +20,6 @@ choose_final_artifact() {
     return 0
   fi
 
-  candidate="$(find "${base_dir}" -maxdepth 1 -type f -name "*${IMG_SUFFIX}*.zip" ! -name "latest${IMG_SUFFIX}.*" | sort -r | head -n 1 || true)"
-  if [ -n "${candidate}" ]; then
-    printf '%s\n' "${candidate}"
-    return 0
-  fi
-
   return 1
 }
 


### PR DESCRIPTION
## Summary
- remove the dead latest* artifact-selection fallback from the pi-image helper
- add focused behavior coverage for choose_final_artifact() and the current image_* contract
- update the pi-image README wording to describe the current artifact selection path

## Testing
- .venv/bin/pytest -q apps/server/tests/hygiene/test_pi_gen_artifact_selection.py apps/server/tests/hygiene/test_ai_smoke.py
- bash -n infra/pi-image/pi-gen/build.sh infra/pi-image/pi-gen/validate-image.sh infra/pi-image/pi-gen/lib/*.sh
- PATH="$PWD/.venv/bin:$PATH" make lint

Closes #969