### PR TITLE
Fix #1057: type report location rows

### DIFF
--- a/apps/server/tests/adapters/pdf/test_diagram_layout.py
+++ b/apps/server/tests/adapters/pdf/test_diagram_layout.py
@@ -19,6 +19,7 @@ from vibesensor.adapters.pdf.diagram_layout import (
     resolve_marker_states,
     source_color,
 )
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
 
 # ── estimate_text_width ──────────────────────────────────────────────────────
 
@@ -249,7 +250,7 @@ def test_extract_amp_by_location_from_intensity() -> None:
     summary: dict[str, object] = {
         "sensor_locations": ["front-left wheel"],
         "sensor_intensity_by_location": [
-            {"location": "front-left wheel", "p95_intensity_db": 22.0},
+            LocationIntensitySummary(location="front-left wheel", p95_intensity_db=22.0),
         ],
     }
     connected, amp = extract_amp_by_location(summary, [])
@@ -262,8 +263,8 @@ def test_extract_amp_by_location_from_rows() -> None:
         "sensor_locations": ["rear-right wheel"],
         "sensor_intensity_by_location": [],
     }
-    rows: list[dict[str, object]] = [
-        {"location": "rear-right wheel", "mean_value": 15.0},
+    rows = [
+        LocationHotspotRow(location="rear-right wheel", mean_value=15.0),
     ]
     connected, amp = extract_amp_by_location(summary, rows)
     assert "rear-right wheel" in connected

--- a/apps/server/tests/adapters/pdf/test_report_mapping_context.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_context.py
@@ -9,7 +9,7 @@ from vibesensor.adapters.pdf.mapping import (
     PrimaryCandidateContext,
     ReportMappingContext,
 )
-from vibesensor.domain import Finding, TestRun
+from vibesensor.domain import Finding, LocationIntensitySummary, TestRun
 from vibesensor.domain.run_capture import RunCapture
 
 # ---------------------------------------------------------------------------
@@ -105,21 +105,22 @@ class TestTopReportCandidate:
 class TestHasSignificantLocationIntensity:
     def test_with_positive_intensity(self) -> None:
         context = _make_context()
-        rows = [{"location": "front_left", "p95_intensity_db": 12.5}]
+        rows = [LocationIntensitySummary(location="front_left", p95_intensity_db=12.5)]
         assert context.has_significant_location_intensity(rows) is True
 
     def test_with_zero_intensity(self) -> None:
         context = _make_context()
-        rows = [{"location": "front_left", "p95_intensity_db": 0.0}]
+        rows = [LocationIntensitySummary(location="front_left", p95_intensity_db=0.0)]
         assert context.has_significant_location_intensity(rows) is False
 
     def test_with_empty_rows(self) -> None:
         context = _make_context()
         assert context.has_significant_location_intensity([]) is False
 
-    def test_with_non_dict_rows(self) -> None:
+    def test_with_missing_intensity_value(self) -> None:
         context = _make_context()
-        assert context.has_significant_location_intensity(["not a dict"]) is False
+        rows = [LocationIntensitySummary(location="front_left")]
+        assert context.has_significant_location_intensity(rows) is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
@@ -4,6 +4,7 @@ from vibesensor.adapters.pdf.mapping import (
     prepare_report_mapping_context,
     resolve_primary_report_candidate,
 )
+from vibesensor.domain import LocationIntensitySummary
 
 
 def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> None:
@@ -29,7 +30,7 @@ def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> 
 
 
 def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> None:
-    sensor_intensity = [{"p95_intensity_db": 21.0}]
+    sensor_intensity = [LocationIntensitySummary(location="", p95_intensity_db=21.0)]
     context = prepare_report_mapping_context(
         {
             "sensor_count_used": 0,

--- a/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
+++ b/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
@@ -215,7 +215,7 @@ def _assert_unit_consistency(rd: ReportTemplateData) -> None:
         _assert_valid_float(pr.strength_db, "strength_db")
         _assert_valid_float(pr.freq_hz, "freq_hz")
 
-    units = {row.get("unit") for row in rd.location_hotspot_rows if isinstance(row, dict)}
+    units = {row.unit for row in rd.location_hotspot_rows}
     assert len(units) <= 1, f"Mixed units in location hotspot rows: {units}"
 
 

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -123,7 +123,7 @@ def test_map_summary_uses_connected_sensors_for_report_evidence() -> None:
     data = map_summary(summary)
     assert data.sensor_count == 2
     assert data.sensor_locations == ["Front Left", "Rear Left"]
-    assert [row["location"] for row in data.sensor_intensity_by_location] == [
+    assert [row.location for row in data.sensor_intensity_by_location] == [
         "Front Left",
         "Rear Left",
     ]

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -11,6 +11,7 @@ from vibesensor.adapters.pdf.diagram_layout import (
 )
 from vibesensor.adapters.pdf.pdf_diagram_render import car_location_diagram
 from vibesensor.adapters.pdf.pdf_style import REPORT_COLORS
+from vibesensor.domain import LocationIntensitySummary
 
 
 def _rectangles_overlap(
@@ -119,7 +120,7 @@ def test_sparse_layout_renders_only_connected_sensor_labels() -> None:
     summary = {
         "sensor_locations": ["front-left wheel", "rear-right wheel"],
         "sensor_intensity_by_location": [
-            {"location": "front-left wheel", "p95_intensity_db": 22.0},
+            LocationIntensitySummary(location="front-left wheel", p95_intensity_db=22.0),
         ],
     }
     diagram = car_location_diagram(
@@ -167,10 +168,10 @@ def test_legend_shows_diagnostic_source_only_and_source_labels_do_not_overlap() 
             "rear-right wheel",
         ],
         "sensor_intensity_by_location": [
-            {"location": "front-left wheel", "p95_intensity_db": 31.1},
-            {"location": "front-right wheel", "p95_intensity_db": 34.9},
-            {"location": "rear-left wheel", "p95_intensity_db": 30.9},
-            {"location": "rear-right wheel", "p95_intensity_db": 31.4},
+            LocationIntensitySummary(location="front-left wheel", p95_intensity_db=31.1),
+            LocationIntensitySummary(location="front-right wheel", p95_intensity_db=34.9),
+            LocationIntensitySummary(location="rear-left wheel", p95_intensity_db=30.9),
+            LocationIntensitySummary(location="rear-right wheel", p95_intensity_db=31.4),
         ],
     }
     diagram = car_location_diagram(

--- a/apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py
+++ b/apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py
@@ -176,8 +176,8 @@ class TestSensorIntensityPhaseContext:
             assert phase_intensity is not None
             assert len(phase_intensity) >= 1
             for stats in phase_intensity.values():
-                assert "count" in stats
-                assert "mean_intensity_db" in stats
+                assert stats.count > 0
+                assert stats.mean_intensity_db is not None
 
     def test_phase_intensity_absent_without_phases(self) -> None:
         rows = _sensor_intensity_by_location(

--- a/apps/server/tests/domain/test_location_hotspot.py
+++ b/apps/server/tests/domain/test_location_hotspot.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from vibesensor.domain.location_hotspot import LocationHotspot
+from vibesensor.domain.location_hotspot import (
+    LocationHotspot,
+    LocationHotspotRow,
+    LocationIntensitySummary,
+    PhaseIntensitySummary,
+    StrengthBucketDistribution,
+)
 
 
 class TestComputeConfidence:
@@ -101,3 +107,57 @@ class TestComputeConfidence:
             total_samples=20,
         )
         assert few > many
+
+
+class TestLocationIntensitySummaryRows:
+    def test_from_dict_parses_typed_nested_values(self) -> None:
+        summary = LocationIntensitySummary.from_dict(
+            {
+                "location": "rear-left",
+                "sample_count": 8,
+                "sample_coverage_ratio": 0.75,
+                "p95_intensity_db": 18.0,
+                "strength_bucket_distribution": {
+                    "total": 8,
+                    "counts": {"l0": 2, "l1": 6},
+                    "percent_time_l0": 25.0,
+                    "percent_time_l1": 75.0,
+                },
+                "phase_intensity": {
+                    "cruise": {
+                        "count": 3,
+                        "mean_intensity_db": 12.0,
+                        "max_intensity_db": 18.0,
+                    },
+                },
+            },
+        )
+
+        assert summary.location == "rear-left"
+        assert summary.strength_bucket_distribution.total == 8
+        assert summary.strength_bucket_distribution.counts["l1"] == 6
+        assert summary.phase_intensity is not None
+        assert summary.phase_intensity["cruise"].max_intensity_db == 18.0
+
+    def test_strength_bucket_distribution_defaults_to_typed_object(self) -> None:
+        summary = LocationIntensitySummary(location="front-left")
+
+        assert isinstance(summary.strength_bucket_distribution, StrengthBucketDistribution)
+        assert summary.strength_bucket_distribution.total == 0
+
+    def test_location_hotspot_row_defaults_to_db_unit(self) -> None:
+        row = LocationHotspotRow(location="front-left", count=2, peak_value=18.0, mean_value=12.0)
+
+        assert row.unit == "db"
+
+    def test_phase_intensity_summary_from_dict(self) -> None:
+        phase = PhaseIntensitySummary.from_dict(
+            {
+                "count": 5,
+                "mean_intensity_db": 10.0,
+                "max_intensity_db": 16.0,
+            },
+        )
+
+        assert phase.count == 5
+        assert phase.mean_intensity_db == 10.0

--- a/apps/server/tests/hygiene/test_domain_new_types.py
+++ b/apps/server/tests/hygiene/test_domain_new_types.py
@@ -16,7 +16,9 @@ from vibesensor.domain import (
     DrivingPhaseInterval,
     LocationIntensitySummary,
     OrderMatchObservation,
+    PhaseIntensitySummary,
     RunMetadataSnapshot,
+    StrengthBucketDistribution,
 )
 
 # ---------------------------------------------------------------------------
@@ -219,7 +221,13 @@ class TestLocationIntensitySummary:
             mean_intensity_db=12.5,
             p95_intensity_db=18.0,
             max_intensity_db=22.0,
-            strength_bucket_distribution={"low": 10, "mid": 50, "high": 40},
+            strength_bucket_distribution=StrengthBucketDistribution(
+                total=100,
+                counts={"l0": 10, "l1": 50, "l2": 40},
+                percent_time_l0=10.0,
+                percent_time_l1=50.0,
+                percent_time_l2=40.0,
+            ),
         )
         assert summary.location == "front_left"
         assert summary.sample_count == 100
@@ -254,15 +262,32 @@ class TestLocationIntensitySummary:
             "max_intensity_db": 20.0,
             "dropped_frames_delta": 0.0,
             "queue_overflow_drops_delta": None,
-            "strength_bucket_distribution": {"low": 5},
-            "phase_intensity": {"cruise": {"mean": 12.0}},
+            "strength_bucket_distribution": {
+                "total": 5,
+                "counts": {"l0": 5},
+                "percent_time_l0": 100.0,
+            },
+            "phase_intensity": {
+                "cruise": {
+                    "count": 2,
+                    "mean_intensity_db": 12.0,
+                    "max_intensity_db": 14.0,
+                },
+            },
         }
         summary = LocationIntensitySummary.from_dict(raw)
         assert summary.location == "rear_axle"
         assert summary.partial_coverage is True
         assert summary.sample_count == 50  # from "samples" key
         assert summary.p95_intensity_db == 15.0
-        assert summary.phase_intensity == {"cruise": {"mean": 12.0}}
+        assert summary.strength_bucket_distribution.total == 5
+        assert summary.phase_intensity == {
+            "cruise": PhaseIntensitySummary(
+                count=2,
+                mean_intensity_db=12.0,
+                max_intensity_db=14.0,
+            ),
+        }
 
     def test_from_dict_sample_count_key(self) -> None:
         raw = {"location": "x", "sample_count": 42, "sample_coverage_ratio": 0.5}
@@ -271,4 +296,4 @@ class TestLocationIntensitySummary:
 
     def test_default_strength_bucket_distribution(self) -> None:
         summary = LocationIntensitySummary(location="x")
-        assert summary.strength_bucket_distribution == {}
+        assert summary.strength_bucket_distribution == StrengthBucketDistribution()

--- a/apps/server/vibesensor/adapters/pdf/_candidate_resolver.py
+++ b/apps/server/vibesensor/adapters/pdf/_candidate_resolver.py
@@ -7,9 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.presentation import strength_label, strength_text
-from vibesensor.domain import ConfidenceAssessment, Finding
+from vibesensor.domain import ConfidenceAssessment, Finding, LocationIntensitySummary
 from vibesensor.report_i18n import human_source
-from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.history.report_interpretation import resolve_primary_report_facts
 
 if TYPE_CHECKING:
@@ -47,7 +46,7 @@ class PrimaryCandidateContext:
 def resolve_primary_report_candidate(
     *,
     context: ReportMappingContext,
-    sensor_intensity: list[JsonObject],
+    sensor_intensity: list[LocationIntensitySummary],
     tr: Callable[..., str],
     lang: str,
 ) -> PrimaryCandidateContext:

--- a/apps/server/vibesensor/adapters/pdf/_panel_diagram.py
+++ b/apps/server/vibesensor/adapters/pdf/_panel_diagram.py
@@ -18,6 +18,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     build_page2_layout,
 )
 from vibesensor.adapters.pdf.report_data import FindingPresentation, ReportTemplateData
+from vibesensor.domain import LocationHotspotRow
 
 
 def fit_rect_preserve_aspect(
@@ -78,7 +79,7 @@ def _draw_car_visual_panel(
     y: float,
     w: float,
     h: float,
-    location_rows: list[dict[str, object]],
+    location_rows: list[LocationHotspotRow],
     top_causes: list[FindingPresentation],
     content_width: float,
 ) -> None:

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -10,6 +10,8 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal
 
+from vibesensor.domain import LocationHotspotRow
+
 # ── Marker & label data types ────────────────────────────────────────────────
 
 MarkerState = Literal["connected-active", "connected-inactive", "disconnected"]
@@ -340,8 +342,8 @@ def location_points(
 
 
 def extract_amp_by_location(
-    summary: dict[str, object],
-    location_rows: list[dict[str, object]],
+    summary: Mapping[str, object],
+    location_rows: Sequence[LocationHotspotRow],
     *,
     as_float: Callable[[object], float | None] | None = None,
 ) -> tuple[set[str], dict[str, float]]:
@@ -376,18 +378,13 @@ def extract_amp_by_location(
     sensor_intensity_rows = summary.get("sensor_intensity_by_location", [])
     if isinstance(sensor_intensity_rows, list):
         for row in sensor_intensity_rows:
-            if not isinstance(row, dict):
-                continue
-            loc = canonical_location(row.get("location"))
-            p95_val = coerce(row.get("p95_intensity_db"))
-            p95_db = p95_val if p95_val is not None else coerce(row.get("mean_intensity_db"))
+            loc = canonical_location(row.location)
+            p95_db = row.p95_intensity_db or row.mean_intensity_db
             if loc and p95_db is not None and p95_db > 0:
                 amp_by_location[loc] = p95_db
     for row in location_rows:
-        if not isinstance(row, dict):
-            continue
-        loc = canonical_location(row.get("location"))
-        mean_val = coerce(row.get("mean_value"))
+        loc = canonical_location(row.location)
+        mean_val = coerce(row.mean_value)
         if loc and loc not in amp_by_location and mean_val is not None and mean_val > 0:
             amp_by_location[loc] = mean_val
     connected_locations.update(amp_by_location.keys())

--- a/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
     from vibesensor.adapters.pdf.diagram_layout import LabelRenderPlan, MarkerRenderPlan
+    from vibesensor.domain import LocationHotspotRow
 
 __all__ = ["car_location_diagram"]
 
@@ -268,8 +269,8 @@ def _draw_source_legend(
 
 def car_location_diagram(
     top_findings: Sequence[Mapping[str, object] | Any],
-    summary: dict[str, object],
-    location_rows: list[dict[str, object]],
+    summary: Mapping[str, object],
+    location_rows: Sequence[LocationHotspotRow],
     *,
     content_width: float,
     tr: Callable[..., str],

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -9,6 +9,7 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 
 from vibesensor.adapters.pdf.report_data import FindingPresentation, ReportTemplateData
+from vibesensor.domain import LocationHotspotRow
 from vibesensor.report_i18n import tr as _tr
 
 # ── Theme ────────────────────────────────────────────────────────────────────
@@ -255,7 +256,7 @@ class PdfRenderContext:
     width: float
     page_top: float
     lang: str
-    location_rows: list
+    location_rows: list[LocationHotspotRow]
     top_causes: list[FindingPresentation]
     tr_fn: Callable[..., str]
     text_fn: Callable[[str, str], str]
@@ -265,7 +266,7 @@ class PdfRenderContext:
         cls,
         data: ReportTemplateData,
         *,
-        location_rows: list | None = None,
+        location_rows: list[LocationHotspotRow] | None = None,
         top_causes: list[FindingPresentation] | None = None,
         tr_fn: Callable[..., str] | None = None,
         text_fn: Callable[[str, str], str] | None = None,

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from vibesensor.adapters.pdf.report_data import PatternEvidence
 from vibesensor.domain import (
     Finding,
+    LocationIntensitySummary,
     TestRun,
     VibrationOrigin,
 )
@@ -83,13 +84,11 @@ class ReportMappingContext:
 
     def has_significant_location_intensity(
         self,
-        sensor_intensity: list[dict[str, object]],
+        sensor_intensity: list[LocationIntensitySummary],
     ) -> bool:
         """Whether any sensor location shows significant above-noise intensity."""
         for row in sensor_intensity:
-            if not isinstance(row, dict):
-                continue
-            p95 = _as_float(row.get("p95_intensity_db"))
+            p95 = _as_float(row.p95_intensity_db)
             if p95 is not None and p95 > 0:
                 return True
         return False

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -24,8 +24,8 @@ __all__ = [
 from dataclasses import dataclass, field
 
 from vibesensor.coerce import coerce_float
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
-from vibesensor.shared.types.json_types import JsonObject
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -182,8 +182,8 @@ class ReportTemplateData:
     # renderer never needs to read raw samples or call analysis code.
     findings: list[FindingPresentation] = field(default_factory=list)
     top_causes: list[FindingPresentation] = field(default_factory=list)
-    sensor_intensity_by_location: list[JsonObject] = field(default_factory=list)
-    location_hotspot_rows: list[JsonObject] = field(default_factory=list)
+    sensor_intensity_by_location: list[LocationIntensitySummary] = field(default_factory=list)
+    location_hotspot_rows: list[LocationHotspotRow] = field(default_factory=list)
 
 
 def build_report_from_summary(summary: AnalysisSummary) -> Report:

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -43,7 +43,13 @@ from .driving_segment import DrivingPhase, DrivingPhaseInterval, DrivingPhaseSeg
 from .finding import Finding, speed_band_sort_key, speed_bin_label
 from .finding_evidence import FindingEvidence, Signature
 from .finding_types import FindingKind, VibrationSource
-from .location_hotspot import LocationHotspot, LocationIntensitySummary
+from .location_hotspot import (
+    LocationHotspot,
+    LocationHotspotRow,
+    LocationIntensitySummary,
+    PhaseIntensitySummary,
+    StrengthBucketDistribution,
+)
 from .order_match import OrderMatchObservation
 from .order_reference import OrderReferenceSpec
 from .run import Run
@@ -90,9 +96,12 @@ __all__ = [
     "FindingEvidence",
     "FindingKind",
     "LocationHotspot",
+    "LocationHotspotRow",
     "LocationIntensitySummary",
     "OrderMatchObservation",
+    "PhaseIntensitySummary",
     "Signature",
+    "StrengthBucketDistribution",
     "StrengthMetrics",
     "StrengthPeak",
     "VibrationOrigin",

--- a/apps/server/vibesensor/domain/location_hotspot.py
+++ b/apps/server/vibesensor/domain/location_hotspot.py
@@ -12,7 +12,13 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-__all__ = ["LocationHotspot", "LocationIntensitySummary"]
+__all__ = [
+    "LocationHotspot",
+    "LocationHotspotRow",
+    "LocationIntensitySummary",
+    "PhaseIntensitySummary",
+    "StrengthBucketDistribution",
+]
 
 from ._numeric import coerce_float, coerce_int
 
@@ -196,6 +202,101 @@ class LocationHotspot:
         return self
 
 
+@dataclass(frozen=True, slots=True)
+class StrengthBucketDistribution:
+    """Typed strength-level bucket distribution for a location."""
+
+    total: int = 0
+    counts: dict[str, int] = field(default_factory=dict)
+    percent_time_l0: float = 0.0
+    percent_time_l1: float = 0.0
+    percent_time_l2: float = 0.0
+    percent_time_l3: float = 0.0
+    percent_time_l4: float = 0.0
+    percent_time_l5: float = 0.0
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object] | None) -> StrengthBucketDistribution:
+        """Parse from a raw bucket-distribution mapping."""
+
+        def _opt_float(value: object) -> float | None:
+            if value is None or not isinstance(value, (int, float, str)):
+                return None
+            try:
+                return coerce_float(value)
+            except (TypeError, ValueError):
+                return None
+
+        if not isinstance(raw, Mapping):
+            return cls()
+        counts_raw = raw.get("counts")
+        counts: dict[str, int] = {}
+        if isinstance(counts_raw, Mapping):
+            for key, value in counts_raw.items():
+                try:
+                    counts[str(key)] = coerce_int(value)
+                except (TypeError, ValueError):
+                    continue
+        try:
+            total = coerce_int(raw.get("total", 0))
+        except (TypeError, ValueError):
+            total = 0
+        return cls(
+            total=total,
+            counts=counts,
+            percent_time_l0=_opt_float(raw.get("percent_time_l0")) or 0.0,
+            percent_time_l1=_opt_float(raw.get("percent_time_l1")) or 0.0,
+            percent_time_l2=_opt_float(raw.get("percent_time_l2")) or 0.0,
+            percent_time_l3=_opt_float(raw.get("percent_time_l3")) or 0.0,
+            percent_time_l4=_opt_float(raw.get("percent_time_l4")) or 0.0,
+            percent_time_l5=_opt_float(raw.get("percent_time_l5")) or 0.0,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseIntensitySummary:
+    """Typed phase-specific intensity metrics for one location."""
+
+    count: int = 0
+    mean_intensity_db: float | None = None
+    max_intensity_db: float | None = None
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object] | None) -> PhaseIntensitySummary:
+        """Parse from a raw phase-intensity mapping."""
+
+        def _opt_float(value: object) -> float | None:
+            if value is None or not isinstance(value, (int, float, str)):
+                return None
+            try:
+                return coerce_float(value)
+            except (TypeError, ValueError):
+                return None
+
+        if not isinstance(raw, Mapping):
+            return cls()
+        try:
+            count = coerce_int(raw.get("count", 0))
+        except (TypeError, ValueError):
+            count = 0
+        return cls(
+            count=count,
+            mean_intensity_db=_opt_float(raw.get("mean_intensity_db")),
+            max_intensity_db=_opt_float(raw.get("max_intensity_db")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LocationHotspotRow:
+    """Precomputed location hotspot row for report/PDF mapping."""
+
+    location: str = ""
+    count: int = 0
+    unit: str = "db"
+    peak_value: float = 0.0
+    mean_value: float = 0.0
+
+
 # ---------------------------------------------------------------------------
 # LocationIntensitySummary
 # ---------------------------------------------------------------------------
@@ -220,18 +321,16 @@ class LocationIntensitySummary:
     max_intensity_db: float | None = None
     dropped_frames_delta: float | None = None
     queue_overflow_drops_delta: float | None = None
-    strength_bucket_distribution: Mapping[str, object] = field(default_factory=dict)
-    phase_intensity: Mapping[str, object] | None = None
+    strength_bucket_distribution: StrengthBucketDistribution = field(
+        default_factory=StrengthBucketDistribution,
+    )
+    phase_intensity: dict[str, PhaseIntensitySummary] | None = None
 
     def __post_init__(self) -> None:
         if self.sample_count < 0:
             raise ValueError("sample_count must be >= 0")
         if not (0.0 <= self.sample_coverage_ratio <= 1.0):
             raise ValueError("sample_coverage_ratio must be in [0.0, 1.0]")
-        # Normalize strength_bucket_distribution from any input to a dict
-        sbd = self.strength_bucket_distribution
-        if not isinstance(sbd, dict):
-            object.__setattr__(self, "strength_bucket_distribution", dict(sbd))
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, object]) -> LocationIntensitySummary:
@@ -261,13 +360,23 @@ class LocationIntensitySummary:
         except (TypeError, ValueError):
             sample_coverage_ratio = 0.0
 
-        sbd = raw.get("strength_bucket_distribution")
-        if not isinstance(sbd, dict):
-            sbd = {}
+        strength_bucket_distribution_raw = raw.get("strength_bucket_distribution")
+        strength_bucket_distribution_payload = (
+            strength_bucket_distribution_raw
+            if isinstance(strength_bucket_distribution_raw, Mapping)
+            else None
+        )
+        sbd = StrengthBucketDistribution.from_dict(strength_bucket_distribution_payload)
 
-        pi = raw.get("phase_intensity")
-        if pi is not None and not isinstance(pi, dict):
-            pi = None
+        phase_intensity_raw = raw.get("phase_intensity")
+        phase_intensity: dict[str, PhaseIntensitySummary] | None = None
+        if isinstance(phase_intensity_raw, Mapping):
+            parsed_phase_intensity = {
+                str(phase_key): PhaseIntensitySummary.from_dict(stats)
+                for phase_key, stats in phase_intensity_raw.items()
+                if isinstance(stats, Mapping)
+            }
+            phase_intensity = parsed_phase_intensity or None
 
         return cls(
             location=str(raw.get("location", "")),
@@ -282,5 +391,5 @@ class LocationIntensitySummary:
             dropped_frames_delta=_opt_float("dropped_frames_delta"),
             queue_overflow_drops_delta=_opt_float("queue_overflow_drops_delta"),
             strength_bucket_distribution=sbd,
-            phase_intensity=pi if isinstance(pi, dict) else None,
+            phase_intensity=phase_intensity,
         )

--- a/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
@@ -6,9 +6,14 @@ import math
 from collections import defaultdict
 from collections.abc import Sequence
 
-from vibesensor.domain import LocationIntensitySummary, speed_band_sort_key, speed_bin_label
+from vibesensor.domain import (
+    LocationIntensitySummary,
+    PhaseIntensitySummary,
+    StrengthBucketDistribution,
+    speed_band_sort_key,
+    speed_bin_label,
+)
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.diagnostics._types import (
     AnalysisSampleInput,
     PhaseSpeedBreakdownRowData,
@@ -191,30 +196,43 @@ def _sensor_intensity_by_location(
         overflow_delta = _counter_delta(overflow_vals)
         bucket_counts = strength_bucket_counts.get(location, _EMPTY_BUCKET_COUNTS)
         bucket_total = max(0, strength_bucket_totals.get(location, 0))
-        bucket_distribution: JsonObject = {
-            "total": bucket_total,
-            "counts": dict(bucket_counts),
-        }
-        for idx in range(6):
-            key = f"l{idx}"
-            bucket_distribution[f"percent_time_{key}"] = (
-                (bucket_counts.get(key, 0) / bucket_total * 100.0) if bucket_total > 0 else 0.0
-            )
+        bucket_distribution = StrengthBucketDistribution(
+            total=bucket_total,
+            counts=dict(bucket_counts),
+            percent_time_l0=(bucket_counts.get("l0", 0) / bucket_total * 100.0)
+            if bucket_total > 0
+            else 0.0,
+            percent_time_l1=(bucket_counts.get("l1", 0) / bucket_total * 100.0)
+            if bucket_total > 0
+            else 0.0,
+            percent_time_l2=(bucket_counts.get("l2", 0) / bucket_total * 100.0)
+            if bucket_total > 0
+            else 0.0,
+            percent_time_l3=(bucket_counts.get("l3", 0) / bucket_total * 100.0)
+            if bucket_total > 0
+            else 0.0,
+            percent_time_l4=(bucket_counts.get("l4", 0) / bucket_total * 100.0)
+            if bucket_total > 0
+            else 0.0,
+            percent_time_l5=(bucket_counts.get("l5", 0) / bucket_total * 100.0)
+            if bucket_total > 0
+            else 0.0,
+        )
         sample_count = int(sample_counts.get(location, 0))
         sample_coverage_ratio = (sample_count / max_sample_count) if max_sample_count > 0 else 1.0
         sample_coverage_warning = max_sample_count >= 5 and sample_coverage_ratio <= 0.20
         partial_coverage = bool(
             connected_locations is not None and location not in connected_locations,
         )
-        location_phase_intensity: JsonObject | None = None
+        location_phase_intensity: dict[str, PhaseIntensitySummary] | None = None
         if has_phases:
             loc_phases = phase_amp.get(location, {})
             location_phase_intensity = {
-                phase_key: {
-                    "count": len(phase_vals),
-                    "mean_intensity_db": _mean(phase_vals) if phase_vals else None,
-                    "max_intensity_db": max(phase_vals) if phase_vals else None,
-                }
+                phase_key: PhaseIntensitySummary(
+                    count=len(phase_vals),
+                    mean_intensity_db=_mean(phase_vals) if phase_vals else None,
+                    max_intensity_db=max(phase_vals) if phase_vals else None,
+                )
                 for phase_key, phase_vals in loc_phases.items()
                 if phase_vals
             }

--- a/apps/server/vibesensor/use_cases/history/report_interpretation.py
+++ b/apps/server/vibesensor/use_cases/history/report_interpretation.py
@@ -7,9 +7,14 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from statistics import mean as _mean
 
-from vibesensor.domain import Finding, TestRun, VibrationOrigin
+from vibesensor.domain import (
+    Finding,
+    LocationHotspotRow,
+    LocationIntensitySummary,
+    TestRun,
+    VibrationOrigin,
+)
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.types.json_types import JsonObject
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,54 +50,50 @@ def normalize_origin_location(origin: VibrationOrigin | None) -> str:
 
 
 def collect_location_intensity(
-    sensor_intensity: Sequence[JsonObject],
+    sensor_intensity: Sequence[LocationIntensitySummary],
 ) -> dict[str, list[float]]:
     """Collect per-location intensity values from summary sensor intensity rows."""
     amp_by_location: dict[str, list[float]] = defaultdict(list)
     for row in sensor_intensity:
-        if not isinstance(row, dict):
-            continue
-        location = str(row.get("location") or "").strip()
-        p95_val = _as_float(row.get("p95_intensity_db"))
-        p95 = p95_val if p95_val is not None else _as_float(row.get("mean_intensity_db"))
+        location = row.location.strip()
+        p95 = row.p95_intensity_db if row.p95_intensity_db is not None else row.mean_intensity_db
         if location and p95 is not None and p95 > 0:
             amp_by_location[location].append(p95)
     return amp_by_location
 
 
 def compute_location_hotspot_rows(
-    sensor_intensity: Sequence[JsonObject],
-) -> list[JsonObject]:
+    sensor_intensity: Sequence[LocationIntensitySummary],
+) -> list[LocationHotspotRow]:
     """Pre-compute location hotspot rows from sensor intensity data."""
     if not sensor_intensity:
         return []
     amp_by_location = collect_location_intensity(sensor_intensity)
-    hotspot_rows: list[JsonObject] = [
-        {
-            "location": location,
-            "count": len(amps),
-            "unit": "db",
-            "peak_value": max(amps),
-            "mean_value": _mean(amps),
-        }
+    hotspot_rows = [
+        LocationHotspotRow(
+            location=location,
+            count=len(amps),
+            unit="db",
+            peak_value=max(amps),
+            mean_value=_mean(amps),
+        )
         for location, amps in amp_by_location.items()
     ]
     hotspot_rows.sort(
-        key=lambda row: (
-            _as_float(row.get("peak_value")) or 0.0,
-            _as_float(row.get("mean_value")) or 0.0,
-        ),
+        key=lambda row: (row.peak_value, row.mean_value),
         reverse=True,
     )
     return hotspot_rows
 
 
-def sensor_fallback_strength_db(sensor_intensity: Sequence[JsonObject]) -> float | None:
+def sensor_fallback_strength_db(
+    sensor_intensity: Sequence[LocationIntensitySummary],
+) -> float | None:
     """Return the best sensor-intensity dB as a last-resort fallback."""
-    sensor_rows = [
-        _as_float(row.get("p95_intensity_db")) for row in sensor_intensity if isinstance(row, dict)
-    ]
-    return max((value for value in sensor_rows if value is not None), default=None)
+    return max(
+        (row.p95_intensity_db for row in sensor_intensity if row.p95_intensity_db is not None),
+        default=None,
+    )
 
 
 def tire_spec_text(meta: Mapping[str, object]) -> str | None:
@@ -115,16 +116,21 @@ def tire_spec_text(meta: Mapping[str, object]) -> str | None:
 def filter_active_sensor_intensity(
     raw_sensor_intensity_all: Sequence[object],
     sensor_locations_active: Sequence[str],
-) -> list[JsonObject]:
+) -> list[LocationIntensitySummary]:
     """Filter sensor intensity rows to only active locations."""
     active_locations = set(sensor_locations_active)
-    if active_locations:
-        return [
-            row
-            for row in raw_sensor_intensity_all
-            if isinstance(row, dict) and str(row.get("location") or "") in active_locations
-        ]
-    return [row for row in raw_sensor_intensity_all if isinstance(row, dict)]
+    rows: list[LocationIntensitySummary] = []
+    for row in raw_sensor_intensity_all:
+        if isinstance(row, LocationIntensitySummary):
+            typed_row = row
+        elif isinstance(row, Mapping):
+            typed_row = LocationIntensitySummary.from_dict(row)
+        else:
+            continue
+        if active_locations and typed_row.location not in active_locations:
+            continue
+        rows.append(typed_row)
+    return rows
 
 
 def resolve_primary_report_facts(
@@ -132,7 +138,7 @@ def resolve_primary_report_facts(
     aggregate: TestRun,
     origin_location: str,
     sensor_locations_active: Sequence[str],
-    sensor_intensity: Sequence[JsonObject],
+    sensor_intensity: Sequence[LocationIntensitySummary],
 ) -> PrimaryReportFacts:
     """Resolve the domain-derived facts for the report's primary candidate."""
     effective = aggregate.effective_top_causes()


### PR DESCRIPTION
Fixes #1057

## Summary
This PR replaces the remaining internal report/history `JsonObject` row bags used for sensor intensity and hotspot data with typed report-domain objects while preserving the existing summary/API payload shape and report output. Before this change, the report path mixed two concepts: boundary JSON rows that are fine at serialization edges, and internal rows that downstream code actually expects to reason about. That leaked into `ReportTemplateData`, report interpretation, and several PDF helpers as dict guards, `.get(...)`, and shape-probing logic. The result was weaker mypy coverage, more branching in report code, and a higher chance that malformed intermediate data would be silently tolerated instead of being normalized once at the domain boundary.

## Implementation approach
I kept the change intentionally narrow. The issue does not require a new external contract, so the goal here was not to redesign the report payload API or add another conversion layer. Instead, the fix tightens the existing domain model and moves normalization to the point where raw summary data first becomes internal report data. Boundary serialization still emits dict-shaped payloads for summaries and API consumers, but the internal report/history path now works with typed dataclasses. That preserves user-visible behavior while removing broad `JsonObject` handling from the places that make report decisions.

## Main code changes

### Domain model
`apps/server/vibesensor/domain/location_hotspot.py` now defines three explicit domain types that were previously implied by nested dicts:
- `StrengthBucketDistribution`
- `PhaseIntensitySummary`
- `LocationHotspotRow`

`LocationIntensitySummary` was strengthened so `strength_bucket_distribution` and `phase_intensity` are typed objects instead of broad mappings. Its `from_dict()` factory now performs the one-time decoding from raw summary payloads into typed nested values. I also re-exported the new types through `vibesensor.domain` so the rest of the report stack can import the canonical domain objects instead of rebuilding local contracts.

### Diagnostics production
`apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py` now constructs typed strength-bucket and phase-intensity objects directly when building per-location sensor intensity summaries. That means the diagnostics producer and the downstream report consumers agree on one in-memory shape instead of converting a typed row back into a dict-like bag and then probing it again later.

### Report interpretation and prepared report data
`apps/server/vibesensor/use_cases/history/report_interpretation.py` was the main consumer-side cleanup. The interpretation helpers now accept `LocationIntensitySummary` and `LocationHotspotRow` rows directly, compute fallback strength from typed attributes, and build hotspot rows as typed objects rather than dicts. `apps/server/vibesensor/adapters/pdf/report_data.py` now reflects that in `ReportTemplateData`, so `sensor_intensity_by_location` and `location_hotspot_rows` are typed lists instead of `list[JsonObject]`.

### PDF/report mapping helpers
The typed row flow continues through the PDF layer:
- `report_context.py`
- `_candidate_resolver.py`
- `diagram_layout.py`
- `pdf_diagram_render.py`
- `_panel_diagram.py`
- `pdf_style.py`

These helpers previously contained defensive `isinstance(row, dict)` branches and repeated `.get(...)` lookups for values like `location`, `p95_intensity_db`, `mean_value`, and `unit`. They now work with the typed row attributes directly. The diagram layout logic still uses the same rendered values and ordering, but it no longer needs to special-case the internal row representation. This keeps the PDF pipeline behavior-stable while making the code substantially easier to reason about and type-check.

## Contracts and behavior
There are no intentional external contract changes in this PR. The important distinction is that the refactor is internal. Summary serialization still emits dict payloads at the boundary, so consumers of persisted summaries, API payloads, and report output keep the same shape they had before. The main semantic change is that malformed intermediate row bags are no longer treated as a normal internal representation; decoding now happens once, and the report stack operates on typed domain objects after that point.

I also kept the report output behavior stable. Hotspot ordering, fallback strength resolution, and diagram highlighting continue to use the same underlying values. The tests below were chosen specifically to validate the rendered/report-facing path, not only the new constructors.

## Test coverage and validation
I updated focused tests to cover both the new domain constructors and the unchanged report behavior:
- `apps/server/tests/domain/test_location_hotspot.py`
- `apps/server/tests/hygiene/test_domain_new_types.py`
- `apps/server/tests/adapters/pdf/test_report_mapping_context.py`
- `apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py`
- `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`
- `apps/server/tests/adapters/pdf/test_report_metrics_consistency.py`
- `apps/server/tests/adapters/pdf/test_diagram_layout.py`
- `apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py`
- `apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py`

Focused validation:
`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/domain/test_location_hotspot.py apps/server/tests/hygiene/test_domain_new_types.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_metrics_consistency.py apps/server/tests/adapters/pdf/test_diagram_layout.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py`
Result: `153 passed`

Broader validation:
`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`
Result: all three jobs passed

During the first broader validation pass, the repo surfaced three real follow-up issues: one mypy narrowing problem in the new `from_dict()` path, one report regression test that still expected `phase_intensity` stats to be dicts, and one formatting complaint in `report_interpretation.py`. I fixed those before the final green pass. I’m calling that out because it demonstrates that the final version was validated against the same broader gates that CI uses for this area, not just against a hand-picked happy path.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff here is that the report stack is now stricter about what counts as an internal row. That is intentional and matches the issue goal, but it means code that previously relied on passing arbitrary dict-shaped rows through internal helpers would need to decode them first. In this repo that is a feature, not a regression: boundary adapters should own raw payload handling, and domain/report code should own typed behavior.

I kept the scope below the larger report-pipeline architecture work that is still open elsewhere in the backlog. This PR does not attempt to collapse the entire report preparation path into a single prepared input, and it does not change persisted summary serialization. Those would be broader follow-up refactors. The goal here is the smaller, composable step: make the existing internal report rows typed and remove the remaining dict-style handling from the interpretation and PDF helpers.

## Follow-up
If this lands cleanly, it should reduce the blast radius for later report-pipeline issues because the internal row contracts are now explicit. The next report-focused refactors can build on `LocationIntensitySummary` and `LocationHotspotRow` directly instead of first untangling `JsonObject` bags from the PDF path.
