### PR TITLE
Optimize Pi backend hot paths

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from threading import Event, Thread
+
+import pytest
+
+from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.shared.types.backend_types import RunMetadata
+
+
+def _metadata(run_id: str) -> RunMetadata:
+    return RunMetadata.from_dict(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2026-01-01T00:00:00Z",
+            "sensor_model": "ADXL345",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "source": "test",
+        }
+    )
+
+
+def test_history_db_read_connection_is_query_only(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    try:
+        assert db._read_conn is not None
+        row = db._read_conn.execute("PRAGMA query_only").fetchone()
+        assert row is not None
+        assert int(row[0]) == 1
+    finally:
+        db.close()
+
+
+def test_history_db_read_errors_clear_read_transaction(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    try:
+        assert db._read_conn is not None
+        with pytest.raises(sqlite3.OperationalError):
+            with db._cursor(commit=False) as cur:
+                cur.execute("SELECT * FROM missing_table")
+        assert not db._read_conn.in_transaction
+    finally:
+        db.close()
+
+
+def test_history_db_allows_reads_during_write_transaction(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-read", "2026-01-01T00:00:00Z", _metadata("run-read"))
+    read_started = Event()
+    read_finished = Event()
+    errors: list[BaseException] = []
+
+    def _reader() -> None:
+        read_started.set()
+        try:
+            runs = db.list_runs()
+            assert [run.run_id for run in runs] == ["run-read"]
+        except BaseException as exc:  # pragma: no cover - re-raised in test thread
+            errors.append(exc)
+        finally:
+            read_finished.set()
+
+    with db.write_transaction_cursor() as cur:
+        cur.execute(
+            "UPDATE runs SET error_message = ? WHERE run_id = ?",
+            ("pending", "run-read"),
+        )
+        thread = Thread(target=_reader)
+        thread.start()
+        try:
+            assert read_started.wait(1.0)
+            assert read_finished.wait(1.0)
+        finally:
+            thread.join(timeout=1.0)
+
+    db.close()
+    if errors:
+        raise errors[0]

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -106,20 +106,25 @@ def test_close_uses_lock_and_clears_connection(tmp_path: Path) -> None:
     events: list[str] = []
 
     class RecordingLock:
+        def __init__(self, label: str) -> None:
+            self._label = label
+
         def __enter__(self) -> None:
-            events.append("enter")
+            events.append(f"{self._label}-enter")
             return None
 
         def __exit__(self, exc_type, exc, tb) -> bool:
-            events.append("exit")
+            events.append(f"{self._label}-exit")
             return False
 
-    db._lock = RecordingLock()  # type: ignore[assignment]
+    db._lock = RecordingLock("write")  # type: ignore[assignment]
+    db._read_lock = RecordingLock("read")  # type: ignore[assignment]
 
     db.close()
 
-    assert events == ["enter", "exit"]
+    assert events == ["write-enter", "write-exit", "read-enter", "read-exit"]
     assert db._conn is None
+    assert db._read_conn is None
 
 
 def test_schema_version_ancient_no_migration_fails_fast(tmp_path: Path) -> None:

--- a/apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.adapters.persistence.history_db._samples import (
+    _V2_COL_OFFSET,
+    _V2_COLUMNS,
+    sample_to_v2_row,
+    v2_row_to_sensor_frame,
+)
+from vibesensor.shared.types.sensor_frame import SensorFrame
+
+
+def _frame() -> SensorFrame:
+    return SensorFrame.from_dict(
+        {
+            "run_id": "run-1",
+            "timestamp_utc": "2026-01-01T00:00:00Z",
+            "t_s": 1.25,
+            "client_id": "client-1",
+            "client_name": "Front left",
+            "location": "front_left",
+            "sample_rate_hz": 800,
+            "speed_kmh": 42.5,
+            "gps_speed_kmh": 43.0,
+            "speed_source": "gps",
+            "engine_rpm": 2100.0,
+            "engine_rpm_source": "obd",
+            "gear": 4.0,
+            "final_drive_ratio": 3.55,
+            "accel_x_g": 0.1,
+            "accel_y_g": 0.2,
+            "accel_z_g": 0.3,
+            "dominant_freq_hz": 56.0,
+            "dominant_axis": "x",
+            "top_peaks": [{"hz": 56.0, "amp_g": 0.42}],
+            "vibration_strength_db": 12.3,
+            "strength_bucket": "moderate",
+            "strength_peak_amp_g": 0.42,
+            "strength_floor_amp_g": 0.02,
+            "frames_dropped_total": 5,
+            "queue_overflow_drops": 2,
+        }
+    )
+
+
+def test_v2_row_to_sensor_frame_round_trips_typed_row() -> None:
+    frame = _frame()
+    row = (123, *sample_to_v2_row(frame.run_id, frame))
+    assert v2_row_to_sensor_frame(row) == frame
+
+
+def test_v2_row_to_sensor_frame_rejects_non_numeric_scalar_columns() -> None:
+    frame = _frame()
+    row = list((123, *sample_to_v2_row(frame.run_id, frame)))
+    row[_V2_COL_OFFSET + _V2_COLUMNS.index("sample_rate_hz")] = "fast"
+
+    with pytest.raises(TypeError, match="sample_rate_hz"):
+        v2_row_to_sensor_frame(tuple(row))

--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 
 from vibesensor.adapters.websocket.hub import WebSocketHub, WSConnection
@@ -256,6 +257,40 @@ async def test_error_payload_is_cached_per_client_id() -> None:
     for ws in (ws1, ws2):
         ws.send_text.assert_awaited_once()
         assert _sent_json(ws) == {"error": "payload_build_failed"}
+
+
+@pytest.mark.asyncio
+async def test_broadcast_serializes_plain_payload_without_recursive_sanitizing() -> None:
+    hub = WebSocketHub()
+    ws = _make_ws()
+    await hub.add(ws, None)
+
+    with patch(
+        "vibesensor.adapters.websocket.hub.sanitize_for_json",
+        side_effect=AssertionError(
+            "sanitize_for_json should not run on the common plain-Python path"
+        ),
+    ):
+        await hub.broadcast(lambda _: {"value": 1.5, "nested": {"ok": True}})
+
+    assert _sent_json(ws) == {"value": 1.5, "nested": {"ok": True}}
+
+
+@pytest.mark.asyncio
+async def test_broadcast_falls_back_to_sanitizer_for_numpy_payload() -> None:
+    hub = WebSocketHub()
+    ws = _make_ws()
+    await hub.add(ws, "client_x")
+    payload = {"freq": np.array([1.0, float("nan"), 3.0], dtype=np.float32)}
+
+    with patch(
+        "vibesensor.adapters.websocket.hub.sanitize_for_json",
+        wraps=sanitize_for_json,
+    ) as sanitize:
+        await hub.broadcast(lambda _: payload)
+
+    assert sanitize.call_count == 1
+    assert _sent_json(ws) == {"freq": [1.0, None, 3.0]}
 
 
 # ── sanitize_for_json unit tests ─────────────────────────────────────────────

--- a/apps/server/tests/infra/processing/test_compute_filtering.py
+++ b/apps/server/tests/infra/processing/test_compute_filtering.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.compute import SignalMetricsComputer
+from vibesensor.infra.processing.models import MetricsSnapshot, ProcessorConfig
+from vibesensor.vibration_strength import empty_vibration_strength_metrics
+
+
+def _config(*, fft_n: int) -> ProcessorConfig:
+    return ProcessorConfig(
+        sample_rate_hz=800,
+        waveform_seconds=8,
+        waveform_display_hz=100,
+        fft_n=fft_n,
+        spectrum_min_hz=5.0,
+        spectrum_max_hz=200.0,
+        accel_scale_g_per_lsb=None,
+    )
+
+
+def _empty_fft_result() -> dict[str, object]:
+    return {
+        "freq_slice": np.array([], dtype=np.float32),
+        "spectrum_by_axis": {},
+        "combined_amp": np.array([], dtype=np.float32),
+        "strength_metrics": empty_vibration_strength_metrics(),
+        "axis_peaks": {"x": [], "y": [], "z": []},
+    }
+
+
+def test_compute_reuses_filtered_time_window_for_fft(monkeypatch) -> None:
+    metrics = SignalMetricsComputer(_config(fft_n=4))
+    time_window = np.arange(24, dtype=np.float32).reshape(3, 8)
+    snapshot = MetricsSnapshot(
+        client_id="client-1",
+        sample_rate_hz=800,
+        ingest_generation=1,
+        time_window=time_window,
+        fft_block=time_window[:, -4:].copy(),
+    )
+    filtered_time_window = np.full((3, 8), 7.0, dtype=np.float32)
+    fft_calls: list[tuple[np.ndarray, bool]] = []
+
+    def _fake_medfilt3(block: np.ndarray) -> np.ndarray:
+        np.testing.assert_array_equal(block, time_window)
+        return filtered_time_window
+
+    def _fake_compute_fft_spectrum(
+        fft_block: np.ndarray,
+        sample_rate_hz: int,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        fft_calls.append((fft_block.copy(), bool(kwargs["spike_filter_enabled"])))
+        return _empty_fft_result()
+
+    monkeypatch.setattr("vibesensor.infra.processing.compute.medfilt3", _fake_medfilt3)
+    monkeypatch.setattr(
+        "vibesensor.infra.processing.compute.compute_fft_spectrum",
+        _fake_compute_fft_spectrum,
+    )
+
+    result = metrics.compute(snapshot)
+
+    assert result.has_fft_data is True
+    assert len(fft_calls) == 1
+    np.testing.assert_array_equal(fft_calls[0][0], filtered_time_window[:, -4:])
+    assert fft_calls[0][1] is False
+
+
+def test_compute_filters_short_fft_block_only_once(monkeypatch) -> None:
+    metrics = SignalMetricsComputer(_config(fft_n=4))
+    time_window = np.arange(6, dtype=np.float32).reshape(3, 2)
+    fft_block = np.arange(12, dtype=np.float32).reshape(3, 4)
+    snapshot = MetricsSnapshot(
+        client_id="client-1",
+        sample_rate_hz=800,
+        ingest_generation=1,
+        time_window=time_window,
+        fft_block=fft_block,
+    )
+    filtered_time_window = np.full((3, 2), 3.0, dtype=np.float32)
+    filtered_fft_block = np.full((3, 4), 9.0, dtype=np.float32)
+    fft_calls: list[tuple[np.ndarray, bool]] = []
+    seen_shapes: list[tuple[int, int]] = []
+
+    def _fake_medfilt3(block: np.ndarray) -> np.ndarray:
+        seen_shapes.append(block.shape)
+        if block.shape == time_window.shape:
+            return filtered_time_window
+        np.testing.assert_array_equal(block, fft_block)
+        return filtered_fft_block
+
+    def _fake_compute_fft_spectrum(
+        fft_input: np.ndarray,
+        sample_rate_hz: int,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        fft_calls.append((fft_input.copy(), bool(kwargs["spike_filter_enabled"])))
+        return _empty_fft_result()
+
+    monkeypatch.setattr("vibesensor.infra.processing.compute.medfilt3", _fake_medfilt3)
+    monkeypatch.setattr(
+        "vibesensor.infra.processing.compute.compute_fft_spectrum",
+        _fake_compute_fft_spectrum,
+    )
+
+    result = metrics.compute(snapshot)
+
+    assert result.has_fft_data is True
+    assert seen_shapes == [time_window.shape, fft_block.shape]
+    assert len(fft_calls) == 1
+    np.testing.assert_array_equal(fft_calls[0][0], filtered_fft_block)
+    assert fft_calls[0][1] is False

--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -130,6 +130,14 @@ class TestFloatList:
         result = float_list([1, 2, 3])
         assert result == [1.0, 2.0, 3.0]
 
+    def test_ndarray_non_finite_values_become_zero_without_mutating_input(self) -> None:
+        arr = np.array([1.0, np.nan, np.inf, -np.inf], dtype=np.float32)
+        result = float_list(arr)
+        assert result == [1.0, 0.0, 0.0, 0.0]
+        assert np.isnan(arr[1])
+        assert np.isposinf(arr[2])
+        assert np.isneginf(arr[3])
+
 
 class TestTopPeaks:
     """Tests for spectral peak detection."""

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -40,39 +40,69 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
     def __init__(self, db_path: Path) -> None:
         self.db_path = db_path
         self._lock = RLock()
+        self._read_lock = RLock()
         db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._use_separate_read_conn = str(db_path) != ":memory:"
         self._conn: sqlite3.Connection | None = sqlite3.connect(db_path, check_same_thread=False)
+        self._read_conn: sqlite3.Connection | None = None
         try:
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA wal_autocheckpoint=500")
-            self._conn.execute("PRAGMA foreign_keys=ON")
-            self._conn.execute("PRAGMA busy_timeout=5000")
+            self._configure_connection(self._conn, read_only=False)
             self._ensure_schema()
             self._run_startup_quick_check()
+            if self._use_separate_read_conn:
+                self._read_conn = sqlite3.connect(db_path, check_same_thread=False)
+                self._configure_connection(self._read_conn, read_only=True)
         except sqlite3.Error:
+            if self._read_conn is not None:
+                self._read_conn.close()
             self._conn.close()
             raise
 
     # -- lifecycle ------------------------------------------------------------
+
+    @staticmethod
+    def _configure_connection(conn: sqlite3.Connection, *, read_only: bool) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        if not read_only:
+            conn.execute("PRAGMA wal_autocheckpoint=500")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA busy_timeout=5000")
+        if read_only:
+            conn.execute("PRAGMA query_only=ON")
 
     def close(self) -> None:
         with self._lock:
             if self._conn is not None:
                 self._conn.close()
                 self._conn = None
+        with self._read_lock:
+            if self._read_conn is not None:
+                self._read_conn.close()
+                self._read_conn = None
+
+    def _cursor_connection(
+        self,
+        *,
+        commit: bool,
+    ) -> tuple[sqlite3.Connection | None, RLock]:
+        if not commit and self._read_conn is not None:
+            return self._read_conn, self._read_lock
+        return self._conn, self._lock
 
     @contextmanager
     def _cursor(self, *, commit: bool = True) -> Iterator[sqlite3.Cursor]:
-        with self._lock:
-            if self._conn is None:
+        conn, lock = self._cursor_connection(commit=commit)
+        with lock:
+            if conn is None:
                 raise RuntimeError("HistoryDB is closed")
-            cur = self._conn.cursor()
+            cur = conn.cursor()
             try:
                 yield cur
                 if commit:
-                    self._conn.commit()
+                    conn.commit()
             except sqlite3.Error:
-                self._conn.rollback()
+                if conn.in_transaction:
+                    conn.rollback()
                 raise
             finally:
                 cur.close()

--- a/apps/server/vibesensor/adapters/persistence/history_db/_samples.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_samples.py
@@ -10,17 +10,13 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import TypeGuard
 
+from vibesensor.domain import StrengthPeak
 from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
-from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_array
+from vibesensor.shared.types.json_types import is_json_array
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _is_json_scalar(value: object) -> TypeGuard[JsonValue]:
-    return value is None or isinstance(value, (bool, int, float, str))
 
 
 # -- Schema column definitions ------------------------------------------------
@@ -99,40 +95,140 @@ def sample_to_v2_row(run_id: str, item: SensorFrame) -> tuple[object, ...]:
     return tuple(vals)
 
 
-def _v2_row_to_json_object(row: tuple[object, ...]) -> JsonObject:
-    """Reconstruct a sample JSON object from a ``samples_v2`` row.
+def _row_optional_float(value: object, *, field: str, row_id: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"row id={row_id}: field {field} expected float-compatible value, got bool")
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        return numeric if _isfinite(numeric) else None
+    raise TypeError(
+        f"row id={row_id}: field {field} expected float-compatible value, "
+        f"got {type(value).__name__}"
+    )
 
-    *row* layout: ``(id, <columns>)``.
-    """
-    d: JsonObject = {}
-    _json_cols = _JSON_COLUMNS
 
-    for i, col in enumerate(_V2_COLUMNS):
-        val = row[_V2_COL_OFFSET + i]
-        if col in _json_cols:
-            if val:
-                parsed = safe_json_loads(str(val), context=f"column {col}")
-                if is_json_array(parsed):
-                    d[col] = parsed
-                else:
-                    if parsed is not None:
-                        LOGGER.warning(
-                            "v2_row_to_dict: column %r for row id=%s parsed to %s, "
-                            "expected list; using []",
-                            col,
-                            row[0],
-                            type(parsed).__name__,
-                        )
-                    d[col] = []
-            else:
-                d[col] = []
-        elif _is_json_scalar(val):
-            d[col] = val
+def _row_optional_int(value: object, *, field: str, row_id: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"row id={row_id}: field {field} expected int-compatible value, got bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    raise TypeError(
+        f"row id={row_id}: field {field} expected int-compatible value, got {type(value).__name__}"
+    )
 
-    return d
+
+def _row_top_peaks(value: object, *, row_id: object) -> tuple[StrengthPeak, ...]:
+    if not value:
+        return ()
+    parsed = safe_json_loads(str(value), context="column top_peaks")
+    if not is_json_array(parsed):
+        if parsed is not None:
+            LOGGER.warning(
+                "v2_row_to_sensor_frame: column %r for row id=%s parsed to %s, "
+                "expected list; using []",
+                "top_peaks",
+                row_id,
+                type(parsed).__name__,
+            )
+        return ()
+    peaks: list[StrengthPeak] = []
+    for peak in parsed[:10]:
+        if not isinstance(peak, dict):
+            continue
+        normalized_peak = StrengthPeak.from_dict(peak)
+        if normalized_peak.is_valid:
+            peaks.append(normalized_peak)
+    return tuple(peaks)
 
 
 def v2_row_to_sensor_frame(row: tuple[object, ...]) -> SensorFrame:
     """Reconstruct a typed SensorFrame from a ``samples_v2`` row."""
-
-    return SensorFrame.from_dict(_v2_row_to_json_object(row))
+    row_id = row[0]
+    (
+        run_id,
+        timestamp_utc,
+        t_s,
+        client_id,
+        client_name,
+        location,
+        sample_rate_hz,
+        speed_kmh,
+        gps_speed_kmh,
+        speed_source,
+        engine_rpm,
+        engine_rpm_source,
+        gear,
+        final_drive_ratio,
+        accel_x_g,
+        accel_y_g,
+        accel_z_g,
+        dominant_freq_hz,
+        dominant_axis,
+        vibration_strength_db,
+        strength_bucket,
+        strength_peak_amp_g,
+        strength_floor_amp_g,
+        frames_dropped_total,
+        queue_overflow_drops,
+        top_peaks_raw,
+    ) = row[_V2_COL_OFFSET : _V2_COL_OFFSET + len(_V2_COLUMNS)]
+    return SensorFrame(
+        run_id=str(run_id or ""),
+        timestamp_utc=str(timestamp_utc or ""),
+        t_s=_row_optional_float(t_s, field="t_s", row_id=row_id),
+        client_id=str(client_id or ""),
+        client_name=str(client_name or ""),
+        location=str(location or ""),
+        sample_rate_hz=_row_optional_int(sample_rate_hz, field="sample_rate_hz", row_id=row_id),
+        speed_kmh=_row_optional_float(speed_kmh, field="speed_kmh", row_id=row_id),
+        gps_speed_kmh=_row_optional_float(gps_speed_kmh, field="gps_speed_kmh", row_id=row_id),
+        speed_source=str(speed_source or ""),
+        engine_rpm=_row_optional_float(engine_rpm, field="engine_rpm", row_id=row_id),
+        engine_rpm_source=str(engine_rpm_source or ""),
+        gear=_row_optional_float(gear, field="gear", row_id=row_id),
+        final_drive_ratio=_row_optional_float(
+            final_drive_ratio,
+            field="final_drive_ratio",
+            row_id=row_id,
+        ),
+        accel_x_g=_row_optional_float(accel_x_g, field="accel_x_g", row_id=row_id),
+        accel_y_g=_row_optional_float(accel_y_g, field="accel_y_g", row_id=row_id),
+        accel_z_g=_row_optional_float(accel_z_g, field="accel_z_g", row_id=row_id),
+        dominant_freq_hz=_row_optional_float(
+            dominant_freq_hz,
+            field="dominant_freq_hz",
+            row_id=row_id,
+        ),
+        dominant_axis=str(dominant_axis or ""),
+        top_peaks=_row_top_peaks(top_peaks_raw, row_id=row_id),
+        vibration_strength_db=_row_optional_float(
+            vibration_strength_db,
+            field="vibration_strength_db",
+            row_id=row_id,
+        ),
+        strength_bucket=str(strength_bucket) if strength_bucket not in (None, "") else None,
+        strength_peak_amp_g=_row_optional_float(
+            strength_peak_amp_g,
+            field="strength_peak_amp_g",
+            row_id=row_id,
+        ),
+        strength_floor_amp_g=_row_optional_float(
+            strength_floor_amp_g,
+            field="strength_floor_amp_g",
+            row_id=row_id,
+        ),
+        frames_dropped_total=(
+            _row_optional_int(frames_dropped_total, field="frames_dropped_total", row_id=row_id)
+            or 0
+        ),
+        queue_overflow_drops=(
+            _row_optional_int(queue_overflow_drops, field="queue_overflow_drops", row_id=row_id)
+            or 0
+        ),
+    )

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -176,30 +176,44 @@ class WebSocketHub:
         _dumps = json.dumps  # local-bind for hot-path
         try:
             raw_payload = payload_builder(selected_client_id)
-            cleaned, had_non_finite = sanitize_for_json(raw_payload)
-            if had_non_finite:
-                LOGGER.warning(
-                    "WebSocket payload for client %r contained NaN/Inf values; replaced with null.",
-                    selected_client_id,
+            payload_for_debug: object = raw_payload
+            try:
+                text = _dumps(
+                    raw_payload,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+                had_non_finite = False
+            except (TypeError, ValueError, OverflowError):
+                payload_for_debug, had_non_finite = sanitize_for_json(raw_payload)
+                if had_non_finite:
+                    LOGGER.warning(
+                        "WebSocket payload for client %r contained NaN/Inf values; "
+                        "replaced with null.",
+                        selected_client_id,
+                    )
+                text = _dumps(
+                    payload_for_debug,
+                    separators=(",", ":"),
+                    allow_nan=False,
                 )
             if debug_info is not None:
                 # Inspect the pre-serialised dict; avoids a redundant json.loads().
                 has_freq = False
                 try:
-                    spectra = cleaned.get("spectra") if isinstance(cleaned, dict) else None
+                    spectra = (
+                        payload_for_debug.get("spectra")
+                        if isinstance(payload_for_debug, dict)
+                        else None
+                    )
                     if isinstance(spectra, dict):
                         for _cid, cs in (spectra.get("clients") or {}).items():
                             if isinstance(cs, dict) and cs.get("freq"):
                                 has_freq = True
                                 break
-                except (AttributeError, TypeError, KeyError):
+                except (AttributeError, TypeError, ValueError, KeyError):
                     LOGGER.debug("Debug freq-inspection failed", exc_info=True)
                 debug_info[selected_client_id] = has_freq
-            text = _dumps(
-                cleaned,
-                separators=(",", ":"),
-                allow_nan=False,
-            )
         # TypeError/ValueError/OverflowError: json.dumps serialization failures
         # KeyError/AttributeError: payload dict construction missing keys/attrs
         # RuntimeError: callback/builder failures propagated from user code

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -68,7 +68,13 @@ class SignalMetricsComputer:
                 del self.fft_cache[oldest]
             return freq_slice, valid_idx
 
-    def compute_fft_spectrum(self, fft_block: FloatArray, sample_rate_hz: int) -> FftSpectrumResult:
+    def compute_fft_spectrum(
+        self,
+        fft_block: FloatArray,
+        sample_rate_hz: int,
+        *,
+        spike_filter_enabled: bool = True,
+    ) -> FftSpectrumResult:
         freq_slice, valid_idx = self.fft_params(sample_rate_hz)
         return compute_fft_spectrum(
             fft_block,
@@ -77,7 +83,7 @@ class SignalMetricsComputer:
             fft_scale=self.fft_scale,
             freq_slice=freq_slice,
             valid_idx=valid_idx,
-            spike_filter_enabled=True,
+            spike_filter_enabled=spike_filter_enabled,
         )
 
     def compute(self, snapshot: MetricsSnapshot) -> MetricsComputationResult:
@@ -116,7 +122,16 @@ class SignalMetricsComputer:
         strength_metrics_dict = empty_vibration_strength_metrics()
         has_fft_data = snapshot.fft_block is not None
         if has_fft_data and snapshot.fft_block is not None:
-            fft_result = self.compute_fft_spectrum(snapshot.fft_block, snapshot.sample_rate_hz)
+            fft_input = (
+                time_window[:, -snapshot.fft_block.shape[1] :]
+                if time_window.shape[1] >= snapshot.fft_block.shape[1]
+                else medfilt3(snapshot.fft_block)
+            )
+            fft_result = self.compute_fft_spectrum(
+                fft_input,
+                snapshot.sample_rate_hz,
+                spike_filter_enabled=False,
+            )
             freq_slice = fft_result["freq_slice"]
             spectrum_by_axis = fft_result["spectrum_by_axis"]
 

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -114,7 +114,17 @@ def float_list(values: FloatArray | list[float]) -> list[float]:
     """
     _isfinite = math.isfinite
     if isinstance(values, np.ndarray):
-        return [float(v) if _isfinite(v) else 0.0 for v in values.ravel().tolist()]
+        return (
+            np.nan_to_num(
+                values,
+                copy=True,
+                nan=0.0,
+                posinf=0.0,
+                neginf=0.0,
+            )
+            .ravel()
+            .tolist()
+        )
     return [float(v) if _isfinite(v) else 0.0 for v in values]
 
 


### PR DESCRIPTION
## Summary
Closes #1119.

This PR removes five backend costs that were all present in the Raspberry Pi runtime path: the WebSocket hub recursively sanitizing every payload before serialization, the history sample loader rebuilding dicts and reparsing them into `SensorFrame`, the ndarray branch in `float_list()` looping through Python one element at a time, the compute path median-filtering overlapping data twice before FFT, and `HistoryDB` forcing all reads and writes through one connection and one `RLock` even when WAL was enabled. Each change is deliberately narrow and keeps the current public behavior and contracts in place; the goal is to reduce CPU and lock contention on the Pi without turning this issue into a broader runtime redesign.

## Implementation approach
I kept the scope constrained to the five hotspots named in the issue and avoided speculative benchmarking scaffolding, metrics dashboards, or unrelated cleanup. The guiding rule was to remove work from the common path while preserving the existing behavior for unusual inputs and error cases. Where the optimization changed internal seams, I paired it with focused regressions so the branch is defended by observable behavior rather than by assumptions about implementation details.

## Main code changes by area
### 1. WebSocket broadcast fast path
`apps/server/vibesensor/adapters/websocket/hub.py` previously ran the full payload through `sanitize_for_json()` before every `json.dumps()`. That guarantees JSON-safe output, but it also means we recursively walk the full live payload on every broadcast tick even when the payload is already plain Python data. The branch now takes an optimistic path: it first attempts `json.dumps(..., allow_nan=False)` directly against the live payload, and only falls back to `sanitize_for_json()` if serialization fails with a `TypeError`, `ValueError`, or `OverflowError`. This keeps the existing correctness guarantees, warning/logging, and debug inspection behavior, but removes the recursive sanitizer from the common case that dominates steady-state Pi usage.

### 2. Direct `samples_v2` row decoding
`apps/server/vibesensor/adapters/persistence/history_db/_samples.py` used to reconstruct a dict from each SQLite row, then pass that dict through `SensorFrame.from_dict()`, which meant repeated coercion and validation work on data that had already been normalized when it was written. The branch replaces that path with a direct typed row decoder. It maps the scalar columns straight into `SensorFrame`, parses only the `top_peaks` JSON field, and performs focused numeric validation where the database boundary still needs it. This keeps the row-schema knowledge inside the persistence adapter, which is the right place for it, while removing an avoidable row -> dict -> domain-object conversion chain from post-analysis reads.

### 3. Vectorized ndarray handling in `float_list()`
`apps/server/vibesensor/infra/processing/fft.py::float_list()` had an ndarray branch that still did most of its work in Python by looping over `values.ravel().tolist()` and calling `float()` plus `math.isfinite()` per element. For large FFT-related arrays, that adds per-element interpreter overhead exactly where we want to stay inside NumPy. The new implementation uses `np.nan_to_num(..., copy=True).ravel().tolist()` for ndarray inputs so non-finite values still become `0.0`, but the normalization work happens in vectorized NumPy code. I kept `copy=True` intentionally so we do not mutate caller-owned arrays as a side effect of a formatting helper.

### 4. Remove duplicate median filtering on the compute path
The compute pipeline was applying `medfilt3()` to overlapping data twice. `SignalMetricsComputer.compute()` already filters `snapshot.time_window`, but the FFT helper in `apps/server/vibesensor/infra/processing/fft.py` could filter the FFT input again when `spike_filter_enabled=True`. On the common path, `snapshot.fft_block` is effectively derived from that same copied time window, so the second filter pass was redundant work. The branch changes `apps/server/vibesensor/infra/processing/compute.py` so the compute path reuses the already-filtered time-window slice for FFT input when that slice is long enough. If the FFT block needs more data than the copied time window contains, the code filters `snapshot.fft_block` once and then calls the FFT helper with `spike_filter_enabled=False`. This preserves the spike-filter behavior while ensuring the compute path applies it exactly once.

### 5. Split `HistoryDB` read and write connections
`apps/server/vibesensor/adapters/persistence/history_db/__init__.py` previously serialized all access through a single SQLite connection and one `RLock`, which meant read-heavy paths could still queue behind unrelated write activity despite WAL mode. The branch keeps the public API intact but routes `commit=False` query paths to a separate query-only read connection with its own lock for file-backed databases. Writes and explicit transactions continue to use the primary connection. There are two important guardrails here. First, `:memory:` databases continue to use the primary connection, because a second in-memory SQLite connection is a completely different database and broke backend tests. Second, failed read queries now roll back if a read transaction is still open, which makes the split-connection behavior more robust on error paths as well.

## Tests and validation
I added or updated focused regressions in the same feature areas as the production changes:

- `apps/server/tests/adapters/websocket/test_ws_hub.py` now proves plain-Python payloads skip sanitization on the common path while numpy/non-finite inputs still fall back to the sanitizer.
- `apps/server/tests/infra/processing/test_processing_fft.py` now covers the ndarray/non-finite `float_list()` behavior without allowing caller mutation.
- `apps/server/tests/infra/processing/test_compute_filtering.py` verifies the compute path filters the FFT input once and passes `spike_filter_enabled=False` into the downstream FFT helper.
- `apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py` covers direct row decoding and invalid scalar rejection.
- `apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py` covers query-only read connections, read progress during a held write transaction, and read-transaction cleanup on error.
- `apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py` was updated so `close()` expectations match the new two-connection lifecycle.

Local validation is green. During iteration I ran the focused backend slice covering the touched websocket, FFT, compute, and history DB areas. After the final cleanup and rollback guard, I reran the broader backend subset with:

`./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

That final run passed all three jobs.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff in this PR is that the performance wins come from trusting the common-case runtime shapes a bit more, while still preserving explicit fallbacks for unusual data. For example, the WebSocket fast path assumes the steady-state payload is already JSON-serializable, but it keeps the sanitizer fallback so we do not regress correctness when numpy or non-finite values leak in. The read/write `HistoryDB` split is intentionally narrow and only applies to `commit=False` query paths; I did not broaden it into a larger persistence redesign or add compatibility shims. I also did not add synthetic benchmarking infrastructure in this PR, because the issue was already explicit about the hotspots and the most valuable outcome here is removing the work while keeping behavior covered by tests. Hosted CI, especially the broader backend and docker-backed jobs, will provide the next confidence step once the PR is open.
