### PR TITLE
Fix #1058: type order phase evidence

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_order_objects.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_objects.py
@@ -15,6 +15,10 @@ from vibesensor.use_cases.diagnostics.order_scoring import (
     OrderFindingBuildContext,
     OrderFindingScore,
 )
+from vibesensor.use_cases.diagnostics.order_statistics import (
+    OrderPhaseEvidence,
+    compute_matched_speed_phase_evidence,
+)
 from vibesensor.use_cases.diagnostics.rotational_physics import OrderHypothesis
 
 # ===========================================================================
@@ -153,12 +157,13 @@ class TestAssembleOrderFinding:
         monkeypatch.setattr(
             order_finding_builder_module,
             "compute_matched_speed_phase_evidence",
-            lambda *args, **kwargs: (
-                60.0,
-                [55.0, 65.0],
-                "60-70 km/h",
-                {"cruise_fraction": 0.5, "phases_detected": ["cruise"]},
-                "cruise",
+            lambda *args, **kwargs: OrderPhaseEvidence(
+                peak_speed_kmh=60.0,
+                speed_window_kmh=(55.0, 65.0),
+                strongest_speed_band="60-70 km/h",
+                cruise_fraction=0.5,
+                phases_detected=("cruise",),
+                dominant_phase="cruise",
             ),
         )
 
@@ -211,6 +216,45 @@ class TestAssembleOrderFinding:
         assert finding.strongest_speed_band == "60-70 km/h"
         assert finding.evidence.frequency_correlation == pytest.approx(0.9)
         assert finding.evidence.phase_confidences == (("cruise", 0.8),)
+
+
+class TestComputeMatchedSpeedPhaseEvidence:
+    def test_returns_typed_evidence_object(self) -> None:
+        points = [
+            OrderMatchObservation(
+                predicted_hz=30.0,
+                matched_hz=30.1,
+                rel_error=0.01,
+                amp=0.4,
+                location="front_left",
+                speed_kmh=62.0,
+                phase="cruise",
+            ),
+            OrderMatchObservation(
+                predicted_hz=30.0,
+                matched_hz=30.2,
+                rel_error=0.02,
+                amp=0.2,
+                location="front_left",
+                speed_kmh=58.0,
+                phase="acceleration",
+            ),
+        ]
+
+        evidence = compute_matched_speed_phase_evidence(
+            points,
+            focused_speed_band=None,
+            hotspot_speed_band="50-60 km/h",
+        )
+
+        assert isinstance(evidence, OrderPhaseEvidence)
+        assert evidence.peak_speed_kmh == pytest.approx(62.0)
+        assert evidence.speed_window_kmh is not None
+        assert evidence.speed_window_kmh[0] <= evidence.speed_window_kmh[1]
+        assert evidence.strongest_speed_band is not None
+        assert evidence.cruise_fraction == pytest.approx(0.5)
+        assert evidence.phases_detected == ("acceleration", "cruise")
+        assert evidence.dominant_phase is None
 
 
 # ===========================================================================

--- a/apps/server/vibesensor/use_cases/diagnostics/order_finding_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/order_finding_builder.py
@@ -9,7 +9,6 @@ from vibesensor.domain import (
     VibrationOrigin,
 )
 from vibesensor.shared.constants import MEMS_NOISE_FLOOR_G
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.use_cases.diagnostics.order_matching import OrderMatchAccumulator
 from vibesensor.use_cases.diagnostics.order_scoring import (
@@ -50,19 +49,11 @@ def assemble_order_finding(
         evidence = dict(evidence)
         evidence["_suffix"] = f" {score.location_line}"
 
-    (
-        _peak_speed_kmh,
-        _speed_window_kmh,
-        strongest_speed_band,
-        phase_evidence,
-        dominant_phase,
-    ) = compute_matched_speed_phase_evidence(
+    phase_evidence = compute_matched_speed_phase_evidence(
         match.matched_points,
         focused_speed_band=context.focused_speed_band,
         hotspot_speed_band=score.hotspot_speed_band,
     )
-    phases_raw = phase_evidence.get("phases_detected")
-    phases_detected = tuple(phases_raw) if isinstance(phases_raw, list) else ()
     finding = DomainFinding(
         finding_id="F_ORDER",
         finding_key=hypothesis.key,
@@ -70,16 +61,16 @@ def assemble_order_finding(
         confidence=score.confidence,
         order=_order_label(hypothesis.order, hypothesis.order_label_base),
         strongest_location=score.strongest_location or None,
-        strongest_speed_band=strongest_speed_band or None,
+        strongest_speed_band=phase_evidence.strongest_speed_band or None,
         kind=FindingKind.DIAGNOSTIC,
-        dominant_phase=dominant_phase,
+        dominant_phase=phase_evidence.dominant_phase,
         ranking_score=score.ranking_score,
         dominance_ratio=score.dominance_ratio,
         diffuse_excitation=score.diffuse_excitation,
         weak_spatial_separation=score.weak_spatial_separation,
         vibration_strength_db=score.absolute_strength_db,
-        cruise_fraction=_as_float(phase_evidence["cruise_fraction"]) or 0.0,
-        phases_detected=phases_detected,
+        cruise_fraction=phase_evidence.cruise_fraction,
+        phases_detected=phase_evidence.phases_detected,
         matched_points=tuple(match.matched_points),
         evidence=FindingEvidence(
             match_rate=context.effective_match_rate,
@@ -106,8 +97,8 @@ def assemble_order_finding(
             suspected_source=hypothesis.suspected_source,
             hotspot=score.domain_hotspot,
             dominance_ratio=score.dominance_ratio,
-            speed_band=strongest_speed_band or None,
-            dominant_phase=dominant_phase,
+            speed_band=phase_evidence.strongest_speed_band or None,
+            dominant_phase=phase_evidence.dominant_phase,
         ),
     )
     return score.ranking_score, finding

--- a/apps/server/vibesensor/use_cases/diagnostics/order_statistics.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/order_statistics.py
@@ -7,6 +7,7 @@ amplitude/error aggregation, and speed-phase evidence derivation.
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import dataclass
 
 from vibesensor.domain import OrderMatchObservation
 from vibesensor.shared.constants import (
@@ -154,12 +155,24 @@ _PHASE_ONSET_RELEVANT: frozenset[str] = frozenset(
 )
 
 
+@dataclass(frozen=True, slots=True)
+class OrderPhaseEvidence:
+    """Typed speed/phase evidence derived from matched order observations."""
+
+    peak_speed_kmh: float | None
+    speed_window_kmh: tuple[float, float] | None
+    strongest_speed_band: str | None
+    cruise_fraction: float
+    phases_detected: tuple[str, ...]
+    dominant_phase: str | None
+
+
 def compute_matched_speed_phase_evidence(
     matched_points: list[OrderMatchObservation],
     *,
     focused_speed_band: str | None,
     hotspot_speed_band: str,
-) -> tuple[float | None, list[float], str | None, dict[str, object], str | None]:
+) -> OrderPhaseEvidence:
     """Derive speed-profile and phase-evidence from matched points."""
     cruise_value = DrivingPhase.CRUISE.value
     speed_points: list[tuple[float, float]] = []
@@ -190,10 +203,8 @@ def compute_matched_speed_phase_evidence(
 
     matched_phase_strs = [str(point.phase or "") for point in matched_points if point.phase]
     cruise_matched = sum(1 for phase in matched_phase_strs if phase == cruise_value)
-    phase_evidence: dict[str, object] = {
-        "cruise_fraction": cruise_matched / len(matched_phase_strs) if matched_phase_strs else 0.0,
-        "phases_detected": sorted(set(matched_phase_strs)),
-    }
+    cruise_fraction = cruise_matched / len(matched_phase_strs) if matched_phase_strs else 0.0
+    phases_detected = tuple(sorted(set(matched_phase_strs)))
     dominant_phase: str | None = None
     onset_phase_labels = [phase for phase in matched_phase_strs if phase in _PHASE_ONSET_RELEVANT]
     if onset_phase_labels and len(onset_phase_labels) >= max(2, len(matched_points) // 2):
@@ -201,11 +212,12 @@ def compute_matched_speed_phase_evidence(
         if top_count / len(matched_points) >= 0.50:
             dominant_phase = top_phase
 
-    return (
+    return OrderPhaseEvidence(
         peak_speed_kmh,
-        list(speed_window_kmh) if speed_window_kmh is not None else [],
+        speed_window_kmh,
         strongest_speed_band or None,
-        phase_evidence,
+        cruise_fraction,
+        phases_detected,
         dominant_phase,
     )
 


### PR DESCRIPTION
Fixes #1058

## Summary
This PR replaces the mixed tuple/dict return from `compute_matched_speed_phase_evidence()` with a typed `OrderPhaseEvidence` object and updates the order-finding assembly code to consume named attributes instead of tuple positions and `dict[str, object]` lookups. The underlying order-analysis behavior is intentionally unchanged. The goal is to tighten one weak helper boundary in the diagnostics pipeline so the semantic fields it already returns—speed-band context, cruise fraction, detected phases, and dominant phase—are represented explicitly instead of being reconstructed from a broad bag in the next step of the pipeline.

## Problem
Before this change, `apps/server/vibesensor/use_cases/diagnostics/order_statistics.py` returned a five-element tuple:

- peak speed
- speed window
- strongest speed band
- a `dict[str, object]` phase-evidence bag
- dominant phase

That shape was a leftover refactoring seam. The returned dict already carried stable semantic fields like `cruise_fraction` and `phases_detected`, but `order_finding_builder.py` still had to re-interpret them through `.get(...)`, index access, and `isinstance(..., list)` checks. That was exactly the sort of half-typed internal contract the current backlog is trying to remove. The issue text referred to `order_analysis.py`, but in the current codebase the real caller has moved into `order_finding_builder.py`, so this PR follows the live code rather than the historical path.

## Implementation approach
I kept the solution narrow and internal-only. I did not introduce a new public API, a backward-compatibility shim, or a second parallel representation. Instead, I replaced the old helper return shape in place with a single frozen dataclass defined in the same module as the helper. That choice is deliberate: `OrderPhaseEvidence` is a small diagnostics-internal value object with one production caller, so keeping it in `order_statistics.py` matches the repo’s bias toward local, direct structures instead of prematurely promoting helper types into broader shared layers.

## Main code changes

### Typed helper result in `order_statistics.py`
`apps/server/vibesensor/use_cases/diagnostics/order_statistics.py` now defines `OrderPhaseEvidence` as a frozen, slotted dataclass with these fields:

- `peak_speed_kmh`
- `speed_window_kmh`
- `strongest_speed_band`
- `cruise_fraction`
- `phases_detected`
- `dominant_phase`

`compute_matched_speed_phase_evidence()` now returns that object instead of `tuple[float | None, list[float], str | None, dict[str, object], str | None]`. The function still computes the same values from the same matched-point data. The only behavioral change is representational: the phase evidence is now expressed as typed attributes rather than a broad dict. I also kept `phases_detected` as a sorted immutable tuple so the output stays deterministic and the caller can pass it through directly without runtime narrowing.

### Caller cleanup in `order_finding_builder.py`
`apps/server/vibesensor/use_cases/diagnostics/order_finding_builder.py` is the single production caller. It no longer unpacks five tuple positions or extracts fields from a generic dict. Instead, it receives one `OrderPhaseEvidence` object and uses direct attribute access for `strongest_speed_band`, `dominant_phase`, `cruise_fraction`, and `phases_detected`.

That removed the old `as_float_or_none()` conversion and the `isinstance(phases_raw, list)` guard, because those checks only existed to defend against the broad helper contract. The downstream `DomainFinding` construction still gets the same semantic values it had before; it just receives them through a typed object boundary.

## Tests
I updated `apps/server/tests/use_cases/diagnostics/test_order_objects.py` in two places.

First, the existing `TestAssembleOrderFinding` monkeypatch now returns an `OrderPhaseEvidence` instance instead of the old tuple literal. That keeps the test aimed at the same contract boundary while reflecting the new typed helper result.

Second, I added a direct `compute_matched_speed_phase_evidence()` test that asserts the function returns an `OrderPhaseEvidence` object with the expected cruise fraction, phase tuple ordering, speed window shape, and dominant-phase result. This gives the new helper contract a focused test instead of only exercising it indirectly through finding assembly.

I did not need to change boundary serialization or PDF/report tests because this issue is confined to the diagnostics helper boundary. The `Finding` aggregate already stores the relevant semantic fields (`cruise_fraction`, `phases_detected`, `dominant_phase`, `strongest_speed_band`) separately, so the serialized payload shape stays unchanged.

## Behavior and contract impact
There are no intentional external contract changes in this PR. This is an internal typing cleanup. The only changed contract is the helper return type between `order_statistics.py` and `order_finding_builder.py`. That boundary is not public and is not persisted directly. All downstream behavior that matters to finding ranking, finding payloads, and report consumers continues to use the same values.

One subtle point is `speed_window_kmh`. The old helper converted it to a mutable list before returning it. The new typed object carries the natural `tuple[float, float] | None` returned by the speed-profile helper. That field is not currently consumed by production code, so this change tightens the type without altering live behavior. Keeping the tuple also avoids inventing mutability where none is needed.

## Validation
Focused validation:
`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_order_objects.py apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/adapters/pdf/test_report_analysis_phase_flow.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
Result: `63 passed`

Broader validation:
`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`
Result: all three jobs passed

I also verified that the change stayed isolated to the expected three files and passed `git diff --check` before committing.

## Risks and tradeoffs
The main tradeoff is that the helper boundary is now stricter: callers can no longer treat the result like an anonymous tuple plus generic dict. That is the point of the change, but it does mean any future internal caller needs to consume the typed object directly. In this repository that is the desired direction, not a drawback.

I intentionally did not move `OrderPhaseEvidence` into `vibesensor.domain` or a broader shared module. That would have made the object look more globally important than it currently is. Keeping it local to `order_statistics.py` matches the fact that it exists to formalize one helper contract inside the diagnostics package. If future work gives it multiple consumers or domain behavior of its own, it can be promoted then with clear justification.

## Out of scope
This PR does not change how `Finding` serializes phase-related fields, and it does not restructure the larger order-analysis pipeline beyond this helper seam. It also does not remove or repurpose `speed_window_kmh`, even though that field is currently unused by the production caller. The issue was about typing the helper boundary, not redesigning the downstream feature set.

## Follow-up
If this lands cleanly, it should make later diagnostics typing work easier because one more mixed helper contract is gone. The next steps in this area can build on a named evidence object instead of first unpacking tuple positions and guessing the shape of a semantic dict bag.
