### PR TITLE
Fix API contract type safety gaps

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -208,6 +208,49 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     }
 
 
+def test_export_schema_contains_debug_endpoint_response_shapes(
+    schema_dict: dict[str, Any],
+) -> None:
+    spectrum_route = schema_dict["paths"]["/api/debug/spectrum/{client_id}"]["get"]
+    raw_samples_route = schema_dict["paths"]["/api/debug/raw-samples/{client_id}"]["get"]
+    debug_spectrum = schema_dict["components"]["schemas"]["DebugSpectrumPayload"]
+    debug_stats = schema_dict["components"]["schemas"]["DebugSpectrumStatsPayload"]
+    debug_top_bin = schema_dict["components"]["schemas"]["DebugSpectrumTopBinPayload"]
+    raw_samples = schema_dict["components"]["schemas"]["RawSamplesPayload"]
+
+    assert spectrum_route["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/DebugSpectrumPayload",
+    }
+    assert raw_samples_route["responses"]["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/RawSamplesPayload",
+    }
+    assert {
+        "client_id",
+        "sample_rate_hz",
+        "fft_n",
+        "fft_scale",
+        "window",
+        "raw_stats",
+        "detrended_std_g",
+        "vibration_strength_db",
+        "top_bins_by_amplitude",
+        "strength_peaks",
+    }.issubset(debug_spectrum["required"])
+    assert debug_spectrum["properties"]["raw_stats"] == {
+        "$ref": "#/components/schemas/DebugSpectrumStatsPayload",
+    }
+    assert debug_spectrum["properties"]["top_bins_by_amplitude"]["items"] == {
+        "$ref": "#/components/schemas/DebugSpectrumTopBinPayload",
+    }
+    assert {"mean_g", "std_g", "min_g", "max_g"} == set(debug_stats["required"])
+    assert {"bin", "freq_hz", "combined_amp_g", "x_amp_g", "y_amp_g", "z_amp_g"} == set(
+        debug_top_bin["required"],
+    )
+    assert {"client_id", "sample_rate_hz", "n_samples", "x", "y", "z"} == set(
+        raw_samples["required"],
+    )
+
+
 def test_export_schema_uses_snake_case_settings_contract_fields(
     schema_dict: dict[str, Any],
 ) -> None:

--- a/apps/server/tests/adapters/persistence/test_car_library.py
+++ b/apps/server/tests/adapters/persistence/test_car_library.py
@@ -157,11 +157,14 @@ def _make_bad_data_file(tmp_path: Path, kind: str) -> Path:
     if kind == "missing":
         return tmp_path / "nonexistent.json"
     bad_file = tmp_path / "bad.json"
+    if kind == "schema_drift":
+        bad_file.write_text('[{"brand":"BMW","type":"Sedan","model":"Broken"}]')
+        return bad_file
     bad_file.write_text("not valid json {{{")
     return bad_file
 
 
-@pytest.mark.parametrize("kind", ["missing", "invalid_json"])
+@pytest.mark.parametrize("kind", ["missing", "invalid_json", "schema_drift"])
 def test_load_library_handles_bad_data(tmp_path: Path, kind: str) -> None:
     """_load_library gracefully returns [] when the data file is missing or malformed."""
     from unittest.mock import patch

--- a/apps/server/tests/shared/types/test_analysis_view_types.py
+++ b/apps/server/tests/shared/types/test_analysis_view_types.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import TypeAdapter
+
+from vibesensor.shared.types.analysis_views import (
+    FindingEvidenceMetrics,
+    LocationHotspotPayload,
+    MatchedPoint,
+    PeakTableRow,
+    PhaseEvidence,
+    PlotDataResult,
+    SpectrogramResult,
+)
+
+_SPECTROGRAM: SpectrogramResult = {
+    "x_axis": "speed_kmh",
+    "x_label_key": "speed",
+    "x_bins": [10.0, 20.0],
+    "y_bins": [5.0, 10.0],
+    "cells": [[0.1, 0.2]],
+    "max_amp": 0.2,
+}
+
+
+@pytest.mark.parametrize(
+    ("typed_dict", "payload"),
+    [
+        (
+            PeakTableRow,
+            {
+                "rank": 1,
+                "frequency_hz": 12.0,
+                "order_label": "1.0x",
+                "max_intensity_db": 22.0,
+                "median_intensity_db": 20.0,
+                "p95_intensity_db": 21.0,
+                "run_noise_baseline_db": 8.0,
+                "median_vs_run_noise_ratio": 2.5,
+                "p95_vs_run_noise_ratio": 2.7,
+                "strength_floor_db": 7.0,
+                "strength_db": 19.0,
+                "presence_ratio": 0.8,
+                "burstiness": 0.1,
+                "persistence_score": 0.9,
+                "suspected_source": "wheel/tire",
+                "peak_classification": "persistent",
+                "typical_speed_band": "50-80 km/h",
+                "unexpected": "drop-me",
+            },
+        ),
+        (
+            MatchedPoint,
+            {
+                "t_s": 1.0,
+                "matched_hz": 12.0,
+                "unexpected": "drop-me",
+            },
+        ),
+        (
+            PhaseEvidence,
+            {
+                "cruise_fraction": 0.5,
+                "phases_detected": ["cruise"],
+                "unexpected": "drop-me",
+            },
+        ),
+        (
+            LocationHotspotPayload,
+            {
+                "dominance_ratio": 0.8,
+                "top_location": "front-left",
+                "unexpected": "drop-me",
+            },
+        ),
+        (
+            FindingEvidenceMetrics,
+            {
+                "match_rate": 0.7,
+                "vibration_strength_db": 21.0,
+                "unexpected": "drop-me",
+            },
+        ),
+        (
+            SpectrogramResult,
+            {
+                **_SPECTROGRAM,
+                "unexpected": "drop-me",
+            },
+        ),
+        (
+            PlotDataResult,
+            {
+                "vib_magnitude": [(0.0, 1.0, "front-left")],
+                "dominant_freq": [(0.0, 12.0)],
+                "amp_vs_speed": [(50.0, 0.2)],
+                "amp_vs_phase": [],
+                "matched_amp_vs_speed": [],
+                "freq_vs_speed_by_finding": [],
+                "steady_speed_distribution": None,
+                "fft_spectrum": [(12.0, 0.2)],
+                "fft_spectrum_raw": [(12.0, 0.2)],
+                "peaks_spectrogram": _SPECTROGRAM,
+                "peaks_spectrogram_raw": _SPECTROGRAM,
+                "peaks_table": [],
+                "phase_segments": [],
+                "phase_boundaries": [],
+                "unexpected": "drop-me",
+            },
+        ),
+    ],
+)
+def test_analysis_view_typed_dicts_ignore_undocumented_fields(
+    typed_dict: Any,
+    payload: dict[str, Any],
+) -> None:
+    validated = TypeAdapter(typed_dict).validate_python(payload)
+
+    assert "unexpected" not in validated

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -8,7 +8,9 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 import pytest
+from test_support.analysis import run_analysis
 from test_support.persisted_analysis import make_persisted_analysis
+from test_support.report_helpers import report_sample
 
 from vibesensor.adapters.history import (
     ProjectedHistoryExportService,
@@ -94,6 +96,27 @@ def _stored_run(run: dict[str, Any]) -> StoredHistoryRun:
         analysis_started_at=cast(str | None, run.get("analysis_started_at")),
         analysis_completed_at=cast(str | None, run.get("analysis_completed_at")),
     )
+
+
+def _projectable_analysis(**overrides: object) -> dict[str, object]:
+    summary = run_analysis(
+        [
+            report_sample(
+                0,
+                speed_kmh=55.0,
+                dominant_freq_hz=15.0,
+                peak_amp_g=0.12,
+            ),
+            report_sample(
+                1,
+                speed_kmh=65.0,
+                dominant_freq_hz=15.0,
+                peak_amp_g=0.14,
+            ),
+        ],
+    )
+    summary.update(overrides)
+    return cast(dict[str, object], summary)
 
 
 def test_raise_delete_run_error_maps_unknown_reason_to_domain_error() -> None:
@@ -209,9 +232,9 @@ async def test_projected_run_service_projects_persisted_summary_through_domain()
                 run={
                     "run_id": "run-1",
                     "status": "complete",
-                    "analysis": {
-                        "lang": "en",
-                        "findings": [
+                    "analysis": _projectable_analysis(
+                        lang="en",
+                        findings=[
                             {
                                 "finding_id": "F001",
                                 "suspected_source": "wheel/tire",
@@ -221,12 +244,12 @@ async def test_projected_run_service_projects_persisted_summary_through_domain()
                                 "evidence_metrics": {"vibration_strength_db": 21.0},
                             },
                         ],
-                        "top_causes": [],
-                        "test_plan": [],
-                        "run_suitability": [],
-                        "most_likely_origin": {},
-                        "_internal": {"secret": True},
-                    },
+                        top_causes=[],
+                        test_plan=[],
+                        run_suitability=[],
+                        most_likely_origin={},
+                        _internal={"secret": True},
+                    ),
                 },
             ),
         )
@@ -234,7 +257,8 @@ async def test_projected_run_service_projects_persisted_summary_through_domain()
 
     run = await service.get_run("run-1")
 
-    analysis = run["analysis"]
+    analysis = run.analysis
+    assert analysis is not None
     assert analysis["top_causes"][0]["finding_id"] == "F001"
     assert analysis["most_likely_origin"]["suspected_source"] == "wheel/tire"
     assert "_internal" not in analysis
@@ -248,19 +272,19 @@ async def test_projected_run_service_drops_persisted_origin_without_primary_find
                 run={
                     "run_id": "run-1",
                     "status": "complete",
-                    "analysis": {
-                        "lang": "en",
-                        "findings": [],
-                        "top_causes": [],
-                        "test_plan": [],
-                        "run_suitability": [],
-                        "most_likely_origin": {
+                    "analysis": _projectable_analysis(
+                        lang="en",
+                        findings=[],
+                        top_causes=[],
+                        test_plan=[],
+                        run_suitability=[],
+                        most_likely_origin={
                             "location": "rear left",
                             "suspected_source": "wheel/tire",
                             "weak_spatial_separation": True,
                         },
-                        "_internal": {"secret": True},
-                    },
+                        _internal={"secret": True},
+                    ),
                 },
             ),
         )
@@ -268,7 +292,8 @@ async def test_projected_run_service_drops_persisted_origin_without_primary_find
 
     run = await service.get_run("run-1")
 
-    analysis = run["analysis"]
+    analysis = run.analysis
+    assert analysis is not None
     assert analysis["most_likely_origin"] == {}
     assert "_internal" not in analysis
 

--- a/apps/server/vibesensor/adapters/history.py
+++ b/apps/server/vibesensor/adapters/history.py
@@ -9,7 +9,15 @@ import zipfile
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, cast
 
+from pydantic import TypeAdapter
+
 from vibesensor.shared.boundaries.analysis_summary_projection import project_analysis_summary
+from vibesensor.shared.types.api_models import (
+    DeleteHistoryRunResponse,
+    HistoryInsightsResponse,
+    HistoryListEntryResponse,
+    HistoryRunResponse,
+)
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.history.exports import (
@@ -25,6 +33,8 @@ from vibesensor.use_cases.history.runs import HistoryRunService
 
 if TYPE_CHECKING:
     from vibesensor.domain import TestRun
+
+_HISTORY_INSIGHTS_ADAPTER = TypeAdapter(HistoryInsightsResponse)
 
 
 def _has_projectable_analysis(analysis: Mapping[str, object]) -> bool:
@@ -97,24 +107,33 @@ class ProjectedHistoryRunService:
     def __init__(self, service: HistoryRunService) -> None:
         self._service = service
 
-    async def list_runs(self) -> list[JsonObject]:
-        return [entry.to_json_object() for entry in await self._service.list_runs()]
+    async def list_runs(self) -> list[HistoryListEntryResponse]:
+        return [
+            HistoryListEntryResponse.model_validate(entry.to_json_object())
+            for entry in await self._service.list_runs()
+        ]
 
-    async def get_run(self, run_id: str) -> JsonObject:
-        return project_history_run_record(await self._service.get_run(run_id))
+    async def get_run(self, run_id: str) -> HistoryRunResponse:
+        return HistoryRunResponse.model_validate(
+            project_history_run_record(await self._service.get_run(run_id))
+        )
 
     async def get_insights(
         self,
         run_id: str,
         requested_lang: str | None = None,
-    ) -> JsonObject | None:
+    ) -> HistoryInsightsResponse | None:
         result = await self._service.get_insights(run_id, requested_lang=requested_lang)
         if result is None:
             return None
-        return project_history_insights(result)
+        validated = _HISTORY_INSIGHTS_ADAPTER.validate_python(project_history_insights(result))
+        return cast(
+            HistoryInsightsResponse,
+            _HISTORY_INSIGHTS_ADAPTER.dump_python(validated, mode="json"),
+        )
 
-    async def delete_run(self, run_id: str) -> dict[str, str]:
-        return await self._service.delete_run(run_id)
+    async def delete_run(self, run_id: str) -> DeleteHistoryRunResponse:
+        return DeleteHistoryRunResponse.model_validate(await self._service.delete_run(run_id))
 
 
 class ProjectedHistoryExportService:

--- a/apps/server/vibesensor/adapters/http/debug.py
+++ b/apps/server/vibesensor/adapters/http/debug.py
@@ -20,35 +20,53 @@ if TYPE_CHECKING:
 __all__ = ["create_debug_routes"]
 
 
+def _is_debug_spectrum_error_payload(
+    payload: DebugSpectrumPayload | DebugSpectrumErrorPayload,
+) -> TypeGuard[DebugSpectrumErrorPayload]:
+    return "error" in payload
+
+
+def _is_debug_spectrum_payload(
+    payload: DebugSpectrumPayload | DebugSpectrumErrorPayload,
+) -> TypeGuard[DebugSpectrumPayload]:
+    return "error" not in payload
+
+
 def _is_raw_samples_error_payload(
     payload: RawSamplesPayload | RawSamplesErrorPayload,
 ) -> TypeGuard[RawSamplesErrorPayload]:
     return "error" in payload
 
 
+def _is_raw_samples_payload(
+    payload: RawSamplesPayload | RawSamplesErrorPayload,
+) -> TypeGuard[RawSamplesPayload]:
+    return "error" not in payload
+
+
 def create_debug_routes(processor: SignalProcessor) -> APIRouter:
     """Create and return the internal debug API routes."""
     router = APIRouter()
 
-    @router.get("/api/debug/spectrum/{client_id}")
-    async def debug_spectrum(
-        client_id: str,
-    ) -> DebugSpectrumPayload | DebugSpectrumErrorPayload:
+    @router.get("/api/debug/spectrum/{client_id}", response_model=DebugSpectrumPayload)
+    async def debug_spectrum(client_id: str) -> DebugSpectrumPayload:
         """Detailed spectrum debug info for independent verification."""
         normalized = normalize_client_id_or_400(client_id)
         result = processor.debug_spectrum(normalized)
-        if isinstance(result, dict) and "error" in result:
+        if _is_debug_spectrum_error_payload(result):
             raise HTTPException(
                 status_code=404,
                 detail=result["error"],
             )
-        return result
+        if _is_debug_spectrum_payload(result):
+            return result
+        raise AssertionError("Unreachable debug spectrum payload state")
 
-    @router.get("/api/debug/raw-samples/{client_id}")
+    @router.get("/api/debug/raw-samples/{client_id}", response_model=RawSamplesPayload)
     async def debug_raw_samples(
         client_id: str,
         n: int = Query(default=2048, ge=1, le=6400),
-    ) -> RawSamplesPayload | RawSamplesErrorPayload:
+    ) -> RawSamplesPayload:
         """Raw time-domain samples in g for offline analysis."""
         normalized = normalize_client_id_or_400(client_id)
         result = processor.raw_samples(normalized, n_samples=n)
@@ -57,6 +75,8 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
                 status_code=404,
                 detail=result["error"],
             )
-        return result
+        if _is_raw_samples_payload(result):
+            return result
+        raise AssertionError("Unreachable raw-samples payload state")
 
     return router

--- a/apps/server/vibesensor/adapters/http/dependencies.py
+++ b/apps/server/vibesensor/adapters/http/dependencies.py
@@ -10,7 +10,12 @@ from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
 from vibesensor.infra.runtime.registry import ClientRegistry
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.api_models import (
+    DeleteHistoryRunResponse,
+    HistoryInsightsResponse,
+    HistoryListEntryResponse,
+    HistoryRunResponse,
+)
 from vibesensor.use_cases.history.exports import HistoryExportDownload
 from vibesensor.use_cases.history.reports import HistoryReportPdf
 from vibesensor.use_cases.run import RunRecorder
@@ -24,17 +29,17 @@ if TYPE_CHECKING:
 
 
 class HistoryRunServiceProtocol(Protocol):
-    async def list_runs(self) -> list[JsonObject]: ...
+    async def list_runs(self) -> list[HistoryListEntryResponse]: ...
 
-    async def get_run(self, run_id: str) -> JsonObject: ...
+    async def get_run(self, run_id: str) -> HistoryRunResponse: ...
 
     async def get_insights(
         self,
         run_id: str,
         requested_lang: str | None = None,
-    ) -> JsonObject | None: ...
+    ) -> HistoryInsightsResponse | None: ...
 
-    async def delete_run(self, run_id: str) -> dict[str, str]: ...
+    async def delete_run(self, run_id: str) -> DeleteHistoryRunResponse: ...
 
 
 class HistoryReportServiceProtocol(Protocol):

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
-from pydantic import TypeAdapter
 
 from vibesensor.adapters.http._helpers import domain_errors_to_http
 from vibesensor.shared.types.api_models import (
@@ -24,8 +23,6 @@ if TYPE_CHECKING:
         HistoryRunServiceProtocol,
     )
 
-_HISTORY_INSIGHTS_ADAPTER = TypeAdapter(HistoryInsightsResponse)
-
 
 def create_history_routes(
     *,
@@ -40,7 +37,7 @@ def create_history_routes(
 
     @router.get("/api/history", response_model=HistoryListResponse)
     async def get_history() -> HistoryListResponse:
-        return HistoryListResponse.model_validate({"runs": await run_service.list_runs()})
+        return HistoryListResponse(runs=await run_service.list_runs())
 
     @router.get(
         "/api/history/{run_id}",
@@ -50,7 +47,7 @@ def create_history_routes(
     )
     async def get_history_run(run_id: str) -> HistoryRunResponse:
         with domain_errors_to_http():
-            return HistoryRunResponse.model_validate(await run_service.get_run(run_id))
+            return await run_service.get_run(run_id)
 
     @router.get(
         "/api/history/{run_id}/insights",
@@ -69,16 +66,12 @@ def create_history_routes(
                 status_code=202,
                 content=analyzing_response.model_dump(),
             )
-        validated = _HISTORY_INSIGHTS_ADAPTER.validate_python(result)
-        return cast(
-            HistoryInsightsResponse,
-            _HISTORY_INSIGHTS_ADAPTER.dump_python(validated, mode="json"),
-        )
+        return result
 
     @router.delete("/api/history/{run_id}", response_model=DeleteHistoryRunResponse)
     async def delete_history_run(run_id: str) -> DeleteHistoryRunResponse:
         with domain_errors_to_http():
-            return DeleteHistoryRunResponse.model_validate(await run_service.delete_run(run_id))
+            return await run_service.delete_run(run_id)
 
     # -- report PDF ------------------------------------------------------------
 

--- a/apps/server/vibesensor/adapters/http/websocket.py
+++ b/apps/server/vibesensor/adapters/http/websocket.py
@@ -8,8 +8,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from pydantic import TypeAdapter, ValidationError
 
 from vibesensor.domain import normalize_sensor_id
+from vibesensor.shared.types.payload_types import WsClientSelectionPayload
 
 if TYPE_CHECKING:
     from vibesensor.adapters.websocket.hub import WebSocketHub
@@ -23,6 +25,8 @@ LOGGER = logging.getLogger(__name__)
 # closes it.  Normal dashboard sessions only send messages when changing the
 # selected sensor, so this is intentionally long.
 _RECEIVE_IDLE_TIMEOUT_S: float = 300.0
+
+_WS_CLIENT_SELECTION_ADAPTER = TypeAdapter(WsClientSelectionPayload)
 
 
 def create_websocket_routes(ws_hub: WebSocketHub) -> APIRouter:
@@ -65,20 +69,19 @@ def create_websocket_routes(ws_hub: WebSocketHub) -> APIRouter:
                         type(payload).__name__,
                     )
                     continue
-                if "client_id" in payload:
-                    value = payload["client_id"]
+                try:
+                    typed_payload = _WS_CLIENT_SELECTION_ADAPTER.validate_python(payload)
+                except ValidationError:
+                    LOGGER.debug("Ignoring invalid WS message payload: %r", payload)
+                    continue
+                if "client_id" in typed_payload:
+                    value = typed_payload["client_id"]
                     try:
                         if value is None:
                             await ws_hub.update_selected_client(ws, None)
-                        elif isinstance(value, str):
+                        else:
                             normalized = normalize_sensor_id(value)
                             await ws_hub.update_selected_client(ws, normalized)
-                        else:
-                            LOGGER.debug(
-                                "Ignoring unsupported client_id type %s in WS message: %r",
-                                type(value).__name__,
-                                value,
-                            )
                     except ValueError:
                         LOGGER.debug(
                             "Ignoring invalid client_id value in WS message: %r",

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import copy
 import json
 import logging
+from typing import Any, Literal
+
+from pydantic import ConfigDict, TypeAdapter, ValidationError
+from typing_extensions import NotRequired, TypedDict  # noqa: UP035 (Pydantic on Python 3.11)
 
 from vibesensor._data_files import resolve_static_data_file
 
@@ -17,6 +21,7 @@ LOGGER = logging.getLogger(__name__)
 
 __all__ = [
     "CAR_LIBRARY",
+    "CarLibraryEntry",
     "get_brands",
     "get_models_for_brand_type",
     "get_types_for_brand",
@@ -25,18 +30,76 @@ __all__ = [
 ]
 
 _DATA_FILE = resolve_static_data_file("car_library.json")
-_TIRE_OVERRIDE_KEYS = ("tire_width_mm", "tire_aspect_pct", "rim_in")
+_STRICT_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")
 
 
-def _entry_matches_identity(entry: dict, *, brand: str, car_type: str, model: str) -> bool:
-    return (
-        entry.get("brand") == brand
-        and entry.get("type") == car_type
-        and entry.get("model") == model
-    )
+class CarLibraryGearbox(TypedDict):
+    name: str
+    final_drive_ratio: float
+    top_gear_ratio: float
+    gear_ratios: NotRequired[list[float]]
 
 
-def _load_library() -> list[dict]:
+class CarLibraryTireOption(TypedDict):
+    name: str
+    tire_width_mm: float
+    tire_aspect_pct: float
+    rim_in: float
+
+
+class CarLibraryVariant(TypedDict):
+    name: str
+    drivetrain: Literal["FWD", "RWD", "AWD"]
+    engine: NotRequired[str]
+    gearboxes: NotRequired[list[CarLibraryGearbox]]
+    tire_options: NotRequired[list[CarLibraryTireOption]]
+    tire_width_mm: NotRequired[float]
+    tire_aspect_pct: NotRequired[float]
+    rim_in: NotRequired[float]
+
+
+class CarLibraryEntry(TypedDict):
+    brand: str
+    type: str
+    model: str
+    gearboxes: list[CarLibraryGearbox]
+    tire_options: list[CarLibraryTireOption]
+    tire_width_mm: float
+    tire_aspect_pct: float
+    rim_in: float
+    variants: list[CarLibraryVariant]
+
+
+def _configure_pydantic_schema(typed_dict: Any) -> None:
+    typed_dict.__pydantic_config__ = _STRICT_TYPEDDICT_CONFIG
+
+
+for _typed_dict in (
+    CarLibraryGearbox,
+    CarLibraryTireOption,
+    CarLibraryVariant,
+    CarLibraryEntry,
+):
+    _configure_pydantic_schema(_typed_dict)
+
+_CAR_LIBRARY_ADAPTER = TypeAdapter(list[CarLibraryEntry])
+
+
+def _entry_matches_identity(
+    entry: CarLibraryEntry, *, brand: str, car_type: str, model: str
+) -> bool:
+    return entry["brand"] == brand and entry["type"] == car_type and entry["model"] == model
+
+
+def _deep_copy_entry(entry: CarLibraryEntry) -> CarLibraryEntry:
+    return copy.deepcopy(entry)
+
+
+def _deep_copy_variants(variants: list[CarLibraryVariant]) -> list[CarLibraryVariant]:
+    return copy.deepcopy(variants)
+
+
+def _load_library() -> list[CarLibraryEntry]:
     """Load and return the car library from the canonical JSON file.
 
     Unlike an ``@lru_cache`` approach, this retries on every call so a
@@ -45,9 +108,15 @@ def _load_library() -> list[dict]:
     """
     try:
         with _DATA_FILE.open(encoding="utf-8") as fh:
-            data: list[dict] = json.load(fh)
-        return data
-    except (FileNotFoundError, json.JSONDecodeError, PermissionError, OSError) as exc:
+            data = json.load(fh)
+        return _CAR_LIBRARY_ADAPTER.validate_python(data)
+    except (
+        FileNotFoundError,
+        json.JSONDecodeError,
+        PermissionError,
+        OSError,
+        ValidationError,
+    ) as exc:
         LOGGER.warning("Could not load car library from %s: %s", _DATA_FILE, exc)
         return []
 
@@ -58,46 +127,46 @@ def _load_library() -> list[dict]:
 
 # Module-level alias keeps
 # ``from vibesensor.adapters.persistence.car_library import CAR_LIBRARY`` working.
-CAR_LIBRARY: list[dict] = _load_library()
+CAR_LIBRARY: list[CarLibraryEntry] = _load_library()
 
 
 def get_brands() -> list[str]:
     """Return sorted list of unique brands in the library."""
-    return sorted({b for e in CAR_LIBRARY if (b := e.get("brand"))})
+    return sorted({entry["brand"] for entry in CAR_LIBRARY})
 
 
 def get_types_for_brand(brand: str) -> list[str]:
     """Return sorted body types available for *brand*."""
-    return sorted({t for e in CAR_LIBRARY if e.get("brand") == brand and (t := e.get("type"))})
+    return sorted({entry["type"] for entry in CAR_LIBRARY if entry["brand"] == brand})
 
 
-def get_models_for_brand_type(brand: str, car_type: str) -> list[dict]:
+def get_models_for_brand_type(brand: str, car_type: str) -> list[CarLibraryEntry]:
     """Return all library entries matching *brand* and *car_type*.
 
     Returns deep copies so callers cannot corrupt the cached library.
     """
     return [
-        copy.deepcopy(e)
-        for e in CAR_LIBRARY
-        if e.get("brand") == brand and e.get("type") == car_type
+        _deep_copy_entry(entry)
+        for entry in CAR_LIBRARY
+        if entry["brand"] == brand and entry["type"] == car_type
     ]
 
 
-def get_variants_for_model(brand: str, car_type: str, model: str) -> list[dict]:
+def get_variants_for_model(brand: str, car_type: str, model: str) -> list[CarLibraryVariant]:
     """Return the variants list for a specific model, or [] if none.
 
     Returns deep copies so callers cannot corrupt the cached library.
     """
-    for e in CAR_LIBRARY:
-        if _entry_matches_identity(e, brand=brand, car_type=car_type, model=model):
-            return copy.deepcopy(e.get("variants") or [])
+    for entry in CAR_LIBRARY:
+        if _entry_matches_identity(entry, brand=brand, car_type=car_type, model=model):
+            return _deep_copy_variants(entry["variants"])
     return []
 
 
 def resolve_variant(
-    base_entry: dict,
+    base_entry: CarLibraryEntry,
     variant_name: str | None,
-) -> dict:
+) -> CarLibraryEntry:
     """Merge a variant's overrides onto a base model entry.
 
     Returns a new dict with the effective gearboxes, tire_options, and
@@ -105,17 +174,20 @@ def resolve_variant(
     deep copy of the base entry so callers cannot corrupt the cached
     library data.
     """
-    result = copy.deepcopy(base_entry)
+    result = _deep_copy_entry(base_entry)
     if not variant_name:
         return result
-    for v in base_entry.get("variants") or []:
-        if v.get("name") == variant_name:
-            if v.get("gearboxes"):
-                result["gearboxes"] = v["gearboxes"]
-            if v.get("tire_options"):
-                result["tire_options"] = v["tire_options"]
-            for k in _TIRE_OVERRIDE_KEYS:
-                if v.get(k) is not None:
-                    result[k] = v[k]
+    for variant in base_entry["variants"]:
+        if variant["name"] == variant_name:
+            if variant.get("gearboxes"):
+                result["gearboxes"] = copy.deepcopy(variant["gearboxes"])
+            if variant.get("tire_options"):
+                result["tire_options"] = copy.deepcopy(variant["tire_options"])
+            if "tire_width_mm" in variant:
+                result["tire_width_mm"] = variant["tire_width_mm"]
+            if "tire_aspect_pct" in variant:
+                result["tire_aspect_pct"] = variant["tire_aspect_pct"]
+            if "rim_in" in variant:
+                result["rim_in"] = variant["rim_in"]
             break
     return result

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from fastapi import WebSocket
 
 from vibesensor.shared.json_utils import sanitize_for_json
-from vibesensor.shared.types.payload_types import LiveWsPayload
+from vibesensor.shared.types.payload_types import LiveWsPayload, WsErrorPayload
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,10 +37,8 @@ _SEND_TIMEOUT_S: float = 0.5
 _SEND_ERROR_LOG_INTERVAL_S: float = 10.0
 """Minimum interval between logged send-error warnings to avoid log spam."""
 
-_ERROR_PAYLOAD: str = json.dumps(
-    {"error": "payload_build_failed"},
-    separators=(",", ":"),
-)
+_ERROR_PAYLOAD_BODY: WsErrorPayload = {"error": "payload_build_failed"}
+_ERROR_PAYLOAD: str = json.dumps(_ERROR_PAYLOAD_BODY, separators=(",", ":"))
 """Pre-serialised error payload sent to clients when their payload build fails."""
 
 _MAX_CONSECUTIVE_FAILURES: int = 10

--- a/apps/server/vibesensor/shared/types/analysis_views.py
+++ b/apps/server/vibesensor/shared/types/analysis_views.py
@@ -31,7 +31,6 @@ __all__ = [
 ]
 
 _IGNORE_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="ignore")
-_ALLOW_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="allow")
 
 
 class PeakTableRow(TypedDict):
@@ -215,13 +214,13 @@ def _configure_pydantic_schema(typed_dict: Any, config: ConfigDict) -> None:
     typed_dict.__pydantic_config__ = config
 
 
-_configure_pydantic_schema(PeakTableRow, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
-_configure_pydantic_schema(MatchedPoint, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
-_configure_pydantic_schema(PhaseEvidence, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
-_configure_pydantic_schema(LocationHotspotPayload, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
-_configure_pydantic_schema(FindingEvidenceMetrics, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
-_configure_pydantic_schema(SpectrogramResult, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
-_configure_pydantic_schema(PlotDataResult, _ALLOW_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(PeakTableRow, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(MatchedPoint, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(PhaseEvidence, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(LocationHotspotPayload, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(FindingEvidenceMetrics, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(SpectrogramResult, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
+_configure_pydantic_schema(PlotDataResult, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
 
 _configure_pydantic_schema(SpeedBreakdownRow, _IGNORE_EXTRA_TYPEDDICT_CONFIG)
 _configure_pydantic_schema(PhaseSpeedBreakdownRow, _IGNORE_EXTRA_TYPEDDICT_CONFIG)

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from typing import Any, Literal
+
+from pydantic import ConfigDict
 from typing_extensions import NotRequired, TypedDict  # noqa: UP035 (Pydantic on Python 3.11)
 
 from vibesensor.vibration_strength import StrengthPeak, VibrationStrengthMetrics
@@ -133,7 +136,7 @@ class DebugSpectrumErrorPayload(TypedDict):
     fft_n: int
 
 
-class DebugSpectrumPayload(TypedDict, total=False):
+class DebugSpectrumPayload(TypedDict):
     client_id: str
     sample_rate_hz: int
     fft_n: int
@@ -148,8 +151,6 @@ class DebugSpectrumPayload(TypedDict, total=False):
     vibration_strength_db: float
     top_bins_by_amplitude: list[DebugSpectrumTopBinPayload]
     strength_peaks: list[StrengthPeak]
-    error: str
-    count: int
 
 
 class RawSamplesErrorPayload(TypedDict):
@@ -164,6 +165,24 @@ class RawSamplesPayload(TypedDict):
     x: list[float]
     y: list[float]
     z: list[float]
+
+
+WsErrorCode = Literal["payload_build_failed"]
+
+
+class WsErrorPayload(TypedDict):
+    error: WsErrorCode
+
+
+class WsClientSelectionPayload(TypedDict, total=False):
+    client_id: str | None
+
+
+def _configure_pydantic_schema(typed_dict: Any, config: ConfigDict) -> None:
+    typed_dict.__pydantic_config__ = config
+
+
+_configure_pydantic_schema(WsClientSelectionPayload, ConfigDict(extra="ignore"))
 
 
 class TimeAlignmentSensorPayload(TypedDict):

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -1648,38 +1648,11 @@
         "title": "DataQualitySpeedCoverageResponse",
         "type": "object"
       },
-      "DebugSpectrumErrorPayload": {
-        "properties": {
-          "count": {
-            "title": "Count",
-            "type": "integer"
-          },
-          "error": {
-            "title": "Error",
-            "type": "string"
-          },
-          "fft_n": {
-            "title": "Fft N",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "error",
-          "count",
-          "fft_n"
-        ],
-        "title": "DebugSpectrumErrorPayload",
-        "type": "object"
-      },
       "DebugSpectrumPayload": {
         "properties": {
           "client_id": {
             "title": "Client Id",
             "type": "string"
-          },
-          "count": {
-            "title": "Count",
-            "type": "integer"
           },
           "detrended_std_g": {
             "items": {
@@ -1687,10 +1660,6 @@
             },
             "title": "Detrended Std G",
             "type": "array"
-          },
-          "error": {
-            "title": "Error",
-            "type": "string"
           },
           "fft_n": {
             "title": "Fft N",
@@ -1746,6 +1715,22 @@
             "type": "string"
           }
         },
+        "required": [
+          "client_id",
+          "sample_rate_hz",
+          "fft_n",
+          "fft_scale",
+          "window",
+          "spectrum_min_hz",
+          "spectrum_max_hz",
+          "freq_bins",
+          "freq_resolution_hz",
+          "raw_stats",
+          "detrended_std_g",
+          "vibration_strength_db",
+          "top_bins_by_amplitude",
+          "strength_peaks"
+        ],
         "title": "DebugSpectrumPayload",
         "type": "object"
       },
@@ -2195,7 +2180,6 @@
         "type": "object"
       },
       "FindingEvidenceMetrics": {
-        "additionalProperties": true,
         "description": "HTTP contract for serialized evidence metrics attached to a finding.",
         "properties": {
           "burstiness": {
@@ -3807,7 +3791,6 @@
         "type": "object"
       },
       "LocationHotspotPayload": {
-        "additionalProperties": true,
         "description": "HTTP contract for serialized location-hotspot evidence.",
         "properties": {
           "ambiguous_location": {
@@ -4074,7 +4057,6 @@
         "type": "object"
       },
       "MatchedPoint": {
-        "additionalProperties": true,
         "description": "HTTP contract for one serialized finding matched-point observation.",
         "properties": {
           "amp": {
@@ -4218,7 +4200,6 @@
         "type": "object"
       },
       "PeakTableRow": {
-        "additionalProperties": true,
         "description": "Typed HTTP contract for one ranked peak table row.",
         "properties": {
           "burstiness": {
@@ -4393,7 +4374,6 @@
         "type": "object"
       },
       "PhaseEvidence": {
-        "additionalProperties": true,
         "description": "HTTP contract for optional driving-phase evidence attached to a finding.",
         "properties": {
           "cruise_fraction": {
@@ -4766,7 +4746,6 @@
         "type": "object"
       },
       "PlotDataResult": {
-        "additionalProperties": true,
         "description": "Typed HTTP contract for serialized plot data attached to a run summary.",
         "properties": {
           "amp_vs_phase": {
@@ -4937,24 +4916,6 @@
           "phase_boundaries"
         ],
         "title": "PlotDataResult",
-        "type": "object"
-      },
-      "RawSamplesErrorPayload": {
-        "properties": {
-          "count": {
-            "title": "Count",
-            "type": "integer"
-          },
-          "error": {
-            "title": "Error",
-            "type": "string"
-          }
-        },
-        "required": [
-          "error",
-          "count"
-        ],
-        "title": "RawSamplesErrorPayload",
         "type": "object"
       },
       "RawSamplesPayload": {
@@ -5265,7 +5226,6 @@
         "type": "object"
       },
       "SpectrogramResult": {
-        "additionalProperties": true,
         "description": "Typed HTTP contract for a serialized spectrogram grid.",
         "properties": {
           "cells": {
@@ -6763,15 +6723,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/RawSamplesPayload"
-                    },
-                    {
-                      "$ref": "#/components/schemas/RawSamplesErrorPayload"
-                    }
-                  ],
-                  "title": "Response Debug Raw Samples Api Debug Raw Samples  Client Id  Get"
+                  "$ref": "#/components/schemas/RawSamplesPayload"
                 }
               }
             },
@@ -6811,15 +6763,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/DebugSpectrumPayload"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DebugSpectrumErrorPayload"
-                    }
-                  ],
-                  "title": "Response Debug Spectrum Api Debug Spectrum  Client Id  Get"
+                  "$ref": "#/components/schemas/DebugSpectrumPayload"
                 }
               }
             },

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -706,48 +706,35 @@ export interface components {
       /** Stddev Kmh */
       stddev_kmh: number | null;
     };
-    /** DebugSpectrumErrorPayload */
-    DebugSpectrumErrorPayload: {
-      /** Count */
-      count: number;
-      /** Error */
-      error: string;
-      /** Fft N */
-      fft_n: number;
-    };
     /** DebugSpectrumPayload */
     DebugSpectrumPayload: {
       /** Client Id */
-      client_id?: string;
-      /** Count */
-      count?: number;
+      client_id: string;
       /** Detrended Std G */
-      detrended_std_g?: number[];
-      /** Error */
-      error?: string;
+      detrended_std_g: number[];
       /** Fft N */
-      fft_n?: number;
+      fft_n: number;
       /** Fft Scale */
-      fft_scale?: number;
+      fft_scale: number;
       /** Freq Bins */
-      freq_bins?: number;
+      freq_bins: number;
       /** Freq Resolution Hz */
-      freq_resolution_hz?: number;
-      raw_stats?: components["schemas"]["DebugSpectrumStatsPayload"];
+      freq_resolution_hz: number;
+      raw_stats: components["schemas"]["DebugSpectrumStatsPayload"];
       /** Sample Rate Hz */
-      sample_rate_hz?: number;
+      sample_rate_hz: number;
       /** Spectrum Max Hz */
-      spectrum_max_hz?: number;
+      spectrum_max_hz: number;
       /** Spectrum Min Hz */
-      spectrum_min_hz?: number;
+      spectrum_min_hz: number;
       /** Strength Peaks */
-      strength_peaks?: components["schemas"]["StrengthPeak"][];
+      strength_peaks: components["schemas"]["StrengthPeak"][];
       /** Top Bins By Amplitude */
-      top_bins_by_amplitude?: components["schemas"]["DebugSpectrumTopBinPayload"][];
+      top_bins_by_amplitude: components["schemas"]["DebugSpectrumTopBinPayload"][];
       /** Vibration Strength Db */
-      vibration_strength_db?: number;
+      vibration_strength_db: number;
       /** Window */
-      window?: string;
+      window: string;
     };
     /** DebugSpectrumStatsPayload */
     DebugSpectrumStatsPayload: {
@@ -965,7 +952,6 @@ export interface components {
       total_samples?: number | null;
       /** Vibration Strength Db */
       vibration_strength_db?: number | null;
-      [key: string]: unknown;
     };
     /**
      * FindingPayload
@@ -1448,7 +1434,6 @@ export interface components {
       top_location?: string | null;
       /** Weak Spatial Separation */
       weak_spatial_separation?: boolean | null;
-      [key: string]: unknown;
     };
     /**
      * LocationIntensitySummaryResponse
@@ -1524,7 +1509,6 @@ export interface components {
       speed_kmh?: number | null;
       /** T S */
       t_s?: number | null;
-      [key: string]: unknown;
     };
     /**
      * OutlierSummaryResponse
@@ -1581,7 +1565,6 @@ export interface components {
       suspected_source: string;
       /** Typical Speed Band */
       typical_speed_band: string;
-      [key: string]: unknown;
     };
     /**
      * PhaseBoundary
@@ -1604,7 +1587,6 @@ export interface components {
       cruise_fraction?: number | null;
       /** Phases Detected */
       phases_detected?: string[];
-      [key: string]: unknown;
     };
     /**
      * PhaseInfoResponse
@@ -1749,14 +1731,6 @@ export interface components {
       } | null;
       /** Vib Magnitude */
       vib_magnitude: [number, number, string][];
-      [key: string]: unknown;
-    };
-    /** RawSamplesErrorPayload */
-    RawSamplesErrorPayload: {
-      /** Count */
-      count: number;
-      /** Error */
-      error: string;
     };
     /** RawSamplesPayload */
     RawSamplesPayload: {
@@ -1900,7 +1874,6 @@ export interface components {
       y_bin_width?: number | null;
       /** Y Bins */
       y_bins: number[];
-      [key: string]: unknown;
     };
     /**
      * SpeedBreakdownRow
@@ -2451,7 +2424,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["RawSamplesPayload"] | components["schemas"]["RawSamplesErrorPayload"];
+          "application/json": components["schemas"]["RawSamplesPayload"];
         };
       };
       /** @description Validation Error */
@@ -2476,7 +2449,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["DebugSpectrumPayload"] | components["schemas"]["DebugSpectrumErrorPayload"];
+          "application/json": components["schemas"]["DebugSpectrumPayload"];
         };
       };
       /** @description Validation Error */


### PR DESCRIPTION
## Summary

Closes #1168.

This PR tightens the backend’s HTTP and WebSocket contract boundaries so the type information that already exists inside the server stops getting erased at the adapter layer. Before this change, the history HTTP dependency protocol collapsed typed responses back to `JsonObject`, the two debug JSON routes were missing explicit `response_model` declarations, the WebSocket path accepted raw JSON dicts and emitted an untyped hardcoded error payload, the car-library persistence helper loaded and returned untyped `dict` values, and several API-facing analysis-view `TypedDict`s still allowed undeclared fields to pass through validation. Those seams made it too easy for backend refactors to change the wire contract without compile-time feedback.

The implementation keeps the existing runtime behavior and wire shapes stable wherever the issue explicitly called that out. I did not redesign the WebSocket message format or introduce a protocol discriminator. Instead, this is a wire-compatible tightening pass that moves typing closer to the existing HTTP and WebSocket boundaries, validates the static car-library data at load time, and regenerates the committed HTTP schema and UI contract output.

## Implementation approach

The highest-value change in this issue was the history API boundary, so I treated that as the anchor and tightened the surrounding seams to the same standard. The main design choice was to return typed response models or typed payloads from the HTTP-facing adapter layer itself instead of continuing to hand raw dicts to the route layer. For the analysis-view payload tree, I chose `extra="ignore"` rather than `extra="forbid"` because it blocks undocumented fields from leaking through the public contract without turning tolerant boundary decoding into a breaking runtime change.

For WebSockets, the issue’s non-goal around preserving the current wire format mattered. Rather than adding a new `type` discriminator or changing the selection message contract, the route now validates the existing `{ "client_id": ... }` shape through a typed adapter that ignores unknown keys and rejects invalid payload values. The error payload is now defined through a typed contract, but the JSON sent over the wire is still the same `{"error":"payload_build_failed"}` value current clients already understand.

## Main code changes

### 1. Typed history HTTP boundary

`HistoryRunServiceProtocol` in `adapters/http/dependencies.py` now exposes concrete history response types instead of `JsonObject`. `ProjectedHistoryRunService` now returns typed `HistoryListEntryResponse`, `HistoryRunResponse`, `DeleteHistoryRunResponse`, and a validated `HistoryInsightsResponse` payload. With that change in place, the history routes stay thin: they now return typed models directly instead of re-validating opaque dict payloads at the last minute. This keeps the domain-aware projection logic in the history adapter while making the HTTP-facing contract visible to static analysis.

### 2. Exact debug route schemas

The two debug JSON endpoints in `adapters/http/debug.py` now declare explicit `response_model`s. I also tightened the payload typing underneath them by making `DebugSpectrumPayload` a success-only schema and keeping the error shape separate as `DebugSpectrumErrorPayload`. The routes still translate the error payloads into `404` responses exactly as before, but the `200` contract is now explicit and shows up in the generated OpenAPI schema and TypeScript output.

### 3. Typed WebSocket inbound and error contracts

The shared payload module now defines `WsErrorPayload`, `WsErrorCode`, and `WsClientSelectionPayload`. The WebSocket hub now builds its fallback error frame from the typed payload constant instead of an anonymous inline dict. The `/ws` route now validates incoming JSON dicts through `TypeAdapter(WsClientSelectionPayload)` before applying selection changes. Unknown keys are still ignored, invalid JSON is still ignored, malformed client IDs are still ignored, and valid client IDs are still normalized exactly as before. The behavior stays compatible, but the contract is no longer “any dict”.

### 4. Typed car-library data model with load-time validation

`adapters/persistence/car_library.py` now defines strict `TypedDict`s for car-library entries, variants, gearboxes, and tire options. The loader validates `car_library.json` through `TypeAdapter(list[CarLibraryEntry])` when the data is loaded, so key drift in the static file now fails immediately instead of waiting until a particular route query hits the bad row. The query helpers and `resolve_variant()` also now return typed data instead of raw `dict` / `list[dict]`. This keeps the existing JSON-backed storage approach, but makes the static dataset participate in normal backend typing and validation.

### 5. Analysis-view extra-field tightening

The remaining API-path analysis-view `TypedDict`s that were still configured with `extra="allow"` are now configured with `extra="ignore"`. That covers `PeakTableRow`, `MatchedPoint`, `PhaseEvidence`, `LocationHotspotPayload`, `FindingEvidenceMetrics`, `SpectrogramResult`, and `PlotDataResult`. This removes the silent pass-through behavior that could leak undocumented fields into API output while avoiding a more disruptive shift to hard-forbid semantics.

## Schema and generated contract updates

Because the debug routes now advertise exact response models and the nested analysis-view schema surface is tighter, the committed HTTP OpenAPI document changed and the generated frontend contract file changed with it. I regenerated:

- `apps/ui/src/contracts/http_api_schema.json`
- `apps/ui/src/generated/http_api_contracts.ts`

That keeps the backend and UI contract artifacts in sync for `#1168` instead of leaving the frontend to consume stale generated types.

## Test and validation coverage

I added or updated focused coverage in the areas directly touched by the contract changes:

- history adapter tests now exercise the typed projected history service with full projected summaries instead of partial mock payloads
- HTTP schema export tests now assert the debug endpoints are present in OpenAPI with the expected success payload components
- car-library tests now verify that malformed or schema-drifted data files fail closed at load time
- a new shared typed-dict test verifies the analysis-view payload types ignore undocumented fields

Local validation completed successfully with:

- focused backend suites for history, WebSocket, and car-library contracts: `130 passed`
- schema and shared-type slices: `32 passed`
- `make typecheck-backend`
- `make lint`
- `cd apps/ui && npm run typecheck && npm run build`
- full backend suite: `5693 passed, 5 skipped, 1 xpassed`

I also attempted the required local Docker stack validation again, but this environment still has no reachable Docker daemon/socket, so `docker compose build --pull && docker compose up -d` fails before the repo stack can start. Separately, the local CI wrapper `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests` is blocked by the host’s PEP 668 policy because its bootstrap step still runs `python3 -m pip install --upgrade pip`. To compensate, I ran the equivalent repo-native gates directly and recorded the passing results above.

## Risks, tradeoffs, and follow-ups

The biggest tradeoff here is that the history HTTP adapter now validates against response models earlier, which is intentionally stricter than the old dict pass-through. I updated the projection tests to use realistic full summary payloads instead of weakening the adapter, because the point of this issue is to catch contract drift sooner. The WebSocket change deliberately does not add a new discriminator or version-negotiation handshake because the issue treats wire-format changes as out of scope.
