### PR TITLE
Harden runtime resilience flows

### DIFF
--- a/apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from vibesensor.cli.hotspot_config import main
+
+
+def _run_cli(
+    config_path: Path,
+    *,
+    monkeypatch,
+    capsys,
+) -> tuple[str, str]:
+    monkeypatch.setattr(sys, "argv", ["vibesensor-hotspot-config", str(config_path)])
+    main()
+    captured = capsys.readouterr()
+    return captured.out, captured.err
+
+
+def test_hotspot_config_cli_warns_and_falls_back_on_parse_error(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    missing_path = tmp_path / "missing.yaml"
+    defaults_out, defaults_err = _run_cli(missing_path, monkeypatch=monkeypatch, capsys=capsys)
+    assert defaults_err == ""
+
+    broken_path = tmp_path / "broken.yaml"
+    broken_path.write_text("ap: [unterminated\n", encoding="utf-8")
+
+    broken_out, broken_err = _run_cli(broken_path, monkeypatch=monkeypatch, capsys=capsys)
+
+    assert broken_out == defaults_out
+    assert "WARNING:" in broken_err
+    assert str(broken_path) in broken_err
+    assert "using defaults" in broken_err

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -223,6 +223,51 @@ def test_recover_stale_recording_logs_warning(
     assert run is not None and run.status.value == "error"
 
 
+def test_history_db_runs_startup_quick_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[Path] = []
+    original = HistoryDB._run_startup_quick_check
+
+    def _tracking(self: HistoryDB) -> None:
+        calls.append(self.db_path)
+        original(self)
+
+    monkeypatch.setattr(HistoryDB, "_run_startup_quick_check", _tracking)
+    db = HistoryDB(tmp_path / "history.db")
+    try:
+        assert calls == [tmp_path / "history.db"]
+    finally:
+        db.close()
+
+
+def test_startup_quick_check_logs_corruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+
+    class _FakeCursor:
+        def execute(self, sql: str) -> None:
+            assert sql == "PRAGMA quick_check"
+
+        def fetchall(self) -> list[tuple[str]]:
+            return [("row 7 missing from index",)]
+
+    @contextmanager
+    def _fake_cursor(*, commit: bool = True):
+        yield _FakeCursor()
+
+    monkeypatch.setattr(db, "_cursor", _fake_cursor)
+    with caplog.at_level(logging.CRITICAL):
+        db._run_startup_quick_check()
+    assert "quick_check reported corruption" in caplog.text
+    assert "row 7 missing from index" in caplog.text
+    db.close()
+
+
 def test_delete_run_cascades_samples(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     db.create_run("run-del", "2026-01-01T00:00:00Z", _metadata("run-del"))

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -10,6 +10,7 @@ from vibesensor.use_cases.run.post_analysis_executor import (
     PostAnalysisExecutionMissingMetadata,
     PostAnalysisExecutionNoSamples,
     PostAnalysisExecutionPersistenceFailure,
+    PostAnalysisExecutionRetryableFailure,
     PostAnalysisExecutionSuccess,
     execute_post_analysis,
 )
@@ -185,3 +186,57 @@ def test_execute_post_analysis_reports_persistence_failure() -> None:
         "post-analysis failed for run run-store-fail: db write failed",
     )
     assert stored_errors == [("run-store-fail", "db write failed")]
+
+
+def test_execute_post_analysis_defers_retryable_persistence_failure() -> None:
+    stored_errors: list[tuple[str, str]] = []
+
+    class FakeDB:
+        def store_analysis(self, run_id, analysis):
+            raise sqlite3.OperationalError("db locked")
+
+        def store_analysis_error(self, run_id, error):
+            stored_errors.append((run_id, error))
+
+    result = execute_post_analysis(
+        run_id="run-retry",
+        db=FakeDB(),
+        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+            run_id=run_id,
+            metadata=_run_metadata(run_id),
+            language="en",
+            samples=[{"t_s": 1.0, "vibration_strength_db": 10.0}],
+            total_sample_count=1,
+            stride=1,
+        ),
+        analysis_runner=lambda **_kwargs: make_persisted_analysis({"run_suitability": []}),
+        defer_retryable_error_storage=True,
+    )
+
+    assert isinstance(result, PostAnalysisExecutionRetryableFailure)
+    assert result.error_message == "db locked"
+    assert result.callback_errors == ("post-analysis failed for run run-retry: db locked",)
+    assert stored_errors == []
+
+
+def test_execute_post_analysis_defers_retryable_load_failure() -> None:
+    stored_errors: list[tuple[str, str]] = []
+
+    class FakeDB:
+        def store_analysis(self, run_id, analysis):
+            raise AssertionError(f"unexpected store_analysis({run_id}, {analysis})")
+
+        def store_analysis_error(self, run_id, error):
+            stored_errors.append((run_id, error))
+
+    result = execute_post_analysis(
+        run_id="run-load-retry",
+        db=FakeDB(),
+        load_run=lambda *, run_id, db: (_ for _ in ()).throw(sqlite3.OperationalError("db busy")),
+        analysis_runner=lambda **_kwargs: make_persisted_analysis({}),
+        defer_retryable_error_storage=True,
+    )
+
+    assert isinstance(result, PostAnalysisExecutionRetryableFailure)
+    assert result.error_message == "db busy"
+    assert stored_errors == []

--- a/apps/server/tests/use_cases/run/test_post_analysis_worker.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_worker.py
@@ -12,7 +12,13 @@ import time
 import pytest
 
 from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.use_cases.run import post_analysis as post_analysis_module
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
+from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisExecutionPersistenceFailure,
+    PostAnalysisExecutionRetryableFailure,
+    PostAnalysisExecutionSuccess,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -274,6 +280,95 @@ class TestPostAnalysisWorkerErrorHandling:
         worker.schedule("run-ok")
         assert worker.wait(timeout_s=3.0)
         assert seen == ["run-ok"]
+
+    def test_worker_retries_retryable_failure_until_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        attempts: list[bool] = []
+        errors: list[str] = []
+        cleared: list[str] = []
+
+        def _execute(
+            *,
+            run_id: str,
+            db,
+            analysis_runner,
+            load_run=None,
+            defer_retryable_error_storage: bool = False,
+        ):
+            attempts.append(defer_retryable_error_storage)
+            if len(attempts) == 1:
+                return PostAnalysisExecutionRetryableFailure(
+                    run_id=run_id,
+                    error_message="db locked",
+                    callback_errors=(f"post-analysis failed for run {run_id}: db locked",),
+                )
+            return PostAnalysisExecutionSuccess(run_id=run_id)
+
+        monkeypatch.setattr(post_analysis_module, "execute_post_analysis", _execute)
+        monkeypatch.setattr(post_analysis_module.time, "sleep", lambda _seconds: None)
+
+        worker = PostAnalysisWorker(
+            history_db=object(),
+            error_callback=errors.append,
+            clear_error_callback=lambda: cleared.append("cleared"),
+        )
+        worker.schedule("run-retry")
+
+        assert worker.wait(timeout_s=3.0)
+        assert attempts == [True, True]
+        assert errors == ["post-analysis failed for run run-retry: db locked"]
+        assert cleared == ["cleared"]
+        snapshot = worker.snapshot()
+        assert snapshot.last_completed_run_id == "run-retry"
+        assert snapshot.last_completed_error is None
+
+    def test_worker_retries_until_budget_exhausted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        attempts: list[bool] = []
+        errors: list[str] = []
+
+        def _execute(
+            *,
+            run_id: str,
+            db,
+            analysis_runner,
+            load_run=None,
+            defer_retryable_error_storage: bool = False,
+        ):
+            attempts.append(defer_retryable_error_storage)
+            if defer_retryable_error_storage:
+                return PostAnalysisExecutionRetryableFailure(
+                    run_id=run_id,
+                    error_message="db locked",
+                    callback_errors=(f"post-analysis failed for run {run_id}: db locked",),
+                )
+            return PostAnalysisExecutionPersistenceFailure(
+                run_id=run_id,
+                completed_error="db locked",
+                callback_errors=(f"post-analysis failed for run {run_id}: db locked",),
+            )
+
+        monkeypatch.setattr(post_analysis_module, "execute_post_analysis", _execute)
+        monkeypatch.setattr(post_analysis_module.time, "sleep", lambda _seconds: None)
+
+        worker = PostAnalysisWorker(
+            history_db=object(),
+            error_callback=errors.append,
+        )
+        worker.schedule("run-exhausted")
+
+        assert worker.wait(timeout_s=3.0)
+        assert attempts == [True] * len(post_analysis_module._RETRY_DELAYS_S) + [False]
+        assert errors == [
+            "post-analysis failed for run run-exhausted: db locked",
+        ] * (len(post_analysis_module._RETRY_DELAYS_S) + 1)
+        snapshot = worker.snapshot()
+        assert snapshot.last_completed_run_id == "run-exhausted"
+        assert snapshot.last_completed_error == "db locked"
 
 
 class TestPostAnalysisWorkerThreadClearing:

--- a/apps/server/tests/use_cases/run/test_recorder_runtime.py
+++ b/apps/server/tests/use_cases/run/test_recorder_runtime.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from vibesensor.use_cases.run import _recorder_runtime
+
+
+class _StopLoop(BaseException):
+    pass
+
+
+async def _raise_stop_loop(_seconds: float) -> None:
+    raise _StopLoop
+
+
+@pytest.mark.asyncio
+async def test_idle_runtime_tick_does_not_create_phantom_run(
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = make_logger(history_db=fake_history_db)
+    active = logger.registry.get("active")
+    assert active is not None
+    active.frames_total = 5
+
+    monkeypatch.setattr(_recorder_runtime.asyncio, "sleep", _raise_stop_loop)
+
+    with pytest.raises(_StopLoop):
+        await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
+
+    status = logger.status()
+    assert status.enabled is False
+    assert status.run_id is None
+    assert fake_history_db.create_calls == []
+    assert fake_history_db.append_calls == []
+
+
+@pytest.mark.asyncio
+async def test_idle_runtime_tick_clears_stale_tick_timeout_error(
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = make_logger()
+    logger._persistence.set_last_write_error(_recorder_runtime._DB_TIMEOUT_ERROR)
+
+    monkeypatch.setattr(_recorder_runtime.asyncio, "sleep", _raise_stop_loop)
+
+    with pytest.raises(_StopLoop):
+        await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
+
+    assert logger.status().write_error is None
+
+
+@pytest.mark.asyncio
+async def test_idle_runtime_tick_preserves_non_tick_write_error(
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = make_logger()
+    logger._persistence.set_last_write_error("history append_samples failed: disk full")
+
+    monkeypatch.setattr(_recorder_runtime.asyncio, "sleep", _raise_stop_loop)
+
+    with pytest.raises(_StopLoop):
+        await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
+
+    assert logger.status().write_error == "history append_samples failed: disk full"

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -48,6 +48,7 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
             self._conn.execute("PRAGMA foreign_keys=ON")
             self._conn.execute("PRAGMA busy_timeout=5000")
             self._ensure_schema()
+            self._run_startup_quick_check()
         except sqlite3.Error:
             self._conn.close()
             raise
@@ -191,6 +192,25 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
             )
             cur.execute("DROP TABLE IF EXISTS settings_kv")
             cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def _run_startup_quick_check(self) -> None:
+        try:
+            with self._cursor(commit=False) as cur:
+                cur.execute("PRAGMA quick_check")
+                problems = [str(row[0]) for row in cur.fetchall() if str(row[0]) != "ok"]
+        except sqlite3.Error:
+            LOGGER.critical(
+                "History DB quick_check failed during startup for %s",
+                self.db_path,
+                exc_info=True,
+            )
+            raise
+        if problems:
+            LOGGER.critical(
+                "History DB quick_check reported corruption for %s: %s",
+                self.db_path,
+                "; ".join(problems),
+            )
 
     # -- settings_snapshot persistence -----------------------------------------
 

--- a/apps/server/vibesensor/cli/hotspot_config.py
+++ b/apps/server/vibesensor/cli/hotspot_config.py
@@ -8,23 +8,42 @@ from pathlib import Path
 from vibesensor.app.settings import DEFAULT_CONFIG
 
 
+def _warn(message: str) -> None:
+    print(f"WARNING: {message}", file=sys.stderr)
+
+
+def _load_ap_config(config_path: Path) -> dict[str, object]:
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError as exc:
+        _warn(f"Failed to import YAML support for {config_path}: {exc}; using defaults.")
+        return {}
+
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        _warn(f"Failed to parse hotspot config {config_path}: {exc}; using defaults.")
+        return {}
+
+    if not isinstance(raw, dict):
+        _warn(f"Hotspot config {config_path} must contain a top-level mapping; using defaults.")
+        return {}
+
+    cfg = raw.get("ap", {}) or {}
+    if not isinstance(cfg, dict):
+        _warn(f"Hotspot config {config_path} has a non-mapping 'ap' section; using defaults.")
+        return {}
+    return cfg
+
+
 def main() -> None:
     config_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/etc/vibesensor/config.yaml")
     ap_defaults = DEFAULT_CONFIG["ap"]
     assert isinstance(ap_defaults, dict), "DEFAULT_CONFIG['ap'] must be a dict"
     defaults = {k: v for k, v in ap_defaults.items() if k != "self_heal"}
-
-    cfg: dict[str, object] = {}
-    if config_path.exists():
-        try:
-            import yaml
-
-            raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-            if isinstance(raw, dict):
-                cfg = raw.get("ap", {}) or {}
-        except Exception:
-            cfg = {}
-
+    cfg = _load_ap_config(config_path)
     ap = {**defaults, **cfg}
     for k, v in ap.items():
         if not isinstance(v, dict):

--- a/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
@@ -23,6 +23,8 @@ __all__ = [
 ]
 
 _DB_THREAD_TIMEOUT_S = 10.0
+_DB_TIMEOUT_ERROR = "metrics logger DB call timed out"
+_TICK_FAILURE_PREFIX = "metrics logger tick failed: "
 
 
 def normalize_accel_scale_g_per_lsb(value: object) -> float | None:
@@ -49,19 +51,30 @@ def active_frames_total(registry: ClientTracker) -> int:
     )
 
 
+def _is_tick_error_message(message: str | None) -> bool:
+    return message == _DB_TIMEOUT_ERROR or bool(
+        message and message.startswith(_TICK_FAILURE_PREFIX),
+    )
+
+
 async def run_loop(recorder: RunRecorder, *, logger: logging.Logger) -> None:
     """Drive the periodic live-sample flush loop for ``RunRecorder``."""
     interval = 1.0 / recorder.metrics_log_hz
     while True:
         try:
-            timestamp_utc = utc_now_iso()
             with recorder._lock:
                 live_start = recorder._live_start_mono_s
-                run_id_for_live = recorder._run_id or "live"
+                snapshot = recorder._session_snapshot()
+            if snapshot is None:
+                if _is_tick_error_message(recorder._persistence.last_write_error):
+                    recorder._persistence.clear_last_write_error()
+                await asyncio.sleep(interval)
+                continue
+            timestamp_utc = utc_now_iso()
             live_rows = await asyncio.wait_for(
                 asyncio.to_thread(
                     recorder._sample_flush.build_sample_records,
-                    run_id=run_id_for_live,
+                    run_id=snapshot.run_id,
                     t_s=max(0.0, time.monotonic() - live_start),
                     timestamp_utc=timestamp_utc,
                 ),
@@ -73,33 +86,33 @@ async def run_loop(recorder: RunRecorder, *, logger: logging.Logger) -> None:
                     type(live_rows).__name__,
                 )
                 live_rows = []
-            snapshot = recorder._session_snapshot()
-            if snapshot is not None:
-                no_data_timeout = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        recorder._sample_flush.append_records,
-                        snapshot.run_id,
-                        snapshot.start_time_utc,
-                        snapshot.start_mono_s,
-                        prebuilt_rows=live_rows,
-                    ),
-                    timeout=_DB_THREAD_TIMEOUT_S,
+            no_data_timeout = await asyncio.wait_for(
+                asyncio.to_thread(
+                    recorder._sample_flush.append_records,
+                    snapshot.run_id,
+                    snapshot.start_time_utc,
+                    snapshot.start_mono_s,
+                    prebuilt_rows=live_rows,
+                ),
+                timeout=_DB_THREAD_TIMEOUT_S,
+            )
+            if no_data_timeout:
+                logger.info(
+                    "Auto-stopping run %s after %.1fs without new data",
+                    snapshot.run_id,
+                    recorder._lifecycle.no_data_timeout_s,
                 )
-                if no_data_timeout:
-                    logger.info(
-                        "Auto-stopping run %s after %.1fs without new data",
-                        snapshot.run_id,
-                        recorder._lifecycle.no_data_timeout_s,
-                    )
-                    recorder.stop_recording(_only_if_run_id=snapshot.run_id)
+                recorder.stop_recording(_only_if_run_id=snapshot.run_id)
+            if _is_tick_error_message(recorder._persistence.last_write_error):
+                recorder._persistence.clear_last_write_error()
         except TimeoutError:
-            recorder._persistence.set_last_write_error("metrics logger DB call timed out")
+            recorder._persistence.set_last_write_error(_DB_TIMEOUT_ERROR)
             logger.warning(
                 "Metrics logger DB call exceeded %.1fs timeout; skipping tick.",
                 _DB_THREAD_TIMEOUT_S,
             )
         except Exception as exc:
-            recorder._persistence.set_last_write_error(f"metrics logger tick failed: {exc}")
+            recorder._persistence.set_last_write_error(f"{_TICK_FAILURE_PREFIX}{exc}")
             logger.warning(
                 "Metrics logger tick failed; will retry next interval.",
                 exc_info=True,

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -123,15 +123,7 @@ class RunRecorder:
         )
 
         with self._lock:
-            snapshot = self._lifecycle.start_new_run(
-                run_id=uuid4().hex,
-                analysis_settings_snapshot=self._analysis_settings_snapshot(),
-                start_time_utc=utc_now_iso(),
-                start_mono_s=time.monotonic(),
-                current_total=_recorder_runtime.active_frames_total(self.registry),
-            )
             self._persistence.reset()
-            self._live_start_mono_s = snapshot.start_mono_s
 
     @property
     def enabled(self) -> bool:
@@ -158,6 +150,18 @@ class RunRecorder:
 
     def _session_snapshot(self) -> ActiveRunSnapshot | None:
         return self._lifecycle.snapshot()
+
+    def _start_new_run_locked(self) -> ActiveRunSnapshot:
+        snapshot = self._lifecycle.start_new_run(
+            run_id=uuid4().hex,
+            analysis_settings_snapshot=self._analysis_settings_snapshot(),
+            start_time_utc=utc_now_iso(),
+            start_mono_s=time.monotonic(),
+            current_total=_recorder_runtime.active_frames_total(self.registry),
+        )
+        self._persistence.reset()
+        self._live_start_mono_s = snapshot.start_mono_s
+        return snapshot
 
     def status(self) -> RunRecorderStatusSnapshot:
         return build_run_recorder_status(
@@ -209,15 +213,7 @@ class RunRecorder:
                         "finalize_run failed for %s; scheduling analysis anyway",
                         run_id,
                     )
-            snapshot = self._lifecycle.start_new_run(
-                run_id=uuid4().hex,
-                analysis_settings_snapshot=self._analysis_settings_snapshot(),
-                start_time_utc=utc_now_iso(),
-                start_mono_s=time.monotonic(),
-                current_total=_recorder_runtime.active_frames_total(self.registry),
-            )
-            self._persistence.reset()
-            self._live_start_mono_s = snapshot.start_mono_s
+            self._start_new_run_locked()
             result = self.status()
         if completed_run_id and self._history_db is not None:
             self.schedule_post_analysis(completed_run_id)

--- a/apps/server/vibesensor/use_cases/run/post_analysis.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis.py
@@ -20,9 +20,11 @@ from threading import RLock, Thread
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.use_cases.run.post_analysis_executor import (
+    PostAnalysisAttemptResult,
     PostAnalysisExecutionAnalysisFailure,
     PostAnalysisExecutionPersistenceFailure,
     PostAnalysisExecutionResult,
+    PostAnalysisExecutionRetryableFailure,
     PostAnalysisExecutionSuccess,
     PostAnalysisRunner,
     execute_post_analysis,
@@ -32,6 +34,7 @@ from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_s
 LOGGER = logging.getLogger(__name__)
 
 _WARN_QUEUE_DEPTH = 10
+_RETRY_DELAYS_S = (0.5, 1.0, 2.0)
 
 
 @dataclass(frozen=True, slots=True)
@@ -239,12 +242,45 @@ class PostAnalysisWorker:
         db = self._history_db
         if db is None:
             return
-        result = execute_post_analysis(
-            run_id=run_id,
-            db=db,
-            analysis_runner=self._analysis_runner,
+        retry_index = 0
+        while True:
+            defer_retryable_error_storage = retry_index < len(_RETRY_DELAYS_S)
+            result: PostAnalysisAttemptResult = execute_post_analysis(
+                run_id=run_id,
+                db=db,
+                analysis_runner=self._analysis_runner,
+                defer_retryable_error_storage=defer_retryable_error_storage,
+            )
+            if isinstance(result, PostAnalysisExecutionRetryableFailure):
+                delay_s = _RETRY_DELAYS_S[retry_index]
+                self._record_retryable_failure(
+                    result,
+                    attempt=retry_index + 1,
+                    delay_s=delay_s,
+                )
+                retry_index += 1
+                time.sleep(delay_s)
+                continue
+            self._record_execution_result(result)
+            return
+
+    def _record_retryable_failure(
+        self,
+        result: PostAnalysisExecutionRetryableFailure,
+        *,
+        attempt: int,
+        delay_s: float,
+    ) -> None:
+        LOGGER.warning(
+            "Retrying post-analysis for run %s in %.1fs after transient failure (retry %d/%d): %s",
+            result.run_id,
+            delay_s,
+            attempt,
+            len(_RETRY_DELAYS_S),
+            result.error_message,
         )
-        self._record_execution_result(result)
+        for error_msg in result.callback_errors:
+            self._error_cb(error_msg)
 
     def _record_execution_result(
         self,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -77,6 +77,13 @@ class PostAnalysisExecutionPersistenceFailure:
     callback_errors: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True, slots=True)
+class PostAnalysisExecutionRetryableFailure:
+    run_id: str
+    error_message: str
+    callback_errors: tuple[str, ...] = ()
+
+
 PostAnalysisExecutionResult = (
     PostAnalysisExecutionSuccess
     | PostAnalysisExecutionMissingMetadata
@@ -85,6 +92,12 @@ PostAnalysisExecutionResult = (
     | PostAnalysisExecutionPersistenceFailure
 )
 
+PostAnalysisAttemptResult = PostAnalysisExecutionResult | PostAnalysisExecutionRetryableFailure
+
+
+def is_retryable_post_analysis_error(exc: Exception) -> bool:
+    return isinstance(exc, (sqlite3.Error, OSError, MemoryError))
+
 
 def execute_post_analysis(
     *,
@@ -92,12 +105,19 @@ def execute_post_analysis(
     db: RunPersistence,
     analysis_runner: PostAnalysisRunner,
     load_run: PostAnalysisLoader = load_post_analysis_run,
-) -> PostAnalysisExecutionResult:
+    defer_retryable_error_storage: bool = False,
+) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
     LOGGER.info("Analysis started for run %s", run_id)
     try:
         load_result = load_run(run_id=run_id, db=db)
     except Exception as exc:  # includes sample-read and metadata-read failures
+        if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
+            return _retryable_failure_result(
+                run_id=run_id,
+                analysis_start=analysis_start,
+                exc=exc,
+            )
         return _failure_result(
             run_id=run_id,
             analysis_start=analysis_start,
@@ -136,6 +156,12 @@ def execute_post_analysis(
         )
         db.store_analysis(loaded.run_id, summary)
     except Exception as exc:
+        if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
+            return _retryable_failure_result(
+                run_id=loaded.run_id,
+                analysis_start=analysis_start,
+                exc=exc,
+            )
         return _failure_result(
             run_id=loaded.run_id,
             analysis_start=analysis_start,
@@ -178,6 +204,27 @@ def _store_load_error(
     return PostAnalysisExecutionNoSamples(
         run_id=run_id,
         completed_error=completed_error,
+    )
+
+
+def _retryable_failure_result(
+    *,
+    run_id: str,
+    analysis_start: float,
+    exc: Exception,
+) -> PostAnalysisExecutionRetryableFailure:
+    duration_s = time.monotonic() - analysis_start
+    LOGGER.warning(
+        "Post-analysis attempt failed for run %s after %.2fs; retrying if budget remains: %s",
+        run_id,
+        duration_s,
+        exc,
+        exc_info=True,
+    )
+    return PostAnalysisExecutionRetryableFailure(
+        run_id=run_id,
+        error_message=str(exc),
+        callback_errors=(f"post-analysis failed for run {run_id}: {exc}",),
     )
 
 


### PR DESCRIPTION
Closes #1116.

## Summary

This PR hardens five runtime resilience gaps in the Pi/server path that were allowing failures to stay invisible or to permanently damage otherwise recoverable runs. The branch prevents transient post-analysis failures from immediately becoming terminal, surfaces hotspot-config parse/import/shape problems while preserving the existing fallback-to-default behavior, adds a startup `PRAGMA quick_check` visibility pass to `HistoryDB`, removes the implicit startup recording session that could turn incoming sensor traffic into phantom runs, and clears only the stale tick-generated persistence errors that previously stayed latched in `/api/health` after the runtime had already recovered.

The goal is to make the runtime fail more honestly and recover more predictably without widening scope into new queue infrastructure, new persisted run states, or broader UI/API redesign. I kept the fix set inside the existing backend seams so the state machine, HTTP contract, and persistence layering remain recognizable to maintainers.

## Implementation approach

The most important design choice was to preserve the current persisted run lifecycle (`recording -> analyzing -> complete|error`) instead of introducing a new schema state. That matters most for post-analysis retry: once `store_analysis_error()` marks a run as `error`, the existing `store_analysis()` transition rules will not allow that run to recover back to `complete`. Because of that, retryable post-analysis failures now have to stay in `analyzing` until the retry budget is exhausted. Only after the final attempt fails do we fall back to the existing terminal error persistence path.

I used the same narrow approach for the phantom-run fix. Rather than adding a new “pending” run concept, `RunRecorder` now simply starts idle and creates the in-memory run only on explicit `start_recording()`. The HTTP/UI recording status contract already allows `enabled=false, run_id=null`, so this removes the unwanted startup behavior without creating a migration problem elsewhere.

The stale health-state fix is similarly scoped: the runtime now clears only the tick-generated timeout/failure messages after a clean tick. It does not wipe real persistence problems from history creation, sample append, finalize, or post-analysis.

## Main code changes by area

### 1. Post-analysis retry without premature terminal state

`apps/server/vibesensor/use_cases/run/post_analysis_executor.py` now distinguishes retryable post-analysis failures from terminal execution outcomes. Retryable failures currently cover `sqlite3.Error`, `OSError`, and `MemoryError`, which are the classes most consistent with transient DB contention, filesystem issues, or memory pressure on the Pi.

`execute_post_analysis()` gained a `defer_retryable_error_storage` path so retryable failures can be returned to the worker without immediately calling `store_analysis_error()`. That keeps the run in `analyzing` while retry is still possible.

`apps/server/vibesensor/use_cases/run/post_analysis.py` now retries those failures with bounded backoff (`0.5s`, `1.0s`, `2.0s`) inside the existing single worker flow. Exhausted retries fall back to the existing terminal result handling. I expanded `test_post_analysis_executor.py` and `test_post_analysis_worker.py` to cover deferred transient failures, retry-until-success, and retry-budget exhaustion.

### 2. Hotspot-config parse failures are now visible

`apps/server/vibesensor/cli/hotspot_config.py` no longer silently swallows every config-loading problem. The new `_load_ap_config()` helper warns to `stderr` when YAML support cannot be imported, when the YAML cannot be parsed, or when the top-level / `ap` shapes are invalid.

The CLI still preserves the existing behavior of falling back to default hotspot exports, which keeps boot resilient. The difference is that a bad config file is now diagnosable instead of silently turning into default credentials. `apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py` verifies that a broken YAML file emits a warning while producing the same default export output as the no-config path.

### 3. HistoryDB startup now performs a quick integrity check

`apps/server/vibesensor/adapters/persistence/history_db/__init__.py` now runs `PRAGMA quick_check` after schema setup/migration. If `quick_check` itself fails, the startup path logs a critical message and re-raises the SQLite error. If SQLite reports corruption rows instead of `ok`, startup now logs that corruption immediately.

This is intentionally detection-first, not repair-first. The issue called out the lack of startup integrity visibility; this patch closes that gap without layering on speculative auto-repair behavior. `test_history_db_lifecycle.py` now covers both startup invocation and the corruption logging behavior.

### 4. Recorder starts idle, so startup traffic no longer creates phantom runs

`apps/server/vibesensor/use_cases/run/logger.py` no longer starts a recording session during `RunRecorder.__init__()`. Instead, the new `_start_new_run_locked()` helper is only invoked from `start_recording()`.

`apps/server/vibesensor/use_cases/run/_recorder_runtime.py` now checks for an active session snapshot before building or appending sample rows. If the recorder is idle, the tick loop skips persistence work entirely. That means connected sensors can no longer create a hidden startup run before the user explicitly starts recording.

The new `apps/server/tests/use_cases/run/test_recorder_runtime.py` proves that idle ticks with advancing sensor frames do not create history rows, which is the practical phantom-run regression we needed to pin.

### 5. Stale idle-time tick errors clear without masking real persistence failures

The recorder runtime now treats timeout/tick-failure messages as a specific error class using explicit markers in `_recorder_runtime.py`. After a clean tick, the runtime clears only those tick-generated messages.

That means a transient idle-time timeout no longer leaves `/api/health` permanently degraded when no recording is active, but a genuine `create_run`, `append_samples`, `finalize_run`, or post-analysis failure still stays visible until the real path succeeds. The new recorder-runtime tests cover both sides of that behavior.

## Validation

I validated this branch in two stages.

First, I ran a focused pytest slice over the directly affected runtime seams:

`pytest -q apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/use_cases/run/test_recorder_runtime.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py`

That run finished green with `90 passed`.

Second, I ran the broader backend CI-parity subset used in this environment:

`python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That broader subset also finished fully green. Local Docker-backed validation is still unavailable in this environment because the Docker daemon cannot start here, so hosted GitHub Actions will provide the remaining Docker-dependent coverage.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that post-analysis retry stays inside the existing single worker instead of introducing a separate durable job queue. That keeps the change set small and maintainable, but it also means one retrying run still occupies the single analysis worker during its short backoff windows.

The `HistoryDB` integrity work is intentionally conservative. This PR detects and logs corruption; it does not try to auto-repair or replace the DB. Likewise, hotspot config still falls back to defaults rather than aborting boot, because the issue asked for diagnosability, not a boot-policy redesign.

Finally, I intentionally kept the related UI/WebSocket stale-data-on-reconnect concern out of this PR. After tracing the current code, that still looks like a separate client-side behavior rather than a tightly coupled root cause in the server/runtime paths touched here.