### PR TITLE
Fix #1061: type GPS speed status snapshot

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_iris4_fixes.py
+++ b/apps/server/tests/adapters/gps/test_gps_iris4_fixes.py
@@ -137,28 +137,28 @@ def test_speed_confidence_3d_fix_returns_high() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Fix 8: status_dict() includes "speed_source" key
+# Fix 8: status snapshot exposes speed_source
 # ---------------------------------------------------------------------------
 
 
-def test_status_dict_includes_speed_source() -> None:
+def test_status_snapshot_includes_speed_source() -> None:
     monitor = GPSSpeedMonitor(gps_enabled=False)
-    status = monitor.status_dict()
-    assert "speed_source" in status, "status_dict() must expose speed_source for diagnostics"
+    status = monitor.status_snapshot()
+    assert status.speed_source == "none"
 
 
-def test_status_dict_speed_source_matches_resolve_speed() -> None:
+def test_status_snapshot_speed_source_matches_resolve_speed() -> None:
     monitor = GPSSpeedMonitor(gps_enabled=False)
     monitor.manual_source_selected = True
     monitor.override_speed_mps = 10.0
-    status = monitor.status_dict()
-    assert status["speed_source"] == "manual"
+    status = monitor.status_snapshot()
+    assert status.speed_source == "manual"
 
 
-def test_status_dict_speed_source_none_when_no_data() -> None:
+def test_status_snapshot_speed_source_none_when_no_data() -> None:
     monitor = GPSSpeedMonitor(gps_enabled=False)
-    status = monitor.status_dict()
-    assert status["speed_source"] == "none"
+    status = monitor.status_snapshot()
+    assert status.speed_source == "none"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py
@@ -1,9 +1,9 @@
-"""Tests for issue #284: effective_speed_mps and status_dict() must not mutate state.
+"""Tests for issue #284: effective_speed_mps and status snapshots must not mutate state.
 
 Verifies that:
 - resolve_speed() is pure (no side effects)
 - effective_speed_mps property does not mutate any instance state
-- status_dict() does not mutate connection_state
+- status_snapshot() does not mutate connection_state
 - fallback_active is always consistent with the speed value returned
 - Multiple reads per tick yield consistent results
 """
@@ -106,13 +106,13 @@ class TestEffectiveSpeedNoMutation:
 
 
 # ---------------------------------------------------------------------------
-# status_dict() does not mutate connection_state
+# status_snapshot() does not mutate connection_state
 # ---------------------------------------------------------------------------
 
 
-class TestStatusDictNoMutation:
-    def test_status_dict_does_not_mutate_connection_state(self) -> None:
-        """Previously, status_dict() would change connection_state from
+class TestStatusSnapshotNoMutation:
+    def test_status_snapshot_does_not_mutate_connection_state(self) -> None:
+        """Previously, GPS status reporting would change connection_state from
         'connected' to 'stale' as a side effect.  It must no longer do so.
         """
         m = GPSSpeedMonitor(gps_enabled=True)
@@ -120,20 +120,20 @@ class TestStatusDictNoMutation:
         m.speed_mps = 5.0
         set_gps_snapshot_age(m, age_s=999)  # stale
 
-        s = m.status_dict()
-        # The dict should report "stale" ...
-        assert s["connection_state"] == "stale"
+        s = m.status_snapshot()
+        # The snapshot should report "stale" ...
+        assert s.connection_state == "stale"
         # ... but the underlying attribute must remain unchanged.
         assert m.connection_state == "connected"
 
-    def test_status_dict_does_not_mutate_on_fresh_data(self) -> None:
+    def test_status_snapshot_does_not_mutate_on_fresh_data(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 10.0
         set_gps_snapshot_age(m)
 
-        s = m.status_dict()
-        assert s["connection_state"] == "connected"
+        s = m.status_snapshot()
+        assert s.connection_state == "connected"
         assert m.connection_state == "connected"
 
 

--- a/apps/server/tests/adapters/gps/test_gps_speed_status.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_status.py
@@ -1,4 +1,4 @@
-"""Tests for GPSSpeedMonitor status_dict(), fallback logic, and set_fallback_settings()."""
+"""Tests for GPSSpeedMonitor status snapshots, fallback logic, and set_fallback_settings()."""
 
 from __future__ import annotations
 
@@ -14,41 +14,41 @@ from vibesensor.adapters.gps.gps_speed import (
 from vibesensor.shared.types.backend_types import SpeedSourceConfig
 
 # ---------------------------------------------------------------------------
-# status_dict()
+# status_snapshot()
 # ---------------------------------------------------------------------------
 
 
-class TestStatusDict:
+class TestStatusSnapshot:
     def test_disabled_monitor_status(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=False)
-        s = m.status_dict()
-        assert s["gps_enabled"] is False
-        assert s["connection_state"] == "disabled"
-        assert s["device"] is None
-        assert s["last_update_age_s"] is None
-        assert s["raw_speed_kmh"] is None
-        assert s["effective_speed_kmh"] is None
-        assert s["last_error"] is None
-        assert s["reconnect_delay_s"] is None
-        assert s["fix_mode"] is None
-        assert s["fix_dimension"] == "none"
-        assert s["speed_confidence"] == "low"
-        assert s["fallback_active"] is False
-        assert s["stale_timeout_s"] == DEFAULT_STALE_TIMEOUT_S
+        s = m.status_snapshot()
+        assert s.gps_enabled is False
+        assert s.connection_state == "disabled"
+        assert s.device is None
+        assert s.last_update_age_s is None
+        assert s.raw_speed_kmh is None
+        assert s.effective_speed_kmh is None
+        assert s.last_error is None
+        assert s.reconnect_delay_s is None
+        assert s.fix_mode is None
+        assert s.fix_dimension == "none"
+        assert s.speed_confidence == "low"
+        assert s.fallback_active is False
+        assert s.stale_timeout_s == DEFAULT_STALE_TIMEOUT_S
 
     def test_connected_with_fresh_data(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 10.0  # 36 km/h
         set_gps_snapshot_age(m)
-        s = m.status_dict()
-        assert s["gps_enabled"] is True
-        assert s["connection_state"] == "connected"
-        assert isinstance(s["last_update_age_s"], float)
-        assert s["last_update_age_s"] < 2.0
-        assert s["raw_speed_kmh"] == pytest.approx(36.0, abs=0.1)
-        assert s["effective_speed_kmh"] == pytest.approx(36.0, abs=0.1)
-        assert s["fallback_active"] is False
+        s = m.status_snapshot()
+        assert s.gps_enabled is True
+        assert s.connection_state == "connected"
+        assert isinstance(s.last_update_age_s, float)
+        assert s.last_update_age_s < 2.0
+        assert s.raw_speed_kmh == pytest.approx(36.0, abs=0.1)
+        assert s.effective_speed_kmh == pytest.approx(36.0, abs=0.1)
+        assert s.fallback_active is False
 
     def test_status_includes_fix_quality_metadata(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
@@ -56,48 +56,48 @@ class TestStatusDict:
         m.last_epx_m = 4.2
         m.last_epy_m = 5.1
         m.last_epv_m = 8.0
-        s = m.status_dict()
-        assert s["fix_mode"] == 2
-        assert s["fix_dimension"] == "2d"
-        assert s["speed_confidence"] == "medium"
-        assert s["epx_m"] == pytest.approx(4.2)
-        assert s["epy_m"] == pytest.approx(5.1)
-        assert s["epv_m"] == pytest.approx(8.0)
+        s = m.status_snapshot()
+        assert s.fix_mode == 2
+        assert s.fix_dimension == "2d"
+        assert s.speed_confidence == "medium"
+        assert s.epx_m == pytest.approx(4.2)
+        assert s.epy_m == pytest.approx(5.1)
+        assert s.epv_m == pytest.approx(8.0)
 
-    def test_stale_detected_on_status_dict(self) -> None:
-        """status_dict() transitions connection_state to stale when GPS data is old."""
+    def test_stale_detected_on_status_snapshot(self) -> None:
+        """status_snapshot() reports stale when GPS data is old."""
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         m.speed_mps = 5.0
         set_gps_snapshot_age(m, age_s=999)  # way older than stale timeout
-        s = m.status_dict()
-        assert s["connection_state"] == "stale"
+        s = m.status_snapshot()
+        assert s.connection_state == "stale"
 
     def test_disconnected_shows_reconnect_delay(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "disconnected"
         m.current_reconnect_delay = 4.0
-        s = m.status_dict()
-        assert s["reconnect_delay_s"] == 4.0
+        s = m.status_snapshot()
+        assert s.reconnect_delay_s == 4.0
 
     def test_connected_hides_reconnect_delay(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.connection_state = "connected"
         set_gps_snapshot_age(m)
-        s = m.status_dict()
-        assert s["reconnect_delay_s"] is None
+        s = m.status_snapshot()
+        assert s.reconnect_delay_s is None
 
     def test_last_error_reported(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.last_error = "Connection refused"
-        s = m.status_dict()
-        assert s["last_error"] == "Connection refused"
+        s = m.status_snapshot()
+        assert s.last_error == "Connection refused"
 
     def test_device_info_reported(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.device_info = "/dev/ttyUSB0"
-        s = m.status_dict()
-        assert s["device"] == "/dev/ttyUSB0"
+        s = m.status_snapshot()
+        assert s.device == "/dev/ttyUSB0"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/adapters/gps/test_speed_status_builder.py
+++ b/apps/server/tests/adapters/gps/test_speed_status_builder.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import time
 
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution
-from vibesensor.adapters.gps.speed_status import GPSSpeedStatusState, build_status_dict
+from vibesensor.adapters.gps.speed_status import GPSSpeedStatusState, build_status_snapshot
 
 
-def test_build_status_dict_reports_stale_fallback_without_transport_loop() -> None:
+def test_build_status_snapshot_reports_stale_fallback_without_transport_loop() -> None:
     now = time.monotonic()
     state = GPSSpeedStatusState(
         gps_enabled=True,
@@ -23,17 +23,17 @@ def test_build_status_dict_reports_stale_fallback_without_transport_loop() -> No
         stale_timeout_s=5.0,
     )
 
-    status = build_status_dict(
+    status = build_status_snapshot(
         state,
         resolution=SpeedResolution(25.0, True, "fallback_manual"),
         effective_connection_state="stale",
         now_mono=now,
     )
 
-    assert status["connection_state"] == "stale"
-    assert status["speed_confidence"] == "medium"
-    assert status["raw_speed_kmh"] == 36.0
-    assert status["effective_speed_kmh"] == 90.0
-    assert status["fallback_active"] is True
-    assert status["speed_source"] == "fallback_manual"
-    assert status["reconnect_delay_s"] is None
+    assert status.connection_state == "stale"
+    assert status.speed_confidence == "medium"
+    assert status.raw_speed_kmh == 36.0
+    assert status.effective_speed_kmh == 90.0
+    assert status.fallback_active is True
+    assert status.speed_source == "fallback_manual"
+    assert status.reconnect_delay_s is None

--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import HTTPException
 from test_support import response_payload
 
+from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
 from vibesensor.domain import AnalysisSettingsSnapshot
 from vibesensor.shared.types.backend_types import CarConfigPayload, CarsSnapshot
 
@@ -33,6 +34,28 @@ def _make_cars_snapshot(
     return CarsSnapshot(
         cars=cars or [_make_car_payload()],
         active_car_id=active_car_id,
+    )
+
+
+def _make_speed_source_status_snapshot() -> SpeedSourceStatusSnapshot:
+    return SpeedSourceStatusSnapshot(
+        gps_enabled=True,
+        connection_state="connected",
+        device="/dev/ttyUSB0",
+        fix_mode=3,
+        fix_dimension="3d",
+        speed_confidence="high",
+        epx_m=1.2,
+        epy_m=1.3,
+        epv_m=2.4,
+        last_update_age_s=0.5,
+        raw_speed_kmh=48.2,
+        effective_speed_kmh=48.2,
+        last_error=None,
+        reconnect_delay_s=None,
+        fallback_active=False,
+        speed_source="gps",
+        stale_timeout_s=8.0,
     )
 
 
@@ -205,25 +228,7 @@ class TestSpeedSourceEndpoint:
         endpoint = _find_endpoint(router, "/api/settings/speed-source/status", "GET")
         assert endpoint is not None
 
-        state.gps_monitor.status_dict.return_value = {
-            "gps_enabled": True,
-            "connection_state": "connected",
-            "device": "/dev/ttyUSB0",
-            "fix_mode": 3,
-            "fix_dimension": "3d",
-            "speed_confidence": "high",
-            "epx_m": 1.2,
-            "epy_m": 1.3,
-            "epv_m": 2.4,
-            "last_update_age_s": 0.5,
-            "raw_speed_kmh": 48.2,
-            "effective_speed_kmh": 48.2,
-            "last_error": None,
-            "reconnect_delay_s": None,
-            "fallback_active": False,
-            "speed_source": "gps",
-            "stale_timeout_s": 8.0,
-        }
+        state.gps_monitor.status_snapshot.return_value = _make_speed_source_status_snapshot()
 
         result = response_payload(await endpoint())
 

--- a/apps/server/vibesensor/adapters/gps/gps_speed.py
+++ b/apps/server/vibesensor/adapters/gps/gps_speed.py
@@ -10,7 +10,8 @@ from vibesensor.adapters.gps.gps_transport import GPSTransportState
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution, SpeedResolutionPolicy
 from vibesensor.adapters.gps.speed_status import (
     GPSSpeedStatusState,
-    build_status_dict,
+    SpeedSourceStatusSnapshot,
+    build_status_snapshot,
     speed_confidence,
 )
 from vibesensor.shared.types.json_types import JsonObject
@@ -223,7 +224,7 @@ class GPSSpeedMonitor:
     def _reset_fix_metadata(self) -> None:
         self._transport._reset_fix_metadata()
 
-    def status_dict(self) -> dict[str, object]:
+    def status_snapshot(self) -> SpeedSourceStatusSnapshot:
         speed_snapshot = self._speed_snapshot
         resolution = self._policy.resolve(
             gps_enabled=self.gps_enabled,
@@ -244,7 +245,7 @@ class GPSSpeedMonitor:
             current_reconnect_delay=self.current_reconnect_delay,
             stale_timeout_s=self.stale_timeout_s,
         )
-        return build_status_dict(
+        return build_status_snapshot(
             status_state,
             resolution=resolution,
             effective_connection_state=self._policy.effective_connection_state(

--- a/apps/server/vibesensor/adapters/gps/speed_status.py
+++ b/apps/server/vibesensor/adapters/gps/speed_status.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution
 from vibesensor.shared.constants import MPS_TO_KMH, NUMERIC_TYPES
+from vibesensor.shared.types.backend_types import ResolvedSpeedSource
 
 _GPS_MAX_EPH_M: float = 40.0
 
@@ -30,6 +31,29 @@ class GPSSpeedStatusState:
     stale_timeout_s: float
 
 
+@dataclass(frozen=True, slots=True)
+class SpeedSourceStatusSnapshot:
+    """Typed GPS/speed-source status snapshot returned inside the runtime."""
+
+    gps_enabled: bool
+    connection_state: str
+    device: str | None
+    fix_mode: int | None
+    fix_dimension: Literal["3d", "2d", "none"]
+    speed_confidence: Literal["low", "medium", "high"]
+    epx_m: float | None
+    epy_m: float | None
+    epv_m: float | None
+    last_update_age_s: float | None
+    raw_speed_kmh: float | None
+    effective_speed_kmh: float | None
+    last_error: str | None
+    reconnect_delay_s: float | None
+    fallback_active: bool
+    speed_source: ResolvedSpeedSource
+    stale_timeout_s: float
+
+
 def speed_confidence(
     last_fix_mode: int | None,
     last_epx_m: float | None,
@@ -46,13 +70,13 @@ def speed_confidence(
     return "low"
 
 
-def build_status_dict(
+def build_status_snapshot(
     state: GPSSpeedStatusState,
     *,
     resolution: SpeedResolution,
     effective_connection_state: str,
     now_mono: float | None = None,
-) -> dict[str, object]:
+) -> SpeedSourceStatusSnapshot:
     now = time.monotonic() if now_mono is None else now_mono
 
     last_update_age_s: float | None = None
@@ -69,36 +93,36 @@ def build_status_dict(
     ):
         effective_speed_kmh = round(float(resolution.speed_mps) * MPS_TO_KMH, 2)
 
-    return {
-        "gps_enabled": state.gps_enabled,
-        "connection_state": effective_connection_state,
-        "device": state.device_info,
-        "fix_mode": state.last_fix_mode,
-        "fix_dimension": (
+    return SpeedSourceStatusSnapshot(
+        gps_enabled=state.gps_enabled,
+        connection_state=effective_connection_state,
+        device=state.device_info,
+        fix_mode=state.last_fix_mode,
+        fix_dimension=(
             "3d"
             if isinstance(state.last_fix_mode, int) and state.last_fix_mode >= 3
             else "2d"
             if state.last_fix_mode == 2
             else "none"
         ),
-        "speed_confidence": speed_confidence(
+        speed_confidence=speed_confidence(
             state.last_fix_mode,
             state.last_epx_m,
             state.last_epy_m,
         ),
-        "epx_m": state.last_epx_m,
-        "epy_m": state.last_epy_m,
-        "epv_m": state.last_epv_m,
-        "last_update_age_s": last_update_age_s,
-        "raw_speed_kmh": raw_speed_kmh,
-        "effective_speed_kmh": effective_speed_kmh,
-        "last_error": state.last_error,
-        "reconnect_delay_s": (
+        epx_m=state.last_epx_m,
+        epy_m=state.last_epy_m,
+        epv_m=state.last_epv_m,
+        last_update_age_s=last_update_age_s,
+        raw_speed_kmh=raw_speed_kmh,
+        effective_speed_kmh=effective_speed_kmh,
+        last_error=state.last_error,
+        reconnect_delay_s=(
             round(state.current_reconnect_delay, 1)
             if effective_connection_state == "disconnected"
             else None
         ),
-        "fallback_active": resolution.fallback_active,
-        "speed_source": resolution.source,
-        "stale_timeout_s": state.stale_timeout_s,
-    }
+        fallback_active=resolution.fallback_active,
+        speed_source=resolution.source,
+        stale_timeout_s=state.stale_timeout_s,
+    )

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -37,6 +37,7 @@ from vibesensor.shared.types.backend_types import (
 
 if TYPE_CHECKING:
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+    from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
     from vibesensor.infra.config.settings_store import SettingsStore
 
 
@@ -60,6 +61,29 @@ def create_settings_routes(
         return CarsResponse(
             cars=[_car_response(car) for car in snapshot.cars],
             activeCarId=snapshot.active_car_id,
+        )
+
+    def _speed_source_status_response(
+        snapshot: SpeedSourceStatusSnapshot,
+    ) -> SpeedSourceStatusResponse:
+        return SpeedSourceStatusResponse(
+            gps_enabled=snapshot.gps_enabled,
+            connection_state=snapshot.connection_state,
+            device=snapshot.device,
+            fix_mode=snapshot.fix_mode,
+            fix_dimension=snapshot.fix_dimension,
+            speed_confidence=snapshot.speed_confidence,
+            epx_m=snapshot.epx_m,
+            epy_m=snapshot.epy_m,
+            epv_m=snapshot.epv_m,
+            last_update_age_s=snapshot.last_update_age_s,
+            raw_speed_kmh=snapshot.raw_speed_kmh,
+            effective_speed_kmh=snapshot.effective_speed_kmh,
+            last_error=snapshot.last_error,
+            reconnect_delay_s=snapshot.reconnect_delay_s,
+            fallback_active=snapshot.fallback_active,
+            speed_source=snapshot.speed_source,
+            stale_timeout_s=snapshot.stale_timeout_s,
         )
 
     def _car_upsert_payload(req: CarUpsertRequest) -> CarConfigUpdatePayload:
@@ -192,7 +216,7 @@ def create_settings_routes(
 
     @router.get("/api/settings/speed-source/status", response_model=SpeedSourceStatusResponse)
     async def get_speed_source_status() -> SpeedSourceStatusResponse:
-        return SpeedSourceStatusResponse.model_validate(gps_monitor.status_dict())
+        return _speed_source_status_response(gps_monitor.status_snapshot())
 
     # -- sensors ---------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1061

## Summary

This PR replaces the internal GPS status dict bag with a typed `SpeedSourceStatusSnapshot` object while preserving the existing HTTP `SpeedSourceStatusResponse` output. The goal is the same pattern used in the recent typing fixes: make the runtime contract explicit and typed, then keep serialization at the edge instead of validating a broad internal dict inside the HTTP route.

Before this change, `GPSSpeedMonitor.status_dict()` returned `dict[str, object]`, the GPS status presenter helper built a raw mapping, and the `/api/settings/speed-source/status` route recovered a typed response only by calling `SpeedSourceStatusResponse.model_validate(...)` on that opaque dict. The shape was stable in practice, but the type safety lived only at the HTTP boundary. Internal monitor callers and tests still interacted with string keys rather than attributes, which is exactly the blind spot described in the issue.

This PR closes that blind spot without changing the external response contract.

## Problem being solved

The GPS monitor status path already had a fixed, well-understood schema:

- whether GPS is enabled
- effective connection state
- fix metadata
- speed confidence
- raw/effective speed values
- reconnect delay
- fallback and source state
- stale-timeout configuration

Even so, the runtime exported that schema as `dict[str, object]`. That had three concrete downsides.

First, the core runtime contract remained loose. `mypy` could not prove the shape of the status payload because the monitor exported anonymous `object` values instead of typed fields.

Second, internal tests were tied to string-key access. That meant internal behavior checks looked more like wire-format assertions than runtime contract assertions.

Third, the HTTP adapter had to perform the real schema recovery by validating an opaque dict into `SpeedSourceStatusResponse`. That is acceptable at a boundary, but it is the wrong place for the runtime to first become typed.

The issue asked specifically for the object route here, not another broad container type, and this PR follows that direction.

## Chosen implementation approach

I introduced a new immutable `SpeedSourceStatusSnapshot` dataclass in `apps/server/vibesensor/adapters/gps/speed_status.py`, close to the existing GPS status presentation helpers. I chose that location because this snapshot is part of the GPS status presentation seam itself, and `speed_status.py` already owns the translation logic from transport/policy state into the final status fields.

That placement keeps the implementation narrow and avoids inventing a more global type owner than necessary. This is not a new broad domain concept; it is the concrete internal output of the status presenter. Keeping it next to `GPSSpeedStatusState` and the status-building helper makes the relationship obvious and keeps the blast radius small.

I also kept the HTTP response model unchanged. The route now explicitly maps the typed snapshot into `SpeedSourceStatusResponse`, but the API contract and payload fields are preserved.

## Main code changes by area

### GPS status presenter

In `apps/server/vibesensor/adapters/gps/speed_status.py`, I added the frozen, slotted `SpeedSourceStatusSnapshot` dataclass. Its fields match the stable status contract already implied by the route and the existing response model:

- `gps_enabled`
- `connection_state`
- `device`
- `fix_mode`
- `fix_dimension`
- `speed_confidence`
- `epx_m`
- `epy_m`
- `epv_m`
- `last_update_age_s`
- `raw_speed_kmh`
- `effective_speed_kmh`
- `last_error`
- `reconnect_delay_s`
- `fallback_active`
- `speed_source`
- `stale_timeout_s`

I then replaced `build_status_dict()` with `build_status_snapshot()`. The underlying logic is intentionally preserved: it still computes age, km/h conversions, fix-dimension labeling, reconnect delay visibility, and fallback/source reporting the same way. The only meaningful change is the return type: a typed object instead of a dict bag.

### GPS monitor facade

In `apps/server/vibesensor/adapters/gps/gps_speed.py`, I replaced `status_dict()` with `status_snapshot()`. The monitor still gathers the same transport/policy inputs and still uses the same `GPSSpeedStatusState` intermediate state. What changed is the output seam. The monitor now returns `SpeedSourceStatusSnapshot` directly, which makes the runtime contract explicit and removes the last internal dependency on string-keyed status values.

### HTTP settings adapter

In `apps/server/vibesensor/adapters/http/settings.py`, I removed the `SpeedSourceStatusResponse.model_validate(gps_monitor.status_dict())` pattern and replaced it with an explicit `_speed_source_status_response(...)` adapter. That helper constructs the existing Pydantic model field-by-field from `SpeedSourceStatusSnapshot`.

This keeps the wire-format transformation in one place, as requested by the issue, and makes the route logic clearer: the runtime returns a typed object, and the HTTP layer turns that typed object into the HTTP response model.

## Test updates

This refactor required updating both internal GPS tests and the HTTP settings endpoint test that mocked the old dict contract.

In the direct GPS tests, I changed the subject-under-test assertions from string-key dict access to snapshot attribute access. That includes:

- status metadata checks
- stale/fresh connection-state reporting
- non-mutation regression coverage
- speed-source presence and value regression coverage
- the isolated presenter-helper test

These tests are now better aligned with what they are actually verifying: the internal GPS status contract, not a JSON-like container.

In the settings endpoint test, I updated the fake GPS monitor to return a real `SpeedSourceStatusSnapshot` instance, then continued asserting the HTTP payload shape through the existing response helper. That separation is important because it preserves the boundary between internal contract testing and serialized response testing.

## Validation performed

I validated the change in two stages.

Focused validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/adapters/gps/test_gps_speed_status.py apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py apps/server/tests/adapters/gps/test_speed_status_builder.py apps/server/tests/adapters/gps/test_gps_iris4_fixes.py apps/server/tests/adapters/http/test_settings_endpoints.py`

This passed with `79 passed`.

Broader backend validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That broader backend subset also passed cleanly. I also did a correctness-only review pass on the working diff after the local validation completed and before committing; it did not surface any substantive issues.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that the typed snapshot lives in the GPS adapter layer rather than in a broader shared-types module. I chose that intentionally. The issue asked for a runtime/shared type near the monitor, and `speed_status.py` is already the owner of the status-presentation logic. Moving this further outward would have made the ownership less clear without improving reuse.

I also kept the HTTP response model unchanged instead of trying to reuse the snapshot object directly as a Pydantic model. That is deliberate. The issue specifically called out keeping JSON serialization at the edge, and that is what this change does.

Out of scope for this PR are broader GPSSpeedMonitor structural changes, the concurrency issues captured in `#1120`, and any settings-route cleanup unrelated to the GPS status contract. This PR is intentionally narrow: it replaces one internal dict seam with a typed object and updates the immediate callers/tests accordingly.
