### PR TITLE
Type runtime intake stats payload

### DIFF
--- a/apps/server/tests/adapters/http/test_health_endpoint.py
+++ b/apps/server/tests/adapters/http/test_health_endpoint.py
@@ -142,3 +142,47 @@ async def test_health_endpoint_validates_through_fastapi_response_field(_health_
     assert payload_dict["data_loss"]["tracked_clients"] == 0
     assert payload_dict["persistence"]["analysis_in_progress"] is False
     assert validated.status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_keeps_public_intake_stats_shape_when_worker_pool_is_present(
+    _health_router,
+):
+    router, state = _health_router
+    endpoint = _find_endpoint(router, "/api/health")
+    assert endpoint is not None
+
+    state.processor.intake_stats.return_value = {
+        "total_ingested_samples": 10,
+        "total_compute_calls": 2,
+        "last_compute_duration_s": 0.1,
+        "last_compute_all_duration_s": 0.2,
+        "last_ingest_duration_s": 0.05,
+        "worker_pool": {
+            "max_workers": 2,
+            "max_queue_size": 2,
+            "max_pending_tasks": 4,
+            "total_tasks": 7,
+            "pending_tasks": 1,
+            "queued_tasks": 0,
+            "running_tasks": 1,
+            "rejected_tasks": 0,
+            "total_run_s": 1.5,
+            "avg_run_s": 0.75,
+            "total_submit_wait_s": 0.2,
+            "avg_submit_wait_s": 0.1,
+            "default_submit_timeout_s": None,
+            "alive": True,
+        },
+    }
+
+    result = response_payload(await endpoint())
+
+    assert result["intake_stats"] == {
+        "total_ingested_samples": 10,
+        "total_compute_calls": 2,
+        "last_compute_duration_s": 0.1,
+        "last_compute_all_duration_s": 0.2,
+        "last_ingest_duration_s": 0.05,
+    }
+    assert "worker_pool" not in result["intake_stats"]

--- a/apps/server/tests/adapters/http/test_health_snapshot.py
+++ b/apps/server/tests/adapters/http/test_health_snapshot.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from vibesensor.adapters.http.health_snapshot import build_health_snapshot
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingHealth, ProcessingLoopState
+from vibesensor.shared.types.payload_types import IntakeStatsPayload, WorkerPoolStats
 
 
 def _clean_data_loss() -> dict:
@@ -27,6 +28,35 @@ def _clean_persistence() -> dict:
     }
 
 
+def _clean_intake_stats() -> IntakeStatsPayload:
+    return {
+        "total_ingested_samples": 0,
+        "total_compute_calls": 0,
+        "last_compute_duration_s": 0.0,
+        "last_compute_all_duration_s": 0.0,
+        "last_ingest_duration_s": 0.0,
+    }
+
+
+def _worker_pool_stats() -> WorkerPoolStats:
+    return {
+        "max_workers": 2,
+        "max_queue_size": 2,
+        "max_pending_tasks": 4,
+        "total_tasks": 7,
+        "pending_tasks": 1,
+        "queued_tasks": 0,
+        "running_tasks": 1,
+        "rejected_tasks": 0,
+        "total_run_s": 1.5,
+        "avg_run_s": 0.75,
+        "total_submit_wait_s": 0.2,
+        "avg_submit_wait_s": 0.1,
+        "default_submit_timeout_s": None,
+        "alive": True,
+    }
+
+
 def _make_deps(
     *,
     data_loss: dict | None = None,
@@ -42,9 +72,9 @@ def _make_deps(
     return registry, run_recorder
 
 
-def _make_processor() -> MagicMock:
+def _make_processor(*, intake_stats: IntakeStatsPayload | None = None) -> MagicMock:
     proc = MagicMock()
-    proc.intake_stats.return_value = {}
+    proc.intake_stats.return_value = intake_stats or _clean_intake_stats()
     return proc
 
 
@@ -83,6 +113,26 @@ class TestBuildHealthSnapshotOk:
             "tick_count",
         ):
             assert key in result
+
+    def test_internal_snapshot_preserves_worker_pool_stats(self) -> None:
+        loop_state = ProcessingLoopState()
+        health_state = RuntimeHealthState()
+        health_state.mark_ready()
+        registry, run_recorder = _make_deps()
+        intake_stats: IntakeStatsPayload = {
+            **_clean_intake_stats(),
+            "worker_pool": _worker_pool_stats(),
+        }
+
+        result = build_health_snapshot(
+            loop_state,
+            health_state,
+            _make_processor(intake_stats=intake_stats),
+            registry,
+            run_recorder,
+        )
+
+        assert result["intake_stats"]["worker_pool"]["total_tasks"] == 7
 
 
 class TestBuildHealthSnapshotDegraded:

--- a/apps/server/tests/infra/processing/test_payload_builders.py
+++ b/apps/server/tests/infra/processing/test_payload_builders.py
@@ -14,6 +14,7 @@ from vibesensor.infra.processing.payload import (
     build_intake_stats_payload,
     build_time_alignment_payload,
 )
+from vibesensor.shared.types.payload_types import IntakeStatsPayload, WorkerPoolStats
 
 
 def _config(fft_n: int = 256) -> ProcessorConfig:
@@ -71,16 +72,28 @@ def test_build_debug_spectrum_payload_returns_debug_metadata() -> None:
 
 
 def test_build_intake_stats_payload_adds_worker_pool_stats() -> None:
-    base_stats = {
+    base_stats: IntakeStatsPayload = {
         "total_ingested_samples": 10,
         "total_compute_calls": 2,
         "last_compute_duration_s": 0.1,
         "last_compute_all_duration_s": 0.2,
         "last_ingest_duration_s": 0.05,
     }
-    worker_pool_stats = {
-        "active_workers": 1,
+    worker_pool_stats: WorkerPoolStats = {
+        "max_workers": 2,
+        "max_queue_size": 2,
+        "max_pending_tasks": 4,
         "total_tasks": 7,
+        "pending_tasks": 1,
+        "queued_tasks": 0,
+        "running_tasks": 1,
+        "rejected_tasks": 0,
+        "total_run_s": 1.5,
+        "avg_run_s": 0.75,
+        "total_submit_wait_s": 0.2,
+        "avg_submit_wait_s": 0.1,
+        "default_submit_timeout_s": None,
+        "alive": True,
     }
 
     payload = build_intake_stats_payload(base_stats, worker_pool_stats)

--- a/apps/server/vibesensor/infra/processing/payload.py
+++ b/apps/server/vibesensor/infra/processing/payload.py
@@ -7,7 +7,7 @@ wrapper methods that handle locking and buffer lookup.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -18,7 +18,6 @@ from vibesensor.infra.processing.models import (
     SpectrumAxisData,
 )
 from vibesensor.infra.processing.time_align import compute_overlap
-from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.payload_types import (
     AlignmentInfoPayload,
     DebugSpectrumErrorPayload,
@@ -32,6 +31,7 @@ from vibesensor.shared.types.payload_types import (
     SpectrumSeriesPayload,
     TimeAlignmentPayload,
     TimeAlignmentSensorPayload,
+    WorkerPoolStats,
 )
 from vibesensor.vibration_strength import empty_vibration_strength_metrics
 
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
     from vibesensor.infra.processing.buffers import ClientBuffer
     from vibesensor.infra.processing.compute import SignalMetricsComputer
-    from vibesensor.infra.workers.worker_pool import WorkerPoolStats
 
 _EMPTY_F32: np.ndarray = np.array([], dtype=np.float32)
 
@@ -156,10 +155,15 @@ def build_intake_stats_payload(
     worker_pool_stats: WorkerPoolStats | None,
 ) -> IntakeStatsPayload:
     """Build the health/debug intake stats payload."""
-    payload: IntakeStatsPayload = dict(base_stats)
+    payload: IntakeStatsPayload = {
+        "total_ingested_samples": base_stats["total_ingested_samples"],
+        "total_compute_calls": base_stats["total_compute_calls"],
+        "last_compute_duration_s": base_stats["last_compute_duration_s"],
+        "last_compute_all_duration_s": base_stats["last_compute_all_duration_s"],
+        "last_ingest_duration_s": base_stats["last_ingest_duration_s"],
+    }
     if worker_pool_stats is not None:
-        worker_pool_payload = cast(JsonObject, dict(worker_pool_stats))
-        payload["worker_pool"] = worker_pool_payload
+        payload["worker_pool"] = worker_pool_stats
     return payload
 
 

--- a/apps/server/vibesensor/infra/workers/worker_pool.py
+++ b/apps/server/vibesensor/infra/workers/worker_pool.py
@@ -29,7 +29,9 @@ import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from types import TracebackType
-from typing import TypedDict, TypeVar
+from typing import TypeVar
+
+from vibesensor.shared.types.payload_types import WorkerPoolStats
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,23 +39,6 @@ __all__ = ["WorkerPool"]
 
 T = TypeVar("T")
 R = TypeVar("R")
-
-
-class WorkerPoolStats(TypedDict):
-    max_workers: int
-    max_queue_size: int
-    max_pending_tasks: int
-    total_tasks: int
-    pending_tasks: int
-    queued_tasks: int
-    running_tasks: int
-    rejected_tasks: int
-    total_run_s: float
-    avg_run_s: float
-    total_submit_wait_s: float
-    avg_submit_wait_s: float
-    default_submit_timeout_s: float | None
-    alive: bool
 
 
 # Sensible default for a 4-core Raspberry Pi.

--- a/apps/server/vibesensor/shared/types/health_snapshot.py
+++ b/apps/server/vibesensor/shared/types/health_snapshot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.payload_types import IntakeStatsPayload
 
 
 class RunRecorderHealthSnapshot(TypedDict):
@@ -44,7 +44,7 @@ class HealthSnapshotData(TypedDict):
     degradation_reasons: list[str]
     data_loss: dict[str, int]
     persistence: RunRecorderHealthSnapshot
-    intake_stats: JsonObject
+    intake_stats: IntakeStatsPayload
     tick_duration_s: float | None
     max_tick_duration_s: float | None
     tick_count: int

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -1,16 +1,37 @@
 from __future__ import annotations
 
-from typing import TypeAlias
-
 from typing_extensions import NotRequired, TypedDict  # noqa: UP035 (Pydantic on Python 3.11)
 
-from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.vibration_strength import StrengthPeak, VibrationStrengthMetrics
 
 # Bump this when the payload shape changes in a backwards-incompatible way.
 SCHEMA_VERSION: str = "1"
 
-IntakeStatsPayload: TypeAlias = JsonObject
+
+class WorkerPoolStats(TypedDict):
+    max_workers: int
+    max_queue_size: int
+    max_pending_tasks: int
+    total_tasks: int
+    pending_tasks: int
+    queued_tasks: int
+    running_tasks: int
+    rejected_tasks: int
+    total_run_s: float
+    avg_run_s: float
+    total_submit_wait_s: float
+    avg_submit_wait_s: float
+    default_submit_timeout_s: float | None
+    alive: bool
+
+
+class IntakeStatsPayload(TypedDict):
+    total_ingested_samples: int
+    total_compute_calls: int
+    last_compute_duration_s: float
+    last_compute_all_duration_s: float
+    last_ingest_duration_s: float
+    worker_pool: NotRequired[WorkerPoolStats]
 
 
 class AxisPeak(TypedDict, total=False):


### PR DESCRIPTION
Closes #1056

## Summary
This PR replaces the last broad JSON typing around runtime intake stats with explicit shared payload contracts. The processing pipeline was already producing a stable shape: total ingested samples, compute counters and durations, and optionally a nested worker-pool stats block. The type layer had not caught up, so the code still treated that payload as `JsonObject`, `HealthSnapshotData` exposed it as a generic bag, and the intake payload builder used a cast when it injected worker-pool stats. That left a stable observability payload typed as a generic bag, which made the contract harder to reason about and encouraged generic indexing and widening instead of deliberate schema ownership.

The fix is intentionally narrow. It tightens the internal runtime payload contract, removes the `JsonObject` cast, and keeps the public `/api/health` response shape unchanged. The user-visible behavior is still the same, but the backend now models the runtime intake payload as an explicit contract instead of a loose JSON alias.

## Implementation approach
I started by tracing the flow that the issue described instead of editing the types in isolation. `SignalBufferStore.intake_stats()` already emits five concrete fields, `SignalProcessor.intake_stats()` only adds optional worker-pool data, `build_intake_stats_payload()` was the only place that widened worker-pool stats back into a generic JSON bag, and `build_health_snapshot()` passes the result into the internal health snapshot. The public FastAPI route then validates that snapshot through `HealthResponse`, which still models only the five base intake fields.

That distinction mattered for the implementation. The issue asked for a precise runtime contract and for the health snapshot typing to stop using `JsonObject`, but it did not require a public API expansion. During validation I confirmed that `/api/health` already validates through a narrower response model and drops undeclared nested extras. That meant I could tighten the internal payload contract without silently widening the external HTTP schema.

My first pass reused `WorkerPoolStats` by importing it into `shared/types/payload_types.py`, but the repository’s backend static guards correctly rejected that new `shared -> infra` dependency. Rather than weakening the change or adding a one-off exception, I moved the canonical `WorkerPoolStats` `TypedDict` into `shared/types/payload_types.py` beside the other shared payload contracts and updated `worker_pool.py` to consume that shared definition. That keeps the dependency direction clean and makes the precise intake payload contract genuinely shared instead of depending on an infra-owned type.

## Main code changes by area
### Shared payload contracts
`apps/server/vibesensor/shared/types/payload_types.py` now owns both `WorkerPoolStats` and the new `IntakeStatsPayload` `TypedDict`. `IntakeStatsPayload` captures the existing stable five-field intake metrics payload and declares `worker_pool` as an optional nested `WorkerPoolStats` block via `NotRequired`. This replaces the previous `IntakeStatsPayload: TypeAlias = JsonObject` definition, which carried no meaningful contract at all.

This change also keeps the schema honest: I did not add speculative fields, a new dataclass, or a second worker-pool payload shape. The issue called out that the structure was already stable, so the new type mirrors the existing runtime payload exactly.

### Runtime worker-pool typing
`apps/server/vibesensor/infra/workers/worker_pool.py` no longer defines a duplicate local `WorkerPoolStats` shape. Instead, it imports the shared contract from `payload_types.py`. That change is small, but it is important because it makes the shared layer the single owner of the payload type and prevents the intake stats contract from depending on infra code.

### Intake payload construction
`apps/server/vibesensor/infra/processing/payload.py` is where the actual broad typing leaked into runtime code. The old implementation copied `base_stats`, converted the worker-pool stats dict, and used `cast(JsonObject, ...)` before attaching it to the payload. The new implementation builds an explicit `IntakeStatsPayload` from the known base fields and attaches the optional `worker_pool` block directly as `WorkerPoolStats`. That removes the cast entirely and keeps the builder aligned with the precise schema.

### Health snapshot typing
`apps/server/vibesensor/shared/types/health_snapshot.py` now types `HealthSnapshotData.intake_stats` as `IntakeStatsPayload` instead of `JsonObject`. That is the main boundary tightening that the issue asked for. The internal health snapshot now communicates that intake stats are a well-defined runtime structure, not an arbitrary nested JSON object.

### Tests
The tests were updated to pin both the new precise contract and the unchanged public API behavior.

In `apps/server/tests/infra/processing/test_payload_builders.py`, the intake payload builder test now uses a fully shaped `WorkerPoolStats` payload instead of a partial ad hoc dict. That keeps the test aligned with the shared schema.

In `apps/server/tests/adapters/http/test_health_snapshot.py`, the processor helper now returns a real `IntakeStatsPayload`, and there is a new assertion that the internal health snapshot preserves nested worker-pool stats when they are present.

In `apps/server/tests/adapters/http/test_health_endpoint.py`, there is a new regression test that feeds worker-pool stats into the processor mock and verifies that `/api/health` still returns only the existing public intake-stats fields. That is the key guard against accidentally widening the external health response while solving an internal typing issue.

## Contract, schema, and documentation impact
There is no schema migration and no documentation update in this PR because the public HTTP contract is intentionally unchanged. I also did not bump the shared schema version, since this change does not introduce a backwards-incompatible payload shape change for the exposed API surface. The work here is specifically about replacing a broad internal alias with a precise runtime contract and removing casts that existed only because the type boundary was too loose.

## Risks, tradeoffs, and edge cases
The main tradeoff in this implementation is deliberate separation between the internal health snapshot type and the public `/api/health` response model. The runtime snapshot can now carry optional worker-pool stats in a typed way, but the HTTP response continues to expose the narrower five-field intake summary. I chose that path because it matches current behavior and keeps this issue scoped to typing and cast removal. If we later decide that worker-pool stats should be part of the public health API, that should happen in a separate contract change with explicit review of clients and generated UI contracts.

Another important edge case was repository architecture. The first implementation direction would have solved the typing problem but violated the static layer-boundary rules. Moving `WorkerPoolStats` into the shared payload contract layer fixed the issue without weakening those guards, so the final change is both type-safe and architecture-safe.

## Validation
I validated the change in two stages.

First, I ran focused tests for the touched areas:

- `.venv/bin/python -m pytest -q apps/server/tests/infra/processing/test_payload_builders.py apps/server/tests/infra/processing/test_processing.py apps/server/tests/infra/workers/test_worker_pool.py apps/server/tests/adapters/http/test_health_snapshot.py apps/server/tests/adapters/http/test_health_endpoint.py`
- Result: `63 passed`

Then I ran the broader backend subset used for local CI-style validation:

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`
- Result: all three jobs passed (`backend-quality`, `backend-typecheck`, and `backend-tests`)

That combination covers the precise payload typing, the health snapshot boundary, the unchanged public health response, backend lint/static guards, mypy, and the broader backend pytest suite.
