### PR TITLE
Remove dict append path from HistoryDB

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -12,6 +12,7 @@ import pytest
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.types.backend_types import RunMetadata, SettingsSnapshotPayload
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 
 def _metadata(run_id: str, **overrides: object) -> RunMetadata:
@@ -77,7 +78,7 @@ def test_append_samples_in_chunks(tmp_path: Path) -> None:
             yield _CursorProxy(cur)
 
     db.write_transaction_cursor = _wrapped_write_transaction
-    samples = [{"i": i, "x": 0.1} for i in range(700)]
+    samples = [SensorFrame.from_dict({"i": i, "x": 0.1}) for i in range(700)]
     db.append_samples("run-1", samples)
     assert sum(calls) == 700
     assert max(calls) <= 256
@@ -89,7 +90,7 @@ def test_history_db_thread_safe_appends(tmp_path: Path) -> None:
     db.create_run("run-2", "2026-01-01T00:00:00Z", _metadata("run-2"))
 
     def _append(start: int) -> None:
-        batch = [{"i": start + i} for i in range(50)]
+        batch = [SensorFrame.from_dict({"i": start + i}) for i in range(50)]
         db.append_samples("run-2", batch)
 
     with ThreadPoolExecutor(max_workers=4) as pool:
@@ -150,7 +151,7 @@ def test_schema_version_future_fails_fast(tmp_path: Path) -> None:
 def test_iter_run_samples_batches(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-3", "2026-01-01T00:00:00Z", _metadata("run-3"))
-    db.append_samples("run-3", [{"i": i} for i in range(11)])
+    db.append_samples("run-3", [SensorFrame.from_dict({"i": i}) for i in range(11)])
     batches = list(db.iter_run_samples("run-3", batch_size=4))
     assert [len(batch) for batch in batches] == [4, 4, 3]
 
@@ -158,7 +159,14 @@ def test_iter_run_samples_batches(tmp_path: Path) -> None:
 def test_list_runs_uses_incremental_sample_count(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-4", "2026-01-01T00:00:00Z", _metadata("run-4"))
-    db.append_samples("run-4", [{"i": 1}, {"i": 2}, {"i": 3}])
+    db.append_samples(
+        "run-4",
+        [
+            SensorFrame.from_dict({"i": 1}),
+            SensorFrame.from_dict({"i": 2}),
+            SensorFrame.from_dict({"i": 3}),
+        ],
+    )
     run = db.list_runs()[0]
     assert run.sample_count == 3
 
@@ -217,7 +225,7 @@ def test_recover_stale_recording_logs_warning(
 def test_delete_run_cascades_samples(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-del", "2026-01-01T00:00:00Z", _metadata("run-del"))
-    db.append_samples("run-del", [{"i": i} for i in range(5)])
+    db.append_samples("run-del", [SensorFrame.from_dict({"i": i}) for i in range(5)])
     assert len(db.get_run_samples("run-del")) == 5
 
     db.delete_run("run-del")
@@ -285,7 +293,10 @@ def test_append_samples_rolls_back_when_metadata_update_fails(tmp_path: Path) ->
     db.write_transaction_cursor = _wrapped_write_transaction
 
     with pytest.raises(sqlite3.OperationalError, match="simulated sample_count failure"):
-        db.append_samples("run-rollback", [{"i": 1}, {"i": 2}])
+        db.append_samples(
+            "run-rollback",
+            [SensorFrame.from_dict({"i": 1}), SensorFrame.from_dict({"i": 2})],
+        )
 
     run = db.get_run("run-rollback")
     assert run is not None
@@ -359,7 +370,7 @@ def test_update_run_metadata_overwrites_stored_metadata(tmp_path: Path) -> None:
 def test_append_empty_samples_is_noop(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-empty", "2026-01-01T00:00:00Z", _metadata("run-empty"))
-    db.append_samples("run-empty", [{"i": 1}])
+    db.append_samples("run-empty", [SensorFrame.from_dict({"i": 1})])
     db.append_samples("run-empty", [])
     run = db.list_runs()[0]
     assert run.sample_count == 1
@@ -386,7 +397,7 @@ def test_client_names_crud(tmp_path: Path) -> None:
 def test_read_only_operations_do_not_commit(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-ro", "2026-01-01T00:00:00Z", _metadata("run-ro"))
-    db.append_samples("run-ro", [{"i": 1}, {"i": 2}])
+    db.append_samples("run-ro", [SensorFrame.from_dict({"i": 1}), SensorFrame.from_dict({"i": 2})])
     db.set_settings_snapshot(_settings_snapshot())
     db.upsert_client_name("client-1", "Alice")
 

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -9,6 +9,7 @@ import pytest
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 
 def _metadata(run_id: str, **overrides: object) -> RunMetadata:
@@ -75,7 +76,7 @@ def test_v2_structured_roundtrip(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-v2", "2026-01-01T00:00:00Z", _metadata("run-v2"))
     originals = [_sensor_frame_dict(i) for i in range(5)]
-    db.append_samples("run-v2", originals)
+    db.append_samples("run-v2", [SensorFrame.from_dict(sample) for sample in originals])
 
     retrieved = db.get_run_samples("run-v2")
     assert len(retrieved) == 5
@@ -93,7 +94,7 @@ def test_v2_nan_inf_sanitized(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-nan", "2026-01-01T00:00:00Z", _metadata("run-nan"))
     sample = {"speed_kmh": float("nan"), "accel_x_g": float("inf"), "t_s": 1.0}
-    db.append_samples("run-nan", [sample])
+    db.append_samples("run-nan", [SensorFrame.from_dict(sample)])
 
     rows = db.get_run_samples("run-nan")
     assert len(rows) == 1
@@ -105,7 +106,7 @@ def test_v2_nan_inf_sanitized(tmp_path: Path) -> None:
 def test_v2_no_json_blobs_in_storage(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-check", "2026-01-01T00:00:00Z", _metadata("run-check"))
-    db.append_samples("run-check", [_sensor_frame_dict(0)])
+    db.append_samples("run-check", [SensorFrame.from_dict(_sensor_frame_dict(0))])
 
     with db._cursor(commit=False) as cur:
         cur.execute("PRAGMA table_info(samples_v2)")
@@ -163,8 +164,6 @@ def test_v4_db_rejected(tmp_path: Path) -> None:
 
 
 def test_v2_sensor_frame_objects(tmp_path: Path) -> None:
-    from vibesensor.shared.types.sensor_frame import SensorFrame
-
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-sf", "2026-01-01T00:00:00Z", _metadata("run-sf"))
 
@@ -181,7 +180,10 @@ def test_v2_sensor_frame_objects(tmp_path: Path) -> None:
 def test_v2_delete_cascades_legacy_and_v2(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-del2", "2026-01-01T00:00:00Z", _metadata("run-del2"))
-    db.append_samples("run-del2", [_sensor_frame_dict(i, run_id="run-del2") for i in range(3)])
+    db.append_samples(
+        "run-del2",
+        [SensorFrame.from_dict(_sensor_frame_dict(i, run_id="run-del2")) for i in range(3)],
+    )
 
     assert len(db.get_run_samples("run-del2")) == 3
     db.delete_run("run-del2")
@@ -199,7 +201,7 @@ def test_v2_record_then_export_roundtrip(tmp_path: Path) -> None:
         batch = [
             _sensor_frame_dict(i, run_id="run-full") for i in range(batch_start, batch_start + 5)
         ]
-        db.append_samples("run-full", batch)
+        db.append_samples("run-full", [SensorFrame.from_dict(sample) for sample in batch])
 
     db.finalize_run("run-full", "2026-01-01T00:00:20Z")
     assert db.get_run("run-full").status.value == "analyzing"
@@ -226,7 +228,7 @@ def test_v2_record_then_export_roundtrip(tmp_path: Path) -> None:
 def test_v2_iter_with_offset(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-off", "2026-01-01T00:00:00Z", _metadata("run-off"))
-    db.append_samples("run-off", [{"t_s": float(i)} for i in range(10)])
+    db.append_samples("run-off", [SensorFrame.from_dict({"t_s": float(i)}) for i in range(10)])
 
     rows0 = [s for b in db.iter_run_samples("run-off", offset=0) for s in b]
     assert [r.t_s for r in rows0] == [float(i) for i in range(10)]
@@ -244,13 +246,16 @@ def test_v2_iter_with_offset(tmp_path: Path) -> None:
 def test_iter_run_samples_skips_corrupt_rows_and_continues(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-corrupt", "2026-01-01T00:00:00Z", _metadata("run-corrupt"))
-    db.append_samples("run-corrupt", [{"t_s": 1.0}, {"t_s": 2.0}])
+    db.append_samples(
+        "run-corrupt",
+        [SensorFrame.from_dict({"t_s": 1.0}), SensorFrame.from_dict({"t_s": 2.0})],
+    )
     with db._cursor() as cur:
         cur.execute(
             "INSERT INTO samples_v2 (run_id, top_peaks) VALUES (?, ?)",
             ("run-corrupt", "{bad"),
         )
-    db.append_samples("run-corrupt", [{"t_s": 3.0}])
+    db.append_samples("run-corrupt", [SensorFrame.from_dict({"t_s": 3.0})])
 
     rows = [
         sample for batch in db.iter_run_samples("run-corrupt", batch_size=2) for sample in batch

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
@@ -10,6 +10,7 @@ from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import sanitize_value
 from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 
 def _metadata(run_id: str, **overrides: object) -> RunMetadata:
@@ -62,7 +63,7 @@ def test_list_runs_clamps_negative_limit_to_all_rows(tmp_path: Path) -> None:
 def test_resolve_keyset_offset_rejects_invalid_table(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-guard", "2026-01-01T00:00:00Z", _metadata("run-guard"))
-    db.append_samples("run-guard", [{"i": i} for i in range(3)])
+    db.append_samples("run-guard", [SensorFrame.from_dict({"i": i}) for i in range(3)])
 
     with pytest.raises(ValueError, match="invalid table name"):
         db._resolve_keyset_offset("injected_table", "run-guard", 1)
@@ -71,19 +72,19 @@ def test_resolve_keyset_offset_rejects_invalid_table(tmp_path: Path) -> None:
 def test_append_samples_empty_run_id_raises(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     with pytest.raises(ValueError, match="run_id"):
-        db.append_samples("", [{"i": 1}])
+        db.append_samples("", [SensorFrame.from_dict({"i": 1})])
 
 
 def test_append_samples_whitespace_run_id_raises(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     with pytest.raises(ValueError, match="run_id"):
-        db.append_samples("   ", [{"i": 1}])
+        db.append_samples("   ", [SensorFrame.from_dict({"i": 1})])
 
 
 def test_iter_run_samples_negative_offset_raises(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-neg-off", "2026-01-01T00:00:00Z", _metadata("run-neg-off"))
-    db.append_samples("run-neg-off", [{"i": i} for i in range(3)])
+    db.append_samples("run-neg-off", [SensorFrame.from_dict({"i": i}) for i in range(3)])
 
     with pytest.raises(ValueError, match="offset"):
         list(db.iter_run_samples("run-neg-off", offset=-1))
@@ -141,7 +142,7 @@ def test_verify_run_integrity_clean_run(tmp_path: Path) -> None:
         "2026-01-01T00:00:00Z",
         _metadata("run-ok", sensor_model="a", sample_rate_hz=100),
     )
-    db.append_samples("run-ok", [{"i": i} for i in range(5)])
+    db.append_samples("run-ok", [SensorFrame.from_dict({"i": i}) for i in range(5)])
     db.finalize_run("run-ok", "2026-01-01T00:10:00Z")
     db.store_analysis("run-ok", _analysis("run-ok"))
     assert db.verify_run_integrity("run-ok") == []
@@ -154,7 +155,7 @@ def test_verify_run_integrity_sample_count_mismatch(tmp_path: Path) -> None:
         "2026-01-01T00:00:00Z",
         _metadata("run-m", sensor_model="a", sample_rate_hz=100),
     )
-    db.append_samples("run-m", [{"i": i} for i in range(5)])
+    db.append_samples("run-m", [SensorFrame.from_dict({"i": i}) for i in range(5)])
     db.finalize_run("run-m", "2026-01-01T00:10:00Z")
     db.store_analysis("run-m", _analysis("run-m"))
     # Manually corrupt sample_count

--- a/apps/server/tests/integration/test_contract_persistence_analysis.py
+++ b/apps/server/tests/integration/test_contract_persistence_analysis.py
@@ -20,6 +20,7 @@ from test_support import (
 from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
 
 
 def _create_populated_db(
@@ -40,7 +41,7 @@ def _create_populated_db(
             }
         ),
     )
-    db.append_samples(run_id, samples)
+    db.append_samples(run_id, [SensorFrame.from_dict(sample) for sample in samples])
     return db, run_id
 
 

--- a/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
@@ -56,7 +56,7 @@ def _seeded_history_db(
     """Create a HistoryDB with one run containing *n_samples* rows."""
     db = _make_history_db(tmp_path, name)
     db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="test"))
-    db.append_samples(run_id, [{"t_s": float(i)} for i in range(n_samples)])
+    db.append_samples(run_id, [SensorFrame.from_dict({"t_s": float(i)}) for i in range(n_samples)])
     return db
 
 

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
@@ -270,7 +270,7 @@ def test_stop_run_triggers_analysis_and_persists(tmp_path: Path, monkeypatch) ->
     db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, language="en"))
     logger._persistence.history_run_created = True
     samples = [_sample(i) for i in range(20)]
-    db.append_samples(run_id, samples)
+    db.append_samples(run_id, [SensorFrame.from_dict(sample) for sample in samples])
     logger._persistence.written_sample_count = len(samples)
 
     # Monkeypatch the adapter summarize_run_data wrapper to a lightweight version for speed

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
@@ -381,7 +381,7 @@ def test_end_to_end_pipeline(db: HistoryDB) -> None:
     assert run.status.value == "recording"
 
     samples = _simple_samples(30)
-    db.append_samples(run_id, samples)
+    db.append_samples(run_id, [normalize_sample_record(sample) for sample in samples])
 
     db.finalize_run(run_id, _END)
     run = db.get_run(run_id)

--- a/apps/server/tests/use_cases/run/conftest.py
+++ b/apps/server/tests/use_cases/run/conftest.py
@@ -19,6 +19,7 @@ from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.shared.types.backend_types import RunMetadata
 from vibesensor.shared.types.history_records import AnalyzingRunHealth
 from vibesensor.shared.types.payload_types import ClientMetrics
+from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
 # ---------------------------------------------------------------------------
@@ -194,7 +195,7 @@ class _FakeHistoryDB:
     def create_run(self, run_id: str, start_time_utc: str, metadata: RunMetadata) -> None:
         self.create_calls.append((run_id, start_time_utc))
 
-    def append_samples(self, run_id: str, samples: list[dict]) -> None:
+    def append_samples(self, run_id: str, samples: list[SensorFrame]) -> None:
         self.append_calls.append((run_id, len(samples)))
 
     def finalize_run(
@@ -230,7 +231,7 @@ class _FailingAppendOnceHistoryDB(_FakeHistoryDB):
 
         self._append_failures_remaining = _MAX_APPEND_RETRIES
 
-    def append_samples(self, run_id: str, samples: list[dict]) -> None:
+    def append_samples(self, run_id: str, samples: list[SensorFrame]) -> None:
         if self._append_failures_remaining > 0:
             self._append_failures_remaining -= 1
             raise sqlite3.OperationalError("append boom")

--- a/apps/server/tests/use_cases/run/test_pipeline_resilience.py
+++ b/apps/server/tests/use_cases/run/test_pipeline_resilience.py
@@ -21,6 +21,7 @@ import pytest
 
 from vibesensor.domain import Run
 from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.run.logger import (
     _MAX_HISTORY_CREATE_RETRIES,
     _RETRY_COOLDOWN_BASE_S,
@@ -55,20 +56,24 @@ def _make_persist_logger(make_logger, *, history_db: object, run_id: str = "run-
     return logger
 
 
+def _sample_rows(count: int) -> list[SensorFrame]:
+    return [SensorFrame.from_dict({"t_s": float(i)}) for i in range(count)]
+
+
 class _FailingDB:
     """History DB that always fails on create_run."""
 
-    def create_run(self, run_id: str, start_time_utc: str, metadata: dict) -> None:
+    def create_run(self, run_id: str, start_time_utc: str, metadata: RunMetadata) -> None:
         raise sqlite3.OperationalError("db locked")
 
 
 class _FailingAppendDB:
     """History DB that succeeds on create_run but fails on append."""
 
-    def create_run(self, run_id: str, start_time_utc: str, metadata: dict) -> None:
+    def create_run(self, run_id: str, start_time_utc: str, metadata: RunMetadata) -> None:
         pass
 
-    def append_samples(self, run_id: str, samples: list[dict]) -> None:
+    def append_samples(self, run_id: str, samples: list[SensorFrame]) -> None:
         raise sqlite3.OperationalError("disk full")
 
 
@@ -79,10 +84,10 @@ class _FailNAppendThenSucceedDB:
         self._remaining = fail_count
         self.appended: list[tuple[str, int]] = []
 
-    def create_run(self, run_id: str, start_time_utc: str, metadata: dict) -> None:
+    def create_run(self, run_id: str, start_time_utc: str, metadata: RunMetadata) -> None:
         pass
 
-    def append_samples(self, run_id: str, samples: list[dict]) -> None:
+    def append_samples(self, run_id: str, samples: list[SensorFrame]) -> None:
         if self._remaining > 0:
             self._remaining -= 1
             raise sqlite3.OperationalError("db locked")
@@ -96,10 +101,10 @@ class _SucceedingDB:
         self.created: list[str] = []
         self.appended: list[tuple[str, int]] = []
 
-    def create_run(self, run_id: str, start_time_utc: str, metadata: dict) -> None:
+    def create_run(self, run_id: str, start_time_utc: str, metadata: RunMetadata) -> None:
         self.created.append(run_id)
 
-    def append_samples(self, run_id: str, samples: list[dict]) -> None:
+    def append_samples(self, run_id: str, samples: list[SensorFrame]) -> None:
         self.appended.append((run_id, len(samples)))
 
 
@@ -110,13 +115,13 @@ class _FailNThenSucceedDB:
         self._remaining = fail_count
         self.created: list[str] = []
 
-    def create_run(self, run_id: str, start_time_utc: str, metadata: dict) -> None:
+    def create_run(self, run_id: str, start_time_utc: str, metadata: RunMetadata) -> None:
         if self._remaining > 0:
             self._remaining -= 1
             raise sqlite3.OperationalError("transient error")
         self.created.append(run_id)
 
-    def append_samples(self, run_id: str, samples: list[dict]) -> None:
+    def append_samples(self, run_id: str, samples: list[SensorFrame]) -> None:
         pass
 
 
@@ -144,7 +149,7 @@ class TestDropCounting:
         result = logger._persistence.append_rows(
             run_id="run-1",
             start_time_utc="2025-01-01T00:00:00Z",
-            rows=[{"sample": 1}, {"sample": 2}, {"sample": 3}],
+            rows=_sample_rows(3),
         )
         assert result.rows_written == 0
         assert logger._persistence.dropped_sample_count == 3
@@ -159,7 +164,7 @@ class TestDropCounting:
         result = logger._persistence.append_rows(
             run_id="run-1",
             start_time_utc="2025-01-01T00:00:00Z",
-            rows=[{"s": 1}, {"s": 2}],
+            rows=_sample_rows(2),
         )
         assert result.rows_written == 0
         assert logger._persistence.dropped_sample_count == 2
@@ -175,7 +180,7 @@ class TestDropCounting:
         result = logger._persistence.append_rows(
             run_id="run-1",
             start_time_utc="2025-01-01T00:00:00Z",
-            rows=[{"s": 1}, {"s": 2}],
+            rows=_sample_rows(2),
         )
         assert result.rows_written == 2
         assert logger._persistence.dropped_sample_count == 0
@@ -190,7 +195,7 @@ class TestDropCounting:
             logger._persistence.append_rows(
                 run_id="run-1",
                 start_time_utc="2025-01-01T00:00:00Z",
-                rows=[{"s": 1}],
+                rows=_sample_rows(1),
             )
         assert logger._persistence.dropped_sample_count == 3
 
@@ -201,7 +206,7 @@ class TestDropCounting:
         logger._persistence.append_rows(
             run_id="run-1",
             start_time_utc="2025-01-01T00:00:00Z",
-            rows=[{"s": 1}, {"s": 2}],
+            rows=_sample_rows(2),
         )
         assert logger._persistence.dropped_sample_count == 2
 
@@ -215,7 +220,7 @@ class TestDropCounting:
         result = logger._persistence.append_rows(
             run_id="run-1",
             start_time_utc="2025-01-01T00:00:00Z",
-            rows=[{"s": 1}, {"s": 2}],
+            rows=_sample_rows(2),
         )
         assert result.rows_written == 2
         assert logger._persistence.dropped_sample_count == 0

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -12,7 +12,6 @@ from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import safe_json_dumps
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.backend_types import RunMetadata
-from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
 LOGGER = logging.getLogger(__name__)
@@ -62,28 +61,24 @@ class _HistoryDBRunLifecycleMixin:
     def append_samples(
         self,
         run_id: str,
-        samples: list[JsonObject] | list[SensorFrame],
+        samples: list[SensorFrame],
     ) -> None:
         if not samples:
             return
         if not run_id or not run_id.strip():
             raise ValueError("append_samples: run_id must be a non-empty string")
-        normalized_samples = [
-            sample if isinstance(sample, SensorFrame) else SensorFrame.from_dict(sample)
-            for sample in samples
-        ]
 
         chunk_size = 256
         with self.write_transaction_cursor() as cur:
-            for start in range(0, len(normalized_samples), chunk_size):
-                batch = normalized_samples[start : start + chunk_size]
+            for start in range(0, len(samples), chunk_size):
+                batch = samples[start : start + chunk_size]
                 cur.executemany(
                     V2_INSERT_SQL,
                     (sample_to_v2_row(run_id, sample) for sample in batch),
                 )
             cur.execute(
                 "UPDATE runs SET sample_count = sample_count + ? WHERE run_id = ?",
-                (len(normalized_samples), run_id),
+                (len(samples), run_id),
             )
 
     def finalize_run(


### PR DESCRIPTION
Closes #1100.

## Summary
This pull request finishes the last production compatibility seam left behind after #1050 by making `HistoryDB.append_samples()` accept only `list[SensorFrame]` and removing the dict-to-`SensorFrame` normalization branch from the standard append path. The rest of the main recording pipeline was already typed: `RunPersistence.append_samples()` in `shared/ports.py` already required `list[SensorFrame]`, `RunPersistenceWriter.append_rows()` in `use_cases/run/persistence_writer.py` already passed typed rows, and the JSONL/history decode boundary already reconstructed `SensorFrame` objects in the right places. The concrete history adapter was the last place where raw dict rows were still treated as a valid internal append input.

## Problem being solved
Issue #1100 called out a real contract mismatch, not just a cosmetic annotation problem. At the abstract boundary level, the repository already claimed that appending samples to persistence meant passing `SensorFrame` objects. In the concrete adapter, though, `_HistoryDBRunLifecycleMixin.append_samples()` still accepted `list[JsonObject] | list[SensorFrame]` and normalized every element with `sample if isinstance(sample, SensorFrame) else SensorFrame.from_dict(sample)`. That leftover fallback kept two competing internal representations alive at once: the typed `SensorFrame` path that #1050 established as canonical, and the old broad dict path that the adapter continued to tolerate.

That mismatch mattered for three reasons. First, it weakened the contract between the port and the implementation: callers could still pass dict rows without noticing that they were bypassing the typed internal model. Second, it made downstream cleanup incomplete, because tests and fake DBs could continue modeling append input as arbitrary dicts. Third, it obscured the true architectural boundary. Dict-to-object conversion is appropriate when decoding persisted JSON or run-log files, but it should not live in the normal in-memory persistence append path after the data is already inside the system.

## Implementation approach
The implementation stays intentionally narrow. I did not reopen sample-pipeline design or alter any true deserialization boundaries. Instead, I removed the final compatibility seam in the concrete history adapter and then migrated the remaining direct callers/tests that still depended on dict-style append inputs.

The key design choice was to keep `SensorFrame.from_dict()` where it belongs and nowhere else. The run-log/history decoding boundary remains free to convert raw payload dicts into `SensorFrame` objects, and existing decode helpers continue to do that. What changed is that once code reaches `HistoryDB.append_samples()`, it now has to provide the canonical typed object rather than relying on the adapter to silently normalize dicts on its behalf.

## Main code changes by area
In `apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py`, `append_samples()` now accepts only `list[SensorFrame]`. I removed the `JsonObject` union from the signature, deleted the per-row normalization list comprehension, and let the method chunk and persist the already-typed `SensorFrame` objects directly. This is the core fix for the issue and brings the concrete adapter back into alignment with the abstract `RunPersistence` port and the existing `RunPersistenceWriter` caller path.

Most of the rest of the diff is deliberately test-facing fallout cleanup. The direct `HistoryDB` lifecycle, validation, and structured-storage tests previously exercised append behavior by handing dict literals or dict fixtures straight into `db.append_samples(...)`. Those tests now build `SensorFrame` objects before calling `append_samples()`. I kept the actual scenario coverage the same: chunking, sample counts, structured round-trips, offset iteration, corrupt-row skipping, rollback behavior, and integrity checks are all still covered. The change is that those tests now model the same typed append contract that production code is supposed to obey.

I made the same adjustment in a few integration-style tests that populate `HistoryDB` directly. The persistence-to-analysis bridge test, the runtime quality regression helper that seeds history rows, and the analysis persistence / analysis pipeline regression cases now construct `SensorFrame` objects before append. That keeps their setup realistic without moving dict normalization back into the wrong layer.

I also tightened the fake DBs used by the run-recorder persistence tests in `apps/server/tests/use_cases/run/`. Those fakes already matched the runtime behavior conceptually, but they still typed `append_samples()` as accepting `list[dict]` and some append-row tests were still building dict rows. I updated those fake append signatures to `list[SensorFrame]` and replaced the append-row fixtures with minimal `SensorFrame` objects. That is not a production behavior change, but it matters because those tests now reinforce the contract instead of preserving the pre-cleanup mental model.

## Config, schema, and boundary impact
There are no schema changes in this PR. The `samples_v2` storage format is unchanged, database migrations are unchanged, and no API contracts changed. This is strictly an internal typing and boundary cleanup. The only production behavior shift is that the in-memory append path no longer accepts dict rows as an alternative internal representation.

Importantly, persisted/history deserialization still works. I did not touch `run_log.py` decoding or the DB row-to-`SensorFrame` reconstruction path in `_samples.py`, because those are real boundaries where raw payloads legitimately become typed domain/application objects.

## Validation performed
I ran a focused validation slice that directly exercises the touched seam and its fallout:

- `apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py`
- `apps/server/tests/use_cases/run/test_pipeline_resilience.py`
- `apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py`
- `apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py`
- `apps/server/tests/integration/test_contract_persistence_analysis.py`
- `apps/server/tests/integration/test_runtime_quality_pass_regressions.py`

That focused slice passed cleanly: `118 passed`.

I then ran the broader backend subset used throughout this backlog run:

- `backend-quality`
- `backend-typecheck`
- `backend-tests`

The first broader run exposed one `ruff` line-length violation introduced while converting a test fixture list to `SensorFrame` objects. I wrapped that list literal and reran the same subset; the rerun finished fully green.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff here is that this is a deliberate tightening of an internal contract. Any internal caller that was still depending on dict append inputs will now fail until it is migrated. That is intentional and is the point of the issue: we want the typed contract enforced instead of silently weakened by compatibility normalization. The blast-radius search in this change set was aimed specifically at those direct call sites, and I migrated the ones still present in repo code and tests.

I did not broaden this PR into a larger sample-model cleanup. There are still places elsewhere in the repository where raw sample dicts exist as real boundary payloads, especially around decoding or summary generation. Those are not regressions relative to this issue, and they were left alone intentionally.
