### PR TITLE
Break settings_store adapter dependencies

### DIFF
--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -82,8 +82,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         # use_cases → adapters
         # use_cases → infra
         # infra → adapters
-        ("infra/config/settings_store.py", "vibesensor.adapters.gps.gps_speed"),
-        ("infra/config/settings_store.py", "vibesensor.adapters.persistence.history_db"),
         ("infra/runtime/processing_loop.py", "vibesensor.adapters.udp.udp_control_tx"),
         ("infra/runtime/registry.py", "vibesensor.adapters.udp.protocol"),
         ("infra/runtime/registry.py", "vibesensor.adapters.persistence.history_db"),

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -16,8 +16,41 @@ from vibesensor.shared.types.backend_types import (
     _parse_manual_speed,
     car_to_persistence_dict,
 )
+from vibesensor.shared.types.json_types import JsonObject
 
 DEFAULT_CAR_ASPECTS = AnalysisSettingsSnapshot.DEFAULTS
+
+
+class FakeSettingsSnapshotStore:
+    def __init__(self, snapshot: JsonObject | None = None) -> None:
+        self.snapshot = snapshot
+
+    def get_settings_snapshot(self) -> JsonObject | None:
+        return self.snapshot
+
+    def set_settings_snapshot(self, snapshot: JsonObject) -> None:
+        self.snapshot = snapshot
+
+
+class FakeSpeedSourceSync:
+    def __init__(self) -> None:
+        self.manual_selected: bool | None = None
+        self.override_kmh: float | None = None
+        self.stale_timeout_s: float | None = None
+
+    def set_manual_source_selected(self, selected: bool) -> None:
+        self.manual_selected = selected
+
+    def set_speed_override_kmh(self, speed_kmh: float | None) -> float | None:
+        self.override_kmh = speed_kmh
+        return speed_kmh
+
+    def set_fallback_settings(
+        self,
+        stale_timeout_s: float | None = None,
+        **_kwargs: object,
+    ) -> None:
+        self.stale_timeout_s = stale_timeout_s
 
 
 def _sabotaged_store(tmp_path: Path) -> SettingsStore:
@@ -240,6 +273,37 @@ def test_store_handles_no_db() -> None:
     store = SettingsStore()
     assert store.snapshot()["cars"] == []
     assert store.snapshot()["activeCarId"] is None
+
+
+def test_store_persists_with_protocol_shaped_snapshot_store() -> None:
+    snapshot_store = FakeSettingsSnapshotStore()
+    store = SettingsStore(db=snapshot_store)
+    created = store.add_car({"name": "Protocol Car", "type": "suv"})
+    car_id = created["cars"][0]["id"]
+    store.set_active_car(car_id)
+
+    reloaded = SettingsStore(db=snapshot_store)
+    snap = reloaded.snapshot()
+    assert len(snap["cars"]) == 1
+    assert snap["cars"][0]["name"] == "Protocol Car"
+    assert snap["activeCarId"] == car_id
+
+
+def test_store_syncs_speed_source_with_protocol_shaped_monitor() -> None:
+    gps_monitor = FakeSpeedSourceSync()
+    store = SettingsStore(gps_monitor=gps_monitor)
+
+    store.update_speed_source(
+        {
+            "speedSource": "manual",
+            "manualSpeedKph": 80,
+            "staleTimeoutS": 17,
+        }
+    )
+
+    assert gps_monitor.manual_selected is True
+    assert gps_monitor.override_kmh == pytest.approx(80.0)
+    assert gps_monitor.stale_timeout_s == pytest.approx(17.0)
 
 
 def test_parse_manual_speed_returns_none_for_invalid() -> None:

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -9,15 +9,16 @@ Boundary note
 Settings management spans two layers:
 
 - ``settings_store.py`` (this module) — user-facing settings (cars, speed
-  source, language, unit, sensors) persisted to ``HistoryDB``.
-  Also owns the in-memory analysis parameter cache
+  source, language, unit, sensors) persisted through a narrow snapshot
+  persistence port. Also owns the in-memory analysis parameter cache
   (tire_diameter, tire_aspect, etc.) recomputed from the active car's
   aspects whenever car settings change.
-- ``history_db/`` — ``get_settings_snapshot()`` / ``set_settings_snapshot()``
-  persist settings as a single JSON blob.
+- concrete adapters such as ``history_db/`` implement
+  ``get_settings_snapshot()`` / ``set_settings_snapshot()`` and persist
+  settings as a single JSON blob.
 
 ``SettingsStore`` owns the semantic meaning of settings, delegates
-persistence to ``HistoryDB``, and is the canonical source for
+persistence to its injected snapshot-store collaborator, and is the canonical source for
 runtime settings queries.
 """
 
@@ -26,7 +27,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from threading import RLock
-from typing import TYPE_CHECKING, cast, get_args
+from typing import cast, get_args
 
 from vibesensor.domain import (
     Car,
@@ -39,6 +40,7 @@ from vibesensor.domain.snapshots import AnalysisSettingsSnapshot
 from vibesensor.infra.config.car_settings import CarSettingsMixin
 from vibesensor.infra.config.car_settings import _clamp_str as _clamp_str
 from vibesensor.shared.exceptions import PersistenceError as PersistenceError
+from vibesensor.shared.ports import SettingsSnapshotPersistence, SpeedSourceSync
 from vibesensor.shared.types.backend_types import (
     LanguageCode,
     SensorConfig,
@@ -52,10 +54,6 @@ from vibesensor.shared.types.backend_types import (
     car_to_persistence_dict,
 )
 from vibesensor.shared.types.json_types import JsonObject
-
-if TYPE_CHECKING:
-    from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
-    from vibesensor.adapters.persistence.history_db import HistoryDB
 
 LOGGER = logging.getLogger(__name__)
 
@@ -102,15 +100,15 @@ def _validated_speed_unit(value: object) -> SpeedUnitCode | None:
 class SettingsStore(CarSettingsMixin):
     """Holds the full app settings: cars, speed source, and sensors.
 
-    Persistence is backed by a :class:`HistoryDB` instance (SQLite).
+    Persistence is backed by a snapshot-store collaborator.
     When no *db* is provided the store operates in memory only (useful for tests).
     """
 
     def __init__(
         self,
-        db: HistoryDB | None = None,
+        db: SettingsSnapshotPersistence | None = None,
         *,
-        gps_monitor: GPSSpeedMonitor | None = None,
+        gps_monitor: SpeedSourceSync | None = None,
     ) -> None:
         """Initialise the settings store, loading persisted settings from *db* if provided."""
         self._lock = RLock()

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -1,4 +1,4 @@
-"""Use-case-facing ports shared across recording, history, and runtime code."""
+"""Cross-layer ports shared across recording, history, runtime, and config code."""
 
 from __future__ import annotations
 
@@ -14,8 +14,10 @@ __all__ = [
     "ResolvedSpeedSnapshot",
     "RunPersistence",
     "SettingsReader",
+    "SettingsSnapshotPersistence",
     "SignalSource",
     "SpeedProvider",
+    "SpeedSourceSync",
     "TrackedClient",
 ]
 
@@ -66,6 +68,14 @@ class SettingsReader(Protocol):
     def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot: ...
 
     def active_car_snapshot(self) -> CarSnapshot | None: ...
+
+
+class SettingsSnapshotPersistence(Protocol):
+    """Minimal settings snapshot persistence surface needed by SettingsStore."""
+
+    def get_settings_snapshot(self) -> JsonObject | None: ...
+
+    def set_settings_snapshot(self, snapshot: JsonObject) -> None: ...
 
 
 class SignalSource(Protocol):
@@ -126,3 +136,17 @@ class SpeedProvider(Protocol):
     speed_mps: float | None
 
     def resolve_speed(self) -> ResolvedSpeedSnapshot: ...
+
+
+class SpeedSourceSync(Protocol):
+    """Minimal speed-source sync surface needed by SettingsStore."""
+
+    def set_manual_source_selected(self, selected: bool) -> None: ...
+
+    def set_speed_override_kmh(self, speed_kmh: float | None) -> float | None: ...
+
+    def set_fallback_settings(
+        self,
+        stale_timeout_s: float | None = None,
+        **kwargs: object,
+    ) -> None: ...


### PR DESCRIPTION
## Summary
- replace `settings_store.py` adapter-specific type imports with narrow shared ports
- remove the matching layer-boundary allowlist entries
- add focused regression coverage for protocol-shaped snapshot and GPS collaborators

## Validation
- `.venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/infra/config/test_settings_store.py`
- `make lint`
- `make typecheck-backend`
- `docker compose up -d` smoke against `/openapi.json` and `/api/settings/speed-source`

Closes #979