### PR TITLE
Finish GPS speed-monitor concurrency cleanup

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+
+import pytest
+
+from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+
+
+def test_resolve_speed_captures_policy_and_transport_snapshots_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monitor = GPSSpeedMonitor(gps_enabled=True)
+    base_transport = monitor._transport.snapshot()
+    base_policy = monitor._policy.snapshot()
+    transport_calls = 0
+    policy_calls = 0
+
+    def _transport_snapshot():
+        nonlocal transport_calls
+        transport_calls += 1
+        if transport_calls == 1:
+            return replace(
+                base_transport,
+                gps_enabled=True,
+                connection_state="connected",
+                speed_snapshot=(10.0, time.monotonic()),
+            )
+        return replace(
+            base_transport,
+            gps_enabled=False,
+            connection_state="disabled",
+            speed_snapshot=(None, None),
+        )
+
+    def _policy_snapshot():
+        nonlocal policy_calls
+        policy_calls += 1
+        if policy_calls == 1:
+            return replace(
+                base_policy,
+                override_speed_mps=25.0,
+                manual_source_selected=True,
+                stale_timeout_s=5.0,
+            )
+        return replace(
+            base_policy,
+            override_speed_mps=None,
+            manual_source_selected=False,
+            stale_timeout_s=120.0,
+        )
+
+    monkeypatch.setattr(monitor._transport, "snapshot", _transport_snapshot)
+    monkeypatch.setattr(monitor._policy, "snapshot", _policy_snapshot)
+
+    resolution = monitor.resolve_speed()
+
+    assert transport_calls == 1
+    assert policy_calls == 1
+    assert resolution.speed_mps == 25.0
+    assert resolution.source == "manual"
+    assert resolution.fallback_active is False
+
+
+def test_status_snapshot_captures_policy_and_transport_snapshots_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monitor = GPSSpeedMonitor(gps_enabled=True)
+    base_transport = monitor._transport.snapshot()
+    base_policy = monitor._policy.snapshot()
+    transport_calls = 0
+    policy_calls = 0
+
+    def _transport_snapshot():
+        nonlocal transport_calls
+        transport_calls += 1
+        if transport_calls == 1:
+            return replace(
+                base_transport,
+                gps_enabled=True,
+                connection_state="connected",
+                speed_snapshot=(10.0, time.monotonic()),
+                device_info="/dev/ttyUSB0",
+                last_fix_mode=3,
+                last_error="old error",
+            )
+        return replace(
+            base_transport,
+            gps_enabled=False,
+            connection_state="disabled",
+            speed_snapshot=(None, None),
+            device_info=None,
+            last_fix_mode=None,
+            last_error=None,
+        )
+
+    def _policy_snapshot():
+        nonlocal policy_calls
+        policy_calls += 1
+        if policy_calls == 1:
+            return replace(
+                base_policy,
+                override_speed_mps=None,
+                manual_source_selected=False,
+                stale_timeout_s=17.0,
+            )
+        return replace(
+            base_policy,
+            override_speed_mps=25.0,
+            manual_source_selected=True,
+            stale_timeout_s=99.0,
+        )
+
+    monkeypatch.setattr(monitor._transport, "snapshot", _transport_snapshot)
+    monkeypatch.setattr(monitor._policy, "snapshot", _policy_snapshot)
+
+    status = monitor.status_snapshot()
+
+    assert transport_calls == 1
+    assert policy_calls == 1
+    assert status.gps_enabled is True
+    assert status.connection_state == "connected"
+    assert status.device == "/dev/ttyUSB0"
+    assert status.fix_mode == 3
+    assert status.raw_speed_kmh == pytest.approx(36.0, abs=0.1)
+    assert status.stale_timeout_s == pytest.approx(17.0)
+
+
+def test_disabling_gps_clears_speed_snapshot_and_zero_speed_streak() -> None:
+    monitor = GPSSpeedMonitor(gps_enabled=True)
+    monitor.connection_state = "connected"
+    monitor.speed_mps = 10.0
+    monitor._zero_speed_streak = 2
+
+    monitor.gps_enabled = False
+
+    assert monitor.gps_enabled is False
+    assert monitor.connection_state == "disabled"
+    assert monitor._speed_snapshot == (None, None)
+    assert monitor._zero_speed_streak == 0

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -37,6 +37,19 @@ class FakeSpeedSourceSync:
         self.stale_timeout_s: float | None = None
         self.calls: list[str] = []
 
+    def apply_speed_source_settings(
+        self,
+        *,
+        effective_speed_kmh: float | None,
+        manual_source_selected: bool,
+        stale_timeout_s: float | None = None,
+    ) -> float | None:
+        self.calls.append("apply")
+        self.manual_selected = manual_source_selected
+        self.override_kmh = effective_speed_kmh
+        self.stale_timeout_s = stale_timeout_s
+        return effective_speed_kmh
+
     def set_manual_source_selected(self, selected: bool) -> None:
         self.calls.append("manual")
         self.manual_selected = selected
@@ -318,7 +331,7 @@ def test_store_syncs_speed_source_with_protocol_shaped_monitor() -> None:
     assert gps_monitor.manual_selected is True
     assert gps_monitor.override_kmh == pytest.approx(80.0)
     assert gps_monitor.stale_timeout_s == pytest.approx(17.0)
-    assert gps_monitor.calls == ["override", "manual", "fallback"]
+    assert gps_monitor.calls == ["apply"]
 
 
 def test_parse_manual_speed_returns_none_for_invalid() -> None:

--- a/apps/server/vibesensor/adapters/gps/gps_speed.py
+++ b/apps/server/vibesensor/adapters/gps/gps_speed.py
@@ -6,8 +6,12 @@ from typing import Literal
 
 from vibesensor.adapters.gps import gps_transport as _gps_transport
 from vibesensor.adapters.gps import speed_resolution as _speed_resolution
-from vibesensor.adapters.gps.gps_transport import GPSTransportState
-from vibesensor.adapters.gps.speed_resolution import SpeedResolution, SpeedResolutionPolicy
+from vibesensor.adapters.gps.gps_transport import GPSTransportSnapshot, GPSTransportState
+from vibesensor.adapters.gps.speed_resolution import (
+    SpeedResolution,
+    SpeedResolutionPolicy,
+    SpeedResolutionPolicySnapshot,
+)
 from vibesensor.adapters.gps.speed_status import (
     GPSSpeedStatusState,
     SpeedSourceStatusSnapshot,
@@ -30,7 +34,12 @@ __all__ = ["GPSSpeedMonitor", "SpeedResolution"]
 
 
 class GPSSpeedMonitor:
-    """Runtime-facing GPS monitor composed from transport, policy, and presenter helpers."""
+    """Runtime-facing GPS monitor over captured transport/policy snapshots.
+
+    Writers replace immutable transport/policy snapshots atomically; readers
+    capture those snapshots once per resolution/status read so concurrent async
+    ingest and threaded settings updates cannot expose half-applied state.
+    """
 
     def __init__(self, gps_enabled: bool):
         self._transport = GPSTransportState(gps_enabled=gps_enabled)
@@ -42,13 +51,7 @@ class GPSSpeedMonitor:
 
     @gps_enabled.setter
     def gps_enabled(self, value: bool) -> None:
-        enabled = bool(value)
-        self._transport.gps_enabled = enabled
-        if not enabled:
-            self._transport.connection_state = "disabled"
-            self._transport.speed_mps = None
-        elif self._transport.connection_state == "disabled":
-            self._transport.connection_state = "disconnected"
+        self._transport.set_enabled(bool(value))
 
     @property
     def override_speed_mps(self) -> float | None:
@@ -175,24 +178,33 @@ class GPSSpeedMonitor:
         return self._transport.last_update_ts
 
     def resolve_speed(self) -> SpeedResolution:
+        transport_snapshot, policy_snapshot = self._captured_snapshots()
         return self._policy.resolve(
-            gps_enabled=self.gps_enabled,
-            connection_state=self.connection_state,
-            speed_snapshot=self._speed_snapshot,
+            gps_enabled=transport_snapshot.gps_enabled,
+            connection_state=transport_snapshot.connection_state,
+            speed_snapshot=transport_snapshot.speed_snapshot,
+            snapshot=policy_snapshot,
         )
 
     def _effective_connection_state(self) -> str:
+        transport_snapshot, policy_snapshot = self._captured_snapshots()
         return self._policy.effective_connection_state(
-            gps_enabled=self.gps_enabled,
-            actual_connection_state=self.connection_state,
-            speed_snapshot=self._speed_snapshot,
+            gps_enabled=transport_snapshot.gps_enabled,
+            actual_connection_state=transport_snapshot.connection_state,
+            speed_snapshot=transport_snapshot.speed_snapshot,
+            snapshot=policy_snapshot,
         )
 
     def _is_gps_stale(self) -> bool:
-        return self._policy.is_gps_stale(self._speed_snapshot)
+        transport_snapshot, policy_snapshot = self._captured_snapshots()
+        return self._policy.is_gps_stale(
+            transport_snapshot.speed_snapshot,
+            snapshot=policy_snapshot,
+        )
 
     def _fallback_speed_value(self) -> float | None:
-        return self._policy.fallback_speed_value()
+        _, policy_snapshot = self._captured_snapshots()
+        return self._policy.fallback_speed_value(snapshot=policy_snapshot)
 
     def set_speed_override_kmh(self, speed_kmh: float | None) -> float | None:
         return self._policy.set_speed_override_kmh(speed_kmh)
@@ -206,6 +218,20 @@ class GPSSpeedMonitor:
         **kwargs: object,
     ) -> None:
         self._policy.set_fallback_settings(stale_timeout_s=stale_timeout_s, **kwargs)
+
+    def apply_speed_source_settings(
+        self,
+        *,
+        effective_speed_kmh: float | None,
+        manual_source_selected: bool,
+        stale_timeout_s: float | None = None,
+    ) -> float | None:
+        """Apply the full speed-source config atomically for concurrent readers."""
+        return self._policy.apply_speed_source_settings(
+            effective_speed_kmh=effective_speed_kmh,
+            manual_source_selected=manual_source_selected,
+            stale_timeout_s=stale_timeout_s,
+        )
 
     @staticmethod
     def _read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
@@ -224,34 +250,42 @@ class GPSSpeedMonitor:
     def _reset_fix_metadata(self) -> None:
         self._transport._reset_fix_metadata()
 
+    def _captured_snapshots(
+        self,
+    ) -> tuple[GPSTransportSnapshot, SpeedResolutionPolicySnapshot]:
+        return self._transport.snapshot(), self._policy.snapshot()
+
     def status_snapshot(self) -> SpeedSourceStatusSnapshot:
-        speed_snapshot = self._speed_snapshot
+        transport_snapshot, policy_snapshot = self._captured_snapshots()
+        speed_snapshot = transport_snapshot.speed_snapshot
         resolution = self._policy.resolve(
-            gps_enabled=self.gps_enabled,
-            connection_state=self.connection_state,
+            gps_enabled=transport_snapshot.gps_enabled,
+            connection_state=transport_snapshot.connection_state,
             speed_snapshot=speed_snapshot,
+            snapshot=policy_snapshot,
         )
         status_state = GPSSpeedStatusState(
-            gps_enabled=self.gps_enabled,
-            connection_state=self.connection_state,
-            device_info=self.device_info,
-            last_fix_mode=self.last_fix_mode,
-            last_epx_m=self.last_epx_m,
-            last_epy_m=self.last_epy_m,
-            last_epv_m=self.last_epv_m,
+            gps_enabled=transport_snapshot.gps_enabled,
+            connection_state=transport_snapshot.connection_state,
+            device_info=transport_snapshot.device_info,
+            last_fix_mode=transport_snapshot.last_fix_mode,
+            last_epx_m=transport_snapshot.last_epx_m,
+            last_epy_m=transport_snapshot.last_epy_m,
+            last_epv_m=transport_snapshot.last_epv_m,
             raw_speed_mps=speed_snapshot[0],
             last_update_ts=speed_snapshot[1],
-            last_error=self.last_error,
-            current_reconnect_delay=self.current_reconnect_delay,
-            stale_timeout_s=self.stale_timeout_s,
+            last_error=transport_snapshot.last_error,
+            current_reconnect_delay=transport_snapshot.current_reconnect_delay,
+            stale_timeout_s=policy_snapshot.stale_timeout_s,
         )
         return build_status_snapshot(
             status_state,
             resolution=resolution,
             effective_connection_state=self._policy.effective_connection_state(
-                gps_enabled=self.gps_enabled,
-                actual_connection_state=self.connection_state,
+                gps_enabled=transport_snapshot.gps_enabled,
+                actual_connection_state=transport_snapshot.connection_state,
                 speed_snapshot=speed_snapshot,
+                snapshot=policy_snapshot,
             ),
         )
 

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -8,7 +8,8 @@ import logging
 import math
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, replace
+from typing import Any, cast
 
 from vibesensor.shared.constants import NUMERIC_TYPES
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
@@ -33,13 +34,13 @@ TpvModeReader = Callable[[JsonObject], int | None]
 MetricReader = Callable[[JsonObject, str], float | None]
 
 
-@dataclass
-class GPSTransportState:
-    """Mutable GPSD connection state and raw TPV ingestion logic."""
+@dataclass(frozen=True, slots=True)
+class GPSTransportSnapshot:
+    """Immutable transport snapshot captured by GPS readers."""
 
     gps_enabled: bool
-    connection_state: str = field(init=False)
-    _speed_snapshot: tuple[float | None, float | None] = (None, None)
+    connection_state: str
+    speed_snapshot: tuple[float | None, float | None] = (None, None)
     last_error: str | None = None
     current_reconnect_delay: float = _GPS_RECONNECT_DELAY_S
     device_info: str | None = None
@@ -47,29 +48,221 @@ class GPSTransportState:
     last_epx_m: float | None = None
     last_epy_m: float | None = None
     last_epv_m: float | None = None
-    _zero_speed_streak: int = 0
+    zero_speed_streak: int = 0
 
-    def __post_init__(self) -> None:
-        self.connection_state = "disabled" if not self.gps_enabled else "disconnected"
+
+class GPSTransportState:
+    """Owns GPS transport state as immutable snapshots atomically swapped by writers."""
+
+    def __init__(self, gps_enabled: bool):
+        self._snapshot = GPSTransportSnapshot(
+            gps_enabled=bool(gps_enabled),
+            connection_state="disabled" if not gps_enabled else "disconnected",
+        )
+
+    def snapshot(self) -> GPSTransportSnapshot:
+        return self._snapshot
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, GPSTransportState) and self._snapshot == other._snapshot
+
+    def _replace_snapshot(self, **changes: object) -> None:
+        self._snapshot = replace(self._snapshot, **cast(dict[str, Any], changes))
+
+    @staticmethod
+    def _normalize_optional_float(value: object) -> float | None:
+        if value is None or isinstance(value, bool) or not isinstance(value, NUMERIC_TYPES):
+            return None
+        numeric_value = float(value)
+        return numeric_value if math.isfinite(numeric_value) else None
+
+    @staticmethod
+    def _normalize_speed_snapshot(
+        value: tuple[float | None, float | None],
+    ) -> tuple[float | None, float | None]:
+        speed, timestamp = value
+        return (
+            GPSTransportState._normalize_optional_float(speed),
+            GPSTransportState._normalize_optional_float(timestamp),
+        )
+
+    @staticmethod
+    def _evaluate_speed_sample(
+        snapshot: GPSTransportSnapshot,
+        speed_mps: float,
+    ) -> tuple[bool, int]:
+        if speed_mps == 0.0:
+            prev_speed = snapshot.speed_snapshot[0]
+            if (
+                isinstance(prev_speed, NUMERIC_TYPES)
+                and not isinstance(prev_speed, bool)
+                and prev_speed > _GPS_ZERO_DROP_PREV_THRESHOLD_MPS
+            ):
+                streak = snapshot.zero_speed_streak + 1
+                return streak >= _GPS_ZERO_CONFIRM_SAMPLES, streak
+        return True, 0
+
+    def _mark_connected(self) -> None:
+        self._replace_snapshot(
+            connection_state="connected",
+            last_error=None,
+            current_reconnect_delay=_GPS_RECONNECT_DELAY_S,
+        )
+
+    def _mark_stream_disconnected(self) -> None:
+        self._replace_snapshot(
+            connection_state="disconnected",
+            speed_snapshot=(None, None),
+            last_fix_mode=None,
+            last_epx_m=None,
+            last_epy_m=None,
+            last_epv_m=None,
+            zero_speed_streak=0,
+            device_info=None,
+        )
+
+    def _mark_connection_error(self, exc: BaseException, reconnect_delay: float) -> None:
+        self._replace_snapshot(
+            connection_state="disconnected",
+            speed_snapshot=(None, None),
+            last_fix_mode=None,
+            last_epx_m=None,
+            last_epy_m=None,
+            last_epv_m=None,
+            zero_speed_streak=0,
+            device_info=None,
+            last_error=str(exc) or type(exc).__name__,
+            current_reconnect_delay=reconnect_delay,
+        )
+
+    def set_enabled(self, enabled: bool) -> None:
+        snapshot = self._snapshot
+        if not enabled:
+            self._snapshot = replace(
+                snapshot,
+                gps_enabled=False,
+                connection_state="disabled",
+                speed_snapshot=(None, None),
+                zero_speed_streak=0,
+            )
+            return
+        if snapshot.connection_state == "disabled":
+            self._snapshot = replace(
+                snapshot,
+                gps_enabled=True,
+                connection_state="disconnected",
+            )
+            return
+        self._snapshot = replace(snapshot, gps_enabled=True)
+
+    @property
+    def gps_enabled(self) -> bool:
+        return self._snapshot.gps_enabled
+
+    @gps_enabled.setter
+    def gps_enabled(self, value: bool) -> None:
+        self.set_enabled(bool(value))
+
+    @property
+    def connection_state(self) -> str:
+        return self._snapshot.connection_state
+
+    @connection_state.setter
+    def connection_state(self, value: str) -> None:
+        self._replace_snapshot(connection_state=str(value))
 
     @property
     def speed_mps(self) -> float | None:
-        return self._speed_snapshot[0]
+        return self._snapshot.speed_snapshot[0]
 
     @speed_mps.setter
     def speed_mps(self, value: float | None) -> None:
         if value is None or isinstance(value, bool) or not isinstance(value, NUMERIC_TYPES):
-            self._speed_snapshot = (None, None)
+            self._replace_snapshot(speed_snapshot=(None, None))
             return
         speed_f = float(value)
         if not math.isfinite(speed_f):
-            self._speed_snapshot = (None, None)
+            self._replace_snapshot(speed_snapshot=(None, None))
             return
-        self._speed_snapshot = (speed_f, time.monotonic())
+        self._replace_snapshot(speed_snapshot=(speed_f, time.monotonic()))
+
+    @property
+    def _speed_snapshot(self) -> tuple[float | None, float | None]:
+        return self._snapshot.speed_snapshot
+
+    @_speed_snapshot.setter
+    def _speed_snapshot(self, value: tuple[float | None, float | None]) -> None:
+        self._replace_snapshot(speed_snapshot=self._normalize_speed_snapshot(value))
 
     @property
     def last_update_ts(self) -> float | None:
-        return self._speed_snapshot[1]
+        return self._snapshot.speed_snapshot[1]
+
+    @property
+    def last_error(self) -> str | None:
+        return self._snapshot.last_error
+
+    @last_error.setter
+    def last_error(self, value: str | None) -> None:
+        self._replace_snapshot(last_error=(str(value) if value is not None else None))
+
+    @property
+    def current_reconnect_delay(self) -> float:
+        return self._snapshot.current_reconnect_delay
+
+    @current_reconnect_delay.setter
+    def current_reconnect_delay(self, value: float) -> None:
+        self._replace_snapshot(current_reconnect_delay=float(value))
+
+    @property
+    def device_info(self) -> str | None:
+        return self._snapshot.device_info
+
+    @device_info.setter
+    def device_info(self, value: str | None) -> None:
+        self._replace_snapshot(device_info=(str(value) if value is not None else None))
+
+    @property
+    def last_fix_mode(self) -> int | None:
+        return self._snapshot.last_fix_mode
+
+    @last_fix_mode.setter
+    def last_fix_mode(self, value: int | None) -> None:
+        self._replace_snapshot(
+            last_fix_mode=value if isinstance(value, int) and not isinstance(value, bool) else None
+        )
+
+    @property
+    def last_epx_m(self) -> float | None:
+        return self._snapshot.last_epx_m
+
+    @last_epx_m.setter
+    def last_epx_m(self, value: float | None) -> None:
+        self._replace_snapshot(last_epx_m=self._normalize_optional_float(value))
+
+    @property
+    def last_epy_m(self) -> float | None:
+        return self._snapshot.last_epy_m
+
+    @last_epy_m.setter
+    def last_epy_m(self, value: float | None) -> None:
+        self._replace_snapshot(last_epy_m=self._normalize_optional_float(value))
+
+    @property
+    def last_epv_m(self) -> float | None:
+        return self._snapshot.last_epv_m
+
+    @last_epv_m.setter
+    def last_epv_m(self, value: float | None) -> None:
+        self._replace_snapshot(last_epv_m=self._normalize_optional_float(value))
+
+    @property
+    def _zero_speed_streak(self) -> int:
+        return self._snapshot.zero_speed_streak
+
+    @_zero_speed_streak.setter
+    def _zero_speed_streak(self, value: int) -> None:
+        self._replace_snapshot(zero_speed_streak=max(0, int(value)))
 
     @staticmethod
     def _read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
@@ -88,25 +281,20 @@ class GPSTransportState:
         return None
 
     def _accept_speed_sample(self, speed_mps: float) -> bool:
-        if speed_mps == 0.0:
-            prev_speed = self._speed_snapshot[0]
-            if (
-                isinstance(prev_speed, NUMERIC_TYPES)
-                and prev_speed > _GPS_ZERO_DROP_PREV_THRESHOLD_MPS
-            ):
-                self._zero_speed_streak += 1
-                return self._zero_speed_streak >= _GPS_ZERO_CONFIRM_SAMPLES
-        self._zero_speed_streak = 0
-        return True
+        accepted, zero_speed_streak = self._evaluate_speed_sample(self._snapshot, speed_mps)
+        self._replace_snapshot(zero_speed_streak=zero_speed_streak)
+        return accepted
 
     def _reset_fix_metadata(self) -> None:
-        self.last_fix_mode = None
-        self.last_epx_m = None
-        self.last_epy_m = None
-        self.last_epv_m = None
-        self._zero_speed_streak = 0
-        self._speed_snapshot = (None, None)
-        self.device_info = None
+        self._replace_snapshot(
+            last_fix_mode=None,
+            last_epx_m=None,
+            last_epy_m=None,
+            last_epv_m=None,
+            zero_speed_streak=0,
+            speed_snapshot=(None, None),
+            device_info=None,
+        )
 
     def ingest_message(
         self,
@@ -119,7 +307,7 @@ class GPSTransportState:
         if payload_class == "VERSION":
             revision = payload.get("rev")
             if isinstance(revision, str):
-                self.device_info = f"gpsd {revision}"
+                self._replace_snapshot(device_info=f"gpsd {revision}")
             return
         if payload_class != "TPV":
             return
@@ -134,12 +322,11 @@ class GPSTransportState:
     ) -> None:
         read_mode = self._tpv_mode if tpv_mode is None else tpv_mode
         metric_reader = self._read_non_negative_metric if read_metric is None else read_metric
+        snapshot = self._snapshot
 
         mode = read_mode(payload)
-        self.last_fix_mode = mode
-        self.last_epx_m = metric_reader(payload, "epx")
-        self.last_epy_m = metric_reader(payload, "epy")
-        self.last_epv_m = metric_reader(payload, "epv")
+        speed_snapshot = snapshot.speed_snapshot
+        zero_speed_streak = snapshot.zero_speed_streak
 
         speed = payload.get("speed")
         if (
@@ -150,16 +337,26 @@ class GPSTransportState:
         ):
             speed_f = float(speed)
             if math.isfinite(speed_f) and 0 <= speed_f <= _GPS_MAX_SPEED_MPS:
-                if self._accept_speed_sample(speed_f):
-                    self._speed_snapshot = (speed_f, time.monotonic())
+                accepted, zero_speed_streak = self._evaluate_speed_sample(snapshot, speed_f)
+                if accepted:
+                    speed_snapshot = (speed_f, time.monotonic())
             else:
-                self._zero_speed_streak = 0
+                zero_speed_streak = 0
         else:
-            self._zero_speed_streak = 0
+            zero_speed_streak = 0
 
         device = payload.get("device")
-        if isinstance(device, str) and device:
-            self.device_info = device
+        device_info = device if isinstance(device, str) and device else snapshot.device_info
+        self._snapshot = replace(
+            snapshot,
+            last_fix_mode=mode if isinstance(mode, int) else None,
+            last_epx_m=metric_reader(payload, "epx"),
+            last_epy_m=metric_reader(payload, "epy"),
+            last_epv_m=metric_reader(payload, "epv"),
+            speed_snapshot=speed_snapshot,
+            zero_speed_streak=zero_speed_streak,
+            device_info=device_info,
+        )
 
     async def run(
         self,
@@ -173,8 +370,7 @@ class GPSTransportState:
         reconnect_delay = _GPS_RECONNECT_DELAY_S
         while True:
             if not self.gps_enabled:
-                self.speed_mps = None
-                self.connection_state = "disabled"
+                self.set_enabled(False)
                 await asyncio.sleep(_GPS_DISABLED_POLL_S)
                 continue
 
@@ -189,16 +385,15 @@ class GPSTransportState:
                 writer = connected_writer
                 writer.write(b'?WATCH={"enable":true,"json":true};\n')
                 await writer.drain()
-                self.connection_state = "connected"
-                self.last_error = None
-                self.current_reconnect_delay = _GPS_RECONNECT_DELAY_S
+                self._mark_connected()
                 reconnect_delay = _GPS_RECONNECT_DELAY_S
                 while True:
+                    if not self.gps_enabled:
+                        self.set_enabled(False)
+                        break
                     line = await asyncio.wait_for(reader.readline(), timeout=_GPS_READ_TIMEOUT_S)
                     if not line:
-                        self.speed_mps = None
-                        self.connection_state = "disconnected"
-                        self._reset_fix_metadata()
+                        self._mark_stream_disconnected()
                         break
                     try:
                         parsed = loads(line.decode("utf-8", errors="replace"))
@@ -224,11 +419,7 @@ class GPSTransportState:
                 EOFError,
                 json.JSONDecodeError,
             ) as exc:
-                self.speed_mps = None
-                self.connection_state = "disconnected"
-                self._reset_fix_metadata()
-                self.last_error = str(exc) or type(exc).__name__
-                self.current_reconnect_delay = reconnect_delay
+                self._mark_connection_error(exc, reconnect_delay)
                 LOGGER.warning(
                     "GPS connection lost, retrying in %gs: %s",
                     reconnect_delay,

--- a/apps/server/vibesensor/adapters/gps/speed_resolution.py
+++ b/apps/server/vibesensor/adapters/gps/speed_resolution.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 import math
 import time
-from dataclasses import dataclass
-from typing import NamedTuple
+from dataclasses import dataclass, replace
+from typing import Any, NamedTuple, cast
 
 from vibesensor.shared.constants import KMH_TO_MPS, NUMERIC_TYPES
 from vibesensor.shared.types.speed_source_config import ResolvedSpeedSource
@@ -28,13 +28,114 @@ class SpeedResolution(NamedTuple):
     source: ResolvedSpeedSource
 
 
-@dataclass
-class SpeedResolutionPolicy:
-    """Encapsulates override priority, stale fallback, and source selection."""
+@dataclass(frozen=True, slots=True)
+class SpeedResolutionPolicySnapshot:
+    """Immutable policy snapshot captured by concurrent GPS readers."""
 
     override_speed_mps: float | None = None
     manual_source_selected: bool = True
     stale_timeout_s: float = DEFAULT_STALE_TIMEOUT_S
+
+
+class SpeedResolutionPolicy:
+    """Owns the immutable policy snapshot swapped atomically by writers."""
+
+    def __init__(
+        self,
+        override_speed_mps: float | None = None,
+        manual_source_selected: bool = True,
+        stale_timeout_s: float = DEFAULT_STALE_TIMEOUT_S,
+    ) -> None:
+        self._snapshot = SpeedResolutionPolicySnapshot(
+            override_speed_mps=self._normalized_override_speed_mps(override_speed_mps),
+            manual_source_selected=bool(manual_source_selected),
+            stale_timeout_s=self._normalized_stale_timeout(stale_timeout_s),
+        )
+
+    def snapshot(self) -> SpeedResolutionPolicySnapshot:
+        return self._snapshot
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, SpeedResolutionPolicy) and self._snapshot == other._snapshot
+
+    def _replace_snapshot(self, **changes: object) -> None:
+        self._snapshot = replace(self._snapshot, **cast(dict[str, Any], changes))
+
+    @property
+    def override_speed_mps(self) -> float | None:
+        return self._snapshot.override_speed_mps
+
+    @override_speed_mps.setter
+    def override_speed_mps(self, value: float | None) -> None:
+        self._replace_snapshot(override_speed_mps=self._normalized_override_speed_mps(value))
+
+    @property
+    def manual_source_selected(self) -> bool:
+        return self._snapshot.manual_source_selected
+
+    @manual_source_selected.setter
+    def manual_source_selected(self, value: bool) -> None:
+        self._replace_snapshot(manual_source_selected=bool(value))
+
+    @property
+    def stale_timeout_s(self) -> float:
+        return self._snapshot.stale_timeout_s
+
+    @stale_timeout_s.setter
+    def stale_timeout_s(self, value: float) -> None:
+        self._replace_snapshot(stale_timeout_s=self._normalized_stale_timeout(value))
+
+    @staticmethod
+    def _normalized_override_speed_mps(value: float | None) -> float | None:
+        if value is None or isinstance(value, bool) or not isinstance(value, NUMERIC_TYPES):
+            return None
+        speed_val = float(value)
+        return speed_val if math.isfinite(speed_val) else None
+
+    @staticmethod
+    def _normalized_stale_timeout(value: float) -> float:
+        return max(MIN_STALE_TIMEOUT_S, min(MAX_STALE_TIMEOUT_S, float(value)))
+
+    @staticmethod
+    def _normalized_override_speed_kmh(
+        speed_kmh: float | None,
+    ) -> tuple[float | None, float | None]:
+        if speed_kmh is None:
+            return None, None
+        speed_val = float(speed_kmh)
+        if speed_val < 0 or not math.isfinite(speed_val):
+            return None, None
+        if speed_val > MAX_MANUAL_SPEED_KMH:
+            LOGGER.warning(
+                "Manual speed override %.1f km/h exceeds cap %.1f km/h; clamping.",
+                speed_val,
+                MAX_MANUAL_SPEED_KMH,
+            )
+            speed_val = MAX_MANUAL_SPEED_KMH
+        return speed_val * KMH_TO_MPS, speed_val
+
+    def apply_speed_source_settings(
+        self,
+        *,
+        effective_speed_kmh: float | None,
+        manual_source_selected: bool,
+        stale_timeout_s: float | None = None,
+    ) -> float | None:
+        override_speed_mps, applied_speed_kmh = self._normalized_override_speed_kmh(
+            effective_speed_kmh
+        )
+        snapshot = self._snapshot
+        resolved_timeout = (
+            snapshot.stale_timeout_s
+            if stale_timeout_s is None
+            else self._normalized_stale_timeout(stale_timeout_s)
+        )
+        self._snapshot = SpeedResolutionPolicySnapshot(
+            override_speed_mps=override_speed_mps,
+            manual_source_selected=bool(manual_source_selected),
+            stale_timeout_s=resolved_timeout,
+        )
+        return applied_speed_kmh
 
     def resolve(
         self,
@@ -42,16 +143,18 @@ class SpeedResolutionPolicy:
         gps_enabled: bool,
         connection_state: str,
         speed_snapshot: tuple[float | None, float | None],
+        snapshot: SpeedResolutionPolicySnapshot | None = None,
     ) -> SpeedResolution:
-        if self.manual_source_selected and isinstance(self.override_speed_mps, NUMERIC_TYPES):
-            override_speed = self.override_speed_mps
+        policy = self._snapshot if snapshot is None else snapshot
+        if policy.manual_source_selected and isinstance(policy.override_speed_mps, NUMERIC_TYPES):
+            override_speed = policy.override_speed_mps
             if override_speed is not None and not isinstance(override_speed, bool):
                 return SpeedResolution(float(override_speed), False, "manual")
 
         gps_speed, _ = speed_snapshot
         if isinstance(gps_speed, NUMERIC_TYPES) and not isinstance(gps_speed, bool):
-            if self.is_gps_stale(speed_snapshot):
-                fallback_speed = self.fallback_speed_value()
+            if self.is_gps_stale(speed_snapshot, snapshot=policy):
+                fallback_speed = self.fallback_speed_value(snapshot=policy)
                 return SpeedResolution(
                     fallback_speed,
                     True,
@@ -63,9 +166,10 @@ class SpeedResolutionPolicy:
             gps_enabled=gps_enabled,
             actual_connection_state=connection_state,
             speed_snapshot=speed_snapshot,
+            snapshot=policy,
         )
         if gps_enabled and effective_connection in ("disconnected", "stale"):
-            fallback_speed = self.fallback_speed_value()
+            fallback_speed = self.fallback_speed_value(snapshot=policy)
             return SpeedResolution(
                 fallback_speed,
                 True,
@@ -80,51 +184,51 @@ class SpeedResolutionPolicy:
         gps_enabled: bool,
         actual_connection_state: str,
         speed_snapshot: tuple[float | None, float | None],
+        snapshot: SpeedResolutionPolicySnapshot | None = None,
     ) -> str:
+        policy = self._snapshot if snapshot is None else snapshot
         if (
             gps_enabled
             and actual_connection_state == "connected"
-            and self.is_gps_stale(speed_snapshot)
+            and self.is_gps_stale(speed_snapshot, snapshot=policy)
         ):
             return "stale"
         return actual_connection_state
 
-    def is_gps_stale(self, speed_snapshot: tuple[float | None, float | None]) -> bool:
+    def is_gps_stale(
+        self,
+        speed_snapshot: tuple[float | None, float | None],
+        *,
+        snapshot: SpeedResolutionPolicySnapshot | None = None,
+    ) -> bool:
+        policy = self._snapshot if snapshot is None else snapshot
         _, timestamp = speed_snapshot
         if timestamp is None:
             return True
         age = time.monotonic() - timestamp
-        return age > self.stale_timeout_s
+        return age > policy.stale_timeout_s
 
-    def fallback_speed_value(self) -> float | None:
-        if isinstance(self.override_speed_mps, NUMERIC_TYPES) and not isinstance(
-            self.override_speed_mps, bool
+    def fallback_speed_value(
+        self,
+        *,
+        snapshot: SpeedResolutionPolicySnapshot | None = None,
+    ) -> float | None:
+        policy = self._snapshot if snapshot is None else snapshot
+        if isinstance(policy.override_speed_mps, NUMERIC_TYPES) and not isinstance(
+            policy.override_speed_mps, bool
         ):
-            override_speed = self.override_speed_mps
+            override_speed = policy.override_speed_mps
             if override_speed is not None:
                 return float(override_speed)
         return None
 
     def set_speed_override_kmh(self, speed_kmh: float | None) -> float | None:
-        if speed_kmh is None:
-            self.override_speed_mps = None
-            return None
-        speed_val = float(speed_kmh)
-        if speed_val < 0 or not math.isfinite(speed_val):
-            self.override_speed_mps = None
-            return None
-        if speed_val > MAX_MANUAL_SPEED_KMH:
-            LOGGER.warning(
-                "Manual speed override %.1f km/h exceeds cap %.1f km/h; clamping.",
-                speed_val,
-                MAX_MANUAL_SPEED_KMH,
-            )
-            speed_val = MAX_MANUAL_SPEED_KMH
-        self.override_speed_mps = speed_val * KMH_TO_MPS
-        return speed_val
+        override_speed_mps, applied_speed_kmh = self._normalized_override_speed_kmh(speed_kmh)
+        self._replace_snapshot(override_speed_mps=override_speed_mps)
+        return applied_speed_kmh
 
     def set_manual_source_selected(self, selected: bool) -> None:
-        self.manual_source_selected = bool(selected)
+        self._replace_snapshot(manual_source_selected=bool(selected))
 
     def set_fallback_settings(
         self,
@@ -132,7 +236,4 @@ class SpeedResolutionPolicy:
         **_kwargs: object,
     ) -> None:
         if stale_timeout_s is not None:
-            self.stale_timeout_s = max(
-                MIN_STALE_TIMEOUT_S,
-                min(MAX_STALE_TIMEOUT_S, float(stale_timeout_s)),
-            )
+            self._replace_snapshot(stale_timeout_s=self._normalized_stale_timeout(stale_timeout_s))

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -155,9 +155,9 @@ class SettingsStore(CarSettingsMixin):
             return
         ss = self.speed_source()
         raw = self.get_speed_source()
-        self._gps_monitor.set_speed_override_kmh(ss.effective_speed_kmh)
-        self._gps_monitor.set_manual_source_selected(ss.is_manual)
-        self._gps_monitor.set_fallback_settings(
+        self._gps_monitor.apply_speed_source_settings(
+            effective_speed_kmh=ss.effective_speed_kmh,
+            manual_source_selected=ss.is_manual,
             stale_timeout_s=raw.get("staleTimeoutS"),
         )
 

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -200,6 +200,14 @@ class SpeedProvider(Protocol):
 class SpeedSourceSync(Protocol):
     """Minimal speed-source sync surface needed by SettingsStore."""
 
+    def apply_speed_source_settings(
+        self,
+        *,
+        effective_speed_kmh: float | None,
+        manual_source_selected: bool,
+        stale_timeout_s: float | None = None,
+    ) -> float | None: ...
+
     def set_manual_source_selected(self, selected: bool) -> None: ...
 
     def set_speed_override_kmh(self, speed_kmh: float | None) -> float | None: ...


### PR DESCRIPTION
## Summary
Closes #1159.

Issue #1120 removed most of the recorder-side concurrency hazards, but the GPS monitor still depended on multiple mutable attributes being read and written across the async GPSD loop, settings-thread paths, and runtime readers. In practice that meant `GPSSpeedMonitor.resolve_speed()` and `status_snapshot()` could observe mixed transport or policy fields, and `SettingsStore._sync_speed_source()` could still publish one speed-source update as three separate mutations. This PR finishes that remaining seam by moving the GPS transport and policy state to immutable snapshots that writers replace atomically, and by making settings-driven speed-source changes land as one grouped update.

## Problem being solved

The remaining risk described in #1159 was not that the GPS code was obviously crashing; it was that correctness still depended on implicit timing and on CPython making unsynchronized attribute writes “usually work.” The transport side kept connection state, speed samples, reconnect delay, fix metadata, and error information as independently mutable fields. The resolution side kept manual override, manual-source selection, and stale timeout as separate mutable values. Readers then composed those values on demand. That left space for torn reads, especially when GPS ingest and settings updates interleaved with status or speed-resolution calls.

The most concrete leftover seam was the settings path. Even after #1120 reordered writes, `_sync_speed_source()` still called `set_speed_override_kmh(...)`, `set_manual_source_selected(...)`, and `set_fallback_settings(...)` separately. A concurrent read could land between any two of those calls and observe a policy state that never existed as a complete configuration.

## Implementation approach

I chose the explicit immutable-snapshot model rather than introducing another lock around every GPS read and write. That direction matches the issue’s allowed outcomes, keeps the read path simple, and makes the concurrency contract easier to document: writers replace a complete snapshot, and readers capture the latest snapshot once and work from that stable copy.

On the transport side, `gps_transport.py` now has a frozen `GPSTransportSnapshot` dataclass that owns the full runtime view the resolver and status presenter care about: enablement, connection state, speed sample and timestamp, reconnect delay, device info, fix metadata, and zero-speed streak. `GPSTransportState` now owns a single `_snapshot` value and updates it with `dataclasses.replace(...)` through focused helpers. That lets operations like connect, disconnect, connection-error handling, zero-speed filtering, TPV ingestion, and GPS enable/disable transitions publish coherent transport state in one swap instead of as a sequence of field mutations.

On the policy side, `speed_resolution.py` now mirrors that structure with `SpeedResolutionPolicySnapshot`. The policy object still exposes the existing property surface for targeted updates, but those setters now replace immutable snapshots rather than mutating standalone attributes. More importantly, the file adds `apply_speed_source_settings(...)`, which computes the effective manual override and timeout once and then publishes the entire policy snapshot in a single assignment.

`gps_speed.py` is the runtime-facing bridge. The class docstring now states the concurrency contract directly, and `resolve_speed()`, `_effective_connection_state()`, `_is_gps_stale()`, `_fallback_speed_value()`, and `status_snapshot()` all capture transport and policy snapshots once before deriving results. That removes the old pattern where a single read operation could traverse multiple mutable fields that might change underneath it. The `gps_enabled` setter now delegates to a grouped transport transition so disabling GPS clears speed/timestamp state and the zero-speed streak coherently.

The settings path is the other important part of the fix. `SettingsStore._sync_speed_source()` now calls one grouped `apply_speed_source_settings(...)` method instead of performing three separate monitor writes. I updated the `SpeedSourceSync` protocol accordingly, keeping the narrower internal contract aligned with the new grouped update path.

## Main code changes by area

In `apps/server/vibesensor/adapters/gps/gps_transport.py`, the transport state now has an explicit owner object around immutable snapshots and dedicated grouped transitions for connected, disconnected, connection-error, and enable/disable state changes.

In `apps/server/vibesensor/adapters/gps/speed_resolution.py`, the resolver now works from immutable policy snapshots, supports grouped policy application for settings sync, and preserves the existing manual-override and stale-fallback behavior while making the state transitions explicit.

In `apps/server/vibesensor/adapters/gps/gps_speed.py`, the monitor changed from reading live mutable fields ad hoc to capturing one transport snapshot and one policy snapshot per read operation. That is the core behavior change that closes the torn-read seam called out in the issue.

In `apps/server/vibesensor/infra/config/settings_store.py` and `apps/server/vibesensor/shared/ports.py`, the settings-sync surface changed from three independent operations to one grouped operation so callers can no longer expose intermediate policy state during a single config sync.

## Tests and validation

I added `apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py` to lock down the new read semantics. Those tests assert that `resolve_speed()` and `status_snapshot()` each capture transport and policy snapshots exactly once, and that disabling GPS clears the speed snapshot and zero-speed streak together.

I also updated `apps/server/tests/infra/config/test_settings_store.py` so the settings-store protocol test now verifies the grouped `apply` call instead of the old sequence of `override`, `manual`, and `fallback` mutations.

Validation was done in layers:

- `pytest -q apps/server/tests/adapters/gps/test_gps_speed.py apps/server/tests/adapters/gps/test_gps_speed_status.py apps/server/tests/adapters/gps/test_gps_speed_run_loop.py apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py apps/server/tests/adapters/gps/test_gps_speed_extended.py apps/server/tests/adapters/gps/test_gps_iris4_fixes.py apps/server/tests/adapters/gps/test_speed_resolution_policy.py apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py apps/server/tests/infra/config/test_settings_store.py`
- `pytest -q apps/server/tests/adapters/gps apps/server/tests/infra/config/test_settings_store.py apps/server/tests/integration/test_coverage_gap_audit_round2.py`
- `make typecheck-backend`
- `make lint`

I also attempted the required local Docker smoke with `docker compose build --pull && docker compose up -d`, but this environment still has no reachable Docker daemon/socket, so that step fails before the stack can start. I am calling that out explicitly rather than claiming a local smoke run that did not happen.

## Risks, tradeoffs, and out-of-scope notes

The main tradeoff here is that transport and policy are still captured as two snapshots rather than one global combined snapshot. I kept that boundary intentionally because they are written by different concerns and the issue only requires that readers stop observing torn internal state. This PR makes each owner publish coherent state atomically and makes each read operate from fixed captured inputs, which removes the partial-update hazard without expanding the design into a broader runtime coordinator.

I did not change any external HTTP or WebSocket contracts, and I did not add new configuration knobs. Existing GPS behavior around manual override priority, stale fallback, reconnect delay, and status shaping is meant to stay intact; the change is in how state is published and read, not in the user-facing rules.
