### PR TITLE
Break runtime GPS adapter dependencies

### DIFF
--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -98,6 +98,10 @@ class _StubGPS:
         self.resolve_calls += 1
         return _SpeedResolution(self.effective_speed_mps, self.fallback_active, "gps")
 
+    @property
+    def speed_mps(self) -> float | None:
+        return self.effective_speed_mps
+
     def update_speed_state(self) -> None:
         pass
 
@@ -207,6 +211,7 @@ def _make_state(
             registry=registry,
             processor=processor,
             gps_monitor=gps_monitor,
+            gps_enabled=gps_monitor.gps_enabled,
             settings_store=settings_store,
         ),
         run_recorder=_StubRunRecorder(),
@@ -369,6 +374,7 @@ def test_build_ws_payload_marks_retained_stale_clients_disconnected(
         registry=registry,
         processor=_StubProcessor(),
         gps_monitor=_StubGPS(),
+        gps_enabled=True,
         settings_store=_StubSettingsStore(),
     )
     payload = ws_broadcast.build_payload(selected_client=None)

--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -82,8 +82,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         # use_cases → adapters
         # use_cases → infra
         # infra → adapters
-        ("infra/runtime/rotational_speeds.py", "vibesensor.adapters.gps.gps_speed"),
-        ("infra/runtime/ws_broadcast.py", "vibesensor.adapters.gps.gps_speed"),
         # infra → app
         # RuntimeState is now lifecycle-focused, but LifecycleManager still consumes
         # the app-owned runtime bag directly.

--- a/apps/server/tests/infra/runtime/test_rotational_speeds.py
+++ b/apps/server/tests/infra/runtime/test_rotational_speeds.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from vibesensor.infra.runtime.rotational_speeds import rotational_basis_speed_source
+
+
+def test_rotational_basis_speed_source_prefers_explicit_resolution_source() -> None:
+    assert (
+        rotational_basis_speed_source(
+            "gps",
+            gps_enabled=True,
+            resolution_source="fallback_manual",
+        )
+        == "fallback_manual"
+    )
+
+
+def test_rotational_basis_speed_source_uses_fallback_flag_without_resolution_source() -> None:
+    assert (
+        rotational_basis_speed_source(
+            "gps",
+            gps_enabled=True,
+            fallback_active=True,
+        )
+        == "fallback_manual"
+    )
+
+
+def test_rotational_basis_speed_source_handles_disabled_gps() -> None:
+    assert (
+        rotational_basis_speed_source("gps", gps_enabled=False, resolution_source="none")
+        == "unknown"
+    )
+
+
+def test_rotational_basis_speed_source_preserves_manual_selection() -> None:
+    assert (
+        rotational_basis_speed_source("manual", gps_enabled=True, resolution_source="gps")
+        == "manual"
+    )

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -59,6 +59,7 @@ class _StubLoggingConfig:
 
 @dataclass(slots=True)
 class _StubGpsConfig:
+    gps_enabled: bool = True
     gpsd_host: str = "127.0.0.1"
     gpsd_port: int = 2947
 
@@ -170,6 +171,7 @@ def _make_runtime(**overrides: Any):
             registry=registry,
             processor=processor,
             gps_monitor=gps_monitor,
+            gps_enabled=config.gps.gps_enabled,
             settings_store=settings_store,
         ),
         run_recorder=diagnostics,

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -151,6 +151,7 @@ def build_runtime(config: AppConfig) -> AppRuntime:
         registry=registry,
         processor=processor,
         gps_monitor=gps_monitor,
+        gps_enabled=config.gps.gps_enabled,
         settings_store=settings_store,
     )
 

--- a/apps/server/vibesensor/infra/runtime/rotational_speeds.py
+++ b/apps/server/vibesensor/infra/runtime/rotational_speeds.py
@@ -3,34 +3,29 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
 
 from vibesensor.domain.speed_source import SpeedSource
 from vibesensor.shared.constants import SECONDS_PER_MINUTE
 from vibesensor.shared.order_bands import build_order_bands, vehicle_orders_hz
+from vibesensor.shared.types.backend_types import ResolvedSpeedSource
 from vibesensor.shared.types.payload_types import (
     RotationalSpeedsPayload,
     RotationalSpeedValuePayload,
 )
 
-if TYPE_CHECKING:
-    from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
-    from vibesensor.infra.config.settings_store import SettingsStore
-
 
 def rotational_basis_speed_source(
-    settings_store: SettingsStore,
-    gps_monitor: GPSSpeedMonitor,
+    selected_source: str,
     *,
-    resolution_source: str | None = None,
+    gps_enabled: bool,
+    fallback_active: bool = False,
+    resolution_source: ResolvedSpeedSource | None = None,
 ) -> str:
     """Determine the basis speed source label for rotational RPM display."""
-    speed_source = settings_store.get_speed_source()
-    selected_source = str(speed_source.get("speedSource") or "gps")
     return SpeedSource.resolve_basis_label(
-        selected_source,
-        gps_enabled=gps_monitor.gps_enabled,
-        fallback_active=gps_monitor.fallback_active,
+        str(selected_source or "gps"),
+        gps_enabled=gps_enabled,
+        fallback_active=fallback_active,
         resolution_source=resolution_source,
     )
 

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -19,9 +19,9 @@ from vibesensor.infra.runtime.rotational_speeds import (
     build_rotational_speeds_payload,
     rotational_basis_speed_source,
 )
+from vibesensor.shared.ports import SpeedProvider
 
 if TYPE_CHECKING:
-    from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
     from vibesensor.infra.config.settings_store import SettingsStore
     from vibesensor.infra.processing import SignalProcessor
     from vibesensor.infra.runtime.registry import ClientRegistry
@@ -34,6 +34,7 @@ class WsBroadcastService:
     """WebSocket payload assembly: tick management and cached payload building."""
 
     __slots__ = (
+        "_gps_enabled",
         "_gps_monitor",
         "_processor",
         "_registry",
@@ -54,7 +55,8 @@ class WsBroadcastService:
         ui_heavy_push_hz: int,
         registry: ClientRegistry,
         processor: SignalProcessor,
-        gps_monitor: GPSSpeedMonitor,
+        gps_monitor: SpeedProvider,
+        gps_enabled: bool,
         settings_store: SettingsStore,
     ) -> None:
         self.tick = 0
@@ -62,6 +64,7 @@ class WsBroadcastService:
         self._shared_payload: LiveWsPayload | None = None
         self._shared_payload_tick: int = -1
         self._shared_payload_heavy: bool = True
+        self._gps_enabled = gps_enabled
         self._ui_push_hz = ui_push_hz
         self._ui_heavy_push_hz = ui_heavy_push_hz
         self._registry = registry
@@ -95,9 +98,10 @@ class WsBroadcastService:
             "clients": clients,
         }
         analysis_settings_snapshot = self._settings_store.analysis_settings_snapshot()
+        speed_source = self._settings_store.get_speed_source()
         basis = rotational_basis_speed_source(
-            self._settings_store,
-            self._gps_monitor,
+            str(speed_source.get("speedSource") or "gps"),
+            gps_enabled=self._gps_enabled,
             resolution_source=resolution.source,
         )
         payload["rotational_speeds"] = build_rotational_speeds_payload(


### PR DESCRIPTION
## Summary
- remove the remaining runtime-layer `gps_speed` type dependency by making rotational basis selection value-based and passing `gps_enabled` explicitly into `WsBroadcastService`
- keep live speed resolution on the existing shared `SpeedProvider` seam and remove the matching boundary allowlist entries
- add focused rotational-speed regression coverage and keep websocket/runtime behavior unchanged

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python - <<'PY'` import smoke for `rotational_basis_speed_source`, `build_rotational_speeds_payload`, and `WsBroadcastService`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/infra/runtime/test_rotational_speeds.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/adapters/websocket/test_build_ws_payload.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck-backend`
- `docker compose up -d`
- `vibesensor-sim --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
- `/api/clients` polling confirmed live clients appeared during simulation and frame totals stabilized at `48` after simulator stop before `docker compose down`

Closes #982
