### PR TITLE
Fix backend concurrency race windows

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_extended.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_extended.py
@@ -137,3 +137,25 @@ async def test_run_cancellation_waits_writer_close_once(
     await asyncio.gather(task, return_exceptions=True)
     assert fake_writer.wait_closed_calls == 1
     assert monitor.speed_mps is None
+
+
+def test_speed_mps_setter_replaces_timestamp_without_preserving_stale_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monitor = GPSSpeedMonitor(gps_enabled=True)
+    monitor._speed_snapshot = (10.0, 5.0)
+
+    monkeypatch.setattr("vibesensor.adapters.gps.gps_transport.time.monotonic", lambda: 42.0)
+
+    monitor.speed_mps = 7.5
+
+    assert monitor._speed_snapshot == (7.5, 42.0)
+
+
+def test_speed_mps_setter_clears_timestamp_when_speed_clears() -> None:
+    monitor = GPSSpeedMonitor(gps_enabled=True)
+    monitor._speed_snapshot = (10.0, 5.0)
+
+    monitor.speed_mps = None
+
+    assert monitor._speed_snapshot == (None, None)

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -37,11 +37,14 @@ class FakeSpeedSourceSync:
         self.manual_selected: bool | None = None
         self.override_kmh: float | None = None
         self.stale_timeout_s: float | None = None
+        self.calls: list[str] = []
 
     def set_manual_source_selected(self, selected: bool) -> None:
+        self.calls.append("manual")
         self.manual_selected = selected
 
     def set_speed_override_kmh(self, speed_kmh: float | None) -> float | None:
+        self.calls.append("override")
         self.override_kmh = speed_kmh
         return speed_kmh
 
@@ -50,6 +53,7 @@ class FakeSpeedSourceSync:
         stale_timeout_s: float | None = None,
         **_kwargs: object,
     ) -> None:
+        self.calls.append("fallback")
         self.stale_timeout_s = stale_timeout_s
 
 
@@ -316,6 +320,7 @@ def test_store_syncs_speed_source_with_protocol_shaped_monitor() -> None:
     assert gps_monitor.manual_selected is True
     assert gps_monitor.override_kmh == pytest.approx(80.0)
     assert gps_monitor.stale_timeout_s == pytest.approx(17.0)
+    assert gps_monitor.calls == ["override", "manual", "fallback"]
 
 
 def test_parse_manual_speed_returns_none_for_invalid() -> None:

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -74,3 +74,26 @@ def test_metrics_computer_operates_on_snapshot_without_shared_state() -> None:
     assert result.ingest_generation == 7
     assert result.metrics["x"]["rms"] > 0
     assert any(abs(float(peak["hz"]) - 20.0) < 1.0 for peak in result.metrics["combined"]["peaks"])
+
+
+def test_buffer_store_does_not_regress_last_t0_us_for_older_frame() -> None:
+    store = SignalBufferStore(_config())
+    client_id = "client-1"
+
+    store.ingest(
+        client_id,
+        np.ones((4, 3), dtype=np.float32),
+        sample_rate_hz=200,
+        t0_us=1_000_000,
+    )
+    store.ingest(
+        client_id,
+        np.ones((2, 3), dtype=np.float32),
+        sample_rate_hz=200,
+        t0_us=900_000,
+    )
+
+    with store.lock:
+        buf = store.buffers[client_id]
+        assert buf.last_t0_us == 1_000_000
+        assert buf.samples_since_t0 == 6

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -129,6 +129,53 @@ def test_registry_sequence_gap(tmp_path: Path) -> None:
     assert row["mac_address"] == "aa:bb:cc:dd:ee:ff"
 
 
+def test_registry_rejects_far_behind_duplicate_without_clearing_dedup(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    registry = ClientRegistry(db=db)
+    client_id = bytes.fromhex("aabbccddeeff")
+
+    hello = HelloMessage(
+        client_id=client_id,
+        control_port=9010,
+        sample_rate_hz=800,
+        name="node-1",
+        firmware_version="fw",
+    )
+    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0)
+
+    samples = np.zeros((200, 3), dtype=np.int16)
+    registry.update_from_data(
+        DataMessage(client_id=client_id, seq=1, t0_us=1_000_000, sample_count=200, samples=samples),
+        ("10.4.0.2", 50000),
+        now=2.0,
+    )
+    registry.update_from_data(
+        DataMessage(
+            client_id=client_id,
+            seq=10,
+            t0_us=1_250_000,
+            sample_count=200,
+            samples=samples,
+        ),
+        ("10.4.0.2", 50000),
+        now=3.0,
+    )
+
+    result = registry.update_from_data(
+        DataMessage(client_id=client_id, seq=1, t0_us=1_000_000, sample_count=200, samples=samples),
+        ("10.4.0.2", 50000),
+        now=4.0,
+    )
+
+    record = registry.get(client_id.hex())
+    assert record is not None
+    assert result.is_duplicate is True
+    assert result.reset_detected is False
+    assert record.frames_total == 2
+    assert record.duplicates_received == 1
+    assert record.last_t0_us == 1_250_000
+
+
 def test_registry_rename_persist(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     registry = ClientRegistry(db=db)

--- a/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
@@ -116,13 +116,14 @@ class TestResolveSpeedAtomicSnapshot:
         assert m.speed_mps == 10.0
         assert m._speed_snapshot[0] == 10.0
 
-    def test_speed_mps_setter_preserves_timestamp(self) -> None:
+    def test_speed_mps_setter_refreshes_timestamp(self) -> None:
         m = _make_gps_monitor()
         ts = time.monotonic()
         m._speed_snapshot = (5.0, ts)
         m.speed_mps = 10.0
-        # Timestamp should be preserved
-        assert m._speed_snapshot == (10.0, ts)
+        assert m._speed_snapshot[0] == 10.0
+        assert m._speed_snapshot[1] is not None
+        assert m._speed_snapshot[1] > ts
 
     def test_resolve_speed_uses_snapshot_speed(self) -> None:
         m = _make_gps_monitor()

--- a/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
+++ b/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
@@ -60,3 +60,82 @@ def test_start_append_stop_produces_complete_run_in_db(
     assert stored["score"] == 42
     assert stored["details"] == "looks good"
     assert "analysis_metadata" in stored
+
+
+class _SpyLock:
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    def __enter__(self) -> None:
+        self.enter_count += 1
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def test_session_snapshot_uses_recorder_lock(make_logger) -> None:
+    logger = make_logger()
+    logger.start_recording()
+
+    spy = _SpyLock()
+    logger._lock = spy
+
+    snapshot = logger._session_snapshot()
+
+    assert snapshot is not None
+    assert spy.enter_count == 1
+
+
+def test_start_recording_holds_lock_during_flush_and_finalize(make_logger) -> None:
+    logger = make_logger()
+    logger.start_recording()
+    active = logger.registry.get("active")
+    assert active is not None
+    active.frames_total = 1
+
+    flush_lock_owned: list[bool] = []
+    finalize_lock_owned: list[bool] = []
+
+    def fake_append_records(*args, **kwargs) -> bool:
+        flush_lock_owned.append(logger._lock._is_owned())
+        return False
+
+    def fake_finalize_run(*args, **kwargs) -> bool:
+        finalize_lock_owned.append(logger._lock._is_owned())
+        return True
+
+    logger._sample_flush.append_records = fake_append_records
+    logger._persistence.finalize_run = fake_finalize_run
+
+    logger.start_recording()
+
+    assert flush_lock_owned == [True]
+    assert finalize_lock_owned == [True]
+
+
+def test_stop_recording_holds_lock_during_flush_and_finalize(make_logger) -> None:
+    logger = make_logger()
+    logger.start_recording()
+    active = logger.registry.get("active")
+    assert active is not None
+    active.frames_total = 1
+
+    flush_lock_owned: list[bool] = []
+    finalize_lock_owned: list[bool] = []
+
+    def fake_append_records(*args, **kwargs) -> bool:
+        flush_lock_owned.append(logger._lock._is_owned())
+        return False
+
+    def fake_finalize_run(*args, **kwargs) -> bool:
+        finalize_lock_owned.append(logger._lock._is_owned())
+        return True
+
+    logger._sample_flush.append_records = fake_append_records
+    logger._persistence.finalize_run = fake_finalize_run
+
+    logger.stop_recording()
+
+    assert flush_lock_owned == [True]
+    assert finalize_lock_owned == [True]

--- a/apps/server/tests/use_cases/run/test_recorder_runtime.py
+++ b/apps/server/tests/use_cases/run/test_recorder_runtime.py
@@ -68,3 +68,42 @@ async def test_idle_runtime_tick_preserves_non_tick_write_error(
         await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
 
     assert logger.status().write_error == "history append_samples failed: disk full"
+
+
+@pytest.mark.asyncio
+async def test_runtime_auto_stop_uses_to_thread(
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = make_logger()
+    logger.start_recording()
+    snapshot = logger._session_snapshot()
+    assert snapshot is not None
+
+    monkeypatch.setattr(logger._sample_flush, "build_sample_records", lambda **_: [])
+    monkeypatch.setattr(logger._sample_flush, "append_records", lambda *args, **kwargs: True)
+
+    stop_calls: list[str] = []
+
+    def fake_stop_recording(*, _only_if_run_id: str | None = None):
+        assert _only_if_run_id is not None
+        stop_calls.append(_only_if_run_id)
+        logger._lifecycle.stop()
+        return logger.status()
+
+    monkeypatch.setattr(logger, "stop_recording", fake_stop_recording)
+
+    to_thread_calls: list[object] = []
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(_recorder_runtime.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(_recorder_runtime.asyncio, "sleep", _raise_stop_loop)
+
+    with pytest.raises(_StopLoop):
+        await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
+
+    assert stop_calls == [snapshot.run_id]
+    assert fake_stop_recording in to_thread_calls

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -58,7 +58,14 @@ class GPSTransportState:
 
     @speed_mps.setter
     def speed_mps(self, value: float | None) -> None:
-        self._speed_snapshot = (value, self._speed_snapshot[1])
+        if value is None or isinstance(value, bool) or not isinstance(value, NUMERIC_TYPES):
+            self._speed_snapshot = (None, None)
+            return
+        speed_f = float(value)
+        if not math.isfinite(speed_f):
+            self._speed_snapshot = (None, None)
+            return
+        self._speed_snapshot = (speed_f, time.monotonic())
 
     @property
     def last_update_ts(self) -> float | None:

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -154,8 +154,8 @@ class SettingsStore(CarSettingsMixin):
             return
         ss = self.speed_source()
         raw = self.get_speed_source()
-        self._gps_monitor.set_manual_source_selected(ss.is_manual)
         self._gps_monitor.set_speed_override_kmh(ss.effective_speed_kmh)
+        self._gps_monitor.set_manual_source_selected(ss.is_manual)
         self._gps_monitor.set_fallback_settings(
             stale_timeout_s=raw.get("staleTimeoutS"),
         )

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -117,8 +117,12 @@ class SignalBufferStore:
             buf.write_idx = end % capacity
             buf.count = min(capacity, buf.count + n)
             if t0_us is not None and t0_us > 0:
-                buf.last_t0_us = int(t0_us)
-                buf.samples_since_t0 = n
+                next_t0_us = int(t0_us)
+                if next_t0_us > buf.last_t0_us:
+                    buf.last_t0_us = next_t0_us
+                    buf.samples_since_t0 = n
+                else:
+                    buf.samples_since_t0 = min(buf.samples_since_t0 + n, _MAX_SAMPLES_SINCE_T0)
             else:
                 buf.samples_since_t0 = min(buf.samples_since_t0 + n, _MAX_SAMPLES_SINCE_T0)
             buf.ingest_generation += 1

--- a/apps/server/vibesensor/infra/runtime/registry_updates.py
+++ b/apps/server/vibesensor/infra/runtime/registry_updates.py
@@ -46,7 +46,12 @@ def apply_data_message_update(
         backward = (
             (record.last_seq - seq) if record.last_seq is not None and record.last_seq > seq else 0
         )
-        if 0 <= backward <= _DEDUP_RESTART_GAP:
+        short_session_restart = (
+            seq == 0
+            and record.last_seq is not None
+            and _DEDUP_RESTART_GAP < backward < _RESTART_SEQ_GAP
+        )
+        if not short_session_restart:
             record.duplicates_received += 1
             return DataUpdateResult(is_duplicate=True)
 

--- a/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
@@ -102,7 +102,13 @@ async def run_loop(recorder: RunRecorder, *, logger: logging.Logger) -> None:
                     snapshot.run_id,
                     recorder._lifecycle.no_data_timeout_s,
                 )
-                recorder.stop_recording(_only_if_run_id=snapshot.run_id)
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        recorder.stop_recording,
+                        _only_if_run_id=snapshot.run_id,
+                    ),
+                    timeout=_DB_THREAD_TIMEOUT_S,
+                )
             if _is_tick_error_message(recorder._persistence.last_write_error):
                 recorder._persistence.clear_last_write_error()
         except TimeoutError:

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -149,7 +149,8 @@ class RunRecorder:
         return _recorder_runtime.analysis_settings_snapshot(self._settings_store)
 
     def _session_snapshot(self) -> ActiveRunSnapshot | None:
-        return self._lifecycle.snapshot()
+        with self._lock:
+            return self._lifecycle.snapshot()
 
     def _start_new_run_locked(self) -> ActiveRunSnapshot:
         snapshot = self._lifecycle.start_new_run(
@@ -181,7 +182,6 @@ class RunRecorder:
 
     def start_recording(self) -> RunRecorderStatusSnapshot:
         completed_run_id: str | None = None
-        flush_snapshot: ActiveRunSnapshot | None = None
         with self._lock:
             if self._lifecycle.shutdown_requested:
                 LOGGER.info(
@@ -190,13 +190,12 @@ class RunRecorder:
                 return self.status()
             if self.enabled and self._run_id:
                 flush_snapshot = self._sample_flush.pending_flush_snapshot()
-        if flush_snapshot is not None:
-            self._sample_flush.append_records(
-                flush_snapshot.run_id,
-                flush_snapshot.start_time_utc,
-                flush_snapshot.start_mono_s,
-            )
-        with self._lock:
+                if flush_snapshot is not None:
+                    self._sample_flush.append_records(
+                        flush_snapshot.run_id,
+                        flush_snapshot.start_time_utc,
+                        flush_snapshot.start_mono_s,
+                    )
             if self.enabled and self._run_id:
                 run_id = self._run_id
                 completed_run_id = self._persistence.ready_for_analysis(run_id)
@@ -224,18 +223,16 @@ class RunRecorder:
         *,
         _only_if_run_id: str | None = None,
     ) -> RunRecorderStatusSnapshot:
-        flush_snapshot: ActiveRunSnapshot | None = None
         with self._lock:
             if _only_if_run_id is not None and self._run_id != _only_if_run_id:
                 return self.status()
             flush_snapshot = self._sample_flush.pending_flush_snapshot()
-        if flush_snapshot is not None:
-            self._sample_flush.append_records(
-                flush_snapshot.run_id,
-                flush_snapshot.start_time_utc,
-                flush_snapshot.start_mono_s,
-            )
-        with self._lock:
+            if flush_snapshot is not None:
+                self._sample_flush.append_records(
+                    flush_snapshot.run_id,
+                    flush_snapshot.start_time_utc,
+                    flush_snapshot.start_mono_s,
+                )
             if _only_if_run_id is not None and self._run_id != _only_if_run_id:
                 return self.status()
             run_id = self._run_id


### PR DESCRIPTION
## Summary

Closes #1120.

This PR fixes the bounded backend concurrency and correctness defects called out in #1120 across the UDP dedup path, signal-buffer timestamp tracking, recorder lifecycle transitions, and GPS/speed-source synchronization. The issue was not a single race in one subsystem; it was a cluster of small but real state-transition gaps that could combine into stale timestamps, duplicate late-frame ingestion, event-loop stalls during auto-stop, transient wrong speed reads, or late sample writes around run finalization.

I kept the implementation intentionally narrow to the six concrete defects described in the issue rather than turning this into a broad recorder or GPS redesign. The goal here is to make the existing lifecycle and synchronization boundaries correct under the concurrency the app already has today, while preserving known behavior that is still intentional, such as short-session sensor restarts that reuse `seq=0`.

## Problem being solved

The issue description identified six concrete failure modes.

First, the registry dedup path could treat an already-seen but sufficiently far-behind retransmitted frame as if it were a restart, clear dedup state, and let that stale frame back into the processing path. Once that happened, the older `t0_us` could also flow through the buffer store and regress the active time base.

Second, the recorder runtime handled the normal flush path with `asyncio.to_thread(...)`, but the auto-stop path still called `stop_recording()` synchronously on the event loop. On Pi-class hardware, that meant the event loop could block during SQLite-backed finalization exactly when the system was already under timing pressure.

Third, recorder lifecycle transitions still had a lock-coverage gap. Although the run loop already called `_session_snapshot()` while holding the recorder lock, `_session_snapshot()` itself did not take the lock, and the start/stop paths released the recorder lock between pending-flush work and finalize/start-new-run transitions. That created a window where late appends could still land after the lifecycle state had moved on.

Fourth and fifth, GPS speed state and settings-driven speed-source sync had logically non-atomic transitions. The `speed_mps` setter reused the prior snapshot timestamp via a read/modify/write pattern, and `_sync_speed_source()` pushed manual selection before the override value. Both allowed short-lived inconsistent snapshots for concurrent readers.

## Implementation approach

The implementation follows the issue boundaries directly.

In `apps/server/vibesensor/infra/runtime/registry_updates.py`, already-seen retransmits are now treated as duplicates instead of clearing the dedup window and falling through as new data. The important nuance is that I did not flatten all restart behavior into “every seen seq is always a duplicate,” because the existing suite already characterizes one intentional case: a short-session restart that goes back to `seq=0`. That case is still preserved, while the stale far-behind duplicate path is now rejected.

In `apps/server/vibesensor/infra/processing/buffer_store.py`, `last_t0_us` is no longer allowed to move backward just because an older positive timestamp shows up later. The buffer still accepts the frame data, but the monotonic timestamp anchor is preserved so downstream windows are not regressed by stale data.

In `apps/server/vibesensor/use_cases/run/_recorder_runtime.py`, auto-stop now uses the same `asyncio.to_thread(...)` plus timeout pattern as the normal blocking persistence path. That keeps the event loop responsive during automatic stop/finalize transitions instead of performing SQLite work inline.

In `apps/server/vibesensor/use_cases/run/logger.py`, `_session_snapshot()` now protects its multi-field read under the recorder lock, and both `start_recording()` and `stop_recording()` now keep the recorder lock held across the pending-flush/finalize transition. This is the key lifecycle correctness change: once the recorder is moving between run states, the flush/finalize boundary is no longer exposed to a concurrent append window.

In `apps/server/vibesensor/adapters/gps/gps_transport.py`, the `speed_mps` setter now replaces `_speed_snapshot` as a whole, using a fresh monotonic timestamp when a speed is written and clearing the tuple fully when speed clears. That removes the read/modify/write pattern that could overwrite a newer snapshot with mixed old state.

In `apps/server/vibesensor/infra/config/settings_store.py`, `_sync_speed_source()` now applies override speed before manual-source selection and fallback settings. That way, if another thread resolves speed during the transition, it sees either the old consistent state or the new consistent state, not the dangerous intermediate case where manual mode is selected but the override value is still missing.

## Tests and validation

I added focused regressions in the existing subsystem owners instead of building one synthetic mega-test.

`apps/server/tests/infra/runtime/test_registry.py` now covers the far-behind duplicate case without breaking the existing short-session restart characterization. `apps/server/tests/infra/processing/test_processing_components.py` locks the `last_t0_us` monotonicity rule. `apps/server/tests/use_cases/run/test_recorder_runtime.py` verifies that auto-stop goes through `asyncio.to_thread(...)`. `apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py` adds lock-coverage regressions for `_session_snapshot()`, `start_recording()`, and `stop_recording()`. `apps/server/tests/adapters/gps/test_gps_speed_extended.py` verifies both timestamp refresh on write and full clear behavior. `apps/server/tests/infra/config/test_settings_store.py` now asserts the safe override/manual/fallback call order.

One broader integration characterization also needed to change: `apps/server/tests/integration/test_review_guardrails_extended_regressions.py` previously pinned the old GPS setter behavior that preserved a stale timestamp exactly. That expectation now conflicts with the intended fix, so the regression was updated to assert the new invariant: writing `speed_mps` refreshes the timestamp rather than preserving an older one.

Focused validation passed with:

`pytest -q apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/use_cases/run/test_recorder_runtime.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/adapters/gps/test_gps_speed_extended.py apps/server/tests/infra/config/test_settings_store.py`

That slice completed with `93 passed`.

I then ran the broader backend subset used throughout this backlog run:

`.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

All three jobs passed locally: `backend-quality`, `backend-typecheck`, and `backend-tests`.

I also ran a correctness-only review pass over the final diff after the green rerun; it did not identify any substantive follow-up issues.

## Risks, tradeoffs, and out-of-scope items

The main deliberate tradeoff in this patch is lock scope. Holding the recorder lock across the pending-flush/finalize transition increases the duration of that critical section, but that is the right trade for correctness here because the previous gap allowed writes to slip across a state transition. Similarly, refreshing the GPS snapshot timestamp on write changes an old test characterization, but the prior behavior was exactly the stale-state reuse that the issue called out.

I did not turn this PR into a broader synchronization framework, a new recorder architecture, or a free-threaded-Python preparation pass. The change set is intentionally bounded to the real defects described in #1120 and the adjacent tests needed to prove those fixes.
