### PR TITLE
Fix #1059: type cars snapshot responses

### DIFF
--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from test_support import response_payload
 
 from vibesensor.domain import AnalysisSettingsSnapshot
+from vibesensor.shared.types.backend_types import CarConfigPayload, CarsSnapshot
 
 
 def _make_default_snapshot() -> AnalysisSettingsSnapshot:
@@ -16,13 +17,23 @@ def _make_default_snapshot() -> AnalysisSettingsSnapshot:
 def _make_car_payload(
     car_id: str = "car-1",
     name: str = "Test Car",
-) -> dict[str, object]:
+) -> CarConfigPayload:
     return {
         "id": car_id,
         "name": name,
         "type": "sedan",
         "aspects": {"tire_width_mm": 225.0},
     }
+
+
+def _make_cars_snapshot(
+    cars: list[dict[str, object]] | None = None,
+    active_car_id: str | None = "car-1",
+) -> CarsSnapshot:
+    return CarsSnapshot(
+        cars=cars or [_make_car_payload()],
+        active_car_id=active_car_id,
+    )
 
 
 def _find_endpoint(router, path: str, method: str = "GET"):
@@ -39,10 +50,7 @@ def _settings_router(fake_state):
     from vibesensor.adapters.http.settings import create_settings_routes
 
     fake_state.settings_store.analysis_settings_snapshot.return_value = _make_default_snapshot()
-    fake_state.settings_store.get_cars.return_value = {
-        "cars": [_make_car_payload()],
-        "activeCarId": "car-1",
-    }
+    fake_state.settings_store.get_cars.return_value = _make_cars_snapshot()
     return create_settings_routes(
         fake_state.settings_store,
         fake_state.gps_monitor,
@@ -84,10 +92,10 @@ class TestDeleteCarEndpoint:
         endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
         assert endpoint is not None
 
-        state.settings_store.get_cars.return_value = {
-            "cars": [],
-            "activeCarId": None,
-        }
+        state.settings_store.get_cars.return_value = _make_cars_snapshot(
+            cars=[],
+            active_car_id=None,
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await endpoint(car_id="no-such-car")
@@ -99,14 +107,11 @@ class TestDeleteCarEndpoint:
         endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
         assert endpoint is not None
 
-        state.settings_store.get_cars.return_value = {
-            "cars": [_make_car_payload()],
-            "activeCarId": "car-1",
-        }
-        state.settings_store.delete_car.return_value = {
-            "cars": [],
-            "activeCarId": None,
-        }
+        state.settings_store.get_cars.return_value = _make_cars_snapshot()
+        state.settings_store.delete_car.return_value = _make_cars_snapshot(
+            cars=[],
+            active_car_id=None,
+        )
 
         result = response_payload(await endpoint(car_id="car-1"))
 
@@ -119,10 +124,7 @@ class TestDeleteCarEndpoint:
         endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
         assert endpoint is not None
 
-        state.settings_store.get_cars.return_value = {
-            "cars": [_make_car_payload()],
-            "activeCarId": "car-1",
-        }
+        state.settings_store.get_cars.return_value = _make_cars_snapshot()
         state.settings_store.delete_car.side_effect = ValueError("cannot delete last car")
 
         with pytest.raises(HTTPException) as exc_info:
@@ -167,10 +169,9 @@ class TestCarsEndpoint:
 
         from vibesensor.shared.types.api_models import CarUpsertRequest
 
-        state.settings_store.add_car.return_value = {
-            "cars": [_make_car_payload(), _make_car_payload(car_id="car-2", name="Second")],
-            "activeCarId": "car-1",
-        }
+        state.settings_store.add_car.return_value = _make_cars_snapshot(
+            cars=[_make_car_payload(), _make_car_payload(car_id="car-2", name="Second")],
+        )
 
         await endpoint(req=CarUpsertRequest(name="Second", variant="Sport"))
 

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -146,7 +146,7 @@ def test_store_add_and_delete_car() -> None:
 def test_store_cannot_delete_last_car() -> None:
     store = SettingsStore()
     created = store.add_car({"name": "Temporary"})
-    car_id = created["cars"][0]["id"]
+    car_id = created.cars[0]["id"]
     store.set_active_car(car_id)
     with pytest.raises(ValueError, match="Cannot delete the last car"):
         store.delete_car(car_id)
@@ -155,7 +155,7 @@ def test_store_cannot_delete_last_car() -> None:
 def test_store_update_car_aspects() -> None:
     store = SettingsStore()
     created = store.add_car({"name": "Aspect Car"})
-    car_id = created["cars"][0]["id"]
+    car_id = created.cars[0]["id"]
     store.set_active_car(car_id)
     store.update_car(car_id, {"aspects": {"tire_width_mm": 245.0}})
     aspects = store.active_car_aspects() or {}
@@ -166,7 +166,7 @@ def test_store_update_car_aspects() -> None:
 def test_store_update_active_car_aspects() -> None:
     store = SettingsStore()
     created = store.add_car({"name": "Editable"})
-    store.set_active_car(created["cars"][0]["id"])
+    store.set_active_car(created.cars[0]["id"])
     updated = store.update_active_car_aspects({"tire_width_mm": 255.0, "rim_in": 19.0})
     assert updated["tire_width_mm"] == 255.0
     assert updated["rim_in"] == 19.0
@@ -267,7 +267,7 @@ def test_store_persists_and_loads(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     store1 = SettingsStore(db=db)
     added = store1.add_car({"name": "Persisted Car", "type": "suv"})
-    store1.set_active_car(added["cars"][0]["id"])
+    store1.set_active_car(added.cars[0]["id"])
     store1.update_speed_source({"speedSource": "manual", "manualSpeedKph": 60})
     store1.set_sensor("11:22:33:44:55:66", {"name": "Rear", "location_code": "rear_left_wheel"})
 
@@ -291,7 +291,7 @@ def test_store_persists_with_protocol_shaped_snapshot_store() -> None:
     snapshot_store = FakeSettingsSnapshotStore()
     store = SettingsStore(db=snapshot_store)
     created = store.add_car({"name": "Protocol Car", "type": "suv"})
-    car_id = created["cars"][0]["id"]
+    car_id = created.cars[0]["id"]
     store.set_active_car(car_id)
 
     reloaded = SettingsStore(db=snapshot_store)
@@ -328,10 +328,10 @@ def test_parse_manual_speed_returns_none_for_invalid() -> None:
 
 def test_store_update_car_name_and_type() -> None:
     store = SettingsStore()
-    cars = store.add_car({"name": "Original"})["cars"]
+    cars = store.add_car({"name": "Original"}).cars
     car_id = cars[0]["id"]
     result = store.update_car(car_id, {"name": "Updated", "type": "SUV"})
-    updated = next(c for c in result["cars"] if c["id"] == car_id)
+    updated = next(c for c in result.cars if c["id"] == car_id)
     assert updated["name"] == "Updated"
     assert updated["type"] == "SUV"
 
@@ -346,12 +346,12 @@ def test_store_delete_selected_car_auto_selects_remaining() -> None:
     store = SettingsStore()
     store.add_car({"name": "First"})
     added = store.add_car({"name": "Second"})
-    car_ids = [c["id"] for c in added["cars"]]
+    car_ids = [c["id"] for c in added.cars]
     store.set_active_car(car_ids[1])
     result = store.delete_car(car_ids[1])
-    assert len(result["cars"]) == 1
+    assert len(result.cars) == 1
     # Auto-selects remaining car instead of clearing to None.
-    assert result["activeCarId"] == car_ids[0]
+    assert result.active_car_id == car_ids[0]
 
 
 def test_store_delete_car_unknown_raises() -> None:
@@ -498,7 +498,7 @@ def test_store_active_car_aspects_with_active_car() -> None:
     """active_car_aspects() returns aspects dict for active car."""
     store = SettingsStore()
     result = store.add_car({"name": "Test", "type": "sedan"})
-    car_id = result["cars"][0]["id"]
+    car_id = result.cars[0]["id"]
     store.set_active_car(car_id)
     aspects = store.active_car_aspects()
     assert aspects is not None

--- a/apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py
+++ b/apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py
@@ -119,12 +119,12 @@ class TestSettingsStoreRollbackDbFailure:
     def store(self) -> Any:
         s = SettingsStore()
         s.add_car({"name": "Test Car", "type": "sedan"})
-        s.set_active_car(s.get_cars()["cars"][0]["id"])
+        s.set_active_car(s.get_cars().cars[0]["id"])
         return s
 
     def test_update_active_car_aspects_rollback(self, store: Any) -> None:
         cars = store.get_cars()
-        original_aspects = dict(cars["cars"][0].get("aspects", {}))
+        original_aspects = dict(cars.cars[0].get("aspects", {}))
 
         with (
             patch.object(store, "_persist", side_effect=PersistenceError("disk full")),
@@ -134,7 +134,7 @@ class TestSettingsStoreRollbackDbFailure:
 
         # Aspects should be rolled back
         current = store.get_cars()
-        assert current["cars"][0].get("aspects", {}) == original_aspects
+        assert current.cars[0].get("aspects", {}) == original_aspects
 
     def test_update_speed_source_rollback(self, store: Any) -> None:
         original = store.get_speed_source()

--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -68,7 +68,7 @@ class TestSettingsStoreRollback:
 
     def test_add_car_rollback_on_persist_failure(self):
         store = SettingsStore(db=None)
-        initial_count = len(store.get_cars()["cars"])
+        initial_count = len(store.get_cars().cars)
 
         # Make persist fail
         store._db = MagicMock()
@@ -77,16 +77,16 @@ class TestSettingsStoreRollback:
         with pytest.raises(PersistenceError):
             store.add_car({"name": "New Car", "type": "suv"})
 
-        assert len(store.get_cars()["cars"]) == initial_count
+        assert len(store.get_cars().cars) == initial_count
 
     def test_delete_car_rollback_on_persist_failure(self):
         store = SettingsStore(db=None)
         store.add_car({"name": "Car 1", "type": "sedan"})
         store.add_car({"name": "Car 2", "type": "suv"})
         cars = store.get_cars()
-        car_count = len(cars["cars"])
+        car_count = len(cars.cars)
         assert car_count >= 2
-        target_id = cars["cars"][-1]["id"]
+        target_id = cars.cars[-1]["id"]
 
         store._db = MagicMock()
         store._db.set_settings_snapshot.side_effect = sqlite3.OperationalError("DB fail")
@@ -94,14 +94,14 @@ class TestSettingsStoreRollback:
         with pytest.raises(PersistenceError):
             store.delete_car(target_id)
 
-        assert len(store.get_cars()["cars"]) == car_count
+        assert len(store.get_cars().cars) == car_count
 
     def test_set_active_car_rollback_on_persist_failure(self):
         store = SettingsStore(db=None)
         store.add_car({"name": "Car 2", "type": "suv"})
         cars = store.get_cars()
-        original_active = cars["activeCarId"]
-        new_id = [c["id"] for c in cars["cars"] if c["id"] != original_active][0]
+        original_active = cars.active_car_id
+        new_id = [c["id"] for c in cars.cars if c["id"] != original_active][0]
 
         store._db = MagicMock()
         store._db.set_settings_snapshot.side_effect = sqlite3.OperationalError("DB fail")
@@ -109,14 +109,14 @@ class TestSettingsStoreRollback:
         with pytest.raises(PersistenceError):
             store.set_active_car(new_id)
 
-        assert store.get_cars()["activeCarId"] == original_active
+        assert store.get_cars().active_car_id == original_active
 
     def test_update_car_rollback_on_persist_failure(self):
         store = SettingsStore(db=None)
         store.add_car({"name": "Original Name", "type": "sedan"})
         cars = store.get_cars()
-        car_id = cars["cars"][0]["id"]
-        original_name = cars["cars"][0]["name"]
+        car_id = cars.cars[0]["id"]
+        original_name = cars.cars[0]["name"]
 
         store._db = MagicMock()
         store._db.set_settings_snapshot.side_effect = sqlite3.OperationalError("DB fail")
@@ -124,7 +124,7 @@ class TestSettingsStoreRollback:
         with pytest.raises(PersistenceError):
             store.update_car(car_id, {"name": "New Name"})
 
-        assert store.get_cars()["cars"][0]["name"] == original_name
+        assert store.get_cars().cars[0]["name"] == original_name
 
 
 # ── 4. Firmware cache streaming download ──────────────────────────────────

--- a/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
+++ b/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
@@ -191,7 +191,7 @@ class TestSettingsStoreRollbackSafety:
         """
         store = SettingsStore(db=None)
         car_data = store.add_car({"name": "TestCar", "type": "sedan"})
-        car_id = car_data["cars"][0]["id"]
+        car_id = car_data.cars[0]["id"]
 
         # Set as active so _find_car works
         store.set_active_car(car_id)

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
@@ -163,7 +163,7 @@ def test_update_merges_valid_values(tmp_path) -> None:
     db = HistoryDB(tmp_path / "test.db")
     store = SettingsStore(db=db)
     initial = store.add_car({"name": "Test"})
-    store.set_active_car(initial["cars"][0]["id"])
+    store.set_active_car(initial.cars[0]["id"])
     store.update_active_car_aspects({"tire_width_mm": 225.0})
     result = store.analysis_settings_snapshot()
     assert result.tire_width_mm == 225.0
@@ -177,7 +177,7 @@ def test_update_rejects_invalid_and_keeps_old(tmp_path) -> None:
     db = HistoryDB(tmp_path / "test.db")
     store = SettingsStore(db=db)
     initial = store.add_car({"name": "Test"})
-    store.set_active_car(initial["cars"][0]["id"])
+    store.set_active_car(initial.cars[0]["id"])
     store.update_active_car_aspects({"tire_width_mm": -5.0})
     assert (
         store.analysis_settings_snapshot().tire_width_mm

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py
@@ -35,7 +35,7 @@ def _wiring(tmp_path: Path):
     db = HistoryDB(tmp_path / "test.db")
     settings_store = SettingsStore(db=db)
     initial = settings_store.add_car({"name": "Primary"})
-    settings_store.set_active_car(initial["cars"][0]["id"])
+    settings_store.set_active_car(initial.cars[0]["id"])
     state = FakeState(
         settings_store=settings_store,
         history_db=db,

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -13,6 +13,7 @@ from vibesensor.shared.types.api_models import (
     ActiveCarRequest,
     AnalysisSettingsRequest,
     AnalysisSettingsResponse,
+    CarResponse,
     CarsResponse,
     CarUpsertRequest,
     LanguageRequest,
@@ -27,7 +28,9 @@ from vibesensor.shared.types.api_models import (
 )
 from vibesensor.shared.types.backend_types import (
     AnalysisSettingsPayload,
+    CarConfigPayload,
     CarConfigUpdatePayload,
+    CarsSnapshot,
     SensorConfigUpdatePayload,
     SpeedSourceUpdatePayload,
 )
@@ -44,8 +47,20 @@ def create_settings_routes(
     """Create and return the device-settings API routes."""
     router = APIRouter()
 
-    def _cars_response(payload: object) -> CarsResponse:
-        return CarsResponse.model_validate(payload)
+    def _car_response(payload: CarConfigPayload) -> CarResponse:
+        return CarResponse(
+            id=payload["id"],
+            name=payload["name"],
+            type=payload["type"],
+            aspects=dict(payload["aspects"]),
+            variant=payload.get("variant"),
+        )
+
+    def _cars_response(snapshot: CarsSnapshot) -> CarsResponse:
+        return CarsResponse(
+            cars=[_car_response(car) for car in snapshot.cars],
+            activeCarId=snapshot.active_car_id,
+        )
 
     def _car_upsert_payload(req: CarUpsertRequest) -> CarConfigUpdatePayload:
         payload: CarConfigUpdatePayload = {}
@@ -143,8 +158,8 @@ def create_settings_routes(
     async def delete_car(car_id: str) -> CarsResponse:
         # Existence check first so unknown-car yields 404 while business-logic
         # errors (e.g. "cannot delete the last car") propagate as 400.
-        cars_snapshot = _cars_response(await asyncio.to_thread(settings_store.get_cars))
-        if not any(car.id == car_id for car in cars_snapshot.cars):
+        cars_snapshot = await asyncio.to_thread(settings_store.get_cars)
+        if not any(car["id"] == car_id for car in cars_snapshot.cars):
             raise HTTPException(status_code=404, detail=f"Car {car_id!r} not found")
         with domain_errors_to_http(catch_value_error=400):
             result = await asyncio.to_thread(settings_store.delete_car, car_id)

--- a/apps/server/vibesensor/infra/config/car_settings.py
+++ b/apps/server/vibesensor/infra/config/car_settings.py
@@ -16,6 +16,7 @@ from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.shared.types.backend_types import (
     AnalysisSettingsPayload,
     CarConfigUpdatePayload,
+    CarsSnapshot,
     car_to_persistence_dict,
     new_car_id,
 )
@@ -58,12 +59,15 @@ class CarSettingsMixin:
 
     # -- car operations --------------------------------------------------------
 
-    def get_cars(self) -> dict[str, object]:
+    def _cars_snapshot_unlocked(self) -> CarsSnapshot:
+        return CarsSnapshot(
+            cars=[car_to_persistence_dict(car) for car in self._cars],
+            active_car_id=self._active_car_id,
+        )
+
+    def get_cars(self) -> CarsSnapshot:
         with self._lock:
-            return {
-                "cars": [car_to_persistence_dict(c) for c in self._cars],
-                "activeCarId": self._active_car_id,
-            }
+            return self._cars_snapshot_unlocked()
 
     def active_car_aspects(self) -> dict[str, float] | None:
         """Return the active car's aspects as a flat analysis-settings dict.
@@ -96,7 +100,7 @@ class CarSettingsMixin:
             return None
         return next((c for c in self._cars if c.id == car_id), None)
 
-    def set_active_car(self, car_id: str) -> dict[str, object]:
+    def set_active_car(self, car_id: str) -> CarsSnapshot:
         with self._lock:
             car = self._find_car(car_id)
             if car is None:
@@ -109,9 +113,9 @@ class CarSettingsMixin:
                 self._active_car_id = old_active
                 raise
             self._sync_analysis_settings()
-            return self.get_cars()
+            return self._cars_snapshot_unlocked()
 
-    def add_car(self, car_data: CarConfigUpdatePayload) -> dict[str, object]:
+    def add_car(self, car_data: CarConfigUpdatePayload) -> CarsSnapshot:
         with self._lock:
             payload: dict[str, object] = dict(car_data)
             payload["id"] = new_car_id()
@@ -123,9 +127,9 @@ class CarSettingsMixin:
                 self._cars.pop()  # rollback in-memory append
                 raise
             self._sync_analysis_settings()
-            return self.get_cars()
+            return self._cars_snapshot_unlocked()
 
-    def update_car(self, car_id: str, car_data: CarConfigUpdatePayload) -> dict[str, object]:
+    def update_car(self, car_id: str, car_data: CarConfigUpdatePayload) -> CarsSnapshot:
         with self._lock:
             car = self._find_car(car_id)
             if car is None:
@@ -167,7 +171,7 @@ class CarSettingsMixin:
                 self._cars[idx] = car  # rollback
                 raise
             self._sync_analysis_settings()
-            return self.get_cars()
+            return self._cars_snapshot_unlocked()
 
     def update_active_car_aspects(
         self,
@@ -195,7 +199,7 @@ class CarSettingsMixin:
             self._sync_analysis_settings()
             return dict(updated.aspects)
 
-    def delete_car(self, car_id: str) -> dict[str, object]:
+    def delete_car(self, car_id: str) -> CarsSnapshot:
         with self._lock:
             car = self._find_car(car_id)
             if car is None:
@@ -214,4 +218,4 @@ class CarSettingsMixin:
                 self._active_car_id = old_active
                 raise
             self._sync_analysis_settings()
-            return self.get_cars()
+            return self._cars_snapshot_unlocked()

--- a/apps/server/vibesensor/shared/types/backend_types.py
+++ b/apps/server/vibesensor/shared/types/backend_types.py
@@ -42,6 +42,7 @@ _RUN_METADATA_FIELD_KEYS: Final[frozenset[str]] = frozenset(
 __all__ = [
     "CarConfigPayload",
     "CarConfigUpdatePayload",
+    "CarsSnapshot",
     "RUN_END_TYPE",
     "RUN_METADATA_TYPE",
     "RUN_SAMPLE_TYPE",
@@ -112,6 +113,14 @@ class SettingsSnapshotPayload(SpeedSourcePayload):
     language: LanguageCode
     speedUnit: SpeedUnitCode
     sensorsByMac: SensorsByMacPayload
+
+
+@dataclass(slots=True)
+class CarsSnapshot:
+    """Typed internal snapshot of car profiles plus active selection."""
+
+    cars: list[CarConfigPayload] = field(default_factory=list)
+    active_car_id: str | None = None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1059

## Summary

This PR tightens the internal contract for the car-settings service by replacing the broad `dict[str, object]` return shape with a typed `CarsSnapshot` object. The user-visible HTTP behavior stays the same: the settings API still returns the existing `CarsResponse` model with the same `cars` array and `activeCarId` fields. What changes is the seam behind that response. Instead of building a generic dict in the settings store and then validating that dict later in the HTTP adapter, the service now returns a small typed snapshot that describes the stable car-settings state directly.

The issue was narrowly scoped to the car-settings CRUD path, so I kept the implementation focused on that seam. I did not widen this into a broader settings snapshot redesign, and I did not introduce a second parallel “canonical” dict representation. The goal here was to make the service contract honest and typed while preserving the existing API output and runtime behavior.

## Problem being solved

The relevant car-settings methods already have a stable response shape:

- `get_cars()`
- `set_active_car()`
- `add_car()`
- `update_car()`
- `delete_car()`

Before this change, all of them returned `dict[str, object]` even though the shape was fixed and already mirrored by an explicit HTTP response model. That loose typing forced downstream code to treat the result as a broad bag rather than a real contract. In practice, the HTTP adapter could only recover a proper model by calling `CarsResponse.model_validate(...)` on the service-layer dict. That kept a too-broad internal seam alive even though the data was semantically simple and well understood.

This PR fixes that by giving the car-settings service its own typed snapshot object and making the HTTP adapter translate that typed object into the existing response model explicitly.

## Chosen implementation approach

I followed the issue’s recommended object route and introduced a small `CarsSnapshot` dataclass with:

- `cars: list[CarConfigPayload]`
- `active_car_id: str | None`

I placed it in `apps/server/vibesensor/shared/types/backend_types.py` instead of introducing a new public domain type. That location is already the home of the typed internal car payload shape (`CarConfigPayload` and `CarConfigUpdatePayload`), and it avoids creating a shared-to-infra dependency in the wrong direction. It also matches the actual ownership of this object: it is an internal backend contract used to move typed data from the settings service to the HTTP edge, not a new business-domain concept with broader application behavior.

This approach keeps the refactor narrow and avoids two common failure modes:

First, it avoids preserving `dict[str, object]` as a second “official” contract just for convenience. The issue specifically called out that the dict bag should stop being the canonical service return type, and the implementation follows that rule.

Second, it avoids turning a small service-return object into a larger architecture change. The full settings snapshot flow still exists elsewhere for other use cases, but this issue was specifically about the car CRUD response seam, not the broader snapshot format.

## Main code changes by area

### Shared backend types

In `apps/server/vibesensor/shared/types/backend_types.py`, I added the `CarsSnapshot` dataclass and exported it through the module’s `__all__`. The object is intentionally small: a list of typed car payloads plus the currently active car id. That is the actual stable data the service returns today, so the dataclass stays close to the real contract instead of inventing extra wrappers or helper machinery.

### Car settings service

In `apps/server/vibesensor/infra/config/car_settings.py`, I changed the car CRUD methods to return `CarsSnapshot` instead of `dict[str, object]`. I also added a shared `_cars_snapshot_unlocked()` helper so the snapshot construction happens in one place while the lock is held. That keeps the thread-safety model unchanged and avoids copy-pasting the same dict-building logic across several methods.

The updated methods now return typed snapshots from:

- `get_cars()`
- `set_active_car()`
- `add_car()`
- `update_car()`
- `delete_car()`

The surrounding behavior stays the same: persistence, rollback behavior, analysis-settings synchronization, and active-car updates all continue to work as before. The refactor only changes the internal return contract and the downstream consumption of that contract.

### HTTP settings adapter

In `apps/server/vibesensor/adapters/http/settings.py`, I replaced the broad `CarsResponse.model_validate(payload)` pattern for this path with explicit translation from `CarsSnapshot` into `CarsResponse`. The adapter now builds `CarResponse` items from each `CarConfigPayload` and then returns a `CarsResponse` with the same wire fields as before.

I also updated the delete-car existence check to work directly against `CarsSnapshot` rather than against a `CarsResponse` produced from a broad dict bag. That keeps the logic typed from service to edge and removes adapter-side broad-object handling that only existed because the service returned a generic dict.

## Test updates

This change had a meaningful but still manageable test blast radius because several tests called the settings store directly and indexed into the returned dicts. I updated the affected tests to use `CarsSnapshot` attributes while keeping the underlying HTTP payload assertions unchanged where the API contract mattered.

The touched test areas include:

- direct settings-store tests
- HTTP settings endpoint tests
- settings-related regression tests in processing and integration areas
- diagnostics tests that use the settings store to seed an active car

In the HTTP endpoint tests, I also updated the fake settings-store responses to return real `CarsSnapshot` instances. That matters because the adapter should now be tested against the actual typed service contract, not against the legacy dict shape.

## Validation performed

I validated the change in two stages.

Focused validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/infra/config/test_settings_store.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py apps/server/tests/use_cases/diagnostics/test_analysis_settings.py apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py`

This passed with `178 passed`.

Broader backend validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That broader subset also passed. One intermediate run caught two Ruff line-length violations in the updated HTTP tests; I fixed those and reran the full backend quality/typecheck/tests subset successfully.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that `CarsSnapshot` holds `CarConfigPayload` rows rather than introducing a separate immutable object per car. I chose that on purpose because the issue was about typing the existing stable service response, not creating a more elaborate model hierarchy. Reusing the existing typed payload keeps the refactor small and minimizes churn.

I also kept the HTTP contract unchanged rather than trying to propagate `CarsSnapshot` beyond the backend service seam. That is deliberate: the point is to make the internal contract typed while preserving the current API behavior for callers.

Out of scope for this PR are broader settings-store reshaping efforts, the persisted settings snapshot format, and any unrelated cleanup around other settings or runtime status dicts. Those have their own issue threads and should stay separate from this focused fix.
