### PR TITLE
Make history/PDF origin resolution domain-first

### DIFF
--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -15,6 +15,9 @@ from vibesensor.domain import (
     TestPlan as DomainTestPlan,
 )
 from vibesensor.shared.boundaries.diagnostic_case import (
+    project_analysis_summary,
+)
+from vibesensor.shared.boundaries.diagnostic_case import (
     test_run_from_summary as _test_run_from_summary,
 )
 from vibesensor.shared.boundaries.finding import step_payloads_from_plan
@@ -101,7 +104,7 @@ class TestSummaryHelpers:
             findings=(primary,),
             top_causes=(primary,),
         )
-        origin = resolve_report_origin(aggregate, _minimal_summary()["most_likely_origin"])
+        origin = resolve_report_origin(aggregate)
         assert origin is not None
         assert origin.projected_location == "Front Left / Front Right"
         assert origin.alternative_locations == ("front_right",)
@@ -154,6 +157,109 @@ class TestSummaryHelpers:
         assert origin["alternative_locations"] == ["front_right"]
         assert origin["dominant_phase"] == "acceleration"
         assert origin["speed_band"] == "80-90 km/h"
+
+    def test_test_run_from_summary_enriches_primary_origin_from_summary_payload(self) -> None:
+        summary = _minimal_summary(
+            top_causes=[
+                {
+                    "finding_id": "F001",
+                    "suspected_source": "wheel/tire",
+                    "strongest_location": "rear left",
+                    "strongest_speed_band": "80-90 km/h",
+                    "confidence": 0.83,
+                }
+            ],
+            most_likely_origin={
+                "location": "rear left / front right",
+                "alternative_locations": ["front right"],
+                "weak_spatial_separation": True,
+                "dominance_ratio": 1.3,
+            },
+        )
+        test_run = _test_run_from_summary(summary)
+        primary = test_run.primary_finding
+        assert primary is not None
+        assert primary.location is not None
+        assert primary.origin is not None
+        assert primary.origin.projected_location == "Rear Left / Front Right"
+        assert primary.origin.has_sufficient_location is True
+
+    def test_project_analysis_summary_uses_domain_enriched_origin(self) -> None:
+        summary = _minimal_summary(
+            top_causes=[
+                {
+                    "finding_id": "F001",
+                    "suspected_source": "wheel/tire",
+                    "strongest_location": "rear left",
+                    "strongest_speed_band": "80-90 km/h",
+                    "confidence": 0.83,
+                }
+            ],
+            most_likely_origin={
+                "location": "rear left / front right",
+                "alternative_locations": ["front right"],
+                "weak_spatial_separation": True,
+            },
+        )
+        projected, test_run = project_analysis_summary(summary)
+        primary = test_run.primary_finding
+        assert primary is not None
+        assert primary.origin is not None
+        assert primary.origin.projected_location == "Rear Left / Front Right"
+        assert projected["most_likely_origin"]["location"] == primary.origin.projected_location
+
+    def test_summary_origin_enrichment_skips_other_duplicate_f_peak_findings(self) -> None:
+        summary = _minimal_summary(
+            findings=[
+                {
+                    "finding_id": "F_PEAK",
+                    "finding_key": "peak_a",
+                    "suspected_source": "wheel/tire",
+                    "strongest_location": "rear left",
+                    "strongest_speed_band": "80-90 km/h",
+                    "confidence": 0.83,
+                    "frequency_hz": 13.2,
+                },
+                {
+                    "finding_id": "F_PEAK",
+                    "finding_key": "peak_b",
+                    "suspected_source": "wheel/tire",
+                    "strongest_location": "front right",
+                    "strongest_speed_band": "80-90 km/h",
+                    "confidence": 0.62,
+                    "frequency_hz": 26.4,
+                },
+            ],
+            top_causes=[
+                {
+                    "finding_id": "F_PEAK",
+                    "finding_key": "peak_a",
+                    "suspected_source": "wheel/tire",
+                    "strongest_location": "rear left",
+                    "strongest_speed_band": "80-90 km/h",
+                    "confidence": 0.83,
+                    "frequency_hz": 13.2,
+                }
+            ],
+            most_likely_origin={
+                "location": "rear left / front right",
+                "alternative_locations": ["front right"],
+                "weak_spatial_separation": True,
+            },
+        )
+        test_run = _test_run_from_summary(summary)
+        primary = test_run.primary_finding
+        assert primary is not None
+        assert primary.origin is not None
+        assert primary.origin.projected_location == "Rear Left / Front Right"
+
+        findings_by_key = {finding.finding_key: finding for finding in test_run.findings}
+        secondary = findings_by_key["peak_b"]
+        assert secondary.origin is not None
+        assert secondary.origin.has_sufficient_location is False
+        assert secondary.origin.projected_location == "Unknown"
+        assert secondary.location is None
+        assert secondary.strongest_location == "front right"
 
     def test_sensor_locations_active_prefers_connected(self) -> None:
         ctx = prepare_report_mapping_context(_minimal_summary())

--- a/apps/server/tests/integration/test_decode_project_roundtrip.py
+++ b/apps/server/tests/integration/test_decode_project_roundtrip.py
@@ -22,19 +22,7 @@ from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.report_data import ReportTemplateData
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.domain import DiagnosticCase, TestRun
-from vibesensor.shared.boundaries.diagnostic_case import (
-    project_analysis_summary,
-    run_suitability_payload,
-)
-from vibesensor.shared.boundaries.diagnostic_case import (
-    test_run_from_summary as _test_run_from_summary,
-)
-from vibesensor.shared.boundaries.finding import (
-    _has_structured_step_content,
-    finding_payload_from_domain,
-    step_payloads_from_plan,
-)
-from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_finding
+from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.use_cases.diagnostics import AnalysisResult, RunAnalysis
 from vibesensor.use_cases.history.exports import build_run_details_json
 
@@ -77,30 +65,8 @@ def _persist_and_reload(tmp_path: Path, summary: dict[str, Any]) -> dict[str, An
 
 def _reproject(analysis_blob: dict[str, Any]) -> dict[str, Any]:
     """Re-serialize domain-owned fields through TestRun reconstruction."""
-    test_run = _test_run_from_summary(analysis_blob)
-    projected: dict[str, Any] = dict(analysis_blob)
-    projected["findings"] = [finding_payload_from_domain(f) for f in test_run.findings]
-    projected["top_causes"] = [
-        finding_payload_from_domain(f) for f in test_run.effective_top_causes()
-    ]
-    primary = test_run.primary_finding
-    origin_fb = analysis_blob.get("most_likely_origin")
-    fb_payload = dict(origin_fb) if isinstance(origin_fb, dict) else {}
-    if primary is None:
-        projected["most_likely_origin"] = fb_payload
-    else:
-        origin_payload = origin_payload_from_finding(primary)
-        origin_location = str(origin_payload.get("location") or "").strip().lower()
-        fallback_location = str(fb_payload.get("location") or "").strip().lower()
-        projected["most_likely_origin"] = (
-            fb_payload
-            if origin_location in {"", "unknown"} and fallback_location not in {"", "unknown"}
-            else origin_payload
-        )
-    if not _has_structured_step_content(analysis_blob.get("test_plan")):
-        projected["test_plan"] = step_payloads_from_plan(test_run.test_plan)
-    projected["run_suitability"] = run_suitability_payload(test_run.suitability)
-    return projected
+    projected, _ = project_analysis_summary(analysis_blob)
+    return dict(projected)
 
 
 def _extract_domain_meaning(summary: dict[str, Any]) -> dict[str, Any]:

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py
@@ -13,15 +13,9 @@ from test_support import (
 from test_support.scenario_ground_truth import ALL_SENSORS, fault_phase
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.shared.boundaries.diagnostic_case import run_suitability_payload
 from vibesensor.shared.boundaries.diagnostic_case import (
-    test_run_from_summary as _test_run_from_summary,
+    project_analysis_summary,
 )
-from vibesensor.shared.boundaries.finding import (
-    finding_payload_from_domain,
-    step_payloads_from_plan,
-)
-from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_finding
 from vibesensor.shared.constants import KMH_TO_MPS
 from vibesensor.use_cases.diagnostics import RunAnalysis, summarize_run_data
 
@@ -92,32 +86,8 @@ def _persist_and_reload_summary(tmp_path: Path, summary: dict[str, Any]) -> dict
     assert run is not None
     analysis = run.get("analysis")
     assert isinstance(analysis, dict)
-    test_run = _test_run_from_summary(analysis)
-    projected: dict[str, Any] = dict(analysis)
-    projected["findings"] = [finding_payload_from_domain(f) for f in test_run.findings]
-    projected["top_causes"] = [
-        finding_payload_from_domain(f) for f in test_run.effective_top_causes()
-    ]
-    primary = test_run.primary_finding
-    origin_fb = analysis.get("most_likely_origin")
-    fb_payload = dict(origin_fb) if isinstance(origin_fb, dict) else {}
-    if primary is None:
-        projected["most_likely_origin"] = fb_payload
-    else:
-        origin_payload = origin_payload_from_finding(primary)
-        origin_location = str(origin_payload.get("location") or "").strip().lower()
-        fallback_location = str(fb_payload.get("location") or "").strip().lower()
-        projected["most_likely_origin"] = (
-            fb_payload
-            if origin_location in {"", "unknown"} and fallback_location not in {"", "unknown"}
-            else origin_payload
-        )
-    from vibesensor.shared.boundaries.finding import _has_structured_step_content
-
-    if not _has_structured_step_content(analysis.get("test_plan")):
-        projected["test_plan"] = step_payloads_from_plan(test_run.test_plan)
-    projected["run_suitability"] = run_suitability_payload(test_run.suitability)
-    return projected
+    projected, _ = project_analysis_summary(analysis)
+    return dict(projected)
 
 
 def _driveline_samples() -> list[dict[str, Any]]:

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -144,8 +144,7 @@ def prepare_report_mapping_context(
     else:
         domain_aggregate = test_run
 
-    origin_fallback = summary.get("most_likely_origin")
-    origin = resolve_report_origin(domain_aggregate, origin_fallback)
+    origin = resolve_report_origin(domain_aggregate)
 
     origin_location = normalize_origin_location(origin)
 

--- a/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
+++ b/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
@@ -8,9 +8,10 @@ belongs on the domain objects themselves.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from typing import cast
 
-from vibesensor.domain import Car, Finding
+from vibesensor.domain import Car, Finding, LocationHotspot, VibrationOrigin
 from vibesensor.domain.diagnostic_case import DiagnosticCase, Symptom
 from vibesensor.domain.driving_segment import DrivingPhase, DrivingSegment
 from vibesensor.domain.run_capture import ConfigurationSnapshot, RunCapture, RunSetup
@@ -94,14 +95,7 @@ def project_analysis_summary(analysis: JsonObject) -> tuple[JsonObject, TestRun]
     if primary is None:
         projected["most_likely_origin"] = fb_payload
     else:
-        origin_payload = origin_payload_from_finding(primary)
-        origin_location = str(origin_payload.get("location") or "").strip().lower()
-        fallback_location = str(fb_payload.get("location") or "").strip().lower()
-        projected["most_likely_origin"] = (
-            fb_payload
-            if origin_location in {"", "unknown"} and fallback_location not in {"", "unknown"}
-            else origin_payload
-        )
+        projected["most_likely_origin"] = origin_payload_from_finding(primary)
     if not _has_structured_step_content(analysis.get("test_plan")):
         projected["test_plan"] = step_payloads_from_plan(test_run.test_plan)
     projected["run_suitability"] = run_suitability_payload(test_run.suitability)
@@ -172,6 +166,128 @@ def _enrich_findings(raw_findings: object) -> tuple[Finding, ...]:
     return tuple(enriched)
 
 
+def _matches_finding(candidate: Finding, target: Finding) -> bool:
+    if candidate == target:
+        return True
+    if not (candidate.finding_id and candidate.finding_id == target.finding_id):
+        return False
+    return (
+        candidate.finding_key == target.finding_key
+        and candidate.strongest_location == target.strongest_location
+        and candidate.strongest_speed_band == target.strongest_speed_band
+        and candidate.frequency_hz == target.frequency_hz
+        and candidate.order == target.order
+        and candidate.suspected_source == target.suspected_source
+    )
+
+
+def _domain_origin_from_summary_payload(
+    payload: Mapping[str, object],
+    *,
+    primary: Finding,
+    domain_origin: VibrationOrigin | None,
+) -> VibrationOrigin | None:
+    raw_location = str(payload.get("location") or "").strip()
+    if not raw_location or raw_location.lower() == "unknown":
+        return None
+    strongest_location = raw_location.split(" / ", maxsplit=1)[0].strip()
+    if not strongest_location or strongest_location.lower() == "unknown":
+        return None
+    alternatives_raw = payload.get("alternative_locations")
+    alternatives = (
+        tuple(str(location).strip() for location in alternatives_raw if str(location).strip())
+        if isinstance(alternatives_raw, list)
+        else ()
+    )
+    dominance_ratio = (
+        domain_origin.dominance_ratio
+        if domain_origin is not None and domain_origin.dominance_ratio is not None
+        else primary.dominance_ratio
+    )
+    if dominance_ratio is None:
+        dominance_ratio = _as_float(payload.get("dominance_ratio"))
+    hotspot = LocationHotspot.from_analysis_inputs(
+        strongest_location=strongest_location,
+        dominance_ratio=dominance_ratio,
+        weak_spatial_separation=(
+            (domain_origin.weak_spatial_separation if domain_origin is not None else False)
+            or primary.weak_spatial_separation
+            or bool(payload.get("weak_spatial_separation", False))
+            or bool(alternatives)
+        ),
+        ambiguous=bool(alternatives),
+        alternative_locations=alternatives,
+    )
+    return VibrationOrigin.from_analysis_inputs(
+        suspected_source=(
+            domain_origin.suspected_source
+            if domain_origin is not None
+            else primary.suspected_source
+        ),
+        hotspot=hotspot,
+        dominance_ratio=dominance_ratio,
+        speed_band=(
+            domain_origin.speed_band
+            if domain_origin is not None and domain_origin.speed_band is not None
+            else primary.strongest_speed_band
+            or (str(payload.get("speed_band") or "").strip() or None)
+        ),
+        dominant_phase=(
+            domain_origin.dominant_phase
+            if domain_origin is not None and domain_origin.dominant_phase is not None
+            else primary.dominant_phase
+            or (str(payload.get("dominant_phase") or "").strip() or None)
+        ),
+        reason=domain_origin.reason if domain_origin is not None else "",
+    )
+
+
+def _enrich_primary_origin_from_summary(
+    summary: Mapping[str, object],
+    *,
+    findings: tuple[Finding, ...],
+    top_causes: tuple[Finding, ...],
+) -> tuple[tuple[Finding, ...], tuple[Finding, ...]]:
+    summary_origin = summary.get("most_likely_origin")
+    if not isinstance(summary_origin, Mapping):
+        return findings, top_causes
+    primary = top_causes[0] if top_causes else next((f for f in findings if f.is_diagnostic), None)
+    if primary is None:
+        return findings, top_causes
+    domain_origin = VibrationOrigin.from_finding(primary)
+    if domain_origin is not None and domain_origin.has_sufficient_location:
+        return findings, top_causes
+    enriched_origin = _domain_origin_from_summary_payload(
+        summary_origin,
+        primary=primary,
+        domain_origin=domain_origin,
+    )
+    if enriched_origin is None or enriched_origin.hotspot is None:
+        return findings, top_causes
+    enriched_primary = replace(
+        primary,
+        strongest_location=primary.strongest_location or enriched_origin.hotspot.strongest_location,
+        dominant_phase=primary.dominant_phase or enriched_origin.dominant_phase,
+        dominance_ratio=(
+            primary.dominance_ratio
+            if primary.dominance_ratio is not None
+            else enriched_origin.dominance_ratio
+        ),
+        weak_spatial_separation=(
+            primary.weak_spatial_separation or enriched_origin.weak_spatial_separation
+        ),
+        location=primary.location or enriched_origin.hotspot,
+        origin=enriched_origin,
+    )
+
+    def _replace_matches(items: tuple[Finding, ...]) -> tuple[Finding, ...]:
+        return tuple(
+            enriched_primary if _matches_finding(item, primary) else item for item in items
+        )
+
+    return _replace_matches(findings), _replace_matches(top_causes)
+
+
 def _require_authoritative_case_id(summary: Mapping[str, object]) -> str:
     case_id = summary.get("case_id")
     if isinstance(case_id, str):
@@ -196,6 +312,11 @@ def test_run_from_summary(summary: Mapping[str, object]) -> TestRun:
             ):
                 merged.append(tc)
         findings = tuple(merged)
+    findings, top_causes = _enrich_primary_origin_from_summary(
+        summary,
+        findings=findings,
+        top_causes=top_causes,
+    )
     actions = _actions_from_steps(summary.get("test_plan"))
     raw_speed_stats = summary.get("speed_stats")
     phase_info = summary.get("phase_info")

--- a/apps/server/vibesensor/use_cases/history/report_interpretation.py
+++ b/apps/server/vibesensor/use_cases/history/report_interpretation.py
@@ -6,10 +6,8 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from statistics import mean as _mean
-from typing import Any
 
-from vibesensor.domain import Finding, LocationHotspot, TestRun, VibrationOrigin
-from vibesensor.shared.boundaries.vibration_origin import vibration_origin_from_payload
+from vibesensor.domain import Finding, TestRun, VibrationOrigin
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonObject
 
@@ -31,57 +29,11 @@ class PrimaryReportFacts:
 
 def resolve_report_origin(
     aggregate: TestRun | None,
-    fallback: Mapping[str, Any] | None,
 ) -> VibrationOrigin | None:
-    """Resolve report origin from the domain aggregate with payload fallback."""
-    fallback_origin: VibrationOrigin | None = None
-    if isinstance(fallback, Mapping):
-        raw_location = str(fallback.get("location") or "").strip()
-        alternatives_raw = fallback.get("alternative_locations")
-        alternatives = (
-            [str(location).strip() for location in alternatives_raw if str(location).strip()]
-            if isinstance(alternatives_raw, list)
-            else []
-        )
-
-        strongest_location = (
-            raw_location.split(" / ", maxsplit=1)[0].strip() if raw_location else ""
-        )
-        hotspot = None
-        if strongest_location and strongest_location.lower() != "unknown":
-            hotspot = LocationHotspot.from_analysis_inputs(
-                strongest_location=strongest_location,
-                dominance_ratio=_as_float(fallback.get("dominance_ratio")),
-                weak_spatial_separation=bool(fallback.get("weak_spatial_separation", False)),
-                ambiguous=bool(alternatives),
-                alternative_locations=alternatives,
-            )
-
-        speed_band = str(fallback.get("speed_band") or "").strip() or None
-        dominant_phase = str(fallback.get("dominant_phase") or "").strip() or None
-        dominance_ratio = _as_float(fallback.get("dominance_ratio"))
-        if (
-            hotspot is not None
-            or speed_band is not None
-            or dominant_phase is not None
-            or dominance_ratio is not None
-        ):
-            fallback_origin = vibration_origin_from_payload(
-                fallback,
-                hotspot=hotspot,
-                dominance_ratio=dominance_ratio,
-                speed_band=speed_band,
-            )
-
-    if aggregate is not None and aggregate.primary_finding is not None:
-        primary_origin = VibrationOrigin.from_finding(aggregate.primary_finding)
-        if primary_origin is None:
-            return fallback_origin
-        if not primary_origin.has_sufficient_location and fallback_origin is not None:
-            return fallback_origin
-        return primary_origin
-
-    return fallback_origin
+    """Resolve report origin from the domain aggregate only."""
+    if aggregate is None or aggregate.primary_finding is None:
+        return None
+    return VibrationOrigin.from_finding(aggregate.primary_finding)
 
 
 def normalize_origin_location(origin: VibrationOrigin | None) -> str:


### PR DESCRIPTION
## Summary
- move historical summary-origin enrichment to the decode boundary when reconstructing a `TestRun`
- make report/history origin resolution domain-first once a `TestRun` exists
- add regression coverage for duplicate `F_PEAK` findings so enrichment cannot hit the wrong finding

## Validation
- `pytest -q apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- Docker/simulator smoke (`docker compose up -d`, health check, `.venv/bin/vibesensor-sim --count 2 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`, `/api/clients` stability check, `docker compose down`)

Closes #988
