### PR TITLE
Remove findings helper re-exports

### DIFF
--- a/apps/server/tests/adapters/gps/test_issue_148_speed_window.py
+++ b/apps/server/tests/adapters/gps/test_issue_148_speed_window.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from vibesensor.domain import OrderMatchObservation
-from vibesensor.use_cases.diagnostics.findings import _speed_breakdown
 from vibesensor.use_cases.diagnostics.location_analysis import _location_speedbin_summary
+from vibesensor.use_cases.diagnostics.signal_aggregation import _speed_breakdown
 
 
 def _obs(speed_kmh: float, amp: float, location: str) -> OrderMatchObservation:

--- a/apps/server/tests/adapters/pdf/test_report_analysis_findings_integration.py
+++ b/apps/server/tests/adapters/pdf/test_report_analysis_findings_integration.py
@@ -14,11 +14,11 @@ from vibesensor.shared.constants import KMH_TO_MPS
 from vibesensor.use_cases.diagnostics import build_findings_for_samples
 from vibesensor.use_cases.diagnostics import findings as findings_builder_module
 from vibesensor.use_cases.diagnostics.findings import _build_findings as _findings_build_findings
-from vibesensor.use_cases.diagnostics.findings import _speed_breakdown
 from vibesensor.use_cases.diagnostics.location_analysis import LocationAnalysisResult
 from vibesensor.use_cases.diagnostics.peak_table import (
     top_peaks_table_rows as _top_peaks_table_rows,
 )
+from vibesensor.use_cases.diagnostics.signal_aggregation import _speed_breakdown
 
 
 def test_speed_breakdown_basic() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_persistence_classification.py
+++ b/apps/server/tests/adapters/pdf/test_report_persistence_classification.py
@@ -4,7 +4,7 @@ import pytest
 from _report_persistence_helpers import build_findings, findings_at_freq, uniform_samples
 from test_support.report_helpers import analysis_sample_with_peaks as sample
 
-from vibesensor.use_cases.diagnostics.findings import _classify_peak_type
+from vibesensor.use_cases.diagnostics.peak_binning import _classify_peak_type
 from vibesensor.use_cases.diagnostics.peak_table import (
     top_peaks_table_rows as _top_peaks_table_rows,
 )

--- a/apps/server/tests/adapters/pdf/test_report_scenario_classification_regression.py
+++ b/apps/server/tests/adapters/pdf/test_report_scenario_classification_regression.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import pytest
 
 from vibesensor.strength_bands import bucket_for_strength
-from vibesensor.use_cases.diagnostics.findings import _classify_peak_type
 from vibesensor.use_cases.diagnostics.helpers import _location_label
+from vibesensor.use_cases.diagnostics.peak_binning import _classify_peak_type
 
 
 class TestStrengthBandsAlignment:

--- a/apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py
+++ b/apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py
@@ -12,15 +12,15 @@ from test_support.sample_scenarios import (
 )
 
 from vibesensor.use_cases.diagnostics import build_findings_for_samples, summarize_run_data
-from vibesensor.use_cases.diagnostics.findings import (
-    _phase_speed_breakdown,
-    _sensor_intensity_by_location,
-)
 from vibesensor.use_cases.diagnostics.phase_segmentation import (
     DrivingPhase,
     diagnostic_sample_mask,
     phase_summary,
     segment_run_phases,
+)
+from vibesensor.use_cases.diagnostics.signal_aggregation import (
+    _phase_speed_breakdown,
+    _sensor_intensity_by_location,
 )
 
 

--- a/apps/server/tests/integration/test_multi_domain_regressions.py
+++ b/apps/server/tests/integration/test_multi_domain_regressions.py
@@ -19,9 +19,9 @@ from vibesensor.report_i18n import resolve_i18n as resolve_i18n_impl
 from vibesensor.report_i18n import tr
 from vibesensor.shared.json_utils import as_float_or_none as runlog_as_float_or_none
 from vibesensor.shared.time_utils import format_duration_mm_ss, parse_iso8601
-from vibesensor.use_cases.diagnostics.findings import _sensor_intensity_by_location
 from vibesensor.use_cases.diagnostics.location_analysis import _weighted_speed_window_label
 from vibesensor.use_cases.diagnostics.phase_segmentation import segment_run_phases
+from vibesensor.use_cases.diagnostics.signal_aggregation import _sensor_intensity_by_location
 from vibesensor.use_cases.diagnostics.statistics import compute_run_timing
 from vibesensor.use_cases.updates.release_fetcher import ReleaseInfo, ServerReleaseFetcher
 

--- a/apps/server/tests/use_cases/diagnostics/test_findings_helpers.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_helpers.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from vibesensor.use_cases.diagnostics.findings import _speed_profile_from_points
 from vibesensor.use_cases.diagnostics.math_utils import _weighted_percentile
 from vibesensor.use_cases.diagnostics.signal_aggregation import _sensor_intensity_by_location
+from vibesensor.use_cases.diagnostics.speed_profile_helpers import _speed_profile_from_points
 
 # ---------------------------------------------------------------------------
 # _weighted_percentile

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -11,6 +11,7 @@ from typing import get_type_hints
 import pytest
 from test_support.findings import make_finding
 
+import vibesensor.use_cases.diagnostics.findings as findings_module
 from vibesensor.domain import OrderMatchObservation
 from vibesensor.shared.boundaries.analysis_payload import (
     AmplitudeMetric,
@@ -23,10 +24,6 @@ from vibesensor.shared.constants import (
     NEGLIGIBLE_STRENGTH_MAX_DB,
 )
 from vibesensor.use_cases.diagnostics._reference_findings import _reference_missing_finding
-from vibesensor.use_cases.diagnostics.findings import (
-    _phase_to_str,
-    _speed_profile_from_points,
-)
 from vibesensor.use_cases.diagnostics.order_analysis import _compute_effective_match_rate
 from vibesensor.use_cases.diagnostics.order_heuristics import (
     detect_diffuse_excitation as _detect_diffuse_excitation,
@@ -44,8 +41,26 @@ from vibesensor.use_cases.diagnostics.signal_aggregation import (
     _sensor_intensity_by_location,
     _speed_breakdown,
 )
+from vibesensor.use_cases.diagnostics.speed_profile_helpers import (
+    _phase_to_str,
+    _speed_profile_from_points,
+)
 
 # -- Subpackage structure tests -----------------------------------------------
+
+
+def test_findings_module_no_longer_reexports_helper_names() -> None:
+    helper_names = (
+        "_classify_peak_type",
+        "_phase_speed_breakdown",
+        "_sensor_intensity_by_location",
+        "_speed_breakdown",
+        "_phase_to_str",
+        "_speed_profile_from_points",
+    )
+
+    for helper_name in helper_names:
+        assert not hasattr(findings_module, helper_name)
 
 
 def test_finding_typed_dict_exposes_core_contract() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py
+++ b/apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py
@@ -12,7 +12,7 @@ from test_support import (
 )
 
 from vibesensor.use_cases.diagnostics import summarize_run_data
-from vibesensor.use_cases.diagnostics.findings import _classify_peak_type
+from vibesensor.use_cases.diagnostics.peak_binning import _classify_peak_type
 
 
 class TestSpeedBandAttribution:

--- a/apps/server/vibesensor/use_cases/diagnostics/findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/findings.py
@@ -1,4 +1,4 @@
-"""Findings orchestration and compatibility re-exports for diagnostics helpers."""
+"""Findings orchestration for diagnostics."""
 
 from __future__ import annotations
 
@@ -16,16 +16,6 @@ from ._peak_findings import (
 from ._types import PhaseLabels, Sample
 from .helpers import _locations_connected_throughout_run, _tire_reference_from_metadata
 from .order_pipeline import _build_order_findings
-from .peak_binning import _classify_peak_type  # noqa: F401
-from .signal_aggregation import (
-    _phase_speed_breakdown,  # noqa: F401
-    _sensor_intensity_by_location,  # noqa: F401
-    _speed_breakdown,  # noqa: F401
-)
-from .speed_profile_helpers import (
-    _phase_to_str,  # noqa: F401
-    _speed_profile_from_points,  # noqa: F401
-)
 
 __all__ = [
     "PeakBin",

--- a/apps/server/vibesensor/use_cases/diagnostics/peak_table.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peak_table.py
@@ -10,11 +10,11 @@ from statistics import median as _median
 from vibesensor.domain import Finding as DomainFinding
 from vibesensor.shared.constants import MEMS_NOISE_FLOOR_G
 from vibesensor.use_cases.diagnostics._types import PeakTableRowData, Sample
-from vibesensor.use_cases.diagnostics.findings import _classify_peak_type
 from vibesensor.use_cases.diagnostics.helpers import (
     _effective_baseline_floor,
     _run_noise_baseline_g,
 )
+from vibesensor.use_cases.diagnostics.peak_binning import _classify_peak_type
 from vibesensor.use_cases.diagnostics.spectrogram import (
     PeakSampleScan,
     safe_percentile,

--- a/apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py
@@ -27,11 +27,6 @@ from vibesensor.use_cases.diagnostics._types import (
     Sample,
     SpeedBreakdownRowData,
 )
-from vibesensor.use_cases.diagnostics.findings import (
-    _phase_speed_breakdown,
-    _sensor_intensity_by_location,
-    _speed_breakdown,
-)
 from vibesensor.use_cases.diagnostics.helpers import (
     _location_label,
     _locations_connected_throughout_run,
@@ -40,6 +35,11 @@ from vibesensor.use_cases.diagnostics.helpers import (
 from vibesensor.use_cases.diagnostics.phase_segmentation import (
     DrivingPhase,
     PhaseSegment,
+)
+from vibesensor.use_cases.diagnostics.signal_aggregation import (
+    _phase_speed_breakdown,
+    _sensor_intensity_by_location,
+    _speed_breakdown,
 )
 from vibesensor.use_cases.diagnostics.speed_profile_helpers import _speed_stats_by_phase
 from vibesensor.use_cases.diagnostics.statistics import (


### PR DESCRIPTION
## Summary
- retarget diagnostics helper imports to `peak_binning.py`, `signal_aggregation.py`, and `speed_profile_helpers.py`
- remove the leftover compatibility re-export block and wording from `use_cases/diagnostics/findings.py`
- add a regression guard that the helper barrel surface stays absent from `findings.py`

## Testing
- `.venv/bin/pytest -q apps/server/tests/hygiene/test_layer_boundaries.py apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_phased_scenario_diagnosis_attribution.py apps/server/tests/integration/test_multi_domain_regressions.py apps/server/tests/adapters/gps/test_issue_148_speed_window.py apps/server/tests/adapters/pdf/test_report_analysis_findings_integration.py apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py apps/server/tests/adapters/pdf/test_report_persistence_classification.py apps/server/tests/adapters/pdf/test_report_scenario_classification_regression.py`
- `make lint`
- `make typecheck-backend`
- `docker compose up -d` + `.venv/bin/vibesensor-sim --count 2 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` + `/api/clients` stability check + `docker compose down`

Closes #985.
