### PR TITLE
Break registry adapter dependencies

### DIFF
--- a/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
+++ b/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
@@ -9,10 +9,10 @@ import numpy as np
 import pytest
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.adapters.udp.protocol import DataMessage, pack_data
+from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage, pack_data
 from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
 from vibesensor.infra.processing import SignalProcessor
-from vibesensor.infra.runtime.registry import ClientRegistry, DataUpdateResult, HelloMessage
+from vibesensor.infra.runtime.registry import ClientRegistry, DataUpdateResult
 
 # ---------------------------------------------------------------------------
 # Unit: SignalProcessor.flush_client_buffer

--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -82,8 +82,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         # use_cases → adapters
         # use_cases → infra
         # infra → adapters
-        ("infra/runtime/registry.py", "vibesensor.adapters.udp.protocol"),
-        ("infra/runtime/registry.py", "vibesensor.adapters.persistence.history_db"),
         ("infra/runtime/rotational_speeds.py", "vibesensor.adapters.gps.gps_speed"),
         ("infra/runtime/ws_broadcast.py", "vibesensor.adapters.gps.gps_speed"),
         # infra → app

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -8,6 +9,98 @@ from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage
 from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
 from vibesensor.infra.runtime.registry import ClientRegistry
+
+
+@dataclass(slots=True)
+class _FakeHelloMessage:
+    client_id: bytes
+    control_port: int
+    sample_rate_hz: int
+    name: str
+    firmware_version: str
+    frame_samples: int = 0
+    queue_overflow_drops: int = 0
+
+
+@dataclass(slots=True)
+class _FakeDataMessage:
+    client_id: bytes
+    seq: int
+    t0_us: int
+    sample_count: int
+
+
+@dataclass(slots=True)
+class _FakeAckMessage:
+    client_id: bytes
+    cmd_seq: int
+    status: int
+
+
+class _FakeClientNameStore:
+    def __init__(self) -> None:
+        self._names: dict[str, str] = {}
+
+    def list_client_names(self) -> dict[str, str]:
+        return dict(self._names)
+
+    def upsert_client_name(self, client_id: str, name: str) -> None:
+        self._names[client_id] = name
+
+    def delete_client_name(self, client_id: str) -> bool:
+        return self._names.pop(client_id, None) is not None
+
+
+def test_registry_accepts_protocol_shaped_messages() -> None:
+    registry = ClientRegistry()
+    client_id = bytes.fromhex("aabbccddeeff")
+    hello = _FakeHelloMessage(
+        client_id=client_id,
+        control_port=9010,
+        sample_rate_hz=800,
+        name="node-1",
+        firmware_version="fw",
+    )
+    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0)
+
+    result = registry.update_from_data(
+        _FakeDataMessage(client_id=client_id, seq=5, t0_us=10, sample_count=200),
+        ("10.4.0.2", 50000),
+        now=2.0,
+    )
+    registry.update_from_ack(
+        _FakeAckMessage(client_id=client_id, cmd_seq=77, status=1),
+        now=3.0,
+    )
+
+    record = registry.get("aabbccddeeff")
+    assert record is not None
+    assert result.is_duplicate is False
+    assert record.frames_total == 1
+    assert record.last_ack_cmd_seq == 77
+    assert record.last_ack_status == 1
+
+
+def test_registry_persists_names_with_protocol_shaped_store() -> None:
+    store = _FakeClientNameStore()
+    registry = ClientRegistry(db=store)
+    registry.set_name("001122334455", "rear")
+
+    reloaded = ClientRegistry(db=store)
+    reloaded.update_from_hello(
+        _FakeHelloMessage(
+            client_id=bytes.fromhex("001122334455"),
+            control_port=9011,
+            sample_rate_hz=800,
+            name="ignored",
+            firmware_version="fw2",
+        ),
+        ("10.4.0.3", 9011),
+        now=5.0,
+    )
+
+    row = snapshot_for_api(reloaded, now=5.0)[0]
+    assert row["name"] == "rear"
 
 
 def test_registry_sequence_gap(tmp_path: Path) -> None:

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -10,14 +10,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from threading import RLock
-from typing import TYPE_CHECKING
 
-from vibesensor.adapters.udp.protocol import (
-    AckMessage,
-    DataMessage,
-    HelloMessage,
-    client_id_hex,
-)
 from vibesensor.domain import normalize_sensor_id as _normalize_client_id
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
@@ -25,10 +18,13 @@ from vibesensor.infra.runtime.registry_updates import (
     DataUpdateResult,
     apply_data_message_update,
 )
+from vibesensor.shared.ports import (
+    ClientNamePersistence,
+    RegistryAckMessage,
+    RegistryDataMessage,
+    RegistryHelloMessage,
+)
 from vibesensor.shared.types.payload_types import ClientMetrics
-
-if TYPE_CHECKING:
-    from vibesensor.adapters.persistence.history_db import HistoryDB
 
 LOGGER = logging.getLogger(__name__)
 
@@ -106,7 +102,7 @@ class ClientRegistry:
 
     def __init__(
         self,
-        db: HistoryDB | None = None,
+        db: ClientNamePersistence | None = None,
         live_ttl_seconds: float = 10.0,
         retention_ttl_seconds: float = 120.0,
     ):
@@ -125,6 +121,10 @@ class ClientRegistry:
             if db is not None
             else None,
         )
+
+    @staticmethod
+    def _normalize_wire_client_id(client_id: bytes) -> str:
+        return _normalize_client_id(client_id.hex())
 
     def _is_live_unlocked(self, record: ClientRecord, mono_now: float) -> bool:
         return bool(
@@ -148,7 +148,7 @@ class ClientRegistry:
 
     def update_from_hello(
         self,
-        hello: HelloMessage,
+        hello: RegistryHelloMessage,
         addr: tuple[str, int],
         now: float | None = None,
         *,
@@ -157,7 +157,7 @@ class ClientRegistry:
         with self._lock:
             now_ts = _resolve_now_wall(now)
             mono = _resolve_now_mono(now_mono)
-            client_id = client_id_hex(hello.client_id)
+            client_id = self._normalize_wire_client_id(hello.client_id)
             record = self._get_or_create(client_id)
             record.last_seen = now_ts
             record.last_seen_mono = mono
@@ -175,7 +175,7 @@ class ClientRegistry:
 
     def update_from_data(
         self,
-        data_msg: DataMessage,
+        data_msg: RegistryDataMessage,
         addr: tuple[str, int],
         now: float | None = None,
         *,
@@ -190,7 +190,7 @@ class ClientRegistry:
         with self._lock:
             now_ts = _resolve_now_wall(now)
             mono = _resolve_now_mono(now_mono)
-            client_id = client_id_hex(data_msg.client_id)
+            client_id = self._normalize_wire_client_id(data_msg.client_id)
             record = self._get_or_create(client_id)
             return apply_data_message_update(
                 record,
@@ -204,7 +204,7 @@ class ClientRegistry:
 
     def update_from_ack(
         self,
-        ack: AckMessage,
+        ack: RegistryAckMessage,
         now: float | None = None,
         *,
         now_mono: float | None = None,
@@ -212,7 +212,7 @@ class ClientRegistry:
         with self._lock:
             now_ts = _resolve_now_wall(now)
             mono = _resolve_now_mono(now_mono)
-            client_id = client_id_hex(ack.client_id)
+            client_id = self._normalize_wire_client_id(ack.client_id)
             record = self._get_or_create(client_id)
             record.last_seen = now_ts
             record.last_seen_mono = mono

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -12,6 +12,10 @@ from vibesensor.shared.types.json_types import JsonObject
 __all__ = [
     "ClockSyncBroadcaster",
     "ClientTracker",
+    "ClientNamePersistence",
+    "RegistryAckMessage",
+    "RegistryDataMessage",
+    "RegistryHelloMessage",
     "ResolvedSpeedSnapshot",
     "RunPersistence",
     "SettingsReader",
@@ -125,6 +129,45 @@ class ClientTracker(Protocol):
         *,
         now_mono: float | None = None,
     ) -> list[str]: ...
+
+
+class ClientNamePersistence(Protocol):
+    """Minimal persisted client-name operations needed by ClientRegistry."""
+
+    def list_client_names(self) -> dict[str, str]: ...
+
+    def upsert_client_name(self, client_id: str, name: str) -> None: ...
+
+    def delete_client_name(self, client_id: str) -> bool | None: ...
+
+
+class RegistryHelloMessage(Protocol):
+    """Decoded HELLO message surface that ClientRegistry consumes."""
+
+    client_id: bytes
+    control_port: int
+    sample_rate_hz: int
+    name: str
+    firmware_version: str
+    frame_samples: int
+    queue_overflow_drops: int
+
+
+class RegistryDataMessage(Protocol):
+    """Decoded DATA message surface that ClientRegistry consumes."""
+
+    client_id: bytes
+    seq: int
+    t0_us: int
+    sample_count: int
+
+
+class RegistryAckMessage(Protocol):
+    """Decoded ACK message surface that ClientRegistry consumes."""
+
+    client_id: bytes
+    cmd_seq: int
+    status: int
 
 
 class ResolvedSpeedSnapshot(Protocol):


### PR DESCRIPTION
## Summary
- replace `ClientRegistry`'s concrete history/UDP type dependencies with narrow shared ports for persisted client names and decoded registry messages
- remove the matching layer-boundary allowlist entries and add fake-based registry seam coverage
- fix the one related stale test import uncovered during review

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python - <<'PY'`
- import smoke for `ClientRegistry`, `ClientNamePersistence`, `RegistryHelloMessage`, `RegistryDataMessage`, `RegistryAckMessage`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/adapters/udp/test_reset_buffer_flush.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck-backend`

Closes #981
