### PR TITLE
Remove GPS timestamp legacy setter

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import math
-import time
 
 import pytest
+from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 
@@ -36,7 +36,7 @@ def test_manual_selected_with_override_returns_override() -> None:
     monitor.manual_source_selected = True
     monitor.override_speed_mps = 25.0
     monitor.speed_mps = 30.0
-    monitor.last_update_ts = time.monotonic()
+    set_gps_snapshot_age(monitor)
 
     assert abs((monitor.effective_speed_mps or 0.0) - 25.0) < 1e-9
     assert monitor.fallback_active is False
@@ -48,7 +48,7 @@ def test_manual_selected_no_override_falls_through_to_gps() -> None:
     monitor.manual_source_selected = True
     # No override set
     monitor.speed_mps = 30.0
-    monitor.last_update_ts = time.monotonic()
+    set_gps_snapshot_age(monitor)
 
     # Should return GPS speed instead of None
     assert monitor.effective_speed_mps is not None
@@ -69,7 +69,7 @@ def test_resolve_speed_default_override_has_priority() -> None:
     assert monitor.manual_source_selected is True
     monitor.override_speed_mps = 12.0
     monitor.speed_mps = 20.0
-    monitor.last_update_ts = time.monotonic()
+    set_gps_snapshot_age(monitor)
 
     resolved = monitor.resolve_speed()
     assert resolved.speed_mps == 12.0
@@ -81,7 +81,7 @@ def test_resolve_speed_stale_gps_falls_back_to_manual_override() -> None:
     monitor = GPSSpeedMonitor(gps_enabled=True)
     monitor.manual_source_selected = False
     monitor.speed_mps = 22.0
-    monitor.last_update_ts = time.monotonic() - 30.0
+    set_gps_snapshot_age(monitor, age_s=30.0)
     monitor.override_speed_mps = 11.0
     monitor.connection_state = "connected"
     monitor.stale_timeout_s = 5.0

--- a/apps/server/tests/adapters/gps/test_gps_speed_extended.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_extended.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import time
 
 import pytest
+from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 
@@ -13,7 +13,7 @@ from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 def test_gps_used_as_fallback_when_no_override() -> None:
     m = GPSSpeedMonitor(gps_enabled=True)
     m.speed_mps = 10.0
-    m.last_update_ts = time.monotonic()  # mark GPS data as fresh
+    set_gps_snapshot_age(m)  # mark GPS data as fresh
     assert m.effective_speed_mps == 10.0
 
 
@@ -70,7 +70,7 @@ def test_integer_speed_mps_treated_as_float() -> None:
     """speed_mps set to int should still be returned as float via effective_speed_mps."""
     m = GPSSpeedMonitor(gps_enabled=True)
     m.speed_mps = 10
-    m.last_update_ts = time.monotonic()  # mark GPS data as fresh
+    set_gps_snapshot_age(m)  # mark GPS data as fresh
     result = m.effective_speed_mps
     assert result is not None
     assert isinstance(result, float)

--- a/apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py
@@ -11,9 +11,9 @@ Verifies that:
 from __future__ import annotations
 
 import copy
-import time
 
 import pytest
+from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor, SpeedResolution
 
@@ -31,14 +31,14 @@ def _snapshot(m: GPSSpeedMonitor) -> dict:
 def _make_fresh_gps() -> GPSSpeedMonitor:
     m = GPSSpeedMonitor(gps_enabled=True)
     m.speed_mps = 10.0
-    m.last_update_ts = time.monotonic()
+    set_gps_snapshot_age(m)
     return m
 
 
 def _make_stale_gps() -> GPSSpeedMonitor:
     m = GPSSpeedMonitor(gps_enabled=True)
     m.speed_mps = 10.0
-    m.last_update_ts = time.monotonic() - 999
+    set_gps_snapshot_age(m, age_s=999)
     return m
 
 
@@ -60,7 +60,7 @@ def _make_override_plus_gps() -> GPSSpeedMonitor:
     m.manual_source_selected = True
     m.override_speed_mps = 25.0
     m.speed_mps = 10.0
-    m.last_update_ts = time.monotonic()
+    set_gps_snapshot_age(m)
     return m
 
 
@@ -91,7 +91,7 @@ class TestEffectiveSpeedNoMutation:
     def test_effective_speed_does_not_mutate(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         before = _snapshot(m)
         _ = m.effective_speed_mps
         assert _snapshot(m) == before
@@ -99,7 +99,7 @@ class TestEffectiveSpeedNoMutation:
     def test_effective_speed_stale_does_not_mutate(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic() - 999
+        set_gps_snapshot_age(m, age_s=999)
         before = _snapshot(m)
         _ = m.effective_speed_mps
         assert _snapshot(m) == before
@@ -118,7 +118,7 @@ class TestStatusDictNoMutation:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 5.0
-        m.last_update_ts = time.monotonic() - 999  # stale
+        set_gps_snapshot_age(m, age_s=999)  # stale
 
         s = m.status_dict()
         # The dict should report "stale" ...
@@ -130,7 +130,7 @@ class TestStatusDictNoMutation:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
 
         s = m.status_dict()
         assert s["connection_state"] == "connected"
@@ -146,7 +146,7 @@ class TestFallbackActiveConsistency:
     def test_fallback_active_consistent_with_speed_fresh_gps(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         r = m.resolve_speed()
         assert r.speed_mps == 10.0
         assert r.fallback_active is False
@@ -159,7 +159,7 @@ class TestFallbackActiveConsistency:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.manual_source_selected = False  # GPS primary, override is fallback only
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic() - 999
+        set_gps_snapshot_age(m, age_s=999)
         m.override_speed_mps = 25.0
         r = m.resolve_speed()
         assert r.fallback_active is True
@@ -197,7 +197,7 @@ class TestMultipleReadsConsistent:
     def test_repeated_reads_consistent_fresh(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         results = [m.resolve_speed() for _ in range(5)]
         assert all(r == results[0] for r in results)
 
@@ -205,7 +205,7 @@ class TestMultipleReadsConsistent:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.manual_source_selected = False  # GPS primary, override is fallback only
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic() - 999
+        set_gps_snapshot_age(m, age_s=999)
         m.override_speed_mps = 25.0
         results = [m.resolve_speed() for _ in range(5)]
         assert all(r == results[0] for r in results)
@@ -214,7 +214,7 @@ class TestMultipleReadsConsistent:
         """Reading effective_speed_mps and fallback_active in any order must agree."""
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic() - 999
+        set_gps_snapshot_age(m, age_s=999)
 
         # Read in different orders — all should be consistent
         speed1 = m.effective_speed_mps
@@ -265,14 +265,14 @@ class TestGPSTransitions:
 
         # Stage 1: fresh GPS
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         r1 = m.resolve_speed()
         assert r1.speed_mps == 10.0
         assert r1.fallback_active is False
         assert r1.source == "gps"
 
         # Stage 2: GPS becomes stale (simulate by backdating last_update_ts)
-        m.last_update_ts = time.monotonic() - m.stale_timeout_s - 5
+        set_gps_snapshot_age(m, age_s=m.stale_timeout_s + 5)
         r2 = m.resolve_speed()
         assert r2.speed_mps == 25.0  # fallback to override
         assert r2.fallback_active is True
@@ -280,7 +280,7 @@ class TestGPSTransitions:
 
         # Stage 3: fresh GPS data arrives
         m.speed_mps = 15.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         r3 = m.resolve_speed()
         assert r3.speed_mps == 15.0
         assert r3.fallback_active is False

--- a/apps/server/tests/adapters/gps/test_gps_speed_status.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_status.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
+from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import (
     DEFAULT_STALE_TIMEOUT_S,
@@ -41,7 +40,7 @@ class TestStatusDict:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 10.0  # 36 km/h
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         s = m.status_dict()
         assert s["gps_enabled"] is True
         assert s["connection_state"] == "connected"
@@ -70,7 +69,7 @@ class TestStatusDict:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 5.0
-        m.last_update_ts = time.monotonic() - 999  # way older than stale timeout
+        set_gps_snapshot_age(m, age_s=999)  # way older than stale timeout
         s = m.status_dict()
         assert s["connection_state"] == "stale"
 
@@ -84,7 +83,7 @@ class TestStatusDict:
     def test_connected_hides_reconnect_delay(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         s = m.status_dict()
         assert s["reconnect_delay_s"] is None
 
@@ -110,7 +109,7 @@ class TestFallback:
     def test_fresh_gps_no_fallback(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         assert m.effective_speed_mps == pytest.approx(10.0)
         assert m.fallback_active is False
 
@@ -121,7 +120,7 @@ class TestFallback:
         """
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic() - 999
+        set_gps_snapshot_age(m, age_s=999)
         # No override set → stale GPS → fallback path → None
         assert m.effective_speed_mps is None
         assert m.fallback_active is True
@@ -129,7 +128,7 @@ class TestFallback:
     def test_stale_gps_no_override_returns_none(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic() - 999
+        set_gps_snapshot_age(m, age_s=999)
         # No override set
         assert m.effective_speed_mps is None
         assert m.fallback_active is True
@@ -155,7 +154,7 @@ class TestFallback:
         m.manual_source_selected = True
         m.override_speed_mps = 25.0
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         assert m.effective_speed_mps == pytest.approx(25.0)
 
     def test_default_override_wins(self) -> None:
@@ -164,7 +163,7 @@ class TestFallback:
         assert m.manual_source_selected is True
         m.override_speed_mps = 25.0
         m.speed_mps = 10.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         assert m.effective_speed_mps == pytest.approx(25.0)
         assert m.fallback_active is False
 
@@ -173,12 +172,12 @@ class TestFallback:
         m.stale_timeout_s = 5.0
         m.speed_mps = 10.0
         # Just under stale threshold
-        m.last_update_ts = time.monotonic() - 4.0
+        set_gps_snapshot_age(m, age_s=4.0)
         assert m.effective_speed_mps == pytest.approx(10.0)
         assert m.fallback_active is False
 
         # Over stale threshold — no override set → fallback returns None
-        m.last_update_ts = time.monotonic() - 6.0
+        set_gps_snapshot_age(m, age_s=6.0)
         assert m.effective_speed_mps is None
         assert m.fallback_active is True
 
@@ -227,12 +226,12 @@ class TestIsGpsStale:
 
     def test_fresh_update_not_stale(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         assert m._is_gps_stale() is False
 
     def test_old_update_is_stale(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
-        m.last_update_ts = time.monotonic() - m.stale_timeout_s - 1
+        set_gps_snapshot_age(m, age_s=m.stale_timeout_s + 1)
         assert m._is_gps_stale() is True
 
 

--- a/apps/server/tests/integration/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/integration/test_io_and_time_guard_regressions.py
@@ -12,13 +12,12 @@ Covers:
   6. report_mapping_pipeline date_str – includes UTC suffix
 """
 
-
-import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.pdf.mapping import map_summary
@@ -131,7 +130,7 @@ class TestResolveSpeedTOCTOU:
     def test_speed_snapshot_used_for_gps_return(self) -> None:
         mon = GPSSpeedMonitor(gps_enabled=True)
         mon.speed_mps = 10.5
-        mon.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(mon)
         mon.connection_state = "connected"
 
         result = mon.resolve_speed()
@@ -141,7 +140,7 @@ class TestResolveSpeedTOCTOU:
     def test_speed_none_after_stale(self) -> None:
         mon = GPSSpeedMonitor(gps_enabled=True)
         mon.speed_mps = 5.0
-        mon.last_update_ts = time.monotonic() - 999  # very stale
+        set_gps_snapshot_age(mon, age_s=999)  # very stale
         mon.connection_state = "connected"
 
         result = mon.resolve_speed()
@@ -167,11 +166,11 @@ class TestIsGpsStaleTOCTOU:
     def test_is_gps_stale(self, ts: Any, expected: bool) -> None:
         mon = GPSSpeedMonitor(gps_enabled=True)
         if ts == "fresh":
-            mon.last_update_ts = time.monotonic()
+            set_gps_snapshot_age(mon)
         elif ts == "old":
-            mon.last_update_ts = time.monotonic() - 999
+            set_gps_snapshot_age(mon, age_s=999)
         else:
-            mon.last_update_ts = None
+            set_gps_snapshot_age(mon, age_s=None)
         assert mon._is_gps_stale() is expected
 
 

--- a/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
@@ -13,6 +13,7 @@ import time
 from unittest.mock import patch
 
 import pytest
+from test_support.gps import set_gps_snapshot_age
 
 import vibesensor.adapters.udp.udp_control_tx as udp_control_tx_mod
 import vibesensor.shared.locations as locations_mod
@@ -132,10 +133,10 @@ class TestResolveSpeedAtomicSnapshot:
         assert r.source == "gps"
 
     def test_resolve_speed_snapshot_consistency(self) -> None:
-        """Setting speed_mps and last_update_ts both update the snapshot."""
+        """Setting speed_mps and the test snapshot helper both update the snapshot."""
         m = _make_gps_monitor()
         m.speed_mps = 15.0
-        m.last_update_ts = time.monotonic()
+        set_gps_snapshot_age(m)
         r = m.resolve_speed()
         assert r.speed_mps == 15.0
         assert r.source == "gps"

--- a/apps/server/tests/test_support/gps.py
+++ b/apps/server/tests/test_support/gps.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import time
+
+from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+
+
+def set_gps_snapshot_age(
+    monitor: GPSSpeedMonitor,
+    *,
+    age_s: float | None = 0.0,
+) -> None:
+    """Set the GPS snapshot timestamp for tests while preserving the current speed."""
+    timestamp = None if age_s is None else time.monotonic() - age_s
+    monitor._speed_snapshot = (monitor.speed_mps, timestamp)

--- a/apps/server/vibesensor/adapters/gps/gps_speed.py
+++ b/apps/server/vibesensor/adapters/gps/gps_speed.py
@@ -151,11 +151,6 @@ class GPSSpeedMonitor:
         """Read timestamp from the atomic snapshot."""
         return self._speed_snapshot[1]
 
-    @last_update_ts.setter
-    def last_update_ts(self, value: float | None) -> None:
-        """Write timestamp via legacy setter — preserves current speed."""
-        self._speed_snapshot = (self._speed_snapshot[0], value)
-
     def _effective_connection_state(self) -> str:
         """Return the effective connection state **without** mutating ``self``."""
         if self.gps_enabled and self.connection_state == "connected" and self._is_gps_stale():


### PR DESCRIPTION
## Summary
- remove the legacy `GPSSpeedMonitor.last_update_ts` setter from production code
- add a shared GPS snapshot-age helper under `test_support` for explicit fresh/stale/none setup in tests
- migrate the affected GPS and integration regressions off direct timestamp mutation

## Testing
- .venv/bin/pytest -q apps/server/tests/adapters/gps apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_review_guardrails_extended_regressions.py
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make typecheck-backend

Closes #971