### PR TITLE
Remove history projector injection from services

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -5,13 +5,18 @@ import io
 import json
 import zipfile
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from fastapi import FastAPI, WebSocketDisconnect
 from test_support import response_payload as _response_payload
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
+from vibesensor.adapters.history import (
+    ProjectedHistoryExportService,
+    ProjectedHistoryRunService,
+    prepare_history_report_analysis,
+)
 from vibesensor.adapters.http import create_router
 from vibesensor.adapters.http.dependencies import (
     HistoryDeps,
@@ -21,7 +26,6 @@ from vibesensor.adapters.http.dependencies import (
     UpdateDeps,
 )
 from vibesensor.infra.runtime import RuntimeHealthState
-from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.reports import HistoryReportService, PdfRendererFn
 from vibesensor.use_cases.history.runs import HistoryRunService
@@ -29,13 +33,17 @@ from vibesensor.use_cases.history.runs import HistoryRunService
 
 def _real_pdf_renderer(analysis_summary: dict, test_run: object | None) -> bytes:
     """Default test renderer wiring the real adapter pipeline."""
-    from typing import cast
-
     from vibesensor.adapters.pdf.mapping import map_summary
     from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
     from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+    from vibesensor.shared.types.json_types import JsonObject
 
-    summary = cast(AnalysisSummary, analysis_summary)
+    projected_summary, projected_test_run = prepare_history_report_analysis(
+        cast(JsonObject, analysis_summary)
+    )
+    if projected_test_run is not None:
+        test_run = projected_test_run
+    summary = cast(AnalysisSummary, projected_summary)
     return build_report_pdf(map_summary(summary, test_run=test_run))
 
 
@@ -272,20 +280,21 @@ class FakeState:
         self.health_state.mark_ready()
         self.update_manager = MagicMock()
         self.esp_flash_manager = MagicMock()
-        self.run_service = HistoryRunService(
-            self.history_db,
-            self.settings_store,
-            analysis_projector=project_analysis_summary,
+        self.run_service = ProjectedHistoryRunService(
+            HistoryRunService(
+                self.history_db,
+                self.settings_store,
+            )
         )
         self.report_service = HistoryReportService(
             self.history_db,
             self.settings_store,
-            analysis_projector=project_analysis_summary,
             pdf_renderer=pdf_renderer,
         )
-        self.export_service = HistoryExportService(
-            self.history_db,
-            analysis_projector=project_analysis_summary,
+        self.export_service = ProjectedHistoryExportService(
+            HistoryExportService(
+                self.history_db,
+            )
         )
 
     @property

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -13,6 +13,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vibesensor.adapters.history import (
+    ProjectedHistoryExportService,
+    ProjectedHistoryRunService,
+)
 from vibesensor.adapters.http.dependencies import (
     HistoryDeps,
     RouterDeps,
@@ -21,7 +25,6 @@ from vibesensor.adapters.http.dependencies import (
     UpdateDeps,
 )
 from vibesensor.infra.runtime import ProcessingLoopState, RuntimeHealthState
-from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.reports import HistoryReportService
 from vibesensor.use_cases.history.runs import HistoryRunService
@@ -62,22 +65,23 @@ class FakeState:
     def __post_init__(self) -> None:
         self.health_state.mark_ready()
         if self.run_service is None:
-            self.run_service = HistoryRunService(
-                self.history_db,
-                self.settings_store,
-                analysis_projector=project_analysis_summary,
+            self.run_service = ProjectedHistoryRunService(
+                HistoryRunService(
+                    self.history_db,
+                    self.settings_store,
+                )
             )
         if self.report_service is None:
             self.report_service = HistoryReportService(
                 self.history_db,
                 self.settings_store,
-                analysis_projector=project_analysis_summary,
                 pdf_renderer=lambda _summary, _test_run: b"%PDF-stub",
             )
         if self.export_service is None:
-            self.export_service = HistoryExportService(
-                self.history_db,
-                analysis_projector=project_analysis_summary,
+            self.export_service = ProjectedHistoryExportService(
+                HistoryExportService(
+                    self.history_db,
+                )
             )
 
     @property

--- a/apps/server/tests/integration/test_decode_project_roundtrip.py
+++ b/apps/server/tests/integration/test_decode_project_roundtrip.py
@@ -19,13 +19,13 @@ from test_support import (
 )
 
 from vibesensor.adapters.analysis_summary import analysis_result_to_summary
+from vibesensor.adapters.history import build_projected_run_details_json
 from vibesensor.adapters.pdf.mapping import map_summary
 from vibesensor.adapters.pdf.report_data import ReportTemplateData
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.domain import DiagnosticCase, TestRun
 from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.use_cases.diagnostics import AnalysisResult, RunAnalysis
-from vibesensor.use_cases.history.exports import build_run_details_json
 
 # -- helpers ---------------------------------------------------------------
 
@@ -187,11 +187,10 @@ def test_export_from_reconstructed_aggregate(tmp_path: Path) -> None:
     direct_summary = analysis_result_to_summary(result)
     run = _persist_and_reload(tmp_path, direct_summary)
 
-    export_json = build_run_details_json(
+    export_json = build_projected_run_details_json(
         run,
         sample_count=35,
         run_id=_RUN_ID,
-        analysis_projector=project_analysis_summary,
     )
     export_data = json.loads(export_json)
 
@@ -240,11 +239,10 @@ def test_cross_boundary_domain_meaning_consistency(tmp_path: Path) -> None:
     assert direct_card_names == reloaded_card_names
 
     # 3. Export-level consistency
-    export_json = build_run_details_json(
+    export_json = build_projected_run_details_json(
         run,
         sample_count=35,
         run_id=_RUN_ID,
-        analysis_projector=project_analysis_summary,
     )
     export_data = json.loads(export_json)
     export_analysis = export_data["analysis"]

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -9,7 +9,11 @@ from typing import Any
 
 import pytest
 
-from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
+from vibesensor.adapters.history import (
+    ProjectedHistoryExportService,
+    ProjectedHistoryRunService,
+    build_projected_run_details_json,
+)
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.use_cases.history.exports import HistoryExportService, build_run_details_json
 from vibesensor.use_cases.history.reports import HistoryReportPdfCache, HistoryReportService
@@ -45,7 +49,6 @@ def test_raise_delete_run_error_maps_unknown_reason_to_domain_error() -> None:
 async def test_delete_service_uses_delete_reason_mapping() -> None:
     service = HistoryRunService(
         _HistoryDbStub(delete_result=(False, "active")),
-        analysis_projector=project_analysis_summary,
     )
 
     with pytest.raises(AnalysisNotReadyError, match="Cannot delete the active run"):
@@ -65,7 +68,6 @@ async def test_report_service_load_report_request_uses_persisted_language() -> N
                 "analysis": {"lang": "nl", "findings": [], "title": "X"},
             },
         ),
-        analysis_projector=project_analysis_summary,
         pdf_renderer=lambda _s, _t: b"%PDF-stub",
     )
 
@@ -77,33 +79,34 @@ async def test_report_service_load_report_request_uses_persisted_language() -> N
 
 
 @pytest.mark.asyncio
-async def test_run_service_projects_persisted_summary_through_domain() -> None:
-    service = HistoryRunService(
-        _HistoryDbStub(
-            run={
-                "run_id": "run-1",
-                "status": "complete",
-                "analysis": {
-                    "lang": "en",
-                    "findings": [
-                        {
-                            "finding_id": "F001",
-                            "suspected_source": "wheel/tire",
-                            "strongest_location": "front-left",
-                            "strongest_speed_band": "50-80 km/h",
-                            "confidence": 0.71,
-                            "evidence_metrics": {"vibration_strength_db": 21.0},
-                        },
-                    ],
-                    "top_causes": [],
-                    "test_plan": [],
-                    "run_suitability": [],
-                    "most_likely_origin": {},
-                    "_internal": {"secret": True},
+async def test_projected_run_service_projects_persisted_summary_through_domain() -> None:
+    service = ProjectedHistoryRunService(
+        HistoryRunService(
+            _HistoryDbStub(
+                run={
+                    "run_id": "run-1",
+                    "status": "complete",
+                    "analysis": {
+                        "lang": "en",
+                        "findings": [
+                            {
+                                "finding_id": "F001",
+                                "suspected_source": "wheel/tire",
+                                "strongest_location": "front-left",
+                                "strongest_speed_band": "50-80 km/h",
+                                "confidence": 0.71,
+                                "evidence_metrics": {"vibration_strength_db": 21.0},
+                            },
+                        ],
+                        "top_causes": [],
+                        "test_plan": [],
+                        "run_suitability": [],
+                        "most_likely_origin": {},
+                        "_internal": {"secret": True},
+                    },
                 },
-            },
-        ),
-        analysis_projector=project_analysis_summary,
+            ),
+        )
     )
 
     run = await service.get_run("run-1")
@@ -114,33 +117,15 @@ async def test_run_service_projects_persisted_summary_through_domain() -> None:
     assert "_internal" not in analysis
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_cache_builds_once_per_key() -> None:
-    cache = HistoryReportPdfCache()
-    calls = 0
-
-    def _build() -> bytes:
-        nonlocal calls
-        calls += 1
-        return b"%PDF-cache"
-
-    first = await cache.get_or_build(("run-1", "nl"), _build, run_id="run-1")
-    second = await cache.get_or_build(("run-1", "nl"), _build, run_id="run-1")
-
-    assert calls == 1
-    assert first == second == b"%PDF-cache"
-
-
 def test_build_run_details_json_strips_internal_analysis_fields() -> None:
     payload = json.loads(
         build_run_details_json(
-            {
+            run={
                 "run_id": "run-1",
                 "analysis": {"visible": 1, "_internal": {"secret": True}},
             },
             sample_count=5,
             run_id="run-1",
-            analysis_projector=project_analysis_summary,
         ),
     )
 
@@ -150,7 +135,7 @@ def test_build_run_details_json_strips_internal_analysis_fields() -> None:
 
 def test_build_run_details_json_projects_analysis_through_domain() -> None:
     payload = json.loads(
-        build_run_details_json(
+        build_projected_run_details_json(
             {
                 "run_id": "run-1",
                 "analysis": {
@@ -170,7 +155,6 @@ def test_build_run_details_json_projects_analysis_through_domain() -> None:
             },
             sample_count=5,
             run_id="run-1",
-            analysis_projector=project_analysis_summary,
         ),
     )
 
@@ -192,7 +176,6 @@ def test_build_run_details_json_sanitizes_non_finite_floats() -> None:
         },
         sample_count=3,
         run_id="run-nan",
-        analysis_projector=project_analysis_summary,
     )
 
     # Must be parseable by json.loads (no NaN/Infinity)
@@ -203,23 +186,22 @@ def test_build_run_details_json_sanitizes_non_finite_floats() -> None:
     assert payload["analysis"]["valid"] == 42.5
 
 
-def test_export_archive_builder_creates_csv_and_json_entries() -> None:
-    service = HistoryExportService(
-        _HistoryDbStub(
-            samples=[{"run_id": "run-1", "t_s": 1.0, "custom": "x"}],
-        ),
-        analysis_projector=project_analysis_summary,
+@pytest.mark.asyncio
+async def test_export_archive_builder_creates_csv_and_json_entries() -> None:
+    service = ProjectedHistoryExportService(
+        HistoryExportService(
+            _HistoryDbStub(
+                run={
+                    "run_id": "run-1",
+                    "analysis": {"score": 1, "_internal": "secret"},
+                },
+                samples=[{"run_id": "run-1", "t_s": 1.0, "custom": "x"}],
+            ),
+        )
     )
 
-    spool = service._build_zip_file(
-        {
-            "run_id": "run-1",
-            "analysis": {"score": 1, "_internal": "secret"},
-        },
-        "run-1",
-    )
-    body = spool.read()
-    spool.close()
+    export = await service.build_export("run-1")
+    body = b"".join(export.iter_bytes())
 
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         assert set(archive.namelist()) == {"run-1.json", "run-1_raw.csv"}
@@ -229,3 +211,20 @@ def test_export_archive_builder_creates_csv_and_json_entries() -> None:
     assert exported["analysis"] == {"score": 1}
     assert "extras" not in rows[0]
     assert "custom" not in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_builds_once_per_key() -> None:
+    cache = HistoryReportPdfCache()
+    calls = 0
+
+    def _build() -> bytes:
+        nonlocal calls
+        calls += 1
+        return b"%PDF-cache"
+
+    first = await cache.get_or_build(("run-1", "nl"), _build, run_id="run-1")
+    second = await cache.get_or_build(("run-1", "nl"), _build, run_id="run-1")
+
+    assert calls == 1
+    assert first == second == b"%PDF-cache"

--- a/apps/server/vibesensor/adapters/history.py
+++ b/apps/server/vibesensor/adapters/history.py
@@ -1,0 +1,153 @@
+"""History delivery adapters that re-project persisted summaries at the edge."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+import zipfile
+from typing import TYPE_CHECKING
+
+from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
+from vibesensor.shared.types.json_types import JsonObject, is_json_object
+from vibesensor.use_cases.history.exports import (
+    EXPORT_SPOOL_THRESHOLD,
+    HistoryExportContext,
+    HistoryExportDownload,
+    HistoryExportService,
+    build_run_details_json,
+)
+from vibesensor.use_cases.history.helpers import HistoryRecord, strip_internal_fields
+from vibesensor.use_cases.history.runs import HistoryRunService
+
+if TYPE_CHECKING:
+    from vibesensor.domain import TestRun
+
+
+def _has_projectable_analysis(analysis: JsonObject) -> bool:
+    return isinstance(analysis.get("findings"), list) or isinstance(
+        analysis.get("top_causes"), list
+    )
+
+
+def _project_history_analysis(
+    analysis: JsonObject,
+    *,
+    strip_internal: bool,
+) -> tuple[JsonObject, TestRun | None]:
+    if _has_projectable_analysis(analysis):
+        projected, test_run = project_analysis_summary(analysis)
+    else:
+        projected = dict(analysis)
+        test_run = None
+    if strip_internal:
+        projected = strip_internal_fields(projected)
+    return projected, test_run
+
+
+def project_history_run_record(run: HistoryRecord) -> HistoryRecord:
+    """Project persisted analysis fields in a history run for API responses."""
+    analysis = run.get("analysis")
+    if not is_json_object(analysis):
+        return run
+    projected, _ = _project_history_analysis(analysis, strip_internal=True)
+    return {**run, "analysis": projected}
+
+
+def project_history_insights(analysis: JsonObject) -> JsonObject:
+    """Project persisted insights payloads for HTTP responses."""
+    projected, _ = _project_history_analysis(analysis, strip_internal=True)
+    return projected
+
+
+def prepare_history_report_analysis(analysis: JsonObject) -> tuple[JsonObject, TestRun | None]:
+    """Project persisted report analysis for PDF rendering without stripping template data."""
+    return _project_history_analysis(analysis, strip_internal=False)
+
+
+def build_projected_run_details_json(
+    run: HistoryRecord,
+    sample_count: int,
+    run_id: str,
+) -> str:
+    """Build the exported JSON metadata document with canonical projected analysis."""
+    analysis = run.get("analysis")
+    if not is_json_object(analysis):
+        return build_run_details_json(run, sample_count, run_id)
+    projected, _ = _project_history_analysis(analysis, strip_internal=True)
+    return build_run_details_json(
+        {**run, "analysis": projected},
+        sample_count=sample_count,
+        run_id=run_id,
+    )
+
+
+class ProjectedHistoryRunService:
+    """Adapter that projects persisted history analysis before HTTP delivery."""
+
+    __slots__ = ("_service",)
+
+    def __init__(self, service: HistoryRunService) -> None:
+        self._service = service
+
+    async def list_runs(self) -> list[JsonObject]:
+        return await self._service.list_runs()
+
+    async def get_run(self, run_id: str) -> HistoryRecord:
+        return project_history_run_record(await self._service.get_run(run_id))
+
+    async def get_insights(
+        self,
+        run_id: str,
+        requested_lang: str | None = None,
+    ) -> JsonObject | None:
+        result = await self._service.get_insights(run_id, requested_lang=requested_lang)
+        if result is None:
+            return None
+        return project_history_insights(result)
+
+    async def delete_run(self, run_id: str) -> dict[str, str]:
+        return await self._service.delete_run(run_id)
+
+
+class ProjectedHistoryExportService:
+    """Adapter that packages projected history exports for HTTP delivery."""
+
+    __slots__ = ("_service",)
+
+    def __init__(self, service: HistoryExportService) -> None:
+        self._service = service
+
+    async def build_export(self, run_id: str) -> HistoryExportDownload:
+        context = await self._service.build_export_context(run_id)
+        return await asyncio.to_thread(self._build_export_download, context)
+
+    def _build_export_download(self, context: HistoryExportContext) -> HistoryExportDownload:
+        spool: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(
+            max_size=EXPORT_SPOOL_THRESHOLD,
+        )
+        try:
+            with zipfile.ZipFile(spool, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+                context.raw_csv_spool.seek(0)
+                with archive.open(f"{context.safe_name}_raw.csv", mode="w") as raw_csv:
+                    shutil.copyfileobj(context.raw_csv_spool, raw_csv)
+                archive.writestr(
+                    f"{context.safe_name}.json",
+                    build_projected_run_details_json(
+                        context.run,
+                        sample_count=context.sample_count,
+                        run_id=context.run_id,
+                    ),
+                )
+            file_size = spool.seek(0, 2)
+            spool.seek(0)
+            return HistoryExportDownload(
+                filename=f"{context.safe_name}.zip",
+                file_size=file_size,
+                spool=spool,
+            )
+        except BaseException:
+            spool.close()
+            raise
+        finally:
+            context.raw_csv_spool.close()

--- a/apps/server/vibesensor/adapters/http/dependencies.py
+++ b/apps/server/vibesensor/adapters/http/dependencies.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
 from vibesensor.infra.runtime.registry import ClientRegistry
-from vibesensor.use_cases.history.exports import HistoryExportService
-from vibesensor.use_cases.history.reports import HistoryReportService
-from vibesensor.use_cases.history.runs import HistoryRunService
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.use_cases.history.exports import HistoryExportDownload
+from vibesensor.use_cases.history.helpers import HistoryRecord
+from vibesensor.use_cases.history.reports import HistoryReportPdf
 from vibesensor.use_cases.run import RunRecorder
 from vibesensor.use_cases.updates.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.manager import UpdateManager
@@ -21,6 +22,28 @@ if TYPE_CHECKING:
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
     from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
     from vibesensor.adapters.websocket.hub import WebSocketHub
+
+
+class HistoryRunServiceProtocol(Protocol):
+    async def list_runs(self) -> list[JsonObject]: ...
+
+    async def get_run(self, run_id: str) -> HistoryRecord: ...
+
+    async def get_insights(
+        self,
+        run_id: str,
+        requested_lang: str | None = None,
+    ) -> JsonObject | None: ...
+
+    async def delete_run(self, run_id: str) -> dict[str, str]: ...
+
+
+class HistoryReportServiceProtocol(Protocol):
+    async def build_pdf(self, run_id: str, requested_lang: str | None) -> HistoryReportPdf: ...
+
+
+class HistoryExportServiceProtocol(Protocol):
+    async def build_export(self, run_id: str) -> HistoryExportDownload: ...
 
 
 @dataclass(slots=True)
@@ -42,9 +65,9 @@ class SettingsDeps:
 
 @dataclass(slots=True)
 class HistoryDeps:
-    run_service: HistoryRunService
-    report_service: HistoryReportService
-    export_service: HistoryExportService
+    run_service: HistoryRunServiceProtocol
+    report_service: HistoryReportServiceProtocol
+    export_service: HistoryExportServiceProtocol
 
 
 @dataclass(slots=True)

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -16,16 +16,18 @@ from vibesensor.shared.types.api_models import (
 )
 
 if TYPE_CHECKING:
-    from vibesensor.use_cases.history.exports import HistoryExportService
-    from vibesensor.use_cases.history.reports import HistoryReportService
-    from vibesensor.use_cases.history.runs import HistoryRunService
+    from vibesensor.adapters.http.dependencies import (
+        HistoryExportServiceProtocol,
+        HistoryReportServiceProtocol,
+        HistoryRunServiceProtocol,
+    )
 
 
 def create_history_routes(
     *,
-    run_service: HistoryRunService,
-    report_service: HistoryReportService,
-    export_service: HistoryExportService,
+    run_service: HistoryRunServiceProtocol,
+    report_service: HistoryReportServiceProtocol,
+    export_service: HistoryExportServiceProtocol,
 ) -> APIRouter:
     """Create and return the run-history / report API routes."""
     router = APIRouter()

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -4,6 +4,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+from vibesensor.adapters.history import (
+    ProjectedHistoryExportService,
+    ProjectedHistoryRunService,
+    prepare_history_report_analysis,
+)
 from vibesensor.adapters.http.dependencies import (
     HistoryDeps,
     RouterDeps,
@@ -27,7 +32,6 @@ from vibesensor.sensor_units import ADXL345_SCALE_G_PER_LSB, SENSOR_MODEL
 
 if TYPE_CHECKING:
     from vibesensor.domain import TestRun
-from vibesensor.shared.boundaries.diagnostic_case import project_analysis_summary
 from vibesensor.shared.constants import (
     FFT_N,
     FFT_UPDATE_HZ,
@@ -54,8 +58,14 @@ def _build_pdf_bytes(analysis_summary: dict, test_run: TestRun | None) -> bytes:
     from vibesensor.adapters.pdf.mapping import map_summary
     from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
     from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+    from vibesensor.shared.types.json_types import JsonObject
 
-    summary = cast(AnalysisSummary, analysis_summary)
+    prepared_summary, prepared_test_run = prepare_history_report_analysis(
+        cast(JsonObject, analysis_summary)
+    )
+    summary = cast(AnalysisSummary, prepared_summary)
+    if prepared_test_run is not None:
+        test_run = prepared_test_run
     mapped = map_summary(summary, test_run=test_run)
     return build_report_pdf(mapped)
 
@@ -91,21 +101,20 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     )
 
     # persistence services
-    run_service = HistoryRunService(
+    history_run_service = HistoryRunService(
         history_db,
         settings_store,
-        analysis_projector=project_analysis_summary,
     )
     report_service = HistoryReportService(
         history_db,
         settings_store,
-        analysis_projector=project_analysis_summary,
         pdf_renderer=_build_pdf_bytes,
     )
-    export_service = HistoryExportService(
+    history_export_service = HistoryExportService(
         history_db,
-        analysis_projector=project_analysis_summary,
     )
+    run_service = ProjectedHistoryRunService(history_run_service)
+    export_service = ProjectedHistoryExportService(history_export_service)
 
     # ingress
     registry = ClientRegistry(

--- a/apps/server/vibesensor/use_cases/history/exports.py
+++ b/apps/server/vibesensor/use_cases/history/exports.py
@@ -8,7 +8,6 @@ import io
 import json
 import logging
 import tempfile
-import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TypeGuard
@@ -17,7 +16,6 @@ from vibesensor.shared.json_utils import sanitize_for_json
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 from vibesensor.use_cases.history.helpers import (
-    AnalysisProjector,
     HistoryRecord,
     async_require_run,
     safe_filename,
@@ -99,82 +97,71 @@ class HistoryExportDownload:
             self.spool.close()
 
 
+@dataclass
+class HistoryExportContext:
+    """Raw export artifacts ready for adapter-level packaging."""
+
+    run_id: str
+    safe_name: str
+    run: HistoryRecord
+    sample_count: int
+    raw_csv_spool: tempfile.SpooledTemporaryFile[bytes]
+
+
 class HistoryExportService:
-    """Build ZIP exports for history runs without route-local business logic."""
+    """Load raw export artifacts for history runs without delivery-layer shaping."""
 
-    __slots__ = ("_analysis_projector", "_history_db")
+    __slots__ = ("_history_db",)
 
-    def __init__(
-        self,
-        history_db: RunPersistence,
-        *,
-        analysis_projector: AnalysisProjector,
-    ) -> None:
-        self._analysis_projector = analysis_projector
+    def __init__(self, history_db: RunPersistence) -> None:
         self._history_db = history_db
 
-    async def build_export(self, run_id: str) -> HistoryExportDownload:
+    async def build_export_context(self, run_id: str) -> HistoryExportContext:
         run = await async_require_run(self._history_db, run_id)
-        spool = await asyncio.to_thread(self._build_zip_file, run, run_id)
-        file_size = spool.seek(0, 2)
-        spool.seek(0)
-        return HistoryExportDownload(
-            filename=f"{safe_filename(run_id)}.zip",
-            file_size=file_size,
-            spool=spool,
+        raw_csv_spool, sample_count = await asyncio.to_thread(self._build_raw_csv_spool, run_id)
+        return HistoryExportContext(
+            run_id=run_id,
+            safe_name=safe_filename(run_id),
+            run=run,
+            sample_count=sample_count,
+            raw_csv_spool=raw_csv_spool,
         )
 
-    def _build_zip_file(
+    def _build_raw_csv_spool(
         self,
-        run: HistoryRecord,
         run_id: str,
-    ) -> tempfile.SpooledTemporaryFile[bytes]:
+    ) -> tuple[tempfile.SpooledTemporaryFile[bytes], int]:
         sample_count = 0
-        safe_name = safe_filename(run_id)
         spool: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(
             max_size=EXPORT_SPOOL_THRESHOLD,
         )
         try:
-            with zipfile.ZipFile(spool, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-                with archive.open(f"{safe_name}_raw.csv", mode="w") as raw_csv:
-                    raw_csv_text = io.TextIOWrapper(raw_csv, encoding="utf-8", newline="")
-                    writer = csv.DictWriter(
-                        raw_csv_text,
-                        fieldnames=EXPORT_CSV_COLUMNS,
-                        extrasaction="ignore",
-                    )
-                    writer.writeheader()
-                    for batch in self._history_db.iter_run_samples(
-                        run_id,
-                        batch_size=EXPORT_BATCH_SIZE,
-                    ):
-                        sample_count += len(batch)
-                        writer.writerows(flatten_for_csv(row) for row in batch)
-                    raw_csv_text.flush()
-
-                archive.writestr(
-                    f"{safe_name}.json",
-                    build_run_details_json(
-                        run,
-                        sample_count,
-                        run_id,
-                        analysis_projector=self._analysis_projector,
-                    ),
-                )
-
+            raw_csv_text = io.TextIOWrapper(spool, encoding="utf-8", newline="")
+            writer = csv.DictWriter(
+                raw_csv_text,
+                fieldnames=EXPORT_CSV_COLUMNS,
+                extrasaction="ignore",
+            )
+            writer.writeheader()
+            for batch in self._history_db.iter_run_samples(
+                run_id,
+                batch_size=EXPORT_BATCH_SIZE,
+            ):
+                sample_count += len(batch)
+                writer.writerows(flatten_for_csv(row) for row in batch)
+            raw_csv_text.flush()
+            raw_csv_text.detach()
             spool.seek(0)
         except BaseException:
             spool.close()
             raise
-        return spool
+        return spool, sample_count
 
 
 def build_run_details_json(
     run: HistoryRecord,
     sample_count: int,
     run_id: str,
-    *,
-    analysis_projector: AnalysisProjector,
 ) -> str:
     """Build the exported JSON metadata document for a history run."""
     run_details: JsonObject = {}
@@ -184,13 +171,7 @@ def build_run_details_json(
     run_details["sample_count"] = sample_count
     analysis = run_details.get("analysis")
     if is_json_object(analysis):
-        has_findings = isinstance(analysis.get("findings"), list)
-        has_top_causes = isinstance(analysis.get("top_causes"), list)
-        if has_findings or has_top_causes:
-            projected, _ = analysis_projector(analysis)
-            run_details["analysis"] = strip_internal_fields(projected)
-        else:
-            run_details["analysis"] = strip_internal_fields(dict(analysis))
+        run_details["analysis"] = strip_internal_fields(dict(analysis))
     sanitized, had_non_finite = sanitize_for_json(run_details)
     if had_non_finite:
         LOGGER.warning("Export run %s: sanitized non-finite floats in analysis data", run_id)

--- a/apps/server/vibesensor/use_cases/history/helpers.py
+++ b/apps/server/vibesensor/use_cases/history/helpers.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from typing_extensions import TypedDict
 
@@ -23,11 +22,7 @@ from vibesensor.shared.exceptions import (
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 
-if TYPE_CHECKING:
-    from vibesensor.domain import TestRun
-
 _SAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._-]")
-AnalysisProjector = Callable[[JsonObject], tuple[JsonObject, "TestRun"]]
 
 
 class HistoryRecord(TypedDict, total=False):

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -21,7 +21,6 @@ from vibesensor.shared.ports import RunPersistence, SettingsReader
 from vibesensor.shared.run_context import add_current_context_warnings, current_car_snapshot_token
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.use_cases.history.helpers import (
-    AnalysisProjector,
     HistoryRecord,
     async_require_run,
     require_analysis_ready,
@@ -64,7 +63,6 @@ class HistoryReportService:
     """Load persisted report data and coordinate cached PDF generation."""
 
     __slots__ = (
-        "_analysis_projector",
         "_history_db",
         "_pdf_cache",
         "_pdf_renderer",
@@ -76,10 +74,8 @@ class HistoryReportService:
         history_db: RunPersistence,
         settings_store: SettingsReader | None = None,
         *,
-        analysis_projector: AnalysisProjector,
         pdf_renderer: PdfRendererFn,
     ) -> None:
-        self._analysis_projector = analysis_projector
         self._history_db = history_db
         self._pdf_cache = HistoryReportPdfCache()
         self._pdf_renderer = pdf_renderer
@@ -121,7 +117,6 @@ class HistoryReportService:
             analysis,
             current_active_car_snapshot=current_active_car_snapshot,
         )
-        analysis_summary, domain_test_run = self._analysis_projector(analysis_summary)
         cache_key = self._report_pdf_cache_key(
             run,
             run_id,
@@ -132,7 +127,6 @@ class HistoryReportService:
             cache_key=cache_key,
             filename=f"{safe_filename(run_id)}_report.pdf",
             analysis_summary=analysis_summary,
-            domain_test_run=domain_test_run,
         )
 
     @staticmethod

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -11,7 +11,6 @@ from vibesensor.shared.ports import RunPersistence, SettingsReader
 from vibesensor.shared.run_context import add_current_context_warnings, localize_warning_list
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.use_cases.history.helpers import (
-    AnalysisProjector,
     HistoryRecord,
     async_require_run,
     require_analysis_ready,
@@ -23,16 +22,13 @@ from vibesensor.use_cases.history.helpers import (
 class HistoryRunService:
     """Run queries and delete operations used by history endpoints."""
 
-    __slots__ = ("_analysis_projector", "_history_db", "_settings_store")
+    __slots__ = ("_history_db", "_settings_store")
 
     def __init__(
         self,
         history_db: RunPersistence,
         settings_store: SettingsReader | None = None,
-        *,
-        analysis_projector: AnalysisProjector,
     ) -> None:
-        self._analysis_projector = analysis_projector
         self._history_db = history_db
         self._settings_store = settings_store
 
@@ -43,15 +39,6 @@ class HistoryRunService:
         run = await async_require_run(self._history_db, run_id)
         analysis = run.get("analysis")
         if is_json_object(analysis):
-            if isinstance(analysis.get("findings"), list) or isinstance(
-                analysis.get("top_causes"), list
-            ):
-                projected, _ = self._analysis_projector(analysis)
-                updated_run: HistoryRecord = {
-                    **run,
-                    "analysis": strip_internal_fields(projected),
-                }
-                return updated_run
             return {**run, "analysis": strip_internal_fields(dict(analysis))}
         return run
 
@@ -67,10 +54,6 @@ class HistoryRunService:
 
         raw_analysis = require_analysis_ready(run)
         analysis: JsonObject = dict(raw_analysis)
-        if isinstance(raw_analysis.get("findings"), list) or isinstance(
-            raw_analysis.get("top_causes"), list
-        ):
-            analysis, _ = self._analysis_projector(raw_analysis)
         current_active_car_snapshot = (
             self._settings_store.active_car_snapshot() if self._settings_store is not None else None
         )

--- a/docs/metrics_to_report_mapping.md
+++ b/docs/metrics_to_report_mapping.md
@@ -11,9 +11,10 @@ values; it reads exclusively from `ReportTemplateData` (built by
 ```
 adapters.analysis_summary.summarize_run_data(meta, samples)
   → summary dict (persisted in history_db as a versioned analysis envelope)
-    → adapters.pdf.mapping.map_summary(summary)
-      → ReportTemplateData (rebuilt on demand)
-        → history_services.reports.HistoryReportService + report.pdf_engine.build_report_pdf(ReportTemplateData)
+    → adapters.history.prepare_history_report_analysis(summary)
+      → adapters.pdf.mapping.map_summary(summary)
+        → ReportTemplateData (rebuilt on demand)
+          → history_services.reports.HistoryReportService + report.pdf_engine.build_report_pdf(ReportTemplateData)
           → PDF bytes
 ```
 

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -9,8 +9,10 @@ The report generation pipeline has two distinct phases:
    then created at the boundary by `vibesensor.shared.boundaries.analysis_summary`
    / `vibesensor.adapters.analysis_summary`.
 2. **Report rendering** (`vibesensor.adapters.pdf`) — loads the persisted
-   `ReportTemplateData` and renders a PDF.  This phase performs **zero
-   analysis** — it only formats and lays out pre-computed data.
+   analysis summary, re-projects domain-owned fields at the history/PDF
+   boundary, rebuilds `ReportTemplateData`, and renders a PDF. This phase
+   performs **zero analysis** — it only canonicalizes persisted summary data
+   and formats pre-computed results.
 
 ```text
 Recording stops
@@ -26,6 +28,8 @@ Recording stops
 
 GET /api/history/{run_id}/report.pdf [vibesensor.adapters.http.history]
   → HistoryReportService.build_pdf() [vibesensor.use_cases.history.reports]
+    → prepare_history_report_analysis() [vibesensor.adapters.history]
+    → _build_pdf_bytes() [vibesensor.app.container]
     → build_report_pdf(data) [vibesensor.adapters.pdf.pdf_engine]
 ```
 


### PR DESCRIPTION
## Summary
- move persisted summary re-projection out of `use_cases/history` and into delivery adapters / the PDF renderer boundary
- keep history run/report/export services projector-free by returning raw history data and export context only
- update history tests and docs to match the new boundary ownership

## Testing
- pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py apps/server/tests/integration/test_decode_project_roundtrip.py
- pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/http
- PATH="$PWD/.venv/bin:$PATH" make lint
- make typecheck-backend
- python3 tools/dev/docs_lint.py
- docker compose up -d + `vibesensor-sim --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` (connected clients `before=0`, `during=2`, `after=0` on `http://127.0.0.1:8000`)

Closes #1017