### PR TITLE
Strengthen backend test coverage for routed, history, and hotspot flows

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -22,6 +22,7 @@ esp = [
   "esptool>=4,<5",
 ]
 dev = [
+  "httpx>=0.27,<1",
   "mypy>=1.19,<2",
   "pypdf>=5,<6",
   "pypdfium2>=4.30,<5",

--- a/apps/server/tests/adapters/http/test_recording_route_http.py
+++ b/apps/server/tests/adapters/http/test_recording_route_http.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.http.recording import create_recording_routes
+from vibesensor.use_cases.run.status_reporting import RunRecorderStatusSnapshot
+
+
+def _make_recording_status_snapshot(
+    *,
+    enabled: bool,
+    run_id: str | None,
+    samples_written: int,
+    samples_dropped: int = 0,
+    write_error: str | None = None,
+    analysis_in_progress: bool = False,
+    last_completed_run_id: str | None = None,
+    last_completed_run_error: str | None = None,
+) -> RunRecorderStatusSnapshot:
+    return RunRecorderStatusSnapshot(
+        enabled=enabled,
+        run_id=run_id,
+        write_error=write_error,
+        analysis_in_progress=analysis_in_progress,
+        samples_written=samples_written,
+        samples_dropped=samples_dropped,
+        last_completed_run_id=last_completed_run_id,
+        last_completed_run_error=last_completed_run_error,
+    )
+
+
+@pytest.fixture
+def recording_client(fake_state):
+    app = FastAPI()
+    app.include_router(create_recording_routes(fake_state.run_recorder))
+    with TestClient(app) as client:
+        yield client, fake_state
+
+
+def test_recording_status_route_returns_serialized_snapshot(recording_client) -> None:
+    client, state = recording_client
+    state.run_recorder.status.return_value = _make_recording_status_snapshot(
+        enabled=True,
+        run_id="run-123",
+        samples_written=84,
+        samples_dropped=3,
+        analysis_in_progress=True,
+        last_completed_run_id="run-122",
+    )
+
+    response = client.get("/api/recording/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "enabled": True,
+        "run_id": "run-123",
+        "write_error": None,
+        "analysis_in_progress": True,
+        "samples_written": 84,
+        "samples_dropped": 3,
+        "last_completed_run_id": "run-122",
+        "last_completed_run_error": None,
+    }
+
+
+def test_recording_start_route_uses_real_http_routing(recording_client) -> None:
+    client, state = recording_client
+    state.run_recorder.start_recording.return_value = _make_recording_status_snapshot(
+        enabled=True,
+        run_id="run-abc",
+        samples_written=42,
+    )
+
+    response = client.post("/api/recording/start")
+
+    assert response.status_code == 200
+    assert response.json()["enabled"] is True
+    assert response.json()["run_id"] == "run-abc"
+    state.run_recorder.start_recording.assert_called_once_with()
+
+
+def test_recording_stop_route_uses_real_http_routing(recording_client) -> None:
+    client, state = recording_client
+    state.run_recorder.stop_recording.return_value = _make_recording_status_snapshot(
+        enabled=False,
+        run_id=None,
+        samples_written=84,
+        last_completed_run_id="run-abc",
+    )
+
+    response = client.post("/api/recording/stop")
+
+    assert response.status_code == 200
+    assert response.json()["enabled"] is False
+    assert response.json()["last_completed_run_id"] == "run-abc"
+    state.run_recorder.stop_recording.assert_called_once_with()

--- a/apps/server/tests/adapters/http/test_update_endpoints.py
+++ b/apps/server/tests/adapters/http/test_update_endpoints.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.http.updates import create_update_routes
+from vibesensor.use_cases.updates.esp_flash_types import (
+    EspFlashHistoryEntry,
+    EspFlashState,
+    EspFlashStatus,
+    SerialPortInfo,
+)
+from vibesensor.use_cases.updates.models import (
+    UpdateIssue,
+    UpdateJobStatus,
+    UpdatePhase,
+    UpdateRuntimeDetails,
+    UpdateState,
+)
+
+
+def _make_update_status(
+    *,
+    state: UpdateState = UpdateState.idle,
+    phase: UpdatePhase = UpdatePhase.idle,
+    ssid: str = "",
+) -> UpdateJobStatus:
+    return UpdateJobStatus(
+        state=state,
+        phase=phase,
+        started_at=10.0 if state != UpdateState.idle else None,
+        phase_started_at=12.0 if state == UpdateState.running else None,
+        updated_at=15.0,
+        ssid=ssid,
+        issues=[UpdateIssue(phase="restore", message="warning", detail="detail")],
+        log_tail=["line-1", "line-2"],
+        runtime=UpdateRuntimeDetails(
+            version="1.2.3",
+            commit="deadbeef",
+            ui_source_hash="ui-hash",
+            static_assets_hash="assets-hash",
+            static_build_source_hash="build-hash",
+            static_build_commit="build-commit",
+            assets_verified=True,
+            has_packaged_static=True,
+        ),
+    )
+
+
+@pytest.fixture
+def update_client(fake_state):
+    app = FastAPI()
+    app.include_router(
+        create_update_routes(fake_state.update_manager, fake_state.esp_flash_manager)
+    )
+    with TestClient(app) as client:
+        yield client, fake_state
+
+
+def test_get_update_status_returns_serialized_status(update_client) -> None:
+    client, state = update_client
+    state.update_manager.status = _make_update_status(
+        state=UpdateState.running,
+        phase=UpdatePhase.checking,
+        ssid="GarageNet",
+    )
+
+    response = client.get("/api/update/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "running"
+    assert payload["phase"] == "checking"
+    assert payload["ssid"] == "GarageNet"
+    assert payload["runtime"]["assets_verified"] is True
+    assert payload["issues"][0]["phase"] == "restore"
+
+
+def test_start_update_returns_started_response(update_client) -> None:
+    client, state = update_client
+
+    response = client.post("/api/update/start", json={"ssid": "GarageNet", "password": "secret123"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "started", "ssid": "GarageNet"}
+    state.update_manager.start.assert_called_once_with("GarageNet", "secret123")
+
+
+def test_start_update_maps_value_error_to_400(update_client) -> None:
+    client, state = update_client
+    state.update_manager.start.side_effect = ValueError("SSID must be 1-64 characters")
+
+    response = client.post("/api/update/start", json={"ssid": "x", "password": ""})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "SSID must be 1-64 characters"
+
+
+def test_start_update_maps_runtime_error_to_409(update_client) -> None:
+    client, state = update_client
+    state.update_manager.start.side_effect = RuntimeError("Update already in progress")
+
+    response = client.post("/api/update/start", json={"ssid": "GarageNet", "password": ""})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Update already in progress"
+
+
+def test_cancel_update_returns_cancelled_flag(update_client) -> None:
+    client, state = update_client
+    state.update_manager.cancel.return_value = True
+
+    response = client.post("/api/update/cancel")
+
+    assert response.status_code == 200
+    assert response.json() == {"cancelled": True}
+
+
+def test_list_esp_flash_ports_returns_detected_ports(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.list_ports.return_value = [
+        SerialPortInfo(
+            port="/dev/ttyUSB0",
+            description="USB Serial",
+            vid=0x10C4,
+            pid=0xEA60,
+            serial_number="abc123",
+        ).to_dict()
+    ]
+
+    response = client.get("/api/esp-flash/ports")
+
+    assert response.status_code == 200
+    assert response.json()["ports"] == [
+        {
+            "port": "/dev/ttyUSB0",
+            "description": "USB Serial",
+            "vid": 4292,
+            "pid": 60000,
+            "serial_number": "abc123",
+        }
+    ]
+
+
+def test_start_esp_flash_returns_started_response(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.start.return_value = 7
+
+    response = client.post(
+        "/api/esp-flash/start",
+        json={"port": "/dev/ttyUSB0", "auto_detect": False},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "started", "job_id": 7}
+    state.esp_flash_manager.start.assert_called_once_with(
+        port="/dev/ttyUSB0",
+        auto_detect=False,
+    )
+
+
+def test_start_esp_flash_rejects_missing_port_when_auto_detect_disabled(update_client) -> None:
+    client, _state = update_client
+
+    response = client.post("/api/esp-flash/start", json={"auto_detect": False})
+
+    assert response.status_code == 422
+    assert "port is required when auto_detect is False" in str(response.json())
+
+
+def test_start_esp_flash_maps_value_error_to_400(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.start.side_effect = ValueError(
+        "port is required when auto_detect is False"
+    )
+
+    response = client.post("/api/esp-flash/start", json={"port": None, "auto_detect": True})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "port is required when auto_detect is False"
+
+
+def test_start_esp_flash_maps_runtime_error_to_409(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.start.side_effect = RuntimeError("Flash already in progress")
+
+    response = client.post("/api/esp-flash/start", json={"port": None, "auto_detect": True})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Flash already in progress"
+
+
+def test_get_esp_flash_status_returns_serialized_status(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.status = EspFlashStatus(
+        state=EspFlashState.running,
+        phase="flashing",
+        job_id=3,
+        selected_port="/dev/ttyUSB0",
+        auto_detect=False,
+        started_at=10.0,
+        last_success_at=5.0,
+        log_count=12,
+    )
+
+    response = client.get("/api/esp-flash/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "state": "running",
+        "phase": "flashing",
+        "job_id": 3,
+        "selected_port": "/dev/ttyUSB0",
+        "auto_detect": False,
+        "started_at": 10.0,
+        "finished_at": None,
+        "last_success_at": 5.0,
+        "exit_code": None,
+        "error": None,
+        "log_count": 12,
+    }
+
+
+def test_get_esp_flash_logs_uses_after_query_param(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.logs_since.return_value = {
+        "from_index": 4,
+        "next_index": 6,
+        "lines": ["line 5", "line 6"],
+    }
+
+    response = client.get("/api/esp-flash/logs", params={"after": 4})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "from_index": 4,
+        "next_index": 6,
+        "lines": ["line 5", "line 6"],
+    }
+    state.esp_flash_manager.logs_since.assert_called_once_with(4)
+
+
+def test_cancel_esp_flash_returns_cancelled_flag(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.cancel.return_value = True
+
+    response = client.post("/api/esp-flash/cancel")
+
+    assert response.status_code == 200
+    assert response.json() == {"cancelled": True}
+
+
+def test_get_esp_flash_history_returns_attempts(update_client) -> None:
+    client, state = update_client
+    state.esp_flash_manager.history.return_value = [
+        EspFlashHistoryEntry(
+            job_id=5,
+            state=EspFlashState.success,
+            selected_port="/dev/ttyUSB0",
+            auto_detect=False,
+            started_at=10.0,
+            finished_at=20.0,
+            exit_code=0,
+            error=None,
+        ).to_dict()
+    ]
+
+    response = client.get("/api/esp-flash/history")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "attempts": [
+            {
+                "job_id": 5,
+                "state": "success",
+                "selected_port": "/dev/ttyUSB0",
+                "auto_detect": False,
+                "started_at": 10.0,
+                "finished_at": 20.0,
+                "exit_code": 0,
+                "error": None,
+            }
+        ]
+    }

--- a/apps/server/tests/adapters/pdf/test_i18n_separation.py
+++ b/apps/server/tests/adapters/pdf/test_i18n_separation.py
@@ -1,5 +1,6 @@
-# ruff: noqa: E501
-"""Tests enforcing the multilingual architecture: language-neutral analysis + render-time translation.
+"""Tests enforcing the multilingual architecture.
+
+Language-neutral analysis plus render-time translation.
 
 These tests verify:
 1. Analysis output contains no localized text — only codes, i18n refs, and parameters.

--- a/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
@@ -1,8 +1,6 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Report pipeline audit – rendering and data consistency regressions."""
 
+from __future__ import annotations
 
 from vibesensor.adapters.pdf.mapping import map_summary, prepare_report_input
 from vibesensor.adapters.pdf.presentation import (

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -9,10 +9,12 @@ sub-directory ``conftest.py`` files exist (which shadow this module in
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
+from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
 from vibesensor.adapters.history import (
     ProjectedHistoryExportService,
     ProjectedHistoryRunService,
@@ -24,14 +26,179 @@ from vibesensor.adapters.http.dependencies import (
     TelemetryDeps,
     UpdateDeps,
 )
+from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
+from vibesensor.adapters.websocket.hub import WebSocketHub
+from vibesensor.domain import AnalysisSettingsSnapshot
+from vibesensor.infra.config.settings_store import SettingsStore
+from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime import ProcessingLoopState, RuntimeHealthState
+from vibesensor.infra.runtime.registry import ClientRegistry
+from vibesensor.shared.types.car_config import CarsSnapshot
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.reports import HistoryReportService
 from vibesensor.use_cases.history.runs import HistoryRunService
+from vibesensor.use_cases.run import RunRecorder
+from vibesensor.use_cases.run.status_reporting import RunRecorderStatusSnapshot
+from vibesensor.use_cases.updates.esp_flash_manager import EspFlashManager
+from vibesensor.use_cases.updates.esp_flash_types import EspFlashStatus
+from vibesensor.use_cases.updates.manager import UpdateManager
+from vibesensor.use_cases.updates.models import UpdateJobStatus
 
 # ---------------------------------------------------------------------------
 # Shared API test helpers
 # ---------------------------------------------------------------------------
+
+
+def _update_manager_mock() -> UpdateManager:
+    manager = create_autospec(UpdateManager, instance=True, spec_set=True)
+    manager.status = UpdateJobStatus()
+    manager.cancel.return_value = False
+    return manager
+
+
+def _esp_flash_manager_mock() -> EspFlashManager:
+    manager = create_autospec(EspFlashManager, instance=True, spec_set=True)
+    manager.status = EspFlashStatus()
+    manager.list_ports = AsyncMock(return_value=[])
+    manager.start.return_value = 1
+    manager.logs_since.return_value = {"from_index": 0, "next_index": 0, "lines": []}
+    manager.cancel.return_value = False
+    manager.history.return_value = []
+    return manager
+
+
+def _run_recorder_mock() -> RunRecorder:
+    recorder = create_autospec(RunRecorder, instance=True, spec_set=True)
+    idle_status = RunRecorderStatusSnapshot(
+        enabled=False,
+        run_id=None,
+        write_error=None,
+        analysis_in_progress=False,
+        samples_written=0,
+        samples_dropped=0,
+        last_completed_run_id=None,
+        last_completed_run_error=None,
+    )
+    recorder.status.return_value = idle_status
+    recorder.start_recording.return_value = idle_status
+    recorder.stop_recording.return_value = idle_status
+    return recorder
+
+
+def _processor_mock() -> SignalProcessor:
+    processor = create_autospec(SignalProcessor, instance=True, spec_set=True)
+    processor.intake_stats.return_value = {
+        "total_ingested_samples": 0,
+        "total_compute_calls": 0,
+        "last_compute_duration_s": 0.0,
+        "last_compute_all_duration_s": 0.0,
+        "last_ingest_duration_s": 0.0,
+    }
+    processor.all_latest_metrics.return_value = {}
+    processor.debug_spectrum.return_value = {
+        "error": "insufficient samples",
+        "count": 0,
+        "fft_n": 0,
+    }
+    processor.raw_samples.return_value = {"error": "no data", "count": 0}
+    return processor
+
+
+def _registry_mock() -> ClientRegistry:
+    registry = create_autospec(ClientRegistry, instance=True, spec_set=True)
+    registry.active_client_ids.return_value = []
+    registry.get.return_value = None
+    registry.remove_client.return_value = False
+    registry.data_loss_snapshot.return_value = {
+        "tracked_clients": 0,
+        "affected_clients": 0,
+        "frames_dropped": 0,
+        "queue_overflow_drops": 0,
+        "server_queue_drops": 0,
+        "parse_errors": 0,
+    }
+    return registry
+
+
+def _control_plane_mock() -> UDPControlPlane:
+    control_plane = create_autospec(UDPControlPlane, instance=True, spec_set=True)
+    control_plane.send_identify.return_value = (False, None)
+    return control_plane
+
+
+def _ws_hub_mock() -> WebSocketHub:
+    ws_hub = create_autospec(WebSocketHub, instance=True, spec_set=True)
+    ws_hub.add = AsyncMock(return_value=None)
+    ws_hub.update_selected_client = AsyncMock(return_value=None)
+    ws_hub.remove = AsyncMock(return_value=None)
+    return ws_hub
+
+
+def _gps_monitor_mock() -> GPSSpeedMonitor:
+    gps_monitor = create_autospec(GPSSpeedMonitor, instance=True, spec_set=True)
+    gps_monitor.status_snapshot.return_value = SpeedSourceStatusSnapshot(
+        gps_enabled=False,
+        connection_state="disconnected",
+        device=None,
+        fix_mode=0,
+        fix_dimension="none",
+        speed_confidence="none",
+        epx_m=None,
+        epy_m=None,
+        epv_m=None,
+        last_update_age_s=None,
+        raw_speed_kmh=None,
+        effective_speed_kmh=None,
+        last_error=None,
+        reconnect_delay_s=None,
+        fallback_active=False,
+        speed_source="manual",
+        stale_timeout_s=8.0,
+    )
+    return gps_monitor
+
+
+def _default_cars_snapshot() -> CarsSnapshot:
+    return CarsSnapshot(
+        cars=[
+            {
+                "id": "car-1",
+                "name": "Test Car",
+                "type": "sedan",
+                "aspects": {"tire_width_mm": 225.0},
+            }
+        ],
+        active_car_id="car-1",
+    )
+
+
+def _settings_store_mock() -> SettingsStore:
+    store = create_autospec(SettingsStore, instance=True, spec_set=True)
+    store.analysis_settings_snapshot.return_value = AnalysisSettingsSnapshot(
+        **AnalysisSettingsSnapshot.DEFAULTS
+    )
+    store.get_cars.return_value = _default_cars_snapshot()
+    store.get_speed_source.return_value = {
+        "speedSource": "manual",
+        "manualSpeedKph": 0.0,
+        "staleTimeoutS": 8.0,
+    }
+    store.get_sensors.return_value = {}
+    store.active_car_snapshot.return_value = None
+    store.add_car.return_value = _default_cars_snapshot()
+    store.update_car.return_value = _default_cars_snapshot()
+    store.delete_car.return_value = _default_cars_snapshot()
+    store.set_active_car.return_value = _default_cars_snapshot()
+    store.update_speed_source.return_value = {
+        "speedSource": "manual",
+        "manualSpeedKph": 0.0,
+        "staleTimeoutS": 8.0,
+    }
+    store.set_language.return_value = "en"
+    store.language = "en"
+    store.set_speed_unit.return_value = "kmh"
+    store.speed_unit = "kmh"
+    return store
 
 
 @dataclass
@@ -43,17 +210,17 @@ class FakeState:
     """
 
     config: object = field(default_factory=MagicMock)
-    registry: object = field(default_factory=MagicMock)
-    processor: object = field(default_factory=MagicMock)
-    control_plane: object = field(default_factory=MagicMock)
+    registry: ClientRegistry = field(default_factory=_registry_mock)
+    processor: SignalProcessor = field(default_factory=_processor_mock)
+    control_plane: UDPControlPlane = field(default_factory=_control_plane_mock)
     worker_pool: object = field(default_factory=MagicMock)
-    ws_hub: object = field(default_factory=MagicMock)
-    gps_monitor: object = field(default_factory=MagicMock)
-    run_recorder: object = field(default_factory=MagicMock)
-    settings_store: object = field(default_factory=MagicMock)
+    ws_hub: WebSocketHub = field(default_factory=_ws_hub_mock)
+    gps_monitor: GPSSpeedMonitor = field(default_factory=_gps_monitor_mock)
+    run_recorder: RunRecorder = field(default_factory=_run_recorder_mock)
+    settings_store: SettingsStore = field(default_factory=_settings_store_mock)
     history_db: object = field(default_factory=MagicMock)
-    update_manager: object = field(default_factory=MagicMock)
-    esp_flash_manager: object = field(default_factory=MagicMock)
+    update_manager: UpdateManager = field(default_factory=_update_manager_mock)
+    esp_flash_manager: EspFlashManager = field(default_factory=_esp_flash_manager_mock)
     processing_loop_state: ProcessingLoopState = field(default_factory=ProcessingLoopState)
     health_state: RuntimeHealthState = field(default_factory=RuntimeHealthState)
     processing_loop: object = field(default_factory=MagicMock)
@@ -132,21 +299,6 @@ class FakeState:
 def fake_state() -> FakeState:
     """Return a fresh ``FakeState`` for each test."""
     state = FakeState()
-    state.processor.intake_stats.return_value = {
-        "total_ingested_samples": 0,
-        "total_compute_calls": 0,
-        "last_compute_duration_s": 0.0,
-        "last_compute_all_duration_s": 0.0,
-        "last_ingest_duration_s": 0.0,
-    }
-    state.registry.data_loss_snapshot.return_value = {
-        "tracked_clients": 0,
-        "affected_clients": 0,
-        "frames_dropped": 0,
-        "queue_overflow_drops": 0,
-        "server_queue_drops": 0,
-        "parse_errors": 0,
-    }
     state.run_recorder.health_snapshot.return_value = {
         "write_error": None,
         "analysis_in_progress": False,

--- a/apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py
+++ b/apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py
@@ -1,8 +1,6 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Metrics cache, settings rollback, and counter-delta regressions."""
 
+from __future__ import annotations
 
 from typing import Any
 from unittest.mock import patch

--- a/apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py
+++ b/apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Spectrum smoothing and peak-selection regressions:
 - _smooth_spectrum uses edge-padding instead of zero-padding to prevent
   boundary attenuation of edge frequency bins.
@@ -8,6 +5,7 @@ from __future__ import annotations
   spectrum bin as a potential peak candidate.
 """
 
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/apps/server/tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py
+++ b/apps/server/tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Strength bucketing and combined-spectrum runtime regressions:
 - order tolerance scales with path_compliance
 - _noise_floor no double bin removal
@@ -8,6 +5,7 @@ from __future__ import annotations
 - dead db_value variable removed from _top_strength_values
 """
 
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/apps/server/tests/integration/test_api_history_processing_regressions.py
+++ b/apps/server/tests/integration/test_api_history_processing_regressions.py
@@ -1,8 +1,6 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Runtime regressions spanning API, history, and processing boundaries."""
 
+from __future__ import annotations
 
 import re
 from pathlib import Path

--- a/apps/server/tests/integration/test_concurrency_generation_guard_regressions.py
+++ b/apps/server/tests/integration/test_concurrency_generation_guard_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Concurrency and generation-guard regressions.
 
 Tests covering:
@@ -10,6 +7,7 @@ Tests covering:
 4. stop_recording / start_recording _finalize_run_locked return-value gating
 """
 
+from __future__ import annotations
 
 import sqlite3
 from pathlib import Path

--- a/apps/server/tests/integration/test_coverage_gap_audit_round2.py
+++ b/apps/server/tests/integration/test_coverage_gap_audit_round2.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Coverage-gap audit (round 2).
 
 Findings addressed
@@ -17,6 +14,7 @@ Findings addressed
 10. API export: _safe_filename sanitization
 """
 
+from __future__ import annotations
 
 import asyncio
 import json

--- a/apps/server/tests/integration/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/integration/test_io_and_time_guard_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """I/O cleanup, time-source, and report-cli guard regressions.
 
 Covers:
@@ -11,6 +8,8 @@ Covers:
   5. report_cli.main() – PDF generation errors return 1 instead of traceback
   6. report_mapping_pipeline date_str – includes UTC suffix
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any

--- a/apps/server/tests/integration/test_multi_domain_regressions.py
+++ b/apps/server/tests/integration/test_multi_domain_regressions.py
@@ -1,12 +1,10 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Cross-cutting multi-domain regressions.
 
 Each test verifies the specific bug fix by reproducing the original failure
 condition and asserting the corrected behavior.
 """
 
+from __future__ import annotations
 
 from datetime import UTC
 from unittest.mock import MagicMock

--- a/apps/server/tests/integration/test_refactor_contract_regressions.py
+++ b/apps/server/tests/integration/test_refactor_contract_regressions.py
@@ -1,12 +1,10 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Cross-module refactor-contract regressions.
 
 Validates that the refactored code preserves behaviour while being more
 maintainable than the originals.
 """
 
+from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import patch

--- a/apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py
+++ b/apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py
@@ -1,11 +1,9 @@
-# ruff: noqa: E402, E501
-from __future__ import annotations
-
 """Report/export resilience regressions: EspFlashManager CancelledError, PDF diagram
 dead fallback removal, PDF diagram ValueError, dead _owns_pool removal,
 report_cli error handling, WebSocketHub circuit breaker,
 """
 
+from __future__ import annotations
 
 import asyncio
 import contextlib

--- a/apps/server/tests/integration/test_report_pipeline.py
+++ b/apps/server/tests/integration/test_report_pipeline.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """End-to-end tests: simulator-style ingestion + PDF report validation.
 
 Test 1 – Realistic multi-sensor ingestion scenario
@@ -420,7 +419,10 @@ class TestPdfReportValidation:
         summary = deepcopy(self.summary)
         summary["test_plan"] = [
             {
-                "what": "Inspect front-left corner under load with road-force balancing and vibration capture.",
+                "what": (
+                    "Inspect front-left corner under load with road-force balancing "
+                    "and vibration capture."
+                ),
                 "why": (
                     "Correlate wheel-order persistence across speed bins and verify repeatability "
                     f"for critical action token STEPEND{i:02d}"

--- a/apps/server/tests/integration/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_core_regressions.py
@@ -1,11 +1,9 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Cross-cutting review guardrail regressions (core set).
 
 Each test group validates one of the hate-list items to prevent regression.
 """
 
+from __future__ import annotations
 
 import importlib
 import time

--- a/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
@@ -1,11 +1,9 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Cross-cutting review guardrail regressions (extended set).
 
 Each test group validates one of the hate-list items to prevent regression.
 """
 
+from __future__ import annotations
 
 import os
 import threading

--- a/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
+++ b/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
@@ -1,12 +1,10 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Runtime fallback and error-guard regressions.
 
 Covers strength_floor_amp_g fallback, wheel_focus_from_location,
 store_analysis_error guard, and i18n formatting.
 """
 
+from __future__ import annotations
 
 import json
 import math

--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -1,12 +1,10 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Runtime NaN handling and update-manager guard regressions:
 NaN guards, correlation clamp, persist rollback,
 firmware cache streaming, CancelledError re-raise,
  _weighted_percentile direct import, _dir_sha256 separators, _corr_abs_clamped,
  canonical_location edge cases, PDF peak suffix i18n."""
 
+from __future__ import annotations
 
 import asyncio
 import sqlite3

--- a/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Runtime quality-pass regressions (issues 20–24).
 
 Covers:
@@ -11,6 +8,7 @@ Covers:
   24 – schema v2→v3 migration (history_db)
 """
 
+from __future__ import annotations
 
 import sqlite3
 from math import pi

--- a/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
@@ -1,8 +1,6 @@
-# ruff: noqa: E402, E501
-from __future__ import annotations
-
 """Runtime queue/history tracking and export-filter regressions."""
 
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
+++ b/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Runtime validation and schema-recovery regressions.
 
 Covers:
@@ -14,6 +11,7 @@ Covers:
   8. json_utils.py — depth limit prevents infinite recursion
 """
 
+from __future__ import annotations
 
 import contextlib
 import math

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Tests for analysis persistence, versioned schema, and reuse by summary/report endpoints."""
 
 from __future__ import annotations

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py
@@ -1,8 +1,6 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Analysis pipeline audit – correctness and determinism regressions."""
 
+from __future__ import annotations
 
 from typing import Any
 

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_guard_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_guard_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Analysis pipeline guard regressions.
 
 Covers:
@@ -11,6 +8,7 @@ Covers:
   5. update/status.py hash_tree survives file deletion mid-scan
 """
 
+from __future__ import annotations
 
 import math
 from pathlib import Path

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
@@ -1,11 +1,9 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Analysis pipeline integration regressions.
 
 Each test is tagged with the fix number it validates.
 """
 
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any

--- a/apps/server/tests/use_cases/diagnostics/test_confidence_scoring_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_confidence_scoring_regressions.py
@@ -1,12 +1,10 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Confidence and scoring regressions:
 - _suppress_engine_aliases filters before slicing (no lost valid findings)
 - Single-sensor confidence no longer triple-penalised
 - Persistent peak negligible cap aligned to 0.40 (matches order cap)
 """
 
+from __future__ import annotations
 
 import pytest
 from test_support.findings import make_finding

--- a/apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py
+++ b/apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py
@@ -1,8 +1,6 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Coverage gap audit – untested critical code paths."""
 
+from __future__ import annotations
 
 import math
 from typing import Any

--- a/apps/server/tests/use_cases/diagnostics/test_findings_ranking_and_guardrail_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_ranking_and_guardrail_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Findings ranking and analysis guardrail regressions:
 - ranking_score synced after engine alias suppression
 - negligible confidence cap aligned with ConfidenceAssessment tier thresholds
@@ -8,6 +5,7 @@ from __future__ import annotations
 - _suppress_engine_aliases cap raised to 5
 """
 
+from __future__ import annotations
 
 import pytest
 from test_support.findings import make_finding

--- a/apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py
+++ b/apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Tests for source-aware localization, diffuse excitation detection,
 no-fault suppression, and confidence calibration.
 

--- a/apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Order analysis and numeric input guard regressions.
 
 Covers:
@@ -11,6 +8,7 @@ Covers:
   5. domain_models._as_float_or_none — NaN handling
 """
 
+from __future__ import annotations
 
 import pytest
 

--- a/apps/server/tests/use_cases/diagnostics/test_strength_and_reason_selection_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_and_reason_selection_regressions.py
@@ -1,6 +1,3 @@
-# ruff: noqa: E402
-from __future__ import annotations
-
 """Strength labeling and confidence assessment regressions.
 
 Covers:
@@ -10,6 +7,7 @@ Covers:
   4. Tests for previously-untested helpers
 """
 
+from __future__ import annotations
 
 import pytest
 

--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -1,0 +1,257 @@
+"""Focused edge-case tests for history report loading, caching, and exports."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import json
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.domain import RunStatus
+from vibesensor.shared.exceptions import AnalysisNotReadyError, ProcessingError
+from vibesensor.shared.types.history_records import StoredHistoryRun
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.use_cases.history.exports import HistoryExportService
+from vibesensor.use_cases.history.report_cache import (
+    REPORT_PDF_CACHE_MAX_ENTRIES,
+    HistoryReportPdfCache,
+)
+from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
+
+
+@dataclass
+class _HistoryDbStub:
+    run: dict[str, Any] | None = None
+    samples: list[dict[str, Any]] | None = None
+
+    def get_run(self, run_id: str) -> StoredHistoryRun | None:
+        if self.run is None:
+            return None
+        return _stored_run(dict(self.run))
+
+    def iter_run_samples(self, run_id: str, batch_size: int = 1000):
+        rows = [
+            row if isinstance(row, SensorFrame) else SensorFrame.from_dict(row)
+            for row in (self.samples or [])
+        ]
+        for start in range(0, len(rows), batch_size):
+            yield rows[start : start + batch_size]
+
+
+def _stored_run(run: dict[str, Any]) -> StoredHistoryRun:
+    run_id = str(run.get("run_id") or "run-1")
+    metadata_payload = {
+        "run_id": run_id,
+        "start_time_utc": str(run.get("start_time_utc") or "2026-01-01T00:00:00Z"),
+        "end_time_utc": run.get("end_time_utc"),
+        "sensor_model": str(run.get("sensor_model") or "ADXL345"),
+        "raw_sample_rate_hz": 800,
+        "sample_rate_hz": 800,
+        "feature_interval_s": 1.0,
+        **dict(run.get("metadata") or {}),
+    }
+    return StoredHistoryRun(
+        run_id=run_id,
+        status=RunStatus(str(run.get("status") or "complete")),
+        start_time_utc=str(run.get("start_time_utc") or "2026-01-01T00:00:00Z"),
+        end_time_utc=cast(str | None, run.get("end_time_utc")),
+        metadata=RunMetadata.from_dict(metadata_payload),
+        created_at=str(run.get("created_at") or "2026-01-01T00:00:00Z"),
+        sample_count=int(run.get("sample_count") or 0),
+        case_id=cast(str | None, run.get("case_id")),
+        analysis=(
+            make_persisted_analysis(cast(dict[str, object], run["analysis"]))
+            if run.get("analysis") is not None
+            else None
+        ),
+        analysis_corrupt=bool(run.get("analysis_corrupt", False)),
+        error_message=cast(str | None, run.get("error_message")),
+        analysis_started_at=cast(str | None, run.get("analysis_started_at")),
+        analysis_completed_at=cast(str | None, run.get("analysis_completed_at")),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("run_payload", "expected_status", "expected_message"),
+    [
+        (
+            {
+                "status": "analyzing",
+                "analysis": {"lang": "en", "findings": []},
+            },
+            "in_progress",
+            "Analysis is still in progress",
+        ),
+        (
+            {
+                "status": "error",
+                "error_message": "Analyzer crashed",
+                "analysis": {"lang": "en", "findings": []},
+            },
+            "error",
+            "Analyzer crashed",
+        ),
+        (
+            {
+                "status": "complete",
+                "analysis_corrupt": True,
+                "analysis": {"lang": "en", "findings": []},
+            },
+            "unavailable",
+            "Report data unavailable for this run",
+        ),
+        (
+            {
+                "status": "complete",
+                "analysis": None,
+            },
+            "unavailable",
+            "No analysis available for this run",
+        ),
+    ],
+)
+async def test_report_loader_rejects_unavailable_report_states(
+    run_payload: dict[str, object],
+    expected_status: str,
+    expected_message: str,
+) -> None:
+    loader = HistoryReportRequestLoader(
+        _HistoryDbStub(
+            run={
+                "run_id": "run-1",
+                "metadata": {"language": "en"},
+                **run_payload,
+            }
+        )
+    )
+
+    with pytest.raises(AnalysisNotReadyError, match=expected_message) as exc_info:
+        await loader.load_report_request("run-1", "en")
+
+    assert exc_info.value.status == expected_status
+
+
+@pytest.mark.asyncio
+async def test_report_loader_uses_requested_lang_when_persisted_lang_is_blank() -> None:
+    loader = HistoryReportRequestLoader(
+        _HistoryDbStub(
+            run={
+                "run_id": "run/1 sample",
+                "status": "complete",
+                "metadata": {"language": "en"},
+                "analysis": {
+                    "lang": "   ",
+                    "findings": [],
+                    "top_causes": [],
+                    "test_plan": [],
+                    "run_suitability": [],
+                    "most_likely_origin": {},
+                },
+            }
+        )
+    )
+
+    request = await loader.load_report_request("run/1 sample", " NL ")
+
+    assert request.language == "nl"
+    assert request.cache_key[1] == "nl"
+    assert request.filename == "run_1_sample_report.pdf"
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_retries_after_build_failure() -> None:
+    cache = HistoryReportPdfCache()
+    cache_key = ("run-1", "en", None, 12, "{}", "none")
+    calls = 0
+
+    def _build() -> bytes:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("boom")
+        return b"%PDF-success"
+
+    with pytest.raises(ProcessingError, match="PDF generation failed due to an internal error"):
+        await cache.get_or_build(cache_key, _build, run_id="run-1")
+
+    assert cache.get(cache_key) is None
+
+    pdf = await cache.get_or_build(cache_key, _build, run_id="run-1")
+
+    assert pdf == b"%PDF-success"
+    assert calls == 2
+
+
+def test_report_pdf_cache_evicts_lru_entries_and_drops_evicted_locks() -> None:
+    cache = HistoryReportPdfCache()
+    keys = [
+        (f"run-{index}", "en", None, index, "{}", "none")
+        for index in range(REPORT_PDF_CACHE_MAX_ENTRIES + 1)
+    ]
+
+    for index, key in enumerate(keys[:-1]):
+        cache._locks[key] = asyncio.Lock()
+        cache._put(key, f"%PDF-{index}".encode())
+
+    assert cache.get(keys[0]) == b"%PDF-0"
+
+    cache._locks[keys[-1]] = asyncio.Lock()
+    cache._put(keys[-1], b"%PDF-new")
+
+    assert cache.get(keys[1]) is None
+    assert keys[1] not in cache._locks
+    assert cache.get(keys[0]) == b"%PDF-0"
+    assert keys[0] in cache._locks
+
+
+@pytest.mark.asyncio
+async def test_export_service_build_export_context_shapes_raw_csv_and_safe_name() -> None:
+    service = HistoryExportService(
+        _HistoryDbStub(
+            run={
+                "run_id": "run/1 sample",
+                "status": "complete",
+            },
+            samples=[
+                {
+                    "run_id": "run/1 sample",
+                    "timestamp_utc": "2026-01-01T00:00:01Z",
+                    "t_s": 1.0,
+                    "client_id": "sensor-1",
+                    "top_peaks": [{"hz": 30.0, "amp": 0.1}],
+                    "vibration_strength_db": 21.5,
+                    "custom": "drop-me",
+                },
+                {
+                    "run_id": "run/1 sample",
+                    "timestamp_utc": "2026-01-01T00:00:02Z",
+                    "t_s": 2.0,
+                    "client_id": "sensor-1",
+                    "speed_kmh": 50.0,
+                    "vibration_strength_db": 18.0,
+                },
+            ],
+        )
+    )
+
+    export = await service.build_export_context("run/1 sample")
+    try:
+        csv_text = export.raw_csv_spool.read().decode("utf-8")
+    finally:
+        export.raw_csv_spool.close()
+
+    rows = list(csv.DictReader(io.StringIO(csv_text)))
+
+    assert export.safe_name == "run_1_sample"
+    assert export.sample_count == 2
+    assert len(rows) == 2
+    assert json.loads(rows[0]["top_peaks"]) == [{"hz": 30.0, "amp": 0.1}]
+    assert rows[0]["vibration_strength_db"] == "21.5"
+    assert "custom" not in rows[0]

--- a/apps/server/tests/use_cases/updates/test_hotspot_recovery.py
+++ b/apps/server/tests/use_cases/updates/test_hotspot_recovery.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from _update_manager_test_helpers import FakeRunner
+
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
+from vibesensor.use_cases.updates.wifi_config import (
+    HOTSPOT_RESTORE_RETRIES,
+    build_default_wifi_config,
+)
+from vibesensor.use_cases.updates.wifi_hotspot_recovery import UpdateHotspotRecovery
+
+
+def _build_recovery(
+    tmp_path: Path,
+    *,
+    delay_s: float = 0.01,
+) -> tuple[UpdateHotspotRecovery, FakeRunner, UpdateStatusTracker]:
+    runner = FakeRunner()
+    tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "state.json"))
+    config = replace(
+        build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
+        hotspot_restore_delay_s=delay_s,
+    )
+    commands = UpdateCommandExecutor(runner=runner, tracker=tracker)
+    recovery = UpdateHotspotRecovery(commands=commands, tracker=tracker, config=config)
+    return recovery, runner, tracker
+
+
+@pytest.mark.asyncio
+async def test_stop_hotspot_returns_true_when_nmcli_reports_inactive(tmp_path: Path) -> None:
+    recovery, runner, tracker = _build_recovery(tmp_path)
+    runner.set_response("connection down VibeSensor-AP", 10, "", "inactive")
+
+    assert await recovery.stop_hotspot() is True
+    assert any(
+        "Hotspot down returned non-zero; may already be inactive" in line
+        for line in tracker.status.log_tail
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_uplink_downs_then_deletes_connection(tmp_path: Path) -> None:
+    recovery, runner, _tracker = _build_recovery(tmp_path)
+
+    await recovery.cleanup_uplink()
+
+    commands = [" ".join(call[0]) for call in runner.calls]
+    assert "connection down VibeSensor-Uplink" in commands[0]
+    assert "connection delete VibeSensor-Uplink" in commands[1]
+
+
+@pytest.mark.asyncio
+async def test_restore_hotspot_retries_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    recovery, runner, tracker = _build_recovery(tmp_path)
+    original_run = runner.run
+    restore_attempts = {"count": 0}
+
+    async def flaky_restore(args, *, timeout=30, env=None):
+        joined = " ".join(args)
+        if "connection up VibeSensor-AP" in joined:
+            restore_attempts["count"] += 1
+            if restore_attempts["count"] < 3:
+                return (10, "", "failed")
+        return await original_run(args, timeout=timeout, env=env)
+
+    runner.run = flaky_restore
+    sleep = AsyncMock(return_value=None)
+    monkeypatch.setattr("vibesensor.use_cases.updates.wifi_hotspot_recovery.asyncio.sleep", sleep)
+
+    assert await recovery.restore_hotspot() is True
+    assert restore_attempts["count"] == 3
+    assert sleep.await_count == 2
+    assert any("Hotspot restored on attempt 3" in line for line in tracker.status.log_tail)
+
+    commands = [" ".join(call[0]) for call in runner.calls]
+    assert "connection down VibeSensor-Uplink" in commands[0]
+    assert "connection delete VibeSensor-Uplink" in commands[1]
+    assert "connection up VibeSensor-AP" in commands[2]
+
+
+@pytest.mark.asyncio
+async def test_restore_hotspot_exhausts_retries_and_records_issue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    recovery, runner, tracker = _build_recovery(tmp_path)
+    runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
+    sleep = AsyncMock(return_value=None)
+    monkeypatch.setattr("vibesensor.use_cases.updates.wifi_hotspot_recovery.asyncio.sleep", sleep)
+
+    assert await recovery.restore_hotspot() is False
+    assert sleep.await_count == HOTSPOT_RESTORE_RETRIES - 1
+    assert any(
+        issue.phase == "restoring_hotspot"
+        and issue.message == "Failed to restore hotspot after retries"
+        for issue in tracker.status.issues
+    )


### PR DESCRIPTION
Closes #1165

## Summary

This PR strengthens the backend test suite where it was still giving false confidence: routed HTTP behavior, hotspot/update recovery, shared router test fixtures, history service edge cases, and blanket Ruff suppressions in `apps/server/tests`.

The issue body was directionally correct, but a live re-audit showed two stale claims. `make lint` already verifies that there are no path-indirection or `sys.path` hacks left in backend tests, and the `SignalBufferStore` bullet overstated the remaining gap because current processing, integration, reset, and debug tests already cover that hot path more broadly than described. I therefore focused this PR on the seams that were still materially under-covered.

## Problem being solved

The most important unresolved problems in `#1165` were all test-quality issues that could let production regressions slip through while the suite stayed green:

- The updater/hotspot recovery path still had no direct tests even though it contains retry, cleanup, and failure-reporting behavior for a headless Pi.
- Update, ESP-flash, and recording routes were still primarily validated with direct endpoint invocation and mock-call assertions rather than routed HTTP behavior.
- The shared `FakeState` in `apps/server/tests/conftest.py` still used broad untyped mocks for router-facing dependencies, so interface drift could go unnoticed.
- The history service layer still had a thin edge-case story for report loading, report-cache retry/eviction behavior, and export-context shaping.
- `apps/server/tests` still carried blanket Ruff suppressions across many regression files, which hid structural lint problems and made the suite harder to trust.

Because these are confidence problems rather than product-feature problems, the goal is not to change runtime behavior. The goal is to make the tests fail in the right places when behavior or interfaces drift.

## Implementation approach

I kept the change set backend-test-focused and only touched packaging where the tests needed a real dependency in editable installs. The only packaging change is adding `httpx` to backend dev extras so the FastAPI/Starlette test client works consistently in local and CI installs. Everything else is test code or test-structure cleanup.

I also kept the history-route helper fakes separate. The richer in-memory history route tests under `tests/adapters/http/_history_endpoint_helpers.py` already use purpose-built fakes and direct persisted-data fixtures; I did not replace those with autospec mocks. Instead, I hardened the shared root `FakeState` only where it is used for lightweight router and endpoint tests.

## Main code changes by area

### 1. Real routed HTTP coverage for update, ESP-flash, and recording endpoints

I added `apps/server/tests/adapters/http/test_update_endpoints.py` and `apps/server/tests/adapters/http/test_recording_route_http.py`.

These use real FastAPI routing with `TestClient` rather than only calling endpoint functions and checking whether a `MagicMock` method was invoked. That means the tests now exercise route registration, request decoding, response shaping, and the actual dependency wiring for:

- `/api/update/status`, `/api/update/start`, and `/api/update/cancel`
- `/api/esp-flash/ports`, `/api/esp-flash/start`, `/api/esp-flash/status`, `/api/esp-flash/logs`, `/api/esp-flash/cancel`, and `/api/esp-flash/history`
- `/api/recording/status`, `/api/recording/start`, and `/api/recording/stop`

This directly addresses the “mock-only route tests” part of the issue.

### 2. Direct hotspot recovery coverage

I added `apps/server/tests/use_cases/updates/test_hotspot_recovery.py` to cover `UpdateHotspotRecovery` behavior that previously had no dedicated tests.

The new tests exercise:

- hotspot stop behavior
- uplink cleanup behavior
- hotspot restore retry-then-success flow
- retry exhaustion with issue reporting

These tests use the existing fake command-runner pattern rather than inventing a second harness, so they stay close to how the updater code already models `nmcli` interactions.

### 3. History service edge-case coverage

I added `apps/server/tests/use_cases/history/test_history_service_edges.py` to cover history service seams that were previously only lightly exercised.

The new tests verify:

- `HistoryReportRequestLoader` rejects analyzing, error, corrupt, and missing-analysis states with the expected domain errors
- requested language is used when persisted report language is blank
- `HistoryReportPdfCache` retries correctly after build failure and does not cache failed output
- the report cache evicts least-recently-used entries and drops the corresponding stale lock entries
- `HistoryExportService.build_export_context()` produces the expected safe export name, sample count, and raw CSV content

This fills the most meaningful history edge cases without duplicating the deeper PDF/report-preparation coverage that already exists elsewhere.

### 4. Harder shared router test fixtures

I tightened `apps/server/tests/conftest.py` so the shared `FakeState` uses autospecced mocks for the router-facing dependencies most likely to drift:

- `SignalProcessor`
- `ClientRegistry`
- `UDPControlPlane`
- `WebSocketHub`
- `GPSSpeedMonitor`
- `SettingsStore`
- `RunRecorder`
- `UpdateManager`
- `EspFlashManager`

I also seeded realistic default payloads for processor intake stats, registry data-loss state, speed-source status, cars/settings snapshots, update status, flash status, and recorder status. This keeps existing convenience while making signature/interface mismatches fail much earlier.

### 5. Removal of blanket Ruff suppressions

I removed every blanket `# ruff: noqa` header from `apps/server/tests`.

That cleanup had two parts:

- delete stale `E501` suppressions that were no longer needed
- rewrite 26 regression files so their module docstrings appear before `from __future__ import annotations`, eliminating the structural `E402` suppressions instead of hiding them

The result is that the backend test tree now carries zero blanket Ruff suppressions.

## Validation and test coverage

I validated this branch in layers while building it up and then with a final broader pass:

- focused update/hotspot/http slices: `60 passed`
- focused recording route slice: `27 passed`
- focused history edge slice: `8 passed`
- HTTP-focused fixture-hardening slice: `126 passed`
- broader targeted suites: `302 passed`
- widened regression sweep over PDF/diagnostics/integration areas: `3349 passed, 5 skipped, 1 xpassed`
- final broad backend slice covering all touched test areas: `3651 passed, 5 skipped, 1 xpassed`
- `make typecheck-backend`
- `make lint`

I also attempted the required local Docker smoke with `docker compose build --pull && docker compose up -d`, but this environment still has no reachable Docker daemon/socket, so that validation remains environment-blocked here as it was for the earlier issues in this run.

## Risks, tradeoffs, and out-of-scope notes

The main tradeoff is that I did not try to rework every remaining test helper in the repository. I tightened the shared router-facing `FakeState` because that was the live false-confidence path, but left heavier specialized fakes alone where they already model richer behavior.

I also did not add new buffer-store tests in this PR. After re-auditing the current suite, that part of the issue description no longer matched the real coverage gap closely enough to justify adding redundant tests. If later review still wants more buffer-specific edge cases, that should be driven by current gaps rather than the stale count in the original issue body.

Overall, this PR is intentionally a confidence-improvement change set: no production behavior changes, but much stronger assurance that future route, updater, and history refactors will break tests when they should.
