### PR TITLE
Type diagnostics sample model

### DIFF
--- a/apps/server/tests/test_support/sample_scenarios.py
+++ b/apps/server/tests/test_support/sample_scenarios.py
@@ -7,6 +7,7 @@ from typing import Any
 from test_support.core import _stable_hash
 from vibesensor.shared.constants import KMH_TO_MPS
 from vibesensor.strength_bands import bucket_for_strength
+from vibesensor.use_cases.diagnostics._types import AnalysisSample
 
 
 def make_sample(
@@ -51,6 +52,12 @@ def make_sample(
     if strength_peak_amp_g is not None:
         sample["strength_peak_amp_g"] = strength_peak_amp_g
     return sample
+
+
+def make_analysis_sample(**kwargs: Any) -> AnalysisSample:
+    """Build one typed diagnostics sample from the shared raw sample builder."""
+
+    return AnalysisSample.from_dict(make_sample(**kwargs))
 
 
 def make_noise_samples(

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_sample.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_sample.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from test_support.sample_scenarios import make_analysis_sample, make_sample
+
+from vibesensor.domain import StrengthPeak
+from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSample,
+    normalize_analysis_samples,
+)
+
+
+def test_analysis_sample_from_dict_types_top_peaks() -> None:
+    raw = make_sample(
+        t_s=1.5,
+        speed_kmh=72.0,
+        client_name="FL",
+        top_peaks=[{"hz": 31.0, "amp": 0.11}],
+        location="FL",
+        dominant_freq_hz=31.0,
+    )
+
+    sample = AnalysisSample.from_dict(raw)
+
+    assert sample.t_s == 1.5
+    assert sample.speed_kmh == 72.0
+    assert sample.location == "FL"
+    assert sample.top_peaks == (StrengthPeak.from_dict({"hz": 31.0, "amp": 0.11}),)
+
+
+def test_normalize_analysis_samples_preserves_raw_rows_and_typed_rows() -> None:
+    raw = make_sample(
+        t_s=0.0,
+        speed_kmh=60.0,
+        client_name="RR",
+        top_peaks=[{"hz": 25.0, "amp": 0.08}],
+    )
+    typed = make_analysis_sample(
+        t_s=2.0,
+        speed_kmh=65.0,
+        client_name="RL",
+        top_peaks=[{"hz": 27.0, "amp": 0.09}],
+    )
+
+    raw_rows, typed_rows = normalize_analysis_samples([raw, typed])
+
+    assert raw_rows[0] == raw
+    assert raw_rows[1]["client_name"] == "RL"
+    assert raw_rows[1]["top_peaks"] == [
+        {
+            "hz": 27.0,
+            "amp": 0.09,
+        },
+    ]
+    assert [sample.client_name for sample in typed_rows] == ["RR", "RL"]

--- a/apps/server/vibesensor/use_cases/diagnostics/_summary_result.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_summary_result.py
@@ -41,7 +41,7 @@ class AnalysisResult:
 
     file_name: str
     metadata: JsonObject
-    samples: tuple[Sample, ...]
+    samples: tuple[JsonObject, ...]
     language: str
     include_samples: bool
     prepared: PreparedRunData
@@ -98,6 +98,7 @@ def build_analysis_result(
     file_name: str,
     metadata: JsonObject,
     samples: list[Sample],
+    raw_samples: list[JsonObject],
     language: str,
     include_samples: bool,
     prepared: PreparedRunData,
@@ -137,7 +138,7 @@ def build_analysis_result(
                 configuration_snapshot=ConfigurationSnapshot.from_metadata(metadata),
             ),
             analysis_settings=_scalar_analysis_settings(metadata),
-            sample_count=len(samples),
+            sample_count=len(raw_samples),
             duration_s=prepared.duration_s,
         ),
         driving_segments=build_domain_driving_segments(prepared.phase_segments),
@@ -157,7 +158,7 @@ def build_analysis_result(
     return AnalysisResult(
         file_name=file_name,
         metadata=dict(metadata),
-        samples=tuple(samples),
+        samples=tuple(raw_samples),
         language=language,
         include_samples=include_samples,
         prepared=prepared,

--- a/apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py
@@ -104,11 +104,7 @@ def build_run_suitability_bundle(
 ) -> tuple[bool, RunSuitability | None, str | None]:
     """Build run-suitability checks and related confidence context."""
     reference_complete = compute_reference_completeness(metadata)
-    sensor_ids = {
-        str(client_id)
-        for sample in samples
-        if isinstance(sample, dict) and (client_id := sample.get("client_id"))
-    }
+    sensor_ids = {client_id for sample in samples if (client_id := sample.client_id)}
     total_dropped, total_overflow = compute_frame_integrity_counts(samples)
     run_suitability = RunSuitability.evaluate(
         steady_speed=prepared.is_steady_speed,

--- a/apps/server/vibesensor/use_cases/diagnostics/_types.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_types.py
@@ -9,16 +9,138 @@ TypedDicts.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TypeAlias, TypedDict
+from typing import TypeAlias, TypedDict, cast
 
-from vibesensor.shared.types.json_types import JsonObject
-from vibesensor.use_cases.diagnostics.phase_segmentation import DrivingPhase
+from vibesensor.domain import DrivingPhase, StrengthPeak
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
-Sample: TypeAlias = JsonObject
-"""A single recorded sample row.  Alias for ``JsonObject``; used for
-semantic clarity across analysis modules, not additional type safety."""
+
+@dataclass(frozen=True, slots=True)
+class AnalysisSample:
+    """A typed diagnostics-internal view of one recorded sample row."""
+
+    t_s: float | None = None
+    speed_kmh: float | None = None
+    accel_x_g: float | None = None
+    accel_y_g: float | None = None
+    accel_z_g: float | None = None
+    vibration_strength_db: float | None = None
+    strength_bucket: str = ""
+    strength_floor_amp_g: float | None = None
+    top_peaks: tuple[StrengthPeak, ...] = ()
+    dominant_freq_hz: float | None = None
+    location: str = ""
+    client_name: str = ""
+    client_id: str = ""
+    engine_rpm: float | None = None
+    engine_rpm_source: str = ""
+    engine_rpm_estimated: float | None = None
+    final_drive_ratio: float | None = None
+    gear: float | None = None
+    frames_dropped_total: float | None = None
+    queue_overflow_drops: float | None = None
+
+    @classmethod
+    def from_dict(cls, raw: JsonObject) -> AnalysisSample:
+        raw_top_peaks = raw.get("top_peaks")
+        top_peaks: list[StrengthPeak] = []
+        if isinstance(raw_top_peaks, Sequence) and not isinstance(
+            raw_top_peaks,
+            (str, bytes, bytearray),
+        ):
+            for peak in raw_top_peaks:
+                if isinstance(peak, Mapping):
+                    top_peaks.append(
+                        StrengthPeak.from_dict(cast(Mapping[str, object], peak)),
+                    )
+        return cls(
+            t_s=_as_float(raw.get("t_s")),
+            speed_kmh=_as_float(raw.get("speed_kmh")),
+            accel_x_g=_as_float(raw.get("accel_x_g")),
+            accel_y_g=_as_float(raw.get("accel_y_g")),
+            accel_z_g=_as_float(raw.get("accel_z_g")),
+            vibration_strength_db=_as_float(raw.get("vibration_strength_db")),
+            strength_bucket=str(raw.get("strength_bucket") or ""),
+            strength_floor_amp_g=_as_float(raw.get("strength_floor_amp_g")),
+            top_peaks=tuple(top_peaks),
+            dominant_freq_hz=_as_float(raw.get("dominant_freq_hz")),
+            location=str(raw.get("location") or ""),
+            client_name=str(raw.get("client_name") or ""),
+            client_id=str(raw.get("client_id") or ""),
+            engine_rpm=_as_float(raw.get("engine_rpm")),
+            engine_rpm_source=str(raw.get("engine_rpm_source") or ""),
+            engine_rpm_estimated=_as_float(raw.get("engine_rpm_estimated")),
+            final_drive_ratio=_as_float(raw.get("final_drive_ratio")),
+            gear=_as_float(raw.get("gear")),
+            frames_dropped_total=_as_float(raw.get("frames_dropped_total")),
+            queue_overflow_drops=_as_float(raw.get("queue_overflow_drops")),
+        )
+
+    def to_json_object(self) -> JsonObject:
+        top_peaks = cast(
+            list[JsonValue],
+            [peak.to_dict() for peak in self.top_peaks],
+        )
+        raw: JsonObject = {
+            "t_s": self.t_s,
+            "speed_kmh": self.speed_kmh,
+            "accel_x_g": self.accel_x_g,
+            "accel_y_g": self.accel_y_g,
+            "accel_z_g": self.accel_z_g,
+            "vibration_strength_db": self.vibration_strength_db,
+            "strength_bucket": self.strength_bucket,
+            "strength_floor_amp_g": self.strength_floor_amp_g,
+            "top_peaks": top_peaks,
+            "dominant_freq_hz": self.dominant_freq_hz,
+            "location": self.location,
+            "client_name": self.client_name,
+            "client_id": self.client_id,
+            "engine_rpm": self.engine_rpm,
+            "engine_rpm_source": self.engine_rpm_source,
+            "engine_rpm_estimated": self.engine_rpm_estimated,
+            "final_drive_ratio": self.final_drive_ratio,
+            "gear": self.gear,
+            "frames_dropped_total": self.frames_dropped_total,
+            "queue_overflow_drops": self.queue_overflow_drops,
+        }
+        return raw
+
+
+Sample: TypeAlias = AnalysisSample
+AnalysisSampleInput: TypeAlias = AnalysisSample | JsonObject
+
+
+def normalize_analysis_samples(
+    samples: Sequence[AnalysisSampleInput],
+) -> tuple[list[JsonObject], list[AnalysisSample]]:
+    """Return raw+typed sample views while normalizing typed access once."""
+
+    raw_samples: list[JsonObject] = []
+    analysis_samples: list[AnalysisSample] = []
+    for sample in samples:
+        if isinstance(sample, AnalysisSample):
+            raw_samples.append(sample.to_json_object())
+            analysis_samples.append(sample)
+            continue
+        raw_sample = cast(JsonObject, dict(sample))
+        raw_samples.append(raw_sample)
+        analysis_samples.append(AnalysisSample.from_dict(raw_sample))
+    return raw_samples, analysis_samples
+
+
+def ensure_analysis_sample(sample: AnalysisSampleInput) -> AnalysisSample:
+    """Normalize one sample row to the typed diagnostics contract."""
+
+    return sample if isinstance(sample, AnalysisSample) else AnalysisSample.from_dict(sample)
+
+
+def ensure_analysis_samples(samples: Sequence[AnalysisSampleInput]) -> list[AnalysisSample]:
+    """Normalize arbitrary sample rows to typed diagnostics samples."""
+
+    return normalize_analysis_samples(samples)[1]
 
 
 class AccelStatistics(TypedDict):

--- a/apps/server/vibesensor/use_cases/diagnostics/helpers.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from pathlib import Path
 
 from vibesensor.domain import OrderReferenceSpec, TireSpec
@@ -16,16 +17,21 @@ from vibesensor.shared.constants import (
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.locations import label_for_code as _label_for_code
 from vibesensor.shared.types.json_types import JsonObject
-from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
+    Sample,
+    ensure_analysis_sample,
+)
 from vibesensor.vibration_strength import percentile
 
 
-def _validate_required_strength_metrics(samples: list[Sample]) -> None:
-    if not samples:
+def _validate_required_strength_metrics(samples: Sequence[AnalysisSampleInput]) -> None:
+    typed_samples = [ensure_analysis_sample(sample) for sample in samples]
+    if not typed_samples:
         return
     first_bad_idx: int | None = None
-    for idx, sample in enumerate(samples):
-        if _as_float(sample.get("vibration_strength_db")) is not None:
+    for idx, sample in enumerate(typed_samples):
+        if sample.vibration_strength_db is not None:
             return  # at least one valid sample → OK
         if first_bad_idx is None:
             first_bad_idx = idx
@@ -76,28 +82,29 @@ def _order_reference_spec_from_context(
 ) -> OrderReferenceSpec | None:
     settings: dict[str, object] = dict(metadata)
     if sample is not None:
-        if (final_drive_ratio := _as_float(sample.get("final_drive_ratio"))) is not None:
+        if (final_drive_ratio := sample.final_drive_ratio) is not None:
             settings["final_drive_ratio"] = final_drive_ratio
-        if (gear_ratio := _as_float(sample.get("gear"))) is not None:
+        if (gear_ratio := sample.gear) is not None:
             settings["current_gear_ratio"] = gear_ratio
     return OrderReferenceSpec.from_settings(settings)
 
 
 def _effective_engine_rpm(
-    sample: Sample,
+    sample: AnalysisSampleInput,
     metadata: JsonObject,
     tire_circumference_m: float | None,
 ) -> tuple[float | None, str]:
-    measured = _as_float(sample.get("engine_rpm"))
+    typed_sample = ensure_analysis_sample(sample)
+    measured = typed_sample.engine_rpm
     if measured is not None and measured > 0:
-        return measured, str(sample.get("engine_rpm_source") or "measured")
+        return measured, typed_sample.engine_rpm_source or "measured"
 
-    estimated_in_sample = _as_float(sample.get("engine_rpm_estimated"))
+    estimated_in_sample = typed_sample.engine_rpm_estimated
     if estimated_in_sample is not None and estimated_in_sample > 0:
         return estimated_in_sample, "estimated_from_speed_and_ratios"
 
-    speed_kmh = _as_float(sample.get("speed_kmh"))
-    spec = _order_reference_spec_from_context(metadata, sample)
+    speed_kmh = typed_sample.speed_kmh
+    spec = _order_reference_spec_from_context(metadata, typed_sample)
     if (
         speed_kmh is not None
         and speed_kmh > 0
@@ -108,10 +115,10 @@ def _effective_engine_rpm(
         if rpm is not None and rpm > 0:
             return rpm, "estimated_from_speed_and_ratios"
 
-    final_drive_ratio = _as_float(sample.get("final_drive_ratio")) or _as_float(
+    final_drive_ratio = typed_sample.final_drive_ratio or _as_float(
         metadata.get("final_drive_ratio"),
     )
-    gear_val = _as_float(sample.get("gear"))
+    gear_val = typed_sample.gear
     gear_ratio = gear_val if gear_val is not None else _as_float(metadata.get("current_gear_ratio"))
     if (
         speed_kmh is None
@@ -140,31 +147,29 @@ def _load_run(path: Path) -> tuple[JsonObject, list[JsonObject], list[str]]:
 
 
 def _primary_vibration_strength_db(sample: Sample) -> float | None:
-    value = _as_float(sample.get("vibration_strength_db"))
+    typed_sample = ensure_analysis_sample(sample)
+    value = typed_sample.vibration_strength_db
     return float(value) if value is not None else None
 
 
-def _sample_top_peaks(sample: Sample) -> list[tuple[float, float]]:
-    top_peaks = sample.get("top_peaks")
+def _sample_top_peaks(sample: AnalysisSampleInput) -> list[tuple[float, float]]:
+    typed_sample = ensure_analysis_sample(sample)
     out: list[tuple[float, float]] = []
-    if isinstance(top_peaks, list):
-        for peak in top_peaks[:8]:
-            if not isinstance(peak, dict):
-                continue
-            hz = _as_float(peak.get("hz"))
-            amp = _as_float(peak.get("amp"))
-            if hz is None or amp is None or hz <= 0:
-                continue
-            # Defence-in-depth: skip sub-road-resonance frequencies that may
-            # exist in old recorded run data (new data is filtered at the FFT
-            # level via ``spectrum_min_hz``).
-            if hz < MIN_ANALYSIS_FREQ_HZ:
-                continue
-            out.append((hz, amp))
+    for peak in typed_sample.top_peaks[:8]:
+        hz = peak.hz
+        amp = peak.amp
+        if hz <= 0 or amp <= 0:
+            continue
+        # Defence-in-depth: skip sub-road-resonance frequencies that may
+        # exist in old recorded run data (new data is filtered at the FFT
+        # level via ``spectrum_min_hz``).
+        if hz < MIN_ANALYSIS_FREQ_HZ:
+            continue
+        out.append((hz, amp))
     return out
 
 
-def _estimate_strength_floor_amp_g(sample: Sample) -> float | None:
+def _estimate_strength_floor_amp_g(sample: AnalysisSampleInput) -> float | None:
     """Estimate per-sample floor amplitude.
 
     Policy: accept strictly positive ``strength_floor_amp_g``; otherwise
@@ -172,17 +177,18 @@ def _estimate_strength_floor_amp_g(sample: Sample) -> float | None:
     three peaks are available (keeps floor estimation aligned with existing
     run-baseline guards and avoids unstable sparse-peak fallbacks).
     """
-    floor_amp = _as_float(sample.get("strength_floor_amp_g"))
+    typed_sample = ensure_analysis_sample(sample)
+    floor_amp = typed_sample.strength_floor_amp_g
     if floor_amp is not None and floor_amp > 0:
         return float(floor_amp)
-    peak_amps = sorted(amp for _hz, amp in _sample_top_peaks(sample) if amp > 0)
+    peak_amps = sorted(amp for _hz, amp in _sample_top_peaks(typed_sample) if amp > 0)
     if len(peak_amps) < 3:
         return None
     floor_from_peaks = float(percentile(peak_amps, 0.20))
     return float(floor_from_peaks) if floor_from_peaks > 0 else None
 
 
-def _run_noise_baseline_g(samples: list[Sample]) -> float | None:
+def _run_noise_baseline_g(samples: Sequence[AnalysisSampleInput]) -> float | None:
     """Estimate run-level noise baseline as median of per-sample floor estimates.
 
     Per-sample floor uses ``strength_floor_amp_g`` when available; otherwise it
@@ -216,39 +222,43 @@ def _effective_baseline_floor(
     return float(max(float(MEMS_NOISE_FLOOR_G), float(val)))
 
 
-def _location_label(sample: Sample, *, lang: str = "en") -> str:
+def _location_label(sample: AnalysisSampleInput, *, lang: str = "en") -> str:
     """Return a stable language-neutral location label for the sample.
 
     NOTE: This is used as a **grouping key** across the data pipeline, so it
     must be language-invariant.  Translation to the report language happens at
     render time in the PDF builder / template layer.
     """
+    typed_sample = ensure_analysis_sample(sample)
     # Prefer structured location code (from SensorConfig) if available
-    location_code = str(sample.get("location") or "").strip()
+    location_code = typed_sample.location.strip()
     if location_code:
         translated = _label_for_code(location_code)
         return str(translated) if translated else location_code
 
-    client_name_raw = str(sample.get("client_name") or "").strip()
+    client_name_raw = typed_sample.client_name.strip()
     if client_name_raw:
         return client_name_raw
-    client_id_raw = str(sample.get("client_id") or "").strip()
+    client_id_raw = typed_sample.client_id.strip()
     if client_id_raw:
         return f"Sensor \u2026{client_id_raw[-4:]}"
     return "Unknown sensor"
 
 
-def _locations_connected_throughout_run(samples: list[Sample], *, lang: str = "en") -> set[str]:
+def _locations_connected_throughout_run(
+    samples: Sequence[AnalysisSampleInput],
+    *,
+    lang: str = "en",
+) -> set[str]:
     by_location_times: dict[str, set[float]] = defaultdict(set)
     all_times: list[float] = []
 
-    for sample in samples:
-        if not isinstance(sample, dict):
-            continue
+    for raw_sample in samples:
+        sample = ensure_analysis_sample(raw_sample)
         location = _location_label(sample, lang=lang)
         if not location:
             continue
-        t_s = _as_float(sample.get("t_s"))
+        t_s = sample.t_s
         if t_s is None:
             continue
         by_location_times[location].add(t_s)

--- a/apps/server/vibesensor/use_cases/diagnostics/order_matching.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/order_matching.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from vibesensor.domain import OrderMatchObservation, speed_bin_label
@@ -13,9 +14,12 @@ from vibesensor.shared.constants import (
     ORDER_TOLERANCE_REL,
     SPEED_BIN_WIDTH_KMH,
 )
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonObject
-from vibesensor.use_cases.diagnostics._types import PhaseLabels, Sample
+from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
+    PhaseLabels,
+    ensure_analysis_sample,
+)
 from vibesensor.use_cases.diagnostics.helpers import (
     _estimate_strength_floor_amp_g,
     _location_label,
@@ -67,7 +71,7 @@ class OrderMatchAccumulator:
 
 
 def match_samples_for_hypothesis(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     cached_peaks: list[list[tuple[float, float]]],
     hypothesis: OrderHypothesis,
     metadata: JsonObject,
@@ -95,7 +99,8 @@ def match_samples_for_hypothesis(
     compliance = getattr(hypothesis, "path_compliance", 1.0)
     compliance_scale = compliance**0.5
 
-    for sample_idx, sample in enumerate(samples):
+    for sample_idx, raw_sample in enumerate(samples):
+        sample = ensure_analysis_sample(raw_sample)
         peaks = cached_peaks[sample_idx]
         if not peaks:
             continue
@@ -108,7 +113,7 @@ def match_samples_for_hypothesis(
         sample_location = _location_label(sample, lang=lang)
         if sample_location:
             possible_by_location[sample_location] += 1
-        sample_speed = _as_float(sample.get("speed_kmh"))
+        sample_speed = sample.speed_kmh
         sample_speed_bin = (
             speed_bin_label(sample_speed, bin_width=SPEED_BIN_WIDTH_KMH)
             if sample_speed is not None and sample_speed > 0
@@ -149,8 +154,8 @@ def match_samples_for_hypothesis(
         measured_vals.append(best_hz)
         matched_points.append(
             OrderMatchObservation(
-                t_s=_as_float(sample.get("t_s")),
-                speed_kmh=_as_float(sample.get("speed_kmh")),
+                t_s=sample.t_s,
+                speed_kmh=sample.speed_kmh,
                 predicted_hz=predicted_hz,
                 matched_hz=best_hz,
                 rel_error=delta_hz / max(1e-9, predicted_hz),

--- a/apps/server/vibesensor/use_cases/diagnostics/peak_accumulation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peak_accumulation.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from math import floor as _math_floor
 
 from vibesensor.domain import speed_bin_label
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
 
-from ._types import PhaseLabels, Sample
+from ._types import AnalysisSampleInput, PhaseLabels, ensure_analysis_sample
 from .helpers import _estimate_strength_floor_amp_g, _location_label, _sample_top_peaks
 from .speed_profile_helpers import _phase_to_str
 
@@ -51,7 +51,7 @@ class PeakBinStats:
 
 
 def accumulate_peak_bin_stats(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     *,
     freq_bin_hz: float,
     freq_bin_hz_half: float,
@@ -62,7 +62,6 @@ def accumulate_peak_bin_stats(
     """Accumulate per-sample data into frequency-bin statistics."""
     stats = PeakBinStats()
 
-    local_as_float = _as_float
     local_speed_bin = speed_bin_label
     local_location = _location_label
     local_top_peaks = _sample_top_peaks
@@ -70,11 +69,10 @@ def accumulate_peak_bin_stats(
     local_phase_str = _phase_to_str
     floor_fn = _math_floor
 
-    for i, sample in enumerate(samples):
-        if not isinstance(sample, dict):
-            continue
+    for i, raw_sample in enumerate(samples):
+        sample = ensure_analysis_sample(raw_sample)
         stats.n_samples += 1
-        speed = local_as_float(sample.get("speed_kmh"))
+        speed = sample.speed_kmh
         sample_speed_bin = local_speed_bin(speed) if speed is not None and speed > 0 else None
         if sample_speed_bin is not None:
             stats.total_speed_bin_counts[sample_speed_bin] += 1

--- a/apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py
@@ -15,13 +15,13 @@ GPS dropouts do not silently discard valid vibration data (issue #287).
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from vibesensor.domain import DrivingPhase
 from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
 from vibesensor.domain.driving_segment import DrivingPhaseSegment
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.use_cases.diagnostics._types import AnalysisSampleInput, ensure_analysis_samples
 
 # Thresholds (tuneable)
 _IDLE_SPEED_KMH = 3.0  # below this → IDLE
@@ -194,7 +194,7 @@ def _interpolate_speed_unknown(phases: list[DrivingPhase]) -> None:
 
 
 def segment_run_phases(
-    samples: list[JsonObject],
+    samples: Sequence[AnalysisSampleInput],
 ) -> tuple[list[DrivingPhase], list[PhaseSegment]]:
     """Classify every sample into a driving phase and return contiguous segments.
 
@@ -206,13 +206,14 @@ def segment_run_phases(
         Contiguous segments of identical phase, sorted by time.
 
     """
-    n = len(samples)
+    typed_samples = ensure_analysis_samples(samples)
+    n = len(typed_samples)
     if n == 0:
         return [], []
 
     # Extract speeds and times (preserve order)
-    speeds: list[float | None] = [_as_float(s.get("speed_kmh")) for s in samples]
-    times: list[float | None] = [_as_float(s.get("t_s")) for s in samples]
+    speeds: list[float | None] = [sample.speed_kmh for sample in typed_samples]
+    times: list[float | None] = [sample.t_s for sample in typed_samples]
 
     # Classify each sample
     per_sample: list[DrivingPhase] = []

--- a/apps/server/vibesensor/use_cases/diagnostics/plots.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/plots.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from vibesensor.domain import Finding as DomainFinding
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.use_cases.diagnostics._types import (
     AmpVsPhaseRowData,
+    AnalysisSampleInput,
     FreqVsSpeedByFindingSeriesData,
     MatchedAmpVsSpeedSeriesData,
     PhaseBoundaryData,
@@ -23,6 +23,7 @@ from vibesensor.use_cases.diagnostics._types import (
     PlotSeriesBundle,
     Sample,
     SpeedBreakdownRowData,
+    ensure_analysis_samples,
 )
 from vibesensor.use_cases.diagnostics.helpers import (
     _primary_vibration_strength_db,
@@ -69,9 +70,7 @@ def build_plot_series(
     freq_vs_speed_by_finding: list[FreqVsSpeedByFindingSeriesData] = []
 
     for i, sample in enumerate(samples):
-        if not isinstance(sample, dict):
-            continue
-        t_s = _as_float(sample.get("t_s"))
+        t_s = sample.t_s
         if t_s is None:
             continue
         phase_label = per_sample_phases[i].value if i < len(per_sample_phases) else "unknown"
@@ -79,7 +78,7 @@ def build_plot_series(
         if vib is not None:
             vib_mag_points.append((t_s, vib, phase_label))
         if raw_sample_rate_hz and raw_sample_rate_hz > 0:
-            dominant_hz = _as_float(sample.get("dominant_freq_hz"))
+            dominant_hz = sample.dominant_freq_hz
             if dominant_hz is not None and dominant_hz > 0:
                 dominant_freq_points.append((t_s, dominant_hz))
 
@@ -227,7 +226,7 @@ def serialize_phase_context(
 
 def _plot_data(
     *,
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     speed_breakdown: list[SpeedBreakdownRowData],
     phase_speed_breakdown: list[PhaseSpeedBreakdownRowData],
     findings: Sequence[DomainFinding],
@@ -237,18 +236,19 @@ def _plot_data(
     per_sample_phases: list[DrivingPhase] | None = None,
     phase_segments: list[PhaseSegment] | None = None,
 ) -> PlotDataResultData:
+    typed_samples = ensure_analysis_samples(samples)
     if run_noise_baseline_g is None:
-        run_noise_baseline_g = _run_noise_baseline_g(samples)
+        run_noise_baseline_g = _run_noise_baseline_g(typed_samples)
 
     if per_sample_phases is not None and phase_segments is not None:
         resolved_phases = per_sample_phases
         resolved_phase_segments = phase_segments
     else:
-        resolved_phases, resolved_phase_segments = _segment_run_phases(samples)
+        resolved_phases, resolved_phase_segments = _segment_run_phases(typed_samples)
 
-    peak_scan = scan_peak_samples(samples)
+    peak_scan = scan_peak_samples(typed_samples)
     series = build_plot_series(
-        samples=samples,
+        samples=typed_samples,
         speed_breakdown=speed_breakdown,
         phase_speed_breakdown=phase_speed_breakdown,
         findings=findings,
@@ -259,7 +259,7 @@ def _plot_data(
     )
     peaks_table = annotate_peak_rows_with_order_labels(
         top_peaks_table_rows(
-            samples,
+            samples=typed_samples,
             run_noise_baseline_g=run_noise_baseline_g,
             peak_scan=peak_scan,
         ),
@@ -274,22 +274,22 @@ def _plot_data(
         freq_vs_speed_by_finding=series.freq_vs_speed_by_finding,
         steady_speed_distribution=series.steady_speed_distribution,
         fft_spectrum=aggregate_fft_spectrum(
-            samples,
+            typed_samples,
             run_noise_baseline_g=run_noise_baseline_g,
             peak_scan=peak_scan,
         ),
         fft_spectrum_raw=aggregate_fft_spectrum_raw(
-            samples,
+            typed_samples,
             run_noise_baseline_g=run_noise_baseline_g,
             peak_scan=peak_scan,
         ),
         peaks_spectrogram=spectrogram_from_peaks(
-            samples,
+            typed_samples,
             run_noise_baseline_g=run_noise_baseline_g,
             peak_scan=peak_scan,
         ),
         peaks_spectrogram_raw=spectrogram_from_peaks_raw(
-            samples,
+            typed_samples,
             run_noise_baseline_g=run_noise_baseline_g,
             peak_scan=peak_scan,
         ),

--- a/apps/server/vibesensor/use_cases/diagnostics/rotational_physics.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/rotational_physics.py
@@ -12,7 +12,11 @@ from vibesensor.domain import OrderReferenceSpec, VibrationSource
 from vibesensor.shared.constants import KMH_TO_MPS, SECONDS_PER_MINUTE
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonObject
-from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
+    Sample,
+    ensure_analysis_sample,
+)
 from vibesensor.use_cases.diagnostics.helpers import (
     _effective_engine_rpm,
     _order_reference_spec_from_context,
@@ -24,17 +28,18 @@ from vibesensor.use_cases.diagnostics.helpers import (
 
 
 def _wheel_hz(
-    sample: Sample,
+    sample: AnalysisSampleInput,
     tire_circumference_m: float | None,
     metadata: JsonObject | None = None,
     order_reference_spec: OrderReferenceSpec | None = None,
 ) -> float | None:
-    speed_kmh = _as_float(sample.get("speed_kmh"))
+    typed_sample = ensure_analysis_sample(sample)
+    speed_kmh = typed_sample.speed_kmh
     if speed_kmh is None or speed_kmh <= 0:
         return None
     spec = order_reference_spec
     if spec is None and metadata is not None:
-        spec = _order_reference_spec_from_context(metadata, sample)
+        spec = _order_reference_spec_from_context(metadata, typed_sample)
     if spec is not None and spec.supports_wheel_reference:
         return spec.wheel_hz_from_speed_kmh(speed_kmh)
     if tire_circumference_m is None or tire_circumference_m <= 0:
@@ -43,12 +48,13 @@ def _wheel_hz(
 
 
 def _driveshaft_hz(
-    sample: Sample,
+    sample: AnalysisSampleInput,
     metadata: JsonObject,
     tire_circumference_m: float | None,
 ) -> float | None:
-    speed_kmh = _as_float(sample.get("speed_kmh"))
-    spec = _order_reference_spec_from_context(metadata, sample)
+    typed_sample = ensure_analysis_sample(sample)
+    speed_kmh = typed_sample.speed_kmh
+    spec = _order_reference_spec_from_context(metadata, typed_sample)
     if (
         speed_kmh is not None
         and speed_kmh > 0
@@ -57,23 +63,27 @@ def _driveshaft_hz(
     ):
         return spec.driveshaft_hz_from_speed_kmh(speed_kmh)
     whz = _wheel_hz(
-        sample,
+        typed_sample,
         tire_circumference_m,
         metadata,
         order_reference_spec=spec,
     )
-    fd = _as_float(sample.get("final_drive_ratio")) or _as_float(metadata.get("final_drive_ratio"))
+    fd = typed_sample.final_drive_ratio or _as_float(metadata.get("final_drive_ratio"))
     if whz is None or fd is None or fd <= 0:
         return None
     return float(whz * fd)
 
 
 def _engine_hz(
-    sample: Sample,
+    sample: AnalysisSampleInput,
     metadata: JsonObject,
     tire_circumference_m: float | None,
 ) -> tuple[float | None, str]:
-    rpm, src = _effective_engine_rpm(sample, metadata, tire_circumference_m)
+    rpm, src = _effective_engine_rpm(
+        ensure_analysis_sample(sample),
+        metadata,
+        tire_circumference_m,
+    )
     if rpm is None or rpm <= 0:
         return None, src
     return float(rpm / SECONDS_PER_MINUTE), src

--- a/apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py
@@ -24,9 +24,10 @@ from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
     PhaseSpeedBreakdownRowData,
-    Sample,
     SpeedBreakdownRowData,
+    ensure_analysis_samples,
 )
 from vibesensor.use_cases.diagnostics.helpers import (
     _location_label,
@@ -104,21 +105,18 @@ def build_domain_driving_segments(
 
 def build_sensor_analysis(
     *,
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     language: str,
     per_sample_phases: list[DrivingPhase],
 ) -> tuple[list[str], set[str], list[LocationIntensitySummary]]:
     """Build sensor location lists and intensity rows from analysed samples."""
+    typed_samples = ensure_analysis_samples(samples)
     sensor_locations = sorted(
-        {
-            label
-            for sample in samples
-            if isinstance(sample, dict) and (label := _location_label(sample, lang=language))
-        },
+        {label for sample in typed_samples if (label := _location_label(sample, lang=language))},
     )
-    connected_locations = _locations_connected_throughout_run(samples, lang=language)
+    connected_locations = _locations_connected_throughout_run(typed_samples, lang=language)
     sensor_intensity_by_location = _sensor_intensity_by_location(
-        samples,
+        typed_samples,
         include_locations=set(sensor_locations),
         lang=language,
         connected_locations=connected_locations,
@@ -168,12 +166,17 @@ class PreparedRunData:
 
 def prepare_run_data(
     metadata: JsonObject,
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     *,
     file_name: str,
 ) -> PreparedRunData:
     """Prepare shared timing, speed, and phase context for summary generation."""
-    run_id, start_ts, end_ts, duration_s = compute_run_timing(metadata, samples, file_name)
+    typed_samples = ensure_analysis_samples(samples)
+    run_id, start_ts, end_ts, duration_s = compute_run_timing(
+        metadata,
+        typed_samples,
+        file_name,
+    )
     (
         speed_values,
         speed_stats,
@@ -181,9 +184,9 @@ def prepare_run_data(
         speed_sufficient,
         per_sample_phases,
         phase_segments,
-    ) = prepare_speed_and_phases(samples)
-    run_noise_baseline_g = _run_noise_baseline_g(samples)
-    speed_breakdown = _speed_breakdown(samples) if speed_sufficient else []
+    ) = prepare_speed_and_phases(typed_samples)
+    run_noise_baseline_g = _run_noise_baseline_g(typed_samples)
+    speed_breakdown = _speed_breakdown(typed_samples) if speed_sufficient else []
     speed_breakdown_skipped_reason: JsonObject | None = None
     if not speed_sufficient:
         speed_breakdown_skipped_reason = i18n_ref(
@@ -207,10 +210,10 @@ def prepare_run_data(
             speed_stats,
             phase_info,
         ),
-        speed_stats_by_phase=_speed_stats_by_phase(samples, per_sample_phases),
+        speed_stats_by_phase=_speed_stats_by_phase(typed_samples, per_sample_phases),
         speed_breakdown=speed_breakdown,
         speed_breakdown_skipped_reason=speed_breakdown_skipped_reason,
-        phase_speed_breakdown=_phase_speed_breakdown(samples, per_sample_phases),
+        phase_speed_breakdown=_phase_speed_breakdown(typed_samples, per_sample_phases),
     )
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from collections.abc import Sequence
 
 from vibesensor.domain import LocationIntensitySummary, speed_band_sort_key, speed_bin_label
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
     PhaseSpeedBreakdownRowData,
-    Sample,
     SpeedBreakdownRowData,
+    ensure_analysis_samples,
 )
 from vibesensor.use_cases.diagnostics.helpers import (
     _location_label,
@@ -43,10 +45,11 @@ _EMPTY_BUCKET_COUNTS: dict[str, int] = {f"l{idx}": 0 for idx in range(6)}
 
 
 def _phase_speed_breakdown(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     per_sample_phases: list[DrivingPhase],
 ) -> list[PhaseSpeedBreakdownRowData]:
     """Group vibration statistics by driving phase (temporal context)."""
+    typed_samples = ensure_analysis_samples(samples)
     grouped_amp: dict[str, list[float]] = defaultdict(list)
     grouped_speeds: dict[str, list[float]] = defaultdict(list)
     counts: dict[str, int] = defaultdict(int)
@@ -54,11 +57,11 @@ def _phase_speed_breakdown(
     _as_float_local = _as_float
     _vib_db = _primary_vibration_strength_db
     n_phases = len(per_sample_phases)
-    for idx, sample in enumerate(samples):
+    for idx, sample in enumerate(typed_samples):
         phase = per_sample_phases[idx] if idx < n_phases else "unknown"
         phase_key = _phase_to_str(phase) or "unknown"
         counts[phase_key] += 1
-        speed = _as_float_local(sample.get("speed_kmh"))
+        speed = sample.speed_kmh
         if speed is not None and speed > 0:
             grouped_speeds[phase_key].append(speed)
         amp = _vib_db(sample)
@@ -86,14 +89,15 @@ def _phase_speed_breakdown(
     return rows
 
 
-def _speed_breakdown(samples: list[Sample]) -> list[SpeedBreakdownRowData]:
+def _speed_breakdown(samples: Sequence[AnalysisSampleInput]) -> list[SpeedBreakdownRowData]:
+    typed_samples = ensure_analysis_samples(samples)
     grouped: dict[str, list[float]] = defaultdict(list)
     counts: dict[str, int] = defaultdict(int)
     _as_float_local = _as_float
     _vib_db = _primary_vibration_strength_db
     _bin_label = speed_bin_label
-    for sample in samples:
-        speed = _as_float_local(sample.get("speed_kmh"))
+    for sample in typed_samples:
+        speed = sample.speed_kmh
         if speed is None or speed <= 0:
             continue
         label = _bin_label(speed)
@@ -117,7 +121,7 @@ def _speed_breakdown(samples: list[Sample]) -> list[SpeedBreakdownRowData]:
 
 
 def _sensor_intensity_by_location(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     include_locations: set[str] | None = None,
     *,
     lang: str = "en",
@@ -125,6 +129,7 @@ def _sensor_intensity_by_location(
     per_sample_phases: list[DrivingPhase] | None = None,
 ) -> list[LocationIntensitySummary]:
     """Compute per-location vibration intensity statistics."""
+    typed_samples = ensure_analysis_samples(samples)
     grouped_amp: dict[str, list[float]] = defaultdict(list)
     sample_counts: dict[str, int] = defaultdict(int)
     dropped_totals: dict[str, list[tuple[float | None, float]]] = defaultdict(list)
@@ -132,14 +137,12 @@ def _sensor_intensity_by_location(
     strength_bucket_counts: dict[str, dict[str, int]] = defaultdict(_EMPTY_BUCKET_COUNTS.copy)
     strength_bucket_totals: dict[str, int] = defaultdict(int)
     phase_amp: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
-    has_phases = per_sample_phases is not None and len(per_sample_phases) == len(samples)
+    has_phases = per_sample_phases is not None and len(per_sample_phases) == len(typed_samples)
 
     _as_float_local = _as_float
     _vib_db = _primary_vibration_strength_db
     _loc_label = _location_label
-    for i, sample in enumerate(samples):
-        if not isinstance(sample, dict):
-            continue
+    for i, sample in enumerate(typed_samples):
         location = _loc_label(sample, lang=lang)
         if not location:
             continue
@@ -153,16 +156,15 @@ def _sensor_intensity_by_location(
                 phase_obj = per_sample_phases[i]
                 phase_key = _phase_to_str(phase_obj) or "unknown"
                 phase_amp[location][phase_key].append(amp)
-        _get = sample.get
-        sample_t_s = _as_float_local(_get("t_s"))
-        dropped_total = _as_float_local(_get("frames_dropped_total"))
+        sample_t_s = sample.t_s
+        dropped_total = sample.frames_dropped_total
         if dropped_total is not None:
             dropped_totals[location].append((sample_t_s, dropped_total))
-        overflow_total = _as_float_local(_get("queue_overflow_drops"))
+        overflow_total = sample.queue_overflow_drops
         if overflow_total is not None:
             overflow_totals[location].append((sample_t_s, overflow_total))
-        vibration_strength_db = _as_float_local(_get("vibration_strength_db"))
-        bucket = str(_get("strength_bucket") or "")
+        vibration_strength_db = sample.vibration_strength_db
+        bucket = sample.strength_bucket
         if vibration_strength_db is None:
             continue
         if bucket:

--- a/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
@@ -8,14 +8,19 @@ dicts into a structured, reusable peak cache, plus the FFT spectrum and
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from math import floor
 from typing import Literal
 
 from vibesensor.domain import speed_bin_label
 from vibesensor.shared.constants import MEMS_NOISE_FLOOR_G
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.use_cases.diagnostics._types import Sample, SpectrogramResultData
+from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
+    Sample,
+    SpectrogramResultData,
+    ensure_analysis_samples,
+)
 from vibesensor.use_cases.diagnostics.helpers import (
     _effective_baseline_floor,
     _estimate_strength_floor_amp_g,
@@ -50,8 +55,9 @@ class PeakSampleScan:
     total_speed_bin_counts: dict[str, int]
 
 
-def scan_peak_samples(samples: list[Sample]) -> PeakSampleScan:
+def scan_peak_samples(samples: Sequence[AnalysisSampleInput]) -> PeakSampleScan:
     """Scan raw samples once and cache the peak-facing data needed by plot builders."""
+    typed_samples = ensure_analysis_samples(samples)
     rows: list[PeakSampleScanRow] = []
     time_values: list[float] = []
     speed_values: list[float] = []
@@ -59,12 +65,10 @@ def scan_peak_samples(samples: list[Sample]) -> PeakSampleScan:
     total_speed_bin_counts: dict[str, int] = defaultdict(int)
     sample_count = 0
 
-    for sample in samples:
-        if not isinstance(sample, dict):
-            continue
+    for sample in typed_samples:
         sample_count += 1
-        t_s = _as_float(sample.get("t_s"))
-        speed = _as_float(sample.get("speed_kmh"))
+        t_s = sample.t_s
+        speed = sample.speed_kmh
         peaks = [(hz, amp) for hz, amp in _sample_top_peaks(sample) if hz > 0 and amp > 0]
         floor_amp = _estimate_strength_floor_amp_g(sample)
         location = _location_label(sample)

--- a/apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py
@@ -14,7 +14,11 @@ from vibesensor.shared.constants import (
 )
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.statistics_utils import _mean_variance
-from vibesensor.use_cases.diagnostics._types import PhaseLabel, Sample
+from vibesensor.use_cases.diagnostics._types import (
+    AnalysisSampleInput,
+    PhaseLabel,
+    ensure_analysis_sample,
+)
 from vibesensor.use_cases.diagnostics.math_utils import _weighted_percentile
 
 
@@ -61,16 +65,17 @@ def _speed_stats(speed_values: list[float]) -> SpeedProfileSummary:
 
 
 def _speed_stats_by_phase(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     per_sample_phases: Sequence[PhaseLabel],
 ) -> dict[str, SpeedProfileSummary]:
     """Compute speed statistics broken down by driving phase."""
     phase_speeds: dict[str, list[float]] = defaultdict(list)
     phase_sample_counts: dict[str, int] = defaultdict(int)
-    for sample, phase in zip(samples, per_sample_phases, strict=True):
+    for raw_sample, phase in zip(samples, per_sample_phases, strict=True):
+        sample = ensure_analysis_sample(raw_sample)
         phase_key = str(phase)
         phase_sample_counts[phase_key] += 1
-        speed = _as_float(sample.get("speed_kmh"))
+        speed = sample.speed_kmh
         if speed is not None and speed > 0:
             phase_speeds[phase_key].append(speed)
     result: dict[str, SpeedProfileSummary] = {}

--- a/apps/server/vibesensor/use_cases/diagnostics/statistics.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/statistics.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 
 from vibesensor.domain.speed_profile_summary import SpeedProfileSummary
@@ -16,13 +17,16 @@ from vibesensor.shared.constants import (
     SPEED_COVERAGE_MIN_PCT,
     SPEED_MIN_POINTS,
 )
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.run_context import order_reference_context_complete
 from vibesensor.shared.statistics_utils import _mean_variance
 from vibesensor.shared.time_utils import parse_iso8601
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.strength_bands import bucket_for_strength
-from vibesensor.use_cases.diagnostics._types import AccelStatistics, Sample
+from vibesensor.use_cases.diagnostics._types import (
+    AccelStatistics,
+    AnalysisSampleInput,
+    ensure_analysis_samples,
+)
 from vibesensor.use_cases.diagnostics.helpers import (
     _primary_vibration_strength_db,
     _sensor_limit_g,
@@ -64,10 +68,11 @@ def _strength_band_key(db_value: float | None) -> str | None:
 
 
 def compute_accel_statistics(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     sensor_model: object,
 ) -> AccelStatistics:
     """Compute per-axis values, aggregate amplitude metrics, and saturation counts."""
+    typed_samples = ensure_analysis_samples(samples)
     sensor_limit = _sensor_limit_g(sensor_model)
     sat_threshold = sensor_limit * _SATURATION_FRACTION if sensor_limit is not None else None
 
@@ -78,10 +83,10 @@ def compute_accel_statistics(
     amp_metric_values: list[float] = []
     sat_count = 0
 
-    for sample in samples:
-        x = _as_float(sample.get("accel_x_g"))
-        y = _as_float(sample.get("accel_y_g"))
-        z = _as_float(sample.get("accel_z_g"))
+    for sample in typed_samples:
+        x = sample.accel_x_g
+        y = sample.accel_y_g
+        z = sample.accel_z_g
         if x is not None:
             accel_x_vals.append(x)
         if y is not None:
@@ -121,18 +126,19 @@ def compute_accel_statistics(
 # ── Frame integrity ──────────────────────────────────────────────────────
 
 
-def compute_frame_integrity_counts(samples: list[Sample]) -> tuple[int, int]:
+def compute_frame_integrity_counts(samples: Sequence[AnalysisSampleInput]) -> tuple[int, int]:
     """Compute ``(total_dropped, total_overflow)`` across all client sensors."""
+    typed_samples = ensure_analysis_samples(samples)
     per_client_dropped: dict[str, list[float]] = defaultdict(list)
     per_client_overflow: dict[str, list[float]] = defaultdict(list)
-    for sample in samples:
-        client_id = str(sample.get("client_id") or "")
+    for sample in typed_samples:
+        client_id = sample.client_id
         if not client_id:
             continue
-        dropped = _as_float(sample.get("frames_dropped_total"))
+        dropped = sample.frames_dropped_total
         if dropped is not None:
             per_client_dropped[client_id].append(dropped)
-        overflow = _as_float(sample.get("queue_overflow_drops"))
+        overflow = sample.queue_overflow_drops
         if overflow is not None:
             per_client_overflow[client_id].append(overflow)
     total_dropped = sum(counter_delta(values) for values in per_client_dropped.values())
@@ -152,20 +158,21 @@ def compute_reference_completeness(metadata: JsonObject) -> bool:
 
 
 def prepare_speed_and_phases(
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
 ) -> tuple[list[float], SpeedProfileSummary, float, bool, list[DrivingPhase], list[PhaseSegment]]:
     """Compute speed stats and phase segmentation shared by multiple entry points."""
+    typed_samples = ensure_analysis_samples(samples)
     speed_values = [
         speed
-        for speed in (_as_float(sample.get("speed_kmh")) for sample in samples)
+        for speed in (sample.speed_kmh for sample in typed_samples)
         if speed is not None and speed > 0
     ]
     speed_stats = _speed_stats(speed_values)
-    speed_non_null_pct = (len(speed_values) / len(samples) * 100.0) if samples else 0.0
+    speed_non_null_pct = (len(speed_values) / len(typed_samples) * 100.0) if typed_samples else 0.0
     speed_sufficient = (
         speed_non_null_pct >= SPEED_COVERAGE_MIN_PCT and len(speed_values) >= SPEED_MIN_POINTS
     )
-    per_sample_phases, phase_segments = segment_run_phases(samples)
+    per_sample_phases, phase_segments = segment_run_phases(typed_samples)
     return (
         speed_values,
         speed_stats,
@@ -181,22 +188,23 @@ def prepare_speed_and_phases(
 
 def compute_run_timing(
     metadata: JsonObject,
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     file_name: str,
 ) -> tuple[str, datetime | None, datetime | None, float]:
     """Extract run_id, start/end timestamps and duration from metadata+samples."""
+    typed_samples = ensure_analysis_samples(samples)
     run_id = str(metadata.get("run_id") or f"run-{file_name}")
     start_ts = parse_iso8601(metadata.get("start_time_utc"))
     end_ts = parse_iso8601(metadata.get("end_time_utc"))
 
-    if end_ts is None and samples:
-        sample_max_t = max((_as_float(sample.get("t_s")) or 0.0) for sample in samples)
+    if end_ts is None and typed_samples:
+        sample_max_t = max((sample.t_s or 0.0) for sample in typed_samples)
         if start_ts is not None:
             end_ts = start_ts + timedelta(seconds=sample_max_t)
     duration_s = 0.0
     if start_ts is not None and end_ts is not None:
         duration_s = max(0.0, (end_ts - start_ts).total_seconds())
-    elif samples:
-        duration_s = max((_as_float(sample.get("t_s")) or 0.0) for sample in samples)
+    elif typed_samples:
+        duration_s = max((sample.t_s or 0.0) for sample in typed_samples)
 
     return run_id, start_ts, end_ts, duration_s

--- a/apps/server/vibesensor/use_cases/diagnostics/summary_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/summary_builder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import (
@@ -13,7 +13,8 @@ from vibesensor.report_i18n import normalize_lang
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.diagnostics._types import (
     AccelStatistics,
-    Sample,
+    AnalysisSampleInput,
+    normalize_analysis_samples,
 )
 from vibesensor.use_cases.diagnostics.findings import _build_findings
 from vibesensor.use_cases.diagnostics.helpers import (
@@ -54,6 +55,7 @@ class RunAnalysis:
 
     __slots__ = (
         "_metadata",
+        "_raw_samples",
         "_samples",
         "_file_name",
         "_language",
@@ -67,7 +69,7 @@ class RunAnalysis:
     def __init__(
         self,
         metadata: JsonObject,
-        samples: list[Sample],
+        samples: Sequence[AnalysisSampleInput],
         *,
         file_name: str = "run",
         lang: str | None = None,
@@ -75,17 +77,17 @@ class RunAnalysis:
         findings_builder: Callable[..., tuple[DomainFinding, ...]] | None = None,
     ) -> None:
         self._metadata = metadata
-        self._samples = samples
+        self._raw_samples, self._samples = normalize_analysis_samples(samples)
         self._file_name = file_name
         self._language = normalize_lang(lang)
         self._include_samples = include_samples
         self._findings_builder = findings_builder
         self._test_run: TestRun | None = None
 
-        _validate_required_strength_metrics(samples)
-        self._prepared = prepare_run_data(metadata, samples, file_name=file_name)
+        _validate_required_strength_metrics(self._samples)
+        self._prepared = prepare_run_data(metadata, self._samples, file_name=file_name)
         self._accel_stats: AccelStatistics = compute_accel_statistics(
-            samples, metadata.get("sensor_model")
+            self._samples, metadata.get("sensor_model")
         )
 
     # -- read-only access --------------------------------------------------
@@ -149,6 +151,7 @@ class RunAnalysis:
             file_name=self._file_name,
             metadata=self._metadata,
             samples=self._samples,
+            raw_samples=self._raw_samples,
             language=self._language,
             include_samples=self._include_samples,
             prepared=self._prepared,
@@ -170,13 +173,13 @@ class RunAnalysis:
 def build_findings_for_samples(
     *,
     metadata: JsonObject,
-    samples: list[Sample],
+    samples: Sequence[AnalysisSampleInput],
     lang: str | None = None,
     findings_builder: Callable[..., tuple[DomainFinding, ...]] | None = None,
 ) -> tuple[DomainFinding, ...]:
     """Build the findings list from *samples* using the full analysis pipeline."""
     language = normalize_lang(lang)
-    rows = list(samples)
+    rows = normalize_analysis_samples(samples)[1]
     _validate_required_strength_metrics(rows)
     prepared = prepare_run_data(metadata, rows, file_name="run")
     builder = findings_builder or _build_findings

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -120,7 +120,9 @@ in order. Each step runs exactly once per analysis invocation.
 ## Data Flow
 
 ```
-Input: samples (list[JsonObject]) + metadata (JsonObject)
+Input: raw samples (list[JsonObject]) + metadata (JsonObject)
+  │
+  ├─ _types.normalize_analysis_samples() → raw rows + typed AnalysisSample objects
   │
   ├─ run_data_preparation.prepare_run_data() → PreparedRunData
   │    ├─ timing, speed stats, noise baseline


### PR DESCRIPTION
## Summary
- replace diagnostics `Sample = JsonObject` with a typed `AnalysisSample` contract plus normalization helpers
- move diagnostics internals onto typed sample fields while keeping raw rows for outward summary serialization
- add focused typed-sample regression coverage and update the analysis pipeline docs

## Testing
- pytest -q apps/server/tests/use_cases/diagnostics/test_analysis_sample.py apps/server/tests/use_cases/diagnostics/test_run_analysis.py apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py apps/server/tests/use_cases/diagnostics/test_plot_data_phase_context.py apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py apps/server/tests/adapters/pdf/test_report_analysis_helpers.py apps/server/tests/adapters/pdf/test_report_persistence_classification.py apps/server/tests/adapters/pdf/test_report_floor_estimation.py apps/server/tests/integration/test_multi_domain_regressions.py
- pytest -q apps/server/tests/use_cases/diagnostics apps/server/tests/adapters/pdf apps/server/tests/integration/test_decode_project_roundtrip.py
- PATH="$PWD/.venv/bin:$PATH" make lint
- make typecheck-backend
- make docs-lint
- docker compose build --pull && docker compose up -d
- python3 -m vibesensor.adapters.simulator.sim_sender --count 2 --duration 12 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server
- python3 -m vibesensor.adapters.simulator.ws_smoke --uri ws://127.0.0.1:8000/ws --min-clients 1 --timeout 20

Closes #1048