### PR TITLE
Invert processing_loop UDP dependency

### DIFF
--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -82,7 +82,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         # use_cases → adapters
         # use_cases → infra
         # infra → adapters
-        ("infra/runtime/processing_loop.py", "vibesensor.adapters.udp.udp_control_tx"),
         ("infra/runtime/registry.py", "vibesensor.adapters.udp.protocol"),
         ("infra/runtime/registry.py", "vibesensor.adapters.persistence.history_db"),
         ("infra/runtime/rotational_speeds.py", "vibesensor.adapters.gps.gps_speed"),

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -65,12 +65,22 @@ class _StubProcessor:
         pass
 
 
+class _StubControlPlane:
+    def __init__(self) -> None:
+        self.broadcast_calls = 0
+
+    def broadcast_sync_clock(self) -> int:
+        self.broadcast_calls += 1
+        return 1
+
+
 def _make_loop(
     *,
     processor: Any = None,
     registry: Any = None,
     sample_rate_hz: int = 800,
     fft_n: int = 2048,
+    control_plane: Any = None,
 ) -> tuple[ProcessingLoop, ProcessingLoopState]:
     state = ProcessingLoopState()
     proc = processor if processor is not None else _StubProcessor()
@@ -82,6 +92,7 @@ def _make_loop(
         fft_n=fft_n,
         registry=reg,
         processor=proc,
+        control_plane=control_plane,
     )
     return loop, state
 
@@ -194,6 +205,17 @@ class TestProcessingLoopFailureTracking:
 
 
 class TestProcessingLoopMismatchDetection:
+    @pytest.mark.asyncio
+    async def test_sync_clock_uses_control_plane_broadcaster(self) -> None:
+        """Sync-clock ticks use the injected control-plane broadcaster seam."""
+        processor = _StubProcessor()
+        control_plane = _StubControlPlane()
+        loop, _state = _make_loop(processor=processor, control_plane=control_plane)
+
+        await loop._run_tick(sync_clock=True)
+
+        assert control_plane.broadcast_calls == 1
+
     @pytest.mark.asyncio
     async def test_sample_rate_mismatch_logged_once(self) -> None:
         """Sample-rate mismatch for a client is recorded in state exactly once."""

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -15,9 +15,9 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from vibesensor.shared.exceptions import ProcessingError
+from vibesensor.shared.ports import ClockSyncBroadcaster
 
 if TYPE_CHECKING:
-    from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
     from vibesensor.infra.processing import SignalProcessor
     from vibesensor.infra.runtime.registry import ClientRegistry
 
@@ -94,7 +94,7 @@ class ProcessingLoop:
         fft_n: int,
         registry: ClientRegistry,
         processor: SignalProcessor,
-        control_plane: UDPControlPlane | None = None,
+        control_plane: ClockSyncBroadcaster | None = None,
     ) -> None:
         self.state = state
         self._fft_update_hz = fft_update_hz

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -10,6 +10,7 @@ from vibesensor.shared.types.backend_types import ResolvedSpeedSource
 from vibesensor.shared.types.json_types import JsonObject
 
 __all__ = [
+    "ClockSyncBroadcaster",
     "ClientTracker",
     "ResolvedSpeedSnapshot",
     "RunPersistence",
@@ -20,6 +21,12 @@ __all__ = [
     "SpeedSourceSync",
     "TrackedClient",
 ]
+
+
+class ClockSyncBroadcaster(Protocol):
+    """Minimal control-plane surface needed to broadcast sync-clock messages."""
+
+    def broadcast_sync_clock(self) -> int: ...
 
 
 class RunPersistence(Protocol):


### PR DESCRIPTION
## Summary
- replace the `ProcessingLoop` adapter-specific control-plane type with a narrow shared clock-sync broadcaster port
- remove the matching layer-boundary allowlist entry
- add focused runtime seam coverage for sync-clock broadcasting

## Validation
- `.venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/infra/runtime/test_runtime.py`
- `make lint`
- `make typecheck-backend`
- `docker compose up -d` smoke against `/openapi.json`

Closes #980