### PR TITLE
Add Audi TDI variants to car library

### DIFF
--- a/apps/server/data/CAR_VARIANT_SOURCES.md
+++ b/apps/server/data/CAR_VARIANT_SOURCES.md
@@ -386,6 +386,9 @@ and the confidence level of the data.
 | 30 TFSI | 1.0L I3 TFSI Turbo | FWD | Audi press release | High |
 | 35 TFSI | 1.5L I4 TFSI Turbo | FWD | Audi press release | High |
 | 40 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | Audi press release | High |
+| 1.6 TDI | 1.6L I4 TDI Diesel | FWD | Audi owner manual / brochure archive | Medium |
+| 2.0 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
+| 2.0 TDI quattro | 2.0L I4 TDI Diesel | AWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
 
 ### A3 (8Y, 2021-2026)
 
@@ -394,6 +397,8 @@ and the confidence level of the data.
 | 30 TFSI | 1.0L I3 TFSI Turbo | FWD | Audi press release | High |
 | 35 TFSI | 1.5L I4 TFSI Turbo | FWD | Audi press release | High |
 | 40 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | Audi press release | High |
+| 30 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / ETKA Europe | Medium |
+| 35 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / ETKA Europe | Medium |
 
 ### A4 (B8, 2011-2016)
 
@@ -403,6 +408,9 @@ and the confidence level of the data.
 | 2.0 TFSI | 2.0L I4 TFSI Turbo | FWD | Audi press release | High |
 | 2.0 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | Audi press release | High |
 | 3.0 TFSI quattro | 3.0L V6 Supercharged | AWD | Audi press release | High |
+| 2.0 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
+| 2.0 TDI quattro | 2.0L I4 TDI Diesel | AWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
+| 3.0 TDI quattro | 3.0L V6 TDI Diesel | AWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
 
 ### A4 (B9, 2016-2024)
 
@@ -411,6 +419,8 @@ and the confidence level of the data.
 | 35 TFSI | 2.0L I4 TFSI Turbo | FWD | 7-speed S tronic FD 4.234 | Audi MediaCenter eTD technical data | High |
 | 40 TFSI | 2.0L I4 TFSI Turbo | FWD | 7-speed S tronic FD 4.234 | Audi MediaCenter eTD / Audi UK technical data | High |
 | 45 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | 7-speed S tronic FD 4.410 | Audi MediaCenter eTD technical data | High |
+| 30 TDI | 2.0L I4 TDI Diesel | FWD | – | Audi owner manual / ETKA Europe | Medium |
+| 35 TDI | 2.0L I4 TDI Diesel | FWD | – | Audi owner manual / ETKA Europe | Medium |
 
 ### A5 (B8, 2012-2016)
 
@@ -485,6 +495,8 @@ and the confidence level of the data.
 |---------|--------|------------|--------|------------|
 | 1.4 TFSI | 1.4L I4 TFSI Turbo | FWD | Audi press release | High |
 | 2.0 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | Audi press release | High |
+| 2.0 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
+| 2.0 TDI quattro | 2.0L I4 TDI Diesel | AWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
 
 ### Q3 (F3, 2019-2026)
 
@@ -493,6 +505,8 @@ and the confidence level of the data.
 | 35 TFSI | 1.5L I4 TFSI Turbo | FWD | Audi press release | High |
 | 40 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | Audi press release | High |
 | 45 TFSI e | 1.4L I4 TFSI Turbo PHEV | FWD | Audi press release | High |
+| 35 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / ETKA Europe | Medium |
+| 40 TDI quattro | 2.0L I4 TDI Diesel | AWD | Audi owner manual / ETKA Europe | Medium |
 
 ### Q5 (8R, 2011-2017)
 
@@ -509,6 +523,8 @@ and the confidence level of the data.
 | 40 TFSI | 2.0L I4 TFSI Turbo | FWD | 7-speed S tronic FD 5.302 | Audi MediaCenter eTD technical data | High |
 | 45 TFSI quattro | 2.0L I4 TFSI Turbo | AWD | 7-speed S tronic FD 5.302 | Audi MediaCenter eTD / Audi UK technical data | High |
 | 55 TFSI e quattro | 2.0L I4 TFSI Turbo PHEV | AWD | 7-speed S tronic FD 5.302 | Audi MediaCenter / technical data PDF | High |
+| 35 TDI quattro | 2.0L I4 TDI Diesel | AWD | – | Audi owner manual / technical data | Medium |
+| 40 TDI quattro | 2.0L I4 TDI Diesel | AWD | – | Audi owner manual / technical data | Medium |
 
 ### Q7 (4M, 2016-2026)
 
@@ -594,5 +610,4 @@ and the confidence level of the data.
 
 ## TODOs
 
-- [ ] Add diesel (TDI) variants for European-market Audi models where relevant
 - [ ] Research and verify electric vehicle motor specifications

--- a/apps/server/data/car_library.json
+++ b/apps/server/data/car_library.json
@@ -2811,6 +2811,21 @@
         "name": "40 TFSI quattro",
         "engine": "2.0L I4 TFSI Turbo",
         "drivetrain": "AWD"
+      },
+      {
+        "name": "1.6 TDI",
+        "engine": "1.6L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "2.0 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "2.0 TDI quattro",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "AWD"
       }
     ]
   },
@@ -2868,6 +2883,16 @@
         "name": "40 TFSI quattro",
         "engine": "2.0L I4 TFSI Turbo",
         "drivetrain": "AWD"
+      },
+      {
+        "name": "30 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "35 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
       }
     ]
   },
@@ -2934,6 +2959,21 @@
       {
         "name": "3.0 TFSI quattro",
         "engine": "3.0L V6 Supercharged",
+        "drivetrain": "AWD"
+      },
+      {
+        "name": "2.0 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "2.0 TDI quattro",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "AWD"
+      },
+      {
+        "name": "3.0 TDI quattro",
+        "engine": "3.0L V6 TDI Diesel",
         "drivetrain": "AWD"
       }
     ]
@@ -3017,6 +3057,16 @@
       {
         "name": "45 TFSI",
         "engine": "2.0L I4 TFSI Turbo",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "30 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "35 TDI",
+        "engine": "2.0L I4 TDI Diesel",
         "drivetrain": "FWD"
       }
     ]
@@ -3550,6 +3600,16 @@
         "name": "2.0 TFSI quattro",
         "engine": "2.0L I4 TFSI Turbo",
         "drivetrain": "AWD"
+      },
+      {
+        "name": "2.0 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "2.0 TDI quattro",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "AWD"
       }
     ]
   },
@@ -3602,6 +3662,16 @@
         "name": "45 TFSI e",
         "engine": "1.4L I4 TFSI Turbo PHEV",
         "drivetrain": "FWD"
+      },
+      {
+        "name": "35 TDI",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "FWD"
+      },
+      {
+        "name": "40 TDI quattro",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "AWD"
       }
     ]
   },
@@ -3717,6 +3787,16 @@
       {
         "name": "55 TFSI e quattro",
         "engine": "2.0L I4 TFSI Turbo PHEV",
+        "drivetrain": "AWD"
+      },
+      {
+        "name": "35 TDI quattro",
+        "engine": "2.0L I4 TDI Diesel",
+        "drivetrain": "AWD"
+      },
+      {
+        "name": "40 TDI quattro",
+        "engine": "2.0L I4 TDI Diesel",
         "drivetrain": "AWD"
       }
     ]

--- a/apps/server/tests/adapters/persistence/test_car_variants.py
+++ b/apps/server/tests/adapters/persistence/test_car_variants.py
@@ -186,6 +186,43 @@ def test_resolve_variant_audi_b9_fy_s_tronic_uses_verified_final_drives(
         raise AssertionError(f"Audi model not found: {model}")
 
 
+@pytest.mark.parametrize(
+    ("model", "variant", "expected_engine", "expected_drivetrain"),
+    [
+        ("A3 (8V, 2013-2020)", "1.6 TDI", "1.6L I4 TDI Diesel", "FWD"),
+        ("A3 (8V, 2013-2020)", "2.0 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("A3 (8V, 2013-2020)", "2.0 TDI quattro", "2.0L I4 TDI Diesel", "AWD"),
+        ("A3 (8Y, 2021-2026)", "30 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("A3 (8Y, 2021-2026)", "35 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("A4 (B8, 2008-2016)", "2.0 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("A4 (B8, 2008-2016)", "2.0 TDI quattro", "2.0L I4 TDI Diesel", "AWD"),
+        ("A4 (B8, 2008-2016)", "3.0 TDI quattro", "3.0L V6 TDI Diesel", "AWD"),
+        ("A4 (B9, 2016-2025)", "30 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("A4 (B9, 2016-2025)", "35 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("Q3 (8U, 2012-2018)", "2.0 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("Q3 (8U, 2012-2018)", "2.0 TDI quattro", "2.0L I4 TDI Diesel", "AWD"),
+        ("Q3 (F3, 2019-2026)", "35 TDI", "2.0L I4 TDI Diesel", "FWD"),
+        ("Q3 (F3, 2019-2026)", "40 TDI quattro", "2.0L I4 TDI Diesel", "AWD"),
+        ("Q5 (FY, 2017-2026)", "35 TDI quattro", "2.0L I4 TDI Diesel", "AWD"),
+        ("Q5 (FY, 2017-2026)", "40 TDI quattro", "2.0L I4 TDI Diesel", "AWD"),
+    ],
+)
+def test_audi_models_include_verified_tdi_variants(
+    model: str, variant: str, expected_engine: str, expected_drivetrain: str
+) -> None:
+    """Audi core European-market models keep the verified TDI coverage added for #974."""
+    for entry in CAR_LIBRARY:
+        if entry["brand"] == "Audi" and entry["model"] == model:
+            variant_entry = next(
+                candidate for candidate in entry["variants"] if candidate["name"] == variant
+            )
+            assert variant_entry["engine"] == expected_engine
+            assert variant_entry["drivetrain"] == expected_drivetrain
+            break
+    else:
+        raise AssertionError(f"Audi model not found: {model}")
+
+
 def test_resolve_variant_unknown_name_returns_base() -> None:
     """resolve_variant with unknown name returns base entry unchanged."""
     base = CAR_LIBRARY[0]


### PR DESCRIPTION
## Summary
- add the missing mainstream European-market Audi TDI variants across A3, A4, Q3, and Q5 families
- document the added Audi diesel coverage in the source notes and remove the resolved TODO
- cover the new variants with focused car-library persistence tests

## Testing
- python3 - <<'PY'
import json
from pathlib import Path
for rel in ['apps/server/data/car_library.json', 'apps/server/data/car_library_ratio_sources.json']:
    json.loads(Path(rel).read_text())
    print(f'json ok: {rel}')
PY
- .venv/bin/pytest -vv apps/server/tests/adapters/persistence/test_car_variants.py apps/server/tests/adapters/persistence/test_car_library.py
- PATH="$PWD/.venv/bin:$PATH" make lint
- docker compose build --pull && docker compose up -d
- live /api/car-library/models probe for the new Audi diesel variants
- docker compose down

Closes #974