### PR TITLE
Split analysis_payload schemas from serializer helpers

### DIFF
--- a/apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import vibesensor.shared.boundaries.analysis_payload as analysis_payload
+
+
+def test_analysis_payload_module_stays_schema_only() -> None:
+    assert not hasattr(analysis_payload, "matched_point_from_observation")
+    assert not hasattr(analysis_payload, "OrderMatchObservation")

--- a/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from vibesensor.domain import Finding, VibrationSource
+from vibesensor.domain import Finding, OrderMatchObservation, VibrationSource
 from vibesensor.shared.boundaries.finding import finding_payload_from_domain
 
 
@@ -43,3 +43,37 @@ def test_projection_omits_removed_dead_contract_fields() -> None:
         "grouped_count",
         "diagnostic_caveat",
     }.isdisjoint(payload)
+
+
+def test_projection_serializes_matched_points_with_boundary_shape() -> None:
+    payload = finding_payload_from_domain(
+        Finding(
+            finding_id="F001",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            matched_points=(
+                OrderMatchObservation(
+                    t_s=1.5,
+                    speed_kmh=62.0,
+                    predicted_hz=11.2,
+                    matched_hz=11.4,
+                    rel_error=0.018,
+                    amp=0.42,
+                    location="front-left",
+                    phase="cruise",
+                ),
+            ),
+        )
+    )
+
+    assert payload["matched_points"] == [
+        {
+            "t_s": 1.5,
+            "speed_kmh": 62.0,
+            "predicted_hz": 11.2,
+            "matched_hz": 11.4,
+            "rel_error": 0.018,
+            "amp": 0.42,
+            "location": "front-left",
+            "phase": "cruise",
+        }
+    ]

--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, NotRequired, Required, TypedDict
 
-from vibesensor.domain import OrderMatchObservation
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
 if TYPE_CHECKING:
@@ -35,7 +34,6 @@ __all__ = [
     "RunSuitabilityCheck",
     "SpectrogramResult",
     "SpeedBreakdownRow",
-    "matched_point_from_observation",
 ]
 
 
@@ -484,22 +482,3 @@ class AnalysisSummary(TypedDict):
     samples: NotRequired[list[JsonObject]]
     plots: NotRequired[PlotDataResult]
     analysis_metadata: NotRequired[JsonObject]
-
-
-# ---------------------------------------------------------------------------
-# Serializer helpers
-# ---------------------------------------------------------------------------
-
-
-def matched_point_from_observation(obs: OrderMatchObservation) -> MatchedPoint:
-    """Serialize a domain ``OrderMatchObservation`` to a boundary ``MatchedPoint`` dict."""
-    return MatchedPoint(
-        t_s=obs.t_s,
-        speed_kmh=obs.speed_kmh,
-        predicted_hz=obs.predicted_hz,
-        matched_hz=obs.matched_hz,
-        rel_error=obs.rel_error,
-        amp=obs.amp,
-        location=obs.location,
-        phase=obs.phase,
-    )

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -17,8 +17,8 @@ from vibesensor.domain import Finding, FindingEvidence, Signature, VibrationSour
 from vibesensor.domain.order_match import OrderMatchObservation
 from vibesensor.domain.test_plan import RecommendedAction, TestPlan
 from vibesensor.shared.boundaries.analysis_payload import (
+    MatchedPoint,
     TestPlanStepPayload,
-    matched_point_from_observation,
 )
 from vibesensor.shared.boundaries.vibration_origin import (
     location_hotspot_from_payload,
@@ -27,6 +27,20 @@ from vibesensor.shared.boundaries.vibration_origin import (
 from vibesensor.shared.json_utils import i18n_ref
 
 _MAX_SIGNATURES_PER_FINDING: int = 3
+
+
+def matched_point_from_observation(obs: OrderMatchObservation) -> MatchedPoint:
+    """Serialize a domain ``OrderMatchObservation`` to a boundary ``MatchedPoint`` dict."""
+    return MatchedPoint(
+        t_s=obs.t_s,
+        speed_kmh=obs.speed_kmh,
+        predicted_hz=obs.predicted_hz,
+        matched_hz=obs.matched_hz,
+        rel_error=obs.rel_error,
+        amp=obs.amp,
+        location=obs.location,
+        phase=obs.phase,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep `shared/boundaries/analysis_payload.py` as the pure payload-schema contract surface
- move `matched_point_from_observation()` into `shared/boundaries/finding.py`, which already owns finding sub-object serialization
- add guardrails that `analysis_payload` no longer exposes serializer helpers while matched-point payload serialization stays unchanged

## Testing
- `pytest -q apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py`
- `pytest -q apps/server/tests/shared apps/server/tests/use_cases/history apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- Docker smoke via `docker compose up -d` + `vibesensor-sim --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` (`connected` clients `before=0`, `during=2`, `after=0`)

Closes #1021