### PR TITLE
Reduce signal hot-path contention and serialization overhead

### DIFF
--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -277,6 +277,28 @@ async def test_broadcast_serializes_plain_payload_without_recursive_sanitizing()
 
 
 @pytest.mark.asyncio
+async def test_broadcast_offloads_serialization_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    hub = WebSocketHub()
+    ws1 = _make_ws()
+    ws2 = _make_ws()
+    await hub.add(ws1, "same")
+    await hub.add(ws2, None)
+    seen_selected_ids: list[str | None] = []
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        seen_selected_ids.append(args[0])
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+
+    await hub.broadcast(lambda selected: {"selected": selected})
+
+    assert seen_selected_ids == ["same", None]
+    assert _sent_json(ws1) == {"selected": "same"}
+    assert _sent_json(ws2) == {"selected": None}
+
+
+@pytest.mark.asyncio
 async def test_broadcast_falls_back_to_sanitizer_for_numpy_payload() -> None:
     hub = WebSocketHub()
     ws = _make_ws()

--- a/apps/server/tests/infra/processing/test_processing.py
+++ b/apps/server/tests/infra/processing/test_processing.py
@@ -109,7 +109,7 @@ def test_clients_with_recent_data_filters_stale() -> None:
     assert result == ["c1"]
 
 
-def test_ingest_waits_while_processor_lock_is_held() -> None:
+def test_ingest_waits_while_same_client_buffer_lock_is_held() -> None:
     processor = SignalProcessor(
         sample_rate_hz=800,
         waveform_seconds=8,
@@ -124,13 +124,46 @@ def test_ingest_waits_while_processor_lock_is_held() -> None:
         processor.ingest("c-lock", samples, sample_rate_hz=800)
         done.set()
 
-    processor._store.lock.acquire()
+    processor.ingest("c-lock", samples, sample_rate_hz=800)
+    with processor._store.lock:
+        client_lock = processor._store._client_locks["c-lock"]
+    client_lock.acquire()
     worker = Thread(target=_ingest)
     worker.start()
     try:
         assert not done.wait(timeout=0.05)
     finally:
-        processor._store.lock.release()
+        client_lock.release()
+    worker.join(timeout=1.0)
+    assert done.is_set()
+
+
+def test_ingest_other_client_not_blocked_by_unrelated_client_lock() -> None:
+    processor = SignalProcessor(
+        sample_rate_hz=800,
+        waveform_seconds=8,
+        waveform_display_hz=100,
+        fft_n=1024,
+        spectrum_max_hz=200,
+    )
+    samples = np.zeros((10, 3), dtype=np.float32)
+    done = Event()
+
+    processor.ingest("c-lock", samples, sample_rate_hz=800)
+    with processor._store.lock:
+        client_lock = processor._store._client_locks["c-lock"]
+    client_lock.acquire()
+
+    def _ingest() -> None:
+        processor.ingest("c-free", samples, sample_rate_hz=800)
+        done.set()
+
+    worker = Thread(target=_ingest)
+    worker.start()
+    try:
+        assert done.wait(timeout=0.2)
+    finally:
+        client_lock.release()
     worker.join(timeout=1.0)
     assert done.is_set()
 

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py
@@ -17,7 +17,7 @@ from vibesensor.use_cases.diagnostics.phase_segmentation import (
 from vibesensor.use_cases.diagnostics.speed_profile_helpers import _speed_stats
 from vibesensor.vibration_strength import (
     compute_vibration_strength_db,
-    noise_floor_amp_p20_g,
+    percentile,
 )
 
 
@@ -84,7 +84,7 @@ class TestDoubleBinRemoval:
             dtype=np.float32,
         )
 
-        correct_floor = noise_floor_amp_p20_g(combined_spectrum_amp_g=[float(v) for v in amps])
+        correct_floor = percentile(sorted(float(v) for v in amps), 0.20)
         actual_floor = noise_floor(amps)
 
         # After fix: both should agree exactly

--- a/apps/server/tests/use_cases/diagnostics/test_noise_floor_consistency.py
+++ b/apps/server/tests/use_cases/diagnostics/test_noise_floor_consistency.py
@@ -1,8 +1,4 @@
-"""Regression tests: live processing and core lib noise floor must agree.
-
-Fixes GitHub issue #297 — duplicate noise floor computation using
-different algorithms (numpy percentile vs core-lib pure-Python percentile).
-"""
+"""Regression tests for the live processing noise-floor helper."""
 
 from __future__ import annotations
 
@@ -10,7 +6,7 @@ import numpy as np
 import pytest
 
 from vibesensor.infra.processing.fft import noise_floor
-from vibesensor.vibration_strength import noise_floor_amp_p20_g
+from vibesensor.vibration_strength import percentile
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -18,12 +14,11 @@ from vibesensor.vibration_strength import noise_floor_amp_p20_g
 
 
 def _core_noise_floor_from_array(arr: np.ndarray) -> float:
-    """Replicate the band/finite filtering that _noise_floor does, then call
-    the core lib — used as the expected-value oracle.
+    """Replicate the live analysis-band filtering and P20 computation.
 
-    For a single non-negative finite value, returns that value directly;
-    ``noise_floor_amp_p20_g`` would treat it as DC-only and return 0.0,
-    but ``fft.noise_floor`` returns the value itself (no minimum to strip).
+    ``fft.noise_floor`` operates on an already-selected analysis band, so it
+    computes the 20th percentile of the provided non-negative amplitudes
+    directly without stripping an assumed DC bin.
     """
     if arr.size == 0:
         return 0.0
@@ -34,12 +29,8 @@ def _core_noise_floor_from_array(arr: np.ndarray) -> float:
     if not non_neg:
         return 0.0
     if len(non_neg) == 1:
-        # fft.noise_floor returns the single element directly rather than
-        # delegating to noise_floor_amp_p20_g (which returns 0.0 for n=1).
         return non_neg[0]
-    return noise_floor_amp_p20_g(
-        combined_spectrum_amp_g=non_neg,
-    )
+    return percentile(non_neg, 0.20)
 
 
 # ---------------------------------------------------------------------------
@@ -51,9 +42,7 @@ _SIZES = [2, 3, 5, 10, 20, 50, 100, 256, 512, 1024]
 
 @pytest.mark.parametrize("n", _SIZES, ids=[f"n={n}" for n in _SIZES])
 def test_live_matches_core_random(n: int) -> None:
-    """noise_floor must return the same value as the core lib
-    noise_floor_amp_p20_g for random spectra of varying length.
-    """
+    """noise_floor must match the direct analysis-band P20 oracle."""
     rng = np.random.default_rng(seed=42 + n)
     amps = rng.random(n).astype(np.float32) * 0.05  # realistic g range
 

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -154,29 +154,54 @@ class WebSocketHub:
             if current is not None and current.connection_id == conn.connection_id:
                 self._connections.pop(id(conn.websocket), None)
 
-    def _build_payload_for(
+    def _build_raw_payload(
         self,
         selected_client_id: str | None,
         payload_builder: Callable[[str | None], LiveWsPayload],
-        payload_cache: dict[str | None, str],
         failed_client_ids: set[str | None],
-        debug_info: dict[str | None, bool] | None = None,
-    ) -> str:
-        """Build and cache the JSON payload for *selected_client_id*.
+    ) -> LiveWsPayload | None:
+        """Build the raw payload for *selected_client_id* on the event-loop thread.
 
-        On failure the error payload is cached and an ERROR log is
-        emitted (once per failing client_id per tick).
-
-        When *debug_info* is provided (``VIBESENSOR_WS_DEBUG=1``), the method
-        inspects the pre-serialisation dict and records whether per-client
-        frequency data is present, avoiding a redundant ``json.loads()`` later.
+        Builder failures keep the transport behavior consistent with the
+        previous implementation: the caller records the failure and falls back
+        to the shared error payload for affected connections.
         """
-        if selected_client_id in payload_cache:
-            return payload_cache[selected_client_id]
+        try:
+            return payload_builder(selected_client_id)
+        except (TypeError, ValueError, OverflowError, KeyError, AttributeError, RuntimeError):
+            LOGGER.error(
+                "WebSocket payload build failed for client %r; "
+                "sending error payload to affected connections.",
+                selected_client_id,
+                exc_info=True,
+            )
+            failed_client_ids.add(selected_client_id)
+            return None
+
+    @staticmethod
+    def _payload_has_per_client_freq(payload: object) -> bool:
+        """Return True when *payload* contains per-client frequency data."""
+        try:
+            spectra = payload.get("spectra") if isinstance(payload, dict) else None
+            if isinstance(spectra, dict):
+                for _cid, cs in (spectra.get("clients") or {}).items():
+                    if isinstance(cs, dict) and cs.get("freq"):
+                        return True
+        except (AttributeError, TypeError, ValueError, KeyError):
+            LOGGER.debug("Debug freq-inspection failed", exc_info=True)
+        return False
+
+    def _serialize_payload(
+        self,
+        selected_client_id: str | None,
+        raw_payload: LiveWsPayload,
+        *,
+        capture_debug: bool,
+    ) -> tuple[str | None, str, bool, bool | None]:
+        """Serialize *raw_payload* off the event loop and report debug metadata."""
+        payload_for_debug: object = raw_payload
         _dumps = json.dumps  # local-bind for hot-path
         try:
-            raw_payload = payload_builder(selected_client_id)
-            payload_for_debug: object = raw_payload
             try:
                 text = _dumps(
                     raw_payload,
@@ -197,26 +222,10 @@ class WebSocketHub:
                     separators=(",", ":"),
                     allow_nan=False,
                 )
-            if debug_info is not None:
-                # Inspect the pre-serialised dict; avoids a redundant json.loads().
-                has_freq = False
-                try:
-                    spectra = (
-                        payload_for_debug.get("spectra")
-                        if isinstance(payload_for_debug, dict)
-                        else None
-                    )
-                    if isinstance(spectra, dict):
-                        for _cid, cs in (spectra.get("clients") or {}).items():
-                            if isinstance(cs, dict) and cs.get("freq"):
-                                has_freq = True
-                                break
-                except (AttributeError, TypeError, ValueError, KeyError):
-                    LOGGER.debug("Debug freq-inspection failed", exc_info=True)
-                debug_info[selected_client_id] = has_freq
-        # TypeError/ValueError/OverflowError: json.dumps serialization failures
-        # KeyError/AttributeError: payload dict construction missing keys/attrs
-        # RuntimeError: callback/builder failures propagated from user code
+            has_freq = (
+                self._payload_has_per_client_freq(payload_for_debug) if capture_debug else None
+            )
+            return selected_client_id, text, False, has_freq
         except (TypeError, ValueError, OverflowError, KeyError, AttributeError, RuntimeError):
             LOGGER.error(
                 "WebSocket payload build failed for client %r; "
@@ -224,29 +233,16 @@ class WebSocketHub:
                 selected_client_id,
                 exc_info=True,
             )
-            failed_client_ids.add(selected_client_id)
-            text = _ERROR_PAYLOAD
-        payload_cache[selected_client_id] = text
-        return text
+            return selected_client_id, _ERROR_PAYLOAD, True, None
 
     async def _send_conn(
         self,
         conn: _WSConnectionSnapshot,
-        payload_builder: Callable[[str | None], LiveWsPayload],
-        payload_cache: dict[str | None, str],
-        failed_client_ids: set[str | None],
-        debug_info: dict[str | None, bool] | None = None,
+        payload_text: str,
     ) -> _WSConnectionSnapshot | None:
         """Send the appropriate payload to *conn*, return the WebSocket on failure."""
         if not await self._is_snapshot_current(conn):
             return None
-        payload_text = self._build_payload_for(
-            conn.selected_client_id,
-            payload_builder,
-            payload_cache,
-            failed_client_ids,
-            debug_info=debug_info,
-        )
         try:
             await asyncio.wait_for(
                 conn.websocket.send_text(payload_text),
@@ -284,15 +280,44 @@ class WebSocketHub:
         failed_client_ids: set[str | None] = set()
         # Collect debug inspection data during build (avoids redundant json.loads later).
         debug_info: dict[str | None, bool] | None = {} if _ws_debug_enabled() else None
+        unique_selected_ids = list(dict.fromkeys(conn.selected_client_id for conn in conns))
+        raw_payloads: dict[str | None, LiveWsPayload] = {}
+
+        for selected_client_id in unique_selected_ids:
+            raw_payload = self._build_raw_payload(
+                selected_client_id,
+                payload_builder,
+                failed_client_ids,
+            )
+            if raw_payload is None:
+                payload_cache[selected_client_id] = _ERROR_PAYLOAD
+                continue
+            raw_payloads[selected_client_id] = raw_payload
+
+        if raw_payloads:
+            serialized_payloads = await asyncio.gather(
+                *(
+                    asyncio.to_thread(
+                        self._serialize_payload,
+                        selected_client_id,
+                        raw_payload,
+                        capture_debug=debug_info is not None,
+                    )
+                    for selected_client_id, raw_payload in raw_payloads.items()
+                ),
+            )
+            for selected_client_id, text, failed, has_freq in serialized_payloads:
+                payload_cache[selected_client_id] = text
+                if failed:
+                    failed_client_ids.add(selected_client_id)
+                if debug_info is not None and has_freq is not None:
+                    debug_info[selected_client_id] = has_freq
 
         dead_ws = await asyncio.gather(
             *(
                 self._send_conn(
                     conn,
-                    payload_builder,
-                    payload_cache,
-                    failed_client_ids,
-                    debug_info=debug_info,
+                    payload_cache[conn.selected_client_id],
                 )
                 for conn in conns
             ),

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from threading import RLock
 
 import numpy as np
@@ -32,18 +33,18 @@ _MAX_SAMPLES_SINCE_T0 = 2**28
 
 
 class SignalBufferStore:
-    """Own shared client buffer state, lifecycle, and lock-protected snapshots."""
+    """Own shared client buffer state, lifecycle, and per-client locked snapshots."""
 
     def __init__(self, config: ProcessorConfig) -> None:
         self.config = config
         self.buffers: dict[str, ClientBuffer] = {}
+        self._client_locks: dict[str, RLock] = {}
         self.lock = RLock()
         self.stats = ProcessorStats()
 
     def flush_client_buffer(self, client_id: str) -> None:
         """Reset the buffer for *client_id*, discarding all stored samples."""
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None:
                 return
             buf.data[:] = 0.0
@@ -71,8 +72,9 @@ class SignalBufferStore:
         if samples.size == 0:
             return
 
-        with self.lock:
-            buf = self._get_or_create_unlocked(client_id)
+        ingested_samples = 0
+        with self.locked_client_buffer(client_id, create=True) as buf:
+            assert buf is not None
             chunk: FloatArray = np.asarray(samples, dtype=np.float32)
             if self.config.accel_scale_g_per_lsb is not None:
                 chunk = chunk * np.float32(self.config.accel_scale_g_per_lsb)
@@ -127,7 +129,9 @@ class SignalBufferStore:
                 buf.samples_since_t0 = min(buf.samples_since_t0 + n, _MAX_SAMPLES_SINCE_T0)
             buf.ingest_generation += 1
             buf.invalidate_caches()
-            self.stats.total_ingested_samples += n
+            ingested_samples = n
+        with self.lock:
+            self.stats.total_ingested_samples += ingested_samples
             self.stats.last_ingest_duration_s = clock() - t_start
 
     def snapshot_for_compute(
@@ -137,8 +141,7 @@ class SignalBufferStore:
         sample_rate_hz: int | None = None,
     ) -> CachedMetricsHit | MetricsSnapshot | None:
         """Return a cached hit or an immutable compute snapshot for *client_id*."""
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None or buf.count == 0:
                 return None
             if sample_rate_hz is not None and sample_rate_hz > 0:
@@ -166,8 +169,7 @@ class SignalBufferStore:
 
     def store_metrics_result(self, result: MetricsComputationResult) -> ClientMetrics:
         """Commit a compute result back into shared state and update stats."""
-        with self.lock:
-            buf = self.buffers.get(result.client_id)
+        with self.locked_client_buffer(result.client_id) as buf:
             if buf is not None and result.ingest_generation >= buf.compute_generation:
                 buf.latest_metrics = result.metrics
                 buf.compute_generation = result.ingest_generation
@@ -180,6 +182,7 @@ class SignalBufferStore:
                     buf.latest_strength_metrics = empty_vibration_strength_metrics()
                 buf.spectrum_generation += 1
                 buf.invalidate_caches()
+        with self.lock:
             self.stats.last_compute_duration_s = result.duration_s
             self.stats.total_compute_calls += 1
         return result.metrics
@@ -189,8 +192,7 @@ class SignalBufferStore:
             self.stats.last_compute_all_duration_s = duration_s
 
     def latest_sample_xyz(self, client_id: str) -> tuple[float, float, float] | None:
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None or buf.count == 0:
                 return None
             idx = (buf.write_idx - 1) % buf.capacity
@@ -201,8 +203,7 @@ class SignalBufferStore:
             )
 
     def latest_sample_rate_hz(self, client_id: str) -> int | None:
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None:
                 return None
             rate = int(buf.sample_rate_hz or 0)
@@ -210,25 +211,23 @@ class SignalBufferStore:
 
     def latest_metrics(self, client_id: str) -> ClientMetrics:
         """Return the most recent computed metrics for *client_id*."""
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None:
                 return {}
             return buf.latest_metrics
 
     def all_latest_metrics(self, client_ids: list[str]) -> dict[str, ClientMetrics]:
-        """Return latest metrics for all requested clients (lock once)."""
-        with self.lock:
+        """Return latest metrics for all requested clients."""
+        with self.locked_client_buffers(client_ids) as buffers:
             result: dict[str, ClientMetrics] = {}
             for cid in client_ids:
-                buf = self.buffers.get(cid)
+                buf = buffers.get(cid)
                 if buf is not None and buf.latest_metrics:
                     result[cid] = buf.latest_metrics
             return result
 
     def debug_request(self, client_id: str) -> DebugSpectrumRequest:
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None:
                 return DebugSpectrumRequest(
                     client_id=client_id,
@@ -257,8 +256,7 @@ class SignalBufferStore:
         *,
         n_samples: int,
     ) -> RawSamplesPayload | RawSamplesErrorPayload:
-        with self.lock:
-            buf = self.buffers.get(client_id)
+        with self.locked_client_buffer(client_id) as buf:
             if buf is None or buf.count == 0:
                 return {"error": "no data", "count": 0}
             sr = buf.sample_rate_hz or self.config.sample_rate_hz
@@ -281,10 +279,10 @@ class SignalBufferStore:
     ) -> list[str]:
         """Return subset of *client_ids* that received data within *max_age_s*."""
         now = time.monotonic()
-        with self.lock:
+        with self.locked_client_buffers(client_ids) as buffers:
             result: list[str] = []
             for client_id in client_ids:
-                buf = self.buffers.get(client_id)
+                buf = buffers.get(client_id)
                 if buf is None or buf.last_ingest_mono_s <= 0:
                     continue
                 if (now - buf.last_ingest_mono_s) <= max_age_s:
@@ -296,8 +294,20 @@ class SignalBufferStore:
             stale_ids = [
                 client_id for client_id in self.buffers if client_id not in keep_client_ids
             ]
+            stale_locks: list[RLock] = []
             for client_id in stale_ids:
-                self.buffers.pop(client_id, None)
+                client_lock = self._client_locks.get(client_id)
+                if client_lock is None:
+                    continue
+                client_lock.acquire()
+                stale_locks.append(client_lock)
+            try:
+                for client_id in stale_ids:
+                    self.buffers.pop(client_id, None)
+                    self._client_locks.pop(client_id, None)
+            finally:
+                for client_lock in reversed(stale_locks):
+                    client_lock.release()
 
     def intake_stats(self) -> IntakeStatsPayload:
         with self.lock:
@@ -315,7 +325,63 @@ class SignalBufferStore:
             data: FloatArray = np.zeros((3, self.config.max_samples), dtype=np.float32)
             buf = ClientBuffer(data=data, capacity=self.config.max_samples)
             self.buffers[client_id] = buf
+            self._client_locks[client_id] = RLock()
         return buf
+
+    def _client_lock_unlocked(self, client_id: str) -> RLock:
+        client_lock = self._client_locks.get(client_id)
+        if client_lock is None:
+            client_lock = RLock()
+            self._client_locks[client_id] = client_lock
+        return client_lock
+
+    @contextmanager
+    def locked_client_buffer(
+        self,
+        client_id: str,
+        *,
+        create: bool = False,
+    ) -> Iterator[ClientBuffer | None]:
+        """Yield a single client buffer while holding only that client's lock.
+
+        Lock acquisition always follows ``self.lock`` → per-client lock so
+        callers that take multiple client locks share a consistent order.
+        """
+        client_lock: RLock | None = None
+        buf: ClientBuffer | None = None
+        with self.lock:
+            if create:
+                buf = self._get_or_create_unlocked(client_id)
+            else:
+                buf = self.buffers.get(client_id)
+            if buf is not None:
+                client_lock = self._client_lock_unlocked(client_id)
+                client_lock.acquire()
+        try:
+            yield buf
+        finally:
+            if client_lock is not None:
+                client_lock.release()
+
+    @contextmanager
+    def locked_client_buffers(self, client_ids: Iterable[str]) -> Iterator[dict[str, ClientBuffer]]:
+        """Yield the requested existing client buffers while holding their locks."""
+        locked_buffers: dict[str, ClientBuffer] = {}
+        acquired_locks: list[RLock] = []
+        with self.lock:
+            for client_id in dict.fromkeys(client_ids):
+                buf = self.buffers.get(client_id)
+                if buf is None:
+                    continue
+                client_lock = self._client_lock_unlocked(client_id)
+                client_lock.acquire()
+                acquired_locks.append(client_lock)
+                locked_buffers[client_id] = buf
+        try:
+            yield locked_buffers
+        finally:
+            for client_lock in reversed(acquired_locks):
+                client_lock.release()
 
     def _resize_buffer_unlocked(self, buf: ClientBuffer, new_capacity: int) -> None:
         new_capacity = max(1, int(new_capacity))

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -9,7 +9,6 @@ This makes them independently testable and reusable outside of the
 from __future__ import annotations
 
 import math
-import warnings
 from typing import TypeAlias
 
 import numpy as np
@@ -24,7 +23,7 @@ from vibesensor.vibration_strength import (
     combined_spectrum_amp_g,
     compute_vibration_strength_db,
     empty_vibration_strength_metrics,
-    noise_floor_amp_p20_g,
+    percentile,
 )
 
 AXES: tuple[Axis, Axis, Axis] = ("x", "y", "z")
@@ -51,11 +50,45 @@ def medfilt3(block: FloatArray) -> FloatArray:
         raise ValueError(f"medfilt3 expects a 2-D (axes, samples) array, got ndim={block.ndim}")
     if block.shape[-1] < 3:
         return block
-    stacked = np.stack([block[:, :-2], block[:, 1:-1], block[:, 2:]], axis=0)
     filtered = block.copy()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)
-        filtered[:, 1:-1] = np.nanmedian(stacked, axis=0)
+    center = filtered[:, 1:-1]
+    left = block[:, :-2]
+    mid = block[:, 1:-1]
+    right = block[:, 2:]
+
+    # Fast path for the common all-finite case: one scratch array + fixed-size
+    # pairwise min/max avoids the large transient stack that ``np.nanmedian``
+    # would allocate for a three-sample window.
+    scratch = np.empty_like(center)
+    np.minimum(left, mid, out=scratch)
+    np.maximum(left, mid, out=center)
+    np.minimum(center, right, out=center)
+    np.maximum(scratch, center, out=center)
+
+    left_valid = ~np.isnan(left)
+    mid_valid = ~np.isnan(mid)
+    right_valid = ~np.isnan(right)
+
+    missing_left = ~left_valid & mid_valid & right_valid
+    center[missing_left] = (mid[missing_left] + right[missing_left]) * np.float32(0.5)
+
+    missing_mid = left_valid & ~mid_valid & right_valid
+    center[missing_mid] = (left[missing_mid] + right[missing_mid]) * np.float32(0.5)
+
+    missing_right = left_valid & mid_valid & ~right_valid
+    center[missing_right] = (left[missing_right] + mid[missing_right]) * np.float32(0.5)
+
+    only_left = left_valid & ~mid_valid & ~right_valid
+    center[only_left] = left[only_left]
+
+    only_mid = ~left_valid & mid_valid & ~right_valid
+    center[only_mid] = mid[only_mid]
+
+    only_right = ~left_valid & ~mid_valid & right_valid
+    center[only_right] = right[only_right]
+
+    all_invalid = ~left_valid & ~mid_valid & ~right_valid
+    center[all_invalid] = np.nan
     return filtered
 
 
@@ -77,16 +110,12 @@ def smooth_spectrum(amps: FloatArray, bins: int = 5) -> FloatArray:
 
 
 def noise_floor(amps: FloatArray) -> float:
-    """Compute the P20 noise floor, filtering non-finite and negative values.
+    """Compute the P20 noise floor from the provided analysis-band amplitudes.
 
-    Returns ``0.0`` for empty or all-invalid inputs.  Delegates the
-    actual percentile computation to
-    :func:`~vibesensor.vibration_strength.noise_floor_amp_p20_g`.
-
-    Pre-sorts the array so that when ``noise_floor_amp_p20_g`` strips the DC
-    bin (index 0), it discards the global minimum amplitude, yielding a
-    slightly more conservative (higher) floor estimate.  A single-element
-    array returns that element directly since there is no minimum to strip.
+    The caller already provides a frequency-ordered spectrum slice, so this
+    helper must not skip index 0 or delegate to helpers that assume DC is still
+    present there. It simply filters invalid values and computes the 20th
+    percentile of the remaining non-negative amplitudes.
     """
     if amps.size == 0:
         return 0.0
@@ -98,12 +127,8 @@ def noise_floor(amps: FloatArray) -> float:
         return 0.0
     sorted_non_neg = np.sort(non_neg).tolist()
     if len(sorted_non_neg) == 1:
-        # noise_floor_amp_p20_g treats a single-element input as DC-only and
-        # returns 0.0, which is correct for the full-spectrum context but not
-        # here — the single value is a valid amplitude reading, not the DC
-        # bias.  Return it directly so callers get a usable floor estimate.
         return float(sorted_non_neg[0])
-    return float(noise_floor_amp_p20_g(combined_spectrum_amp_g=sorted_non_neg))
+    return float(percentile(sorted_non_neg, 0.20))
 
 
 def float_list(values: FloatArray | list[float]) -> list[float]:

--- a/apps/server/vibesensor/infra/processing/processor.py
+++ b/apps/server/vibesensor/infra/processing/processor.py
@@ -153,15 +153,21 @@ class SignalProcessor:
         return result
 
     def spectrum_payload(self, client_id: str) -> SpectrumSeriesPayload:
-        with self._store.lock:
-            return self._spectrum_payload_unlocked(client_id)
+        with self._store.locked_client_buffer(client_id) as buf:
+            if buf is None:
+                return _empty_spectrum_payload()
+            return build_spectrum_payload(buf)
 
     def multi_spectrum_payload(self, client_ids: list[str]) -> SpectraPayload:
-        with self._store.lock:
+        with self._store.locked_client_buffers(client_ids) as buffers:
+
+            def _spectrum_payload(client_id: str) -> SpectrumSeriesPayload:
+                return self._spectrum_payload_from_buffers(buffers, client_id)
+
             return build_multi_spectrum_payload(
-                self._store.buffers,
+                buffers,
                 client_ids,
-                spectrum_fn=self._spectrum_payload_unlocked,
+                spectrum_fn=_spectrum_payload,
                 analysis_time_range_fn=self._analysis_time_range_unlocked,
             )
 
@@ -200,20 +206,20 @@ class SignalProcessor:
         worker_pool_stats = self._worker_pool.stats() if self._worker_pool is not None else None
         return build_intake_stats_payload(self._store.intake_stats(), worker_pool_stats)
 
-    def _analysis_time_range(self, buf: ClientBuffer) -> tuple[float, float, bool] | None:
-        with self._store.lock:
-            return self._analysis_time_range_unlocked(buf)
-
     def time_alignment_info(self, client_ids: list[str]) -> TimeAlignmentPayload:
-        with self._store.lock:
+        with self._store.locked_client_buffers(client_ids) as buffers:
             return build_time_alignment_payload(
-                self._store.buffers,
+                buffers,
                 client_ids,
                 analysis_time_range_fn=self._analysis_time_range_unlocked,
             )
 
-    def _spectrum_payload_unlocked(self, client_id: str) -> SpectrumSeriesPayload:
-        buf = self._store.buffers.get(client_id)
+    def _spectrum_payload_from_buffers(
+        self,
+        buffers: dict[str, ClientBuffer],
+        client_id: str,
+    ) -> SpectrumSeriesPayload:
+        buf = buffers.get(client_id)
         if buf is None:
             return _empty_spectrum_payload()
         return build_spectrum_payload(buf)


### PR DESCRIPTION
Closes #1166.

## Summary

This PR reduces the main signal-processing hot-path costs that were still compounding on Raspberry Pi hardware after the earlier processing refactors. The previous code still serialized unrelated sensors behind a single `SignalBufferStore` lock, paid a large transient allocation penalty inside `medfilt3()` on every compute tick, performed WebSocket JSON serialization synchronously on the event loop, and computed `fft.noise_floor()` by sorting amplitudes before delegating to a helper that assumes frequency order. Those costs all lived directly in the ingest → compute → broadcast path, so they amplified each other under multi-sensor load.

The updated implementation keeps the external behavior and payload shapes stable while reducing contention and moving the heaviest remaining synchronous serialization work off the loop. It also corrects the noise-floor calculation so analysis-band peak thresholding is based on the provided frequency slice instead of accidentally skipping the global minimum amplitude.

## Implementation approach

I treated the issue body as a current-state hypothesis rather than assuming every original claim was still equally valid. Re-auditing the live code showed that the single global `RLock`, the `medfilt3()` allocation pattern, synchronous WebSocket serialization, and the `noise_floor()` ordering bug were all still real. The single UDP consumer is also still real, but the issue itself describes multi-consumer fan-out as a phase-5 follow-up after the higher-impact contention work. I therefore implemented the four confirmed hot-path fixes first and left the lifecycle/UDP task shape alone for this branch.

The design goal was to reduce contention without introducing deadlocks or widening the blast radius. The store now uses a narrow shared lock for client-map and stats ownership and per-client locks for buffer mutation and snapshotting. Multi-client read paths explicitly lock only the requested client buffers, preserving consistency for alignment/spectrum payloads without serializing unrelated sensors.

## Main code changes

### 1. Per-client buffer locking in `SignalBufferStore`

`apps/server/vibesensor/infra/processing/buffer_store.py` now maintains a private per-client `RLock` alongside the existing shared store lock. The shared lock still protects buffer/lock creation, eviction, and shared stats updates, but ingest, compute snapshots, stored metric commits, raw-sample reads, and client-local accessors now run under the selected client lock instead of a store-wide hot-path mutex.

To keep the locking story explicit and safe, the store now exposes internal context managers for a single locked client buffer and a set of locked client buffers. Both follow the same lock hierarchy: acquire the shared store lock only long enough to resolve/create the client entries and acquire the relevant client locks, then release the shared lock while the caller works with the per-client state. That preserves a consistent acquisition order and avoids deadlocks.

I also updated `evict_clients()` to acquire the relevant client locks before removing buffers, so eviction cannot race with an in-flight ingest or snapshot and leave half-removed state behind.

### 2. Narrowed multi-client reads in `SignalProcessor`

`apps/server/vibesensor/infra/processing/processor.py` previously wrapped `spectrum_payload()`, `multi_spectrum_payload()`, and `time_alignment_info()` in the store-wide lock. Those methods now rely on the new per-client locking helpers so single-client spectrum reads lock only one client and multi-client spectrum/alignment payloads lock only the requested clients.

This matters because the WebSocket heavy-tick path reads spectra for the subset of fresh clients. With the previous store-wide lock, those reads could block unrelated ingest/snapshot/store work. The updated code keeps the same payload builders, but now feeds them from a locked subset buffer mapping rather than the entire store dictionary.

### 3. Lower-allocation `medfilt3()` and corrected `noise_floor()`

`apps/server/vibesensor/infra/processing/fft.py` got the main compute-path cleanup. `medfilt3()` no longer builds a stacked `(3, axes, samples-2)` temporary and runs `np.nanmedian()` over it for a fixed-width three-sample window. Instead it computes the three-point median using pairwise min/max operations on one copied output buffer plus one scratch array, then patches the NaN edge cases explicitly so the existing NaN-resilience behavior stays intact.

I measured the change with a one-off `tracemalloc` comparison on a `(3, 6400)` block: the previous implementation peaked at `2,993,331` traced bytes and the new one peaked at `386,144` traced bytes, which is roughly an `87.1%` reduction. That is comfortably beyond the issue’s “50% reduction by measurement or audit” target.

The same file also fixes `noise_floor()`. The old implementation sorted the provided amplitudes and then delegated to `noise_floor_amp_p20_g()`, which assumes index `0` is the DC bin and skips it. In this call path the input is already the analysis-band slice, so sorting first turned “skip DC” into “skip the minimum amplitude.” `noise_floor()` now computes the P20 directly from the provided non-negative finite amplitudes, keeping the result tied to the caller’s actual analysis band.

### 4. Off-thread WebSocket JSON serialization

`apps/server/vibesensor/adapters/websocket/hub.py` still cached one payload per unique `selected_client_id`, but it serialized those payloads synchronously on the event loop. The new flow keeps payload building and cache semantics intact, then offloads the expensive JSON serialization step through `asyncio.to_thread()` per unique payload. That removes the event-loop blocking cost without changing the connection-facing API.

The sanitizer/error behavior is preserved: plain Python payloads still take the fast `json.dumps(..., allow_nan=False)` path, numpy/non-finite payloads still fall back through `sanitize_for_json()`, failures still send the shared error payload, and the per-client failure summary logging remains intact.

## Test and validation work

I added and updated tests alongside the implementation so the new behavior is pinned by observable outcomes rather than hand-wavy performance claims:

- processing regressions now verify that holding one client lock blocks only that client’s ingest and does not block ingest for a different client
- websocket regressions now verify that broadcast serialization is routed through `asyncio.to_thread()` while preserving cached-per-selection behavior
- diagnostics/noise-floor regressions now use the correct direct analysis-band P20 oracle instead of the DC-skipping helper

Validation completed locally:

- focused suites: `356 passed`
- broader processing/runtime/diagnostics suites: `1912 passed, 1 xpassed`
- `make typecheck-backend`
- `make lint`
- CI-parity backend subset via `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests`

I also attempted the required local Docker smoke (`docker compose build --pull && docker compose up -d`), but this environment still has no reachable Docker daemon/socket, so that path remains locally blocked and will need GitHub CI to cover it again.

## Risks, tradeoffs, and out-of-scope items

The main risk in this change set was introducing lock-order bugs while reducing contention. The implementation keeps a single acquisition hierarchy and avoids ever taking the shared store lock after entering a per-client critical section. The other tradeoff is scope: I intentionally did not change the UDP receiver to multi-consumer form in this PR because the issue itself frames that as an optional follow-up after the higher-impact fixes land. If Pi profiling after this branch still shows the UDP consumer as the next ceiling, that should be a smaller and better-isolated next step rather than bundled into this already broad hot-path refactor.
