### PR TITLE
Fix #1089: drop raw origin fallback after projection

### DIFF
--- a/apps/server/tests/shared/boundaries/test_analysis_summary_projection.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_summary_projection.py
@@ -35,3 +35,25 @@ def test_project_analysis_summary_projects_run_suitability_from_reconstructed_te
             "explanation": test_run.suitability.checks[0].explanation_i18n_ref(),
         }
     ]
+
+
+def test_project_analysis_summary_drops_persisted_origin_without_primary_finding() -> None:
+    summary = {
+        "case_id": "case-001",
+        "run_id": "run-001",
+        "metadata": {"car_name": "Guard Car", "car_type": "sedan"},
+        "findings": [],
+        "top_causes": [],
+        "test_plan": [],
+        "run_suitability": [],
+        "most_likely_origin": {
+            "location": "rear left",
+            "suspected_source": "wheel/tire",
+            "weak_spatial_separation": True,
+        },
+    }
+
+    projected, test_run = project_analysis_summary(summary)
+
+    assert test_run.primary_finding is None
+    assert projected["most_likely_origin"] == {}

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -154,6 +154,39 @@ async def test_projected_run_service_projects_persisted_summary_through_domain()
     assert "_internal" not in analysis
 
 
+@pytest.mark.asyncio
+async def test_projected_run_service_drops_persisted_origin_without_primary_finding() -> None:
+    service = ProjectedHistoryRunService(
+        HistoryRunService(
+            _HistoryDbStub(
+                run={
+                    "run_id": "run-1",
+                    "status": "complete",
+                    "analysis": {
+                        "lang": "en",
+                        "findings": [],
+                        "top_causes": [],
+                        "test_plan": [],
+                        "run_suitability": [],
+                        "most_likely_origin": {
+                            "location": "rear left",
+                            "suspected_source": "wheel/tire",
+                            "weak_spatial_separation": True,
+                        },
+                        "_internal": {"secret": True},
+                    },
+                },
+            ),
+        )
+    )
+
+    run = await service.get_run("run-1")
+
+    analysis = run["analysis"]
+    assert analysis["most_likely_origin"] == {}
+    assert "_internal" not in analysis
+
+
 def test_build_run_details_json_strips_internal_analysis_fields() -> None:
     payload = json.loads(
         build_run_details_json(

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import cast
 
 from vibesensor.domain.test_run import TestRun
@@ -26,12 +25,9 @@ def project_analysis_summary(analysis: JsonObject) -> tuple[JsonObject, TestRun]
         finding_payload_from_domain(f) for f in test_run.effective_top_causes()
     ]
     primary = test_run.primary_finding
-    origin_fb = analysis.get("most_likely_origin")
-    fb_payload = dict(origin_fb) if isinstance(origin_fb, Mapping) else {}
-    if primary is None:
-        projected["most_likely_origin"] = fb_payload
-    else:
-        projected["most_likely_origin"] = origin_payload_from_finding(primary)
+    projected["most_likely_origin"] = (
+        origin_payload_from_finding(primary) if primary is not None else {}
+    )
     if not _has_structured_step_content(analysis.get("test_plan")):
         projected["test_plan"] = step_payloads_from_plan(test_run.test_plan)
     projected["run_suitability"] = run_suitability_payload(test_run.suitability)


### PR DESCRIPTION
Fixes #1089

## Summary

This PR removes the last remaining raw `most_likely_origin` payload fallback from `analysis_summary_projection.py`. After a persisted analysis summary has been reconstructed into a domain `TestRun`, the canonical projection path now derives origin data from reconstructed domain state only. When the reconstructed run has no canonical primary finding, the projector now emits the explicit empty origin representation (`{}`) instead of copying the persisted raw origin payload through unchanged.

This is the remaining follow-through work from `#988`. The broader report/PDF path was already moved to domain-first origin handling in earlier changes, but the canonical summary projection path still had one escape hatch where legacy payload data could survive reconstruction and become a second live source of truth for origin semantics. This PR closes that gap.

## Problem being solved

The issue pointed to a narrow but important inconsistency in the history/projection path.

`apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py` reconstructs persisted summary payloads through `test_run_from_summary(...)`, then reserializes canonical boundary fields from the reconstructed domain aggregate. That is exactly the normalization step we want. However, one branch still bypassed the reconstructed domain state:

- if `test_run.primary_finding` existed, projection used `origin_payload_from_finding(primary)`
- if `test_run.primary_finding` was `None`, projection copied `analysis["most_likely_origin"]` straight through as a fallback

That meant post-reconstruction origin projection was still partly domain-derived and partly payload-derived. In practice, persisted data could carry `most_likely_origin` detail that no longer had a canonical domain owner after reconstruction, and the projector would continue surfacing it anyway.

That undermines the domain-first migration in two ways.

First, it leaves a second source of truth alive after normalization has already happened. Once a `TestRun` exists, the projector should serialize the reconstructed aggregate, not preserve arbitrary pieces of the old payload because they look useful.

Second, it makes history/export/API behavior subtly depend on pre-reconstruction payload quirks. The report-side consumers had already been cleaned up to resolve origin from the domain aggregate only, but the canonical projection path still had an exception. The result was an avoidable mismatch between the normalization boundary and downstream consumers.

## Chosen implementation approach

I kept the fix deliberately narrow.

I first traced the decode/reconstruction path in `apps/server/vibesensor/shared/boundaries/diagnostic_case.py` to verify whether any required historical origin detail was still supposed to be carried forward during reconstruction. That decoder already has `_enrich_primary_origin_from_summary(...)`, which uses persisted `most_likely_origin` data to enrich a primary finding when a canonical primary exists but lacks sufficient location detail.

That matters because it means the system already has a legitimate place for summary-origin enrichment: decode time, while building the domain aggregate. In other words, if historical origin detail is genuinely needed, it should be attached to the reconstructed finding there.

What remained in `analysis_summary_projection.py` was narrower: the projector was preserving raw origin payloads only for the case where reconstruction produced no primary finding at all. There is no canonical domain origin in that case, so copying the raw payload through is not serialization of reconstructed state. It is just a payload passthrough.

Given that, the cleanest fix is:

- keep projection domain-derived when a primary finding exists
- emit the canonical empty origin payload (`{}`) when no primary finding exists
- do not add new special-case decode machinery unless a real historical regression proves it is necessary

That approach follows the issue guidance directly: keep `TestRun` reconstruction authoritative, and remove the raw payload fallback from projection.

## Main code changes by area

### Canonical projection path

In `apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py`, I removed the old fallback logic that read `analysis.get("most_likely_origin")`, copied it into `fb_payload`, and emitted it whenever `test_run.primary_finding` was missing.

The relevant branch is now simple and explicit:

- if there is a reconstructed primary finding, project origin with `origin_payload_from_finding(primary)`
- otherwise, project `{}`

This keeps the projector aligned with the rest of the domain-first boundary behavior. The function still reconstructs findings, top causes, test plan, and run suitability through the same canonical path; only the non-canonical origin fallback was removed.

### Boundary regression coverage

In `apps/server/tests/shared/boundaries/test_analysis_summary_projection.py`, I added a focused regression that builds a minimal summary with no findings, no top causes, and a non-empty persisted `most_likely_origin` payload. The test asserts that reconstruction yields `test_run.primary_finding is None` and that projection now emits `most_likely_origin == {}`.

That test specifically locks the previously problematic branch: no canonical primary finding means no projected origin payload.

### History-service regression coverage

In `apps/server/tests/use_cases/history/test_history_http_services.py`, I added a second focused regression at the history delivery layer. It exercises `ProjectedHistoryRunService` with a stored run whose analysis payload contains a non-empty `most_likely_origin` but no findings or top causes. The projected history payload must now return an empty origin object and still strip internal fields correctly.

This is important because `#1089` is not just about a helper function in isolation; it is about stopping stale origin payload data from surviving into real history/API delivery after domain reconstruction.

## Validation performed

Focused boundary/history validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_analysis_summary_projection.py apps/server/tests/use_cases/history/test_history_http_services.py`

This passed with `12 passed`.

Expanded adjacent projector/report coverage:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_analysis_summary_projection.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/adapters/pdf/test_summary_view.py`

This passed with `28 passed`.

Broader backend validation:

`export PATH="$PWD/.venv/bin:$PATH" && .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That broader subset also passed cleanly.

I also ran a correctness-focused review of the diff after the local validation. That review found no substantive issues.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is intentional: historical runs that have a persisted `most_likely_origin` payload but no canonical reconstructed primary finding will now surface `{}` through the canonical projection path instead of that raw payload. This is the desired behavior for the issue, because the raw payload is no longer treated as authoritative once reconstruction has happened.

I intentionally did not add new decode-side enrichment for the no-primary case. The current decoder already enriches primary findings when one exists and needs help from historical origin payloads. Adding a second path to preserve origin semantics without a primary finding would recreate the same architectural ambiguity this issue is trying to remove.

Also out of scope here are broader changes to report interpretation, PDF mapping, or summary schema redesign. Those parts were already moved toward domain-first behavior earlier. This PR only removes the final projector-level fallback that let raw origin payloads leak through after reconstruction.
