### PR TITLE
Localize domain numeric coercion

### DIFF
--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -78,13 +78,8 @@ def _import_target_layer(module: str) -> str | None:
 _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
     {
         # domain → shared (root-level utilities)
-        ("domain/finding_evidence.py", "vibesensor.coerce"),
-        ("domain/location_hotspot.py", "vibesensor.coerce"),
-        ("domain/order_match.py", "vibesensor.coerce"),
         ("domain/run_capture.py", "vibesensor.strength_bands"),
         ("domain/run_capture.py", "vibesensor.vibration_strength"),
-        ("domain/snapshots.py", "vibesensor.coerce"),
-        ("domain/strength_metrics.py", "vibesensor.coerce"),
         # shared → adapters
         # use_cases → adapters
         # use_cases → infra

--- a/apps/server/vibesensor/coerce.py
+++ b/apps/server/vibesensor/coerce.py
@@ -1,31 +1,7 @@
-"""Type-safe numeric coercion for boundary deserialization.
-
-``coerce_float`` and ``coerce_int`` accept ``object`` input and narrow
-via ``isinstance`` so mypy validates the call without ``type: ignore``.
-"""
+"""Type-safe numeric coercion for boundary deserialization."""
 
 from __future__ import annotations
 
+from vibesensor.domain._numeric import coerce_float, coerce_int
+
 __all__ = ["coerce_float", "coerce_int"]
-
-
-def coerce_float(value: object) -> float:
-    """Coerce an untrusted ``object`` to ``float`` without ``type: ignore``.
-
-    Narrows via ``isinstance`` so the call is statically valid for mypy.
-    Raises ``TypeError`` or ``ValueError`` on non-numeric input — callers
-    must handle those when the source is untrusted.
-    """
-    if isinstance(value, (int, float, str, bytes)):
-        return float(value)
-    raise TypeError(f"Cannot coerce {type(value).__name__} to float")
-
-
-def coerce_int(value: object) -> int:
-    """Coerce an untrusted ``object`` to ``int`` without ``type: ignore``.
-
-    Uses ``round()`` on the float conversion for fractional values.
-    """
-    if isinstance(value, int) and not isinstance(value, bool):
-        return value
-    return round(coerce_float(value))

--- a/apps/server/vibesensor/domain/_numeric.py
+++ b/apps/server/vibesensor/domain/_numeric.py
@@ -1,0 +1,24 @@
+"""Domain-owned numeric coercion helpers for tolerant mapping parsers."""
+
+from __future__ import annotations
+
+__all__ = ["coerce_float", "coerce_int"]
+
+
+def coerce_float(value: object) -> float:
+    """Coerce an untrusted ``object`` to ``float`` for domain factories.
+
+    Domain value-object factories still parse persisted/runtime mappings, so they
+    need a local helper instead of importing the root shared utility layer.
+    Raises ``TypeError`` or ``ValueError`` on non-numeric input.
+    """
+    if isinstance(value, (int, float, str, bytes)):
+        return float(value)
+    raise TypeError(f"Cannot coerce {type(value).__name__} to float")
+
+
+def coerce_int(value: object) -> int:
+    """Coerce an untrusted ``object`` to ``int`` using rounded float parsing."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return round(coerce_float(value))

--- a/apps/server/vibesensor/domain/finding_evidence.py
+++ b/apps/server/vibesensor/domain/finding_evidence.py
@@ -6,8 +6,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import ClassVar
 
-from vibesensor.coerce import coerce_float
 from vibesensor.domain.finding_types import VibrationSource
+
+from ._numeric import coerce_float
 
 __all__ = [
     "FindingEvidence",

--- a/apps/server/vibesensor/domain/location_hotspot.py
+++ b/apps/server/vibesensor/domain/location_hotspot.py
@@ -12,9 +12,9 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from vibesensor.coerce import coerce_float, coerce_int
-
 __all__ = ["LocationHotspot", "LocationIntensitySummary"]
+
+from ._numeric import coerce_float, coerce_int
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/domain/order_match.py
+++ b/apps/server/vibesensor/domain/order_match.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from vibesensor.coerce import coerce_float
-
 __all__ = ["OrderMatchObservation"]
+
+from ._numeric import coerce_float
 
 _CLOSE_MATCH_THRESHOLD = 0.05  # 5% relative error
 

--- a/apps/server/vibesensor/domain/snapshots.py
+++ b/apps/server/vibesensor/domain/snapshots.py
@@ -19,8 +19,7 @@ from dataclasses import asdict, dataclass, field
 from types import MappingProxyType
 from typing import ClassVar
 
-from vibesensor.coerce import coerce_float
-
+from ._numeric import coerce_float
 from .car import CarSnapshot, OrderReferenceSpec
 from .driving_segment import DrivingPhaseSegment
 

--- a/apps/server/vibesensor/domain/strength_metrics.py
+++ b/apps/server/vibesensor/domain/strength_metrics.py
@@ -16,12 +16,12 @@ import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from vibesensor.coerce import coerce_float
-
 __all__ = [
     "StrengthMetrics",
     "StrengthPeak",
 ]
+
+from ._numeric import coerce_float
 
 
 def _float_or(d: Mapping[str, object], key: str, default: float = 0.0) -> float:


### PR DESCRIPTION
## Summary
- add a domain-owned numeric coercion helper and switch the five cited domain modules to use it
- keep `vibesensor.coerce` as the shared wrapper for non-domain callers
- remove the matching layer-boundary allowlist debt now that the imports are gone

## Testing
- python import smoke for `vibesensor.coerce` and `vibesensor.shared.boundaries.finding`
- .venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/domain/test_domain_value_objects.py apps/server/tests/domain/test_location_hotspot.py apps/server/tests/domain/test_strength_metrics.py apps/server/tests/domain/test_snapshots.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py
- PATH="$PWD/.venv/bin:$PATH" make lint
- PATH="$PWD/.venv/bin:$PATH" make typecheck-backend
- docker compose build --pull && docker compose up -d
- live `/openapi.json` and `/api/car-library/models` smoke requests
- docker compose down

Closes #977