### PR TITLE
Finish report preparation domain-first seam

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.adapters.pdf.mapping import (
     prepare_report_input,
     prepare_report_mapping_context,
     resolve_primary_report_candidate,
 )
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.use_cases.history.report_preparation import prepare_persisted_report_input
 
 
 def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> None:
@@ -27,11 +31,7 @@ def test_prepare_report_mapping_context_prefers_connected_sensor_locations() -> 
     )
     assert prepared.domain_test_run is not None
     assert prepared.report_facts is not None
-    context = prepare_report_mapping_context(
-        prepared.analysis_summary,
-        report_facts=prepared.report_facts,
-        test_run=prepared.domain_test_run,
-    )
+    context = prepare_report_mapping_context(prepared)
 
     assert context.sensor_locations_active == ["rear-right"]
 
@@ -75,11 +75,7 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
     )
     assert prepared.domain_test_run is not None
     assert prepared.report_facts is not None
-    context = prepare_report_mapping_context(
-        prepared.analysis_summary,
-        report_facts=prepared.report_facts,
-        test_run=prepared.domain_test_run,
-    )
+    context = prepare_report_mapping_context(prepared)
 
     def tr(key: str, **_kw: object) -> str:
         return key
@@ -95,3 +91,67 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
     assert primary.primary_location == "front-left"
     assert primary.strength_db == 21.0
     assert primary.tier in {"B", "C"}
+
+
+def test_prepare_persisted_report_input_does_not_roundtrip_through_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    analysis = PersistedAnalysis.from_json_object(
+        {
+            "run_id": "persisted-run",
+            "lang": "en",
+            "metadata": {"car_name": "Track Car", "car_type": "coupe"},
+            "report_date": "2026-03-23T07:31:01Z",
+            "record_length": "5m",
+            "rows": 120,
+            "duration_s": 300.0,
+            "sensor_count_used": 2,
+            "sensor_locations": ["front-left", "rear-right"],
+            "sensor_locations_connected_throughout": ["front-left"],
+            "sensor_intensity_by_location": [],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "test_plan": [],
+            "findings": [],
+            "top_causes": [],
+            "plots": {"peaks_table": [{"rank": 1, "strength_db": 12.0}]},
+            "warnings": [{"code": "PERSISTED_ONLY"}],
+        }
+    )
+
+    def _explode(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("prepare_persisted_report_input should not replay PersistedAnalysis")
+
+    monkeypatch.setattr(PersistedAnalysis, "to_json_object", _explode)
+
+    prepared = prepare_persisted_report_input(analysis)
+
+    assert prepared.renderer_payload.run_id == "persisted-run"
+    assert prepared.report_facts is not None
+    assert [warning["code"] for warning in prepared.report_facts.warnings] == ["PERSISTED_ONLY"]
+
+
+def test_prepare_report_input_tolerates_invalid_count_strings() -> None:
+    prepared = prepare_report_input(
+        {
+            "run_id": "bad-counts",
+            "rows": "not-a-number",
+            "sensor_count_used": "",
+            "lang": "en",
+            "metadata": {},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "findings": [],
+            "top_causes": [],
+            "sensor_locations": [],
+            "sensor_locations_connected_throughout": [],
+            "speed_stats": {},
+            "most_likely_origin": {},
+            "run_suitability": [],
+        }
+    )
+
+    assert prepared.renderer_payload.sample_count == 0
+    assert prepared.renderer_payload.sensor_count == 0

--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -263,22 +263,14 @@ class TestSummaryHelpers:
         prepared = prepare_report_input(_minimal_summary())
         assert prepared.domain_test_run is not None
         assert prepared.report_facts is not None
-        ctx = prepare_report_mapping_context(
-            prepared.analysis_summary,
-            report_facts=prepared.report_facts,
-            test_run=prepared.domain_test_run,
-        )
+        ctx = prepare_report_mapping_context(prepared)
         assert ctx.sensor_locations_active == ["front_left"]
 
     def test_sensor_locations_active_fallback(self) -> None:
         prepared = prepare_report_input(_minimal_summary(sensor_locations_connected_throughout=[]))
         assert prepared.domain_test_run is not None
         assert prepared.report_facts is not None
-        ctx = prepare_report_mapping_context(
-            prepared.analysis_summary,
-            report_facts=prepared.report_facts,
-            test_run=prepared.domain_test_run,
-        )
+        ctx = prepare_report_mapping_context(prepared)
         assert "front_left" in ctx.sensor_locations_active
 
     def test_boundary_test_plan_payload_projects_semantic_action_fields(self) -> None:

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -28,11 +28,7 @@ def test_report_mapping_context_has_domain_aggregate() -> None:
     prepared = prepare_report_input(summary)
     assert prepared.domain_test_run is not None
     assert prepared.report_facts is not None
-    context = prepare_report_mapping_context(
-        prepared.analysis_summary,
-        report_facts=prepared.report_facts,
-        test_run=prepared.domain_test_run,
-    )
+    context = prepare_report_mapping_context(prepared)
     assert context.domain_aggregate is not None
     assert isinstance(context.domain_aggregate, TestRun)
     assert len(context.domain_aggregate.findings) == 1
@@ -180,11 +176,7 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
     prepared = prepare_report_input(summary)
     assert prepared.domain_test_run is not None
     assert prepared.report_facts is not None
-    context = prepare_report_mapping_context(
-        prepared.analysis_summary,
-        report_facts=prepared.report_facts,
-        test_run=prepared.domain_test_run,
-    )
+    context = prepare_report_mapping_context(prepared)
     assert context.domain_aggregate is not None
     assert isinstance(context.domain_aggregate, TestRun)
 
@@ -199,6 +191,35 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
     assert isinstance(primary.primary_source, VibrationSource), (
         "primary_source must be a VibrationSource enum when domain aggregate is present"
     )
+
+
+def test_prepared_report_input_no_longer_exposes_summary_payload() -> None:
+    """Prepared report inputs must expose explicit fields instead of a raw summary dict."""
+    from test_support.findings import make_finding_payload
+
+    from vibesensor.adapters.pdf.mapping import prepare_report_input
+
+    prepared = prepare_report_input(
+        {
+            "run_id": "guardrails",
+            "findings": [make_finding_payload(finding_id="F001")],
+            "top_causes": [make_finding_payload(finding_id="F001")],
+            "lang": "en",
+            "metadata": {},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "sensor_locations": [],
+            "sensor_locations_connected_throughout": [],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "plots": {},
+        }
+    )
+
+    assert not hasattr(prepared, "analysis_summary")
+    assert prepared.renderer_payload.run_id == "guardrails"
 
 
 def test_next_steps_consume_prepared_actions() -> None:

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -129,11 +129,7 @@ def test_report_certainty_uses_confidence_assessment_reason() -> None:
     assert prepared.report_facts is not None
     assert prepared.domain_test_run.speed_profile is not None
 
-    context = prepare_report_mapping_context(
-        prepared.analysis_summary,
-        report_facts=prepared.report_facts,
-        test_run=prepared.domain_test_run,
-    )
+    context = prepare_report_mapping_context(prepared)
 
     primary = resolve_primary_report_candidate(
         context=context,

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -193,7 +193,8 @@ async def test_report_service_load_report_request_keeps_persisted_summary_immuta
     assert [warning["code"] for warning in stored_analysis.analysis["warnings"]] == [
         WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
     ]
-    assert [warning["code"] for warning in prepared.analysis_summary["warnings"]] == [
+    assert prepared.report_facts is not None
+    assert [warning["code"] for warning in prepared.report_facts.warnings] == [
         WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
         WARNING_CODE_CAR_SETTINGS_CHANGED,
     ]

--- a/apps/server/vibesensor/adapters/pdf/__init__.py
+++ b/apps/server/vibesensor/adapters/pdf/__init__.py
@@ -23,6 +23,7 @@ Module topology
 
 Dependency rule: pages → primitives → data; diagrams → primitives → data.
 Modules must not import from ``vibesensor.use_cases.diagnostics`` sub-modules.
-``mapping.py`` must not import from ``vibesensor.use_cases`` —
-``report_context.py`` handles that bridge.
+``mapping.py`` may consume the prepared report-input contract from
+``vibesensor.use_cases.history.report_preparation`` but must not call back into
+history-layer interpretation or diagnostics helpers directly.
 """

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -23,7 +23,7 @@ from vibesensor.adapters.pdf._card_builder import (
     humanize_signatures,
 )
 from vibesensor.adapters.pdf.pattern_parts import why_parts_listed
-from vibesensor.adapters.pdf.peak_table import build_peak_rows_from_plots
+from vibesensor.adapters.pdf.peak_table import build_peak_rows
 from vibesensor.adapters.pdf.presentation import order_label_human
 from vibesensor.adapters.pdf.report_context import (
     ReportMappingContext,
@@ -47,7 +47,6 @@ from vibesensor.domain import (
 )
 from vibesensor.report_i18n import human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportFacts,
@@ -171,9 +170,17 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
     reconstruction have already happened on the history side, so the PDF
     adapter can stay focused on mapping and rendering decisions.
     """
-    summary = prepared.analysis_summary
-    lang = str(normalize_lang(summary.get("lang")))
-    report = build_report_from_summary(summary)
+    lang = str(normalize_lang(prepared.language))
+    report = Report(
+        run_id=prepared.renderer_payload.run_id,
+        lang=lang,
+        car_name=prepared.renderer_payload.car_name,
+        car_type=prepared.renderer_payload.car_type,
+        report_date=prepared.renderer_payload.report_date,
+        duration_s=prepared.renderer_payload.duration_s,
+        sample_count=prepared.renderer_payload.sample_count,
+        sensor_count=prepared.renderer_payload.sensor_count,
+    )
     domain_test_run = prepared.domain_test_run
     report_facts = prepared.report_facts
     if domain_test_run is None:
@@ -185,7 +192,7 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
         return str(_tr(lang, key, **kw))
 
     return _build_report_template_data(
-        summary,
+        prepared,
         report=report,
         lang=lang,
         tr=tr,
@@ -208,7 +215,7 @@ def _finding_to_presentation(f: Finding) -> FindingPresentation:
 
 
 def _build_report_template_data(
-    summary: AnalysisSummary,
+    prepared: PreparedReportInput,
     *,
     report: Report,
     lang: str,
@@ -216,16 +223,12 @@ def _build_report_template_data(
     test_run: TestRun,
     report_facts: PreparedReportFacts,
 ) -> ReportTemplateData:
-    """Map a summary dict into the final report template data structure.
+    """Map a prepared report input into the final report template data structure.
 
-    The *report* domain object provides high-level metadata; rendering-
-    specific fields are resolved from the full *summary* dict.
+    The *report* metadata and renderer payload are prepared on the history side;
+    the PDF adapter only resolves final presentation details.
     """
-    context = prepare_report_mapping_context(
-        summary,
-        report_facts=report_facts,
-        test_run=test_run,
-    )
+    context = prepare_report_mapping_context(prepared)
     raw_sensor_intensity = list(report_facts.active_sensor_intensity)
     primary = resolve_primary_report_candidate(
         context=context,
@@ -259,7 +262,7 @@ def _build_report_template_data(
         lang,
         tr,
     )
-    peak_rows = build_peak_rows_from_plots(summary, lang=lang, tr=tr)
+    peak_rows = build_peak_rows(prepared.renderer_payload.peak_table_rows, lang=lang, tr=tr)
     version_marker = build_version_marker()
 
     hotspot_rows = list(report_facts.location_hotspot_rows)

--- a/apps/server/vibesensor/adapters/pdf/peak_table.py
+++ b/apps/server/vibesensor/adapters/pdf/peak_table.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 
 from vibesensor.adapters.pdf.presentation import order_label_human, peak_classification_text
 from vibesensor.adapters.pdf.report_data import PeakRow
@@ -12,10 +12,24 @@ from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 
 __all__ = [
+    "build_peak_rows",
     "build_peak_row",
     "build_peak_rows_from_plots",
     "peak_row_system_label",
 ]
+
+
+def build_peak_rows(
+    rows: Sequence[PeakTableRow],
+    *,
+    lang: str,
+    tr: Callable[..., str],
+) -> list[PeakRow]:
+    """Build peak-table rows from prepared peak-table payload rows."""
+    raw_peaks = [row for row in rows if isinstance(row, Mapping)]
+    above_noise = [row for row in raw_peaks if (_as_float(row.get("strength_db")) or 0.0) > 0]
+    ranked = above_noise or raw_peaks
+    return [build_peak_row(row, lang=lang, tr=tr) for row in ranked[:8]]
 
 
 def build_peak_rows_from_plots(
@@ -26,12 +40,12 @@ def build_peak_rows_from_plots(
 ) -> list[PeakRow]:
     """Build peak-table rows from the plots section."""
     plots = summary.get("plots")
-    if plots is None:
+    if not isinstance(plots, Mapping):
         return []
-    raw_peaks = [row for row in (plots.get("peaks_table", []) or []) if isinstance(row, dict)]
-    above_noise = [row for row in raw_peaks if (_as_float(row.get("strength_db")) or 0.0) > 0]
-    ranked = above_noise or raw_peaks
-    return [build_peak_row(row, lang=lang, tr=tr) for row in ranked[:8]]
+    raw_peaks = plots.get("peaks_table")
+    if not isinstance(raw_peaks, list):
+        return []
+    return build_peak_rows(raw_peaks, lang=lang, tr=tr)
 
 
 def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> PeakRow:

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -17,13 +17,12 @@ from vibesensor.domain import (
     TestRun,
     VibrationOrigin,
 )
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.time_utils import utc_now_iso
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
-    from vibesensor.use_cases.history.report_preparation import PreparedReportFacts
+    from vibesensor.use_cases.history.report_preparation import PreparedReportInput
 
 __all__ = [
     "ReportMappingContext",
@@ -106,26 +105,27 @@ class ReportMappingContext:
 
 
 def prepare_report_mapping_context(
-    summary: AnalysisSummary,
-    *,
-    report_facts: PreparedReportFacts,
-    test_run: TestRun,
+    prepared: PreparedReportInput,
 ) -> ReportMappingContext:
-    """Extract structural summary context for report mapping.
+    """Extract structural prepared-report context for report mapping.
 
-    Consumes the prepared domain ``TestRun`` aggregate and history-prepared
-    semantic report facts so downstream business decisions stay domain-first
-    without calling back into history-layer interpretation helpers.
+    Consumes the prepared domain ``TestRun`` aggregate plus minimal
+    renderer-edge metadata so downstream business decisions stay domain-first
+    without depending on a raw summary payload.
     """
-    meta = summary["metadata"]
-    car_name = str(meta.get("car_name") or "").strip() or None
-    car_type = str(meta.get("car_type") or "").strip() or None
-    report_date = str(summary["report_date"] or "") or utc_now_iso()
+    report_facts = prepared.report_facts
+    test_run = prepared.domain_test_run
+    if report_facts is None:
+        raise ValueError("PreparedReportInput must include report_facts for report mapping")
+    if test_run is None:
+        raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
+    renderer_payload = prepared.renderer_payload
+    report_date = renderer_payload.report_date or utc_now_iso()
     date_str = str(report_date)[:19].replace("T", " ") + " UTC"
 
     return ReportMappingContext(
-        car_name=car_name,
-        car_type=car_type,
+        car_name=renderer_payload.car_name,
+        car_type=renderer_payload.car_type,
         date_str=date_str,
         origin=report_facts.origin,
         origin_location=report_facts.origin_location,

--- a/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
+++ b/apps/server/vibesensor/shared/boundaries/diagnostic_case.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import replace
 
+from vibesensor.coerce import coerce_int
 from vibesensor.domain import Car, Finding, LocationHotspot, VibrationOrigin
 from vibesensor.domain.diagnostic_case import DiagnosticCase, Symptom
 from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
@@ -302,7 +303,10 @@ def test_run_from_summary(summary: Mapping[str, object]) -> TestRun:
         configuration_snapshot=ConfigurationSnapshot.from_metadata(meta),
     )
     rows_raw = summary.get("rows")
-    row_count = int(rows_raw) if isinstance(rows_raw, (int, float, str)) else 0
+    try:
+        row_count = coerce_int(rows_raw) if rows_raw is not None else 0
+    except (TypeError, ValueError):
+        row_count = 0
     capture = RunCapture(
         run_id=str(summary.get("run_id") or "unknown"),
         setup=setup,

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from vibesensor.coerce import coerce_float, coerce_int
 from vibesensor.domain import (
     LocationHotspotRow,
     LocationIntensitySummary,
@@ -15,12 +16,13 @@ from vibesensor.domain import (
 from vibesensor.report_i18n import normalize_lang
 from vibesensor.shared.boundaries.analysis_payload import (
     AnalysisSummary,
+    PeakTableRow,
     RunSuitabilityCheck,
     SummaryWarningPayload,
 )
-from vibesensor.shared.boundaries.analysis_summary import analysis_summary_with_warnings
 from vibesensor.shared.boundaries.diagnostic_case import test_run_from_summary
 from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
+from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.helpers import safe_filename
 from vibesensor.use_cases.history.report_cache import ReportPdfCacheKey
@@ -38,15 +40,108 @@ if TYPE_CHECKING:
     from vibesensor.domain import TestRun
 
 
-def _has_projectable_analysis(analysis: AnalysisSummary) -> bool:
-    return isinstance(analysis.get("findings"), list) or isinstance(
-        analysis.get("top_causes"), list
-    )
+def _has_projectable_payload(payload: Mapping[str, object]) -> bool:
+    return isinstance(payload.get("findings"), list) or isinstance(payload.get("top_causes"), list)
 
 
-def _default_report_filename(summary: AnalysisSummary) -> str:
-    run_id = str(summary.get("run_id") or summary.get("file_name") or "report")
+def _default_report_filename(payload: Mapping[str, object]) -> str:
+    run_id = str(payload.get("run_id") or payload.get("file_name") or "report")
     return f"{safe_filename(run_id)}_report.pdf"
+
+
+def _summary_metadata(payload: Mapping[str, object]) -> Mapping[str, object]:
+    metadata = payload.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _active_sensor_locations(payload: Mapping[str, object]) -> tuple[str, ...]:
+    connected = payload.get("sensor_locations_connected_throughout")
+    locations = connected if isinstance(connected, list) else []
+    active = tuple(str(loc).strip() for loc in locations if str(loc).strip())
+    if active:
+        return active
+    fallback = payload.get("sensor_locations")
+    fallback_locations = fallback if isinstance(fallback, list) else []
+    return tuple(str(loc).strip() for loc in fallback_locations if str(loc).strip())
+
+
+def _summary_warnings(
+    payload: Mapping[str, object],
+    *,
+    warnings: object | None = None,
+) -> tuple[SummaryWarningPayload, ...]:
+    raw_warnings = warnings if warnings is not None else payload.get("warnings")
+    return tuple(summary_warning_payloads(raw_warnings))
+
+
+def _report_duration_s(payload: Mapping[str, object]) -> float | None:
+    duration_s_raw = payload.get("duration_s")
+    if duration_s_raw is None:
+        return None
+    try:
+        return coerce_float(duration_s_raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _peak_table_rows(payload: Mapping[str, object]) -> tuple[PeakTableRow, ...]:
+    plots = payload.get("plots")
+    if not isinstance(plots, Mapping):
+        return ()
+    raw_peaks = plots.get("peaks_table")
+    if not isinstance(raw_peaks, list):
+        return ()
+    return tuple(cast(PeakTableRow, row) for row in raw_peaks if isinstance(row, Mapping))
+
+
+def _sensor_intensity_payload(payload: Mapping[str, object]) -> tuple[object, ...]:
+    raw_sensor_intensity = payload.get("sensor_intensity_by_location")
+    if not isinstance(raw_sensor_intensity, list):
+        return ()
+    return tuple(raw_sensor_intensity)
+
+
+def _coerce_count(value: object) -> int:
+    if value is None:
+        return 0
+    try:
+        return coerce_int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedReportRendererPayload:
+    """Minimal renderer-edge payload prepared from summary or persisted analysis."""
+
+    run_id: str
+    car_name: str | None
+    car_type: str | None
+    report_date: str | None
+    duration_s: float | None
+    sample_count: int
+    sensor_count: int
+    peak_table_rows: tuple[PeakTableRow, ...]
+
+
+def _build_renderer_payload(payload: Mapping[str, object]) -> PreparedReportRendererPayload:
+    metadata = _summary_metadata(payload)
+    rows = payload.get("rows")
+    sample_count = _coerce_count(rows)
+    sensor_count_raw = payload.get("sensor_count_used")
+    sensor_count = _coerce_count(sensor_count_raw)
+    report_date = payload.get("report_date")
+    report_date_str = str(report_date).strip() or None if isinstance(report_date, str) else None
+    return PreparedReportRendererPayload(
+        run_id=str(payload.get("run_id") or "unknown") or "unknown",
+        car_name=str(metadata.get("car_name") or "").strip() or None,
+        car_type=str(metadata.get("car_type") or "").strip() or None,
+        report_date=report_date_str,
+        duration_s=_report_duration_s(payload),
+        sample_count=sample_count,
+        sensor_count=sensor_count,
+        peak_table_rows=_peak_table_rows(payload),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,17 +172,17 @@ class PreparedReportInput:
     """Resolved report input ready for PDF mapping and rendering.
 
     Invariants:
-    - ``analysis_summary`` is a renderer-facing payload copy, not the
-      authoritative internal report representation.
     - ``domain_test_run`` is reconstructed at most once and shared across the
       downstream PDF mapping helpers as the authoritative report aggregate.
     - ``report_facts`` contains the semantic report facts that the PDF adapter
       needs so it does not have to call back into history-layer interpretation.
-    - ``language`` is canonicalized and copied back onto ``analysis_summary`` so
-      renderer helpers consume one consistent locale choice.
+    - ``renderer_payload`` contains only the minimal final-edge payload that the
+      PDF mapper still needs after domain/report preparation is complete.
+    - ``language`` is canonicalized once so the renderer consumes one
+      consistent locale choice.
     """
 
-    analysis_summary: AnalysisSummary
+    renderer_payload: PreparedReportRendererPayload
     language: str
     filename: str
     domain_test_run: TestRun | None
@@ -95,48 +190,26 @@ class PreparedReportInput:
     report_facts: PreparedReportFacts | None = None
 
 
-def _reconstruct_report_test_run(analysis_summary: AnalysisSummary) -> TestRun | None:
-    if not _has_projectable_analysis(analysis_summary):
+def _reconstruct_report_test_run(payload: Mapping[str, object]) -> TestRun | None:
+    if not _has_projectable_payload(payload):
         return None
-    return test_run_from_summary(analysis_summary)
-
-
-def _summary_metadata(summary: AnalysisSummary) -> Mapping[str, object]:
-    metadata = summary.get("metadata")
-    return metadata if isinstance(metadata, dict) else {}
-
-
-def _active_sensor_locations(summary: AnalysisSummary) -> tuple[str, ...]:
-    connected = summary.get("sensor_locations_connected_throughout")
-    locations = connected if isinstance(connected, list) else []
-    active = tuple(str(loc).strip() for loc in locations if str(loc).strip())
-    if active:
-        return active
-    fallback = summary.get("sensor_locations")
-    fallback_locations = fallback if isinstance(fallback, list) else []
-    return tuple(str(loc).strip() for loc in fallback_locations if str(loc).strip())
-
-
-def _summary_warnings(summary: AnalysisSummary) -> tuple[SummaryWarningPayload, ...]:
-    warnings = summary.get("warnings")
-    if not isinstance(warnings, list):
-        return ()
-    return tuple(warning for warning in warnings if isinstance(warning, dict))
+    return test_run_from_summary(payload)
 
 
 def _prepare_report_facts(
-    analysis_summary: AnalysisSummary,
+    payload: Mapping[str, object],
     *,
     test_run: TestRun,
+    warnings: object | None = None,
 ) -> PreparedReportFacts:
-    metadata = _summary_metadata(analysis_summary)
-    sensor_locations_active = _active_sensor_locations(analysis_summary)
+    metadata = _summary_metadata(payload)
+    sensor_locations_active = _active_sensor_locations(payload)
     origin = resolve_report_origin(test_run)
     origin_location = normalize_origin_location(origin)
     config_snap = test_run.capture.setup.configuration_snapshot
     active_sensor_intensity = tuple(
         filter_active_sensor_intensity(
-            analysis_summary.get("sensor_intensity_by_location") or [],
+            _sensor_intensity_payload(payload),
             sensor_locations_active,
         )
     )
@@ -150,9 +223,9 @@ def _prepare_report_facts(
         origin=origin,
         origin_location=origin_location,
         sensor_locations_active=sensor_locations_active,
-        duration_text=str(analysis_summary.get("record_length") or "").strip() or None,
-        start_time_utc=str(analysis_summary.get("start_time_utc") or "").strip() or None,
-        end_time_utc=str(analysis_summary.get("end_time_utc") or "").strip() or None,
+        duration_text=str(payload.get("record_length") or "").strip() or None,
+        start_time_utc=str(payload.get("start_time_utc") or "").strip() or None,
+        end_time_utc=str(payload.get("end_time_utc") or "").strip() or None,
         sample_rate_hz=(
             f"{config_snap.raw_sample_rate_hz:g}"
             if config_snap.raw_sample_rate_hz is not None
@@ -167,30 +240,29 @@ def _prepare_report_facts(
         primary_candidate_facts=primary_candidate_facts,
         recommended_actions=test_run.recommended_actions,
         suitability_checks=tuple(run_suitability_payload(test_run.suitability)),
-        warnings=_summary_warnings(analysis_summary),
+        warnings=_summary_warnings(payload, warnings=warnings),
     )
 
 
 def _build_prepared_report_input(
-    analysis_summary: AnalysisSummary,
+    payload: Mapping[str, object],
     *,
     filename: str | None,
     language: str | None,
     cache_key: ReportPdfCacheKey | None,
+    warnings: object | None = None,
 ) -> PreparedReportInput:
-    domain_test_run = _reconstruct_report_test_run(analysis_summary)
-    prepared_summary = cast(AnalysisSummary, dict(analysis_summary))
-    prepared_language = str(normalize_lang(language or prepared_summary.get("lang")))
-    prepared_summary["lang"] = prepared_language
+    domain_test_run = _reconstruct_report_test_run(payload)
+    prepared_language = str(normalize_lang(language or payload.get("lang")))
     report_facts = (
-        _prepare_report_facts(prepared_summary, test_run=domain_test_run)
+        _prepare_report_facts(payload, test_run=domain_test_run, warnings=warnings)
         if domain_test_run is not None
         else None
     )
     return PreparedReportInput(
-        analysis_summary=prepared_summary,
+        renderer_payload=_build_renderer_payload(payload),
         language=prepared_language,
-        filename=filename or _default_report_filename(prepared_summary),
+        filename=filename or _default_report_filename(payload),
         domain_test_run=domain_test_run,
         cache_key=cache_key,
         report_facts=report_facts,
@@ -206,7 +278,7 @@ def prepare_report_input(
 ) -> PreparedReportInput:
     """Prepare a direct summary payload for domain-first report mapping."""
     return _build_prepared_report_input(
-        cast(AnalysisSummary, dict(analysis_summary)),
+        analysis_summary,
         filename=filename,
         language=language,
         cache_key=cache_key,
@@ -222,12 +294,10 @@ def prepare_persisted_report_input(
     cache_key: ReportPdfCacheKey | None = None,
 ) -> PreparedReportInput:
     """Prepare a persisted history payload for domain-first report mapping."""
-    prepared_summary = cast(AnalysisSummary, analysis.to_json_object())
-    if warnings is not None:
-        prepared_summary = analysis_summary_with_warnings(prepared_summary, warnings)
     return _build_prepared_report_input(
-        prepared_summary,
+        analysis,
         filename=filename,
         language=language,
         cache_key=cache_key,
+        warnings=warnings,
     )


### PR DESCRIPTION
## Summary
Closes #1152.

This PR finishes the last summary-first seam that survived the earlier history/report cleanup. After `#1142`, the history report loader and service already carried `PersistedAnalysis` through the report boundary, and the PDF adapter already stopped reconstructing report facts for itself. The remaining gap was inside `report_preparation.py`: persisted history reports still converted `PersistedAnalysis` back into an `AnalysisSummary`, then reconstructed `TestRun` from that summary payload, and finally carried both the replayed summary dict and the reconstructed domain aggregate through the rest of the pipeline.

This change finishes that move instead of layering another small compatibility patch on top of it. `PreparedReportInput` is now domain-first in the way the issue asked for: it carries the authoritative `domain_test_run`, the existing prepared semantic `report_facts`, and a much smaller renderer-edge payload with only the metadata the PDF mapper still genuinely needs at the final step. The normal persisted-report path no longer calls `PersistedAnalysis.to_json_object()` just to rebuild summary-shaped state, and the mapper/context helpers no longer treat `analysis_summary` as a first-class input.

## Implementation approach
The fix was kept inside the report-preparation seam rather than broadening into unrelated PDF, history, or diagnostics refactors. The core decision was to keep the existing `test_run_from_summary(...)` domain decoder as the single place that knows how to rebuild a `TestRun`, but to stop forcing persisted history reports through a summary copy before calling it. `PersistedAnalysis` already implements the mapping interface the decoder expects, so the previous `to_json_object()` replay step was unnecessary. Once that direct decode path was in place, the rest of the work became a contract cleanup: remove the raw prepared summary dict from `PreparedReportInput`, extract the minimal renderer payload explicitly, and update the PDF mapping/context helpers to consume that prepared contract rather than reaching back into a summary payload.

## Main code changes
In `apps/server/vibesensor/use_cases/history/report_preparation.py`, I introduced `PreparedReportRendererPayload` as the final-edge data carrier for report metadata that is still renderer-specific: run ID, car name/type, report date, sample count, sensor count, duration, and the raw peak-table payload rows. `PreparedReportInput` now holds that renderer payload plus `language`, `filename`, `domain_test_run`, `cache_key`, and `report_facts`; it no longer exposes `analysis_summary`. The preparation helpers were generalized to operate on `Mapping[str, object]` so the same path can consume either a direct summary payload or a `PersistedAnalysis` instance without replaying through `AnalysisSummary` first. `prepare_persisted_report_input()` now decodes the domain aggregate directly from `PersistedAnalysis`, prepares warnings via the shared warning serializer, and never calls `to_json_object()`.

That same file also now centralizes the minimal renderer extraction explicitly. Instead of copying a summary dict and letting downstream adapter code rummage through it, report preparation now builds the small renderer payload itself, including the peak-table row payload slice that the PDF edge still needs. While touching that code, I also tightened count parsing with tolerant coercion helpers so malformed string values degrade to `0` instead of raising in the new payload builder.

In `apps/server/vibesensor/adapters/pdf/mapping.py`, the report mapper stopped building a `Report` object from a raw summary dict. It now constructs that metadata object from the prepared renderer payload and uses `prepared.language` as the canonical locale. The mapper still consumes the already-prepared `domain_test_run` and `report_facts`, but it no longer has a prepared summary dict to fall back to. Peak-table construction is now driven from the prepared peak-table rows rather than by passing the whole summary object into the peak-table helper.

In `apps/server/vibesensor/adapters/pdf/report_context.py`, `prepare_report_mapping_context()` now accepts the prepared report input directly. That keeps the adapter context assembly aligned with the actual domain-first contract: the function reads report date and vehicle metadata from the prepared renderer payload, while business-facing decisions still come from `report_facts` and the authoritative domain aggregate.

In `apps/server/vibesensor/adapters/pdf/peak_table.py`, I split the peak-table helper so the mapper can build final `PeakRow` entries from already-prepared peak-table payload rows. The older summary-based helper remains as a thin wrapper, which keeps existing callers and tests stable while removing the need for the normal prepared-report path to pass a whole summary payload around.

Finally, in `apps/server/vibesensor/shared/boundaries/diagnostic_case.py`, I hardened the `rows` parsing used when reconstructing `RunCapture.sample_count`. The new report-preparation tests exposed that the boundary decoder still used a bare `int(rows_raw)` on untrusted payload data. Because `#1152` now leans more explicitly on that direct decode path, I switched it to the shared tolerant integer coercion helper so malformed persisted count strings do not crash report reconstruction.

## Tests and validation
I updated the report guardrails and focused pipeline tests to reflect the new prepared-input contract. The mapping-context tests, contract bridge tests, summary-view tests, and history warning-path test now consume `PreparedReportInput` directly instead of reaching into `prepared.analysis_summary`. I also added two focused regressions:

- a persisted-report preparation test that monkeypatches `PersistedAnalysis.to_json_object()` to raise, proving the normal persisted report path no longer round-trips through a summary replay step;
- a malformed count-string test that proves prepared report input tolerates bad `rows` and `sensor_count_used` values without crashing.

Validation run locally:

- `pytest -q apps/server/tests/adapters/pdf/test_report_analysis_separation.py apps/server/tests/integration/test_report_pipeline.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/use_cases/history/test_history_http_services.py`
- `make typecheck-backend`
- `make lint`

I also attempted the required local Docker smoke path with `docker compose build --pull && docker compose up -d`, but this environment still does not have a reachable Docker daemon/socket, so that validation remains environment-blocked rather than code-blocked.

## Risks, tradeoffs, and compatibility notes
The main tradeoff here is that `PreparedReportInput` is intentionally stricter and more explicit than before. That is the point of the change: the report mapper should not have a raw summary dict available as a quiet fallback once report preparation has already produced the authoritative domain aggregate and renderer payload. The PR keeps the external `map_summary(prepare_report_input(...))` workflow stable, but it removes the internal prepared-summary crutch so future changes cannot silently reintroduce summary-first behavior in the normal history/PDF path.

Behavior-wise, the goal was stability rather than visible output changes. The PDF adapter still receives the same semantic report facts, warning payloads, and peak-table data it used before; the difference is that those inputs now arrive through explicit prepared fields instead of by replaying or re-reading a summary dict. The extra numeric-coercion hardening is intentionally conservative and only affects malformed count payloads, where the safer fallback is `0` rather than raising during report preparation.

## Out of scope
This PR does not attempt a broader redesign of the PDF/report adapter package, the direct-summary CLI helper path, or unrelated report metadata cleanup. It is focused on closing the exact seam described in `#1152`: remove the remaining summary-first reconstruction loop from the normal persisted history report path while keeping report behavior stable and tightening the regression guardrails around that contract.
