### PR TITLE
Consolidate shared history-analysis contracts

### DIFF
--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -3,13 +3,30 @@ from __future__ import annotations
 from typing import Protocol
 
 import pytest
-from pydantic import BaseModel
 
 from vibesensor.shared.boundaries.analysis_payload import (
     AmplitudeMetric as BoundaryAmplitudeMetric,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
     AmpVsPhaseRow as BoundaryAmpVsPhaseRow,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    AnalysisSummary as BoundaryAnalysisSummary,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    DataQualityAccelSanityPayload as BoundaryDataQualityAccelSanityPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    DataQualityOutliersPayload as BoundaryDataQualityOutliersPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    DataQualityPayload as BoundaryDataQualityPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    DataQualityRequiredMissingPctPayload as BoundaryDataQualityRequiredMissingPctPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    DataQualitySpeedCoveragePayload as BoundaryDataQualitySpeedCoveragePayload,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
     FindingEvidenceMetrics as BoundaryFindingEvidenceMetrics,
@@ -24,10 +41,16 @@ from vibesensor.shared.boundaries.analysis_payload import (
     LocationHotspotPayload as BoundaryLocationHotspotPayload,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
+    LocationIntensitySummaryPayload as BoundaryLocationIntensitySummaryPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
     MatchedAmpVsSpeedSeries as BoundaryMatchedAmpVsSpeedSeries,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
     MatchedPoint as BoundaryMatchedPoint,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    OutlierSummaryPayload as BoundaryOutlierSummaryPayload,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
     PeakTableRow as BoundaryPeakTableRow,
@@ -39,10 +62,22 @@ from vibesensor.shared.boundaries.analysis_payload import (
     PhaseEvidence as BoundaryPhaseEvidence,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
+    PhaseInfoPayload as BoundaryPhaseInfoPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    PhaseIntensityStatsPayload as BoundaryPhaseIntensityStatsPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
     PhaseSegmentOut as BoundaryPhaseSegmentOut,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
+    PhaseSegmentSummaryPayload as BoundaryPhaseSegmentSummaryPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
     PhaseSpeedBreakdownRow as BoundaryPhaseSpeedBreakdownRow,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    PhaseTimelineEntryPayload as BoundaryPhaseTimelineEntryPayload,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
     PlotDataResult as BoundaryPlotDataResult,
@@ -56,11 +91,44 @@ from vibesensor.shared.boundaries.analysis_payload import (
 from vibesensor.shared.boundaries.analysis_payload import (
     SpeedBreakdownRow as BoundarySpeedBreakdownRow,
 )
+from vibesensor.shared.boundaries.analysis_payload import (
+    SpeedStatsPayload as BoundarySpeedStatsPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    StrengthBucketDistributionPayload as BoundaryStrengthBucketDistributionPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    SummaryWarningPayload as BoundarySummaryWarningPayload,
+)
+from vibesensor.shared.boundaries.analysis_payload import (
+    TestPlanStepPayload as BoundaryTestPlanStepPayload,
+)
+from vibesensor.shared.boundaries.vibration_origin import (
+    SuspectedVibrationOrigin as BoundarySuspectedVibrationOrigin,
+)
 from vibesensor.shared.types.api_models.history import (
     AmplitudeMetric as ApiAmplitudeMetric,
 )
 from vibesensor.shared.types.api_models.history import (
     AmpVsPhaseRow as ApiAmpVsPhaseRow,
+)
+from vibesensor.shared.types.api_models.history import (
+    AnalysisSummaryResponse as ApiAnalysisSummaryResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    DataQualityAccelSanityResponse as ApiDataQualityAccelSanityResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    DataQualityOutliersResponse as ApiDataQualityOutliersResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    DataQualityRequiredMissingPctResponse as ApiDataQualityRequiredMissingPctResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    DataQualityResponse as ApiDataQualityResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    DataQualitySpeedCoverageResponse as ApiDataQualitySpeedCoverageResponse,
 )
 from vibesensor.shared.types.api_models.history import (
     FindingEvidenceMetrics as ApiFindingEvidenceMetrics,
@@ -75,10 +143,16 @@ from vibesensor.shared.types.api_models.history import (
     LocationHotspotPayload as ApiLocationHotspotPayload,
 )
 from vibesensor.shared.types.api_models.history import (
+    LocationIntensitySummaryResponse as ApiLocationIntensitySummaryResponse,
+)
+from vibesensor.shared.types.api_models.history import (
     MatchedAmpVsSpeedSeries as ApiMatchedAmpVsSpeedSeries,
 )
 from vibesensor.shared.types.api_models.history import (
     MatchedPoint as ApiMatchedPoint,
+)
+from vibesensor.shared.types.api_models.history import (
+    OutlierSummaryResponse as ApiOutlierSummaryResponse,
 )
 from vibesensor.shared.types.api_models.history import (
     PeakTableRow as ApiPeakTableRow,
@@ -90,10 +164,22 @@ from vibesensor.shared.types.api_models.history import (
     PhaseEvidence as ApiPhaseEvidence,
 )
 from vibesensor.shared.types.api_models.history import (
+    PhaseInfoResponse as ApiPhaseInfoResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    PhaseIntensityStatsResponse as ApiPhaseIntensityStatsResponse,
+)
+from vibesensor.shared.types.api_models.history import (
     PhaseSegmentOut as ApiPhaseSegmentOut,
 )
 from vibesensor.shared.types.api_models.history import (
+    PhaseSegmentSummaryResponse as ApiPhaseSegmentSummaryResponse,
+)
+from vibesensor.shared.types.api_models.history import (
     PhaseSpeedBreakdownRow as ApiPhaseSpeedBreakdownRow,
+)
+from vibesensor.shared.types.api_models.history import (
+    PhaseTimelineEntryResponse as ApiPhaseTimelineEntryResponse,
 )
 from vibesensor.shared.types.api_models.history import (
     PlotDataResult as ApiPlotDataResult,
@@ -107,6 +193,21 @@ from vibesensor.shared.types.api_models.history import (
 from vibesensor.shared.types.api_models.history import (
     SpeedBreakdownRow as ApiSpeedBreakdownRow,
 )
+from vibesensor.shared.types.api_models.history import (
+    SpeedStatsResponse as ApiSpeedStatsResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    StrengthBucketDistributionResponse as ApiStrengthBucketDistributionResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    SummaryWarningResponse as ApiSummaryWarningResponse,
+)
+from vibesensor.shared.types.api_models.history import (
+    SuspectedVibrationOriginPayload as ApiSuspectedVibrationOriginPayload,
+)
+from vibesensor.shared.types.api_models.history import (
+    TestPlanStepResponse as ApiTestPlanStepResponse,
+)
 
 
 class TypedDictClass(Protocol):
@@ -114,26 +215,39 @@ class TypedDictClass(Protocol):
     __optional_keys__: frozenset[str]
 
 
-PydanticModelType = type[BaseModel]
-
-
-def _typed_dict_fields(typed_dict: TypedDictClass) -> set[str]:
-    return set(typed_dict.__required_keys__) | set(typed_dict.__optional_keys__)
-
-
-def _pydantic_fields(model: PydanticModelType) -> set[str]:
-    return set(model.model_fields)
-
-
 @pytest.mark.parametrize(
     ("name", "boundary_shape", "api_shape"),
     [
+        ("AmplitudeMetric", BoundaryAmplitudeMetric, ApiAmplitudeMetric),
+        ("AnalysisSummary", BoundaryAnalysisSummary, ApiAnalysisSummaryResponse),
         ("AmpVsPhaseRow", BoundaryAmpVsPhaseRow, ApiAmpVsPhaseRow),
+        (
+            "DataQualityAccelSanityPayload",
+            BoundaryDataQualityAccelSanityPayload,
+            ApiDataQualityAccelSanityResponse,
+        ),
+        (
+            "DataQualityOutliersPayload",
+            BoundaryDataQualityOutliersPayload,
+            ApiDataQualityOutliersResponse,
+        ),
+        ("DataQualityPayload", BoundaryDataQualityPayload, ApiDataQualityResponse),
+        (
+            "DataQualityRequiredMissingPctPayload",
+            BoundaryDataQualityRequiredMissingPctPayload,
+            ApiDataQualityRequiredMissingPctResponse,
+        ),
+        (
+            "DataQualitySpeedCoveragePayload",
+            BoundaryDataQualitySpeedCoveragePayload,
+            ApiDataQualitySpeedCoverageResponse,
+        ),
         (
             "FindingEvidenceMetrics",
             BoundaryFindingEvidenceMetrics,
             ApiFindingEvidenceMetrics,
         ),
+        ("FindingPayload", BoundaryFindingPayload, ApiFindingPayload),
         (
             "FreqVsSpeedByFindingSeries",
             BoundaryFreqVsSpeedByFindingSeries,
@@ -141,51 +255,63 @@ def _pydantic_fields(model: PydanticModelType) -> set[str]:
         ),
         ("LocationHotspotPayload", BoundaryLocationHotspotPayload, ApiLocationHotspotPayload),
         (
+            "LocationIntensitySummaryPayload",
+            BoundaryLocationIntensitySummaryPayload,
+            ApiLocationIntensitySummaryResponse,
+        ),
+        (
             "MatchedAmpVsSpeedSeries",
             BoundaryMatchedAmpVsSpeedSeries,
             ApiMatchedAmpVsSpeedSeries,
         ),
         ("MatchedPoint", BoundaryMatchedPoint, ApiMatchedPoint),
+        ("OutlierSummaryPayload", BoundaryOutlierSummaryPayload, ApiOutlierSummaryResponse),
         ("PeakTableRow", BoundaryPeakTableRow, ApiPeakTableRow),
         ("PhaseBoundary", BoundaryPhaseBoundary, ApiPhaseBoundary),
         ("PhaseEvidence", BoundaryPhaseEvidence, ApiPhaseEvidence),
+        ("PhaseInfoPayload", BoundaryPhaseInfoPayload, ApiPhaseInfoResponse),
+        (
+            "PhaseIntensityStatsPayload",
+            BoundaryPhaseIntensityStatsPayload,
+            ApiPhaseIntensityStatsResponse,
+        ),
         ("PhaseSegmentOut", BoundaryPhaseSegmentOut, ApiPhaseSegmentOut),
+        (
+            "PhaseSegmentSummaryPayload",
+            BoundaryPhaseSegmentSummaryPayload,
+            ApiPhaseSegmentSummaryResponse,
+        ),
         ("PhaseSpeedBreakdownRow", BoundaryPhaseSpeedBreakdownRow, ApiPhaseSpeedBreakdownRow),
+        (
+            "PhaseTimelineEntryPayload",
+            BoundaryPhaseTimelineEntryPayload,
+            ApiPhaseTimelineEntryResponse,
+        ),
         ("PlotDataResult", BoundaryPlotDataResult, ApiPlotDataResult),
+        ("RunSuitabilityCheck", BoundaryRunSuitabilityCheck, ApiRunSuitabilityCheck),
         ("SpectrogramResult", BoundarySpectrogramResult, ApiSpectrogramResult),
         ("SpeedBreakdownRow", BoundarySpeedBreakdownRow, ApiSpeedBreakdownRow),
+        ("SpeedStatsPayload", BoundarySpeedStatsPayload, ApiSpeedStatsResponse),
+        (
+            "StrengthBucketDistributionPayload",
+            BoundaryStrengthBucketDistributionPayload,
+            ApiStrengthBucketDistributionResponse,
+        ),
+        ("SummaryWarningPayload", BoundarySummaryWarningPayload, ApiSummaryWarningResponse),
+        (
+            "SuspectedVibrationOrigin",
+            BoundarySuspectedVibrationOrigin,
+            ApiSuspectedVibrationOriginPayload,
+        ),
+        ("TestPlanStepPayload", BoundaryTestPlanStepPayload, ApiTestPlanStepResponse),
     ],
 )
-def test_exact_shared_shapes_have_single_owner_alias(
+def test_shared_analysis_history_shapes_have_single_owner_alias(
     name: str,
     boundary_shape: TypedDictClass,
     api_shape: TypedDictClass,
 ) -> None:
     assert boundary_shape is api_shape, (
         f"{name} should be re-exported from one shared owner instead of "
-        "duplicated in analysis_payload and api_models.history"
-    )
-
-
-@pytest.mark.parametrize(
-    ("name", "typed_dict", "model"),
-    [
-        ("AmplitudeMetric", BoundaryAmplitudeMetric, ApiAmplitudeMetric),
-        ("FindingPayload", BoundaryFindingPayload, ApiFindingPayload),
-        ("RunSuitabilityCheck", BoundaryRunSuitabilityCheck, ApiRunSuitabilityCheck),
-    ],
-)
-def test_remaining_boundary_typed_dict_fields_match_http_api_models(
-    name: str,
-    typed_dict: TypedDictClass,
-    model: PydanticModelType,
-) -> None:
-    boundary_fields = _typed_dict_fields(typed_dict)
-    api_fields = _pydantic_fields(model)
-
-    assert api_fields == boundary_fields, (
-        f"{name} drifted between shared.boundaries.analysis_payload and "
-        f"shared.types.api_models.history: "
-        f"typed_dict_only={sorted(boundary_fields - api_fields)}, "
-        f"api_model_only={sorted(api_fields - boundary_fields)}"
+        "duplicated across boundary and api_models.history modules"
     )

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import TypeAdapter
 
 from vibesensor.adapters.http._helpers import domain_errors_to_http
 from vibesensor.shared.types.api_models import (
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
         HistoryReportServiceProtocol,
         HistoryRunServiceProtocol,
     )
+
+_HISTORY_INSIGHTS_ADAPTER = TypeAdapter(HistoryInsightsResponse)
 
 
 def create_history_routes(
@@ -65,7 +68,11 @@ def create_history_routes(
                 status_code=202,
                 content=analyzing_response.model_dump(),
             )
-        return HistoryInsightsResponse.model_validate(result)
+        validated = _HISTORY_INSIGHTS_ADAPTER.validate_python(result)
+        return cast(
+            HistoryInsightsResponse,
+            _HISTORY_INSIGHTS_ADAPTER.dump_python(validated, mode="json"),
+        )
 
     @router.delete("/api/history/{run_id}", response_model=DeleteHistoryRunResponse)
     async def delete_history_run(run_id: str) -> DeleteHistoryRunResponse:

--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -1,14 +1,14 @@
 """Boundary serialization types for analysis payloads.
 
-These TypedDicts define the wire/persistence shapes for analysis data
-that crosses the domain-adapter boundary. Stable exact history/view shapes
-shared with the HTTP layer live in ``shared.types.analysis_views``; this
-module keeps the boundary-specific wrappers and composite payload owners.
+These aliases define the wire/persistence shapes for analysis data that
+crosses the domain-adapter boundary. Stable exact history/view shapes shared
+with the HTTP layer live in ``shared.types.analysis_views``; shared
+analysis/history wrapper and composite owners live in
+``shared.types.history_analysis_contracts`` and are re-exported here under
+boundary-friendly payload names.
 """
 
 from __future__ import annotations
-
-from typing import TYPE_CHECKING, Literal, NotRequired, Required, TypedDict
 
 from vibesensor.shared.types.analysis_views import (
     AmpVsPhaseRow,
@@ -26,293 +26,92 @@ from vibesensor.shared.types.analysis_views import (
     SpectrogramResult,
     SpeedBreakdownRow,
 )
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
-
-if TYPE_CHECKING:
-    from vibesensor.shared.boundaries.vibration_origin import SuspectedVibrationOrigin
+from vibesensor.shared.types.history_analysis_contracts import (
+    AmplitudeMetric,
+    FindingPayload,
+    RunSuitabilityCheck,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummaryResponse as AnalysisSummary,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    DataQualityAccelSanityResponse as DataQualityAccelSanityPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    DataQualityOutliersResponse as DataQualityOutliersPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    DataQualityRequiredMissingPctResponse as DataQualityRequiredMissingPctPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    DataQualityResponse as DataQualityPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    DataQualitySpeedCoverageResponse as DataQualitySpeedCoveragePayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    LocationIntensitySummaryResponse as LocationIntensitySummaryPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    OutlierSummaryResponse as OutlierSummaryPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    PhaseInfoResponse as PhaseInfoPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    PhaseIntensityStatsResponse as PhaseIntensityStatsPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    PhaseSegmentSummaryResponse as PhaseSegmentSummaryPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    PhaseTimelineEntryResponse as PhaseTimelineEntryPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    SpeedStatsResponse as SpeedStatsPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    StrengthBucketDistributionResponse as StrengthBucketDistributionPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    SummaryWarningResponse as SummaryWarningPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    TestPlanStepResponse as TestPlanStepPayload,
+)
 
 __all__ = [
     "AmpVsPhaseRow",
     "AmplitudeMetric",
     "AnalysisSummary",
+    "DataQualityAccelSanityPayload",
+    "DataQualityOutliersPayload",
+    "DataQualityPayload",
+    "DataQualityRequiredMissingPctPayload",
+    "DataQualitySpeedCoveragePayload",
     "FindingEvidenceMetrics",
     "FindingPayload",
     "FreqVsSpeedByFindingSeries",
     "LocationHotspotPayload",
+    "LocationIntensitySummaryPayload",
     "MatchedAmpVsSpeedSeries",
     "MatchedPoint",
+    "OutlierSummaryPayload",
     "PeakTableRow",
     "PhaseBoundary",
     "PhaseEvidence",
+    "PhaseInfoPayload",
+    "PhaseIntensityStatsPayload",
     "PhaseSegmentOut",
+    "PhaseSegmentSummaryPayload",
     "PhaseSpeedBreakdownRow",
+    "PhaseTimelineEntryPayload",
     "PlotDataResult",
     "RunSuitabilityCheck",
     "SpectrogramResult",
     "SpeedBreakdownRow",
+    "SpeedStatsPayload",
+    "StrengthBucketDistributionPayload",
+    "SummaryWarningPayload",
+    "TestPlanStepPayload",
 ]
-
-
-class AmplitudeMetric(TypedDict):
-    """Presentation-only vibration-strength summary attached to a finding payload."""
-
-    name: str
-    value: float | None
-    units: str
-    definition: JsonValue
-
-
-class RunSuitabilityCheck(TypedDict):
-    check: str
-    check_key: str
-    state: str
-    explanation: JsonValue
-
-
-class SummaryWarningPayload(TypedDict):
-    code: str
-    severity: Literal["warn", "error"]
-    applies_to: str
-    title: JsonValue
-    detail: JsonValue
-
-
-class TestPlanStepPayload(TypedDict):
-    action_id: str
-    what: str
-    why: str | None
-    confirm: str | None
-    falsify: str | None
-    eta: str | None
-
-
-class PhaseTimelineEntryPayload(TypedDict):
-    phase: str
-    start_t_s: float | None
-    end_t_s: float | None
-    speed_min_kmh: float | None
-    speed_max_kmh: float | None
-    has_fault_evidence: bool
-
-
-class PhaseSegmentSummaryPayload(TypedDict):
-    phase: str
-    start_idx: int
-    end_idx: int
-    start_t_s: float | None
-    end_t_s: float | None
-    speed_min_kmh: float | None
-    speed_max_kmh: float | None
-    sample_count: int
-
-
-class SpeedStatsPayload(TypedDict):
-    min_kmh: float | None
-    max_kmh: float | None
-    mean_kmh: float | None
-    stddev_kmh: float | None
-    range_kmh: float | None
-    steady_speed: bool
-    sample_count: int
-
-
-class PhaseInfoPayload(TypedDict):
-    phase_counts: dict[str, int]
-    phase_pcts: dict[str, float]
-    total_samples: int
-    segment_count: int
-    has_cruise: bool
-    has_acceleration: bool
-    cruise_pct: float
-    idle_pct: float
-    speed_unknown_pct: float
-
-
-class OutlierSummaryPayload(TypedDict):
-    count: int
-    outlier_count: int
-    outlier_pct: float
-    lower_bound: float | None
-    upper_bound: float | None
-
-
-class DataQualityRequiredMissingPctPayload(TypedDict):
-    t_s: float
-    speed_kmh: float
-    accel_x: float
-    accel_y: float
-    accel_z: float
-
-
-class DataQualitySpeedCoveragePayload(TypedDict):
-    non_null_pct: float
-    min_kmh: float | None
-    max_kmh: float | None
-    mean_kmh: float | None
-    stddev_kmh: float | None
-    count_non_null: int
-
-
-class DataQualityAccelSanityPayload(TypedDict):
-    x_mean: float | None
-    x_variance: float | None
-    y_mean: float | None
-    y_variance: float | None
-    z_mean: float | None
-    z_variance: float | None
-    sensor_limit: float | None
-    saturation_count: int | None
-
-
-class DataQualityOutliersPayload(TypedDict):
-    accel_magnitude: OutlierSummaryPayload
-    amplitude_metric: OutlierSummaryPayload
-
-
-class DataQualityPayload(TypedDict):
-    required_missing_pct: DataQualityRequiredMissingPctPayload
-    speed_coverage: DataQualitySpeedCoveragePayload
-    accel_sanity: DataQualityAccelSanityPayload
-    outliers: DataQualityOutliersPayload
-
-
-class StrengthBucketDistributionPayload(TypedDict):
-    total: int
-    counts: dict[str, int]
-    percent_time_l0: float
-    percent_time_l1: float
-    percent_time_l2: float
-    percent_time_l3: float
-    percent_time_l4: float
-    percent_time_l5: float
-
-
-class PhaseIntensityStatsPayload(TypedDict):
-    count: int
-    mean_intensity_db: float | None
-    max_intensity_db: float | None
-
-
-class LocationIntensitySummaryPayload(TypedDict):
-    location: str
-    partial_coverage: bool
-    sample_count: int
-    sample_coverage_ratio: float
-    sample_coverage_warning: bool
-    mean_intensity_db: float | None
-    p50_intensity_db: float | None
-    p95_intensity_db: float | None
-    max_intensity_db: float | None
-    dropped_frames_delta: float | None
-    queue_overflow_drops_delta: float | None
-    strength_bucket_distribution: StrengthBucketDistributionPayload
-    phase_intensity: dict[str, PhaseIntensityStatsPayload] | None
-
-
-# ---------------------------------------------------------------------------
-# Composite payload shapes
-# ---------------------------------------------------------------------------
-
-
-class FindingPayload(TypedDict, total=False):
-    """Serialized finding payload used at transport and persistence boundaries.
-
-    This payload intentionally remains a superset of the domain
-    :class:`~vibesensor.domain.Finding`:
-
-    * direct domain fields are copied across unchanged,
-    * ``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,
-      and the confidence label fields are presentation-oriented projections
-      computed during ``finding_payload_from_domain()``,
-    * ``matched_points``, ``phase_evidence``, ``evidence_metrics``,
-      ``location_hotspot``, and ``signatures_observed`` are boundary mirrors
-      of richer domain sub-objects.
-    """
-
-    # Direct domain-owned finding state.
-    finding_id: Required[str]
-    finding_key: str
-    suspected_source: Required[str]
-    confidence: Required[float | None]
-    finding_kind: str
-    severity: str
-    strongest_location: str | None
-    strongest_speed_band: str | None
-    dominant_phase: str | None
-    dominance_ratio: float | None
-    weak_spatial_separation: bool
-    diffuse_excitation: bool
-    ranking_score: float
-    peak_classification: str
-    order: str
-
-    # Presentation-only projections computed from domain-owned data.
-    evidence_summary: Required[JsonValue]
-    frequency_hz_or_order: Required[JsonValue]
-    amplitude_metric: Required[AmplitudeMetric]
-    confidence_label_key: str
-    confidence_tone: str
-    confidence_pct: str
-
-    # Boundary mirrors of richer nested domain objects.
-    matched_points: list[MatchedPoint]
-    location_hotspot: LocationHotspotPayload | None
-    phase_evidence: PhaseEvidence | None
-    evidence_metrics: FindingEvidenceMetrics
-    signatures_observed: list[str]
-
-
-class AnalysisSummary(TypedDict):
-    """Full analysis summary payload.
-
-    Required fields are always set by :func:`build_summary_payload`.
-    Optional fields are set later in the pipeline or may be removed:
-
-    * ``samples`` – present unless ``include_samples=False`` removes it.
-    * ``plots`` – set by :func:`_plot_data` after initial assembly.
-    * ``analysis_metadata`` – set by post-analysis workers.
-    """
-
-    file_name: str
-    run_id: str
-    rows: int
-    duration_s: float
-    record_length: str
-    lang: str
-    report_date: JsonValue
-    start_time_utc: JsonValue
-    end_time_utc: JsonValue
-    sensor_model: JsonValue
-    firmware_version: JsonValue
-    raw_sample_rate_hz: float | None
-    feature_interval_s: float | None
-    fft_window_size_samples: JsonValue
-    fft_window_type: JsonValue
-    peak_picker_method: JsonValue
-    accel_scale_g_per_lsb: float | None
-    incomplete_for_order_analysis: bool
-    metadata: JsonObject
-    case_id: NotRequired[str]
-    warnings: list[SummaryWarningPayload]
-    speed_breakdown: list[SpeedBreakdownRow]
-    phase_speed_breakdown: list[PhaseSpeedBreakdownRow]
-    phase_segments: list[PhaseSegmentSummaryPayload]
-    run_noise_baseline_db: float | None
-    speed_breakdown_skipped_reason: JsonObject | None
-    findings: list[FindingPayload]
-    top_causes: list[FindingPayload]
-    most_likely_origin: SuspectedVibrationOrigin
-    test_plan: list[TestPlanStepPayload]
-    phase_timeline: list[PhaseTimelineEntryPayload]
-    speed_stats: SpeedStatsPayload
-    speed_stats_by_phase: dict[str, SpeedStatsPayload]
-    phase_info: PhaseInfoPayload
-    sensor_locations: list[str]
-    sensor_locations_connected_throughout: list[str]
-    sensor_count_used: int
-    sensor_intensity_by_location: list[LocationIntensitySummaryPayload]
-    run_suitability: list[RunSuitabilityCheck]
-    data_quality: DataQualityPayload
-    samples: NotRequired[list[JsonObject]]
-    plots: NotRequired[PlotDataResult]
-    analysis_metadata: NotRequired[JsonObject]

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -123,7 +123,8 @@ def analysis_result_to_summary(result: AnalysisResultLike) -> AnalysisSummary:
             reference_complete=result.reference_complete,
         )
     )
-    summary["report_date"] = result.metadata.get("end_time_utc") or utc_now_iso()
+    report_date = result.metadata.get("end_time_utc")
+    summary["report_date"] = report_date if isinstance(report_date, str) else utc_now_iso()
     summary["plots"] = serialize_plot_data(result.plot_data)
     cast(dict[str, object], summary)["_summary_version"] = 2
     if not result.include_samples:

--- a/apps/server/vibesensor/shared/boundaries/run_suitability.py
+++ b/apps/server/vibesensor/shared/boundaries/run_suitability.py
@@ -7,6 +7,7 @@ from typing import cast
 
 from vibesensor.domain.run_suitability import RunSuitability, SuitabilityCheck
 from vibesensor.shared.boundaries.analysis_payload import RunSuitabilityCheck
+from vibesensor.shared.types.history_analysis_contracts import PayloadValue
 from vibesensor.shared.types.json_types import JsonValue
 
 
@@ -28,7 +29,7 @@ def _payload_for_check(check: SuitabilityCheck) -> RunSuitabilityCheck:
         "check": check.check_key,
         "check_key": check.check_key,
         "state": check.state,
-        "explanation": cast(JsonValue, check.explanation_i18n_ref()),
+        "explanation": cast(PayloadValue, cast(JsonValue, check.explanation_i18n_ref())),
     }
 
 

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -33,7 +33,8 @@ from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.statistics_utils import _json_outlier_summary, _percent_missing
 from vibesensor.shared.time_utils import format_duration_mm_ss
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.history_analysis_contracts import PayloadObject, PayloadValue
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
 from vibesensor.vibration_strength import compute_db
 
 from ._contracts import (
@@ -60,6 +61,30 @@ def _float_list(stats: AccelStatisticsLike, key: str) -> list[float]:
 def _int_value(stats: AccelStatisticsLike, key: str) -> int | None:
     value = stats.get(key)
     return int(value) if isinstance(value, (int, float)) else None
+
+
+def _json_object(value: JsonObject) -> PayloadObject:
+    return cast(PayloadObject, value)
+
+
+def _json_object_or_none(value: JsonObject | None) -> PayloadObject | None:
+    return None if value is None else _json_object(value)
+
+
+def _json_objects(values: Sequence[JsonObject]) -> list[PayloadObject]:
+    return cast(list[PayloadObject], list(values))
+
+
+def _json_value(value: JsonValue | None) -> PayloadValue:
+    return cast(PayloadValue, value)
+
+
+def _json_str(value: JsonValue | None) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _json_int(value: JsonValue | None) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def noise_baseline_db(run_noise_baseline_g: float | None) -> float | None:
@@ -133,7 +158,7 @@ def serialize_origin_summary(
             "suspected_source": "unknown",
             "dominance_ratio": None,
             "weak_spatial_separation": True,
-            "explanation": i18n_ref("ORIGIN_NO_RANKED_FINDING_AVAILABLE"),
+            "explanation": _json_value(i18n_ref("ORIGIN_NO_RANKED_FINDING_AVAILABLE")),
         }
 
     location = origin.summary_location
@@ -151,13 +176,15 @@ def serialize_origin_summary(
         "weak_spatial_separation": weak,
         "speed_band": speed_band or None,
         "dominant_phase": dominant_phase or None,
-        "explanation": build_origin_explanation(
-            source=source,
-            speed_band=speed_band,
-            location=location,
-            dominance=dominance,
-            weak=weak,
-            dominant_phase=dominant_phase,
+        "explanation": _json_value(
+            build_origin_explanation(
+                source=source,
+                speed_band=speed_band,
+                location=location,
+                dominance=dominance,
+                weak=weak,
+                dominant_phase=dominant_phase,
+            ),
         ),
     }
 
@@ -212,25 +239,26 @@ def build_summary_payload(
         "duration_s": duration_s,
         "record_length": format_duration_mm_ss(duration_s),
         "lang": language,
-        "report_date": metadata.get("end_time_utc") or metadata.get("report_date"),
-        "start_time_utc": metadata.get("start_time_utc"),
-        "end_time_utc": metadata.get("end_time_utc"),
-        "sensor_model": metadata.get("sensor_model"),
-        "firmware_version": metadata.get("firmware_version"),
+        "report_date": _json_str(metadata.get("end_time_utc"))
+        or _json_str(metadata.get("report_date")),
+        "start_time_utc": _json_str(metadata.get("start_time_utc")),
+        "end_time_utc": _json_str(metadata.get("end_time_utc")),
+        "sensor_model": _json_str(metadata.get("sensor_model")),
+        "firmware_version": _json_str(metadata.get("firmware_version")),
         "raw_sample_rate_hz": raw_sample_rate_hz,
         "feature_interval_s": _as_float(metadata.get("feature_interval_s")),
-        "fft_window_size_samples": metadata.get("fft_window_size_samples"),
-        "fft_window_type": metadata.get("fft_window_type"),
-        "peak_picker_method": metadata.get("peak_picker_method"),
+        "fft_window_size_samples": _json_int(metadata.get("fft_window_size_samples")),
+        "fft_window_type": _json_str(metadata.get("fft_window_type")),
+        "peak_picker_method": _json_str(metadata.get("peak_picker_method")),
         "accel_scale_g_per_lsb": _as_float(metadata.get("accel_scale_g_per_lsb")),
         "incomplete_for_order_analysis": bool(metadata.get("incomplete_for_order_analysis")),
-        "metadata": metadata,
+        "metadata": _json_object(metadata),
         "warnings": [],
         "speed_breakdown": serialize_speed_breakdown(speed_breakdown),
         "phase_speed_breakdown": serialize_phase_speed_breakdown(phase_speed_breakdown),
         "phase_segments": serialize_phase_segments(phase_segments),
         "run_noise_baseline_db": noise_baseline_db(run_noise_baseline_g),
-        "speed_breakdown_skipped_reason": speed_breakdown_skipped_reason,
+        "speed_breakdown_skipped_reason": _json_object_or_none(speed_breakdown_skipped_reason),
         "findings": serialize_findings(findings),
         "top_causes": serialize_findings(top_causes),
         "most_likely_origin": serialize_origin_summary(most_likely_origin),
@@ -249,7 +277,7 @@ def build_summary_payload(
             for row in sensor_intensity_by_location
         ],
         "run_suitability": run_suitability_payload(run_suitability),
-        "samples": samples,
+        "samples": _json_objects(samples),
         "data_quality": build_data_quality_dict(
             samples,
             speed_values,

--- a/apps/server/vibesensor/shared/boundaries/summary_warning.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_warning.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import cast
 
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.analysis_payload import SummaryWarningPayload
 from vibesensor.shared.run_context import RunContextWarning, normalize_run_context_warnings
+from vibesensor.shared.types.history_analysis_contracts import PayloadValue
 from vibesensor.shared.types.json_types import JsonObject
 
 
@@ -16,8 +18,8 @@ def summary_warning_payload(warning: RunContextWarning) -> SummaryWarningPayload
         "code": warning.code,
         "severity": warning.severity,
         "applies_to": warning.applies_to,
-        "title": warning.title,
-        "detail": warning.detail,
+        "title": cast(PayloadValue, warning.title),
+        "detail": cast(PayloadValue, warning.detail),
     }
     return payload
 

--- a/apps/server/vibesensor/shared/boundaries/vibration_origin.py
+++ b/apps/server/vibesensor/shared/boundaries/vibration_origin.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TypedDict
 
 from vibesensor.coerce import coerce_float, coerce_int
 from vibesensor.domain import Finding, VibrationSource
@@ -12,6 +11,9 @@ from vibesensor.domain.vibration_origin import VibrationOrigin
 from vibesensor.shared.constants import PHASE_I18N_KEYS
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
+from vibesensor.shared.types.history_analysis_contracts import (
+    SuspectedVibrationOriginPayload as SuspectedVibrationOrigin,
+)
 from vibesensor.shared.types.json_types import JsonValue
 
 
@@ -67,25 +69,6 @@ __all__ = [
     "origin_payload_from_finding",
     "vibration_origin_from_payload",
 ]
-
-
-class SuspectedVibrationOrigin(TypedDict, total=False):
-    """Boundary-only JSON payload shape for origin data.
-
-    This TypedDict is the serialization format for
-    ``AnalysisSummary.most_likely_origin`` and persisted run payloads.
-    Domain code must use :class:`~vibesensor.domain.VibrationOrigin`
-    instead.  This type exists solely at ingress/egress boundaries.
-    """
-
-    location: str
-    alternative_locations: list[str]
-    suspected_source: str
-    dominance_ratio: float | None
-    weak_spatial_separation: bool
-    speed_band: str | None
-    dominant_phase: str | None
-    explanation: JsonValue
 
 
 def _source_from_payload(

--- a/apps/server/vibesensor/shared/types/api_models/history.py
+++ b/apps/server/vibesensor/shared/types/api_models/history.py
@@ -1,15 +1,17 @@
 """History and finding-oriented HTTP API models.
 
 Stable exact analysis/history view shapes live in
-``vibesensor.shared.types.analysis_views`` so the HTTP and boundary layers do
-not maintain duplicate owners for the same schema concepts.
+``vibesensor.shared.types.analysis_views``. Shared wrapper/composite contracts
+that must stay aligned with persisted boundary payloads live in
+``vibesensor.shared.types.history_analysis_contracts`` so this module only
+keeps HTTP-specific wrappers and localized response models.
 """
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from vibesensor.shared.types.analysis_views import (
     AmpVsPhaseRow,
@@ -27,24 +29,68 @@ from vibesensor.shared.types.analysis_views import (
     SpectrogramResult,
     SpeedBreakdownRow,
 )
+from vibesensor.shared.types.history_analysis_contracts import (
+    AmplitudeMetric,
+    AnalysisSummaryCoreResponse,
+    AnalysisSummaryResponse,
+    DataQualityAccelSanityResponse,
+    DataQualityOutliersResponse,
+    DataQualityRequiredMissingPctResponse,
+    DataQualityResponse,
+    DataQualitySpeedCoverageResponse,
+    FindingPayload,
+    LocationIntensitySummaryResponse,
+    OutlierSummaryResponse,
+    PhaseInfoResponse,
+    PhaseIntensityStatsResponse,
+    PhaseSegmentSummaryResponse,
+    PhaseTimelineEntryResponse,
+    RunSuitabilityCheck,
+    SpeedStatsResponse,
+    StrengthBucketDistributionResponse,
+    SummaryWarningResponse,
+    SuspectedVibrationOriginPayload,
+    TestPlanStepResponse,
+)
 
-from .base import ApiPayloadObject, ApiPayloadValue, _StrictBase
+from .base import ApiPayloadObject, _StrictBase
 
 __all__ = [
+    "AmplitudeMetric",
     "AmpVsPhaseRow",
+    "AnalysisSummaryCoreResponse",
+    "AnalysisSummaryResponse",
+    "DataQualityAccelSanityResponse",
+    "DataQualityOutliersResponse",
+    "DataQualityRequiredMissingPctResponse",
+    "DataQualityResponse",
+    "DataQualitySpeedCoverageResponse",
     "FindingEvidenceMetrics",
+    "FindingPayload",
     "FreqVsSpeedByFindingSeries",
     "LocationHotspotPayload",
+    "LocationIntensitySummaryResponse",
     "MatchedAmpVsSpeedSeries",
     "MatchedPoint",
+    "OutlierSummaryResponse",
     "PeakTableRow",
     "PhaseBoundary",
     "PhaseEvidence",
+    "PhaseInfoResponse",
+    "PhaseIntensityStatsResponse",
     "PhaseSegmentOut",
+    "PhaseSegmentSummaryResponse",
     "PhaseSpeedBreakdownRow",
+    "PhaseTimelineEntryResponse",
     "PlotDataResult",
+    "RunSuitabilityCheck",
     "SpectrogramResult",
     "SpeedBreakdownRow",
+    "SpeedStatsResponse",
+    "StrengthBucketDistributionResponse",
+    "SummaryWarningResponse",
+    "SuspectedVibrationOriginPayload",
+    "TestPlanStepResponse",
 ]
 
 
@@ -86,297 +132,6 @@ class HistoryInsightWarningResponse(BaseModel):
     detail: str | None = None
 
 
-class SummaryWarningResponse(BaseModel):
-    """Response body for a persisted summary warning before localization."""
-
-    code: str
-    severity: Literal["warn", "error"]
-    applies_to: str
-    title: ApiPayloadValue
-    detail: ApiPayloadValue = None
-
-
-class TestPlanStepResponse(BaseModel):
-    """Response body for one recommended next-step action."""
-
-    action_id: str
-    what: str
-    why: str | None
-    confirm: str | None
-    falsify: str | None
-    eta: str | None
-
-
-class PhaseTimelineEntryResponse(BaseModel):
-    """Response body for one summarized phase-timeline interval."""
-
-    phase: str
-    start_t_s: float | None
-    end_t_s: float | None
-    speed_min_kmh: float | None
-    speed_max_kmh: float | None
-    has_fault_evidence: bool
-
-
-class SpeedStatsResponse(BaseModel):
-    """Response body for one summarized speed-profile snapshot."""
-
-    min_kmh: float | None
-    max_kmh: float | None
-    mean_kmh: float | None
-    stddev_kmh: float | None
-    range_kmh: float | None
-    steady_speed: bool
-    sample_count: int
-
-
-class PhaseInfoResponse(BaseModel):
-    """Response body for aggregate driving-phase coverage metrics."""
-
-    phase_counts: dict[str, int]
-    phase_pcts: dict[str, float]
-    total_samples: int
-    segment_count: int
-    has_cruise: bool
-    has_acceleration: bool
-    cruise_pct: float
-    idle_pct: float
-    speed_unknown_pct: float
-
-
-class OutlierSummaryResponse(BaseModel):
-    """Response body for an outlier-summary bucket."""
-
-    count: int
-    outlier_count: int
-    outlier_pct: float
-    lower_bound: float | None
-    upper_bound: float | None
-
-
-class DataQualityRequiredMissingPctResponse(BaseModel):
-    """Response body for required-field missing percentages."""
-
-    t_s: float
-    speed_kmh: float
-    accel_x: float
-    accel_y: float
-    accel_z: float
-
-
-class DataQualitySpeedCoverageResponse(BaseModel):
-    """Response body for summarized speed-coverage statistics."""
-
-    non_null_pct: float
-    min_kmh: float | None
-    max_kmh: float | None
-    mean_kmh: float | None
-    stddev_kmh: float | None
-    count_non_null: int
-
-
-class DataQualityAccelSanityResponse(BaseModel):
-    """Response body for acceleration sanity diagnostics."""
-
-    x_mean: float | None
-    x_variance: float | None
-    y_mean: float | None
-    y_variance: float | None
-    z_mean: float | None
-    z_variance: float | None
-    sensor_limit: float | None
-    saturation_count: int | None
-
-
-class DataQualityOutliersResponse(BaseModel):
-    """Response body for grouped outlier summaries."""
-
-    accel_magnitude: OutlierSummaryResponse
-    amplitude_metric: OutlierSummaryResponse
-
-
-class DataQualityResponse(BaseModel):
-    """Response body for run-level data-quality diagnostics."""
-
-    required_missing_pct: DataQualityRequiredMissingPctResponse
-    speed_coverage: DataQualitySpeedCoverageResponse
-    accel_sanity: DataQualityAccelSanityResponse
-    outliers: DataQualityOutliersResponse
-
-
-class StrengthBucketDistributionResponse(BaseModel):
-    """Response body for per-location strength-bucket coverage."""
-
-    total: int
-    counts: dict[str, int]
-    percent_time_l0: float
-    percent_time_l1: float
-    percent_time_l2: float
-    percent_time_l3: float
-    percent_time_l4: float
-    percent_time_l5: float
-
-
-class PhaseIntensityStatsResponse(BaseModel):
-    """Response body for per-phase intensity aggregates at one location."""
-
-    count: int
-    mean_intensity_db: float | None
-    max_intensity_db: float | None
-
-
-class LocationIntensitySummaryResponse(BaseModel):
-    """Response body for one sensor-location intensity summary row."""
-
-    location: str
-    partial_coverage: bool
-    sample_count: int
-    sample_coverage_ratio: float
-    sample_coverage_warning: bool
-    mean_intensity_db: float | None
-    p50_intensity_db: float | None
-    p95_intensity_db: float | None
-    max_intensity_db: float | None
-    dropped_frames_delta: float | None
-    queue_overflow_drops_delta: float | None
-    strength_bucket_distribution: StrengthBucketDistributionResponse
-    phase_intensity: dict[str, PhaseIntensityStatsResponse] | None = None
-
-
-class AmplitudeMetric(_StrictBase):
-    """HTTP contract for finding amplitude/strength metadata."""
-
-    name: str | None = None
-    value: float | None = None
-    units: str | None = None
-    definition: ApiPayloadValue = None
-
-
-class FindingPayload(_StrictBase):
-    """HTTP contract for one serialized finding in analysis history payloads.
-
-    This schema mirrors ``shared.boundaries.analysis_payload.FindingPayload``.
-    It intentionally includes a few presentation-oriented projections
-    (``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,
-    and the confidence label fields) alongside the domain-owned finding data.
-    """
-
-    finding_id: str
-    finding_key: str | None = None
-    suspected_source: str
-    evidence_summary: ApiPayloadValue
-    frequency_hz_or_order: ApiPayloadValue
-    amplitude_metric: AmplitudeMetric
-    confidence: float | None
-    finding_kind: str | None = None
-    severity: str | None = None
-    confidence_label_key: str | None = None
-    confidence_tone: str | None = None
-    confidence_pct: str | None = None
-    matched_points: list[MatchedPoint] = Field(default_factory=list)
-    location_hotspot: LocationHotspotPayload | None = None
-    strongest_location: str | None = None
-    strongest_speed_band: str | None = None
-    dominant_phase: str | None = None
-    dominance_ratio: float | None = None
-    weak_spatial_separation: bool | None = None
-    diffuse_excitation: bool | None = None
-    phase_evidence: PhaseEvidence | None = None
-    evidence_metrics: FindingEvidenceMetrics | None = None
-    ranking_score: float | None = None
-    peak_classification: str | None = None
-    signatures_observed: list[str] = Field(default_factory=list)
-    order: str | None = None
-
-
-class RunSuitabilityCheck(_StrictBase):
-    """Typed HTTP contract for one run-suitability diagnostic check."""
-
-    check: str
-    check_key: str
-    state: str
-    explanation: ApiPayloadValue = None
-
-
-class PhaseSegmentSummaryResponse(BaseModel):
-    """Typed HTTP contract for a summarized driving-phase segment."""
-
-    phase: str
-    start_idx: int
-    end_idx: int
-    start_t_s: float | None
-    end_t_s: float | None
-    speed_min_kmh: float | None
-    speed_max_kmh: float | None
-    sample_count: int
-
-
-class SuspectedVibrationOriginPayload(_StrictBase):
-    """Typed HTTP contract for the serialized likely-origin payload."""
-
-    location: str | None = None
-    alternative_locations: list[str] = Field(default_factory=list)
-    suspected_source: str | None = None
-    dominance_ratio: float | None = None
-    weak_spatial_separation: bool | None = None
-    speed_band: str | None = None
-    dominant_phase: str | None = None
-    explanation: ApiPayloadValue = None
-
-
-class _AnalysisSummaryCoreResponse(_StrictBase):
-    """Shared typed HTTP contract fields used by history-run analysis payloads."""
-
-    file_name: str
-    run_id: str
-    case_id: str | None = None
-    rows: int
-    duration_s: float
-    record_length: str
-    lang: str
-    report_date: str | None = None
-    start_time_utc: str | None = None
-    end_time_utc: str | None = None
-    sensor_model: str | None = None
-    firmware_version: str | None = None
-    raw_sample_rate_hz: float | None
-    feature_interval_s: float | None
-    fft_window_size_samples: int | None = None
-    fft_window_type: str | None = None
-    peak_picker_method: str | None = None
-    accel_scale_g_per_lsb: float | None
-    incomplete_for_order_analysis: bool
-    metadata: ApiPayloadObject
-    speed_breakdown: list[SpeedBreakdownRow]
-    phase_speed_breakdown: list[PhaseSpeedBreakdownRow]
-    phase_segments: list[PhaseSegmentSummaryResponse]
-    run_noise_baseline_db: float | None
-    speed_breakdown_skipped_reason: ApiPayloadObject | None
-    findings: list[FindingPayload]
-    top_causes: list[FindingPayload]
-    most_likely_origin: SuspectedVibrationOriginPayload
-    test_plan: list[TestPlanStepResponse]
-    phase_timeline: list[PhaseTimelineEntryResponse]
-    speed_stats: SpeedStatsResponse
-    speed_stats_by_phase: dict[str, SpeedStatsResponse]
-    phase_info: PhaseInfoResponse
-    sensor_locations: list[str]
-    sensor_locations_connected_throughout: list[str]
-    sensor_count_used: int
-    sensor_intensity_by_location: list[LocationIntensitySummaryResponse]
-    run_suitability: list[RunSuitabilityCheck]
-    data_quality: DataQualityResponse
-    samples: list[ApiPayloadObject] = Field(default_factory=list)
-    plots: PlotDataResult | None = None
-    analysis_metadata: ApiPayloadObject = Field(default_factory=dict)
-
-
-class AnalysisSummaryResponse(_AnalysisSummaryCoreResponse):
-    """Typed HTTP contract for the persisted analysis summary on one history run."""
-
-    warnings: list[SummaryWarningResponse]
-
-
 class HistoryInsightsAnalyzingResponse(BaseModel):
     """Response body for a history run whose analysis is still in progress."""
 
@@ -384,11 +139,18 @@ class HistoryInsightsAnalyzingResponse(BaseModel):
     status: Literal["analyzing"]
 
 
-class HistoryInsightsResponse(_AnalysisSummaryCoreResponse):
+class HistoryInsightsResponse(AnalysisSummaryCoreResponse, total=False):
     """Response body for the localized history insights endpoint payload."""
 
-    status: Literal["complete"] = "complete"
-    warnings: list[HistoryInsightWarningResponse] = Field(default_factory=list)
+    status: Annotated[Literal["complete"], Field(default="complete")]
+    warnings: list[HistoryInsightWarningResponse]
+
+
+def _configure_pydantic_schema(typed_dict: Any) -> None:
+    typed_dict.__pydantic_config__ = ConfigDict(extra="forbid")
+
+
+_configure_pydantic_schema(HistoryInsightsResponse)
 
 
 class DeleteHistoryRunResponse(BaseModel):

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -1,0 +1,383 @@
+"""Shared analysis/history wrapper contracts reused by boundary and HTTP layers.
+
+These TypedDicts are the single semantic owners for analysis/history wrapper
+and composite contracts that are shared between persisted boundary payloads and
+the HTTP/OpenAPI response schema. Boundary modules alias them under payload
+names, while endpoint-specific HTTP wrappers remain local to
+``shared.types.api_models.history``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Required, TypeAlias
+
+from pydantic import ConfigDict
+from typing_extensions import TypedDict
+
+from vibesensor.shared.types.analysis_views import (
+    FindingEvidenceMetrics,
+    LocationHotspotPayload,
+    MatchedPoint,
+    PhaseEvidence,
+    PhaseSpeedBreakdownRow,
+    PlotDataResult,
+    SpeedBreakdownRow,
+)
+
+__all__ = [
+    "AmplitudeMetric",
+    "AnalysisSummaryCoreResponse",
+    "AnalysisSummaryResponse",
+    "DataQualityAccelSanityResponse",
+    "DataQualityOutliersResponse",
+    "DataQualityRequiredMissingPctResponse",
+    "DataQualityResponse",
+    "DataQualitySpeedCoverageResponse",
+    "FindingPayload",
+    "LocationIntensitySummaryResponse",
+    "OutlierSummaryResponse",
+    "PayloadObject",
+    "PayloadValue",
+    "PhaseInfoResponse",
+    "PhaseIntensityStatsResponse",
+    "PhaseSegmentSummaryResponse",
+    "PhaseTimelineEntryResponse",
+    "RunSuitabilityCheck",
+    "SpeedStatsResponse",
+    "StrengthBucketDistributionResponse",
+    "SummaryWarningResponse",
+    "SuspectedVibrationOriginPayload",
+    "TestPlanStepResponse",
+]
+
+PayloadObject: TypeAlias = dict[str, object]
+PayloadValue: TypeAlias = None | bool | int | float | str | list[object] | PayloadObject
+
+_FORBID_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")
+_IGNORE_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="ignore")
+
+
+class AmplitudeMetric(TypedDict, total=False):
+    """HTTP contract for finding amplitude/strength metadata."""
+
+    name: str | None
+    value: float | None
+    units: str | None
+    definition: PayloadValue
+
+
+class RunSuitabilityCheck(TypedDict, total=False):
+    """Typed HTTP contract for one run-suitability diagnostic check."""
+
+    check: Required[str]
+    check_key: Required[str]
+    state: Required[str]
+    explanation: PayloadValue
+
+
+class SummaryWarningResponse(TypedDict, total=False):
+    """Response body for a persisted summary warning before localization."""
+
+    code: Required[str]
+    severity: Required[Literal["warn", "error"]]
+    applies_to: Required[str]
+    title: Required[PayloadValue]
+    detail: PayloadValue
+
+
+class TestPlanStepResponse(TypedDict):
+    """Response body for one recommended next-step action."""
+
+    action_id: str
+    what: str
+    why: str | None
+    confirm: str | None
+    falsify: str | None
+    eta: str | None
+
+
+class PhaseTimelineEntryResponse(TypedDict):
+    """Response body for one summarized phase-timeline interval."""
+
+    phase: str
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    has_fault_evidence: bool
+
+
+class PhaseSegmentSummaryResponse(TypedDict):
+    """Typed HTTP contract for a summarized driving-phase segment."""
+
+    phase: str
+    start_idx: int
+    end_idx: int
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    sample_count: int
+
+
+class SpeedStatsResponse(TypedDict):
+    """Response body for one summarized speed-profile snapshot."""
+
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    range_kmh: float | None
+    steady_speed: bool
+    sample_count: int
+
+
+class PhaseInfoResponse(TypedDict):
+    """Response body for aggregate driving-phase coverage metrics."""
+
+    phase_counts: dict[str, int]
+    phase_pcts: dict[str, float]
+    total_samples: int
+    segment_count: int
+    has_cruise: bool
+    has_acceleration: bool
+    cruise_pct: float
+    idle_pct: float
+    speed_unknown_pct: float
+
+
+class OutlierSummaryResponse(TypedDict):
+    """Response body for an outlier-summary bucket."""
+
+    count: int
+    outlier_count: int
+    outlier_pct: float
+    lower_bound: float | None
+    upper_bound: float | None
+
+
+class DataQualityRequiredMissingPctResponse(TypedDict):
+    """Response body for required-field missing percentages."""
+
+    t_s: float
+    speed_kmh: float
+    accel_x: float
+    accel_y: float
+    accel_z: float
+
+
+class DataQualitySpeedCoverageResponse(TypedDict):
+    """Response body for summarized speed-coverage statistics."""
+
+    non_null_pct: float
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    count_non_null: int
+
+
+class DataQualityAccelSanityResponse(TypedDict):
+    """Response body for acceleration sanity diagnostics."""
+
+    x_mean: float | None
+    x_variance: float | None
+    y_mean: float | None
+    y_variance: float | None
+    z_mean: float | None
+    z_variance: float | None
+    sensor_limit: float | None
+    saturation_count: int | None
+
+
+class DataQualityOutliersResponse(TypedDict):
+    """Response body for grouped outlier summaries."""
+
+    accel_magnitude: OutlierSummaryResponse
+    amplitude_metric: OutlierSummaryResponse
+
+
+class DataQualityResponse(TypedDict):
+    """Response body for run-level data-quality diagnostics."""
+
+    required_missing_pct: DataQualityRequiredMissingPctResponse
+    speed_coverage: DataQualitySpeedCoverageResponse
+    accel_sanity: DataQualityAccelSanityResponse
+    outliers: DataQualityOutliersResponse
+
+
+class StrengthBucketDistributionResponse(TypedDict):
+    """Response body for per-location strength-bucket coverage."""
+
+    total: int
+    counts: dict[str, int]
+    percent_time_l0: float
+    percent_time_l1: float
+    percent_time_l2: float
+    percent_time_l3: float
+    percent_time_l4: float
+    percent_time_l5: float
+
+
+class PhaseIntensityStatsResponse(TypedDict):
+    """Response body for per-phase intensity aggregates at one location."""
+
+    count: int
+    mean_intensity_db: float | None
+    max_intensity_db: float | None
+
+
+class LocationIntensitySummaryResponse(TypedDict, total=False):
+    """Response body for one sensor-location intensity summary row."""
+
+    location: Required[str]
+    partial_coverage: Required[bool]
+    sample_count: Required[int]
+    sample_coverage_ratio: Required[float]
+    sample_coverage_warning: Required[bool]
+    mean_intensity_db: Required[float | None]
+    p50_intensity_db: Required[float | None]
+    p95_intensity_db: Required[float | None]
+    max_intensity_db: Required[float | None]
+    dropped_frames_delta: Required[float | None]
+    queue_overflow_drops_delta: Required[float | None]
+    strength_bucket_distribution: Required[StrengthBucketDistributionResponse]
+    phase_intensity: dict[str, PhaseIntensityStatsResponse] | None
+
+
+class FindingPayload(TypedDict, total=False):
+    """HTTP contract for one serialized finding in analysis history payloads.
+
+    This schema mirrors ``shared.boundaries.analysis_payload.FindingPayload``.
+    It intentionally includes a few presentation-oriented projections
+    (``evidence_summary``, ``frequency_hz_or_order``, ``amplitude_metric``,
+    and the confidence label fields) alongside the domain-owned finding data.
+    """
+
+    finding_id: Required[str]
+    finding_key: str | None
+    suspected_source: Required[str]
+    evidence_summary: Required[PayloadValue]
+    frequency_hz_or_order: Required[PayloadValue]
+    amplitude_metric: Required[AmplitudeMetric]
+    confidence: Required[float | None]
+    finding_kind: str | None
+    severity: str | None
+    confidence_label_key: str | None
+    confidence_tone: str | None
+    confidence_pct: str | None
+    matched_points: list[MatchedPoint]
+    location_hotspot: LocationHotspotPayload | None
+    strongest_location: str | None
+    strongest_speed_band: str | None
+    dominant_phase: str | None
+    dominance_ratio: float | None
+    weak_spatial_separation: bool | None
+    diffuse_excitation: bool | None
+    phase_evidence: PhaseEvidence | None
+    evidence_metrics: FindingEvidenceMetrics | None
+    ranking_score: float | None
+    peak_classification: str | None
+    signatures_observed: list[str]
+    order: str | None
+
+
+class SuspectedVibrationOriginPayload(TypedDict, total=False):
+    """Typed HTTP contract for the serialized likely-origin payload."""
+
+    location: str | None
+    alternative_locations: list[str]
+    suspected_source: str | None
+    dominance_ratio: float | None
+    weak_spatial_separation: bool | None
+    speed_band: str | None
+    dominant_phase: str | None
+    explanation: PayloadValue
+
+
+class AnalysisSummaryCoreResponse(TypedDict, total=False):
+    """Shared core fields reused by persisted and localized history summaries."""
+
+    file_name: Required[str]
+    run_id: Required[str]
+    case_id: str | None
+    rows: Required[int]
+    duration_s: Required[float]
+    record_length: Required[str]
+    lang: Required[str]
+    report_date: str | None
+    start_time_utc: str | None
+    end_time_utc: str | None
+    sensor_model: str | None
+    firmware_version: str | None
+    raw_sample_rate_hz: Required[float | None]
+    feature_interval_s: Required[float | None]
+    fft_window_size_samples: int | None
+    fft_window_type: str | None
+    peak_picker_method: str | None
+    accel_scale_g_per_lsb: Required[float | None]
+    incomplete_for_order_analysis: Required[bool]
+    metadata: Required[PayloadObject]
+    speed_breakdown: Required[list[SpeedBreakdownRow]]
+    phase_speed_breakdown: Required[list[PhaseSpeedBreakdownRow]]
+    phase_segments: Required[list[PhaseSegmentSummaryResponse]]
+    run_noise_baseline_db: Required[float | None]
+    speed_breakdown_skipped_reason: Required[PayloadObject | None]
+    findings: Required[list[FindingPayload]]
+    top_causes: Required[list[FindingPayload]]
+    most_likely_origin: Required[SuspectedVibrationOriginPayload]
+    test_plan: Required[list[TestPlanStepResponse]]
+    phase_timeline: Required[list[PhaseTimelineEntryResponse]]
+    speed_stats: Required[SpeedStatsResponse]
+    speed_stats_by_phase: Required[dict[str, SpeedStatsResponse]]
+    phase_info: Required[PhaseInfoResponse]
+    sensor_locations: Required[list[str]]
+    sensor_locations_connected_throughout: Required[list[str]]
+    sensor_count_used: Required[int]
+    sensor_intensity_by_location: Required[list[LocationIntensitySummaryResponse]]
+    run_suitability: Required[list[RunSuitabilityCheck]]
+    data_quality: Required[DataQualityResponse]
+    samples: list[PayloadObject]
+    plots: PlotDataResult | None
+    analysis_metadata: PayloadObject
+
+
+class AnalysisSummaryResponse(AnalysisSummaryCoreResponse):
+    """Typed HTTP contract for the persisted analysis summary on one history run."""
+
+    warnings: Required[list[SummaryWarningResponse]]
+
+
+def _configure_pydantic_schema(typed_dict: Any, config: ConfigDict) -> None:
+    typed_dict.__pydantic_config__ = config
+
+
+for _typed_dict in (
+    SummaryWarningResponse,
+    TestPlanStepResponse,
+    PhaseTimelineEntryResponse,
+    PhaseSegmentSummaryResponse,
+    SpeedStatsResponse,
+    PhaseInfoResponse,
+    OutlierSummaryResponse,
+    DataQualityRequiredMissingPctResponse,
+    DataQualitySpeedCoverageResponse,
+    DataQualityAccelSanityResponse,
+    DataQualityOutliersResponse,
+    DataQualityResponse,
+    StrengthBucketDistributionResponse,
+    PhaseIntensityStatsResponse,
+    LocationIntensitySummaryResponse,
+):
+    _configure_pydantic_schema(_typed_dict, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+
+
+for _strict_typed_dict in (
+    AmplitudeMetric,
+    RunSuitabilityCheck,
+    FindingPayload,
+    SuspectedVibrationOriginPayload,
+    AnalysisSummaryCoreResponse,
+    AnalysisSummaryResponse,
+):
+    _configure_pydantic_schema(_strict_typed_dict, _FORBID_EXTRA_TYPEDDICT_CONFIG)

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -13,6 +13,7 @@ from vibesensor.shared.boundaries.persisted_analysis_codec import (
     persisted_analysis_from_summary,
 )
 from vibesensor.shared.types.backend_types import RunMetadata
+from vibesensor.shared.types.history_analysis_contracts import PayloadObject
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.sensor_frame import SensorFrame
@@ -47,7 +48,7 @@ def build_post_analysis_summary(
         "total_sample_count": total_sample_count,
         "sampling_method": "full" if stride == 1 else f"stride_{stride}",
     }
-    summary_payload["analysis_metadata"] = analysis_metadata
+    summary_payload["analysis_metadata"] = cast(PayloadObject, analysis_metadata)
 
     if stride > 1:
         stride_check = SuitabilityCheck(

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -42,7 +42,7 @@ This file is the repo map, not a workflow or policy guide. Use `.github/copilot-
 - `use_cases/history/`: history queries, report loading/preparation/caching, and export orchestration. See `docs/report_pipeline.md` for report-specific flow.
 - `use_cases/run/`: recording pipeline orchestration. `logger.py` is the `RunRecorder` entrypoint, and the `post_analysis*.py` modules split queueing, loading, execution, and summary shaping.
 - `use_cases/updates/`: wheel-based updater workflow, firmware handling, Wi-Fi, rollback, and status coordination.
-- `shared/`: cross-cutting ports, model/payload types, JSON helpers, and boundary codecs. Key stable owners include `shared/types/persisted_analysis.py`, `shared/types/analysis_views.py`, and the codec/projection modules under `shared/boundaries/`.
+- `shared/`: cross-cutting ports, model/payload types, JSON helpers, and boundary codecs. Key stable owners include `shared/types/persisted_analysis.py`, `shared/types/analysis_views.py`, `shared/types/history_analysis_contracts.py`, and the codec/projection modules under `shared/boundaries/`.
 - `domain/`: domain model package for classification, ranking, lifecycle, and query logic. See `docs/domain-model.md` for the domain object graph.
 - `apps/ui/src/app/runtime/`: UI composition root and runtime controllers.
 - `apps/ui/src/app/features/`: UI feature workflows for settings, realtime, history, updates, cars, and ESP flash.


### PR DESCRIPTION
## Summary

Closes #1144.

This PR removes the highest-value remaining duplication seam between persisted history-analysis boundary payloads and the HTTP history schema by introducing one shared owner for the contracts both layers were still maintaining in parallel. Before this change, `shared/boundaries/analysis_payload.py` and `shared/types/api_models/history.py` still carried overlapping wrapper/composite definitions for findings, suitability checks, warnings, phase timeline rows, speed/profile snapshots, data-quality payloads, location intensity rows, origin payloads, and the persisted analysis summary core. Some of those duplicates were exact mirrors, some had drift-prone field-presence differences, and the repository needed explicit parity tests just to prove the two owners had not diverged.

The implementation here extracts those shared history-analysis contracts into a new `vibesensor.shared.types.history_analysis_contracts` module, then rewires both the boundary layer and the HTTP API models to re-export those canonical `TypedDict` owners instead of redefining them independently. The HTTP layer now keeps only the wrappers that are genuinely endpoint-specific, such as the localized insight warning model and the top-level route responses. The shared summary core also became the source for `HistoryInsightsResponse`, so the localized insights endpoint no longer duplicates the full persisted summary field list by hand.

## Problem being solved

Issue #1144 was about more than a few duplicated leaf types. The real maintenance burden lived in the wrapper/composite layer. The repo had already consolidated exact plot and evidence shapes into `analysis_views.py`, but the surrounding history-analysis contracts still had two primary owners:

- boundary `TypedDict` payloads for persistence/report consumers,
- Pydantic HTTP models for response validation/OpenAPI generation.

That meant a change to a history-analysis wrapper often required mirrored edits in both files, plus parity tests, plus schema export checks. That left ongoing ambiguity about where the canonical contract lived and kept nullability/field-presence drift risk alive.

## Implementation approach

I chose the narrowest complete fix that removes the duplicated ownership without destabilizing the HTTP schema:

1. add a focused shared contract module for the duplicated history-analysis wrappers and summary core,
2. preserve the current OpenAPI component names and schema surface,
3. keep endpoint-specific HTTP-only wrappers local,
4. update boundary builders with explicit type narrowing/casts where they already produce JSON-safe runtime shapes,
5. tighten the hygiene/parity test so it enforces alias identity rather than field-parity-only mirroring.

The key design decision was to use shared `TypedDict` contracts instead of shared BaseModel contracts. That keeps the boundary layer dict-native while still allowing the HTTP schema exporter to generate the same OpenAPI components through Pydantic’s TypedDict support. 
## Main code changes

### 1. New canonical shared contract owner

`apps/server/vibesensor/shared/types/history_analysis_contracts.py` is the new source of truth for the formerly duplicated history-analysis wrappers and summary core. It now owns contracts including:

- `AmplitudeMetric`
- `RunSuitabilityCheck`
- `SummaryWarningResponse`
- `TestPlanStepResponse`
- `PhaseTimelineEntryResponse`
- `PhaseSegmentSummaryResponse`
- `SpeedStatsResponse`
- `PhaseInfoResponse`
- the full data-quality wrapper hierarchy
- intensity/location summary rows
- `FindingPayload`
- `SuspectedVibrationOriginPayload`
- `AnalysisSummaryCoreResponse`
- `AnalysisSummaryResponse`

These contracts are configured so the generated HTTP schema stays aligned with the pre-refactor OpenAPI output, including `additionalProperties` behavior and required/optional key handling.

### 2. Boundary payload module now aliases shared owners

`shared/boundaries/analysis_payload.py` no longer defines the duplicated wrapper/composite payload types locally. Instead, it re-exports the shared contract owners under the existing boundary-friendly names such as `SummaryWarningPayload`, `SpeedStatsPayload`, `PhaseTimelineEntryPayload`, `LocationIntensitySummaryPayload`, and `AnalysisSummary`.

That keeps the boundary import surface stable for the rest of the backend while removing the parallel local definitions.

### 3. Origin payload duplication removed

`shared/boundaries/vibration_origin.py` now aliases the shared `SuspectedVibrationOriginPayload` owner instead of keeping a separate boundary-only typed definition for the same serialized shape.

### 4. HTTP history models now keep only HTTP-specific wrappers

`shared/types/api_models/history.py` now imports the canonical shared contracts instead of redefining the duplicated nested models. The remaining local models in that module are the genuinely HTTP-facing wrappers like:

- `HistoryListEntryResponse`
- `HistoryListResponse`
- `HistoryRunResponse`
- `HistoryInsightWarningResponse`
- `HistoryInsightsAnalyzingResponse`
- `DeleteHistoryRunResponse`

`HistoryInsightsResponse` now also reuses the shared `AnalysisSummaryCoreResponse` instead of duplicating that field list locally.

### 5. Route serialization kept plain-JSON for direct endpoint tests

Because `HistoryInsightsResponse` now validates through a shared TypedDict core, the direct route-call path needed one extra step to keep nested localized warnings as plain dict JSON instead of nested BaseModel instances during tests. `adapters/http/history.py` now validates with a cached `TypeAdapter` and then dumps back to plain JSON-shaped Python data with `dump_python(..., mode="json")` before returning.

### 6. Parity guardrail updated to match the new architecture

`tests/hygiene/test_api_model_boundary_parity.py` no longer treats the remaining overlap as acceptable duplication guarded only by field parity. It now asserts that the boundary and HTTP modules re-export the exact same shared contract owners for the analysis/history shapes covered by this change.

## Schema, docs, and compatibility

The committed HTTP schema artifact stays in sync with generated output after the refactor. I deliberately preserved the existing OpenAPI component names so the UI contract file does not need a churn-only update.

I also updated `docs/ai/repo-map.md` so the repo map now points at `shared/types/history_analysis_contracts.py` as one of the stable shared contract owners in this area.

## Validation

Focused validation:

- `python -m pytest -q -o addopts='' tests/hygiene/test_api_model_boundary_parity.py tests/adapters/http/test_http_api_schema_export.py tests/shared/boundaries/test_finding_roundtrip.py tests/hygiene/test_domain_boundary_parity.py`
- Result: `62 passed`

Broader contract/history/report slice:

- `python -m pytest -q -o addopts='' tests/adapters/http tests/shared/boundaries tests/use_cases/history/test_history_http_services.py tests/use_cases/diagnostics/test_findings_subpackage.py tests/domain/test_domain_objects.py tests/integration/test_contract_analysis_report.py`
- Result: `344 passed`

Repository quality gates:

- `make lint`
- `make typecheck-backend`

Both passed after the refactor.

I attempted the required local Docker smoke with:

- `docker compose build --pull && docker compose up -d`

That is still blocked in this environment because the Docker daemon/socket is unavailable, so compose fails before the stack can start. I am calling that out explicitly rather than pretending a runtime smoke passed locally. CI should still exercise the docker-backed path once the PR is open.

## Risks and tradeoffs

The main risk in this refactor was keeping the schema and direct route behavior stable while changing the canonical owner of so many nested contracts. I mitigated that by preserving the existing OpenAPI names, validating the generated schema continuously, and keeping the direct route return path JSON-shaped for tests.

The other tradeoff is that the shared contract module now carries a couple of helper aliases (`PayloadObject`, `PayloadValue`) and boundary-side narrowing casts to bridge from the repo’s broader `JsonValue`/`JsonObject` shapes into the stricter shared HTTP-safe contracts. I preferred that to weakening the shared contract owners back into vague `object` bags or reintroducing duplicate models.

## Out of scope

This PR does not try to reorganize unrelated shared-type modules like `backend_types.py` from #1145, and it does not redesign the localized history insights endpoint shape beyond removing the duplicated summary-core field list. It also does not change the external HTTP contract intentionally; the goal here is to consolidate ownership, not to redesign the API.
