### PR TITLE
Replace SummaryWarningPayload with app-level warning models

### DIFF
--- a/apps/server/tests/shared/boundaries/test_summary_warning.py
+++ b/apps/server/tests/shared/boundaries/test_summary_warning.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.summary_warning import (
+    localize_warning_list,
+    summary_warning_payloads,
+)
+from vibesensor.shared.run_context import RunContextWarning
+
+
+def test_summary_warning_payloads_keep_existing_wire_shape() -> None:
+    warnings = [
+        RunContextWarning(
+            code="reference_context_incomplete",
+            severity="warn",
+            applies_to="order_analysis",
+            title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+            detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+        )
+    ]
+
+    assert summary_warning_payloads(warnings) == [
+        {
+            "code": "reference_context_incomplete",
+            "severity": "warn",
+            "applies_to": "order_analysis",
+            "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+            "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+        }
+    ]
+
+
+def test_localize_warning_list_resolves_run_context_warning_models() -> None:
+    warnings = [
+        RunContextWarning(
+            code="reference_context_incomplete",
+            severity="warn",
+            applies_to="order_analysis",
+            title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+            detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+        )
+    ]
+
+    assert localize_warning_list(warnings, lang="nl") == [
+        {
+            "code": "reference_context_incomplete",
+            "severity": "warn",
+            "applies_to": "order_analysis",
+            "title": "De referentiecontext voor ordeanalyse was onvolledig voor deze run",
+            "detail": (
+                "Voor deze run ontbreekt een deel van de wiel-/motorreferentie die "
+                "nodig is voor betrouwbare ordeanalyse. Ordegebaseerde bevindingen "
+                "kunnen nog steeds worden getoond, maar behandel ze als voorlopig "
+                "totdat de run met volledige voertuigreferentiegegevens wordt "
+                "herhaald."
+            ),
+        }
+    ]

--- a/apps/server/tests/shared/test_run_context.py
+++ b/apps/server/tests/shared/test_run_context.py
@@ -8,8 +8,13 @@ import pytest
 
 from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot, RunContextSnapshot
 from vibesensor.shared.run_context import (
+    WARNING_CODE_CAR_SETTINGS_CHANGED,
+    WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+    RunContextWarning,
+    add_current_context_warnings,
     apply_run_context_snapshot,
     build_run_context_snapshot,
+    build_summary_warnings,
     current_car_snapshot_token,
     order_reference_context_complete,
 )
@@ -189,3 +194,54 @@ class TestBoundaryHelpers:
             "variant": "track",
             "aspects": {"rim_in": 19.0, "tire_width_mm": 255.0},
         }
+
+
+class TestRunContextWarnings:
+    def test_build_summary_warnings_returns_app_level_models(self) -> None:
+        warnings = build_summary_warnings(
+            {"incomplete_for_order_analysis": True},
+            reference_complete=False,
+        )
+
+        assert warnings == [
+            RunContextWarning(
+                code=WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+                severity="warn",
+                applies_to="order_analysis",
+                title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+                detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+            )
+        ]
+
+    def test_add_current_context_warnings_returns_app_level_models(self) -> None:
+        warnings = add_current_context_warnings(
+            [
+                RunContextWarning(
+                    code=WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+                    severity="warn",
+                    applies_to="order_analysis",
+                    title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+                    detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+                )
+            ],
+            metadata={
+                "active_car_snapshot": {
+                    "id": "car-a",
+                    "name": "Track Car",
+                    "type": "coupe",
+                    "aspects": {"tire_width_mm": 245.0},
+                }
+            },
+            current_active_car_snapshot=CarSnapshot(
+                car_id="car-b",
+                name="Daily Car",
+                car_type="wagon",
+                aspects={"tire_width_mm": 225.0},
+            ),
+        )
+
+        assert [warning.code for warning in warnings] == [
+            WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+            WARNING_CODE_CAR_SETTINGS_CHANGED,
+        ]
+        assert all(isinstance(warning, RunContextWarning) for warning in warnings)

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -25,6 +25,7 @@ from vibesensor.shared.boundaries.summary_serialization import (
     build_summary_payload,
     serialize_plot_data,
 )
+from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.run_context import build_summary_warnings
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import JsonObject
@@ -104,9 +105,11 @@ def analysis_result_to_summary(result: AnalysisResultLike) -> AnalysisSummary:
         accel_stats=result.accel_stats,
         amp_metric_values=_amp_metric_values(result.accel_stats),
     )
-    summary["warnings"] = build_summary_warnings(
-        result.metadata,
-        reference_complete=result.reference_complete,
+    summary["warnings"] = summary_warning_payloads(
+        build_summary_warnings(
+            result.metadata,
+            reference_complete=result.reference_complete,
+        )
     )
     summary["report_date"] = result.metadata.get("end_time_utc") or utc_now_iso()
     summary["plots"] = serialize_plot_data(result.plot_data)

--- a/apps/server/vibesensor/shared/boundaries/summary_warning.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_warning.py
@@ -1,0 +1,60 @@
+"""Boundary serialization helpers for run-context summary warnings."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from vibesensor.report_i18n import tr as _tr
+from vibesensor.shared.boundaries.analysis_payload import SummaryWarningPayload
+from vibesensor.shared.run_context import RunContextWarning, normalize_run_context_warnings
+from vibesensor.shared.types.json_types import JsonObject
+
+
+def summary_warning_payload(warning: RunContextWarning) -> SummaryWarningPayload:
+    """Serialize a run-context warning into the persisted/API summary payload shape."""
+    payload: SummaryWarningPayload = {
+        "code": warning.code,
+        "severity": warning.severity,
+        "applies_to": warning.applies_to,
+        "title": warning.title,
+        "detail": warning.detail,
+    }
+    return payload
+
+
+def summary_warning_payloads(warnings: object) -> list[SummaryWarningPayload]:
+    """Serialize warning models into the summary payload list shape."""
+    return [
+        summary_warning_payload(warning) for warning in normalize_run_context_warnings(warnings)
+    ]
+
+
+def localize_warning_list(
+    warnings: object,
+    *,
+    lang: str,
+) -> list[JsonObject]:
+    """Resolve warning models into response-ready text at the HTTP boundary."""
+    localized: list[JsonObject] = []
+    for warning in normalize_run_context_warnings(warnings):
+        localized.append(
+            {
+                "code": warning.code,
+                "severity": warning.severity,
+                "applies_to": warning.applies_to,
+                "title": _resolve_i18n(lang, warning.title),
+                "detail": _resolve_optional_i18n(lang, warning.detail),
+            },
+        )
+    return localized
+
+
+def _resolve_optional_i18n(lang: str, value: object) -> str | None:
+    resolved = _resolve_i18n(lang, value).strip()
+    return resolved or None
+
+
+def _resolve_i18n(lang: str, value: object) -> str:
+    from vibesensor.report_i18n import resolve_i18n
+
+    return resolve_i18n(lang, value, tr=partial(_tr, lang))

--- a/apps/server/vibesensor/shared/run_context.py
+++ b/apps/server/vibesensor/shared/run_context.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import cast
+from dataclasses import dataclass
+from typing import Literal, cast
 
 from vibesensor.domain import (
     AnalysisSettingsSnapshot,
@@ -12,14 +13,24 @@ from vibesensor.domain import (
     OrderReferenceSpec,
     RunContextSnapshot,
 )
-from vibesensor.report_i18n import tr as _tr
-from vibesensor.shared.boundaries.analysis_payload import SummaryWarningPayload
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 
 WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE = "reference_context_incomplete"
 WARNING_CODE_CAR_SETTINGS_CHANGED = "car_settings_changed"
+WarningSeverity = Literal["warn", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class RunContextWarning:
+    """App-level warning model shared by diagnostics and history workflows."""
+
+    code: str
+    severity: WarningSeverity
+    applies_to: str
+    title: JsonValue
+    detail: JsonValue | None = None
 
 
 def build_run_context_snapshot(
@@ -76,60 +87,39 @@ def build_summary_warnings(
     metadata: Mapping[str, object],
     *,
     reference_complete: bool,
-) -> list[SummaryWarningPayload]:
+) -> list[RunContextWarning]:
     """Build language-neutral trust warnings stored with the analysis summary."""
-    warnings: list[SummaryWarningPayload] = []
+    warnings: list[RunContextWarning] = []
     if not reference_complete or bool(metadata.get("incomplete_for_order_analysis")):
         warnings.append(
-            {
-                "code": WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
-                "severity": "warn",
-                "applies_to": "order_analysis",
-                "title": i18n_ref("RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"),
-                "detail": i18n_ref("RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"),
-            },
+            RunContextWarning(
+                code=WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+                severity="warn",
+                applies_to="order_analysis",
+                title=i18n_ref("RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"),
+                detail=i18n_ref("RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"),
+            )
         )
     return warnings
 
 
 def add_current_context_warnings(
-    summary: Mapping[str, JsonValue],
-    *,
-    current_active_car_snapshot: CarSnapshot | None,
-) -> JsonObject:
-    """Return a summary copy enriched with dynamic current-context warnings."""
-    enriched = dict(summary)
-    warnings = _normalized_warning_list(enriched.get("warnings"))
-    dynamic_warning = _build_car_settings_changed_warning(
-        enriched.get("metadata"),
-        current_active_car_snapshot=current_active_car_snapshot,
-    )
-    if dynamic_warning is not None and dynamic_warning["code"] not in {
-        str(item.get("code") or "") for item in warnings
-    }:
-        warnings.append(dynamic_warning)
-    enriched["warnings"] = list(warnings)
-    return enriched
-
-
-def localize_warning_list(
     warnings: object,
     *,
-    lang: str,
-) -> list[JsonObject]:
-    """Resolve language-neutral warning entries into response-ready text."""
-    localized: list[JsonObject] = []
-    for warning in _normalized_warning_list(warnings):
-        localized.append(
-            {
-                "code": str(warning.get("code") or ""),
-                "severity": str(warning.get("severity") or "warn"),
-                "applies_to": str(warning.get("applies_to") or "order_analysis"),
-                "title": _resolve_i18n(lang, warning.get("title")),
-                "detail": _resolve_optional_i18n(lang, warning.get("detail")),
-            },
-        )
-    return localized
+    metadata: object,
+    current_active_car_snapshot: CarSnapshot | None,
+) -> list[RunContextWarning]:
+    """Return warning models enriched with any current-context warning."""
+    normalized = normalize_run_context_warnings(warnings)
+    dynamic_warning = _build_car_settings_changed_warning(
+        metadata,
+        current_active_car_snapshot=current_active_car_snapshot,
+    )
+    if dynamic_warning is not None and dynamic_warning.code not in {
+        warning.code for warning in normalized
+    }:
+        normalized.append(dynamic_warning)
+    return normalized
 
 
 def current_car_snapshot_token(current_active_car_snapshot: CarSnapshot | None) -> str:
@@ -146,7 +136,7 @@ def _build_car_settings_changed_warning(
     metadata: object,
     *,
     current_active_car_snapshot: CarSnapshot | None,
-) -> JsonObject | None:
+) -> RunContextWarning | None:
     if not is_json_object(metadata) or current_active_car_snapshot is None:
         return None
     recorded_snapshot = metadata.get("active_car_snapshot")
@@ -155,23 +145,39 @@ def _build_car_settings_changed_warning(
     current_dict = current_active_car_snapshot.to_dict()
     if _normalized_aspects(recorded_snapshot) == _normalized_aspects(current_dict):
         return None
-    return {
-        "code": WARNING_CODE_CAR_SETTINGS_CHANGED,
-        "severity": "warn",
-        "applies_to": "order_analysis",
-        "title": i18n_ref("RUN_CONTEXT_WARNING_CAR_SETTINGS_CHANGED_TITLE"),
-        "detail": i18n_ref(
+    return RunContextWarning(
+        code=WARNING_CODE_CAR_SETTINGS_CHANGED,
+        severity="warn",
+        applies_to="order_analysis",
+        title=i18n_ref("RUN_CONTEXT_WARNING_CAR_SETTINGS_CHANGED_TITLE"),
+        detail=i18n_ref(
             "RUN_CONTEXT_WARNING_CAR_SETTINGS_CHANGED_DETAIL",
             run_car=_car_label(recorded_snapshot),
             current_car=_car_label(current_dict),
         ),
-    }
+    )
 
 
-def _normalized_warning_list(warnings: object) -> list[JsonObject]:
+def normalize_run_context_warnings(warnings: object) -> list[RunContextWarning]:
     if not isinstance(warnings, list):
         return []
-    return [warning for warning in warnings if is_json_object(warning)]
+    normalized: list[RunContextWarning] = []
+    for warning in warnings:
+        if isinstance(warning, RunContextWarning):
+            normalized.append(warning)
+            continue
+        if not is_json_object(warning):
+            continue
+        normalized.append(
+            RunContextWarning(
+                code=str(warning.get("code") or ""),
+                severity=cast(WarningSeverity, str(warning.get("severity") or "warn")),
+                applies_to=str(warning.get("applies_to") or "order_analysis"),
+                title=warning.get("title"),
+                detail=warning.get("detail"),
+            )
+        )
+    return normalized
 
 
 def _normalized_aspects(snapshot: Mapping[str, object]) -> tuple[tuple[str, float], ...]:
@@ -196,16 +202,3 @@ def _car_label(snapshot: Mapping[str, object]) -> str:
     if car_type:
         return car_type
     return "captured vehicle profile"
-
-
-def _resolve_optional_i18n(lang: str, value: object) -> str | None:
-    resolved = _resolve_i18n(lang, value).strip()
-    return resolved or None
-
-
-def _resolve_i18n(lang: str, value: object) -> str:
-    from functools import partial
-
-    from vibesensor.report_i18n import resolve_i18n
-
-    return resolve_i18n(lang, value, tr=partial(_tr, lang))

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -13,13 +13,14 @@ import logging
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from vibesensor.domain import CarSnapshot
+from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.exceptions import AnalysisNotReadyError, ProcessingError
 from vibesensor.shared.ports import RunPersistence, SettingsReader
 from vibesensor.shared.run_context import add_current_context_warnings, current_car_snapshot_token
-from vibesensor.shared.types.json_types import JsonObject, is_json_object
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 from vibesensor.use_cases.history.helpers import (
     HistoryRecord,
     async_require_run,
@@ -113,10 +114,13 @@ class HistoryReportService:
         current_active_car_snapshot = (
             self._settings_store.active_car_snapshot() if self._settings_store is not None else None
         )
-        analysis_summary = add_current_context_warnings(
-            analysis,
+        warnings = add_current_context_warnings(
+            analysis.get("warnings"),
+            metadata=analysis.get("metadata"),
             current_active_car_snapshot=current_active_car_snapshot,
         )
+        analysis_summary = dict(analysis)
+        analysis_summary["warnings"] = cast(JsonValue, summary_warning_payloads(warnings))
         cache_key = self._report_pdf_cache_key(
             run,
             run_id,

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Never
+from typing import Never, cast
 
 from vibesensor.domain import RunStatus
+from vibesensor.shared.boundaries.summary_warning import localize_warning_list
 from vibesensor.shared.exceptions import AnalysisNotReadyError, RunNotFoundError
 from vibesensor.shared.ports import RunPersistence, SettingsReader
-from vibesensor.shared.run_context import add_current_context_warnings, localize_warning_list
-from vibesensor.shared.types.json_types import JsonObject, is_json_object
+from vibesensor.shared.run_context import add_current_context_warnings
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 from vibesensor.use_cases.history.helpers import (
     HistoryRecord,
     async_require_run,
@@ -57,16 +58,13 @@ class HistoryRunService:
         current_active_car_snapshot = (
             self._settings_store.active_car_snapshot() if self._settings_store is not None else None
         )
-        analysis = add_current_context_warnings(
-            analysis,
+        warnings = add_current_context_warnings(
+            analysis.get("warnings"),
+            metadata=analysis.get("metadata"),
             current_active_car_snapshot=current_active_car_snapshot,
         )
         response_lang = resolve_run_language(run, requested_lang)
-        localized_warnings = localize_warning_list(
-            analysis.get("warnings"),
-            lang=response_lang,
-        )
-        analysis["warnings"] = list(localized_warnings)
+        analysis["warnings"] = cast(JsonValue, localize_warning_list(warnings, lang=response_lang))
         analysis["run_id"] = str(run.get("run_id") or run_id)
         analysis["status"] = RunStatus.COMPLETE.value
 


### PR DESCRIPTION
## Summary
- introduce an app-level `RunContextWarning` model in shared run-context logic
- move warning payload serialization and HTTP localization into `shared/boundaries/summary_warning.py`
- keep persisted/history/report warning payloads unchanged while removing `SummaryWarningPayload` from shared logic

## Testing
- pytest -q apps/server/tests/shared/test_run_context.py apps/server/tests/shared/boundaries/test_summary_warning.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
- pytest -q apps/server/tests/shared apps/server/tests/use_cases/history apps/server/tests/adapters/http apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/integration/test_decode_project_roundtrip.py
- PATH="$PWD/.venv/bin:$PATH" make lint
- make typecheck-backend
- docker compose up -d + `vibesensor-sim --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` (connected clients `before=0`, `during=2`, `after=0` on `http://127.0.0.1:8000`)

Closes #1018