### PR TITLE
Break lifecycle runtime_state dependency

### DIFF
--- a/apps/server/tests/hygiene/test_layer_boundaries.py
+++ b/apps/server/tests/hygiene/test_layer_boundaries.py
@@ -83,9 +83,6 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         # use_cases → infra
         # infra → adapters
         # infra → app
-        # RuntimeState is now lifecycle-focused, but LifecycleManager still consumes
-        # the app-owned runtime bag directly.
-        ("infra/runtime/lifecycle.py", "vibesensor.app.runtime_state"),
         # adapters → app
         ("adapters/hotspot/self_heal.py", "vibesensor.app.settings"),
     }

--- a/apps/server/tests/infra/runtime/test_lifecycle.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
+from typing import get_type_hints
 from unittest.mock import MagicMock, patch
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.lifecycle import LifecycleManager
+from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
 
 # ---------------------------------------------------------------------------
 # Minimal stubs
@@ -19,12 +19,28 @@ def _make_lifecycle(db_path: str | None) -> tuple[LifecycleManager, RuntimeHealt
     health_state = RuntimeHealthState()
     health_state.mark_ready()
 
-    logging_cfg = SimpleNamespace(history_db_path=db_path)
-    config = SimpleNamespace(logging=logging_cfg)
-
-    runtime = MagicMock()
-    runtime.config = config
-    runtime.health_state = health_state
+    runtime = LifecycleRuntime(
+        health_state=health_state,
+        history_db_path=db_path,
+        udp_data_host="0.0.0.0",
+        udp_data_port=9000,
+        udp_data_queue_maxsize=64,
+        gpsd_host="127.0.0.1",
+        gpsd_port=2947,
+        shutdown_analysis_timeout_s=5.0,
+        registry=MagicMock(),
+        processor=MagicMock(),
+        control_plane=MagicMock(),
+        processing_loop=MagicMock(),
+        ws_hub=MagicMock(),
+        ws_broadcast=MagicMock(),
+        run_recorder=MagicMock(),
+        gps_monitor=MagicMock(),
+        update_manager=MagicMock(job_task=None),
+        esp_flash_manager=MagicMock(job_task=None),
+        worker_pool=MagicMock(),
+        history_db=MagicMock(),
+    )
 
     lifecycle = LifecycleManager(runtime=runtime, start_udp_receiver=MagicMock())
     return lifecycle, health_state
@@ -93,3 +109,14 @@ class TestValidateStartupDiskCheck:
 
         mock_usage.assert_not_called()
         assert health_state.startup_warnings == []
+
+
+def test_lifecycle_manager_uses_lifecycle_owned_runtime_contract() -> None:
+    import vibesensor.infra.runtime.lifecycle as lifecycle_module
+
+    hints = get_type_hints(
+        LifecycleManager.__init__,
+        globalns=vars(lifecycle_module),
+    )
+
+    assert hints["runtime"] is lifecycle_module.LifecycleRuntime

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -122,7 +122,7 @@ def _make_runtime(**overrides: Any):
     """Build a RuntimeState with stubs for lifecycle testing."""
     import vibesensor.infra.runtime as runtime_module
     from vibesensor.app.runtime_state import RuntimeState
-    from vibesensor.infra.runtime.lifecycle import LifecycleManager
+    from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
     from vibesensor.infra.runtime.processing_loop import (
         ProcessingLoop,
         ProcessingLoopState,
@@ -178,7 +178,29 @@ def _make_runtime(**overrides: Any):
         update_manager=update_manager,
         esp_flash_manager=esp_flash_manager,
     )
-    lifecycle = LifecycleManager(runtime=rt, start_udp_receiver=AsyncMock())
+    lifecycle_runtime = LifecycleRuntime(
+        health_state=health_state,
+        history_db_path=config.logging.history_db_path,
+        udp_data_host=config.udp.data_host,
+        udp_data_port=config.udp.data_port,
+        udp_data_queue_maxsize=config.udp.data_queue_maxsize,
+        gpsd_host=config.gps.gpsd_host,
+        gpsd_port=config.gps.gpsd_port,
+        shutdown_analysis_timeout_s=config.logging.shutdown_analysis_timeout_s,
+        registry=registry,
+        processor=processor,
+        control_plane=control_plane,
+        processing_loop=rt.processing_loop,
+        ws_hub=rt.ws_hub,
+        ws_broadcast=rt.ws_broadcast,
+        run_recorder=diagnostics,
+        gps_monitor=gps_monitor,
+        update_manager=update_manager,
+        esp_flash_manager=esp_flash_manager,
+        worker_pool=worker_pool,
+        history_db=history_db,
+    )
+    lifecycle = LifecycleManager(runtime=lifecycle_runtime, start_udp_receiver=AsyncMock())
     if overrides:
         for name, value in overrides.items():
             setattr(rt, name, value)

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -25,7 +25,7 @@ from vibesensor.adapters.udp.udp_data_rx import start_udp_data_receiver
 from vibesensor.app.container import build_runtime
 from vibesensor.app.runtime_state import AppRuntime
 from vibesensor.app.settings import load_config
-from vibesensor.infra.runtime.lifecycle import LifecycleManager
+from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
 
 __all__ = ["create_app", "main"]
 
@@ -72,7 +72,28 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     _setup_file_logging(config.logging.app_log_path)
     runtime = build_runtime(config)
     lifecycle = LifecycleManager(
-        runtime=runtime.lifecycle,
+        runtime=LifecycleRuntime(
+            health_state=runtime.lifecycle.health_state,
+            history_db_path=config.logging.history_db_path,
+            udp_data_host=config.udp.data_host,
+            udp_data_port=config.udp.data_port,
+            udp_data_queue_maxsize=config.udp.data_queue_maxsize,
+            gpsd_host=config.gps.gpsd_host,
+            gpsd_port=config.gps.gpsd_port,
+            shutdown_analysis_timeout_s=config.logging.shutdown_analysis_timeout_s,
+            registry=runtime.lifecycle.registry,
+            processor=runtime.lifecycle.processor,
+            control_plane=runtime.lifecycle.control_plane,
+            processing_loop=runtime.lifecycle.processing_loop,
+            ws_hub=runtime.lifecycle.ws_hub,
+            ws_broadcast=runtime.lifecycle.ws_broadcast,
+            run_recorder=runtime.lifecycle.run_recorder,
+            gps_monitor=runtime.lifecycle.gps_monitor,
+            update_manager=runtime.lifecycle.update_manager,
+            esp_flash_manager=runtime.lifecycle.esp_flash_manager,
+            worker_pool=runtime.lifecycle.worker_pool,
+            history_db=runtime.lifecycle.history_db,
+        ),
         start_udp_receiver=start_udp_data_receiver,
     )
 

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -14,18 +14,117 @@ import contextlib
 import logging
 import shutil
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Protocol
 
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.shared.constants import UI_PUSH_HZ
+from vibesensor.shared.types.payload_types import LiveWsPayload
 
-if TYPE_CHECKING:
-    from vibesensor.app.runtime_state import RuntimeState
+StartUdpReceiver = Callable[
+    ...,
+    Coroutine[object, object, tuple[asyncio.DatagramTransport, asyncio.Task[None]]],
+]
 
-    StartUdpReceiver = Callable[
-        ...,
-        Coroutine[object, object, tuple[asyncio.DatagramTransport, asyncio.Task[None]]],
-    ]
+
+class LifecycleControlPlane(Protocol):
+    async def start(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class LifecycleProcessingLoop(Protocol):
+    async def run(self) -> object: ...
+
+
+class LifecycleWsBroadcast(Protocol):
+    def build_payload(self, selected_client: str | None) -> LiveWsPayload: ...
+
+    def on_tick(self) -> None: ...
+
+
+class LifecycleWsHub(Protocol):
+    async def run(
+        self,
+        hz: int,
+        payload_builder: Callable[[str | None], LiveWsPayload],
+        on_tick: Callable[[], None] | None = None,
+    ) -> None: ...
+
+
+class LifecycleShutdownReport(Protocol):
+    @property
+    def completed(self) -> bool: ...
+
+    @property
+    def analysis_queue_depth(self) -> int: ...
+
+    @property
+    def analysis_active_run_id(self) -> str | None: ...
+
+    @property
+    def analysis_queue_oldest_age_s(self) -> float | None: ...
+
+    @property
+    def active_run_id_before_stop(self) -> str | None: ...
+
+    @property
+    def write_error(self) -> str | None: ...
+
+
+class LifecycleRunRecorder(Protocol):
+    async def run(self) -> object: ...
+
+    def shutdown_report(self, timeout_s: float = ...) -> LifecycleShutdownReport: ...
+
+
+class LifecycleGpsMonitor(Protocol):
+    async def run(self, *, host: str, port: int) -> object: ...
+
+
+class LifecycleManagedJobs(Protocol):
+    @property
+    def job_task(self) -> asyncio.Task[None] | None: ...
+
+
+class LifecycleUpdateManager(LifecycleManagedJobs, Protocol):
+    async def startup_recover(self) -> object: ...
+
+
+class LifecycleWorkerPool(Protocol):
+    def shutdown(self, wait: bool) -> None: ...
+
+
+class LifecycleHistoryDb(Protocol):
+    def close(self) -> None: ...
+
+
+@dataclass(slots=True)
+class LifecycleRuntime:
+    """Lifecycle-owned dependency bundle consumed by LifecycleManager."""
+
+    health_state: RuntimeHealthState
+    history_db_path: str | Path | None
+    udp_data_host: str
+    udp_data_port: int
+    udp_data_queue_maxsize: int
+    gpsd_host: str
+    gpsd_port: int
+    shutdown_analysis_timeout_s: float
+    registry: object
+    processor: object
+    control_plane: LifecycleControlPlane
+    processing_loop: LifecycleProcessingLoop
+    ws_hub: LifecycleWsHub
+    ws_broadcast: LifecycleWsBroadcast
+    run_recorder: LifecycleRunRecorder
+    gps_monitor: LifecycleGpsMonitor
+    update_manager: LifecycleUpdateManager
+    esp_flash_manager: LifecycleManagedJobs
+    worker_pool: LifecycleWorkerPool
+    history_db: LifecycleHistoryDb
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +144,7 @@ class LifecycleManager:
     def __init__(
         self,
         *,
-        runtime: RuntimeState,
+        runtime: LifecycleRuntime,
         start_udp_receiver: StartUdpReceiver,
     ) -> None:
         self._runtime = runtime
@@ -93,7 +192,7 @@ class LifecycleManager:
     def _validate_startup(self) -> None:
         """Run lightweight startup precondition checks (warnings only)."""
         try:
-            db_path = self._runtime.config.logging.history_db_path
+            db_path = self._runtime.history_db_path
             data_dir = Path(db_path).parent if db_path else None
         except (AttributeError, TypeError):
             return
@@ -120,11 +219,11 @@ class LifecycleManager:
             phase = "udp_receiver"
             self._health_state.set_phase(phase)
             self._data_transport, self._data_consumer_task = await self._start_udp_receiver(
-                host=self._runtime.config.udp.data_host,
-                port=self._runtime.config.udp.data_port,
+                host=self._runtime.udp_data_host,
+                port=self._runtime.udp_data_port,
                 registry=self._runtime.registry,
                 processor=self._runtime.processor,
-                queue_maxsize=self._runtime.config.udp.data_queue_maxsize,
+                queue_maxsize=self._runtime.udp_data_queue_maxsize,
             )
 
             phase = "control_plane"
@@ -159,8 +258,8 @@ class LifecycleManager:
             self.tasks.append(
                 self._start_task(
                     self._runtime.gps_monitor.run(
-                        host=self._runtime.config.gps.gpsd_host,
-                        port=self._runtime.config.gps.gpsd_port,
+                        host=self._runtime.gpsd_host,
+                        port=self._runtime.gpsd_port,
                     ),
                     name=phase,
                 ),
@@ -224,7 +323,7 @@ class LifecycleManager:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await asyncio.wait_for(asyncio.shield(managed_task), timeout=10.0)
 
-        analysis_timeout_s = self._runtime.config.logging.shutdown_analysis_timeout_s
+        analysis_timeout_s = self._runtime.shutdown_analysis_timeout_s
         shutdown_report = await asyncio.to_thread(
             self._runtime.run_recorder.shutdown_report,
             analysis_timeout_s,


### PR DESCRIPTION
## Summary
- replace the `LifecycleManager` dependency on the app-owned `RuntimeState` bag with a lifecycle-owned `LifecycleRuntime` contract
- construct the lifecycle runtime bundle in `app/bootstrap.py` and update lifecycle/runtime tests to use the new seam directly
- remove the matching layer-boundary allowlist entry and keep the lifecycle shutdown-report typing local to infra

## Testing
- `.venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/infra/runtime/test_lifecycle.py apps/server/tests/infra/runtime/test_runtime.py`
- `make lint`
- `make typecheck-backend`
- `docker compose up -d` + `.venv/bin/vibesensor-sim --count 2 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` + `/api/clients` stability check + `docker compose down`

Closes #983.
