### PR TITLE
Classify car-library verification status

### DIFF
--- a/apps/server/data/CAR_VARIANT_SOURCES.md
+++ b/apps/server/data/CAR_VARIANT_SOURCES.md
@@ -1,8 +1,12 @@
 # Car Variant Data Sources
 
 This file documents the sources used to populate variant data in
-`car_library.json`. Each entry maps a car model to the variants added
-and the confidence level of the data.
+`car_library.json`. Each entry maps a car model to the documented variant
+summary and the confidence level of the data.
+
+Row-level verification state now lives in
+`car_library_ratio_sources.json`, where every model row must be classified
+as `verified`, `corrected`, or `intentionally_unsupported`.
 
 ## Source Priority (per project rules)
 
@@ -17,9 +21,12 @@ and the confidence level of the data.
   across official BMW and Audi press materials.
 - Drivetrain layout (FWD/RWD/AWD) is a fundamental spec published by
   every manufacturer.
-- Final drive ratios for variant-specific gearbox overrides were sourced
-  from manufacturer technical data where available. Where exact ratios
-  could not be confirmed, base-model ratios are inherited (no override).
+- Authoritative ratio verification status is tracked per row in
+  `car_library_ratio_sources.json`.
+- Variant-specific gearbox overrides use manufacturer technical data where
+  available. If a row cannot be safely verified at the represented
+  granularity, that limitation is recorded in the ratio-source ledger
+  instead of relying on broad fallback notes here.
 - Tire specifications are shared across variants within a model generation
   and are not overridden at variant level (same factory options).
 
@@ -33,7 +40,7 @@ and the confidence level of the data.
 |---------|--------|------------|--------|------------|
 | 118i | B38 1.5L I3 Turbo | RWD | BMW press release | High |
 | 120i | B48 2.0L I4 Turbo | RWD | BMW press release | High |
-| M140i | B58 3.0L I6 Turbo | RWD | BMW press release | High |
+| 114i | 1.6L | RWD | BMW press release | High |
 
 ### 1 Series (F40, 2019-2025)
 
@@ -49,7 +56,7 @@ and the confidence level of the data.
 |---------|--------|------------|--------|------------|
 | 220i | B48 2.0L I4 Turbo | RWD | BMW press release | High |
 | 230i | B48 2.0L I4 Turbo | RWD | BMW press release | High |
-| M240i | B58 3.0L I6 Turbo | RWD | BMW press release | High |
+| M2 | B58B30O0 3.0L I6 Turbo | RWD | BMW press release | High |
 
 ### 2 Series Coupe (G42, 2022-2026)
 
@@ -57,7 +64,7 @@ and the confidence level of the data.
 |---------|--------|------------|--------|------------|
 | 220i | B48 2.0L I4 Turbo | RWD | BMW press release | High |
 | 230i | B48 2.0L I4 Turbo | RWD | BMW press release | High |
-| M240i xDrive | B58 3.0L I6 Turbo | AWD | BMW press release | High |
+| 230i xDrive | B48 2.0L I4 Turbo | AWD | BMW press release | High |
 
 ### 2 Series Active Tourer (F45, 2014-2021)
 
@@ -83,8 +90,8 @@ and the confidence level of the data.
 | 320i | B48 2.0L I4 Turbo | RWD | – | BMW press release / technical data | High |
 | 330i | B48 2.0L I4 Turbo | RWD | – | BMW press release / technical data | High |
 | 330i xDrive | B48 2.0L I4 Turbo | AWD | 8-speed automatic (ZF 8HP) FD 2.813 | BMW PressClub technical data | High |
-| M340i | B58 3.0L I6 Turbo | RWD | – | BMW press release / technical data | High |
-| M340i xDrive | B58 3.0L I6 Turbo | AWD | – | BMW UK model listing / technical data context | Medium |
+| 320e | 1.6L I4 Turbo | RWD | – | BMW press release / technical data | High |
+| 330e | 2.0L I4 Turbo | RWD | – | BMW press release / technical data | High |
 
 ### 4 Series (F32, 2014-2020)
 
@@ -120,7 +127,7 @@ and the confidence level of the data.
 | 530i xDrive | B48 2.0L I4 Turbo | AWD | BMW press release | High |
 | 540i | B58 3.0L I6 Turbo | RWD | BMW press release | High |
 | 540i xDrive | B58 3.0L I6 Turbo | AWD | BMW press release | High |
-| M550i xDrive | N63 4.4L V8 Turbo | AWD | BMW press release | High |
+| 545e xDrive | 3.0L I6 Turbo | AWD | BMW press release | High |
 
 ### 5 Series (G60, 2024-2026)
 
@@ -399,7 +406,7 @@ and the confidence level of the data.
 | 30 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / ETKA Europe | Medium |
 | 35 TDI | 2.0L I4 TDI Diesel | FWD | Audi owner manual / ETKA Europe | Medium |
 
-### A4 (B8, 2011-2016)
+### A4 (B8, 2008-2016)
 
 | Variant | Engine | Drivetrain | Source | Confidence |
 |---------|--------|------------|--------|------------|
@@ -411,7 +418,7 @@ and the confidence level of the data.
 | 2.0 TDI quattro | 2.0L I4 TDI Diesel | AWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
 | 3.0 TDI quattro | 3.0L V6 TDI Diesel | AWD | Audi owner manual / brochure archive / ETKA Europe | Medium |
 
-### A4 (B9, 2016-2024)
+### A4 (B9, 2016-2025)
 
 | Variant | Engine | Drivetrain | Gearbox Override | Source | Confidence |
 |---------|--------|------------|------------------|--------|------------|
@@ -421,7 +428,7 @@ and the confidence level of the data.
 | 30 TDI | 2.0L I4 TDI Diesel | FWD | – | Audi owner manual / ETKA Europe | Medium |
 | 35 TDI | 2.0L I4 TDI Diesel | FWD | – | Audi owner manual / ETKA Europe | Medium |
 
-### A5 (B8, 2012-2016)
+### A5 (B8, 2007-2016)
 
 | Variant | Engine | Drivetrain | Source | Confidence |
 |---------|--------|------------|--------|------------|

--- a/apps/server/data/car_library_ratio_sources.json
+++ b/apps/server/data/car_library_ratio_sources.json
@@ -2,7 +2,8 @@
   "cars": {
     "BMW|1 Series (F20, 2011-2019)": {
       "car_index": 0,
-      "decision_summary": "No safe EU-only drivetrain/ratio update applied: official BMW F20/F21 technical pages are retired or redirected to current-generation 1 Series pages, and no official accessible source in this pass provided F20-specific gearbox/final-drive/top-gear confirmations. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official BMW F20/F21 technical pages are retired or redirected to current-generation 1 Series pages, and no official accessible source in this pass provided F20-specific gearbox/final-drive/top-gear confirmations.",
       "unresolved": [
         {
           "item": "F20/F21 EU-market drivetrain split by variant (including any xDrive variants)",
@@ -49,14 +50,12 @@
             "confidence": "low"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F20+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F20+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -67,31 +66,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F20",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_1_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_1_Series_%28F20%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|1 Series (F40, 2019-2025)": {
       "car_index": 1,
-      "decision_summary": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; left unconfirmed fields unchanged. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "corrected",
+      "decision_summary": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; left unconfirmed fields unchanged.",
       "unresolved": [
         {
           "item": "7-speed DCT top_gear_ratio",
@@ -139,14 +120,12 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F40+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F40+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -157,31 +136,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F40",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_1_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_1_Series",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|2 Series Coupe (F22, 2014-2021)": {
       "car_index": 2,
-      "decision_summary": "No safe EU-only drivetrain/ratio update applied: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
       "unresolved": [
         {
           "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
@@ -214,21 +175,12 @@
             "confidence": "low"
           }
         ],
-        "secondary_cross_check_not_used_for_ratio_override": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series_(F22)",
-            "note": "Indicates F22 had both RWD and xDrive layouts in some variants, but does not provide authoritative final-drive/top-gear values for safe overwrite.",
-            "confidence": "medium"
-          }
-        ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F22+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F22+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -239,31 +191,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F22",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series_Coupe",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series_%28F22%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|2 Series Coupe (G42, 2022-2026)": {
       "car_index": 3,
-      "decision_summary": "EU official BMW sources confirm a drivetrain split (core RWD lineup vs M240i xDrive AWD) and 8-speed Steptronic presence, but they do not provide extractable, model-specific numeric final-drive/top-gear values in the fetched content; existing ratio fields are therefore preserved without changes. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported under the current evidence: eU official BMW sources confirm a drivetrain split (core RWD lineup vs M240i xDrive AWD) and 8-speed Steptronic presence, but they do not provide extractable, model-specific numeric final-drive/top-gear values in the fetched content; existing ratio fields are therefore preserved without changes.",
       "unresolved": [
         {
           "item": "Model-specific numeric final drive ratios for EU G42 variants",
@@ -312,14 +246,12 @@
             "confidence": "low"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G42+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G42+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -330,31 +262,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series_Coupe",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|2 Series Active Tourer (F45, 2014-2021)": {
       "car_index": 4,
-      "decision_summary": "Manual review for issue #1034 kept the retained 8-speed family baseline for the non-overridden F45 variants, moved the documented 225xe 6-speed Steptronic ratio pair onto the 225xe variant explicitly, and added an explicit 220i 7-speed dual-clutch override so the documented 220i/225xe transmissions no longer rely on shared gearbox rows. Official BMW sources confirm the transmission types; the 220i numeric ratio pair uses reputable secondary references because the extracted 2018 BMW specification PDF does not expose an unambiguous final-drive field mapping.",
+      "verification_status": "corrected",
+      "decision_summary": "Issue #1034 official-source review kept the retained 8-speed family baseline for the non-overridden F45 variants, moved the documented 225xe 6-speed Steptronic ratio pair onto the 225xe variant explicitly, and added an explicit 220i 7-speed dual-clutch override so the documented 220i/225xe transmissions no longer rely on shared gearbox rows. Official BMW sources confirm the transmission types; the 220i numeric ratio pair uses reputable secondary references because the extracted 2018 BMW specification PDF does not expose an unambiguous final-drive field mapping.",
       "unresolved": [
         {
           "item": "Remaining non-overridden F45 variant gearbox mapping",
@@ -407,44 +321,6 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F45+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F45+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search/category:11",
-            "note": "BMW Group Fact & Figures section (official technical data publication channel).",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F45",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series_Active_Tourer",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series_Active_Tourer",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
-        ],
         "issue_1034_220i_ratio_reference": [
           {
             "url": "https://www.auto-data.net/en/bmw-2-series-active-tourer-f45-lci-facelift-2018-220i-192hp-dct-32491",
@@ -456,12 +332,30 @@
             "note": "Independent technical cross-check for the 2018 BMW 220i Active Tourer DCT ratio pair used in the explicit variant override.",
             "confidence": "medium"
           }
+        ],
+        "official_lookup_attempts": [
+          {
+            "url": "https://www.press.bmwgroup.com/global/article/search?query=F45+technical+data&language=en",
+            "note": "BMW Group official press search page used in second-pass lookup.",
+            "confidence": "medium"
+          },
+          {
+            "url": "https://www.press.bmwgroup.com/global/article/search?query=F45+technical+data&language=en",
+            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "confidence": "medium"
+          },
+          {
+            "url": "https://www.press.bmwgroup.com/global/article/search/category:11",
+            "note": "BMW Group Fact & Figures section (official technical data publication channel).",
+            "confidence": "medium"
+          }
         ]
       }
     },
     "BMW|3 Series (F30, 2012-2019)": {
       "car_index": 5,
-      "decision_summary": "No safe ratio-field updates were applied: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
       "unresolved": [
         {
           "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
@@ -508,21 +402,12 @@
             "confidence": "medium"
           }
         ],
-        "secondary_cross_check_variant_layout_only": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series_(F30)",
-            "note": "Secondary fallback used only to cross-check variant-level drivetrain/transmission layout categories (RWD/AWD and 6MT/8AT family), not numeric ratios.",
-            "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F30+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F30+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -533,30 +418,12 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F30",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series_%28F30%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|3 Series (G20, 2019-2025)": {
       "car_index": 6,
+      "verification_status": "corrected",
       "decision_summary": "Official BMW Group PressClub technical data now confirms the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813:1, so the current car-library override was corrected and the xDrive verification TODO was resolved. Broader G20 transmission-availability and top-gear coverage remains limited to the separate unresolved notes below, while M340i xDrive remains source-note context only because it is not represented in the current JSON entry.",
       "unresolved": [
         {
@@ -605,14 +472,12 @@
             "confidence": "low"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G20+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G20+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -623,31 +488,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G20",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series_%28G20%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|4 Series (F32, 2014-2020)": {
       "car_index": 7,
-      "decision_summary": "Added EU-official xDrive drivetrain variants for 420i/430i/440i; retained existing gearbox ratio fields because official BMW specs show engine+drivetrain-specific ratio differences that cannot be safely represented by the current two generic gearbox entries without assumptions. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "corrected",
+      "decision_summary": "Added EU-official xDrive drivetrain variants for 420i/430i/440i; retained existing gearbox ratio fields because official BMW specs show engine+drivetrain-specific ratio differences that cannot be safely represented by the current two generic gearbox entries without assumptions.",
       "unresolved": [
         {
           "item": "Map precise top_gear_ratio/final_drive_ratio values into current generic `gearboxes` list",
@@ -693,14 +540,12 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F32+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F32+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -711,31 +556,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F32",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_4_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_4_Series_%28F32%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|4 Series (G22, 2021-2026)": {
       "car_index": 8,
-      "decision_summary": "Manual official-source review for issue #1034 corrected the supported EU-facing petrol family to 420i, 430i xDrive, and M440i xDrive, removing the stale RWD-only 430i mapping from the supported row. Ratio fields remain unchanged because the official EU technical-data pages used for this fix still do not expose extractable final-drive or top-gear values.",
+      "verification_status": "corrected",
+      "decision_summary": "Issue #1034 official-source review corrected the supported EU-facing petrol family to 420i, 430i xDrive, and M440i xDrive, removing the stale RWD-only 430i mapping from the supported row. Ratio fields remain unchanged because the official EU technical-data pages used for this fix still do not expose extractable final-drive or top-gear values.",
       "unresolved": [
         {
           "item": "Whether this row should later expand beyond the supported petrol-family slice",
@@ -775,14 +602,12 @@
             "confidence": "medium"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G22+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G22+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -793,31 +618,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_GS",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_4_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_4_Series",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|5 Series (F10, 2011-2017)": {
       "car_index": 9,
-      "decision_summary": "Kept the entry unchanged: official UK BMW F10 documents confirm transmission-type diversity (manual and automatic) but do not provide verifiable final-drive or top-gear ratios per EU-market variant, so no safe ratio updates were possible. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported under the current evidence: official UK BMW F10 documents confirm transmission-type diversity (manual and automatic) but do not provide verifiable final-drive or top-gear ratios per EU-market variant, so no safe ratio updates were possible.",
       "unresolved": [
         {
           "item": "Per-variant final_drive_ratio and top_gear_ratio for EU F10 520i/530i/535i/550i",
@@ -848,14 +655,12 @@
             "confidence": "medium"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F10+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F10+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -866,31 +671,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F10",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series_%28F10%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|5 Series (G30, 2017-2023)": {
       "car_index": 10,
-      "decision_summary": "No safe EU-only ratio update applied for G30 (2017-2023): official sources found were either generation-mismatched (G60 current data), older-generation-mismatched (F10 brochure), or did not expose extractable G30 ratio tables in a verifiable way. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official sources found were either generation-mismatched (G60 current data), older-generation-mismatched (F10 brochure), or did not expose extractable G30 ratio tables in a verifiable way.",
       "unresolved": [
         {
           "item": "Per-variant final drive ratios for BMW 5 Series G30 EU-market 520i, 530i/530i xDrive, 540i/540i xDrive, M550i xDrive",
@@ -914,18 +701,6 @@
             "confidence": "high"
           }
         ],
-        "fallback_cross_check_rejected": [
-          {
-            "url": "https://bmwbrochures.co.uk/5S-Saloon/files/inc/328e68b828.pdf",
-            "note": "UK brochure text resolves to F10 LCI-era model set (e.g., 528i/535i/550i and July 2013 context), not G30; cannot support G30 ratio updates.",
-            "confidence": "medium"
-          },
-          {
-            "url": "http://www.bmw-brochure-downloads.co.uk/BMW_5_Series_Saloon_Performance_and_Technical_Data.pdf",
-            "note": "Document content corresponds to i5/5 Series current-era lineup (e.g., 550e, Nov 2025), not G30; excluded.",
-            "confidence": "medium"
-          }
-        ],
         "official_but_unusable_for_extraction": [
           {
             "url": "https://www.press.bmwgroup.com/united-kingdom/article/attachment/T0125651EN_GB/186485",
@@ -933,14 +708,12 @@
             "confidence": "low"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G30+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G30+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -952,22 +725,15 @@
             "confidence": "medium"
           }
         ],
-        "wikipedia_overview": [
+        "secondary_cross_check_rejected": [
           {
-            "url": "https://en.wikipedia.org/wiki/BMW_G30",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
+            "url": "https://bmwbrochures.co.uk/5S-Saloon/files/inc/328e68b828.pdf",
+            "note": "UK brochure text resolves to F10 LCI-era model set (e.g., 528i/535i/550i and July 2013 context), not G30; cannot support G30 ratio updates.",
             "confidence": "medium"
           },
           {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series_%28G30%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
+            "url": "http://www.bmw-brochure-downloads.co.uk/BMW_5_Series_Saloon_Performance_and_Technical_Data.pdf",
+            "note": "Document content corresponds to i5/5 Series current-era lineup (e.g., 550e, Nov 2025), not G30; excluded.",
             "confidence": "medium"
           }
         ]
@@ -975,7 +741,8 @@
     },
     "BMW|5 Series (G60, 2024-2026)": {
       "car_index": 11,
-      "decision_summary": "Manual official-source review for issue #1034 kept the supported EU row narrow to 520i plus the i5 eDrive40 and i5 M60 xDrive BEVs, and moved the i5 variants onto explicit single-speed EV gearbox overrides so they no longer inherit the 520i 8-speed automatic row. The 520i 8-speed ratio pair remains the official 03/2025 BMW value.",
+      "verification_status": "corrected",
+      "decision_summary": "Issue #1034 official-source review kept the supported EU row narrow to 520i plus the i5 eDrive40 and i5 M60 xDrive BEVs, and moved the i5 variants onto explicit single-speed EV gearbox overrides so they no longer inherit the 520i 8-speed automatic row. The 520i 8-speed ratio pair remains the official 03/2025 BMW value.",
       "unresolved": [
         {
           "item": "Per-axle reduction detail for the i5 M60 xDrive",
@@ -1014,14 +781,12 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G60+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G60+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1032,31 +797,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G60",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_CLAR_platform",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|6 Series Gran Coupe (F06, 2013-2018)": {
       "car_index": 12,
-      "decision_summary": "Used BMW official EU/global press technical material to add missing EU ratio-relevant drivetrain variants and to replace a single ambiguous final-drive value with two officially documented final-drive groups from the BMW 6 Series technical sheet (12/2014). Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "corrected",
+      "decision_summary": "Used BMW official EU/global press technical material to add missing EU ratio-relevant drivetrain variants and to replace a single ambiguous final-drive value with two officially documented final-drive groups from the BMW 6 Series technical sheet (12/2014).",
       "unresolved": [
         {
           "item": "Model-year coverage for 2013-2014 within the combined '2013-2018' entry",
@@ -1090,14 +837,12 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F06+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F06+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1108,31 +853,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F06",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series_Gran_Coup%C3%A9",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_6_Series",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|6 Series Gran Turismo (G32, 2018-2024)": {
       "car_index": 13,
-      "decision_summary": "No safe ratio-field updates applied: official EU BMW pages reviewed did not publish explicit per-variant final-drive or top-gear values for G32 in accessible content. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official EU BMW pages reviewed did not publish explicit per-variant final-drive or top-gear values for G32 in accessible content.",
       "unresolved": [
         {
           "item": "Per-variant final-drive ratios for EU G32 lineup",
@@ -1167,14 +894,12 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G32+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G32+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1185,31 +910,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G32",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_6_Series_Gran_Turismo",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_6_Series_%28G32%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|7 Series (F01, 2011-2015)": {
       "car_index": 14,
-      "decision_summary": "No safe EU-only ratio update was applied because accessible official BMW sources did not yield verifiable F01 (2011-2015) drivetrain-specific top-gear/final-drive tables for these variants. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: No safe EU-only ratio update was applied because accessible official BMW sources did not yield verifiable F01 (2011-2015) drivetrain-specific top-gear/final-drive tables for these variants.",
       "unresolved": [
         {
           "item": "Variant-specific final drive ratios for EU 740i (RWD), 750i (RWD), and 750i xDrive (AWD) within F01 LCI model years",
@@ -1243,14 +950,12 @@
             "confidence": "high"
           }
         ],
-        "second_pass_official_enrichment": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F01+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F01+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1261,35 +966,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F01",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_7_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_7_Series_%28F01%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|7 Series (G11, 2016-2022)": {
       "car_index": 15,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW 7 Series (G11, 2016-2022) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW 7 Series (G11, 2016-2022) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1297,7 +984,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1312,16 +999,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+7+Series+%28G11%2C+2016-2022%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G11+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G11+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1332,31 +1015,13 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G11",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_7_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_7_Series_%28G11%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|7 Series (G70, 2023-2026)": {
       "car_index": 16,
-      "decision_summary": "Manual official-source review for issue #1034 corrected the supported EU variant set to 740d xDrive, 750e xDrive, M760e xDrive, i7 eDrive50, and i7 M70 xDrive, removing the non-European petrol variants and moving the i7 variants onto explicit single-speed EV gearbox overrides so they no longer inherit the shared 8-speed row.",
+      "verification_status": "corrected",
+      "decision_summary": "Issue #1034 official-source review corrected the supported EU variant set to 740d xDrive, 750e xDrive, M760e xDrive, i7 eDrive50, and i7 M70 xDrive, removing the non-European petrol variants and moving the i7 variants onto explicit single-speed EV gearbox overrides so they no longer inherit the shared 8-speed row.",
       "unresolved": [
         {
           "item": "Variant-level final_drive_ratio and top_gear_ratio confirmation for the EU combustion/PHEV variants",
@@ -1368,61 +1033,6 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
-          {
-            "url": "https://www.bmw.com/en/index.html",
-            "note": "BMW global official portal entrypoint for model documentation paths.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global",
-            "note": "BMW Group official press/media source used for EU technical documents and attachments.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+7+Series+%28G70%2C+2023-2026%29+technical+data+Europe",
-            "note": "Targeted lookup for official BMW press documents for this model.",
-            "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G70+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G70+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search/category:11",
-            "note": "BMW Group Fact & Figures section (official technical data publication channel).",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G70",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_7_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_7_Series_%28G70%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
-        ],
         "issue_1034_eu_scope": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/detail/T0380173EN/the-new-bmw-7-series",
@@ -1441,16 +1051,49 @@
             "note": "Reputable technical reference used to encode a representative single-speed EV reduction ratio for the i7 once official BMW sources confirmed the drivetrain layout but not the numeric ratio.",
             "confidence": "medium"
           }
+        ],
+        "official_lookup_attempts": [
+          {
+            "url": "https://www.bmw.com/en/index.html",
+            "note": "BMW global official portal entrypoint for model documentation paths.",
+            "confidence": "medium"
+          },
+          {
+            "url": "https://www.press.bmwgroup.com/global",
+            "note": "BMW Group official press/media source used for EU technical documents and attachments.",
+            "confidence": "medium"
+          },
+          {
+            "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+7+Series+%28G70%2C+2023-2026%29+technical+data+Europe",
+            "note": "Targeted lookup for official BMW press documents for this model.",
+            "confidence": "low"
+          },
+          {
+            "url": "https://www.press.bmwgroup.com/global/article/search?query=G70+technical+data&language=en",
+            "note": "BMW Group official press search page used in second-pass lookup.",
+            "confidence": "medium"
+          },
+          {
+            "url": "https://www.press.bmwgroup.com/global/article/search?query=G70+technical+data&language=en",
+            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "confidence": "medium"
+          },
+          {
+            "url": "https://www.press.bmwgroup.com/global/article/search/category:11",
+            "note": "BMW Group Fact & Figures section (official technical data publication channel).",
+            "confidence": "medium"
+          }
         ]
       }
     },
     "BMW|8 Series Coupe (G15, 2019-2025)": {
       "car_index": 17,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW 8 Series Coupe (G15, 2019-2025) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW 8 Series Coupe (G15, 2019-2025) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1458,7 +1101,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1473,16 +1116,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+8+Series+Coupe+%28G15%2C+2019-2025%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G15+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G15+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1493,35 +1132,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series_(F10)",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series_Coupe",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_8_Series_%28G15%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|8 Series Convertible (G14, 2019-2025)": {
       "car_index": 18,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW 8 Series Convertible (G14, 2019-2025) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW 8 Series Convertible (G14, 2019-2025) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1529,7 +1150,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1544,16 +1165,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+8+Series+Convertible+%28G14%2C+2019-2025%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G14+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G14+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1564,30 +1181,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|8 Series Gran Coupe (G16, 2020-2025)": {
       "car_index": 19,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW 8 Series Gran Coupe (G16, 2020-2025) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW 8 Series Gran Coupe (G16, 2020-2025) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1595,7 +1199,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1610,16 +1214,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+8+Series+Gran+Coupe+%28G16%2C+2020-2025%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G16+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G16+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1630,35 +1230,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_1_Series_(E87)",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_2_Series_Gran_Coup%C3%A9",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X1 (F48, 2016-2022)": {
       "car_index": 20,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X1 (F48, 2016-2022) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X1 (F48, 2016-2022) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1666,7 +1248,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1681,16 +1263,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X1+%28F48%2C+2016-2022%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F48+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F48+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1701,35 +1279,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F48",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X1",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X1_%28F48%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X1 (U11, 2023-2026)": {
       "car_index": 21,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X1 (U11, 2023-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X1 (U11, 2023-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1737,7 +1297,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1752,16 +1312,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X1+%28U11%2C+2023-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=U11+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=U11+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1772,35 +1328,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_1_Series_(E87)",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X1",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X2 (F39, 2018-2023)": {
       "car_index": 22,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1808,7 +1346,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1823,16 +1361,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X2+%28F39%2C+2018-2023%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F39+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F39+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1843,35 +1377,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X6",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X2",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X2",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X2 (U10, 2024-2026)": {
       "car_index": 23,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X2 (U10, 2024-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X2 (U10, 2024-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1879,7 +1395,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1894,16 +1410,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X2+%28U10%2C+2024-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=U10+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=U10+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1914,35 +1426,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X2",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_B48",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X3 (F25, 2011-2017)": {
       "car_index": 24,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X3 (F25, 2011-2017) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X3 (F25, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -1950,7 +1444,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -1965,16 +1459,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X3+%28F25%2C+2011-2017%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F25+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F25+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -1985,35 +1475,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F25",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_N20",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X3 (G01, 2018-2024)": {
       "car_index": 25,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X3 (G01, 2018-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X3 (G01, 2018-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2021,7 +1493,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2036,16 +1508,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X3+%28G01%2C+2018-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G01+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G01+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2056,35 +1524,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+X3+%28G01%2C+2018-2024%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X3 (G45, 2025-2026)": {
       "car_index": 26,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X3 (G45, 2025-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X3 (G45, 2025-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2092,7 +1542,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2107,16 +1557,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X3+%28G45%2C+2025-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G45+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G45+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2127,35 +1573,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G450X",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+X3+%28G45%2C+2025-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X4 (F26, 2015-2018)": {
       "car_index": 27,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X4 (F26, 2015-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X4 (F26, 2015-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2163,7 +1591,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2178,16 +1606,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X4+%28F26%2C+2015-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F26+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F26+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2198,35 +1622,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X6",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+X4+%28F26%2C+2015-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X4 (G02, 2019-2025)": {
       "car_index": 28,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X4 (G02, 2019-2025) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X4 (G02, 2019-2025) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2234,7 +1640,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2249,16 +1655,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X4+%28G02%2C+2019-2025%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G02+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G02+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2269,35 +1671,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_B58",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X5 (F15, 2014-2018)": {
       "car_index": 29,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X5 (F15, 2014-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X5 (F15, 2014-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2305,7 +1689,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2320,16 +1704,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X5+%28F15%2C+2014-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F15+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F15+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2340,35 +1720,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F15",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X5",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+X5+%28F15%2C+2014-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X5 (G05, 2019-2026)": {
       "car_index": 30,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X5 (G05, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X5 (G05, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2376,7 +1738,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2391,16 +1753,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X5+%28G05%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G05+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G05+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2411,35 +1769,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_5_Series_(F10)",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X5",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X6",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X6 (F16, 2015-2019)": {
       "car_index": 31,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X6 (F16, 2015-2019) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X6 (F16, 2015-2019) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2447,7 +1787,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2462,16 +1802,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X6+%28F16%2C+2015-2019%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F16+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F16+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2482,30 +1818,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X6",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+X6+%28F16%2C+2015-2019%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X6 (G06, 2020-2026)": {
       "car_index": 32,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X6 (G06, 2020-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X6 (G06, 2020-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2513,7 +1836,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2528,16 +1851,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X6+%28G06%2C+2020-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G06+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G06+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2548,35 +1867,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X6",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_B58",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|X7 (G07, 2019-2026)": {
       "car_index": 33,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW X7 (G07, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW X7 (G07, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2584,7 +1885,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2599,16 +1900,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+X7+%28G07%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G07+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G07+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2619,35 +1916,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_3_Series",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X7",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|Z4 (G29, 2019-2026)": {
       "car_index": 34,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW Z4 (G29, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW Z4 (G29, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2655,7 +1934,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2670,16 +1949,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+Z4+%28G29%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G29+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G29+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2690,35 +1965,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_GS",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_Z4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+Z4+%28G29%2C+2019-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|M3 (F80, 2014-2018)": {
       "car_index": 35,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW M3 (F80, 2014-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW M3 (F80, 2014-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2726,7 +1983,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2741,16 +1998,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+M3+%28F80%2C+2014-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F80+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F80+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2761,35 +2014,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F80",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+M3+%28F80%2C+2014-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|M3 (G80, 2021-2026)": {
       "car_index": 36,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW M3 (G80, 2021-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW M3 (G80, 2021-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2797,7 +2032,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2812,16 +2047,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+M3+%28G80%2C+2021-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G80+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G80+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2832,35 +2063,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_X3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M4",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|M4 (F82, 2014-2020)": {
       "car_index": 37,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW M4 (F82, 2014-2020) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW M4 (F82, 2014-2020) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2868,7 +2081,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2883,16 +2096,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+M4+%28F82%2C+2014-2020%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F82+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F82+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2903,35 +2112,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_F82",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_N55",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|M4 (G82, 2021-2026)": {
       "car_index": 38,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW M4 (G82, 2021-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW M4 (G82, 2021-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -2939,7 +2130,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -2954,16 +2145,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+M4+%28G82%2C+2021-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G82+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G82+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -2974,35 +2161,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_G82",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+M4+%28G82%2C+2021-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|M5 (F90, 2018-2024)": {
       "car_index": 39,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW M5 (F90, 2018-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW M5 (F90, 2018-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3010,7 +2179,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -3025,16 +2194,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+M5+%28F90%2C+2018-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F90+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F90+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -3045,30 +2210,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+M5+%28F90%2C+2018-2024%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_M5",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|iX (I20, 2022-2026)": {
       "car_index": 40,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW iX (I20, 2022-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW iX (I20, 2022-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3076,7 +2228,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -3091,16 +2243,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+iX+%28I20%2C+2022-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=I20+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=I20+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -3111,30 +2259,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_iX",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+iX+%28I20%2C+2022-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "BMW|i4 (G26, 2022-2026)": {
       "car_index": 41,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "BMW i4 (G26, 2022-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "BMW i4 (G26, 2022-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3142,7 +2277,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.bmw.com/en/index.html",
             "note": "BMW global official portal entrypoint for model documentation paths.",
@@ -3157,16 +2292,12 @@
             "url": "https://www.google.com/search?q=site%3Apress.bmwgroup.com+BMW+i4+%28G26%2C+2022-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official BMW press documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G26+technical+data&language=en",
             "note": "BMW Group official press search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G26+technical+data&language=en",
             "note": "BMW Group official PressClub search for model-code technical data documents.",
@@ -3177,30 +2308,17 @@
             "note": "BMW Group Fact & Figures section (official technical data publication channel).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=BMW+i4+%28G26%2C+2022-2026%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/BMW_i4",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A1 (8X, 2011-2018)": {
       "car_index": 42,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A1 (8X, 2011-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A1 (8X, 2011-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3208,7 +2326,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3223,16 +2341,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A1+%288X%2C+2011-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8X",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8X",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3243,30 +2357,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A1",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A1+%288X%2C+2011-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A1 (GB, 2019-2024)": {
       "car_index": 43,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A1 (GB, 2019-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A1 (GB, 2019-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3274,7 +2375,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3289,16 +2390,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A1+%28GB%2C+2019-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=GB",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=GB",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3309,30 +2406,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A1",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/List_of_Audi_vehicles",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A3 (8V, 2013-2020)": {
       "car_index": 44,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A3 (8V, 2013-2020) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A3 (8V, 2013-2020) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3340,7 +2424,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3355,16 +2439,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A3+%288V%2C+2013-2020%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8V",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8V",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3375,30 +2455,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A3+%288V%2C+2013-2020%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A3 (8Y, 2021-2026)": {
       "car_index": 45,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A3 (8Y, 2021-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A3 (8Y, 2021-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3406,7 +2473,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3421,16 +2488,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A3+%288Y%2C+2021-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8Y",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8Y",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3441,30 +2504,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A3+%288Y%2C+2021-2026%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/FAW-Volkswagen",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
-    "Audi|A4 (B8, 2011-2016)": {
+    "Audi|A4 (B8, 2008-2016)": {
       "car_index": 46,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3472,7 +2522,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3487,16 +2537,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A4+%28B8%2C+2011-2016%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3507,25 +2553,12 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A4",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A4+%28B8%2C+2011-2016%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
-    "Audi|A4 (B9, 2016-2024)": {
+    "Audi|A4 (B9, 2016-2025)": {
       "car_index": 47,
+      "verification_status": "corrected",
       "decision_summary": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. The shared FWD S tronic entry and the 35/40 TFSI variant overrides now use 4.234, while the 45 TFSI quattro override now uses the officially documented 4.410.",
       "unresolved": [
         {
@@ -3553,13 +2586,14 @@
         ]
       }
     },
-    "Audi|A5 (B8, 2012-2016)": {
+    "Audi|A5 (B8, 2007-2016)": {
       "car_index": 48,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3567,7 +2601,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3582,16 +2616,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A5+%28B8%2C+2012-2016%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3602,25 +2632,12 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A5+%28B8%2C+2012-2016%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A5 (B9, 2017-2024)": {
       "car_index": 49,
+      "verification_status": "corrected",
       "decision_summary": "Verified Audi A5 B9 S tronic final-drive ratios from official Audi UK and Audi MediaCenter technical PDFs. The shared FWD S tronic entry now uses 4.234, and the 45 TFSI quattro variant now carries the officially documented 4.410 override.",
       "unresolved": [
         {
@@ -3655,11 +2672,12 @@
     },
     "Audi|A6 (C7, 2011-2018)": {
       "car_index": 50,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A6 (C7, 2011-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A6 (C7, 2011-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3667,7 +2685,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3682,9 +2700,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A6+%28C7%2C+2011-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C7",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -3694,9 +2710,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-s6-avant-c7-v8-comfort-for-every-journey-127765",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C7",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3707,30 +2721,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A6+%28C7%2C+2011-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A6 (C8, 2019-2026)": {
       "car_index": 51,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A6 (C8, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A6 (C8, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3738,7 +2739,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3753,9 +2754,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A6+%28C8%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -3765,9 +2764,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3778,30 +2775,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A6+%28C8%2C+2019-2026%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A6",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A7 Sportback (C7, 2011-2018)": {
       "car_index": 52,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A7 Sportback (C7, 2011-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A7 Sportback (C7, 2011-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3809,7 +2793,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3824,9 +2808,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A7+Sportback+%28C7%2C+2011-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C7",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -3836,9 +2818,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-s6-avant-c7-v8-comfort-for-every-journey-127765",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C7",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3849,35 +2829,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A7_sportback_h-tron",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A7+Sportback+%28C7%2C+2011-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A7 Sportback (C8, 2019-2026)": {
       "car_index": 53,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A7 Sportback (C8, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A7 Sportback (C8, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3885,7 +2847,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3900,9 +2862,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A7+Sportback+%28C8%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -3912,9 +2872,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3925,30 +2883,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A7_sportback_h-tron",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+A7+Sportback+%28C8%2C+2019-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A8 (D4, 2011-2017)": {
       "car_index": 54,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A8 (D4, 2011-2017) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A8 (D4, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -3956,7 +2901,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -3971,16 +2916,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A8+%28D4%2C+2011-2017%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=D4",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=D4",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -3991,30 +2932,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A8",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_S8",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|A8 (D5, 2018-2026)": {
       "car_index": 55,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi A8 (D5, 2018-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi A8 (D5, 2018-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4022,7 +2950,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4037,16 +2965,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+A8+%28D5%2C+2018-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=D5",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=D5",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4057,30 +2981,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A8",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A8",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|Q2 (GA, 2017-2024)": {
       "car_index": 56,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi Q2 (GA, 2017-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi Q2 (GA, 2017-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4088,7 +2999,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4103,9 +3014,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+Q2+%28GA%2C+2017-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=GA",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -4135,9 +3044,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-e-gas-plant-9865",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=GA",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4148,30 +3055,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q2+%28GA%2C+2017-2024%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|Q3 (8U, 2012-2018)": {
       "car_index": 57,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4179,7 +3073,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4194,16 +3088,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+Q3+%288U%2C+2012-2018%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8U",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8U",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4214,30 +3104,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q3+%288U%2C+2012-2018%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q3+%288U%2C+2012-2018%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|Q3 (F3, 2019-2026)": {
       "car_index": 58,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi Q3 (F3, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi Q3 (F3, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4245,7 +3122,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4260,16 +3137,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+Q3+%28F3%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=F3",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=F3",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4280,30 +3153,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/FAW-Volkswagen",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|Q5 (8R, 2011-2017)": {
       "car_index": 59,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4311,7 +3171,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4326,16 +3186,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+Q5+%288R%2C+2011-2017%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8R",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8R",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4346,25 +3202,12 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q5+%288R%2C+2011-2017%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/List_of_Audi_vehicles",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|Q5 (FY, 2017-2026)": {
       "car_index": 60,
+      "verification_status": "corrected",
       "decision_summary": "Verified Audi Q5 FY S tronic final-drive ratios from official Audi MediaCenter and Audi technical data PDFs. The shared Q5 FY S tronic entry now uses 5.302, and the stored 45 TFSI quattro override was corrected to the same officially documented value.",
       "unresolved": [
         {
@@ -4394,11 +3237,12 @@
     },
     "Audi|Q7 (4M, 2016-2026)": {
       "car_index": 61,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi Q7 (4M, 2016-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi Q7 (4M, 2016-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4406,7 +3250,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4421,16 +3265,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+Q7+%284M%2C+2016-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4M",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4M",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4441,30 +3281,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q7+%284M%2C+2016-2026%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q7+%284M%2C+2016-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|Q8 (4M8, 2019-2026)": {
       "car_index": 62,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi Q8 (4M8, 2019-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi Q8 (4M8, 2019-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4472,7 +3299,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4487,16 +3314,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+Q8+%284M8%2C+2019-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4M8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4M8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4507,30 +3330,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A6",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+Q8+%284M8%2C+2019-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|TT (8J, 2011-2014)": {
       "car_index": 63,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi TT (8J, 2011-2014) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi TT (8J, 2011-2014) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4538,7 +3348,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4553,16 +3363,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+TT+%288J%2C+2011-2014%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8J",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8J",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4573,30 +3379,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+TT+%288J%2C+2011-2014%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+TT+%288J%2C+2011-2014%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|TT (8S, 2015-2023)": {
       "car_index": 64,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi TT (8S, 2015-2023) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi TT (8S, 2015-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4604,7 +3397,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4619,16 +3412,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+TT+%288S%2C+2015-2023%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8S",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8S",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4639,30 +3428,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+TT+%288S%2C+2015-2023%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|R8 (4S, 2015-2024)": {
       "car_index": 65,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi R8 (4S, 2015-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi R8 (4S, 2015-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4670,7 +3446,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4685,16 +3461,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+R8+%284S%2C+2015-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4S",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4S",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4705,30 +3477,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+R8+%284S%2C+2015-2024%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_R8_%28Type_4S%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|RS 3 (8V/8Y, 2017-2026)": {
       "car_index": 66,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi RS 3 (8V/8Y, 2017-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi RS 3 (8V/8Y, 2017-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4736,7 +3495,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4751,16 +3510,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+RS+3+%288V%2F8Y%2C+2017-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8V%2F8Y",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8V%2F8Y",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4771,30 +3526,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_V8",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_S_and_RS_models",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|RS 4 Avant (B9, 2018-2024)": {
       "car_index": 67,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi RS 4 Avant (B9, 2018-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi RS 4 Avant (B9, 2018-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4802,7 +3544,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4817,16 +3559,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+RS+4+Avant+%28B9%2C+2018-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B9",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B9",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4837,30 +3575,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+RS+4+Avant+%28B9%2C+2018-2024%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+RS+4+Avant+%28B9%2C+2018-2024%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|RS 5 (B9, 2018-2024)": {
       "car_index": 68,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed. Low-signal Wikipedia fragment placeholder notes were removed in issue #976; remaining unresolved items are intentionally limited to concise manual-review bullets.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi RS 5 (B9, 2018-2024) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi RS 5 (B9, 2018-2024) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4868,7 +3593,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4883,16 +3608,12 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+RS+5+%28B9%2C+2018-2024%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B9",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B9",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4903,30 +3624,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_S_and_RS_models",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|RS 6 Avant (C8, 2020-2026)": {
       "car_index": 69,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi RS 6 Avant (C8, 2020-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi RS 6 Avant (C8, 2020-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -4934,7 +3642,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -4949,9 +3657,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+RS+6+Avant+%28C8%2C+2020-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -4961,9 +3667,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -4974,30 +3678,17 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+RS+6+Avant+%28C8%2C+2020-2026%29",
-            "note": "Wikipedia search fallback for model overview when exact page match was not auto-resolved.",
-            "confidence": "low"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/w/index.php?search=Audi+RS+6+Avant+%28C8%2C+2020-2026%29",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|RS 7 Sportback (C8, 2020-2026)": {
       "car_index": 70,
-      "decision_summary": "No safe EU-only ratio update applied in fallback pass; retained existing entry and flagged for manual evidence-backed review. Second pass completed with additional official-source discovery; ratios remain unchanged unless explicitly confirmed in prior high-confidence evidence. Full-library redo completed with official-source and Wikipedia-overview cross-checking; ratio fields remain unchanged unless explicitly evidence-confirmed.",
+      "verification_status": "intentionally_unsupported",
+      "decision_summary": "This row is intentionally unsupported pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
       "unresolved": [
         {
           "item": "Audi RS 7 Sportback (C8, 2020-2026) EU ratio-relevant variant mapping",
-          "reason": "Fallback pass without per-model authoritative ratio extraction; no-guess policy kept existing values."
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference."
         },
         {
           "item": "Audi RS 7 Sportback (C8, 2020-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -5005,7 +3696,7 @@
         }
       ],
       "sources": {
-        "fallback_official_lookup": [
+        "official_lookup_attempts": [
           {
             "url": "https://www.audi.com/en.html",
             "note": "Audi global official portal entrypoint for model documentation paths.",
@@ -5020,9 +3711,7 @@
             "url": "https://www.google.com/search?q=site%3Aaudi-mediacenter.com+Audi+RS+7+Sportback+%28C8%2C+2020-2026%29+technical+data+Europe",
             "note": "Targeted lookup for official Audi media technical documents for this model.",
             "confidence": "low"
-          }
-        ],
-        "second_pass_official_enrichment": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search page used in second-pass lookup.",
@@ -5032,9 +3721,7 @@
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
             "confidence": "medium"
-          }
-        ],
-        "official_redo_lookup": [
+          },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
             "note": "Audi MediaCenter official search for model-code technical releases.",
@@ -5045,26 +3732,13 @@
             "note": "Audi MediaCenter official model hub (entry point for model-specific documents).",
             "confidence": "medium"
           }
-        ],
-        "wikipedia_overview": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A3",
-            "note": "Wikipedia overview used to cross-check model/engine/variant availability across production years.",
-            "confidence": "medium"
-          }
-        ],
-        "wikipedia_variant_tables": [
-          {
-            "url": "https://en.wikipedia.org/wiki/Audi_A7",
-            "note": "Wikipedia model/table page used to cross-check variant completeness (names + engine context).",
-            "confidence": "medium"
-          }
         ]
       }
     },
     "Audi|e-tron GT (J1, 2022-2026)": {
       "car_index": 71,
-      "decision_summary": "Manual official-source review for issue #975 confirmed the EU BEV variant mapping for Audi e-tron GT J1: the supported base variant is `e-tron GT quattro`, and the standalone `e-tron GT` alias was removed from the car library. Ratio fields remain unchanged because this issue verified variant naming and motor layout, not EV reduction-ratio mapping into the current schema.",
+      "verification_status": "corrected",
+      "decision_summary": "Issue #975 official-source review confirmed the EU BEV variant mapping for Audi e-tron GT J1: the supported base variant is `e-tron GT quattro`, and the standalone `e-tron GT` alias was removed from the car library. Ratio fields remain unchanged because this issue verified variant naming and motor layout, not EV reduction-ratio mapping into the current schema.",
       "unresolved": [
         {
           "item": "Audi e-tron GT (J1, 2022-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",
@@ -5093,7 +3767,8 @@
     },
     "Audi|Q4 e-tron (FZ, 2022-2026)": {
       "car_index": 72,
-      "decision_summary": "Manual official-source review for issue #975 confirmed the supported EU Q4 e-tron BEV variant mapping: `40 e-tron` is the single-motor RWD entry and `50 e-tron quattro` is the dual-motor AWD entry. The unsupported non-quattro `50 e-tron` alias was removed from the car library. Ratio fields remain unchanged because this issue verified variant naming and motor layout, not EV reduction-ratio mapping into the current schema.",
+      "verification_status": "corrected",
+      "decision_summary": "Issue #975 official-source review confirmed the supported EU Q4 e-tron BEV variant mapping: `40 e-tron` is the single-motor RWD entry and `50 e-tron quattro` is the dual-motor AWD entry. The unsupported non-quattro `50 e-tron` alias was removed from the car library. Ratio fields remain unchanged because this issue verified variant naming and motor layout, not EV reduction-ratio mapping into the current schema.",
       "unresolved": [
         {
           "item": "Audi Q4 e-tron (FZ, 2022-2026) variant-level final_drive_ratio and top_gear_ratio confirmation",

--- a/apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py
+++ b/apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py
@@ -5,10 +5,44 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 
-from vibesensor.adapters.persistence.car_library import _DATA_FILE
+from vibesensor.adapters.persistence.car_library import _DATA_FILE, CAR_LIBRARY
 
 _RATIO_SOURCES_FILE = _DATA_FILE.with_name("car_library_ratio_sources.json")
 _PLACEHOLDER_PHRASE = "preserved pending official-source confirmation"
+_ALLOWED_VERIFICATION_STATUSES = {
+    "verified",
+    "corrected",
+    "intentionally_unsupported",
+}
+_LEGACY_AUDIT_PHRASES = (
+    "fallback",
+    "manual-review",
+    "manual review",
+    "wikipedia",
+)
+_LEGACY_SOURCE_KEYS = {
+    "fallback_official_lookup",
+    "second_pass_official_enrichment",
+    "official_redo_lookup",
+    "wikipedia_overview",
+    "wikipedia_variant_tables",
+}
+_STATUS_SPOT_CHECKS = {
+    "BMW|1 Series (F20, 2011-2019)": "intentionally_unsupported",
+    "BMW|2 Series Active Tourer (F45, 2014-2021)": "corrected",
+    "BMW|5 Series (G60, 2024-2026)": "corrected",
+    "Audi|A4 (B9, 2016-2025)": "corrected",
+}
+
+
+def _load_ratio_sources() -> dict[str, dict[str, object]]:
+    with _RATIO_SOURCES_FILE.open() as fh:
+        data = json.load(fh)
+    return data["cars"]
+
+
+def _car_key(entry: dict[str, object]) -> str:
+    return f"{entry['brand']}|{entry['model']}"
 
 
 def _walk_strings(value: object) -> Iterator[str]:
@@ -26,18 +60,67 @@ def _walk_strings(value: object) -> Iterator[str]:
 
 def test_car_library_ratio_sources_json_parseable() -> None:
     """The ratio-source JSON is valid and keeps the expected top-level shape."""
-    with _RATIO_SOURCES_FILE.open() as fh:
-        data = json.load(fh)
+    cars = _load_ratio_sources()
 
-    assert isinstance(data, dict)
-    assert isinstance(data.get("cars"), dict)
-    assert data["cars"], "Expected ratio-source metadata for at least one car"
+    assert isinstance(cars, dict)
+    assert cars, "Expected ratio-source metadata for at least one car"
 
 
 def test_ratio_sources_do_not_contain_placeholder_preserved_notes() -> None:
     """Low-signal placeholder notes should not survive in ratio-source metadata."""
-    with _RATIO_SOURCES_FILE.open() as fh:
-        data = json.load(fh)
+    data = _load_ratio_sources()
 
     offenders = [text for text in _walk_strings(data) if _PLACEHOLDER_PHRASE in text]
     assert offenders == []
+
+
+def test_ratio_sources_all_rows_have_explicit_verification_status() -> None:
+    data = _load_ratio_sources()
+
+    for car_key, entry in data.items():
+        status = entry.get("verification_status")
+        assert status in _ALLOWED_VERIFICATION_STATUSES, (
+            f"{car_key} missing valid verification_status: {status!r}"
+        )
+
+
+def test_ratio_sources_unsupported_rows_keep_explicit_justification() -> None:
+    data = _load_ratio_sources()
+
+    for car_key, entry in data.items():
+        if entry.get("verification_status") != "intentionally_unsupported":
+            continue
+        assert entry.get("unresolved"), (
+            f"{car_key} must keep explicit justification when intentionally unsupported"
+        )
+
+
+def test_ratio_sources_do_not_contain_legacy_audit_wording_or_keys() -> None:
+    data = _load_ratio_sources()
+
+    offenders = [
+        text
+        for text in _walk_strings(data)
+        if any(phrase in text.lower() for phrase in _LEGACY_AUDIT_PHRASES)
+    ]
+    assert offenders == []
+
+    legacy_source_keys = {
+        car_key: sorted(set(entry.get("sources", {})) & _LEGACY_SOURCE_KEYS)
+        for car_key, entry in data.items()
+        if set(entry.get("sources", {})) & _LEGACY_SOURCE_KEYS
+    }
+    assert legacy_source_keys == {}
+
+
+def test_ratio_sources_cover_every_car_library_row() -> None:
+    ratio_source_keys = set(_load_ratio_sources())
+    library_keys = {_car_key(entry) for entry in CAR_LIBRARY}
+    assert ratio_source_keys == library_keys
+
+
+def test_ratio_sources_status_spot_checks() -> None:
+    data = _load_ratio_sources()
+
+    observed = {car_key: data[car_key]["verification_status"] for car_key in _STATUS_SPOT_CHECKS}
+    assert observed == _STATUS_SPOT_CHECKS

--- a/apps/server/tests/hygiene/test_car_library_artifact_sync.py
+++ b/apps/server/tests/hygiene/test_car_library_artifact_sync.py
@@ -1,0 +1,90 @@
+"""Guard: car-library JSON, ratio ledger, and variant-source docs stay aligned."""
+
+from __future__ import annotations
+
+import json
+
+from vibesensor.adapters.persistence.car_library import _DATA_FILE, CAR_LIBRARY
+
+_RATIO_SOURCES_FILE = _DATA_FILE.with_name("car_library_ratio_sources.json")
+_VARIANT_SOURCES_FILE = _DATA_FILE.with_name("CAR_VARIANT_SOURCES.md")
+
+
+def _car_key(entry: dict[str, object]) -> str:
+    return f"{entry['brand']}|{entry['model']}"
+
+
+def _variant_rows_from_docs() -> dict[str, list[tuple[str, str, str]]]:
+    rows: dict[str, list[tuple[str, str, str]]] = {}
+    current_brand: str | None = None
+    lines = _VARIANT_SOURCES_FILE.read_text().splitlines()
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith("## "):
+            heading = line[3:].strip()
+            if heading in {"BMW", "Audi"}:
+                current_brand = heading
+            index += 1
+            continue
+
+        if not line.startswith("### "):
+            index += 1
+            continue
+
+        assert current_brand is not None, f"Model heading {line!r} missing brand section"
+        model = line[4:].strip()
+        index += 1
+
+        while index < len(lines) and not lines[index].startswith("| Variant |"):
+            if lines[index].startswith("### ") or lines[index].startswith("## "):
+                break
+            index += 1
+
+        if index >= len(lines) or not lines[index].startswith("| Variant |"):
+            raise AssertionError(f"{current_brand}|{model} missing variant table")
+
+        index += 2
+        variants: list[tuple[str, str, str]] = []
+        while index < len(lines) and lines[index].startswith("|"):
+            cells = [cell.strip() for cell in lines[index].split("|")[1:-1]]
+            if len(cells) >= 3 and cells[0]:
+                variants.append((cells[0], cells[1], cells[2]))
+            index += 1
+
+        rows[f"{current_brand}|{model}"] = variants
+
+    return rows
+
+
+def _variant_rows_from_library() -> dict[str, list[tuple[str, str, str]]]:
+    rows: dict[str, list[tuple[str, str, str]]] = {}
+    for entry in CAR_LIBRARY:
+        rows[_car_key(entry)] = [
+            (variant["name"], variant["engine"], variant["drivetrain"])
+            for variant in entry["variants"]
+        ]
+    return rows
+
+
+def test_car_library_artifact_model_sets_match() -> None:
+    with _RATIO_SOURCES_FILE.open() as fh:
+        ratio_source_rows = json.load(fh)["cars"]
+
+    library_rows = _variant_rows_from_library()
+    doc_rows = _variant_rows_from_docs()
+
+    assert set(library_rows) == set(ratio_source_rows) == set(doc_rows)
+
+
+def test_variant_source_docs_match_car_library_variants() -> None:
+    doc_rows = _variant_rows_from_docs()
+    library_rows = _variant_rows_from_library()
+
+    for car_key, library_variants in library_rows.items():
+        library_variant_set = set(library_variants)
+        missing = [variant for variant in doc_rows[car_key] if variant not in library_variant_set]
+        assert missing == [], (
+            f"{car_key} documents variants not present in car_library.json: {missing}"
+        )


### PR DESCRIPTION
## Summary
- classify every remaining car-library ratio-source row explicitly as `corrected` or `intentionally_unsupported`
- remove fallback/manual-review boilerplate and low-signal Wikipedia references from the verification ledger while consolidating generic audit keys into `official_lookup_attempts`
- add row-sync guardrails so `car_library.json`, `car_library_ratio_sources.json`, and `CAR_VARIANT_SOURCES.md` cannot silently drift again

## Validation
- `pytest -q apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_variants.py apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py apps/server/tests/hygiene/test_car_library_artifact_sync.py`
- `pytest -q apps/server/tests/adapters/persistence apps/server/tests/hygiene/test_car_library_artifact_sync.py apps/server/tests/integration/test_review_guardrails_core_regressions.py apps/server/tests/integration/test_review_guardrails_extended_regressions.py`
- `make lint`
- `make typecheck-backend`
- `docker compose up -d`
- `python3 -m vibesensor.adapters.simulator.sim_sender --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
- `vibesensor-ws-smoke --uri ws://127.0.0.1:8000/ws --min-clients 1 --timeout 20` (`before=0`, `during=2`, `after=0`)

Closes #1035.