### PR TITLE
Remove PDF report_context helper re-exports

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_context.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from vibesensor.adapters.pdf import report_context
 from vibesensor.adapters.pdf.mapping import (
     PrimaryCandidateContext,
     ReportMappingContext,
@@ -183,3 +184,18 @@ class TestTypedMetadata:
         assert context.sample_count == 500
         assert context.sensor_model == "ESP32"
         assert context.firmware_version == "1.0.0"
+
+
+def test_report_context_module_no_longer_reexports_pdf_helper_facade() -> None:
+    removed_names = (
+        "PrimaryCandidateContext",
+        "Report",
+        "build_report_from_summary",
+        "build_system_cards",
+        "compute_location_hotspot_rows",
+        "filter_active_sensor_intensity",
+        "humanize_signatures",
+        "resolve_primary_report_candidate",
+    )
+    for name in removed_names:
+        assert not hasattr(report_context, name)

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -27,8 +27,6 @@ from vibesensor.adapters.pdf.peak_table import build_peak_rows_from_plots
 from vibesensor.adapters.pdf.presentation import order_label_human
 from vibesensor.adapters.pdf.report_context import (
     ReportMappingContext,
-    compute_location_hotspot_rows,
-    filter_active_sensor_intensity,
     prepare_report_mapping_context,
 )
 from vibesensor.adapters.pdf.report_data import (
@@ -51,6 +49,10 @@ from vibesensor.report_i18n import human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
+from vibesensor.use_cases.history.report_interpretation import (
+    compute_location_hotspot_rows,
+    filter_active_sensor_intensity,
+)
 
 __all__ = [
     "PrimaryCandidateContext",

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -3,10 +3,6 @@
 Owns :class:`ReportMappingContext` plus
 :func:`prepare_report_mapping_context`, which bridge persisted analysis
 summaries into normalized context consumed by ``mapping.py``.
-
-Focused helper implementations now live in ``_card_builder.py``,
-``_candidate_resolver.py``, and ``report_data.py``. Compatibility
-re-exports are kept at the bottom of this module.
 """
 
 from __future__ import annotations
@@ -24,8 +20,6 @@ from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.use_cases.history.report_interpretation import (
-    compute_location_hotspot_rows,
-    filter_active_sensor_intensity,
     normalize_origin_location,
     resolve_report_origin,
     tire_spec_text,
@@ -35,16 +29,8 @@ if TYPE_CHECKING:
     from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
 
 __all__ = [
-    "PrimaryCandidateContext",
-    "Report",
     "ReportMappingContext",
-    "build_report_from_summary",
-    "build_system_cards",
-    "compute_location_hotspot_rows",
-    "filter_active_sensor_intensity",
-    "humanize_signatures",
     "prepare_report_mapping_context",
-    "resolve_primary_report_candidate",
 ]
 
 
@@ -183,15 +169,3 @@ def prepare_report_mapping_context(
         firmware_version=config_snap.firmware_version,
         domain_aggregate=domain_aggregate,
     )
-
-
-# Legacy compatibility re-exports. New implementations live in focused modules.
-from vibesensor.adapters.pdf._candidate_resolver import (  # noqa: E402
-    PrimaryCandidateContext,
-    resolve_primary_report_candidate,
-)
-from vibesensor.adapters.pdf._card_builder import (  # noqa: E402
-    build_system_cards,
-    humanize_signatures,
-)
-from vibesensor.adapters.pdf.report_data import Report, build_report_from_summary  # noqa: E402


### PR DESCRIPTION
Closes #986

## Summary
- remove the leftover PDF helper facade from `report_context.py`
- retarget `mapping.py` to import interpretation helpers from their owning module
- add a regression test that keeps the removed facade names absent from `report_context`

## Validation
- pytest -q apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/hygiene/test_domain_architecture.py
- PATH="$PWD/.venv/bin:$PATH" make lint
- make typecheck-backend
- docker compose up -d + `.venv/bin/vibesensor-sim --count 2 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` smoke