### PR TITLE
Type server release GitHub objects

### DIFF
--- a/apps/server/tests/use_cases/updates/test_release_fetcher.py
+++ b/apps/server/tests/use_cases/updates/test_release_fetcher.py
@@ -115,7 +115,9 @@ class TestGitHubRelease:
             draft=False,
             prerelease=False,
             published_at="2025-06-15T02:00:00Z",
-            assets=(GitHubReleaseAsset(name="vibesensor-2025.6.15-py3-none-any.whl", url="https://a"),),
+            assets=(
+                GitHubReleaseAsset(name="vibesensor-2025.6.15-py3-none-any.whl", url="https://a"),
+            ),
         )
 
     def test_from_api_payload_rejects_non_release_shapes(self) -> None:

--- a/apps/server/vibesensor/use_cases/updates/release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/release_fetcher.py
@@ -170,7 +170,8 @@ class GitHubAPIClient:
         validate_https_url(url, context=self._api_context)
         req = Request(url, headers=self._api_headers())
         with urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            result: JsonValue = json.loads(resp.read().decode("utf-8"))
+            return result
 
 
 class ServerReleaseFetcher(GitHubAPIClient):


### PR DESCRIPTION
## Summary
Closes #1055.

This PR removes the last `Any` / `dict[str, Any]` release-row handling from the server wheel release fetcher and replaces it with typed GitHub release objects decoded at the API boundary. The observable release-selection behavior is intentionally unchanged: the updater still queries GitHub Releases, skips drafts, looks for `server-v*` tags, finds the matching `vibesensor-*.whl` asset, and returns the distilled `ReleaseInfo` used downstream. What changes is where shape validation happens. Instead of pushing raw JSON bags deeper into selection logic and relying on repeated `.get(...)` lookups throughout the core flow, the fetcher now turns GitHub release rows into explicit dataclasses as soon as the JSON payload crosses the HTTP boundary. That gives this updater path the same explicit contract the rest of the repo has been moving toward, while keeping `ReleaseInfo` as the smaller downstream object callers already understand.

## Problem being solved

Issue #1055 called out one of the remaining weakly typed external API boundaries in the updater stack. `GitHubAPIClient._api_get()` returned `Any`, `_find_wheel_asset()` accepted and returned `dict[str, Any]`, and `find_latest_release()` walked raw release dictionaries through `.get(...)` lookups even though the semantics of those rows are already stable. That left the server release fetcher behind the more explicit typing discipline used elsewhere in the backend. The practical downside is not just aesthetics: once raw dict bags survive beyond the boundary, malformed payload handling becomes diffuse, static guarantees weaken, and it becomes easier for future changes to quietly widen the contract again.

## Implementation approach

The branch follows the issue’s preferred object-decoding route. Rather than broadening `ReleaseInfo` or inventing compatibility layers, it introduces a small pair of typed GitHub row models that exist specifically to represent the API response shape the fetcher needs: `GitHubReleaseAsset` and `GitHubRelease`. Each object owns its own boundary decode through `from_api_payload(...)`, so the HTTP boundary is responsible for validating field presence and type correctness before the selection logic runs. That keeps the core release-selection path simple and explicit: once the payload has been decoded, the rest of the flow works with typed attributes rather than stringly typed JSON bags.

I kept `ReleaseInfo` in place as the downstream distilled object because it still matches the rest of the updater path well. The issue explicitly allowed that, and there was no value in widening the blast radius just to remove an already-useful final representation. The main design decision here was therefore not to replace everything with one new giant model, but to separate the raw GitHub response shape from the smaller application-facing release metadata shape.

## Main code changes by area

In `apps/server/vibesensor/use_cases/updates/release_fetcher.py`, the branch adds `GitHubReleaseAsset` and `GitHubRelease` as frozen dataclasses with focused boundary decoders. `GitHubAPIClient._api_get()` is tightened from `Any` to `JsonValue`, and its `json.loads(...)` result is explicitly typed so mypy no longer sees an unchecked `Any` escaping from the API boundary. `find_latest_release()` now validates that the top-level response is a JSON array, decodes each row into a `GitHubRelease`, and raises early if a malformed release row appears instead of letting partially valid dict bags drift farther into business logic. `_find_wheel_asset()` now operates on `GitHubRelease` and returns `GitHubReleaseAsset | None`, so the tag filtering and asset selection logic are expressed in typed attributes rather than generic dict access.

In `apps/server/tests/use_cases/updates/test_release_fetcher.py`, I extended coverage to match the new contract. The tests now verify successful decoding for both typed GitHub row objects, reject malformed asset/release payload shapes, and assert that malformed release rows cause `find_latest_release()` to fail immediately with the expected boundary error. Existing tests for draft skipping, release absence, update detection, download behavior, and header construction remain in place, which gives confidence that the refactor preserved the externally visible release-selection semantics.

There were no schema, configuration, or documentation changes for this issue. The JSON contract change is intentionally internal to the Python boundary: HTTP requests to GitHub are still the same, persisted server-release metadata still flows through `ReleaseInfo`, and no user-facing config or API surface had to move.

## Validation and tests performed

Local validation was run on the rebased branch after bringing it onto current `main`. First, the focused updater suite for this area passed with `pytest -q apps/server/tests/use_cases/updates/test_release_fetcher.py` (21 tests). I then ran the broader backend/release subset via `tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests --job release-smoke`.

That first broader pass usefully caught two real branch follow-ups: Ruff wanted one long assertion in `test_release_fetcher.py` reformatted, and mypy flagged the `json.loads(...)` result inside `_api_get()` as an `Any` escape despite the function’s `JsonValue` return annotation. I fixed both in follow-up commit `0faa094e` by applying Ruff’s preferred wrapping and making the parsed JSON result explicitly typed as `JsonValue`. After that, the focused updater tests still passed, and the full backend/release subset passed cleanly: `backend-quality`, `backend-typecheck`, `backend-tests`, and `release-smoke` all succeeded.

## Risks, tradeoffs, and edge cases considered

The main tradeoff in this change is stricter boundary rejection. A malformed release row that previously might have been skipped indirectly or tolerated through missing-key defaults now fails earlier during decode. That is intentional and matches the issue acceptance criteria: malformed GitHub response shapes should fail at the boundary instead of leaking ambiguous bag parsing deeper into the updater logic. I kept that strictness targeted, though. The fetcher still only validates the fields it actually relies on, and `ReleaseInfo` remains the downstream contract so the change does not force unrelated updater code to understand raw GitHub payload structure.

I also considered whether the server release fetcher should be converted to reuse the firmware-release typed payload approach directly. I chose not to fold the two modules together here because the issue scope was narrower: tighten this server-fetch boundary, not redesign both fetchers into a single abstraction. The resulting implementation stays small, local, and reviewable while still aligning with the repo’s direction toward explicit payload/domain contracts.

## Out of scope and follow-up notes

This PR does not attempt to collapse the server and firmware release fetchers into one shared release-decoding layer, and it does not change how release version comparison, wheel download, rollback staging, or GitHub authentication headers work. Those behaviors are preserved as-is. If future updater work wants to unify the server and firmware fetch paths further, it can build on the typed models introduced here rather than starting from raw dict bags again.
