### PR TITLE
Fix #1062: type run recorder status snapshot

### DIFF
--- a/apps/server/tests/adapters/http/test_recording_endpoints.py
+++ b/apps/server/tests/adapters/http/test_recording_endpoints.py
@@ -5,27 +5,30 @@ from __future__ import annotations
 import pytest
 from test_support import response_payload
 
-_RECORDING_STATUS_DICT = {
-    "enabled": True,
-    "run_id": "run-abc",
-    "write_error": None,
-    "analysis_in_progress": False,
-    "samples_written": 42,
-    "samples_dropped": 0,
-    "last_completed_run_id": None,
-    "last_completed_run_error": None,
-}
+from vibesensor.use_cases.run.status_reporting import RunRecorderStatusSnapshot
 
-_IDLE_STATUS_DICT = {
-    "enabled": False,
-    "run_id": None,
-    "write_error": None,
-    "analysis_in_progress": False,
-    "samples_written": 0,
-    "samples_dropped": 0,
-    "last_completed_run_id": None,
-    "last_completed_run_error": None,
-}
+
+def _make_recording_status_snapshot(
+    *,
+    enabled: bool,
+    run_id: str | None,
+    samples_written: int,
+    samples_dropped: int = 0,
+    write_error: str | None = None,
+    analysis_in_progress: bool = False,
+    last_completed_run_id: str | None = None,
+    last_completed_run_error: str | None = None,
+) -> RunRecorderStatusSnapshot:
+    return RunRecorderStatusSnapshot(
+        enabled=enabled,
+        run_id=run_id,
+        write_error=write_error,
+        analysis_in_progress=analysis_in_progress,
+        samples_written=samples_written,
+        samples_dropped=samples_dropped,
+        last_completed_run_id=last_completed_run_id,
+        last_completed_run_error=last_completed_run_error,
+    )
 
 
 def _find_endpoint(router, path: str):
@@ -39,9 +42,21 @@ def _find_endpoint(router, path: str):
 def _recording_router(fake_state):
     from vibesensor.adapters.http.recording import create_recording_routes
 
-    fake_state.run_recorder.status.return_value = _IDLE_STATUS_DICT
-    fake_state.run_recorder.start_recording.return_value = _RECORDING_STATUS_DICT
-    fake_state.run_recorder.stop_recording.return_value = _IDLE_STATUS_DICT
+    fake_state.run_recorder.status.return_value = _make_recording_status_snapshot(
+        enabled=False,
+        run_id=None,
+        samples_written=0,
+    )
+    fake_state.run_recorder.start_recording.return_value = _make_recording_status_snapshot(
+        enabled=True,
+        run_id="run-abc",
+        samples_written=42,
+    )
+    fake_state.run_recorder.stop_recording.return_value = _make_recording_status_snapshot(
+        enabled=False,
+        run_id=None,
+        samples_written=0,
+    )
     return create_recording_routes(fake_state.run_recorder), fake_state
 
 
@@ -93,7 +108,11 @@ class TestRecordingStartEndpoint:
         """start_recording is idempotent — called again it still returns a valid status."""
         router, state = _recording_router
         endpoint = _find_endpoint(router, "/api/recording/start")
-        state.run_recorder.start_recording.return_value = _RECORDING_STATUS_DICT
+        state.run_recorder.start_recording.return_value = _make_recording_status_snapshot(
+            enabled=True,
+            run_id="run-abc",
+            samples_written=42,
+        )
 
         result = response_payload(await endpoint())
 
@@ -118,7 +137,11 @@ class TestRecordingStopEndpoint:
         """stop_recording when not recording is safe — returns idle status."""
         router, state = _recording_router
         endpoint = _find_endpoint(router, "/api/recording/stop")
-        state.run_recorder.stop_recording.return_value = _IDLE_STATUS_DICT
+        state.run_recorder.stop_recording.return_value = _make_recording_status_snapshot(
+            enabled=False,
+            run_id=None,
+            samples_written=0,
+        )
 
         result = response_payload(await endpoint())
 

--- a/apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py
@@ -1,7 +1,7 @@
 """Tests for history DB write-failure handling in RunRecorder (issue #296).
 
 Verifies that DB write failures are:
-1. Exposed via status()['write_error']
+1. Exposed via status().write_error
 2. Logged at the correct severity
 3. Tracked with a consecutive failure counter
 4. Samples are logged as dropped when history run creation persistently fails
@@ -147,8 +147,8 @@ class TestCreateRunFailureExposesWriteError:
         )
 
         status = logger.status()
-        assert status["write_error"] is not None
-        assert "disk full" in status["write_error"]
+        assert status.write_error is not None
+        assert "disk full" in status.write_error
         assert not logger._persistence.history_run_created
 
     def test_create_run_success_clears_write_error(self, tmp_path: Path) -> None:
@@ -163,7 +163,7 @@ class TestCreateRunFailureExposesWriteError:
             run_id,
             start_utc,
         )
-        assert logger.status()["write_error"] is not None
+        assert logger.status().write_error is not None
 
         # Second call succeeds
         logger._persistence.ensure_history_run(
@@ -171,7 +171,7 @@ class TestCreateRunFailureExposesWriteError:
             start_utc,
         )
         assert logger._persistence.history_run_created
-        assert logger.status()["write_error"] is None
+        assert logger.status().write_error is None
 
 
 class TestPersistentCreateRunFailureStopsRetrying:
@@ -194,8 +194,8 @@ class TestPersistentCreateRunFailureStopsRetrying:
         assert db.create_run.call_count == _MAX_HISTORY_CREATE_RETRIES
         assert logger._persistence.history_create_fail_count == _MAX_HISTORY_CREATE_RETRIES
         assert not logger._persistence.history_run_created
-        assert logger.status()["write_error"] is not None
-        assert "create_run failed" in logger.status()["write_error"]
+        assert logger.status().write_error is not None
+        assert "create_run failed" in str(logger.status().write_error)
 
     def test_retry_counter_resets_on_new_session(self, tmp_path: Path) -> None:
         db = MagicMock()
@@ -232,8 +232,8 @@ class TestAppendSamplesFailureExposesError:
         logger._sample_flush.append_records(run_id, start_utc, start_mono)
 
         status = logger.status()
-        assert status["write_error"] is not None
-        assert "write error" in status["write_error"]
+        assert status.write_error is not None
+        assert "write error" in str(status.write_error)
         # Sample count should NOT increment on failure
         assert logger._persistence.written_sample_count == 0
 
@@ -268,13 +268,12 @@ class TestDroppedSamplesLogged:
 
 
 class TestStatusAlwaysIncludesWriteError:
-    """The status dict always has a write_error key."""
+    """The status snapshot always exposes write_error."""
 
     def test_write_error_none_by_default(self, tmp_path: Path) -> None:
         logger = _make_logger(None, tmp_path)
         status = logger.status()
-        assert "write_error" in status
-        assert status["write_error"] is None
+        assert status.write_error is None
 
     def test_write_error_survives_through_recording(self, tmp_path: Path) -> None:
         db = MagicMock()
@@ -288,8 +287,8 @@ class TestStatusAlwaysIncludesWriteError:
         )
 
         # Error persists across status calls
-        assert logger.status()["write_error"] is not None
-        assert len(logger.status()["write_error"]) > 0
+        assert logger.status().write_error is not None
+        assert len(str(logger.status().write_error)) > 0
 
     def test_stop_recording_resets_write_error(self, tmp_path: Path) -> None:
         db = MagicMock()
@@ -301,7 +300,7 @@ class TestStatusAlwaysIncludesWriteError:
             run_id,
             start_utc,
         )
-        assert logger.status()["write_error"] is not None
+        assert logger.status().write_error is not None
 
         logger.stop_recording()
-        assert logger.status()["write_error"] is None
+        assert logger.status().write_error is None

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -198,7 +198,7 @@ def test_start_recording_rollover_flushes_first_pending_sample_batch(
     monkeypatch.setattr(logger, "schedule_post_analysis", scheduled.append)
 
     initial_status = logger.start_recording()
-    initial_run_id = str(initial_status["run_id"])
+    initial_run_id = str(initial_status.run_id)
     active = logger.registry.get("active")
     assert active is not None
     active.frames_total = 1
@@ -211,7 +211,7 @@ def test_start_recording_rollover_flushes_first_pending_sample_batch(
     assert fake_history_db.append_calls == [(created_run_id, 1)]
     assert fake_history_db.finalize_calls == [created_run_id]
     assert scheduled == [created_run_id]
-    assert next_status["run_id"] != created_run_id
+    assert next_status.run_id != created_run_id
 
 
 def test_finalize_refreshes_run_metadata_from_latest_settings(
@@ -254,9 +254,9 @@ def test_append_records_surfaces_create_run_failure_in_status(
     logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
     status = logger.status()
 
-    assert status["write_error"] is not None
-    assert "history create_run failed" in str(status["write_error"])
-    assert "create_run boom" in str(status["write_error"])
+    assert status.write_error is not None
+    assert "history create_run failed" in str(status.write_error)
+    assert "create_run boom" in str(status.write_error)
 
 
 def test_append_records_clears_write_error_after_successful_retry(
@@ -274,12 +274,12 @@ def test_append_records_clears_write_error_after_successful_retry(
 
     logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
     failed_status = logger.status()
-    assert failed_status["write_error"] is not None
-    assert "history append_samples failed" in str(failed_status["write_error"])
+    assert failed_status.write_error is not None
+    assert "history append_samples failed" in str(failed_status.write_error)
 
     logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
     recovered_status = logger.status()
-    assert recovered_status["write_error"] is None
+    assert recovered_status.write_error is None
 
 
 def test_append_records_reports_timeout_when_no_data_for_threshold(
@@ -473,8 +473,8 @@ def test_shutdown_blocks_new_start_recording_until_wait_completes(
     def _wait(timeout_s: float = 30.0) -> bool:
         assert timeout_s == 30.0
         start_result = logger.start_recording()
-        assert start_result["enabled"] is False
-        assert start_result["run_id"] is None
+        assert start_result.enabled is False
+        assert start_result.run_id is None
         # Session was stopped by shutdown
         assert logger._run_id is None
         allow_wait.set()
@@ -485,9 +485,9 @@ def test_shutdown_blocks_new_start_recording_until_wait_completes(
     assert logger.shutdown() is True
     assert allow_wait.is_set()
     restarted = logger.start_recording()
-    assert restarted["enabled"] is True
-    assert restarted["run_id"] is not None
-    assert restarted["run_id"] != initial_run_id
+    assert restarted.enabled is True
+    assert restarted.run_id is not None
+    assert restarted.run_id != initial_run_id
 
 
 def test_shutdown_report_exposes_timeout_state(
@@ -518,7 +518,7 @@ def test_shutdown_report_exposes_timeout_state(
     assert report.active_run_id_before_stop is not None
     assert report.analysis_queue_depth == 2
     assert report.analysis_active_run_id == "run-slow"
-    assert report.final_status["enabled"] is False
+    assert report.final_status.enabled is False
 
 
 def test_post_analysis_uses_run_language_from_metadata(

--- a/apps/server/tests/use_cases/run/test_pipeline_resilience.py
+++ b/apps/server/tests/use_cases/run/test_pipeline_resilience.py
@@ -462,20 +462,16 @@ class TestLoggingStatusEnrichment:
         logger = make_logger(history_db=db)
 
         status = logger.status()
-        assert "samples_written" in status
-        assert "samples_dropped" in status
-        assert status["samples_written"] == 0
-        assert status["samples_dropped"] == 0
+        assert status.samples_written == 0
+        assert status.samples_dropped == 0
 
     def test_status_includes_last_completed_fields(self, make_logger, tmp_path) -> None:
         """Status response includes last_completed_run_id and last_completed_run_error."""
         logger = make_logger()
 
         status = logger.status()
-        assert "last_completed_run_id" in status
-        assert "last_completed_run_error" in status
-        assert status["last_completed_run_id"] is None
-        assert status["last_completed_run_error"] is None
+        assert status.last_completed_run_id is None
+        assert status.last_completed_run_error is None
 
 
 # ---------------------------------------------------------------------------
@@ -524,4 +520,4 @@ class TestHealthSnapshotEnrichment:
 
         # First append fails → drops counted
         assert health["samples_dropped"] > 0
-        assert status["samples_dropped"] > 0
+        assert status.samples_dropped > 0

--- a/apps/server/vibesensor/adapters/http/recording.py
+++ b/apps/server/vibesensor/adapters/http/recording.py
@@ -10,8 +10,22 @@ from vibesensor.shared.types.api_models import RecordingStatusResponse
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.run import RunRecorder
+    from vibesensor.use_cases.run.status_reporting import RunRecorderStatusSnapshot
 
 __all__ = ["create_recording_routes"]
+
+
+def _recording_status_response(snapshot: RunRecorderStatusSnapshot) -> RecordingStatusResponse:
+    return RecordingStatusResponse(
+        enabled=snapshot.enabled,
+        run_id=snapshot.run_id,
+        write_error=snapshot.write_error,
+        analysis_in_progress=snapshot.analysis_in_progress,
+        samples_written=snapshot.samples_written,
+        samples_dropped=snapshot.samples_dropped,
+        last_completed_run_id=snapshot.last_completed_run_id,
+        last_completed_run_error=snapshot.last_completed_run_error,
+    )
 
 
 def create_recording_routes(
@@ -22,14 +36,14 @@ def create_recording_routes(
 
     @router.get("/api/recording/status", response_model=RecordingStatusResponse)
     async def get_logging_status() -> RecordingStatusResponse:
-        return RecordingStatusResponse.model_validate(run_recorder.status())
+        return _recording_status_response(run_recorder.status())
 
     @router.post("/api/recording/start", response_model=RecordingStatusResponse)
     async def start_logging() -> RecordingStatusResponse:
-        return RecordingStatusResponse.model_validate(run_recorder.start_recording())
+        return _recording_status_response(run_recorder.start_recording())
 
     @router.post("/api/recording/stop", response_model=RecordingStatusResponse)
     async def stop_logging() -> RecordingStatusResponse:
-        return RecordingStatusResponse.model_validate(run_recorder.stop_recording())
+        return _recording_status_response(run_recorder.stop_recording())
 
     return router

--- a/apps/server/vibesensor/use_cases/run/_recorder_types.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_types.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from vibesensor.shared.types.json_types import JsonObject
 
 from .sample_builder import build_run_metadata, firmware_version_for_run
+from .status_reporting import RunRecorderStatusSnapshot
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.run.logger import RunRecorder
@@ -42,7 +43,7 @@ class RecorderShutdownReport:
     analysis_queue_oldest_age_s: float | None
     analysis_in_progress: bool
     write_error: str | None
-    final_status: dict[str, object]
+    final_status: RunRecorderStatusSnapshot
 
 
 def _build_run_metadata_record(

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -28,6 +28,7 @@ from vibesensor.use_cases.run.persistence_writer import (
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker, build_post_analysis_summary
 from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator
 from vibesensor.use_cases.run.status_reporting import (
+    RunRecorderStatusSnapshot,
     build_run_recorder_health_snapshot,
     build_run_recorder_status,
 )
@@ -157,7 +158,7 @@ class RunRecorder:
     def _session_snapshot(self) -> ActiveRunSnapshot | None:
         return self._lifecycle.snapshot()
 
-    def status(self) -> dict[str, object]:
+    def status(self) -> RunRecorderStatusSnapshot:
         return build_run_recorder_status(
             enabled=self.enabled,
             run_id=self._run_id,
@@ -173,7 +174,7 @@ class RunRecorder:
             logger=LOGGER,
         )
 
-    def start_recording(self) -> dict[str, object]:
+    def start_recording(self) -> RunRecorderStatusSnapshot:
         completed_run_id: str | None = None
         flush_snapshot: ActiveRunSnapshot | None = None
         with self._lock:
@@ -225,7 +226,7 @@ class RunRecorder:
         self,
         *,
         _only_if_run_id: str | None = None,
-    ) -> dict[str, object]:
+    ) -> RunRecorderStatusSnapshot:
         flush_snapshot: ActiveRunSnapshot | None = None
         with self._lock:
             if _only_if_run_id is not None and self._run_id != _only_if_run_id:

--- a/apps/server/vibesensor/use_cases/run/status_reporting.py
+++ b/apps/server/vibesensor/use_cases/run/status_reporting.py
@@ -1,10 +1,11 @@
-"""Status and health payload helpers extracted from ``RunRecorder``."""
+"""Status and health snapshot helpers extracted from ``RunRecorder``."""
 
 from __future__ import annotations
 
 import logging
 import sqlite3
 import time
+from dataclasses import dataclass
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.health_snapshot import RunRecorderHealthSnapshot
@@ -12,9 +13,22 @@ from vibesensor.use_cases.run.persistence_writer import RunPersistenceWriter
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 
 __all__ = [
+    "RunRecorderStatusSnapshot",
     "build_run_recorder_health_snapshot",
     "build_run_recorder_status",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class RunRecorderStatusSnapshot:
+    enabled: bool
+    run_id: str | None
+    write_error: str | None
+    analysis_in_progress: bool
+    samples_written: int = 0
+    samples_dropped: int = 0
+    last_completed_run_id: str | None = None
+    last_completed_run_error: str | None = None
 
 
 def build_run_recorder_status(
@@ -23,19 +37,19 @@ def build_run_recorder_status(
     run_id: str | None,
     persistence: RunPersistenceWriter,
     post_analysis: PostAnalysisWorker,
-) -> dict[str, object]:
+) -> RunRecorderStatusSnapshot:
     post_snapshot = post_analysis.snapshot()
     persist = persistence.status_snapshot()
-    return {
-        "enabled": enabled,
-        "run_id": run_id,
-        "write_error": persist.write_error,
-        "analysis_in_progress": post_analysis.is_active,
-        "samples_written": persist.written_sample_count,
-        "samples_dropped": persist.dropped_sample_count,
-        "last_completed_run_id": post_snapshot.last_completed_run_id,
-        "last_completed_run_error": post_snapshot.last_completed_error,
-    }
+    return RunRecorderStatusSnapshot(
+        enabled=enabled,
+        run_id=run_id,
+        write_error=persist.write_error,
+        analysis_in_progress=post_analysis.is_active,
+        samples_written=persist.written_sample_count,
+        samples_dropped=persist.dropped_sample_count,
+        last_completed_run_id=post_snapshot.last_completed_run_id,
+        last_completed_run_error=post_snapshot.last_completed_error,
+    )
 
 
 def build_run_recorder_health_snapshot(


### PR DESCRIPTION
Fixes #1062

## Summary

This PR replaces the run recorder’s internal recording-status dict bag with a typed `RunRecorderStatusSnapshot` object while preserving the existing HTTP `RecordingStatusResponse` payload. The core goal is the same as the recent internal-contract cleanup work in this repo: keep the runtime contract typed inside the application, then let the HTTP adapter perform the final boundary translation instead of recovering structure from an opaque `dict[str, object]`.

Before this change, the status shape was already stable in practice, but the code still treated it like an anonymous JSON-ish mapping through the recorder core. `build_run_recorder_status(...)` returned `dict[str, object]`, `RunRecorder.status()`, `start_recording()`, and `stop_recording()` returned that dict directly, and the recording routes restored typing only by calling `RecordingStatusResponse.model_validate(...)` over the opaque result. That meant internal code and tests still depended on string keys instead of real attributes, and the strongest type guarantees appeared only at the HTTP edge.

This PR moves that status contract into a real immutable runtime object without changing the external API.

## Problem being solved

The recording-status flow already had a fixed schema:

- whether recording is enabled
- the active `run_id`
- the latest persistence `write_error`
- whether post-analysis is still active
- sample counters for written and dropped samples
- the last completed run id and last completed error

Even though that schema was stable, the runtime exported it as `dict[str, object]`. That caused three concrete problems.

First, type information was weak in the middle of the stack. `mypy` could not follow the recorder status fields precisely because the recorder core exported them as a broad dict with `object` values rather than a typed object.

Second, direct recorder tests asserted on string-key lookups instead of the internal contract itself. Those tests were effectively checking a JSON-style bag in places where the real subject under test was the recorder runtime seam.

Third, the HTTP adapter had to recover the real schema by validating an opaque dict into `RecordingStatusResponse`. That is acceptable at a boundary, but it is not the right place for the application to first become typed.

Issue `#1062` asked specifically to promote this status contract to a typed immutable object and to keep the HTTP model as an edge concern. This PR follows that direction.

## Chosen implementation approach

I added a new frozen, slotted `RunRecorderStatusSnapshot` dataclass in `apps/server/vibesensor/use_cases/run/status_reporting.py`, next to the existing recorder status builder. I chose that location because `status_reporting.py` already owns the translation from recorder collaborators (`RunPersistenceWriter` and `PostAnalysisWorker`) into the outward status fields. This is not a broad shared domain type; it is the concrete internal output of the recorder status presenter, so keeping the object beside that builder makes the ownership clear.

I then replaced the dict-returning builder and recorder methods with this typed snapshot, and I kept HTTP serialization at the boundary by adding a narrow adapter helper in `apps/server/vibesensor/adapters/http/recording.py`.

There was one directly connected blast-radius seam worth including in the same change: `RecorderShutdownReport.final_status`. Because `shutdown_report()` captures the result of `stop_recording()`, leaving that field typed as a raw dict would have preserved a shadow dict contract even after the main recorder methods became typed. This PR updates that field to the same `RunRecorderStatusSnapshot` object so the recorder package stays internally consistent.

## Main code changes by area

### Recorder status builder

In `apps/server/vibesensor/use_cases/run/status_reporting.py`, I introduced `RunRecorderStatusSnapshot` with the stable status fields already implied by the recorder routes and tests:

- `enabled`
- `run_id`
- `write_error`
- `analysis_in_progress`
- `samples_written`
- `samples_dropped`
- `last_completed_run_id`
- `last_completed_run_error`

I then changed `build_run_recorder_status()` to return that object directly instead of constructing a dict. The underlying logic is intentionally preserved. It still reads the same persistence counters and post-analysis state; the meaningful change is the contract at the seam.

### RunRecorder facade

In `apps/server/vibesensor/use_cases/run/logger.py`, I changed `status()`, `start_recording()`, and `stop_recording()` to return `RunRecorderStatusSnapshot`. That removes the remaining internal `dict[str, object]` recorder-status API and makes the recorder’s outward runtime contract explicit.

### Shutdown-report seam

In `apps/server/vibesensor/use_cases/run/_recorder_types.py`, `RecorderShutdownReport.final_status` now uses `RunRecorderStatusSnapshot` instead of `dict[str, object]`. This is a small but important follow-through step because `shutdown_report()` is another recorder-facing surface that carries the final status result.

### HTTP recording adapter

In `apps/server/vibesensor/adapters/http/recording.py`, I removed the `RecordingStatusResponse.model_validate(run_recorder.status())` pattern and replaced it with an explicit `_recording_status_response(...)` helper. That helper builds the existing Pydantic response model field-by-field from `RunRecorderStatusSnapshot`.

This keeps the wire-format conversion in one obvious place and makes the boundary clearer: recorder core returns a typed snapshot, and the HTTP adapter turns that snapshot into the response model.

## Related cleanup from the issue

The issue also called out a nearby follow-up in the recorder health path: once the persistence health contract was typed, `build_run_recorder_health_snapshot()` should stop parsing it like raw JSON. I verified the current code already satisfies that expectation. The health helper now reads `analyzing_run_health()` through typed fields directly rather than through `.get(...)` and `isinstance(...)` probing, so there was no remaining health-path cleanup to add in this PR.

## Test updates

I updated the direct recorder tests so they now assert on snapshot attributes where the recorder runtime contract is the subject under test. That includes:

- recorder lifecycle/helper tests under `apps/server/tests/use_cases/run/test_metrics_log_helpers.py`
- status-enrichment coverage in `apps/server/tests/use_cases/run/test_pipeline_resilience.py`
- write-error and retry-path regressions in `apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py`

I also updated `apps/server/tests/adapters/http/test_recording_endpoints.py` so the fake recorder returns `RunRecorderStatusSnapshot` objects while the test still asserts on the serialized HTTP payload shape. That separation is important because it keeps runtime-contract testing and response-shape testing at the correct layers.

## Validation performed

Focused validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/adapters/http/test_recording_endpoints.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_pipeline_resilience.py apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py`

This passed with `62 passed`.

Broader backend validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That broader subset also passed cleanly.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that `RunRecorderStatusSnapshot` lives near the recorder status presenter instead of in a broader shared-types package. I chose that intentionally because this object represents the recorder runtime seam itself, not a generally shared application contract. Moving it outward would not improve reuse and would blur ownership.

I also kept `RecordingStatusResponse` as a boundary model rather than trying to collapse the runtime snapshot and HTTP model into one type. That separation is deliberate and matches the issue’s request to keep boundary shaping at the edge.

Out of scope here are larger `RunRecorder` structural refactors, the broader run-package cleanup in `#1106`, and unrelated health-endpoint model changes. This PR is intentionally narrow: it replaces one recorder-status dict seam with a typed object, updates the connected shutdown-report field, and keeps the HTTP/API contract stable.
