### PR TITLE
Fix #1063: use analysis settings snapshot in runtime math

### DIFF
--- a/apps/server/tests/integration/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_core_regressions.py
@@ -65,6 +65,8 @@ class TestBuildOrderBandsLocation:
         assert not hasattr(rt, "_build_order_bands")
 
     def test_build_order_bands_basic(self) -> None:
+        from vibesensor.shared.order_bands import build_diagnostic_settings
+
         orders = {
             "wheel_hz": 10.0,
             "drive_hz": 30.0,
@@ -73,7 +75,7 @@ class TestBuildOrderBandsLocation:
             "drive_uncertainty_pct": 0.03,
             "engine_uncertainty_pct": 0.04,
         }
-        settings = {}
+        settings = build_diagnostic_settings({})
         bands = build_order_bands(orders, settings)
         assert isinstance(bands, list)
         assert len(bands) >= 4  # wheel_1x, wheel_2x, drive/engine, engine_2x

--- a/apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py
+++ b/apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py
@@ -4,6 +4,7 @@ from math import pi
 
 import pytest
 
+from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.shared.constants import KMH_TO_MPS
 from vibesensor.shared.order_bands import (
     build_diagnostic_settings,
@@ -23,7 +24,7 @@ SPEED_KMH = 100.0
 SPEED_MPS = SPEED_KMH * KMH_TO_MPS
 
 
-def _default_orders() -> tuple[dict[str, float], dict[str, float]]:
+def _default_orders() -> tuple[AnalysisSettingsSnapshot, dict[str, float]]:
     settings = build_diagnostic_settings({})
     orders = vehicle_orders_hz(speed_mps=SPEED_MPS, settings=settings)
     assert orders is not None
@@ -34,12 +35,12 @@ def test_default_100_kmh_order_calculation_matches_vehicle_spec() -> None:
     settings, orders = _default_orders()
 
     # Independent manual calculation from default tire and drivetrain values.
-    sidewall_mm = settings["tire_width_mm"] * (settings["tire_aspect_pct"] / 100.0)
-    diameter_m = ((settings["rim_in"] * 25.4) + (2.0 * sidewall_mm)) / 1000.0
-    circumference_m = pi * diameter_m * settings["tire_deflection_factor"]
+    sidewall_mm = settings.tire_width_mm * (settings.tire_aspect_pct / 100.0)
+    diameter_m = ((settings.rim_in * 25.4) + (2.0 * sidewall_mm)) / 1000.0
+    circumference_m = pi * diameter_m * settings.tire_deflection_factor
     wheel_hz_manual = SPEED_MPS / circumference_m
-    drive_hz_manual = wheel_hz_manual * settings["final_drive_ratio"]
-    engine_hz_manual = drive_hz_manual * settings["current_gear_ratio"]
+    drive_hz_manual = wheel_hz_manual * settings.final_drive_ratio
+    engine_hz_manual = drive_hz_manual * settings.current_gear_ratio
 
     assert orders["wheel_hz"] == pytest.approx(wheel_hz_manual, rel=1e-6)
     assert orders["drive_hz"] == pytest.approx(drive_hz_manual, rel=1e-6)

--- a/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from math import inf, nan
 
+from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.shared.order_bands import (
     build_diagnostic_settings,
     tolerance_for_order,
@@ -11,7 +12,7 @@ from vibesensor.shared.order_bands import (
 _DEFAULT_SPEED_MPS = 27.7777777778  # 100 km/h
 
 
-def _default_settings_and_orders() -> tuple[dict, dict]:
+def _default_settings_and_orders() -> tuple[AnalysisSettingsSnapshot, dict[str, float]]:
     """Return ``(settings, orders)`` at the default 100 km/h test speed."""
     settings = build_diagnostic_settings({})
     orders = vehicle_orders_hz(speed_mps=_DEFAULT_SPEED_MPS, settings=settings)
@@ -33,12 +34,8 @@ def test_tolerance_for_order_honors_floor_and_cap() -> None:
 
 def test_vehicle_orders_hz_uses_tire_deflection_factor() -> None:
     """vehicle_orders_hz should compute frequencies with the deflected circumference."""
-    from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
-
-    settings_no_deflection = dict(AnalysisSettingsSnapshot.DEFAULTS)
-    settings_no_deflection["tire_deflection_factor"] = 1.0
-    settings_with_deflection = dict(AnalysisSettingsSnapshot.DEFAULTS)
-    settings_with_deflection["tire_deflection_factor"] = 0.97
+    settings_no_deflection = build_diagnostic_settings({"tire_deflection_factor": 1.0})
+    settings_with_deflection = build_diagnostic_settings({"tire_deflection_factor": 0.97})
 
     orders_no = vehicle_orders_hz(speed_mps=30.0, settings=settings_no_deflection)
     orders_with = vehicle_orders_hz(speed_mps=30.0, settings=settings_with_deflection)

--- a/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py
@@ -38,18 +38,18 @@ def test_as_float_non_convertible() -> None:
 
 def test_build_diagnostic_settings_defaults() -> None:
     result = build_diagnostic_settings(None)
-    assert result["tire_width_mm"] == 285.0
-    assert result["rim_in"] == 21.0
+    assert result.tire_width_mm == 285.0
+    assert result.rim_in == 21.0
 
 
 def test_build_diagnostic_settings_override() -> None:
     result = build_diagnostic_settings({"tire_width_mm": 225.0})
-    assert result["tire_width_mm"] == 225.0
+    assert result.tire_width_mm == 225.0
 
 
 def test_build_diagnostic_settings_ignores_unknown() -> None:
     result = build_diagnostic_settings({"unknown_key": 99.0})
-    assert "unknown_key" not in result
+    assert not hasattr(result, "unknown_key")
 
 
 # -- combined_relative_uncertainty ---------------------------------------------
@@ -90,13 +90,14 @@ def test_tolerance_for_order_basic() -> None:
 
 
 def test_vehicle_orders_no_speed() -> None:
-    assert vehicle_orders_hz(speed_mps=None, settings={}) is None
-    assert vehicle_orders_hz(speed_mps=0.0, settings={}) is None
-    assert vehicle_orders_hz(speed_mps=-1.0, settings={}) is None
+    settings = build_diagnostic_settings({})
+    assert vehicle_orders_hz(speed_mps=None, settings=settings) is None
+    assert vehicle_orders_hz(speed_mps=0.0, settings=settings) is None
+    assert vehicle_orders_hz(speed_mps=-1.0, settings=settings) is None
 
 
 def test_vehicle_orders_with_defaults() -> None:
-    result = vehicle_orders_hz(speed_mps=25.0, settings={})
+    result = vehicle_orders_hz(speed_mps=25.0, settings=build_diagnostic_settings({}))
     assert result is not None
     assert result["wheel_hz"] > 0
     assert result["drive_hz"] > 0
@@ -106,12 +107,12 @@ def test_vehicle_orders_with_defaults() -> None:
 
 
 def test_vehicle_orders_bad_tire_returns_none() -> None:
-    settings = {"tire_width_mm": 0.0}
+    settings = build_diagnostic_settings({"tire_width_mm": 0.0})
     assert vehicle_orders_hz(speed_mps=25.0, settings=settings) is None
 
 
 def test_vehicle_orders_bad_ratios_returns_none() -> None:
-    settings = {"final_drive_ratio": 0.0}
+    settings = build_diagnostic_settings({"final_drive_ratio": 0.0})
     assert vehicle_orders_hz(speed_mps=25.0, settings=settings) is None
 
 
@@ -138,7 +139,10 @@ def test_vehicle_orders_projects_boundary_settings_into_order_reference_spec(
 
     monkeypatch.setattr(OrderReferenceSpec, "from_settings", _fake_from_settings)
 
-    result = vehicle_orders_hz(speed_mps=25.0, settings={"final_drive_ratio": 3.55})
+    result = vehicle_orders_hz(
+        speed_mps=25.0,
+        settings=build_diagnostic_settings({"final_drive_ratio": 3.55}),
+    )
 
     assert result == {
         "wheel_hz": 1.0,

--- a/apps/server/vibesensor/infra/runtime/rotational_speeds.py
+++ b/apps/server/vibesensor/infra/runtime/rotational_speeds.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
+from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.domain.speed_source import SpeedSource
 from vibesensor.shared.constants import SECONDS_PER_MINUTE
 from vibesensor.shared.order_bands import build_order_bands, vehicle_orders_hz
@@ -34,7 +33,7 @@ def build_rotational_speeds_payload(
     *,
     basis_speed_source: str,
     speed_mps: float | None,
-    analysis_settings: Mapping[str, object],
+    analysis_settings: AnalysisSettingsSnapshot,
 ) -> RotationalSpeedsPayload:
     """Assemble the ``rotational_speeds`` sub-dict for the WS payload."""
     if speed_mps is None or speed_mps <= 0:

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -10,7 +10,6 @@ those are produced by the post-run analysis pipeline and flow through
 
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
@@ -107,7 +106,7 @@ class WsBroadcastService:
         payload["rotational_speeds"] = build_rotational_speeds_payload(
             basis_speed_source=basis,
             speed_mps=speed_mps,
-            analysis_settings=asdict(analysis_settings_snapshot),
+            analysis_settings=analysis_settings_snapshot,
         )
         spectra: SpectraPayload | None = None
         if self.include_heavy:

--- a/apps/server/vibesensor/shared/order_bands.py
+++ b/apps/server/vibesensor/shared/order_bands.py
@@ -26,16 +26,18 @@ __all__ = [
 ]
 
 
-def build_diagnostic_settings(overrides: Mapping[str, object] | None = None) -> dict[str, float]:
-    """Return analysis settings merged with validated *overrides*."""
+def build_diagnostic_settings(
+    overrides: Mapping[str, object] | None = None,
+) -> AnalysisSettingsSnapshot:
+    """Return analysis settings merged with validated *overrides* as a snapshot."""
     out = dict(AnalysisSettingsSnapshot.DEFAULTS)
     if not overrides:
-        return out
+        return AnalysisSettingsSnapshot.from_dict(out)
     for key in AnalysisSettingsSnapshot.DEFAULTS:
         parsed = as_float_or_none(overrides.get(key))
         if parsed is not None:
             out[key] = parsed
-    return out
+    return AnalysisSettingsSnapshot.from_dict(out)
 
 
 def combined_relative_uncertainty(*parts: float) -> float:
@@ -97,11 +99,10 @@ def order_tolerances(
 
 def build_order_bands(
     orders_hz: dict[str, float],
-    analysis_settings: Mapping[str, object],
+    analysis_settings: AnalysisSettingsSnapshot,
 ) -> list[OrderBandPayload]:
     """Pre-compute order tolerance bands so the frontend doesn't duplicate this math."""
-    resolved = build_diagnostic_settings(analysis_settings)
-    order_reference_spec = OrderReferenceSpec.from_settings(resolved)
+    order_reference_spec = analysis_settings.order_reference_spec
     if order_reference_spec is None:
         return []
     wheel_hz = float(orders_hz["wheel_hz"])
@@ -136,13 +137,12 @@ def build_order_bands(
 def vehicle_orders_hz(
     *,
     speed_mps: float | None,
-    settings: Mapping[str, object],
+    settings: AnalysisSettingsSnapshot,
 ) -> dict[str, float] | None:
     """Return per-order frequencies in Hz for the given speed and settings."""
     if speed_mps is None or not isfinite(speed_mps) or speed_mps <= 0:
         return None
-    spec_settings = build_diagnostic_settings(settings)
-    order_reference_spec = OrderReferenceSpec.from_settings(spec_settings)
+    order_reference_spec = settings.order_reference_spec
     if order_reference_spec is None:
         return None
     return order_reference_spec.orders_hz_from_speed_mps(speed_mps)


### PR DESCRIPTION
Fixes #1063

## Summary

This PR removes the remaining `AnalysisSettingsSnapshot -> asdict(...) -> Mapping[str, object] -> float reparsing` loop from the live rotational-speed and order-band runtime path. The runtime now keeps `AnalysisSettingsSnapshot` as the typed contract end to end through the order-band helpers, rotational-speed payload builder, and WebSocket broadcast assembly, while preserving the existing payload shape for the UI.

Before this change, the runtime already had a fully typed `AnalysisSettingsSnapshot`, but the live math helpers still accepted generic mappings. The WebSocket path therefore downgraded a typed snapshot to a dict with `asdict(...)`, then the shared helpers reparsed floats back out of that dict. The data was already structured and typed, but the runtime had to pretend it was generic JSON anyway. This PR removes that downgrade loop and keeps any permissive override coercion isolated to the helper that actually needs it.

## Problem being solved

The issue called out a very specific typing hole in the live runtime path:

- `shared/order_bands.py` still accepted `Mapping[str, object]`
- `infra/runtime/rotational_speeds.py` still accepted `Mapping[str, object]`
- `infra/runtime/ws_broadcast.py` converted `analysis_settings_snapshot` to a dict with `asdict(...)`

That caused the runtime to lose type information even though it already held a real `AnalysisSettingsSnapshot`. The live path then reparsed those values back into floats in order-band and rotational-speed helpers.

That pattern had three concrete downsides.

First, it weakened the runtime contract. Internal math helpers no longer expressed that they operate on the real analysis-settings snapshot used by the rest of the runtime.

Second, it created unnecessary conversion work and indirection in a hot live-update path. The runtime built a dataclass, converted it to a dict, then derived typed math inputs from that dict again.

Third, it encouraged tests to keep exercising raw mapping inputs for runtime helpers instead of using the typed object directly. That blurs the difference between a permissive boundary helper and the actual internal runtime contract.

Issue `#1063` asked specifically to remove that downgrade loop and standardize the live path on `AnalysisSettingsSnapshot` or a narrower typed object. This PR follows the simpler route and uses `AnalysisSettingsSnapshot` directly.

## Chosen implementation approach

I kept `AnalysisSettingsSnapshot` as the runtime contract rather than introducing a new smaller settings object. The existing snapshot already contains the fields the rotational-speed and order-band helpers need, and it already exposes `order_reference_spec`, which is the natural typed projection for the downstream math.

That made the cleanest implementation:

- keep `build_diagnostic_settings(...)` only as a permissive boundary helper
- make it return `AnalysisSettingsSnapshot`
- switch runtime helpers to accept `AnalysisSettingsSnapshot`
- use `analysis_settings.order_reference_spec` instead of reparsing mapping fields
- remove `asdict(...)` from `ws_broadcast.py`

This keeps the live path fully typed while still preserving one explicit place where partial override bags can be merged with defaults for tests or other boundary-style callers.

## Main code changes by area

### Shared order-band helpers

In `apps/server/vibesensor/shared/order_bands.py`, I changed `build_diagnostic_settings(...)` to return `AnalysisSettingsSnapshot` instead of `dict[str, float]`. Importantly, I did not change its permissive merge behavior. It still starts from `AnalysisSettingsSnapshot.DEFAULTS`, applies any finite override values for known keys, ignores unknown keys, and returns the resolved settings. The difference is that the result is now a typed snapshot object rather than a flat dict bag.

I then changed `build_order_bands(...)` and `vehicle_orders_hz(...)` to consume `AnalysisSettingsSnapshot` directly. Instead of calling `build_diagnostic_settings(...)` again and then passing a mapping into `OrderReferenceSpec.from_settings(...)`, both helpers now use `analysis_settings.order_reference_spec`. That removes the mapping-based settings access from the live runtime path while keeping the actual order-band/output behavior intact.

### Rotational-speed runtime helper

In `apps/server/vibesensor/infra/runtime/rotational_speeds.py`, `build_rotational_speeds_payload(...)` now accepts `AnalysisSettingsSnapshot` instead of `Mapping[str, object]`. Its behavior is intentionally preserved: it still returns the same basis-source label, the same per-component RPM structure, and the same `order_bands` payload shape. The meaningful change is the input contract: this helper now explicitly receives the typed analysis-settings object that the runtime already had.

### WebSocket broadcast path

In `apps/server/vibesensor/infra/runtime/ws_broadcast.py`, I removed the `asdict(analysis_settings_snapshot)` downgrade. The broadcast service now passes the typed `analysis_settings_snapshot` directly into `build_rotational_speeds_payload(...)`.

That is the core runtime cleanup the issue asked for. The live telemetry path no longer converts the typed settings snapshot into a dict just to satisfy old helper signatures.

## Test updates

The biggest follow-through here was test alignment. Once the runtime helpers consume `AnalysisSettingsSnapshot`, the tests that exercise that runtime contract should do the same.

I updated:

- `apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py`
- `apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py`
- `apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py`
- `apps/server/tests/integration/test_review_guardrails_core_regressions.py`

The pattern is deliberate:

- tests that exercise the permissive boundary helper still call `build_diagnostic_settings(...)`
- tests that exercise the runtime math path now pass typed snapshots rather than raw dicts
- assertions that used to read settings through string keys now use snapshot attributes where appropriate

This keeps the boundary-helper behavior covered without preserving a raw-mapping contract in the runtime tests.

The WebSocket payload tests did not need major assertion changes because they already exercised the assembled payload shape rather than the internal settings type directly. They remain useful coverage for the `ws_broadcast.py` runtime path after the `asdict(...)` removal.

## Why I kept build_diagnostic_settings

The issue allowed keeping permissive override parsing if it remained at an explicit boundary helper only. I kept `build_diagnostic_settings(...)` for exactly that purpose.

It still provides a convenient way to merge partial/loose override bags with defaults in tests and boundary-style callers, but it no longer forces the live runtime path to stay on broad mappings. The runtime contract now starts and stays typed once it enters the order-band/rotational-speed helpers.

That felt like the best balance between tightening the live path and avoiding churn around a helper that still has legitimate boundary-style use.

## Validation performed

Focused validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py apps/server/tests/integration/test_review_guardrails_core_regressions.py apps/server/tests/adapters/websocket/test_build_ws_payload.py`

This passed with `50 passed`.

Broader backend validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That broader subset also passed cleanly.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that `OrderReferenceSpec.from_settings(...)` still accepts a mapping internally, and `AnalysisSettingsSnapshot.order_reference_spec` still projects into that API. I left that alone intentionally. Issue `#1063` is about removing the broad mapping contract from the live/runtime helper path, not redesigning every order-reference boundary in the domain layer.

I also intentionally kept `build_diagnostic_settings(...)` instead of deleting it. Removing it entirely would have mixed two separate concerns: boundary coercion and runtime math typing. This PR makes the runtime path typed end to end while keeping the permissive boundary behavior in one explicit place.

Out of scope here are broader diagnostics refactors, any redesign of `OrderReferenceSpec.from_settings(...)`, and other analysis-settings boundary cleanup outside the live rotational-speed/order-band path. This PR is intentionally narrow: it eliminates the runtime downgrade loop, keeps payload behavior stable, and tightens the internal math contract around `AnalysisSettingsSnapshot`.
