### PR TITLE
Slim UpdateManager Wi-Fi coupling

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -148,8 +148,8 @@ class TestUpdateManagerAsync:
         runner.set_response("socket.getaddrinfo", 1, "", "Temporary failure in name resolution")
         with (
             patch_release_fetcher() as mock_fetcher,
-            patch("vibesensor.use_cases.updates.manager.DNS_READY_MIN_WAIT_S", 0.05),
-            patch("vibesensor.use_cases.updates.manager.DNS_RETRY_INTERVAL_S", 0.01),
+            patch("vibesensor.use_cases.updates.wifi.DNS_READY_MIN_WAIT_S", 0.05),
+            patch("vibesensor.use_cases.updates.wifi.DNS_RETRY_INTERVAL_S", 0.01),
         ):
             await run_update(manager)
             mock_fetcher.assert_not_called()
@@ -170,8 +170,8 @@ class TestUpdateManagerAsync:
         runner.run = run_with_dns_retry
         with (
             patch_release_fetcher() as mock_fetcher,
-            patch("vibesensor.use_cases.updates.manager.DNS_READY_MIN_WAIT_S", 0.2),
-            patch("vibesensor.use_cases.updates.manager.DNS_RETRY_INTERVAL_S", 0.01),
+            patch("vibesensor.use_cases.updates.wifi.DNS_READY_MIN_WAIT_S", 0.2),
+            patch("vibesensor.use_cases.updates.wifi.DNS_RETRY_INTERVAL_S", 0.01),
         ):
             mock_fetcher.return_value.check_update_available.return_value = None
             await run_update(manager)
@@ -319,7 +319,7 @@ class TestUpdateManagerAsync:
         with (
             patch("shutil.which", mock_which),
             patch("vibesensor.use_cases.updates.manager.UPDATE_TIMEOUT_S", 0.5),
-            patch("vibesensor.use_cases.updates.manager.HOTSPOT_RESTORE_RETRIES", 1),
+            patch("vibesensor.use_cases.updates.wifi.HOTSPOT_RESTORE_RETRIES", 1),
         ):
             manager.start("TestNet", "pass")
             await asyncio.wait_for(manager._task, timeout=3)

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -13,7 +13,7 @@ Module topology
 - **Services**: ``manager.py`` — backend restart scheduling and runtime update
   lifecycle orchestration.
 - **Operations**: ``installer.py`` (install/rollback), ``wifi.py`` (Wi-Fi
-  connect/restore, diagnostics, network constants), ``releases.py``
+  connect/restore, diagnostics, and default-config assembly), ``releases.py``
   (GitHub release discovery), ``runner.py`` (process execution and
   command helpers), ``firmware_release_fetcher.py`` (GitHub firmware HTTP
   discovery/download), ``firmware_bundle.py`` (firmware bundle filesystem

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -33,18 +33,8 @@ from vibesensor.use_cases.updates.validation import (
     validate_prerequisites,
 )
 from vibesensor.use_cases.updates.wifi import (
-    DNS_PROBE_HOST,
-    DNS_READY_MIN_WAIT_S,
-    DNS_RETRY_INTERVAL_S,
-    HOTSPOT_RESTORE_DELAY_S,
-    HOTSPOT_RESTORE_RETRIES,
-    NMCLI_TIMEOUT_S,
-    UPLINK_CONNECT_RETRIES,
-    UPLINK_CONNECT_WAIT_S,
-    UPLINK_CONNECTION_NAME,
-    UPLINK_FALLBACK_DNS,
-    UpdateWifiConfig,
     UpdateWifiController,
+    build_default_wifi_config,
     parse_wifi_diagnostics,
 )
 
@@ -386,19 +376,9 @@ class UpdateManager:
         return UpdateWifiController(
             commands=commands or self._build_command_executor(),
             tracker=self._tracker,
-            config=UpdateWifiConfig(
+            config=build_default_wifi_config(
                 ap_con_name=self._ap_con_name,
                 wifi_ifname=self._wifi_ifname,
-                uplink_connection_name=UPLINK_CONNECTION_NAME,
-                uplink_connect_wait_s=UPLINK_CONNECT_WAIT_S,
-                uplink_connect_retries=UPLINK_CONNECT_RETRIES,
-                uplink_fallback_dns=UPLINK_FALLBACK_DNS,
-                dns_ready_min_wait_s=DNS_READY_MIN_WAIT_S,
-                dns_retry_interval_s=DNS_RETRY_INTERVAL_S,
-                dns_probe_host=DNS_PROBE_HOST,
-                nmcli_timeout_s=NMCLI_TIMEOUT_S,
-                hotspot_restore_retries=HOTSPOT_RESTORE_RETRIES,
-                hotspot_restore_delay_s=HOTSPOT_RESTORE_DELAY_S,
             ),
         )
 

--- a/apps/server/vibesensor/use_cases/updates/wifi.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi.py
@@ -73,6 +73,23 @@ class UpdateWifiConfig:
     hotspot_restore_delay_s: float
 
 
+def build_default_wifi_config(*, ap_con_name: str, wifi_ifname: str) -> UpdateWifiConfig:
+    return UpdateWifiConfig(
+        ap_con_name=ap_con_name,
+        wifi_ifname=wifi_ifname,
+        uplink_connection_name=UPLINK_CONNECTION_NAME,
+        uplink_connect_wait_s=UPLINK_CONNECT_WAIT_S,
+        uplink_connect_retries=UPLINK_CONNECT_RETRIES,
+        uplink_fallback_dns=UPLINK_FALLBACK_DNS,
+        dns_ready_min_wait_s=DNS_READY_MIN_WAIT_S,
+        dns_retry_interval_s=DNS_RETRY_INTERVAL_S,
+        dns_probe_host=DNS_PROBE_HOST,
+        nmcli_timeout_s=NMCLI_TIMEOUT_S,
+        hotspot_restore_retries=HOTSPOT_RESTORE_RETRIES,
+        hotspot_restore_delay_s=HOTSPOT_RESTORE_DELAY_S,
+    )
+
+
 class UpdateWifiController:
     """Owns hotspot shutdown, uplink connection, DNS readiness, and restore."""
 


### PR DESCRIPTION
## Summary
- move updater Wi-Fi default-config assembly behind a wifi-owned factory instead of building it inline in `manager.py`
- slim `UpdateManager` imports so it no longer depends directly on the Wi-Fi timing/default constants
- retarget updater tests to patch Wi-Fi tuning knobs through `vibesensor.use_cases.updates.wifi` and update the updater package docs

## Validation
- `python3 -m ruff check --fix apps/server/vibesensor/use_cases/updates/wifi.py apps/server/vibesensor/use_cases/updates/manager.py apps/server/vibesensor/use_cases/updates/__init__.py apps/server/tests/use_cases/updates/test_update_manager_async.py`
- `pytest -q apps/server/tests/use_cases/updates apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap`
- `docker compose up -d` smoke with `vibesensor-sim --count 2 --duration 12 --speed-kmh 0 --no-auto-server` (`before=0`, `during=2`, `after=0`)

Closes #993