### PR TITLE
Require committed UI schema artifacts

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -6,7 +6,7 @@ import json
 from typing import Any
 
 import pytest
-from _paths import SERVER_ROOT
+from _paths import REPO_ROOT
 
 from vibesensor.cli.http_api_schema_export import export_schema
 
@@ -39,11 +39,11 @@ def test_export_schema_writes_to_file(tmp_path) -> None:
 
 
 def test_export_schema_matches_committed_schema(schema_text: str) -> None:
-    committed_path = (
-        SERVER_ROOT.parent / "apps" / "ui" / "src" / "contracts" / "http_api_schema.json"
+    committed_path = REPO_ROOT / "apps" / "ui" / "src" / "contracts" / "http_api_schema.json"
+    assert committed_path.exists(), (
+        f"Committed UI contract file is missing: {committed_path}. "
+        "Normal repo test runs require checked-in UI contract artifacts."
     )
-    if not committed_path.exists():
-        pytest.skip("UI contracts not available")
     committed = committed_path.read_text(encoding="utf-8")
     assert committed == schema_text, (
         "Committed http_api_schema.json is out of sync with generated schema. "

--- a/apps/server/tests/adapters/websocket/test_ws_schema_export.py
+++ b/apps/server/tests/adapters/websocket/test_ws_schema_export.py
@@ -6,7 +6,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from _paths import SERVER_ROOT
+from _paths import REPO_ROOT
 
 from vibesensor.cli.ws_schema_export import export_schema
 
@@ -65,12 +65,12 @@ def test_export_schema_creates_parent_dirs(tmp_path: Path) -> None:
 
 def test_export_schema_matches_committed_schema(schema_text: str) -> None:
     """Generated schema must match the committed contract file."""
-    committed_path = (
-        SERVER_ROOT.parent / "apps" / "ui" / "src" / "contracts" / "ws_payload_schema.json"
+    committed_path = REPO_ROOT / "apps" / "ui" / "src" / "contracts" / "ws_payload_schema.json"
+    assert committed_path.exists(), (
+        f"Committed UI contract file is missing: {committed_path}. "
+        "Normal repo test runs require checked-in UI contract artifacts."
     )
-    if not committed_path.exists():
-        pytest.skip("UI contracts not available")
-    committed = committed_path.read_text()
+    committed = committed_path.read_text(encoding="utf-8")
     assert committed == schema_text, (
         "Committed ws_payload_schema.json is out of sync with generated schema. "
         "Run 'python -m vibesensor.cli.ws_schema_export' and commit the result."


### PR DESCRIPTION
## Summary
- make the HTTP and WS schema export tests fail explicitly when the committed UI contract files are missing in a normal repo checkout
- fix both tests to resolve committed UI contract files from REPO_ROOT instead of the broken SERVER_ROOT.parent / "apps" / ... path
- keep the existing out-of-sync content checks and regeneration guidance once existence is enforced

## Validation
- pytest -q apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/adapters/websocket/test_ws_schema_export.py
- ruff format --check apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/adapters/websocket/test_ws_schema_export.py
- python3 tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck

Closes #1007