### PR TITLE
Broaden Docker physical-scenario E2E coverage

### DIFF
--- a/apps/server/tests_e2e/e2e_helpers.py
+++ b/apps/server/tests_e2e/e2e_helpers.py
@@ -4,10 +4,12 @@ import csv
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 import zipfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import HTTPError
@@ -103,6 +105,20 @@ def api_bytes(
 def pdf_text(pdf_bytes: bytes) -> str:
     reader = PdfReader(io.BytesIO(pdf_bytes))
     return "\n".join(filter(None, (page.extract_text() for page in reader.pages))).lower()
+
+
+def normalize_location(text: str) -> str:
+    """Lowercase and collapse whitespace/hyphens/underscores to a single space."""
+    return re.sub(r"[\s\-_]+", " ", str(text).strip().lower())
+
+
+def non_ref_findings(data: dict) -> list[dict]:
+    """Return non-reference findings from a payload containing a findings list."""
+    return [
+        finding
+        for finding in data.get("findings", [])
+        if isinstance(finding, dict) and not str(finding.get("finding_id", "")).startswith("REF_")
+    ]
 
 
 def run_simulator(
@@ -205,3 +221,15 @@ def parse_export_zip(raw: bytes) -> tuple[dict, list[dict[str, str]], set[str]]:
         run_json = json.loads(archive.read(json_name).decode("utf-8"))
         rows = list(csv.DictReader(io.StringIO(archive.read(csv_name).decode("utf-8"))))
     return run_json, rows, names
+
+
+def run_cleanup_steps(*steps: tuple[str, Callable[[], object]]) -> None:
+    errors: list[Exception] = []
+    for label, step in steps:
+        try:
+            step()
+        except Exception as exc:
+            exc.add_note(f"cleanup step failed: {label}")
+            errors.append(exc)
+    if errors:
+        raise ExceptionGroup("one or more E2E cleanup steps failed", errors)

--- a/apps/server/tests_e2e/test_e2e_docker_engine_order_fault.py
+++ b/apps/server/tests_e2e/test_e2e_docker_engine_order_fault.py
@@ -1,0 +1,111 @@
+"""Docker E2E test for full-stack engine-order diagnosis."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+
+import pytest
+
+from tests_e2e._docker_edge_helpers import _cleanup_clients, _cleanup_run
+from tests_e2e.e2e_helpers import (
+    api_bytes,
+    api_json,
+    history_run_ids,
+    non_ref_findings,
+    parse_export_zip,
+    pdf_text,
+    run_simulator,
+    run_cleanup_steps,
+    wait_for,
+    wait_run_status,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+def test_e2e_docker_engine_order_fault() -> None:
+    base_url = os.environ["VIBESENSOR_BASE_URL"]
+    sim_host = os.environ["VIBESENSOR_SIM_SERVER_HOST"]
+    sim_data_port = os.environ["VIBESENSOR_SIM_DATA_PORT"]
+    sim_control_port = os.environ["VIBESENSOR_SIM_CONTROL_PORT"]
+    sim_duration = os.environ["VIBESENSOR_SIM_DURATION"]
+    run_id: str | None = None
+    _cleanup_clients(base_url)
+    wait_for(
+        lambda: not api_json(base_url, "/api/clients").get("clients"),
+        timeout_s=5.0,
+        interval_s=0.5,
+        message="simulator clients did not quiesce before engine-order E2E run",
+    )
+    time.sleep(2.5)
+    try:
+        api_json(
+            base_url,
+            "/api/settings/speed-source",
+            method="POST",
+            body={"speedSource": "manual", "manualSpeedKph": 100.0},
+        )
+        start = api_json(base_url, "/api/recording/start", method="POST")
+        assert start["enabled"] is True
+        run_id = str(start["run_id"])
+        run_simulator(
+            base_url=base_url,
+            sim_host=sim_host,
+            sim_data_port=sim_data_port,
+            sim_control_port=sim_control_port,
+            duration_s=float(sim_duration),
+            count=4,
+            scenario="engine-order",
+        )
+
+        api_json(base_url, "/api/recording/stop", method="POST")
+        wait_for(
+            lambda: run_id if run_id in history_run_ids(base_url) else None,
+            timeout_s=10.0,
+            interval_s=0.5,
+            message=f"Run {run_id} did not become visible in history",
+        )
+        wait_run_status(base_url, run_id, timeout_s=90.0)
+
+        insights = api_json(base_url, f"/api/history/{run_id}/insights")
+        findings = non_ref_findings(insights)
+        assert findings, "Expected non-reference findings for engine-order scenario"
+
+        primary = findings[0]
+        assert primary.get("suspected_source") == "engine"
+        frequency_label = str(primary.get("frequency_hz_or_order") or "").lower()
+        assert "engine" in frequency_label
+
+        top_causes = [item for item in insights.get("top_causes", []) if isinstance(item, dict)]
+        assert top_causes, "Expected ranked top causes for engine-order scenario"
+        assert top_causes[0].get("suspected_source") == "engine"
+
+        run_payload = api_json(base_url, f"/api/history/{run_id}")
+        run_analysis = run_payload.get("analysis") or {}
+        analysis_findings = non_ref_findings(run_analysis)
+        assert analysis_findings, "Expected non-reference findings in run analysis"
+        assert analysis_findings[0].get("suspected_source") == "engine"
+
+        export_resp = api_bytes(base_url, f"/api/history/{run_id}/export")
+        assert str(export_resp.headers.get("content-type", "")).startswith("application/zip")
+        _, rows, names = parse_export_zip(export_resp.body)
+        assert names == {f"{run_id}.json", f"{run_id}_raw.csv"}
+        assert rows, "Expected raw export rows for engine-order scenario"
+
+        pdf_resp = api_bytes(base_url, f"/api/history/{run_id}/report.pdf?lang=en")
+        assert str(pdf_resp.headers.get("content-type", "")).startswith("application/pdf")
+        assert pdf_resp.body[:5] == b"%PDF-"
+        report_text = pdf_text(pdf_resp.body)
+        assert "primary system:" in report_text
+        assert re.search(r"primary system:\s*engine\b", report_text)
+        assert not re.search(r"primary system:\s*wheel / tire\b", report_text)
+    finally:
+        cleanup_steps = [
+            ("stop recording", lambda: api_json(base_url, "/api/recording/stop", method="POST")),
+            ("cleanup simulator clients", lambda: _cleanup_clients(base_url)),
+        ]
+        if run_id is not None:
+            cleanup_steps.insert(1, ("cleanup run", lambda rid=run_id: _cleanup_run(base_url, rid)))
+        run_cleanup_steps(*cleanup_steps)

--- a/apps/server/tests_e2e/test_e2e_docker_rear_left_wheel_fault.py
+++ b/apps/server/tests_e2e/test_e2e_docker_rear_left_wheel_fault.py
@@ -5,40 +5,27 @@ import json
 import math
 import os
 import re
+import time
 from math import floor
 
 import pytest
 
+from tests_e2e._docker_edge_helpers import _cleanup_clients, _cleanup_run
 from tests_e2e.e2e_helpers import (
     api_bytes,
     api_json,
     history_run_ids,
+    non_ref_findings,
+    normalize_location,
     parse_export_zip,
     pdf_text,
     run_simulator,
+    run_cleanup_steps,
     wait_for,
+    wait_run_status,
 )
 
 pytestmark = pytest.mark.e2e
-
-
-# ---------------------------------------------------------------------------
-# Parsing and aggregation helpers used by validation functions
-# ---------------------------------------------------------------------------
-
-
-def _normalize_location(s: str) -> str:
-    """Lowercase and collapse whitespace/hyphens/underscores to a single space."""
-    return re.sub(r"[\s\-_]+", " ", str(s).strip().lower())
-
-
-def _non_ref_findings(data: dict) -> list[dict]:
-    """Return non-reference findings from a payload containing a 'findings' list."""
-    return [
-        f
-        for f in data.get("findings", [])
-        if isinstance(f, dict) and not str(f.get("finding_id", "")).startswith("REF_")
-    ]
 
 
 def _parse_csv_value(value: str) -> object:
@@ -263,8 +250,8 @@ def _validate_primary_finding_consistency(
     Asserts that suspected_source, strongest_location, and frequency_hz_or_order
     are identical in both payloads for the first non-reference finding.
     """
-    run_findings = _non_ref_findings(run_analysis)
-    ins_findings = _non_ref_findings(insights)
+    run_findings = non_ref_findings(run_analysis)
+    ins_findings = non_ref_findings(insights)
     assert run_findings, "[cross-source] run.analysis has no non-reference findings"
     assert ins_findings, "[cross-source] insights has no non-reference findings"
 
@@ -275,8 +262,8 @@ def _validate_primary_finding_consistency(
         f"[cross-source] suspected_source mismatch: "
         f"run={run_pf.get('suspected_source')!r} insights={ins_pf.get('suspected_source')!r}"
     )
-    assert _normalize_location(str(run_pf.get("strongest_location") or "")) == (
-        _normalize_location(str(ins_pf.get("strongest_location") or ""))
+    assert normalize_location(str(run_pf.get("strongest_location") or "")) == (
+        normalize_location(str(ins_pf.get("strongest_location") or ""))
     ), (
         f"[cross-source] strongest_location mismatch: "
         f"run={run_pf.get('strongest_location')!r} insights={ins_pf.get('strongest_location')!r}"
@@ -350,17 +337,17 @@ def _validate_bucket_distribution(
 
     strongest_by_p95 = max(p95_by_loc, key=lambda k: p95_by_loc[k])
 
-    run_findings = _non_ref_findings(run_analysis)
+    run_findings = non_ref_findings(run_analysis)
     if run_findings:
         primary_location = str(run_findings[0].get("strongest_location") or "")
-        assert _normalize_location(strongest_by_p95) == _normalize_location(primary_location), (
+        assert normalize_location(strongest_by_p95) == normalize_location(primary_location), (
             f"[bucket] strongest_location_by_p95={strongest_by_p95!r} does not match "
             f"primary finding strongest_location={primary_location!r}"
         )
 
     if analysis_rows:
         first_location = str(analysis_rows[0].get("location") or "")
-        assert _normalize_location(first_location) == _normalize_location(strongest_by_p95), (
+        assert normalize_location(first_location) == normalize_location(strongest_by_p95), (
             f"[bucket] sensor_intensity_by_location[0]={first_location!r} "
             f"expected strongest={strongest_by_p95!r} (by p95)"
         )
@@ -420,7 +407,7 @@ def _validate_primary_finding_vs_graph(run_analysis: dict) -> None:
     The top-amplitude spike in the peaks_table (or fft_spectrum as fallback) must be
     within max(1.0 Hz, 10% relative) of the median matched_hz in the primary finding.
     """
-    run_findings = _non_ref_findings(run_analysis)
+    run_findings = non_ref_findings(run_analysis)
     if not run_findings:
         return
 
@@ -480,10 +467,10 @@ def _validate_pdf_report(pdf_bytes: bytes, primary_finding: dict) -> None:
         "[pdf] primary suspected_source ('wheel / tire') not found in PDF"
     )
 
-    # --- strongest location (rear-left) ---
+    # --- strongest location ---
     location_raw = str(primary_finding.get("strongest_location") or "")
     if location_raw:
-        loc_normalized = _normalize_location(location_raw)
+        loc_normalized = normalize_location(location_raw)
         assert loc_normalized in pdf or location_raw.lower() in pdf, (
             f"[pdf] strongest_location {location_raw!r} not found in PDF"
         )
@@ -512,97 +499,111 @@ def _validate_pdf_report(pdf_bytes: bytes, primary_finding: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_e2e_docker_rear_left_wheel_fault() -> None:
+@pytest.mark.parametrize(
+    "fault_wheel", ["front-left", "rear-left"], ids=["front-left", "rear-left"]
+)
+def test_e2e_docker_localized_wheel_fault(fault_wheel: str) -> None:
     base_url = os.environ["VIBESENSOR_BASE_URL"]
     sim_host = os.environ["VIBESENSOR_SIM_SERVER_HOST"]
     sim_data_port = os.environ["VIBESENSOR_SIM_DATA_PORT"]
     sim_control_port = os.environ["VIBESENSOR_SIM_CONTROL_PORT"]
     sim_duration = os.environ["VIBESENSOR_SIM_DURATION"]
-    before_ids = history_run_ids(base_url)
-
-    api_json(
-        base_url,
-        "/api/settings/speed-source",
-        method="POST",
-        body={"speedSource": "manual", "manualSpeedKph": 100.0},
-    )
-    start = api_json(base_url, "/api/recording/start", method="POST")
-    assert start["enabled"] is True
-    run_id = str(start["run_id"])
-    run_simulator(
-        base_url=base_url,
-        sim_host=sim_host,
-        sim_data_port=sim_data_port,
-        sim_control_port=sim_control_port,
-        duration_s=float(sim_duration),
-        count=4,
-    )
-
-    api_json(base_url, "/api/recording/stop", method="POST")
-    run = wait_for(
-        lambda: api_json(base_url, f"/api/history/{run_id}") if run_id not in before_ids else None,
+    expected_location = normalize_location(fault_wheel)
+    run_id: str | None = None
+    _cleanup_clients(base_url)
+    wait_for(
+        lambda: not api_json(base_url, "/api/clients").get("clients"),
         timeout_s=5.0,
         interval_s=0.5,
-        message=f"Run {run_id} did not become visible in history",
+        message="simulator clients did not quiesce before wheel-fault E2E run",
     )
-    assert run.get("status") in {"analyzing", "complete"}
-    wait_for(
-        lambda: (
-            api_json(base_url, f"/api/history/{run_id}")
-            if api_json(base_url, f"/api/history/{run_id}").get("status") == "complete"
-            else None
-        ),
-        timeout_s=90.0,
-        interval_s=1.0,
-        message=f"Run {run_id} did not complete in time",
-    )
+    time.sleep(2.5)
+    try:
+        api_json(
+            base_url,
+            "/api/settings/speed-source",
+            method="POST",
+            body={"speedSource": "manual", "manualSpeedKph": 100.0},
+        )
+        start = api_json(base_url, "/api/recording/start", method="POST")
+        assert start["enabled"] is True
+        run_id = str(start["run_id"])
+        run_simulator(
+            base_url=base_url,
+            sim_host=sim_host,
+            sim_data_port=sim_data_port,
+            sim_control_port=sim_control_port,
+            duration_s=float(sim_duration),
+            count=4,
+            fault_wheel=fault_wheel,
+        )
 
-    insights = api_json(base_url, f"/api/history/{run_id}/insights")
-    findings = _non_ref_findings(insights)
-    assert findings, "Expected non-reference findings"
+        api_json(base_url, "/api/recording/stop", method="POST")
+        wait_for(
+            lambda: run_id if run_id in history_run_ids(base_url) else None,
+            timeout_s=10.0,
+            interval_s=0.5,
+            message=f"Run {run_id} did not become visible in history",
+        )
+        run = api_json(base_url, f"/api/history/{run_id}")
+        assert run.get("status") in {"analyzing", "complete"}
+        wait_run_status(base_url, run_id, timeout_s=90.0)
 
-    primary = findings[0]
-    assert primary.get("suspected_source") == "wheel/tire"
-    primary_location = str(primary.get("strongest_location") or "").lower()
-    assert "rear left" in primary_location or "rear-left" in primary_location
-    top_causes = [item for item in insights.get("top_causes", []) if isinstance(item, dict)]
-    assert top_causes, "Expected ranked top causes"
-    assert top_causes[0].get("suspected_source") == "wheel/tire"
+        insights = api_json(base_url, f"/api/history/{run_id}/insights")
+        findings = non_ref_findings(insights)
+        assert findings, "Expected non-reference findings"
 
-    pdf_resp = api_bytes(base_url, f"/api/history/{run_id}/report.pdf?lang=en")
-    assert str(pdf_resp.headers.get("content-type", "")).startswith("application/pdf")
-    assert pdf_resp.body[:5] == b"%PDF-"
-    report_text = pdf_text(pdf_resp.body)
-    assert "primary system:" in report_text
-    assert "wheel / tire" in report_text
-    assert "rear left" in report_text or "rear-left" in report_text
-    assert "primary system: driveline" not in report_text
-    assert "primary system: engine" not in report_text
+        primary = findings[0]
+        assert primary.get("suspected_source") == "wheel/tire"
+        primary_location = normalize_location(str(primary.get("strongest_location") or ""))
+        assert expected_location in primary_location
+        top_causes = [item for item in insights.get("top_causes", []) if isinstance(item, dict)]
+        assert top_causes, "Expected ranked top causes"
+        assert top_causes[0].get("suspected_source") == "wheel/tire"
 
-    # ------------------------------------------------------------------
-    # Alignment validation: cross-source consistency checks
-    # ------------------------------------------------------------------
+        pdf_resp = api_bytes(base_url, f"/api/history/{run_id}/report.pdf?lang=en")
+        assert str(pdf_resp.headers.get("content-type", "")).startswith("application/pdf")
+        assert pdf_resp.body[:5] == b"%PDF-"
+        report_text = pdf_text(pdf_resp.body)
+        report_text_normalized = normalize_location(report_text)
+        assert "primary system:" in report_text
+        assert "wheel / tire" in report_text
+        assert expected_location in report_text_normalized
+        assert "primary system: driveline" not in report_text
+        assert "primary system: engine" not in report_text
 
-    run_payload = api_json(base_url, f"/api/history/{run_id}")
-    export_resp = api_bytes(base_url, f"/api/history/{run_id}/export")
-    assert str(export_resp.headers.get("content-type", "")).startswith("application/zip")
-    _, raw_export_samples, _ = parse_export_zip(export_resp.body)
-    export_samples = [
-        {k: _parse_csv_value(v) for k, v in row.items()} for row in raw_export_samples
-    ]
-    run_analysis = run_payload.get("analysis") or {}
+        # ------------------------------------------------------------------
+        # Alignment validation: cross-source consistency checks
+        # ------------------------------------------------------------------
 
-    # Validation 1: primary finding consistent across run payload and insights
-    _validate_primary_finding_consistency(run_analysis, insights)
+        run_payload = api_json(base_url, f"/api/history/{run_id}")
+        export_resp = api_bytes(base_url, f"/api/history/{run_id}/export")
+        assert str(export_resp.headers.get("content-type", "")).startswith("application/zip")
+        _, raw_export_samples, _ = parse_export_zip(export_resp.body)
+        export_samples = [
+            {k: _parse_csv_value(v) for k, v in row.items()} for row in raw_export_samples
+        ]
+        run_analysis = run_payload.get("analysis") or {}
 
-    # Validation 2: bucket distribution matches raw exported samples
-    _validate_bucket_distribution(run_analysis, export_samples)
+        # Validation 1: primary finding consistent across run payload and insights
+        _validate_primary_finding_consistency(run_analysis, insights)
 
-    # Validation 3: fft_spectrum bins match independently computed spectrum
-    _validate_graph_spikes(run_analysis, export_samples)
+        # Validation 2: bucket distribution matches raw exported samples
+        _validate_bucket_distribution(run_analysis, export_samples)
 
-    # Validation 4: primary finding matched Hz aligns with top graph spike
-    _validate_primary_finding_vs_graph(run_analysis)
+        # Validation 3: fft_spectrum bins match independently computed spectrum
+        _validate_graph_spikes(run_analysis, export_samples)
 
-    # Validation 5: PDF reflects primary finding source, location, and order label
-    _validate_pdf_report(pdf_resp.body, primary)
+        # Validation 4: primary finding matched Hz aligns with top graph spike
+        _validate_primary_finding_vs_graph(run_analysis)
+
+        # Validation 5: PDF reflects primary finding source, location, and order label
+        _validate_pdf_report(pdf_resp.body, primary)
+    finally:
+        cleanup_steps = [
+            ("stop recording", lambda: api_json(base_url, "/api/recording/stop", method="POST")),
+            ("cleanup simulator clients", lambda: _cleanup_clients(base_url)),
+        ]
+        if run_id is not None:
+            cleanup_steps.insert(1, ("cleanup run", lambda rid=run_id: _cleanup_run(base_url, rid)))
+        run_cleanup_steps(*cleanup_steps)

--- a/apps/server/vibesensor/adapters/simulator/commands.py
+++ b/apps/server/vibesensor/adapters/simulator/commands.py
@@ -104,6 +104,18 @@ def apply_road_fixed_scenario(clients: list[Any]) -> None:
         client.noise_scale = 1.00
 
 
+def apply_engine_order_scenario(clients: list[Any]) -> None:
+    """Apply a deterministic engine-order scenario across all sensors."""
+    for client in clients:
+        client.profile_name = "engine_order"
+        client.scene_mode = "engine-order"
+        client.scene_gain = 0.74
+        client.scene_noise_gain = 1.02
+        client.common_event_gain = 0.10
+        client.amp_scale = 0.94
+        client.noise_scale = 0.98
+
+
 def find_targets(clients: list[Any], token: str) -> list[Any]:
     target = token.strip().lower()
     if target == "all":

--- a/apps/server/vibesensor/adapters/simulator/profiles.py
+++ b/apps/server/vibesensor/adapters/simulator/profiles.py
@@ -70,6 +70,21 @@ PROFILE_LIBRARY: dict[str, Profile] = {
         modulation_hz=0.35,
         modulation_depth=0.10,
     ),
+    "engine_order": Profile(
+        name="engine_order",
+        tones=(
+            (DEFAULT_ORDER_HZ["engine_1x"], (185.0, 128.0, 248.0)),
+            (DEFAULT_ORDER_HZ["engine_2x"], (62.0, 46.0, 92.0)),
+            (DEFAULT_ORDER_HZ["engine_1x"] * 0.5, (30.0, 22.0, 44.0)),
+        ),
+        noise_std=18.0,
+        bump_probability=0.001,
+        bump_decay=0.96,
+        bump_strength=(16.0, 13.0, 24.0),
+        modulation_hz=0.24,
+        modulation_depth=0.10,
+        reference_speed_kmh=DEFAULT_SPEED_KMH,
+    ),
     "rough_road": Profile(
         name="rough_road",
         tones=(

--- a/apps/server/vibesensor/adapters/simulator/sim_sender.py
+++ b/apps/server/vibesensor/adapters/simulator/sim_sender.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from vibesensor.adapters.simulator.commands import (
+    apply_engine_order_scenario,
     apply_one_wheel_mild_scenario,
     apply_road_fixed_scenario,
     choose_default_profile,
@@ -56,6 +57,8 @@ async def async_main(args: argparse.Namespace) -> None:
 
     if args.scenario == "one-wheel-mild":
         apply_one_wheel_mild_scenario(clients, args.fault_wheel)
+    elif args.scenario == "engine-order":
+        apply_engine_order_scenario(clients)
     elif args.scenario == "road-fixed":
         apply_road_fixed_scenario(clients)
 
@@ -154,11 +157,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--scenario",
-        choices=("road", "one-wheel-mild", "road-fixed"),
+        choices=("road", "one-wheel-mild", "engine-order", "road-fixed"),
         default="road",
         help=(
-            "Simulation scenario: random road scene, deterministic mild"
-            " single-wheel fault, or fixed road baseline (no randomization)"
+            "Simulation scenario: random road scene, deterministic mild "
+            "single-wheel fault, deterministic engine-order excitation, "
+            "or fixed road baseline (no randomization)"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- broaden the Docker wheel-fault scenario from a single case to front-left and rear-left localized coverage
- add a new full-stack engine-order Docker E2E path and simulator support for `--scenario engine-order`
- harden the new E2E tests around shared-compose lifecycle cleanup, history visibility, and multiline PDF report assertions

## Validation
- `ruff format --check apps/server/tests_e2e/e2e_helpers.py apps/server/tests_e2e/test_e2e_docker_rear_left_wheel_fault.py apps/server/tests_e2e/test_e2e_docker_engine_order_fault.py`
- `VIBESENSOR_SIM_DURATION=8 pytest -n 0 -q tests_e2e/test_e2e_docker_rear_left_wheel_fault.py`
- `VIBESENSOR_SIM_DURATION=8 pytest -n 0 -q tests_e2e/test_e2e_docker_engine_order_fault.py`
- `python3 tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck`
- `VIBESENSOR_SIM_DURATION=8 pytest -n 0 -q tests_e2e/test_e2e_docker_rear_left_wheel_fault.py tests_e2e/test_e2e_docker_engine_order_fault.py`

Fixes #1013
