### PR TITLE
Split updater installer workflows

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 
 import pytest
 
+from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator
+from vibesensor.use_cases.updates.firmware_refresh import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
+from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
 from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
 
 
@@ -112,7 +115,7 @@ async def test_snapshot_for_rollback_fails_when_metadata_write_fails(tmp_path: P
 
     with (
         patch("vibesensor.__version__", "2025.6.14"),
-        patch.object(UpdateInstaller, "_write_rollback_metadata", side_effect=OSError("disk full")),
+        patch.object(RollbackSnapshotStore, "write_metadata", side_effect=OSError("disk full")),
     ):
         assert await installer.snapshot_for_rollback() is False
 
@@ -178,4 +181,45 @@ async def test_rollback_without_metadata_uses_valid_newest_wheel(tmp_path: Path)
         "Rollback metadata missing; falling back to newest rollback wheel without checksum pin"
         in line
         for line in tracker.status.log_tail
+    )
+
+
+def test_wheel_validator_rejects_corrupt_wheel_without_installer(tmp_path: Path) -> None:
+    tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "update_status.json"))
+    validator = WheelArtifactValidator(tracker)
+    broken_wheel = tmp_path / "broken.whl"
+    broken_wheel.write_text("not a wheel", encoding="utf-8")
+
+    ok = validator.validate_wheel(
+        broken_wheel,
+        phase="installing",
+        context="Downloaded wheel",
+        fatal=False,
+    )
+
+    assert not ok
+    assert any(issue.message == "Downloaded wheel is corrupt" for issue in tracker.status.issues)
+
+
+@pytest.mark.asyncio
+async def test_firmware_refresher_uses_module_fallback_without_installer(tmp_path: Path) -> None:
+    installer, commands, tracker = _make_installer(tmp_path)
+    refresher = FirmwareRefresher(
+        commands=commands,
+        tracker=tracker,
+        repo=installer._config.repo,
+        timeout_s=30,
+    )
+
+    await refresher.refresh_esp_firmware("server-v2025.6.15")
+
+    assert any(
+        call[0][:3]
+        == [
+            str(installer._config.repo / "apps" / "server" / ".venv" / "bin" / "python3"),
+            "-m",
+            "vibesensor.use_cases.updates.firmware_cache",
+        ]
+        and call[0][-2:] == ["--tag", "server-v2025.6.15"]
+        for call in commands.calls
     )

--- a/apps/server/tests/use_cases/updates/test_update_manager_models.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vibesensor.use_cases.updates.installer import UpdateInstaller
 from vibesensor.use_cases.updates.models import (
     UpdateIssue,
     UpdateJobStatus,
@@ -10,6 +9,10 @@ from vibesensor.use_cases.updates.models import (
     UpdateState,
 )
 from vibesensor.use_cases.updates.runner import sanitize_log_line as sanitize_log_line
+from vibesensor.use_cases.updates.venv_paths import (
+    is_reinstall_venv_ready,
+    reinstall_python_executable,
+)
 from vibesensor.use_cases.updates.wifi import parse_wifi_diagnostics
 
 
@@ -53,13 +56,13 @@ class TestUpdaterInterpreterSelection:
         venv_python.write_text("#!/usr/bin/env python3\n")
         venv_python.chmod(0o755)
         (repo / "apps" / "server" / ".venv" / "pyvenv.cfg").write_text("home = /usr/bin\n")
-        assert UpdateInstaller.reinstall_python_executable(repo) == str(venv_python)
+        assert reinstall_python_executable(repo) == str(venv_python)
 
     def test_reinstall_python_uses_server_venv_path_even_if_missing(self, tmp_path) -> None:
         repo = tmp_path / "repo"
         repo.mkdir()
         expected = repo / "apps" / "server" / ".venv" / "bin" / "python3"
-        assert UpdateInstaller.reinstall_python_executable(repo) == str(expected)
+        assert reinstall_python_executable(repo) == str(expected)
 
     def test_reinstall_venv_readiness_requires_pyvenv_cfg(self, tmp_path) -> None:
         repo = tmp_path / "repo"
@@ -67,9 +70,9 @@ class TestUpdaterInterpreterSelection:
         venv_python.parent.mkdir(parents=True)
         venv_python.write_text("#!/usr/bin/env python3\n")
         venv_python.chmod(0o755)
-        assert not UpdateInstaller.is_reinstall_venv_ready(repo)
+        assert not is_reinstall_venv_ready(repo)
         (repo / "apps" / "server" / ".venv" / "pyvenv.cfg").write_text("home = /usr/bin\n")
-        assert UpdateInstaller.is_reinstall_venv_ready(repo)
+        assert is_reinstall_venv_ready(repo)
 
 
 class TestSanitizeLogLine:

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -12,9 +12,13 @@ Module topology
   privileges, rollback storage, and disk space before update orchestration.
 - **Services**: ``manager.py`` — backend restart scheduling and runtime update
   lifecycle orchestration.
-- **Operations**: ``installer.py`` (install/rollback), ``wifi.py`` (Wi-Fi
-  connect/restore, diagnostics, and default-config assembly), ``releases.py``
-  (GitHub release discovery), ``runner.py`` (process execution and
+- **Operations**: ``installer.py`` (install/rollback orchestration),
+  ``artifact_validation.py`` (wheel validation + checksums),
+  ``rollback_snapshot.py`` (rollback metadata + stored wheels),
+  ``firmware_refresh.py`` (ESP firmware cache refresh),
+  ``venv_paths.py`` (reinstall venv discovery),
+  ``wifi.py`` (Wi-Fi connect/restore, diagnostics, and default-config assembly),
+  ``releases.py`` (GitHub release discovery), ``runner.py`` (process execution and
   command helpers), ``firmware_release_fetcher.py`` (GitHub firmware HTTP
   discovery/download), ``firmware_bundle.py`` (firmware bundle filesystem
   validation/extraction/metadata), ``firmware_types.py`` (firmware cache

--- a/apps/server/vibesensor/use_cases/updates/artifact_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/artifact_validation.py
@@ -1,0 +1,116 @@
+"""Wheel artifact validation helpers for updater workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from pathlib import Path
+
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+
+__all__ = ["WheelArtifactValidator", "sha256_file"]
+
+
+class WheelArtifactValidator:
+    """Validate updater wheel artifacts and report failures through the status tracker."""
+
+    __slots__ = ("_tracker",)
+
+    def __init__(self, tracker: UpdateStatusTracker) -> None:
+        self._tracker = tracker
+
+    def _report_failure(
+        self,
+        *,
+        phase: str,
+        message: str,
+        detail: str,
+        fatal: bool,
+    ) -> None:
+        if fatal:
+            self._tracker.fail(phase, message, detail)
+        else:
+            self._tracker.add_issue(phase, message, detail)
+
+    def validate_wheel(
+        self,
+        wheel_path: Path,
+        *,
+        phase: str,
+        context: str,
+        fatal: bool,
+        expected_sha256: str | None = None,
+    ) -> bool:
+        if not wheel_path.is_file():
+            self._report_failure(
+                phase=phase,
+                message=f"{context} is missing",
+                detail=str(wheel_path),
+                fatal=fatal,
+            )
+            return False
+        if wheel_path.suffix != ".whl":
+            self._report_failure(
+                phase=phase,
+                message=f"{context} is not a wheel",
+                detail=str(wheel_path),
+                fatal=fatal,
+            )
+            return False
+        if not zipfile.is_zipfile(wheel_path):
+            self._report_failure(
+                phase=phase,
+                message=f"{context} is corrupt",
+                detail=f"{wheel_path} is not a valid wheel archive",
+                fatal=fatal,
+            )
+            return False
+        try:
+            with zipfile.ZipFile(wheel_path) as wheel_zip:
+                bad_member = wheel_zip.testzip()
+                if bad_member is not None:
+                    self._report_failure(
+                        phase=phase,
+                        message=f"{context} is corrupt",
+                        detail=f"{wheel_path} failed archive CRC validation at {bad_member}",
+                        fatal=fatal,
+                    )
+                    return False
+                if not any(name.endswith(".dist-info/METADATA") for name in wheel_zip.namelist()):
+                    self._report_failure(
+                        phase=phase,
+                        message=f"{context} is incomplete",
+                        detail=f"{wheel_path} is missing dist-info metadata",
+                        fatal=fatal,
+                    )
+                    return False
+        except (OSError, zipfile.BadZipFile) as exc:
+            self._report_failure(
+                phase=phase,
+                message=f"{context} could not be opened",
+                detail=f"{wheel_path}: {exc}",
+                fatal=fatal,
+            )
+            return False
+        if expected_sha256:
+            actual_sha256 = sha256_file(wheel_path)
+            if actual_sha256 != expected_sha256.lower():
+                self._report_failure(
+                    phase=phase,
+                    message=f"{context} checksum mismatch",
+                    detail=(
+                        f"expected={expected_sha256.lower()} actual={actual_sha256} "
+                        f"path={wheel_path}"
+                    ),
+                    fatal=fatal,
+                )
+                return False
+        return True
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/apps/server/vibesensor/use_cases/updates/firmware_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware_refresh.py
@@ -1,0 +1,58 @@
+"""ESP firmware cache refresh collaborator for updater runs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
+
+__all__ = ["FirmwareRefresher"]
+
+
+class FirmwareRefresher:
+    """Refresh the updater firmware cache independently from install orchestration."""
+
+    __slots__ = ("_commands", "_repo", "_timeout_s", "_tracker")
+
+    def __init__(
+        self,
+        *,
+        commands: UpdateCommandExecutor,
+        tracker: UpdateStatusTracker,
+        repo: Path,
+        timeout_s: float,
+    ) -> None:
+        self._commands = commands
+        self._tracker = tracker
+        self._repo = repo
+        self._timeout_s = timeout_s
+
+    async def refresh_esp_firmware(self, pinned_tag: str = "") -> None:
+        self._tracker.log("Refreshing ESP firmware cache...")
+        venv_python = reinstall_python_executable(self._repo)
+        refresh_exe = str(Path(venv_python).with_name("vibesensor-fw-refresh"))
+        refresh_args = ["--cache-dir", "/var/lib/vibesensor/firmware"]
+        if pinned_tag:
+            refresh_args.extend(["--tag", pinned_tag])
+        refresh_cmd = (
+            [venv_python, "-m", "vibesensor.use_cases.updates.firmware_cache", *refresh_args]
+            if not Path(refresh_exe).is_file()
+            else [refresh_exe, *refresh_args]
+        )
+        rc, _, stderr = await self._commands.run(
+            refresh_cmd,
+            phase="downloading",
+            timeout=self._timeout_s,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.add_issue(
+                "downloading",
+                f"ESP firmware cache refresh failed (exit {rc})",
+                stderr,
+            )
+            self._tracker.log("ESP firmware refresh failed; continuing with existing cache")
+            return
+        self._tracker.log("ESP firmware cache refresh completed successfully")

--- a/apps/server/vibesensor/use_cases/updates/installer.py
+++ b/apps/server/vibesensor/use_cases/updates/installer.py
@@ -1,27 +1,19 @@
-"""Local install, rollback, and firmware-refresh operations for updater runs."""
+"""Local install and rollback orchestration for updater runs."""
 
 from __future__ import annotations
 
-import hashlib
-import json
-import os
 import tempfile
-import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator, sha256_file
+from vibesensor.use_cases.updates.rollback_snapshot import (
+    RollbackSnapshotMetadata,
+    RollbackSnapshotStore,
+)
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-
-
-@dataclass(frozen=True, slots=True)
-class RollbackSnapshotMetadata:
-    version: str
-    wheel_name: str
-    sha256: str
-
-
-_ROLLBACK_METADATA_FILE = "rollback_snapshot.json"
+from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,9 +25,9 @@ class UpdateInstallerConfig:
 
 
 class UpdateInstaller:
-    """Owns install, rollback snapshotting, rollback, and firmware cache refresh."""
+    """Owns install, rollback snapshot orchestration, and rollback execution."""
 
-    __slots__ = ("_commands", "_config", "_tracker")
+    __slots__ = ("_commands", "_config", "_rollback_snapshots", "_tracker", "_wheel_validator")
 
     def __init__(
         self,
@@ -47,195 +39,12 @@ class UpdateInstaller:
         self._commands = commands
         self._tracker = tracker
         self._config = config
-
-    def _rollback_metadata_path(self) -> Path:
-        return self._config.rollback_dir / _ROLLBACK_METADATA_FILE
-
-    def _write_rollback_metadata(self, metadata: RollbackSnapshotMetadata) -> None:
-        self._config.rollback_dir.mkdir(parents=True, exist_ok=True)
-        payload = (
-            json.dumps(
-                {
-                    "version": metadata.version,
-                    "wheel_name": metadata.wheel_name,
-                    "sha256": metadata.sha256,
-                },
-                indent=2,
-            )
-            + "\n"
-        )
-        fd, temp_path_text = tempfile.mkstemp(
-            prefix=".rollback_snapshot.",
-            suffix=".tmp",
-            dir=self._config.rollback_dir,
-            text=True,
-        )
-        temp_path = Path(temp_path_text)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(payload)
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(temp_path, self._rollback_metadata_path())
-        finally:
-            temp_path.unlink(missing_ok=True)
-
-    def _rollback_wheels(self) -> list[Path]:
-        return sorted(
-            self._config.rollback_dir.glob("vibesensor-*.whl"),
-            key=lambda path: path.stat().st_mtime,
-            reverse=True,
-        )
-
-    def _prune_rollback_wheels(self, *, keep_name: str) -> None:
-        for old_wheel in self._rollback_wheels():
-            if old_wheel.name != keep_name:
-                old_wheel.unlink(missing_ok=True)
-
-    def _load_rollback_metadata(self) -> RollbackSnapshotMetadata | None:
-        metadata_path = self._rollback_metadata_path()
-        if not metadata_path.is_file():
-            return None
-        try:
-            raw = json.loads(metadata_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            self._tracker.add_issue(
-                "installing",
-                "Rollback metadata is unreadable",
-                f"{metadata_path}: {exc}",
-            )
-            return None
-        version = str(raw.get("version") or "")
-        wheel_name = str(raw.get("wheel_name") or "")
-        sha256 = str(raw.get("sha256") or "")
-        if not version or not wheel_name or not sha256:
-            self._tracker.add_issue(
-                "installing",
-                "Rollback metadata is incomplete",
-                f"{metadata_path} is missing version, wheel_name, or sha256",
-            )
-            return None
-        return RollbackSnapshotMetadata(version=version, wheel_name=wheel_name, sha256=sha256)
-
-    def _report_artifact_validation_failure(
-        self,
-        *,
-        phase: str,
-        message: str,
-        detail: str,
-        fatal: bool,
-    ) -> None:
-        if fatal:
-            self._tracker.fail(phase, message, detail)
-        else:
-            self._tracker.add_issue(phase, message, detail)
-
-    def _validate_wheel_file(
-        self,
-        wheel_path: Path,
-        *,
-        phase: str,
-        context: str,
-        fatal: bool,
-        expected_sha256: str | None = None,
-    ) -> bool:
-        if not wheel_path.is_file():
-            self._report_artifact_validation_failure(
-                phase=phase,
-                message=f"{context} is missing",
-                detail=str(wheel_path),
-                fatal=fatal,
-            )
-            return False
-        if wheel_path.suffix != ".whl":
-            self._report_artifact_validation_failure(
-                phase=phase,
-                message=f"{context} is not a wheel",
-                detail=str(wheel_path),
-                fatal=fatal,
-            )
-            return False
-        if not zipfile.is_zipfile(wheel_path):
-            self._report_artifact_validation_failure(
-                phase=phase,
-                message=f"{context} is corrupt",
-                detail=f"{wheel_path} is not a valid wheel archive",
-                fatal=fatal,
-            )
-            return False
-        try:
-            with zipfile.ZipFile(wheel_path) as wheel_zip:
-                bad_member = wheel_zip.testzip()
-                if bad_member is not None:
-                    self._report_artifact_validation_failure(
-                        phase=phase,
-                        message=f"{context} is corrupt",
-                        detail=f"{wheel_path} failed archive CRC validation at {bad_member}",
-                        fatal=fatal,
-                    )
-                    return False
-                if not any(name.endswith(".dist-info/METADATA") for name in wheel_zip.namelist()):
-                    self._report_artifact_validation_failure(
-                        phase=phase,
-                        message=f"{context} is incomplete",
-                        detail=f"{wheel_path} is missing dist-info metadata",
-                        fatal=fatal,
-                    )
-                    return False
-        except (OSError, zipfile.BadZipFile) as exc:
-            self._report_artifact_validation_failure(
-                phase=phase,
-                message=f"{context} could not be opened",
-                detail=f"{wheel_path}: {exc}",
-                fatal=fatal,
-            )
-            return False
-        if expected_sha256:
-            actual_sha256 = _sha256_file(wheel_path)
-            if actual_sha256 != expected_sha256.lower():
-                self._report_artifact_validation_failure(
-                    phase=phase,
-                    message=f"{context} checksum mismatch",
-                    detail=(
-                        f"expected={expected_sha256.lower()} actual={actual_sha256} "
-                        f"path={wheel_path}"
-                    ),
-                    fatal=fatal,
-                )
-                return False
-        return True
-
-    async def refresh_esp_firmware(self, pinned_tag: str = "") -> None:
-        self._tracker.log("Refreshing ESP firmware cache...")
-        venv_python = self.reinstall_python_executable(self._config.repo)
-        refresh_exe = str(Path(venv_python).with_name("vibesensor-fw-refresh"))
-        refresh_args = ["--cache-dir", "/var/lib/vibesensor/firmware"]
-        if pinned_tag:
-            refresh_args.extend(["--tag", pinned_tag])
-        refresh_cmd = (
-            [venv_python, "-m", "vibesensor.use_cases.updates.firmware_cache", *refresh_args]
-            if not Path(refresh_exe).is_file()
-            else [refresh_exe, *refresh_args]
-        )
-        rc, _, stderr = await self._commands.run(
-            refresh_cmd,
-            phase="downloading",
-            timeout=self._config.firmware_refresh_timeout_s,
-            sudo=False,
-        )
-        if rc != 0:
-            self._tracker.add_issue(
-                "downloading",
-                f"ESP firmware cache refresh failed (exit {rc})",
-                stderr,
-            )
-            self._tracker.log("ESP firmware refresh failed; continuing with existing cache")
-            return
-        self._tracker.log("ESP firmware cache refresh completed successfully")
+        self._rollback_snapshots = RollbackSnapshotStore(config.rollback_dir, tracker)
+        self._wheel_validator = WheelArtifactValidator(tracker)
 
     async def snapshot_for_rollback(self) -> bool:
         self._config.rollback_dir.mkdir(parents=True, exist_ok=True)
-        venv_python = self.reinstall_python_executable(self._config.repo)
+        venv_python = reinstall_python_executable(self._config.repo)
         from vibesensor import __version__ as current_version
 
         self._tracker.log(f"Creating rollback snapshot (version={current_version})")
@@ -276,18 +85,18 @@ class UpdateInstaller:
                 )
                 return False
             rollback_wheel = staged_wheels[0]
-            if not self._validate_wheel_file(
+            if not self._wheel_validator.validate_wheel(
                 rollback_wheel,
                 phase="installing",
                 context="Rollback snapshot wheel",
                 fatal=False,
             ):
                 return False
-            rollback_sha256 = _sha256_file(rollback_wheel)
+            rollback_sha256 = sha256_file(rollback_wheel)
             promoted_wheel = self._config.rollback_dir / rollback_wheel.name
             rollback_wheel.replace(promoted_wheel)
             try:
-                self._write_rollback_metadata(
+                self._rollback_snapshots.write_metadata(
                     RollbackSnapshotMetadata(
                         version=current_version,
                         wheel_name=promoted_wheel.name,
@@ -301,7 +110,7 @@ class UpdateInstaller:
                     str(exc),
                 )
                 return False
-            self._prune_rollback_wheels(keep_name=promoted_wheel.name)
+            self._rollback_snapshots.prune_wheels(keep_name=promoted_wheel.name)
             self._tracker.log(
                 "Rollback snapshot created successfully "
                 f"(wheel={promoted_wheel.name}, sha256={rollback_sha256})",
@@ -309,14 +118,14 @@ class UpdateInstaller:
             return True
 
     async def install_release(self, wheel_path: Path, expected_version: str) -> bool:
-        if not self._validate_wheel_file(
+        if not self._wheel_validator.validate_wheel(
             wheel_path,
             phase="installing",
             context="Downloaded wheel",
             fatal=True,
         ):
             return False
-        venv_python = self.reinstall_python_executable(self._config.repo)
+        venv_python = reinstall_python_executable(self._config.repo)
         rc, _, stderr = await self._commands.run(
             [
                 venv_python,
@@ -349,8 +158,8 @@ class UpdateInstaller:
 
     async def rollback(self) -> bool:
         self._tracker.log("Rolling back to previous version...")
-        metadata = self._load_rollback_metadata()
-        rollback_wheels = self._rollback_wheels()
+        metadata = self._rollback_snapshots.load_metadata()
+        rollback_wheels = self._rollback_snapshots.rollback_wheels()
         if not rollback_wheels:
             self._tracker.add_issue("installing", "No rollback wheel available")
             return False
@@ -378,7 +187,7 @@ class UpdateInstaller:
                 "rollback wheel without checksum pin",
             )
 
-        if not self._validate_wheel_file(
+        if not self._wheel_validator.validate_wheel(
             wheel,
             phase="installing",
             context="Rollback wheel",
@@ -387,7 +196,7 @@ class UpdateInstaller:
         ):
             return False
 
-        venv_python = self.reinstall_python_executable(self._config.repo)
+        venv_python = reinstall_python_executable(self._config.repo)
         rc, _, stderr = await self._commands.run(
             [
                 venv_python,
@@ -433,7 +242,7 @@ class UpdateInstaller:
         return True
 
     async def _verify_installed_version(self, *, phase: str) -> str | None:
-        venv_python = self.reinstall_python_executable(self._config.repo)
+        venv_python = reinstall_python_executable(self._config.repo)
         rc, stdout, stderr = await self._commands.run(
             [venv_python, "-c", "from vibesensor import __version__; print(__version__)"],
             phase=phase,
@@ -452,30 +261,3 @@ class UpdateInstaller:
         else:
             self._tracker.add_issue(phase, message, stderr)
         return None
-
-    @staticmethod
-    def reinstall_venv_python_path(repo: Path) -> Path:
-        return repo / "apps" / "server" / ".venv" / "bin" / "python3"
-
-    @staticmethod
-    def reinstall_venv_config_path(repo: Path) -> Path:
-        return repo / "apps" / "server" / ".venv" / "pyvenv.cfg"
-
-    @classmethod
-    def is_reinstall_venv_ready(cls, repo: Path) -> bool:
-        venv_python = cls.reinstall_venv_python_path(repo)
-        if not (venv_python.is_file() and os.access(venv_python, os.X_OK)):
-            return False
-        return cls.reinstall_venv_config_path(repo).is_file()
-
-    @classmethod
-    def reinstall_python_executable(cls, repo: Path) -> str:
-        return str(cls.reinstall_venv_python_path(repo))
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from vibesensor.use_cases.updates.firmware_refresh import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
@@ -208,6 +209,7 @@ class UpdateManager:
             tracker=tracker,
             config=self._installer_config,
         )
+        firmware_refresher = self._build_firmware_refresher(commands=commands)
         cancel_requested = self._cancel_event.is_set
 
         if not await validate_prerequisites(
@@ -241,7 +243,7 @@ class UpdateManager:
             return
         if release_check.release is None:
             tracker.log(f"Already up-to-date (version={current_version})")
-            await installer.refresh_esp_firmware(pinned_tag=release_check.latest_tag)
+            await firmware_refresher.refresh_esp_firmware(pinned_tag=release_check.latest_tag)
             if cancel_requested():
                 return
             await self._complete_update_success(
@@ -274,7 +276,7 @@ class UpdateManager:
             )
             if not await verify_download(tracker, release_check.release, wheel_path):
                 return
-            await installer.refresh_esp_firmware(pinned_tag=release_check.release.tag)
+            await firmware_refresher.refresh_esp_firmware(pinned_tag=release_check.release.tag)
             if cancel_requested():
                 return
 
@@ -380,6 +382,18 @@ class UpdateManager:
                 ap_con_name=self._ap_con_name,
                 wifi_ifname=self._wifi_ifname,
             ),
+        )
+
+    def _build_firmware_refresher(
+        self,
+        *,
+        commands: UpdateCommandExecutor | None = None,
+    ) -> FirmwareRefresher:
+        return FirmwareRefresher(
+            commands=commands or self._build_command_executor(),
+            tracker=self._tracker,
+            repo=self._repo,
+            timeout_s=self._installer_config.firmware_refresh_timeout_s,
         )
 
     async def _snapshot_for_rollback(self) -> bool:

--- a/apps/server/vibesensor/use_cases/updates/releases.py
+++ b/apps/server/vibesensor/use_cases/updates/releases.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 
-from vibesensor.use_cases.updates.installer import _sha256_file
+from vibesensor.use_cases.updates.artifact_validation import sha256_file
 from vibesensor.use_cases.updates.release_fetcher import ReleaseInfo
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
@@ -81,7 +81,7 @@ async def verify_download(
     """Verify SHA-256 digest of a downloaded wheel."""
     if not release.sha256:
         return True
-    actual_sha256 = await asyncio.to_thread(_sha256_file, wheel_path)
+    actual_sha256 = await asyncio.to_thread(sha256_file, wheel_path)
     expected_sha256 = release.sha256.lower()
     if actual_sha256 == expected_sha256:
         tracker.log(f"SHA-256 verified: {actual_sha256}")

--- a/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
@@ -1,0 +1,101 @@
+"""Rollback snapshot storage for updater workflows."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+
+__all__ = ["RollbackSnapshotMetadata", "RollbackSnapshotStore"]
+
+_ROLLBACK_METADATA_FILE = "rollback_snapshot.json"
+
+
+@dataclass(frozen=True, slots=True)
+class RollbackSnapshotMetadata:
+    version: str
+    wheel_name: str
+    sha256: str
+
+
+class RollbackSnapshotStore:
+    """Persist rollback snapshot wheel metadata and manage stored rollback wheels."""
+
+    __slots__ = ("_rollback_dir", "_tracker")
+
+    def __init__(self, rollback_dir: Path, tracker: UpdateStatusTracker) -> None:
+        self._rollback_dir = rollback_dir
+        self._tracker = tracker
+
+    def _metadata_path(self) -> Path:
+        return self._rollback_dir / _ROLLBACK_METADATA_FILE
+
+    def write_metadata(self, metadata: RollbackSnapshotMetadata) -> None:
+        self._rollback_dir.mkdir(parents=True, exist_ok=True)
+        payload = (
+            json.dumps(
+                {
+                    "version": metadata.version,
+                    "wheel_name": metadata.wheel_name,
+                    "sha256": metadata.sha256,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        fd, temp_path_text = tempfile.mkstemp(
+            prefix=".rollback_snapshot.",
+            suffix=".tmp",
+            dir=self._rollback_dir,
+            text=True,
+        )
+        temp_path = Path(temp_path_text)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self._metadata_path())
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def rollback_wheels(self) -> list[Path]:
+        return sorted(
+            self._rollback_dir.glob("vibesensor-*.whl"),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+
+    def prune_wheels(self, *, keep_name: str) -> None:
+        for old_wheel in self.rollback_wheels():
+            if old_wheel.name != keep_name:
+                old_wheel.unlink(missing_ok=True)
+
+    def load_metadata(self) -> RollbackSnapshotMetadata | None:
+        metadata_path = self._metadata_path()
+        if not metadata_path.is_file():
+            return None
+        try:
+            raw = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            self._tracker.add_issue(
+                "installing",
+                "Rollback metadata is unreadable",
+                f"{metadata_path}: {exc}",
+            )
+            return None
+        version = str(raw.get("version") or "")
+        wheel_name = str(raw.get("wheel_name") or "")
+        sha256 = str(raw.get("sha256") or "")
+        if not version or not wheel_name or not sha256:
+            self._tracker.add_issue(
+                "installing",
+                "Rollback metadata is incomplete",
+                f"{metadata_path} is missing version, wheel_name, or sha256",
+            )
+            return None
+        return RollbackSnapshotMetadata(version=version, wheel_name=wheel_name, sha256=sha256)

--- a/apps/server/vibesensor/use_cases/updates/venv_paths.py
+++ b/apps/server/vibesensor/use_cases/updates/venv_paths.py
@@ -1,0 +1,32 @@
+"""Shared path helpers for the updater reinstall virtual environment."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = [
+    "is_reinstall_venv_ready",
+    "reinstall_python_executable",
+    "reinstall_venv_config_path",
+    "reinstall_venv_python_path",
+]
+
+
+def reinstall_venv_python_path(repo: Path) -> Path:
+    return repo / "apps" / "server" / ".venv" / "bin" / "python3"
+
+
+def reinstall_venv_config_path(repo: Path) -> Path:
+    return repo / "apps" / "server" / ".venv" / "pyvenv.cfg"
+
+
+def is_reinstall_venv_ready(repo: Path) -> bool:
+    venv_python = reinstall_venv_python_path(repo)
+    if not (venv_python.is_file() and os.access(venv_python, os.X_OK)):
+        return False
+    return reinstall_venv_config_path(repo).is_file()
+
+
+def reinstall_python_executable(repo: Path) -> str:
+    return str(reinstall_venv_python_path(repo))


### PR DESCRIPTION
## Summary
- split updater artifact validation, rollback snapshot storage, firmware refresh, and venv path helpers into focused modules
- keep `UpdateInstaller` focused on install/rollback orchestration and wire `FirmwareRefresher` directly from `UpdateManager`
- add direct tests for the new validator and firmware refresher so those collaborators can be exercised without importing the full installer workflow

## Testing
- `pytest -q apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/test_update_manager_models.py apps/server/tests/use_cases/updates/test_update_manager_async.py`
- `pytest -q apps/server/tests/use_cases/updates`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- Docker smoke via `docker compose up -d` + `vibesensor-sim --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server` (`connected` clients `before=0`, `during=2`, `after=0`)

Closes #1023