### PR TITLE
Fix #1143: prepare report facts before PDF mapping

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
+++ b/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
@@ -56,7 +56,48 @@ def test_report_package_imports_without_analysis() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2.  Report generation fails clearly when ReportData is missing
+# 2.  Runtime import guard — verify the report package does not pull in
+#     history-layer interpretation helpers at module import time.
+# ---------------------------------------------------------------------------
+
+
+def test_report_package_imports_without_history_interpretation() -> None:
+    """Importing ``vibesensor.adapters.pdf`` must not import report interpretation."""
+    import vibesensor.adapters.pdf as pdf_pkg
+
+    history_helper = "vibesensor.use_cases.history.report_interpretation"
+    pdf_module_names = [f"vibesensor.adapters.pdf.{mod_path.stem}" for mod_path in _REPORT_MODULES]
+    saved_attrs = {
+        mod_path.stem: getattr(pdf_pkg, mod_path.stem, None) for mod_path in _REPORT_MODULES
+    }
+    saved_modules = {name: sys.modules.get(name) for name in [history_helper, *pdf_module_names]}
+
+    try:
+        sys.modules.pop(history_helper, None)
+        for mod_name in pdf_module_names:
+            sys.modules.pop(mod_name, None)
+
+        for mod_name in pdf_module_names:
+            importlib.import_module(mod_name)
+
+        assert history_helper not in sys.modules
+    finally:
+        for name in pdf_module_names:
+            sys.modules.pop(name, None)
+        sys.modules.pop(history_helper, None)
+        for name, module in saved_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+        for attr_name, module in saved_attrs.items():
+            if module is None:
+                if hasattr(pdf_pkg, attr_name):
+                    delattr(pdf_pkg, attr_name)
+            else:
+                setattr(pdf_pkg, attr_name, module)
+
+
+# ---------------------------------------------------------------------------
+# 3.  Report generation fails clearly when ReportData is missing
 # ---------------------------------------------------------------------------
 
 
@@ -72,7 +113,7 @@ def test_build_report_pdf_accepts_report_template_data() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3.  Report output fidelity — rendered facts match ReportData
+# 4.  Report output fidelity — rendered facts match ReportData
 # ---------------------------------------------------------------------------
 
 

--- a/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
@@ -5,7 +5,6 @@ from vibesensor.adapters.pdf.mapping import (
     prepare_report_mapping_context,
     resolve_primary_report_candidate,
 )
-from vibesensor.domain import LocationIntensitySummary
 
 
 def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> None:
@@ -27,8 +26,10 @@ def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> 
         },
     )
     assert prepared.domain_test_run is not None
+    assert prepared.report_facts is not None
     context = prepare_report_mapping_context(
         prepared.analysis_summary,
+        report_facts=prepared.report_facts,
         test_run=prepared.domain_test_run,
     )
 
@@ -36,7 +37,6 @@ def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> 
 
 
 def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> None:
-    sensor_intensity = [LocationIntensitySummary(location="", p95_intensity_db=21.0)]
     prepared = prepare_report_input(
         {
             "sensor_count_used": 0,
@@ -74,8 +74,10 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
         },
     )
     assert prepared.domain_test_run is not None
+    assert prepared.report_facts is not None
     context = prepare_report_mapping_context(
         prepared.analysis_summary,
+        report_facts=prepared.report_facts,
         test_run=prepared.domain_test_run,
     )
 
@@ -84,7 +86,7 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
 
     primary = resolve_primary_report_candidate(
         context=context,
-        sensor_intensity=sensor_intensity,
+        facts=prepared.report_facts.primary_candidate_facts,
         tr=tr,
         lang="en",
     )

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
@@ -17,8 +17,8 @@ from vibesensor.adapters.pdf.presentation import (
     strength_text,
 )
 from vibesensor.adapters.pdf.report_sections import (
-    build_data_trust_from_summary,
-    build_next_steps_from_summary,
+    build_data_trust,
+    build_next_steps,
 )
 from vibesensor.domain.confidence_assessment import ConfidenceAssessment
 
@@ -81,8 +81,8 @@ def test_extracted_pdf_builders_are_importable() -> None:
     assert callable(build_peak_rows_from_plots)
     assert callable(build_peak_row)
     assert callable(peak_row_system_label)
-    assert callable(build_next_steps_from_summary)
-    assert callable(build_data_trust_from_summary)
+    assert callable(build_next_steps)
+    assert callable(build_data_trust)
 
 
 @pytest.mark.parametrize(

--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -262,8 +262,10 @@ class TestSummaryHelpers:
     def test_sensor_locations_active_prefers_connected(self) -> None:
         prepared = prepare_report_input(_minimal_summary())
         assert prepared.domain_test_run is not None
+        assert prepared.report_facts is not None
         ctx = prepare_report_mapping_context(
             prepared.analysis_summary,
+            report_facts=prepared.report_facts,
             test_run=prepared.domain_test_run,
         )
         assert ctx.sensor_locations_active == ["front_left"]
@@ -271,8 +273,10 @@ class TestSummaryHelpers:
     def test_sensor_locations_active_fallback(self) -> None:
         prepared = prepare_report_input(_minimal_summary(sensor_locations_connected_throughout=[]))
         assert prepared.domain_test_run is not None
+        assert prepared.report_facts is not None
         ctx = prepare_report_mapping_context(
             prepared.analysis_summary,
+            report_facts=prepared.report_facts,
             test_run=prepared.domain_test_run,
         )
         assert "front_left" in ctx.sensor_locations_active

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -27,8 +27,10 @@ def test_report_mapping_context_has_domain_aggregate() -> None:
     }
     prepared = prepare_report_input(summary)
     assert prepared.domain_test_run is not None
+    assert prepared.report_facts is not None
     context = prepare_report_mapping_context(
         prepared.analysis_summary,
+        report_facts=prepared.report_facts,
         test_run=prepared.domain_test_run,
     )
     assert context.domain_aggregate is not None
@@ -177,8 +179,10 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
 
     prepared = prepare_report_input(summary)
     assert prepared.domain_test_run is not None
+    assert prepared.report_facts is not None
     context = prepare_report_mapping_context(
         prepared.analysis_summary,
+        report_facts=prepared.report_facts,
         test_run=prepared.domain_test_run,
     )
     assert context.domain_aggregate is not None
@@ -186,7 +190,7 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
 
     primary = resolve_primary_report_candidate(
         context=context,
-        sensor_intensity=[],
+        facts=prepared.report_facts.primary_candidate_facts,
         tr=lambda key, **kw: tr(lang, key, **kw),
         lang=lang,
     )
@@ -197,33 +201,13 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
     )
 
 
-def test_next_steps_domain_path_is_primary() -> None:
-    """``build_next_steps_from_summary`` must use domain aggregate only.
+def test_next_steps_consume_prepared_actions() -> None:
+    """``build_next_steps`` must accept prepared actions, not summary dicts."""
+    from inspect import signature
 
-    The function must check ``aggregate.recommended_actions`` as its
-    sole source for next steps.  No payload fallback loop should exist.
-    Prevents regression of T12.
-    """
-    from tests._paths import SERVER_ROOT
+    from vibesensor.adapters.pdf.report_sections import build_next_steps
 
-    sections_path = SERVER_ROOT / "vibesensor" / "adapters" / "pdf" / "report_sections.py"
-    source = sections_path.read_text()
-
-    # Find the function body
-    func_start = source.find("def build_next_steps_from_summary(")
-    assert func_start != -1, "build_next_steps_from_summary not found in report_sections.py"
-
-    # Find end of function (next top-level def or end of file)
-    next_def = source.find("\ndef ", func_start + 1)
-    func_body = source[func_start : next_def if next_def != -1 else len(source)]
-
-    # The domain aggregate if-guard must exist
-    domain_guard = func_body.find("if aggregate is not None and aggregate.recommended_actions")
-    assert domain_guard != -1, (
-        "build_next_steps_from_summary must check aggregate.recommended_actions"
-    )
-    # No payload fallback loop should remain
-    payload_loop = func_body.find("for step in summary_steps")
-    assert payload_loop == -1, (
-        "build_next_steps_from_summary must not have a payload fallback loop — domain-only"
-    )
+    params = signature(build_next_steps).parameters
+    assert "recommended_actions" in params
+    assert "summary" not in params
+    assert "aggregate" not in params

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -20,7 +20,6 @@ from vibesensor.adapters.analysis_summary import (
     summarize_run_data,
 )
 from vibesensor.adapters.pdf.mapping import (
-    filter_active_sensor_intensity,
     map_summary,
     prepare_report_input,
     prepare_report_mapping_context,
@@ -125,25 +124,27 @@ def test_report_certainty_uses_confidence_assessment_reason() -> None:
     result = analysis.summarize()
     summary = analysis_result_to_summary(result)
 
-    assert analysis.test_run is not None
-    assert analysis.test_run.speed_profile is not None
+    prepared = prepare_report_input(summary)
+    assert prepared.domain_test_run is not None
+    assert prepared.report_facts is not None
+    assert prepared.domain_test_run.speed_profile is not None
 
-    context = prepare_report_mapping_context(summary, test_run=analysis.test_run)
-
-    sensor_intensity = filter_active_sensor_intensity(
-        summary["sensor_intensity_by_location"],
-        context.sensor_locations_active,
+    context = prepare_report_mapping_context(
+        prepared.analysis_summary,
+        report_facts=prepared.report_facts,
+        test_run=prepared.domain_test_run,
     )
+
     primary = resolve_primary_report_candidate(
         context=context,
-        sensor_intensity=sensor_intensity,
+        facts=prepared.report_facts.primary_candidate_facts,
         tr=lambda key, **_kw: key,
         lang="en",
     )
 
     # Reason must come from ConfidenceAssessment, not from the deleted certainty_label()
-    effective = analysis.test_run.effective_top_causes()
-    domain_primary = effective[0] if effective else analysis.test_run.primary_finding
+    effective = prepared.domain_test_run.effective_top_causes()
+    domain_primary = effective[0] if effective else prepared.domain_test_run.primary_finding
     assert domain_primary is not None
     assert domain_primary.confidence_assessment is not None
     assert primary.certainty_reason == domain_primary.confidence_assessment.reason

--- a/apps/server/vibesensor/adapters/pdf/_candidate_resolver.py
+++ b/apps/server/vibesensor/adapters/pdf/_candidate_resolver.py
@@ -7,12 +7,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.presentation import strength_label, strength_text
-from vibesensor.domain import ConfidenceAssessment, Finding, LocationIntensitySummary
+from vibesensor.domain import ConfidenceAssessment, Finding
 from vibesensor.report_i18n import human_source
-from vibesensor.use_cases.history.report_interpretation import resolve_primary_report_facts
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf.report_context import ReportMappingContext
+    from vibesensor.use_cases.history.report_interpretation import PrimaryReportFacts
 
 __all__ = [
     "PrimaryCandidateContext",
@@ -46,18 +46,12 @@ class PrimaryCandidateContext:
 def resolve_primary_report_candidate(
     *,
     context: ReportMappingContext,
-    sensor_intensity: list[LocationIntensitySummary],
+    facts: PrimaryReportFacts,
     tr: Callable[..., str],
     lang: str,
 ) -> PrimaryCandidateContext:
     """Resolve the primary candidate and all derived certainty fields."""
-    primary_candidate = context.top_report_candidate()
-    facts = resolve_primary_report_facts(
-        aggregate=context.domain_aggregate,
-        origin_location=context.origin_location,
-        sensor_locations_active=context.sensor_locations_active,
-        sensor_intensity=sensor_intensity,
-    )
+    primary_candidate = facts.domain_primary or context.top_report_candidate()
     primary_system = (
         human_source(facts.primary_source, tr=tr) if facts.primary_source else tr("UNKNOWN")
     )

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -37,8 +37,8 @@ from vibesensor.adapters.pdf.report_data import (
     build_report_from_summary,
 )
 from vibesensor.adapters.pdf.report_sections import (
-    build_data_trust_from_summary,
-    build_next_steps_from_summary,
+    build_data_trust,
+    build_next_steps,
 )
 from vibesensor.domain import (
     Finding,
@@ -49,11 +49,8 @@ from vibesensor.report_i18n import human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
-from vibesensor.use_cases.history.report_interpretation import (
-    compute_location_hotspot_rows,
-    filter_active_sensor_intensity,
-)
 from vibesensor.use_cases.history.report_preparation import (
+    PreparedReportFacts,
     PreparedReportInput,
     prepare_report_input,
 )
@@ -65,7 +62,6 @@ __all__ = [
     "ReportMappingContext",
     "build_report_from_summary",
     "build_system_cards",
-    "filter_active_sensor_intensity",
     "humanize_signatures",
     "map_summary",
     "prepare_report_input",
@@ -179,8 +175,11 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
     lang = str(normalize_lang(summary.get("lang")))
     report = build_report_from_summary(summary)
     domain_test_run = prepared.domain_test_run
+    report_facts = prepared.report_facts
     if domain_test_run is None:
         raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
+    if report_facts is None:
+        raise ValueError("PreparedReportInput must include report_facts for report mapping")
 
     def tr(key: str, **kw: object) -> str:
         return str(_tr(lang, key, **kw))
@@ -191,6 +190,7 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
         lang=lang,
         tr=tr,
         test_run=domain_test_run,
+        report_facts=report_facts,
     )
 
 
@@ -214,20 +214,22 @@ def _build_report_template_data(
     lang: str,
     tr: Callable[..., str],
     test_run: TestRun,
+    report_facts: PreparedReportFacts,
 ) -> ReportTemplateData:
     """Map a summary dict into the final report template data structure.
 
     The *report* domain object provides high-level metadata; rendering-
     specific fields are resolved from the full *summary* dict.
     """
-    context = prepare_report_mapping_context(summary, test_run=test_run)
-    raw_sensor_intensity = filter_active_sensor_intensity(
-        summary["sensor_intensity_by_location"],
-        context.sensor_locations_active,
+    context = prepare_report_mapping_context(
+        summary,
+        report_facts=report_facts,
+        test_run=test_run,
     )
+    raw_sensor_intensity = list(report_facts.active_sensor_intensity)
     primary = resolve_primary_report_candidate(
         context=context,
-        sensor_intensity=raw_sensor_intensity,
+        facts=report_facts.primary_candidate_facts,
         tr=tr,
         lang=lang,
     )
@@ -238,17 +240,16 @@ def _build_report_template_data(
         lang,
         tr,
     )
-    next_steps = build_next_steps_from_summary(
-        summary,
-        aggregate=context.domain_aggregate,
+    next_steps = build_next_steps(
+        recommended_actions=report_facts.recommended_actions,
         tier=primary.tier,
         cert_reason=primary.certainty_reason,
         lang=lang,
         tr=tr,
     )
-    data_trust = build_data_trust_from_summary(
-        summary,
-        aggregate=context.domain_aggregate,
+    data_trust = build_data_trust(
+        suitability_checks=report_facts.suitability_checks,
+        warnings=report_facts.warnings,
         lang=lang,
         tr=tr,
     )
@@ -261,7 +262,7 @@ def _build_report_template_data(
     peak_rows = build_peak_rows_from_plots(summary, lang=lang, tr=tr)
     version_marker = build_version_marker()
 
-    hotspot_rows = compute_location_hotspot_rows(raw_sensor_intensity)
+    hotspot_rows = list(report_facts.location_hotspot_rows)
 
     return ReportTemplateData(
         title=tr("DIAGNOSTIC_WORKSHEET"),

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -1,8 +1,8 @@
 """Report context assembly for the PDF mapper.
 
 Owns :class:`ReportMappingContext` plus
-:func:`prepare_report_mapping_context`, which bridge persisted analysis
-summaries into normalized context consumed by ``mapping.py``.
+:func:`prepare_report_mapping_context`, which bridge prepared report facts
+into normalized context consumed by ``mapping.py``.
 """
 
 from __future__ import annotations
@@ -20,14 +20,10 @@ from vibesensor.domain import (
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.use_cases.history.report_interpretation import (
-    normalize_origin_location,
-    resolve_report_origin,
-    tire_spec_text,
-)
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
+    from vibesensor.use_cases.history.report_preparation import PreparedReportFacts
 
 __all__ = [
     "ReportMappingContext",
@@ -112,13 +108,14 @@ class ReportMappingContext:
 def prepare_report_mapping_context(
     summary: AnalysisSummary,
     *,
+    report_facts: PreparedReportFacts,
     test_run: TestRun,
 ) -> ReportMappingContext:
     """Extract structural summary context for report mapping.
 
-    Consumes the prepared domain ``TestRun`` aggregate supplied by the
-    report-preparation seam so downstream business decisions stay
-    domain-first without reconstructing from summary payloads again.
+    Consumes the prepared domain ``TestRun`` aggregate and history-prepared
+    semantic report facts so downstream business decisions stay domain-first
+    without calling back into history-layer interpretation helpers.
     """
     meta = summary["metadata"]
     car_name = str(meta.get("car_name") or "").strip() or None
@@ -126,34 +123,20 @@ def prepare_report_mapping_context(
     report_date = str(summary["report_date"] or "") or utc_now_iso()
     date_str = str(report_date)[:19].replace("T", " ") + " UTC"
 
-    connected = summary["sensor_locations_connected_throughout"]
-    sensor_locations_active = [loc for loc in connected if loc.strip()]
-    if not sensor_locations_active:
-        sensor_locations_active = [loc for loc in summary["sensor_locations"] if loc.strip()]
-
-    domain_aggregate = test_run
-
-    origin = resolve_report_origin(domain_aggregate)
-
-    origin_location = normalize_origin_location(origin)
-
-    config_snap = domain_aggregate.capture.setup.configuration_snapshot
-    rate = config_snap.raw_sample_rate_hz
-
     return ReportMappingContext(
         car_name=car_name,
         car_type=car_type,
         date_str=date_str,
-        origin=origin,
-        origin_location=origin_location,
-        sensor_locations_active=sensor_locations_active,
-        duration_text=summary["record_length"] or None,
-        start_time_utc=str(summary["start_time_utc"] or "").strip() or None,
-        end_time_utc=str(summary["end_time_utc"] or "").strip() or None,
-        sample_rate_hz=f"{rate:g}" if rate is not None else None,
-        tire_spec_text=tire_spec_text(meta),
-        sample_count=domain_aggregate.capture.sample_count,
-        sensor_model=config_snap.sensor_model,
-        firmware_version=config_snap.firmware_version,
-        domain_aggregate=domain_aggregate,
+        origin=report_facts.origin,
+        origin_location=report_facts.origin_location,
+        sensor_locations_active=list(report_facts.sensor_locations_active),
+        duration_text=report_facts.duration_text,
+        start_time_utc=report_facts.start_time_utc,
+        end_time_utc=report_facts.end_time_utc,
+        sample_rate_hz=report_facts.sample_rate_hz,
+        tire_spec_text=report_facts.tire_spec_text,
+        sample_count=report_facts.sample_count,
+        sensor_model=report_facts.sensor_model,
+        firmware_version=report_facts.firmware_version,
+        domain_aggregate=test_run,
     )

--- a/apps/server/vibesensor/adapters/pdf/report_sections.py
+++ b/apps/server/vibesensor/adapters/pdf/report_sections.py
@@ -2,30 +2,28 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from vibesensor.adapters.pdf.report_data import DataTrustItem, NextStep
-from vibesensor.domain import TestRun
+from vibesensor.domain import RecommendedAction
 from vibesensor.report_i18n import is_i18n_ref, resolve_i18n
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
-from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
+from vibesensor.shared.boundaries.analysis_payload import RunSuitabilityCheck, SummaryWarningPayload
 
 __all__ = [
-    "build_data_trust_from_summary",
-    "build_next_steps_from_summary",
+    "build_data_trust",
+    "build_next_steps",
 ]
 
 
-def build_next_steps_from_summary(
-    summary: AnalysisSummary,
+def build_next_steps(
     *,
-    aggregate: TestRun | None,
+    recommended_actions: Sequence[RecommendedAction],
     tier: str,
     cert_reason: str,
     lang: str,
     tr: Callable[..., str],
 ) -> list[NextStep]:
-    """Build next-step actions from a run summary dict."""
+    """Build next-step actions from prepared report facts."""
     if tier == "A":
         return [
             NextStep(action=action, why=cert_reason)
@@ -37,25 +35,24 @@ def build_next_steps_from_summary(
         ]
 
     next_steps: list[NextStep] = []
-    if aggregate is not None and aggregate.recommended_actions:
-        for action in aggregate.recommended_actions:
-            next_steps.append(
-                NextStep(
-                    action=_resolve_step_value(action.instruction, lang=lang, tr=tr),
-                    why=_resolve_optional_step_value(action.rationale, lang=lang, tr=tr),
-                    confirm=_resolve_optional_step_value(
-                        action.confirmation_signal,
-                        lang=lang,
-                        tr=tr,
-                    ),
-                    falsify=_resolve_optional_step_value(
-                        action.falsification_signal,
-                        lang=lang,
-                        tr=tr,
-                    ),
-                    eta=action.estimated_duration,
+    for action in recommended_actions:
+        next_steps.append(
+            NextStep(
+                action=_resolve_step_value(action.instruction, lang=lang, tr=tr),
+                why=_resolve_optional_step_value(action.rationale, lang=lang, tr=tr),
+                confirm=_resolve_optional_step_value(
+                    action.confirmation_signal,
+                    lang=lang,
+                    tr=tr,
                 ),
-            )
+                falsify=_resolve_optional_step_value(
+                    action.falsification_signal,
+                    lang=lang,
+                    tr=tr,
+                ),
+                eta=action.estimated_duration,
+            ),
+        )
     return next_steps
 
 
@@ -79,26 +76,24 @@ def _resolve_optional_step_value(
     return resolved or None
 
 
-def build_data_trust_from_summary(
-    summary: AnalysisSummary,
+def build_data_trust(
     *,
-    aggregate: TestRun | None,
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
     lang: str,
     tr: Callable[..., str],
 ) -> list[DataTrustItem]:
-    """Build the data-trust checklist from run-suitability items."""
+    """Build the data-trust checklist from prepared report facts."""
     data_trust: list[DataTrustItem] = []
-    if aggregate is not None and aggregate.suitability is not None:
-        projected = run_suitability_payload(aggregate.suitability)
-        for proj in projected:
-            data_trust.append(
-                DataTrustItem(
-                    check=_resolve_check_text(proj.get("check_key"), lang=lang, tr=tr),
-                    state=str(proj.get("state") or "warn"),
-                    detail=_resolve_detail_text(proj.get("explanation"), lang=lang, tr=tr),
-                ),
-            )
-    for warning in summary["warnings"]:
+    for proj in suitability_checks:
+        data_trust.append(
+            DataTrustItem(
+                check=_resolve_check_text(proj.get("check_key"), lang=lang, tr=tr),
+                state=str(proj.get("state") or "warn"),
+                detail=_resolve_detail_text(proj.get("explanation"), lang=lang, tr=tr),
+            ),
+        )
+    for warning in warnings:
         data_trust.append(
             DataTrustItem(
                 check=_resolve_detail_text(warning.get("title"), lang=lang, tr=tr) or "",

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -2,16 +2,37 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from vibesensor.domain import (
+    LocationHotspotRow,
+    LocationIntensitySummary,
+    RecommendedAction,
+    VibrationOrigin,
+)
 from vibesensor.report_i18n import normalize_lang
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.boundaries.analysis_payload import (
+    AnalysisSummary,
+    RunSuitabilityCheck,
+    SummaryWarningPayload,
+)
 from vibesensor.shared.boundaries.analysis_summary import analysis_summary_with_warnings
 from vibesensor.shared.boundaries.diagnostic_case import test_run_from_summary
+from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.helpers import safe_filename
 from vibesensor.use_cases.history.report_cache import ReportPdfCacheKey
+from vibesensor.use_cases.history.report_interpretation import (
+    PrimaryReportFacts,
+    compute_location_hotspot_rows,
+    filter_active_sensor_intensity,
+    normalize_origin_location,
+    resolve_primary_report_facts,
+    resolve_report_origin,
+    tire_spec_text,
+)
 
 if TYPE_CHECKING:
     from vibesensor.domain import TestRun
@@ -29,6 +50,29 @@ def _default_report_filename(summary: AnalysisSummary) -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class PreparedReportFacts:
+    """History-prepared semantic report facts consumed by the PDF adapter."""
+
+    origin: VibrationOrigin | None
+    origin_location: str
+    sensor_locations_active: tuple[str, ...]
+    duration_text: str | None
+    start_time_utc: str | None
+    end_time_utc: str | None
+    sample_rate_hz: str | None
+    tire_spec_text: str | None
+    sample_count: int
+    sensor_model: str | None
+    firmware_version: str | None
+    active_sensor_intensity: tuple[LocationIntensitySummary, ...]
+    location_hotspot_rows: tuple[LocationHotspotRow, ...]
+    primary_candidate_facts: PrimaryReportFacts
+    recommended_actions: tuple[RecommendedAction, ...]
+    suitability_checks: tuple[RunSuitabilityCheck, ...]
+    warnings: tuple[SummaryWarningPayload, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedReportInput:
     """Resolved report input ready for PDF mapping and rendering.
 
@@ -37,6 +81,8 @@ class PreparedReportInput:
       authoritative internal report representation.
     - ``domain_test_run`` is reconstructed at most once and shared across the
       downstream PDF mapping helpers as the authoritative report aggregate.
+    - ``report_facts`` contains the semantic report facts that the PDF adapter
+      needs so it does not have to call back into history-layer interpretation.
     - ``language`` is canonicalized and copied back onto ``analysis_summary`` so
       renderer helpers consume one consistent locale choice.
     """
@@ -46,12 +92,83 @@ class PreparedReportInput:
     filename: str
     domain_test_run: TestRun | None
     cache_key: ReportPdfCacheKey | None = None
+    report_facts: PreparedReportFacts | None = None
 
 
 def _reconstruct_report_test_run(analysis_summary: AnalysisSummary) -> TestRun | None:
     if not _has_projectable_analysis(analysis_summary):
         return None
     return test_run_from_summary(analysis_summary)
+
+
+def _summary_metadata(summary: AnalysisSummary) -> Mapping[str, object]:
+    metadata = summary.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _active_sensor_locations(summary: AnalysisSummary) -> tuple[str, ...]:
+    connected = summary.get("sensor_locations_connected_throughout")
+    locations = connected if isinstance(connected, list) else []
+    active = tuple(str(loc).strip() for loc in locations if str(loc).strip())
+    if active:
+        return active
+    fallback = summary.get("sensor_locations")
+    fallback_locations = fallback if isinstance(fallback, list) else []
+    return tuple(str(loc).strip() for loc in fallback_locations if str(loc).strip())
+
+
+def _summary_warnings(summary: AnalysisSummary) -> tuple[SummaryWarningPayload, ...]:
+    warnings = summary.get("warnings")
+    if not isinstance(warnings, list):
+        return ()
+    return tuple(warning for warning in warnings if isinstance(warning, dict))
+
+
+def _prepare_report_facts(
+    analysis_summary: AnalysisSummary,
+    *,
+    test_run: TestRun,
+) -> PreparedReportFacts:
+    metadata = _summary_metadata(analysis_summary)
+    sensor_locations_active = _active_sensor_locations(analysis_summary)
+    origin = resolve_report_origin(test_run)
+    origin_location = normalize_origin_location(origin)
+    config_snap = test_run.capture.setup.configuration_snapshot
+    active_sensor_intensity = tuple(
+        filter_active_sensor_intensity(
+            analysis_summary.get("sensor_intensity_by_location") or [],
+            sensor_locations_active,
+        )
+    )
+    primary_candidate_facts = resolve_primary_report_facts(
+        aggregate=test_run,
+        origin_location=origin_location,
+        sensor_locations_active=sensor_locations_active,
+        sensor_intensity=active_sensor_intensity,
+    )
+    return PreparedReportFacts(
+        origin=origin,
+        origin_location=origin_location,
+        sensor_locations_active=sensor_locations_active,
+        duration_text=str(analysis_summary.get("record_length") or "").strip() or None,
+        start_time_utc=str(analysis_summary.get("start_time_utc") or "").strip() or None,
+        end_time_utc=str(analysis_summary.get("end_time_utc") or "").strip() or None,
+        sample_rate_hz=(
+            f"{config_snap.raw_sample_rate_hz:g}"
+            if config_snap.raw_sample_rate_hz is not None
+            else None
+        ),
+        tire_spec_text=tire_spec_text(metadata),
+        sample_count=test_run.capture.sample_count,
+        sensor_model=config_snap.sensor_model,
+        firmware_version=config_snap.firmware_version,
+        active_sensor_intensity=active_sensor_intensity,
+        location_hotspot_rows=tuple(compute_location_hotspot_rows(active_sensor_intensity)),
+        primary_candidate_facts=primary_candidate_facts,
+        recommended_actions=test_run.recommended_actions,
+        suitability_checks=tuple(run_suitability_payload(test_run.suitability)),
+        warnings=_summary_warnings(analysis_summary),
+    )
 
 
 def _build_prepared_report_input(
@@ -65,12 +182,18 @@ def _build_prepared_report_input(
     prepared_summary = cast(AnalysisSummary, dict(analysis_summary))
     prepared_language = str(normalize_lang(language or prepared_summary.get("lang")))
     prepared_summary["lang"] = prepared_language
+    report_facts = (
+        _prepare_report_facts(prepared_summary, test_run=domain_test_run)
+        if domain_test_run is not None
+        else None
+    )
     return PreparedReportInput(
         analysis_summary=prepared_summary,
         language=prepared_language,
         filename=filename or _default_report_filename(prepared_summary),
         domain_test_run=domain_test_run,
         cache_key=cache_key,
+        report_facts=report_facts,
     )
 
 

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -177,8 +177,10 @@ After `RunAnalysis.summarize()` returns, `PostAnalysisWorker`:
 
 History readers unwrap the envelope back to the summary shape.
 Report endpoints rebuild `ReportTemplateData` from that summary on demand
-via `use_cases/history/report_preparation.py:prepare_report_input()` and
-`adapters/pdf/mapping.py:map_summary()`.
+via `use_cases/history/report_preparation.py:prepare_report_input()`, which
+reconstructs the domain aggregate and precomputes semantic report facts, and
+`adapters/pdf/mapping.py:map_summary()`, which stays focused on adapter-local
+mapping and rendering data assembly.
 
 Persisted post-stop analysis strength/intensity outputs are dB-only.
 Raw ingest/sample acceleration fields may still be expressed in g.
@@ -191,6 +193,8 @@ Raw ingest/sample acceleration fields may still be expressed in g.
    pipeline.
 3. If the new output is needed by the renderer, add any report-facing shaping
    in `use_cases/history/report_preparation.py`, then update
-   `adapters/pdf/mapping.py:map_summary()` and `ReportTemplateData`.
+   `adapters/pdf/mapping.py:map_summary()` and `ReportTemplateData`. Keep
+   semantic interpretation on the history/preparation side rather than in
+   `adapters/pdf/*`.
 4. Export any new public symbol from `use_cases/diagnostics/__init__.py`.
 5. Run `pytest apps/server/tests/` to verify tests still pass.

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -11,10 +11,11 @@ The report generation pipeline has two distinct phases:
 2. **History-side report preparation + rendering** (`vibesensor.use_cases.history`
    → `vibesensor.adapters.pdf`) — loads the persisted analysis object, shapes
    runtime warnings and cache metadata, prepares one explicit
-   `PreparedReportInput` with an authoritative reconstructed domain aggregate,
-   maps that prepared input to `ReportTemplateData`, and renders a PDF. This
-   phase performs **zero analysis** — it only shapes persisted report data and
-   formats pre-computed results.
+   `PreparedReportInput` with an authoritative reconstructed domain aggregate
+   plus precomputed semantic report facts, maps that prepared input to
+   `ReportTemplateData`, and renders a PDF. This phase performs **zero
+   analysis** — it only shapes persisted report data and formats pre-computed
+   results.
 
 ```text
 Recording stops
@@ -25,7 +26,7 @@ Recording stops
       → analysis_result_to_summary() [vibesensor.shared.boundaries.analysis_summary]
       → findings.py + _reference_findings.py + _context_decode.py/_context_projection.py + _sample_metrics.py + _analysis_models.py + orders/{pipeline,matching,scoring,finding_builder,statistics,heuristics,settings}.py + peaks/{findings,accumulation,classification,scoring,finding_builder,statistics,settings,table}.py + signal_aggregation.py + top_cause_selection.py + plots.py
     → map_summary() [vibesensor.adapters.pdf.mapping]
-      → report_context.py (context assembly, card decisions) + mapping.py (thin template mapper) + peak_table.py + report_sections.py
+      → report_context.py (adapter-local context over prepared facts) + mapping.py (thin template mapper) + peak_table.py + report_sections.py
     → store_analysis() [vibesensor.adapters.persistence.history_db]
 
 GET /api/history/{run_id}/report.pdf [vibesensor.adapters.http.history]
@@ -58,7 +59,7 @@ The `vibesensor.adapters.pdf` package contains **only** rendering code:
 | `pdf_drawing.py`, `pdf_text.py` | Shared drawing and text helpers |
 | `pdf_diagram_render.py` | Diagram planning, drawing, and location normalization |
 | `report_data.py` | Dataclass definitions (pure data) |
-| `report_context.py` | Context assembly and card decisions over a prepared summary + prebuilt domain aggregate |
+| `report_context.py` | Thin adapter-local context wrapper over prepared report facts + prebuilt domain aggregate |
 | `mapping.py` | Thin mapper: `PreparedReportInput` → `ReportTemplateData` |
 | `presentation.py` | Rendering-only label helpers (strength/order/classification text) |
 | `peak_table.py` | Peak-row builders for the report evidence table |
@@ -71,12 +72,15 @@ enforces this.
 
 History-side report preparation now lives in
 `vibesensor.use_cases.history.report_preparation`, which owns the explicit
-`PreparedReportInput` seam passed into the PDF adapter and reconstructs the
-authoritative domain aggregate exactly once. Pure report-domain interpretation
-that reads domain findings/test runs but does not perform i18n or PDF
-dataclass assembly still lives in
-`vibesensor.use_cases.history.report_interpretation`, which the PDF adapter
-consumes without reloading or reprojecting persisted summaries.
+`PreparedReportInput` seam passed into the PDF adapter, reconstructs the
+authoritative domain aggregate exactly once, and precomputes the semantic
+report facts the adapter needs (origin, active sensor intensity, hotspot rows,
+primary-candidate facts, next-step inputs, and data-trust inputs). Pure
+report-domain interpretation that reads domain findings/test runs but does not
+perform i18n or PDF dataclass assembly still lives in
+`vibesensor.use_cases.history.report_interpretation`, but it is now consumed by
+history-side preparation rather than imported directly by `adapters.pdf`
+modules.
 
 ### ReportTemplateData schema
 
@@ -118,4 +122,5 @@ needs:
    `vibesensor.use_cases.history.report_preparation`, then populate the final
    renderer field in `map_summary()` in `vibesensor.adapters.pdf.mapping`.
 4. Render the new field through `pdf_engine.py`, usually by wiring it into the relevant page or section module under `vibesensor.adapters.pdf`.
-5. Never add analysis logic to the renderer package — always pre-compute.
+5. Never add history/report semantic interpretation logic to the renderer
+   package — always pre-compute it in `report_preparation.py`.


### PR DESCRIPTION
## Summary

Closes #1143.

This PR tightens the remaining PDF/report layering seam by moving report-semantic fact preparation fully onto the history-side `PreparedReportInput` boundary. Before this change, the persisted history seam from #1142 was already domain-first, but the PDF adapter still finished too much semantic work on its own: it imported `use_cases.history.report_interpretation`, filtered active sensor intensity rows, derived hotspot rows, resolved primary-candidate facts, and combined summary warnings plus run-suitability state inside adapter modules. That left the report package in an awkward middle state where it was no longer reconstructing the domain aggregate from summary payloads, but it was still computing history/report facts after the preparation seam had supposedly finished.

The implementation here makes the seam more honest. `report_preparation.py` now computes a `PreparedReportFacts` snapshot alongside the authoritative `TestRun`, and the PDF package consumes that prepared state instead of calling back into history interpretation helpers. The adapter still owns mapping, localization, and renderer-facing formatting, but it no longer decides which report facts to derive from the summary/domain pair on the fly.

## What changed

### 1. `PreparedReportInput` now carries prepared report facts, not just the reconstructed aggregate

The core change is in `apps/server/vibesensor/use_cases/history/report_preparation.py`. I added a new `PreparedReportFacts` dataclass and populated it during both direct-summary and persisted-history preparation. That prepared fact bundle includes the semantic report inputs the PDF adapter had still been deriving for itself:

- resolved origin and origin location,
- active sensor locations,
- filtered active sensor-intensity rows,
- precomputed location hotspot rows,
- primary-candidate facts from `resolve_primary_report_facts()`,
- recommended actions,
- projected run-suitability checks,
- summary warnings,
- prepared display metadata such as duration, timestamps, sample rate, tire spec text, sample count, sensor model, and firmware version.

That means the history-side preparation seam now owns the semantic shaping work the adapter used to perform after the handoff.

### 2. PDF adapter modules no longer import `use_cases.history.report_interpretation`

The adapter changes were intentionally surgical. `mapping.py`, `report_context.py`, `_candidate_resolver.py`, and `report_sections.py` now consume prepared facts instead of importing history helpers.

Concretely:

- `mapping.py` no longer imports `compute_location_hotspot_rows()` or `filter_active_sensor_intensity()` from the history layer.
- `report_context.py` now takes `PreparedReportFacts` and acts as a thin adapter-local wrapper over already prepared report state instead of resolving origin/tire/active-sensor facts itself.
- `_candidate_resolver.py` now formats an already prepared `PrimaryReportFacts` object into `PrimaryCandidateContext` rather than recalculating those facts from the domain aggregate and sensor-intensity rows.
- `report_sections.py` no longer takes a raw summary plus aggregate pair. It now consumes narrowed prepared inputs: recommended actions, suitability checks, and warnings.

This is the real architectural outcome for #1143: the adapter still maps and localizes, but it stops asking the history layer to finish the report’s semantic preparation after the boundary seam has already been crossed.

### 3. The section builders now reflect the prepared-facts boundary explicitly

The previous section builders were still named and shaped around raw summary traversal. I changed them so they consume the prepared semantic inputs directly.

`build_next_steps()` now accepts prepared recommended actions plus the tier/certainty context produced during mapping.

`build_data_trust()` now accepts prepared suitability checks plus warnings, instead of reaching back through the aggregate and summary payload.

That change matters because `report_sections.py` was one of the clearest examples of the adapter still owning history/report interpretation logic. After this PR, it only performs section-level rendering preparation over data that has already been semantically shaped upstream.

### 4. Guardrails and focused tests were updated to match the new seam

I updated the focused PDF/report tests to pass `prepared.report_facts` through the new seam and to resolve primary candidates from prepared facts rather than by recomputing history-layer data inside the adapter. I also added a runtime import guard to prove that importing the PDF package no longer pulls in `vibesensor.use_cases.history.report_interpretation` at module import time.

That guard required a little care to keep the test reversible; the final version restores the original package/module objects so later tests do not see stale or mixed module identities.

### 5. Docs now describe the real layering

I updated `docs/report_pipeline.md` and `docs/analysis_pipeline.md` so they no longer imply that the PDF adapter consumes `report_interpretation` helpers directly. The docs now describe the post-#1143 boundary accurately: history-side preparation reconstructs the domain aggregate once and precomputes the semantic report facts, while the adapter stays focused on mapping and rendering.

## Why this approach

I deliberately kept this PR scoped to the remaining adapter/package layering seam rather than expanding into broader contract unification work from #1144. The goal here is not to redesign every report-facing type. The goal is to make the `PreparedReportInput` seam truthful enough that `adapters/pdf` can stop depending on history interpretation helpers and raw summary-plus-aggregate combinations.

I also avoided pushing adapter dataclasses back into the use-case layer. Instead, history preparation now produces a narrow semantic fact bundle, and the adapter continues to own final localization and `ReportTemplateData` assembly. That keeps the dependency direction sane while still moving the report-semantic work upstream.

## Validation

Focused seam validation:

- `python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/adapters/pdf/test_report_analysis_separation.py apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/adapters/pdf/test_report_mapping_context.py`
- Result: `81 passed`

Broader report/history regression slice:

- `python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf apps/server/tests/integration/test_report_pipeline.py apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/integration/test_contract_analysis_report.py`
- Result: `589 passed`

Repository checks:

- `make lint`
- `make typecheck-backend`

Both passed after the refactor.

I also attempted the required local Docker smoke (`docker compose build --pull && docker compose up -d`), but the environment here does not have a working Docker daemon/socket, so the compose step failed before the stack could start. I’m calling that out explicitly rather than pretending the runtime smoke completed. CI should still exercise the Docker/E2E path once the PR is open.

## Risks and tradeoffs

The main risk was moving just enough semantic work upstream without turning `PreparedReportInput` into a renderer-specific blob. I mitigated that by keeping the prepared bundle report-semantic rather than PDF-layout-specific: origin facts, primary-candidate facts, hotspot rows, warnings, suitability checks, and recommended actions are still meaningful outside the final page renderer.

The other meaningful risk was test flakiness from the new runtime import guard. The final test restores both `sys.modules` entries and the `vibesensor.adapters.pdf` package attributes so later tests keep stable module identities.

## Out of scope

This PR does not try to unify boundary and HTTP contracts from #1144, and it does not attempt a larger decomposition of shared catch-all type modules from #1145. It also does not change persisted or HTTP report schemas. The visible PDF output should remain stable; this is an internal seam cleanup that narrows where report semantics are prepared.
