### PR TITLE
Fix Playwright smoke entrypoint

### DIFF
--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -1,0 +1,49 @@
+"""Guard: UI smoke command and Playwright smoke config stay aligned."""
+
+from __future__ import annotations
+
+import json
+
+from tests._paths import REPO_ROOT
+
+_UI_PACKAGE_JSON = REPO_ROOT / "apps" / "ui" / "package.json"
+_SMOKE_CONFIG = REPO_ROOT / "apps" / "ui" / "playwright.smoke.config.ts"
+_UI_TESTS_DIR = REPO_ROOT / "apps" / "ui" / "tests"
+_EXPECTED_CORE_SMOKE_SPECS = {
+    "smoke.bootstrap.spec.ts",
+    "smoke.settings.spec.ts",
+    "smoke.history.spec.ts",
+    "smoke.cars.spec.ts",
+    "smoke.esp-flash.spec.ts",
+}
+
+
+def _smoke_script() -> str:
+    package_json = json.loads(_UI_PACKAGE_JSON.read_text())
+    return str(package_json["scripts"]["test:smoke"])
+
+
+def test_ui_smoke_script_defers_test_selection_to_smoke_config() -> None:
+    script = _smoke_script()
+
+    assert "--config=playwright.smoke.config.ts" in script
+    assert "--project=laptop-light" in script
+    assert "--workers=1" in script
+    assert "tests/" not in script, (
+        "Smoke file selection should live in playwright.smoke.config.ts, "
+        "not as hard-coded paths in package.json."
+    )
+
+
+def test_ui_smoke_config_uses_split_smoke_glob() -> None:
+    config_text = _SMOKE_CONFIG.read_text()
+
+    assert "testMatch" in config_text
+    assert "smoke*.spec.ts" in config_text
+
+
+def test_core_ui_smoke_specs_exist() -> None:
+    smoke_specs = {path.name for path in _UI_TESTS_DIR.glob("smoke*.spec.ts")}
+
+    missing = _EXPECTED_CORE_SMOKE_SPECS - smoke_specs
+    assert not missing, f"Missing core smoke specs: {sorted(missing)}"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -12,7 +12,7 @@
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4173",
     "typecheck": "tsc --noEmit",
-    "test:smoke": "npx playwright test --config=playwright.smoke.config.ts tests/smoke.spec.ts tests/api_http.spec.ts --project=laptop-light --workers=1",
+    "test:smoke": "npx playwright test --config=playwright.smoke.config.ts --project=laptop-light --workers=1",
     "test:visual": "npx playwright test",
     "test:visual:update": "npx playwright test --update-snapshots",
     "screenshot": "node take-screenshot.mjs",

--- a/apps/ui/playwright.smoke.config.ts
+++ b/apps/ui/playwright.smoke.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "tests",
+  // Smoke selection lives here so package.json and CI stay on one contract.
+  testMatch: ["smoke*.spec.ts"],
   timeout: 45_000,
   use: {
     baseURL: "http://127.0.0.1:4173",


### PR DESCRIPTION
## Summary
- move smoke-suite selection into `playwright.smoke.config.ts` so `npm run test:smoke` stops naming deleted files
- keep CI on the same contract by leaving `.github/workflows/ci.yml` pointed at the package script
- add a hygiene guard that fails if the package script hard-codes stale smoke file paths or the core split smoke specs disappear

## Validation
- `cd apps/ui && npm run test:smoke -- --list`
- `cd apps/ui && npm run test:smoke`
- `pytest -q apps/server/tests/hygiene/test_ui_smoke_contract.py`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `make lint`
- `docker compose up -d`
- `python3 -m vibesensor.adapters.simulator.sim_sender --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
- `vibesensor-ws-smoke --uri ws://127.0.0.1:8000/ws --min-clients 1 --timeout 20` (`before=0`, `during=2`, `after=0`)

Closes #1043.