### PR TITLE
Refactor frontend app state ownership

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -38,7 +38,8 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
   const { state, els, t, escapeHtml, fmt, fmtTs, formatInt } = deps;
 
   const history = createHistoryFeature({
-    state,
+    history: state.history,
+    getLanguage: () => state.shell.lang,
     els,
     t,
     escapeHtml,
@@ -48,7 +49,8 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
   });
 
   const realtime = createRealtimeFeature({
-    state,
+    realtime: state.realtime,
+    getLanguage: () => state.shell.lang,
     els,
     t,
     escapeHtml,
@@ -60,7 +62,8 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
   });
 
   const settings = createSettingsFeature({
-    state,
+    settings: state.settings,
+    getSpeedUnit: () => state.shell.speedUnit,
     els,
     t,
     escapeHtml,

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,7 +1,7 @@
 import { EXPECTED_SCHEMA_VERSION } from "../contracts/ws_payload_types";
 
 type DemoDeps = {
-  state: { wsState: string; hasReceivedPayload: boolean };
+  state: { transport: { wsState: string; hasReceivedPayload: boolean } };
   renderWsState: () => void;
   applyPayload: (payload: unknown) => void;
 };
@@ -15,7 +15,7 @@ declare global {
 export function runDemoMode(deps: DemoDeps): void {
   const { state, renderWsState, applyPayload } = deps;
 
-  state.wsState = "connected";
+  state.transport.wsState = "connected";
   renderWsState();
 
   const demoClients = [
@@ -135,11 +135,13 @@ export function runDemoMode(deps: DemoDeps): void {
     schema_version: EXPECTED_SCHEMA_VERSION,
     server_time: new Date().toISOString(),
     clients: demoClients,
+    selected_client_id: demoClients[0]?.id ?? null,
     speed_mps: 22.2,
+    rotational_speeds: null,
     spectra: { clients: demoSpectra },
   };
 
-  state.hasReceivedPayload = true;
+  state.transport.hasReceivedPayload = true;
   applyPayload(demoPayload);
 
   window.__vibesensorDemoCleanup = undefined;

--- a/apps/ui/src/app/features/history_detail_module.ts
+++ b/apps/ui/src/app/features/history_detail_module.ts
@@ -1,9 +1,10 @@
 import { getHistoryInsights } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState, RunDetail } from "../ui_app_state";
+import type { HistoryState, RunDetail } from "../ui_app_state";
 
 export interface HistoryDetailModuleDeps extends FeatureDepsBase {
-  state: AppState;
+  history: HistoryState;
+  getLanguage: () => string;
   ensureRunDetail: (runId: string) => RunDetail;
   collapseExpandedRun: () => void;
   renderHistoryTable: () => void;
@@ -17,7 +18,7 @@ export interface HistoryDetailModule {
 }
 
 export function createHistoryDetailModule(ctx: HistoryDetailModuleDeps): HistoryDetailModule {
-  const { state, t } = ctx;
+  const { history, t } = ctx;
 
   async function loadRunPreview(runId: string, force = false): Promise<void> {
     if (!runId) return;
@@ -27,7 +28,7 @@ export function createHistoryDetailModule(ctx: HistoryDetailModuleDeps): History
     detail.previewError = "";
     ctx.renderHistoryTable();
     try {
-      const response = await getHistoryInsights(runId, state.lang);
+      const response = await getHistoryInsights(runId, ctx.getLanguage());
       detail.preview = response.status === "complete" ? response : null;
     } catch (err) {
       detail.previewError = err instanceof Error ? err.message : t("report.unable_load_insights");
@@ -45,7 +46,7 @@ export function createHistoryDetailModule(ctx: HistoryDetailModuleDeps): History
     detail.insightsError = "";
     ctx.renderHistoryTable();
     try {
-      const response = await getHistoryInsights(runId, state.lang);
+      const response = await getHistoryInsights(runId, ctx.getLanguage());
       detail.insights = response.status === "complete" ? response : null;
     } catch (err) {
       detail.insightsError = err instanceof Error ? err.message : t("report.unable_load_insights");
@@ -57,23 +58,23 @@ export function createHistoryDetailModule(ctx: HistoryDetailModuleDeps): History
 
   function toggleRunDetails(runId: string): void {
     if (!runId) return;
-    if (state.expandedRunId === runId) {
+    if (history.expandedRunId === runId) {
       ctx.collapseExpandedRun();
       ctx.renderHistoryTable();
       return;
     }
     ctx.collapseExpandedRun();
-    state.expandedRunId = runId;
+    history.expandedRunId = runId;
     ctx.renderHistoryTable();
     void loadRunPreview(runId);
   }
 
   function reloadExpandedRunOnLanguageChange(): void {
-    if (!state.expandedRunId) return;
-    const runId = state.expandedRunId;
-    const detail = state.runDetailsById[runId];
+    if (!history.expandedRunId) return;
+    const runId = history.expandedRunId;
+    const detail = history.runDetailsById[runId];
     const shouldReloadInsights = Boolean(detail?.insights);
-    delete state.runDetailsById[runId];
+    delete history.runDetailsById[runId];
     void loadRunPreview(runId, true).then(() => {
       if (shouldReloadInsights) {
         void loadRunInsights(runId, true);

--- a/apps/ui/src/app/features/history_download_delete_module.ts
+++ b/apps/ui/src/app/features/history_download_delete_module.ts
@@ -1,5 +1,5 @@
 import { deleteHistoryRun as deleteHistoryRunApi, historyReportPdfUrl } from "../../api";
-import type { AppState, RunDetail } from "../ui_app_state";
+import type { HistoryState, RunDetail } from "../ui_app_state";
 
 const DOWNLOAD_REVOKE_DELAY_MS = 1000;
 
@@ -46,7 +46,8 @@ export async function downloadBlobFile(url: string, fallbackName: string): Promi
 }
 
 export interface HistoryDownloadDeleteModuleDeps {
-  state: AppState;
+  history: HistoryState;
+  getLanguage: () => string;
   t: (key: string, vars?: Record<string, unknown>) => string;
   ensureRunDetail: (runId: string) => RunDetail;
   collapseExpandedRun: () => void;
@@ -65,7 +66,7 @@ export interface HistoryDownloadDeleteModule {
 export function createHistoryDownloadDeleteModule(
   ctx: HistoryDownloadDeleteModuleDeps,
 ): HistoryDownloadDeleteModule {
-  const { state, t } = ctx;
+  const { history, t } = ctx;
 
   async function deleteRun(runId: string): Promise<void> {
     if (!runId) return;
@@ -77,19 +78,19 @@ export function createHistoryDownloadDeleteModule(
       window.alert(err instanceof Error ? err.message : t("history.delete_failed"));
       return;
     }
-    if (state.expandedRunId === runId) {
+    if (history.expandedRunId === runId) {
       ctx.collapseExpandedRun();
     }
     await ctx.refreshHistory();
   }
 
   async function deleteAllRuns(): Promise<void> {
-    const names = state.runs.map((row) => row.run_id).filter(Boolean);
+    const names = history.runs.map((row) => row.run_id).filter(Boolean);
     if (!names.length) return;
     const ok = window.confirm(t("history.delete_all_confirm", { count: names.length }));
     if (!ok) return;
 
-    state.deleteAllRunsInFlight = true;
+    history.deleteAllRunsInFlight = true;
     ctx.renderHistoryTable();
     let deleted = 0;
     let failed = 0;
@@ -98,8 +99,8 @@ export function createHistoryDownloadDeleteModule(
       try {
         await deleteHistoryRunApi(name);
         deleted += 1;
-        delete state.runDetailsById[name];
-        if (state.expandedRunId === name) {
+        delete history.runDetailsById[name];
+        if (history.expandedRunId === name) {
           ctx.collapseExpandedRun();
         }
       } catch (err) {
@@ -109,7 +110,7 @@ export function createHistoryDownloadDeleteModule(
         }
       }
     }
-    state.deleteAllRunsInFlight = false;
+    history.deleteAllRunsInFlight = false;
     await ctx.refreshHistory();
     if (failed > 0) {
       const summary = t("history.delete_all_partial", { deleted, total: names.length, failed });
@@ -124,7 +125,7 @@ export function createHistoryDownloadDeleteModule(
     detail.pdfError = "";
     ctx.renderHistoryTable();
     try {
-      await downloadBlobFile(historyReportPdfUrl(runId, state.lang), `${runId}_report.pdf`);
+      await downloadBlobFile(historyReportPdfUrl(runId, ctx.getLanguage()), `${runId}_report.pdf`);
     } catch (err) {
       detail.pdfError = err instanceof Error ? err.message : t("history.pdf_failed");
     } finally {

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -1,5 +1,5 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState, RunDetail } from "../ui_app_state";
+import type { HistoryState, RunDetail } from "../ui_app_state";
 import {
   getHistoryTableAction,
   getHistoryTableRowRunId,
@@ -18,7 +18,8 @@ import {
 } from "./history_list_module";
 
 export interface HistoryFeatureDeps extends FeatureDepsBase {
-  state: AppState;
+  history: HistoryState;
+  getLanguage: () => string;
   fmt: (n: number, digits?: number) => string;
   fmtTs: (iso: string) => string;
   formatInt: (value: number) => string;
@@ -35,12 +36,12 @@ export interface HistoryFeature {
 }
 
 export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
-  const { state, els } = ctx;
+  const { history, els } = ctx;
   let handlersBound = false;
 
   function ensureRunDetail(runId: string): RunDetail {
-    if (!state.runDetailsById[runId]) {
-      state.runDetailsById[runId] = {
+    if (!history.runDetailsById[runId]) {
+      history.runDetailsById[runId] = {
         preview: null,
         previewLoading: false,
         previewError: "",
@@ -51,30 +52,33 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         pdfError: "",
       };
     }
-    return state.runDetailsById[runId];
+    return history.runDetailsById[runId];
   }
 
   function collapseExpandedRun(): void {
-    const previous = state.expandedRunId;
-    state.expandedRunId = null;
+    const previous = history.expandedRunId;
+    history.expandedRunId = null;
     if (previous) {
-      delete state.runDetailsById[previous];
+      delete history.runDetailsById[previous];
     }
   }
 
   const listModule: HistoryListModule = createHistoryListModule({
     ...ctx,
+    history,
     ensureRunDetail,
     collapseExpandedRun,
   });
   const detailModule: HistoryDetailModule = createHistoryDetailModule({
     ...ctx,
+    history,
     ensureRunDetail,
     collapseExpandedRun,
     renderHistoryTable: () => listModule.renderHistoryTable(),
   });
   const downloadDeleteModule: HistoryDownloadDeleteModule = createHistoryDownloadDeleteModule({
-    state,
+    history,
+    getLanguage: ctx.getLanguage,
     t: ctx.t,
     ensureRunDetail,
     collapseExpandedRun,
@@ -99,7 +103,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         event.stopPropagation();
         void downloadDeleteModule.onHistoryTableAction(
           action.action,
-          action.runId ?? state.expandedRunId ?? "",
+          action.runId ?? history.expandedRunId ?? "",
         );
         return;
       }

--- a/apps/ui/src/app/features/history_list_module.ts
+++ b/apps/ui/src/app/features/history_list_module.ts
@@ -1,13 +1,13 @@
 import { getHistory, historyExportUrl } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState, RunDetail } from "../ui_app_state";
+import type { HistoryState, RunDetail } from "../ui_app_state";
 import {
   renderHistoryEmptyState,
   renderHistoryTable as renderHistoryTableView,
 } from "../views/history_table_view";
 
 export interface HistoryListModuleDeps extends FeatureDepsBase {
-  state: AppState;
+  history: HistoryState;
   fmt: (n: number, digits?: number) => string;
   fmtTs: (iso: string) => string;
   formatInt: (value: number) => string;
@@ -21,13 +21,13 @@ export interface HistoryListModule {
 }
 
 export function createHistoryListModule(ctx: HistoryListModuleDeps): HistoryListModule {
-  const { state, els, t, escapeHtml, fmt, fmtTs, formatInt } = ctx;
+  const { history, els, t, escapeHtml, fmt, fmtTs, formatInt } = ctx;
 
   function renderHistoryTable(): void {
     if (els.deleteAllRunsBtn) {
-      els.deleteAllRunsBtn.disabled = state.deleteAllRunsInFlight || state.runs.length === 0;
+      els.deleteAllRunsBtn.disabled = history.deleteAllRunsInFlight || history.runs.length === 0;
     }
-    if (!state.runs.length) {
+    if (!history.runs.length) {
       if (els.historySummary) {
         els.historySummary.textContent = t("history.none");
       }
@@ -37,20 +37,20 @@ export function createHistoryListModule(ctx: HistoryListModuleDeps): HistoryList
       ctx.collapseExpandedRun();
       return;
     }
-    if (state.expandedRunId && !state.runs.some((row) => row.run_id === state.expandedRunId)) {
+    if (history.expandedRunId && !history.runs.some((row) => row.run_id === history.expandedRunId)) {
       ctx.collapseExpandedRun();
     }
     if (els.historySummary) {
-      els.historySummary.textContent = t("history.available_count", { count: state.runs.length });
+      els.historySummary.textContent = t("history.available_count", { count: history.runs.length });
     }
-    for (const run of state.runs) {
+    for (const run of history.runs) {
       ctx.ensureRunDetail(run.run_id);
     }
     if (els.historyTableBody) {
       renderHistoryTableView(els.historyTableBody, {
-        runs: state.runs,
-        expandedRunId: state.expandedRunId,
-        runDetailsById: state.runDetailsById,
+        runs: history.runs,
+        expandedRunId: history.expandedRunId,
+        runDetailsById: history.runDetailsById,
         t,
         escapeHtml,
         fmt,
@@ -64,7 +64,7 @@ export function createHistoryListModule(ctx: HistoryListModuleDeps): HistoryList
   async function refreshHistory(): Promise<void> {
     try {
       const payload = await getHistory();
-      state.runs = payload.runs ?? [];
+      history.runs = payload.runs ?? [];
       renderHistoryTable();
     } catch (_err) {
       renderHistoryTable();

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -1,5 +1,5 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState } from "../ui_app_state";
+import type { RealtimeState } from "../ui_app_state";
 import type { LocationOption } from "../../api/types";
 import type { AdaptedClient } from "../../server_payload";
 import * as I18N from "../../i18n";
@@ -20,7 +20,8 @@ import {
 } from "../views/realtime_sensor_table_view";
 
 export interface RealtimeFeatureDeps extends FeatureDepsBase {
-  state: AppState;
+  realtime: RealtimeState;
+  getLanguage: () => string;
   formatInt: (value: number) => string;
   setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
   setStatValue: (container: HTMLElement | null, value: string | number) => void;
@@ -43,7 +44,7 @@ export interface RealtimeFeature {
 }
 
 export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature {
-  const { state, els, t, escapeHtml, formatInt, setPillState } = ctx;
+  const { realtime, els, t, escapeHtml, formatInt, setPillState } = ctx;
   let handlersBound = false;
 
   const SHORTHAND_LOCATION_MAP: Record<string, string> = {
@@ -59,7 +60,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
   }
 
   function locationLabel(code: string): string {
-    return locationLabelForLang(state.lang, code);
+    return locationLabelForLang(ctx.getLanguage(), code);
   }
 
   function buildLocationOptions(codes: readonly string[]): LocationOption[] {
@@ -68,54 +69,56 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
 
   function locationCodeForClient(client: AdaptedClient): string {
     const explicitCode = String(client.location_code || "").trim();
-    if (explicitCode && state.locationCodes.includes(explicitCode)) return explicitCode;
+    if (explicitCode && realtime.locationCodes.includes(explicitCode)) return explicitCode;
     const name = String(client.name || "").trim();
     if (!name) return "";
     const normalizedName = name.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
     for (const [token, code] of Object.entries(SHORTHAND_LOCATION_MAP)) {
-      if (normalizedName.includes(token) && state.locationCodes.includes(code)) return code;
+      if (normalizedName.includes(token) && realtime.locationCodes.includes(code)) return code;
     }
-    for (const code of state.locationCodes) {
+    for (const code of realtime.locationCodes) {
       const labels = I18N.getForAllLangs(`location.${code}`);
       if (labels.some((label) => label === name)) return code;
     }
-    const match = state.locationOptions.find((loc) => loc.label === name);
+    const match = realtime.locationOptions.find((loc) => loc.label === name);
     return match ? match.code : "";
   }
 
   function sensorsSettingsSignature(): string {
-    const clientPart = state.clients
+    const clientPart = realtime.clients
       .map((client) => {
         const connected = client.connected ? "1" : "0";
         return `${client.id}|${client.name || ""}|${client.mac_address || ""}|${connected}|${client.location_code || ""}`;
       })
       .join("||");
-    const locationPart = state.locationOptions.map((loc) => `${loc.code}|${loc.label}`).join("||");
+    const locationPart = realtime.locationOptions.map((loc) => `${loc.code}|${loc.label}`).join("||");
     return `${clientPart}##${locationPart}`;
   }
 
   function maybeRenderSensorsSettingsList(force = false): void {
     const nextSig = sensorsSettingsSignature();
-    if (!force && nextSig === state.sensorsSettingsSignature) return;
-    state.sensorsSettingsSignature = nextSig;
+    if (!force && nextSig === realtime.sensorsSettingsSignature) return;
+    realtime.sensorsSettingsSignature = nextSig;
     renderSensorsSettingsList();
   }
 
   function updateClientSelection(): void {
-    const firstConnected = state.clients.find((c) => Boolean(c.connected));
-    if (!state.selectedClientId && state.clients.length > 0) {
-      state.selectedClientId = firstConnected ? firstConnected.id : state.clients[0].id;
+    const firstConnected = realtime.clients.find((c) => Boolean(c.connected));
+    if (!realtime.selectedClientId && realtime.clients.length > 0) {
+      realtime.selectedClientId = firstConnected ? firstConnected.id : realtime.clients[0].id;
     }
-    if (state.selectedClientId && !state.clients.some((c) => c.id === state.selectedClientId)) {
-      state.selectedClientId = firstConnected ? firstConnected.id : state.clients.length ? state.clients[0].id : null;
+    if (realtime.selectedClientId && !realtime.clients.some((c) => c.id === realtime.selectedClientId)) {
+      realtime.selectedClientId = firstConnected
+        ? firstConnected.id
+        : realtime.clients.length ? realtime.clients[0].id : null;
     }
   }
 
   function renderSensorsSettingsList(): void {
     if (!els.sensorsSettingsBody) return;
     renderRealtimeSensorTable(els.sensorsSettingsBody, {
-      clients: state.clients,
-      locationOptions: state.locationOptions,
+      clients: realtime.clients,
+      locationOptions: realtime.locationOptions,
       locationCodeForClient,
       t,
       escapeHtml,
@@ -137,9 +140,9 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
   }
 
   function renderLoggingStatus(): void {
-    const status = state.loggingStatus;
+    const status = realtime.loggingStatus;
     const on = Boolean(status.enabled);
-    const hasActiveClients = state.clients.some((client) => Boolean(client?.connected));
+    const hasActiveClients = realtime.clients.some((client) => Boolean(client?.connected));
     if (status.write_error) {
       setPillState(els.loggingStatus, "bad", status.write_error);
     } else {
@@ -151,7 +154,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
 
   async function refreshLoggingStatus(): Promise<void> {
     try {
-      state.loggingStatus = await getLoggingStatus();
+      realtime.loggingStatus = await getLoggingStatus();
       renderLoggingStatus();
     } catch (_err) {
       setPillState(els.loggingStatus, "bad", t("status.unavailable"));
@@ -160,7 +163,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
 
   async function startLogging(): Promise<void> {
     try {
-      state.loggingStatus = await startLoggingRun();
+      realtime.loggingStatus = await startLoggingRun();
       renderLoggingStatus();
       await ctx.refreshHistory();
     } catch (err) {
@@ -171,7 +174,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
 
   async function stopLogging(): Promise<void> {
     try {
-      state.loggingStatus = await stopLoggingRun();
+      realtime.loggingStatus = await stopLoggingRun();
       renderLoggingStatus();
       await ctx.refreshHistory();
     } catch (err) {
@@ -186,18 +189,18 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       const codes = Array.isArray(payload.locations)
         ? payload.locations.map((row) => row.code).filter((code): code is string => typeof code === "string")
         : [];
-      state.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
-      state.locationOptions = buildLocationOptions(state.locationCodes);
+      realtime.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
+      realtime.locationOptions = buildLocationOptions(realtime.locationCodes);
     } catch (_err) {
-      state.locationCodes = defaultLocationCodes.slice();
-      state.locationOptions = buildLocationOptions(state.locationCodes);
+      realtime.locationCodes = defaultLocationCodes.slice();
+      realtime.locationOptions = buildLocationOptions(realtime.locationCodes);
     }
     maybeRenderSensorsSettingsList(true);
   }
 
   async function setClientLocation(clientId: string, locationCode: string): Promise<void> {
     if (!clientId) return;
-    const existing = state.clients.find((c) => c.id === clientId);
+    const existing = realtime.clients.find((c) => c.id === clientId);
     if (existing && locationCodeForClient(existing) === locationCode) return;
     try {
       await setClientLocationApi(clientId, locationCode);
@@ -205,7 +208,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       window.alert(err instanceof Error ? err.message : t("actions.set_location_failed"));
       return;
     }
-    const client = state.clients.find((c) => c.id === clientId);
+    const client = realtime.clients.find((c) => c.id === clientId);
     if (client) {
       client.location_code = locationCode;
       maybeRenderSensorsSettingsList();
@@ -227,13 +230,13 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       window.alert(err instanceof Error ? err.message : t("actions.remove_client_failed"));
       return;
     }
-    const prevSelected = state.selectedClientId;
-    state.clients = state.clients.filter((c) => c.id !== clientId);
-    if (state.selectedClientId === clientId) state.selectedClientId = null;
+    const prevSelected = realtime.selectedClientId;
+    realtime.clients = realtime.clients.filter((c) => c.id !== clientId);
+    if (realtime.selectedClientId === clientId) realtime.selectedClientId = null;
     updateClientSelection();
     maybeRenderSensorsSettingsList();
     renderLoggingStatus();
-    if (prevSelected !== state.selectedClientId) ctx.sendSelection();
+    if (prevSelected !== realtime.selectedClientId) ctx.sendSelection();
   }
 
   function bindHandlers(): void {

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -1,7 +1,7 @@
 import type { AnalysisSettingsRequest, AnalysisSettingsPayload } from "../../api/types";
 import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState } from "../ui_app_state";
+import type { SettingsState } from "../ui_app_state";
 
 const ANALYSIS_SETTING_KEYS = [
   "tire_width_mm",
@@ -22,7 +22,7 @@ const ANALYSIS_SETTING_KEYS = [
 ] as const satisfies readonly (keyof AnalysisSettingsPayload)[];
 
 export interface SettingsAnalysisModuleDeps extends FeatureDepsBase {
-  state: AppState;
+  settings: SettingsState;
   renderSpectrum: () => void;
   hasValidActiveCar: () => boolean;
   onMissingActiveCar: () => void;
@@ -37,24 +37,24 @@ export interface SettingsAnalysisModule {
 }
 
 export function createSettingsAnalysisModule(ctx: SettingsAnalysisModuleDeps): SettingsAnalysisModule {
-  const { state, els, t } = ctx;
+  const { settings, els, t } = ctx;
 
   function syncSettingsInputs(): void {
-    if (els.wheelBandwidthInput) els.wheelBandwidthInput.value = String(state.vehicleSettings.wheel_bandwidth_pct);
-    if (els.driveshaftBandwidthInput) els.driveshaftBandwidthInput.value = String(state.vehicleSettings.driveshaft_bandwidth_pct);
-    if (els.engineBandwidthInput) els.engineBandwidthInput.value = String(state.vehicleSettings.engine_bandwidth_pct);
-    if (els.speedUncertaintyInput) els.speedUncertaintyInput.value = String(state.vehicleSettings.speed_uncertainty_pct);
-    if (els.tireDiameterUncertaintyInput) els.tireDiameterUncertaintyInput.value = String(state.vehicleSettings.tire_diameter_uncertainty_pct);
-    if (els.finalDriveUncertaintyInput) els.finalDriveUncertaintyInput.value = String(state.vehicleSettings.final_drive_uncertainty_pct);
-    if (els.gearUncertaintyInput) els.gearUncertaintyInput.value = String(state.vehicleSettings.gear_uncertainty_pct);
-    if (els.minAbsBandHzInput) els.minAbsBandHzInput.value = String(state.vehicleSettings.min_abs_band_hz);
-    if (els.maxBandHalfWidthInput) els.maxBandHalfWidthInput.value = String(state.vehicleSettings.max_band_half_width_pct);
+    if (els.wheelBandwidthInput) els.wheelBandwidthInput.value = String(settings.vehicleSettings.wheel_bandwidth_pct);
+    if (els.driveshaftBandwidthInput) els.driveshaftBandwidthInput.value = String(settings.vehicleSettings.driveshaft_bandwidth_pct);
+    if (els.engineBandwidthInput) els.engineBandwidthInput.value = String(settings.vehicleSettings.engine_bandwidth_pct);
+    if (els.speedUncertaintyInput) els.speedUncertaintyInput.value = String(settings.vehicleSettings.speed_uncertainty_pct);
+    if (els.tireDiameterUncertaintyInput) els.tireDiameterUncertaintyInput.value = String(settings.vehicleSettings.tire_diameter_uncertainty_pct);
+    if (els.finalDriveUncertaintyInput) els.finalDriveUncertaintyInput.value = String(settings.vehicleSettings.final_drive_uncertainty_pct);
+    if (els.gearUncertaintyInput) els.gearUncertaintyInput.value = String(settings.vehicleSettings.gear_uncertainty_pct);
+    if (els.minAbsBandHzInput) els.minAbsBandHzInput.value = String(settings.vehicleSettings.min_abs_band_hz);
+    if (els.maxBandHalfWidthInput) els.maxBandHalfWidthInput.value = String(settings.vehicleSettings.max_band_half_width_pct);
   }
 
   function applyAnalysisSettingsPayload(serverSettings: AnalysisSettingsPayload): void {
     for (const key of ANALYSIS_SETTING_KEYS) {
       const value = serverSettings[key];
-      if (typeof value === "number") state.vehicleSettings[key] = value;
+      if (typeof value === "number") settings.vehicleSettings[key] = value;
     }
     syncSettingsInputs();
     ctx.renderSpectrum();
@@ -113,7 +113,7 @@ export function createSettingsAnalysisModule(ctx: SettingsAnalysisModuleDeps): S
     };
     for (const key of ANALYSIS_SETTING_KEYS) {
       if (!(key in payload)) {
-        payload[key] = state.vehicleSettings[key];
+        payload[key] = settings.vehicleSettings[key];
       }
     }
     void syncAnalysisSettingsToServer(payload);

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,5 +1,5 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState } from "../ui_app_state";
+import type { SettingsState } from "../ui_app_state";
 import type { CarUpsertRequest, CarsPayload } from "../../api/types";
 import {
   addSettingsCar,
@@ -26,7 +26,8 @@ import {
 import { bindSettingsTabs } from "./settings_tabs_controller";
 
 export interface SettingsFeatureDeps extends FeatureDepsBase {
-  state: AppState;
+  settings: SettingsState;
+  getSpeedUnit: () => string;
   fmt: (n: number, digits?: number) => string;
   renderSpectrum: () => void;
   renderSpeedReadout: () => void;
@@ -50,7 +51,7 @@ export interface SettingsFeature {
 }
 
 export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature {
-  const { state, els, t, escapeHtml, fmt } = ctx;
+  const { settings, els, t, escapeHtml, fmt } = ctx;
   let handlersBound = false;
 
   function showSettingsSaveError(error: unknown): void {
@@ -58,7 +59,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   }
 
   function hasValidActiveCar(): boolean {
-    return Boolean(state.activeCarId && state.cars.some((car) => car.id === state.activeCarId));
+    return Boolean(settings.activeCarId && settings.cars.some((car) => car.id === settings.activeCarId));
   }
 
   function syncCarDependentUiState(): void {
@@ -76,7 +77,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     els,
     t,
     escapeHtml,
-    state,
+    settings,
     renderSpectrum: ctx.renderSpectrum,
     hasValidActiveCar,
     onMissingActiveCar: syncCarDependentUiState,
@@ -86,7 +87,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     els,
     t,
     escapeHtml,
-    state,
+    settings,
     renderSpeedReadout: ctx.renderSpeedReadout,
     onSaveError: showSettingsSaveError,
   });
@@ -94,18 +95,19 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     els,
     t,
     escapeHtml,
-    state,
+    settings,
+    getSpeedUnit: ctx.getSpeedUnit,
     fmt,
     renderSpeedReadout: ctx.renderSpeedReadout,
   });
 
   function applyCarsPayload(payload: CarsPayload): void {
-    state.cars = payload.cars;
+    settings.cars = payload.cars;
     const requestedActiveCarId = payload.active_car_id;
     const hasRequestedActive = requestedActiveCarId
-      ? state.cars.some((car) => car.id === requestedActiveCarId)
+      ? settings.cars.some((car) => car.id === requestedActiveCarId)
       : false;
-    state.activeCarId = hasRequestedActive ? requestedActiveCarId : null;
+    settings.activeCarId = hasRequestedActive ? requestedActiveCarId : null;
     syncCarDependentUiState();
   }
 
@@ -133,7 +135,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
 
   async function handleDeleteCar(carId: string): Promise<void> {
     if (!carId) return;
-    const car = state.cars.find((entry) => entry.id === carId);
+    const car = settings.cars.find((entry) => entry.id === carId);
     const ok = window.confirm(t("settings.car.delete_confirm", { name: car?.name || "" }));
     if (!ok) return;
     try {
@@ -150,8 +152,8 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   function renderCarList(): void {
     if (!els.carListBody) return;
     renderSettingsCarList(els.carListBody, {
-      cars: state.cars,
-      activeCarId: state.activeCarId,
+      cars: settings.cars,
+      activeCarId: settings.activeCarId,
       t,
       escapeHtml,
       fmt,
@@ -159,14 +161,14 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   }
 
   function syncActiveCarToInputs(): void {
-    const car = state.cars.find((entry) => entry.id === state.activeCarId);
+    const car = settings.cars.find((entry) => entry.id === settings.activeCarId);
     if (!car) {
       syncCarDependentUiState();
       return;
     }
     if (car.aspects && typeof car.aspects === "object") {
       for (const key of Object.keys(car.aspects)) {
-        state.vehicleSettings[key] = car.aspects[key];
+        settings.vehicleSettings[key] = car.aspects[key];
       }
     }
     analysisModule.syncSettingsInputs();
@@ -206,13 +208,13 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     variant?: string,
   ): Promise<void> {
     try {
-      const fullAspects = { ...state.vehicleSettings, ...aspects };
+      const fullAspects = { ...settings.vehicleSettings, ...aspects };
       const payload: CarUpsertRequest = { name, type: carType, aspects: fullAspects };
       if (variant) payload.variant = variant;
       const result = await addSettingsCar(payload);
       if (Array.isArray(result.cars)) {
         applyCarsPayload(result);
-        const newCar = state.cars[state.cars.length - 1];
+        const newCar = settings.cars[settings.cars.length - 1];
         if (newCar) {
           const setResult = await setActiveSettingsCar(newCar.id);
           applyCarsPayload(setResult);

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -1,7 +1,7 @@
 import type { SpeedSourceStatusPayload } from "../../api/types";
 import { getSpeedSourceStatus } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState } from "../ui_app_state";
+import type { SettingsState } from "../ui_app_state";
 
 const GPS_POLL_FAST = 2_000;
 const GPS_POLL_SLOW = 10_000;
@@ -13,7 +13,8 @@ const CONNECTION_STATE_I18N: Record<string, string> = {
 };
 
 export interface SettingsGpsStatusModuleDeps extends FeatureDepsBase {
-  state: AppState;
+  settings: SettingsState;
+  getSpeedUnit: () => string;
   fmt: (n: number, digits?: number) => string;
   renderSpeedReadout: () => void;
 }
@@ -24,7 +25,7 @@ export interface SettingsGpsStatusModule {
 }
 
 export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps): SettingsGpsStatusModule {
-  const { state, els, t, fmt } = ctx;
+  const { settings, els, t, fmt } = ctx;
   let gpsPollTimer: ReturnType<typeof setTimeout> | null = null;
 
   function connectionStateLabel(connectionState: string): string {
@@ -34,11 +35,11 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
 
   function speedKmhInSelectedUnit(speedKmh: number | null): number | null {
     if (speedKmh === null || !Number.isFinite(speedKmh)) return null;
-    return state.speedUnit === "mps" ? speedKmh / 3.6 : speedKmh;
+    return ctx.getSpeedUnit() === "mps" ? speedKmh / 3.6 : speedKmh;
   }
 
   function selectedSpeedUnitLabel(): string {
-    return state.speedUnit === "mps" ? t("speed.unit.mps") : t("speed.unit.kmh");
+    return ctx.getSpeedUnit() === "mps" ? t("speed.unit.mps") : t("speed.unit.kmh");
   }
 
   function renderGpsStatus(status: SpeedSourceStatusPayload): void {
@@ -89,11 +90,11 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
   async function pollGpsStatus(): Promise<void> {
     try {
       const status = await getSpeedSourceStatus();
-      state.gpsFallbackActive = status.fallback_active
+      settings.gpsFallbackActive = status.fallback_active
         || (
-          state.speedSource !== "manual"
-          && typeof state.manualSpeedKph === "number"
-          && state.manualSpeedKph > 0
+          settings.speedSource !== "manual"
+          && typeof settings.manualSpeedKph === "number"
+          && settings.manualSpeedKph > 0
           && status.connection_state !== "connected"
         );
       renderGpsStatus(status);

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -1,12 +1,12 @@
 import type { SpeedSourceKind, SpeedSourcePayload, SpeedSourceRequest } from "../../api/types";
 import { getSettingsSpeedSource, updateSettingsSpeedSource } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { AppState } from "../ui_app_state";
+import type { SettingsState } from "../ui_app_state";
 
 const SPEED_SOURCE_KINDS = ["gps", "manual", "obd2"] as const satisfies readonly SpeedSourceKind[];
 
 export interface SettingsSpeedSourceModuleDeps extends FeatureDepsBase {
-  state: AppState;
+  settings: SettingsState;
   renderSpeedReadout: () => void;
   onSaveError: (error: unknown) => void;
 }
@@ -20,7 +20,7 @@ export interface SettingsSpeedSourceModule {
 }
 
 export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDeps): SettingsSpeedSourceModule {
-  const { state, els } = ctx;
+  const { settings, els } = ctx;
 
   function isSpeedSourceKind(value: string): value is SpeedSourceKind {
     return SPEED_SOURCE_KINDS.some((kind) => kind === value);
@@ -28,20 +28,22 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
 
   function syncSpeedSourceInputs(): void {
     els.speedSourceRadios.forEach((radio) => {
-      radio.checked = radio.value === state.speedSource;
+      radio.checked = radio.value === settings.speedSource;
     });
-    if (els.manualSpeedInput) els.manualSpeedInput.value = state.manualSpeedKph != null ? String(state.manualSpeedKph) : "";
+    if (els.manualSpeedInput) {
+      els.manualSpeedInput.value = settings.manualSpeedKph != null ? String(settings.manualSpeedKph) : "";
+    }
     if (els.headerManualSpeedInput) {
-      els.headerManualSpeedInput.value = state.manualSpeedKph != null ? String(state.manualSpeedKph) : "";
+      els.headerManualSpeedInput.value = settings.manualSpeedKph != null ? String(settings.manualSpeedKph) : "";
     }
     if (els.headerManualOverrideGroup) {
-      els.headerManualOverrideGroup.hidden = state.speedSource !== "manual";
+      els.headerManualOverrideGroup.hidden = settings.speedSource !== "manual";
     }
   }
 
   function applySpeedSourcePayload(payload: SpeedSourcePayload): void {
-    state.speedSource = payload.speed_source;
-    state.manualSpeedKph = payload.manual_speed_kph;
+    settings.speedSource = payload.speed_source;
+    settings.manualSpeedKph = payload.manual_speed_kph;
     if (els.staleTimeoutInput) els.staleTimeoutInput.value = String(payload.stale_timeout_s);
     syncSpeedSourceInputs();
     ctx.renderSpeedReadout();

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -42,8 +42,8 @@ export class UiLiveTransportController {
   }
 
   sendSelection(): void {
-    if (this.state.ws) {
-      this.state.ws.send({ client_id: this.state.selectedClientId });
+    if (this.state.transport.ws) {
+      this.state.transport.ws.send({ client_id: this.state.realtime.selectedClientId });
     }
   }
 
@@ -61,19 +61,19 @@ export class UiLiveTransportController {
   }
 
   private queueRender(): void {
-    if (this.state.renderQueued) return;
-    this.state.renderQueued = true;
+    if (this.state.transport.renderQueued) return;
+    this.state.transport.renderQueued = true;
     window.requestAnimationFrame(() => {
-      this.state.renderQueued = false;
+      this.state.transport.renderQueued = false;
       const now = Date.now();
-      if (now - this.state.lastRenderTsMs < this.state.minRenderIntervalMs) {
+      if (now - this.state.transport.lastRenderTsMs < this.state.transport.minRenderIntervalMs) {
         this.queueRender();
         return;
       }
-      const payload = this.state.pendingPayload;
+      const payload = this.state.transport.pendingPayload;
       if (!payload) return;
-      this.state.pendingPayload = null;
-      this.state.lastRenderTsMs = now;
+      this.state.transport.pendingPayload = null;
+      this.state.transport.lastRenderTsMs = now;
       this.applyPayload(payload);
     });
   }
@@ -84,33 +84,33 @@ export class UiLiveTransportController {
     try {
       adapted = adaptServerPayload(payload);
     } catch (error) {
-      this.state.payloadError = error instanceof Error ? error.message : this.payloadErrorMessage();
-      this.state.hasSpectrumData = false;
+      this.state.transport.payloadError = error instanceof Error ? error.message : this.payloadErrorMessage();
+      this.state.spectrum.hasSpectrumData = false;
       this.renderWsState();
       this.updateSpectrumOverlay();
       return;
     }
 
-    this.state.payloadError = null;
+    this.state.transport.payloadError = null;
     this.renderWsState();
 
-    const prevSelected = this.state.selectedClientId;
-    this.state.clients = adapted.clients;
+    const prevSelected = this.state.realtime.selectedClientId;
+    this.state.realtime.clients = adapted.clients;
     const spectrumTick = applySpectrumTick(
-      this.state.spectra,
-      this.state.hasSpectrumData,
+      this.state.spectrum.spectra,
+      this.state.spectrum.hasSpectrumData,
       adapted.spectra,
     );
-    this.state.spectra = spectrumTick.spectra;
+    this.state.spectrum.spectra = spectrumTick.spectra;
     features.realtime.updateClientSelection();
     features.realtime.maybeRenderSensorsSettingsList();
     features.realtime.renderLoggingStatus();
-    if (prevSelected !== this.state.selectedClientId) {
+    if (prevSelected !== this.state.realtime.selectedClientId) {
       this.sendSelection();
     }
-    this.state.speedMps = adapted.speed_mps;
-    this.state.rotationalSpeeds = adapted.rotational_speeds;
-    this.state.hasSpectrumData = spectrumTick.hasSpectrumData;
+    this.state.realtime.speedMps = adapted.speed_mps;
+    this.state.realtime.rotationalSpeeds = adapted.rotational_speeds;
+    this.state.spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
     this.renderSpeedReadout();
     if (spectrumTick.hasNewSpectrumFrame) {
       this.renderSpectrum();
@@ -118,21 +118,21 @@ export class UiLiveTransportController {
       this.updateSpectrumOverlay();
     }
     features.realtime.renderStatus(
-      this.state.clients.find((client) => client.id === this.state.selectedClientId),
+      this.state.realtime.clients.find((client) => client.id === this.state.realtime.selectedClientId),
     );
   }
 
   private connectWs(): void {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    this.state.ws = new WsClient({
+    this.state.transport.ws = new WsClient({
       url: `${protocol}//${window.location.host}/ws`,
       onPayload: (payload) => {
-        this.state.hasReceivedPayload = true;
-        this.state.pendingPayload = payload;
+        this.state.transport.hasReceivedPayload = true;
+        this.state.transport.pendingPayload = payload;
         this.queueRender();
       },
       onStateChange: (nextState) => {
-        this.state.wsState = nextState;
+        this.state.transport.wsState = nextState;
         this.renderWsState();
         this.updateSpectrumOverlay();
         if (nextState === "connected" || nextState === "no_data") {
@@ -140,7 +140,7 @@ export class UiLiveTransportController {
         }
       },
     });
-    this.state.ws.connect();
+    this.state.transport.ws.connect();
   }
 
   private requireFeatures(): AppFeatureBundle {

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -42,20 +42,23 @@ export class UiShellController {
     this.state = deps.state;
     this.els = deps.els;
     this.navigation = createUiShellNavigationModule({
-      state: this.state,
+      shell: this.state.shell,
       els: this.els,
       onDashboardViewActivated: () => {
-        this.state.spectrumPlot?.resize();
+        this.state.spectrum.spectrumPlot?.resize();
       },
     });
     this.status = createUiShellStatusModule({
-      state: this.state,
+      shell: this.state.shell,
+      transport: this.state.transport,
+      realtime: this.state.realtime,
+      settings: this.state.settings,
       els: this.els,
       t: (key, vars) => this.t(key, vars),
       setPillState: (el, variant, text) => this.setPillState(el, variant, text),
     });
     this.preferences = createUiShellPreferencesModule({
-      state: this.state,
+      shell: this.state.shell,
       els: this.els,
       t: (key, vars) => this.t(key, vars),
       normalizeLanguage: (lang) => I18N.normalizeLang(lang),
@@ -77,11 +80,11 @@ export class UiShellController {
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
-    return I18N.get(this.state.lang, key, vars);
+    return I18N.get(this.state.shell.lang, key, vars);
   }
 
   localFormatInt(value: number): string {
-    return formatIntLocale(value, this.state.lang);
+    return formatIntLocale(value, this.state.shell.lang);
   }
 
   setStatValue(container: HTMLElement | null, value: string | number): void {
@@ -119,24 +122,24 @@ export class UiShellController {
 
   applyLanguage(forceReloadInsights = false): void {
     const features = this.requireFeatures();
-    document.documentElement.lang = this.state.lang;
+    document.documentElement.lang = this.state.shell.lang;
     document.querySelectorAll("[data-i18n]").forEach((element) => {
       const key = element.getAttribute("data-i18n");
       if (key) element.textContent = this.t(key);
     });
-    if (this.els.languageSelect) this.els.languageSelect.value = this.state.lang;
-    if (this.els.speedUnitSelect) this.els.speedUnitSelect.value = this.state.speedUnit;
-    this.state.locationOptions = features.realtime.buildLocationOptions(this.state.locationCodes);
-    this.state.sensorsSettingsSignature = "";
+    if (this.els.languageSelect) this.els.languageSelect.value = this.state.shell.lang;
+    if (this.els.speedUnitSelect) this.els.speedUnitSelect.value = this.state.shell.speedUnit;
+    this.state.realtime.locationOptions = features.realtime.buildLocationOptions(this.state.realtime.locationCodes);
+    this.state.realtime.sensorsSettingsSignature = "";
     features.realtime.maybeRenderSensorsSettingsList(true);
     this.renderSpeedReadout();
     features.realtime.renderLoggingStatus();
     features.history.renderHistoryTable();
     this.renderWsState();
     this.renderCarSelectionWarning();
-    if (this.state.spectrumPlot) {
-      this.state.spectrumPlot.destroy();
-      this.state.spectrumPlot = null;
+    if (this.state.spectrum.spectrumPlot) {
+      this.state.spectrum.spectrumPlot.destroy();
+      this.state.spectrum.spectrumPlot = null;
       this.renderSpectrumChart?.();
     }
     if (forceReloadInsights) {

--- a/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
@@ -1,10 +1,10 @@
 import type { UiDomElements } from "../ui_dom_registry";
-import type { AppState } from "../ui_app_state";
+import type { ShellState } from "../ui_app_state";
 
 export const DEFAULT_SHELL_VIEW_ID = "dashboardView";
 
 export interface UiShellNavigationModuleDeps {
-  state: AppState;
+  shell: ShellState;
   els: UiDomElements;
   onDashboardViewActivated?: () => void;
 }
@@ -17,23 +17,23 @@ export interface UiShellNavigationModule {
 export function createUiShellNavigationModule(
   ctx: UiShellNavigationModuleDeps,
 ): UiShellNavigationModule {
-  const { state, els } = ctx;
+  const { shell, els } = ctx;
 
   function setActiveView(viewId: string): void {
     const valid = els.views.some((view) => view.id === viewId);
-    state.activeViewId = valid ? viewId : DEFAULT_SHELL_VIEW_ID;
+    shell.activeViewId = valid ? viewId : DEFAULT_SHELL_VIEW_ID;
     for (const view of els.views) {
-      const isActive = view.id === state.activeViewId;
+      const isActive = view.id === shell.activeViewId;
       view.classList.toggle("active", isActive);
       view.hidden = !isActive;
     }
     for (const button of els.menuButtons) {
-      const isActive = button.dataset.view === state.activeViewId;
+      const isActive = button.dataset.view === shell.activeViewId;
       button.classList.toggle("active", isActive);
       button.setAttribute("aria-selected", isActive ? "true" : "false");
       button.tabIndex = isActive ? 0 : -1;
     }
-    if (state.activeViewId === DEFAULT_SHELL_VIEW_ID) {
+    if (shell.activeViewId === DEFAULT_SHELL_VIEW_ID) {
       ctx.onDashboardViewActivated?.();
     }
   }

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -5,10 +5,10 @@ import {
   setSettingsSpeedUnit,
 } from "../../api/settings";
 import type { UiDomElements } from "../ui_dom_registry";
-import type { AppState } from "../ui_app_state";
+import type { ShellState } from "../ui_app_state";
 
 export interface UiShellPreferencesModuleDeps {
-  state: AppState;
+  shell: ShellState;
   els: UiDomElements;
   t: (key: string, vars?: Record<string, unknown>) => string;
   normalizeLanguage: (lang: string) => string;
@@ -26,7 +26,7 @@ export interface UiShellPreferencesModule {
 export function createUiShellPreferencesModule(
   ctx: UiShellPreferencesModuleDeps,
 ): UiShellPreferencesModule {
-  const { state, els } = ctx;
+  const { shell, els } = ctx;
 
   function normalizeSpeedUnit(raw: string): string {
     return raw === "mps" ? "mps" : "kmh";
@@ -36,7 +36,7 @@ export function createUiShellPreferencesModule(
     try {
       const languageResponse = await getSettingsLanguage();
       if (languageResponse?.language) {
-        state.lang = ctx.normalizeLanguage(languageResponse.language);
+        shell.lang = ctx.normalizeLanguage(languageResponse.language);
         ctx.applyLanguage(true);
       }
     } catch (error) {
@@ -45,9 +45,9 @@ export function createUiShellPreferencesModule(
     try {
       const speedUnitResponse = await getSettingsSpeedUnit();
       if (speedUnitResponse?.speed_unit) {
-        state.speedUnit = normalizeSpeedUnit(speedUnitResponse.speed_unit);
+        shell.speedUnit = normalizeSpeedUnit(speedUnitResponse.speed_unit);
         if (els.speedUnitSelect) {
-          els.speedUnitSelect.value = state.speedUnit;
+          els.speedUnitSelect.value = shell.speedUnit;
         }
         ctx.renderSpeedReadout();
       }
@@ -57,13 +57,13 @@ export function createUiShellPreferencesModule(
   }
 
   async function saveLanguage(lang: string): Promise<void> {
-    const previousLang = state.lang;
+    const previousLang = shell.lang;
     const nextLang = ctx.normalizeLanguage(lang);
     try {
       const payload = await setSettingsLanguage(nextLang);
-      state.lang = ctx.normalizeLanguage(payload?.language || nextLang);
+      shell.lang = ctx.normalizeLanguage(payload?.language || nextLang);
       if (els.languageSelect) {
-        els.languageSelect.value = state.lang;
+        els.languageSelect.value = shell.lang;
       }
       ctx.applyLanguage(true);
     } catch (error) {
@@ -75,13 +75,13 @@ export function createUiShellPreferencesModule(
   }
 
   async function saveSpeedUnit(unit: string): Promise<void> {
-    const previousUnit = state.speedUnit;
+    const previousUnit = shell.speedUnit;
     const nextUnit = normalizeSpeedUnit(unit);
     try {
       const payload = await setSettingsSpeedUnit(nextUnit);
-      state.speedUnit = normalizeSpeedUnit(payload?.speed_unit || nextUnit);
+      shell.speedUnit = normalizeSpeedUnit(payload?.speed_unit || nextUnit);
       if (els.speedUnitSelect) {
-        els.speedUnitSelect.value = state.speedUnit;
+        els.speedUnitSelect.value = shell.speedUnit;
       }
       ctx.renderSpeedReadout();
     } catch (error) {
@@ -95,7 +95,7 @@ export function createUiShellPreferencesModule(
   function bindHandlers(): void {
     const languageSelect = els.languageSelect;
     if (languageSelect) {
-      languageSelect.value = state.lang;
+      languageSelect.value = shell.lang;
       languageSelect.addEventListener("change", () => {
         void saveLanguage(languageSelect.value);
       });
@@ -103,7 +103,7 @@ export function createUiShellPreferencesModule(
 
     const speedUnitSelect = els.speedUnitSelect;
     if (speedUnitSelect) {
-      speedUnitSelect.value = state.speedUnit;
+      speedUnitSelect.value = shell.speedUnit;
       speedUnitSelect.addEventListener("change", () => {
         void saveSpeedUnit(speedUnitSelect.value);
       });

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -1,6 +1,6 @@
 import { fmt } from "../../format";
 import type { UiDomElements } from "../ui_dom_registry";
-import type { AppState } from "../ui_app_state";
+import type { RealtimeState, SettingsState, ShellState, TransportState } from "../ui_app_state";
 
 const WS_KEY_BY_STATE: Record<string, string> = {
   connecting: "ws.connecting",
@@ -25,7 +25,10 @@ const WS_BANNER_CFG: Record<string, { key: string; cls: string }> = {
 };
 
 export interface UiShellStatusModuleDeps {
-  state: AppState;
+  shell: ShellState;
+  transport: TransportState;
+  realtime: RealtimeState;
+  settings: SettingsState;
   els: UiDomElements;
   t: (key: string, vars?: Record<string, unknown>) => string;
   setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
@@ -38,27 +41,27 @@ export interface UiShellStatusModule {
 }
 
 export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShellStatusModule {
-  const { state, els } = ctx;
+  const { shell, transport, realtime, settings, els } = ctx;
 
   function speedValueInSelectedUnit(speedMps: number | null): number | null {
     if (!(typeof speedMps === "number") || !Number.isFinite(speedMps)) return null;
-    return state.speedUnit === "mps" ? speedMps : speedMps * 3.6;
+    return shell.speedUnit === "mps" ? speedMps : speedMps * 3.6;
   }
 
   function selectedSpeedUnitLabel(): string {
-    return state.speedUnit === "mps" ? ctx.t("speed.unit.mps") : ctx.t("speed.unit.kmh");
+    return shell.speedUnit === "mps" ? ctx.t("speed.unit.mps") : ctx.t("speed.unit.kmh");
   }
 
   function renderSpeedReadout(): void {
     if (!els.speed) return;
     const unitLabel = selectedSpeedUnitLabel();
-    if (typeof state.speedMps === "number" && Number.isFinite(state.speedMps)) {
-      const value = speedValueInSelectedUnit(state.speedMps);
-      const isManualSource = state.speedSource === "manual"
-        && typeof state.manualSpeedKph === "number"
-        && state.manualSpeedKph > 0;
-      const isFallbackOverride = state.gpsFallbackActive
-        || state.rotationalSpeeds?.basis_speed_source === "fallback_manual";
+    if (typeof realtime.speedMps === "number" && Number.isFinite(realtime.speedMps)) {
+      const value = speedValueInSelectedUnit(realtime.speedMps);
+      const isManualSource = settings.speedSource === "manual"
+        && typeof settings.manualSpeedKph === "number"
+        && settings.manualSpeedKph > 0;
+      const isFallbackOverride = settings.gpsFallbackActive
+        || realtime.rotationalSpeeds?.basis_speed_source === "fallback_manual";
       const isOverride = isManualSource || isFallbackOverride;
       els.speed.textContent = ctx.t(isOverride ? "speed.override" : "speed.gps", {
         value: fmt(value!, 1),
@@ -70,19 +73,19 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
   }
 
   function renderWsState(): void {
-    if (state.payloadError) {
+    if (transport.payloadError) {
       ctx.setPillState(els.linkState, "bad", ctx.t("ws.payload_error_pill"));
       return;
     }
     ctx.setPillState(
       els.linkState,
-      WS_VARIANT_BY_STATE[state.wsState] || "muted",
-      ctx.t(WS_KEY_BY_STATE[state.wsState] || "ws.connecting"),
+      WS_VARIANT_BY_STATE[transport.wsState] || "muted",
+      ctx.t(WS_KEY_BY_STATE[transport.wsState] || "ws.connecting"),
     );
 
     const banner = els.connectionBanner;
     if (banner) {
-      const cfg = WS_BANNER_CFG[state.wsState];
+      const cfg = WS_BANNER_CFG[transport.wsState];
       if (cfg) {
         banner.hidden = false;
         banner.textContent = ctx.t(cfg.key);
@@ -95,7 +98,7 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
     }
 
     if (els.appShellWrap) {
-      const degraded = state.wsState === "reconnecting" || state.wsState === "stale";
+      const degraded = transport.wsState === "reconnecting" || transport.wsState === "stale";
       els.appShellWrap.classList.toggle("wrap--stale", degraded);
     }
   }
@@ -104,7 +107,7 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
     const banner = els.carSelectionBanner;
     if (!banner) return;
     const hasValidActiveCar = Boolean(
-      state.activeCarId && state.cars.some((car) => car.id === state.activeCarId),
+      settings.activeCarId && settings.cars.some((car) => car.id === settings.activeCarId),
     );
     if (hasValidActiveCar) {
       banner.hidden = true;

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -111,27 +111,27 @@ export class UiSpectrumController {
 
   updateSpectrumOverlay(): void {
     if (!this.els.spectrumOverlay) return;
-    if (this.state.payloadError) {
+    if (this.state.transport.payloadError) {
       this.els.spectrumOverlay.hidden = false;
-      this.els.spectrumOverlay.textContent = this.state.payloadError;
+      this.els.spectrumOverlay.textContent = this.state.transport.payloadError;
       return;
     }
-    if (!this.state.hasReceivedPayload && this.state.wsState === "connecting") {
+    if (!this.state.transport.hasReceivedPayload && this.state.transport.wsState === "connecting") {
       this.els.spectrumOverlay.hidden = false;
       this.els.spectrumOverlay.textContent = this.t("spectrum.loading");
       return;
     }
-    if (this.state.wsState === "connecting" || this.state.wsState === "reconnecting") {
+    if (this.state.transport.wsState === "connecting" || this.state.transport.wsState === "reconnecting") {
       this.els.spectrumOverlay.hidden = false;
       this.els.spectrumOverlay.textContent = this.t("ws.connecting");
       return;
     }
-    if (this.state.wsState === "stale") {
+    if (this.state.transport.wsState === "stale") {
       this.els.spectrumOverlay.hidden = false;
       this.els.spectrumOverlay.textContent = this.t("spectrum.stale");
       return;
     }
-    if (!this.state.hasSpectrumData) {
+    if (!this.state.spectrum.hasSpectrumData) {
       this.els.spectrumOverlay.hidden = false;
       this.els.spectrumOverlay.textContent = this.t("spectrum.empty");
       return;
@@ -145,9 +145,9 @@ export class UiSpectrumController {
     const entries: SpectrumSeriesEntry[] = [];
     let targetFreq: number[] = [];
 
-    for (const [index, client] of this.state.clients.entries()) {
+    for (const [index, client] of this.state.realtime.clients.entries()) {
       if (!client?.connected) continue;
-      const spectrum = this.state.spectra.clients?.[client.id];
+      const spectrum = this.state.spectrum.spectra.clients?.[client.id];
       if (!spectrum || !Array.isArray(spectrum.combined)) continue;
       const clientFreq = Array.isArray(spectrum.freq) && spectrum.freq.length
         ? spectrum.freq
@@ -191,10 +191,10 @@ export class UiSpectrumController {
       });
     }
 
-    if (!this.state.spectrumPlot || this.state.spectrumPlot.getSeriesCount() !== entries.length + 1) {
+    if (!this.state.spectrum.spectrumPlot || this.state.spectrum.spectrumPlot.getSeriesCount() !== entries.length + 1) {
       this.recreateSpectrumPlot(entries);
     } else {
-      this.state.spectrumPlot.ensurePlot(
+      this.state.spectrum.spectrumPlot.ensurePlot(
         entries,
         {
           title: this.t("chart.spectrum_title"),
@@ -204,11 +204,11 @@ export class UiSpectrumController {
         [this.bandPlugin()],
       );
     }
-    this.state.spectrumPlot!.renderLegend(this.els.legend!, entries);
-    this.state.chartBands = this.calculateBands();
+    this.state.spectrum.spectrumPlot!.renderLegend(this.els.legend!, entries);
+    this.state.spectrum.chartBands = this.calculateBands();
     if (this.els.bandLegend) {
       this.els.bandLegend.innerHTML = "";
-      for (const band of this.state.chartBands) {
+      for (const band of this.state.spectrum.chartBands) {
         const row = document.createElement("div");
         row.className = "legend-item";
         row.innerHTML = `<span class="swatch" style="--swatch-color:${escapeHtml(band.color)}"></span><span>${escapeHtml(band.label)}</span>`;
@@ -219,13 +219,13 @@ export class UiSpectrumController {
     if (!targetFreq.length || !entries.length) {
       this.stopSpectrumTween();
       this.spectrumLastFrame = null;
-      this.state.hasSpectrumData = false;
-      this.state.spectrumPlot!.setData([[], ...entries.map(() => [] as number[])]);
+      this.state.spectrum.hasSpectrumData = false;
+      this.state.spectrum.spectrumPlot!.setData([[], ...entries.map(() => [] as number[])]);
       this.updateSpectrumOverlay();
       return;
     }
 
-    this.state.hasSpectrumData = true;
+    this.state.spectrum.hasSpectrumData = true;
     const minLen = Math.min(targetFreq.length, ...entries.map((entry) => entry.values.length));
     // Build frame without redundant copies — entries already own their arrays.
     const nextFrame: SpectrumHeavyFrame = {
@@ -235,7 +235,7 @@ export class UiSpectrumController {
         entry.values.length === minLen ? entry.values : entry.values.slice(0, minLen),
       ),
     };
-    const canTween = this.state.wsState === "connected"
+    const canTween = this.state.transport.wsState === "connected"
       && areHeavyFramesCompatible(this.spectrumLastFrame, nextFrame);
     this.stopSpectrumTween();
     if (!canTween || !this.spectrumLastFrame) {
@@ -273,15 +273,15 @@ export class UiSpectrumController {
   }
 
   private setSpectrumDataFromFrame(frame: SpectrumHeavyFrame): void {
-    if (!this.state.spectrumPlot) return;
-    this.state.spectrumPlot.setData([frame.freq, ...frame.values]);
+    if (!this.state.spectrum.spectrumPlot) return;
+    this.state.spectrum.spectrumPlot.setData([frame.freq, ...frame.values]);
     // Store a shallow snapshot for tween comparison.
     // The frame's arrays are not mutated after construction, so no deep clone needed.
     this.spectrumLastFrame = frame;
   }
 
   private calculateBandsFromBackend(): ChartBand[] | null {
-    const bands = this.state.rotationalSpeeds?.order_bands;
+    const bands = this.state.realtime.rotationalSpeeds?.order_bands;
     if (!Array.isArray(bands) || !bands.length) return null;
     const out: ChartBand[] = [];
     for (const band of bands) {
@@ -309,10 +309,10 @@ export class UiSpectrumController {
       hooks: {
         draw: [
           (plot: uPlot) => {
-            if (!this.state.chartBands.length) return;
+            if (!this.state.spectrum.chartBands.length) return;
             const top = plot.bbox.top;
             const height = plot.bbox.height;
-            for (const band of this.state.chartBands) {
+            for (const band of this.state.spectrum.chartBands) {
               if (!(band.max_hz > band.min_hz)) continue;
               const x1 = plot.valToPos(band.min_hz, "x", true);
               const x2 = plot.valToPos(band.max_hz, "x", true);
@@ -328,17 +328,17 @@ export class UiSpectrumController {
   private recreateSpectrumPlot(seriesMeta: SpectrumSeriesEntry[]): void {
     this.stopSpectrumTween();
     this.spectrumLastFrame = null;
-    if (this.state.spectrumPlot) {
-      this.state.spectrumPlot.destroy();
-      this.state.spectrumPlot = null;
+    if (this.state.spectrum.spectrumPlot) {
+      this.state.spectrum.spectrumPlot.destroy();
+      this.state.spectrum.spectrumPlot = null;
     }
-    this.state.spectrumPlot = new SpectrumChart(
+    this.state.spectrum.spectrumPlot = new SpectrumChart(
       this.els.specChart!,
       this.els.spectrumOverlay,
       360,
       this.els.specChartWrap,
     );
-    this.state.spectrumPlot.ensurePlot(
+    this.state.spectrum.spectrumPlot.ensurePlot(
       seriesMeta,
       {
         title: this.t("chart.spectrum_title"),

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -83,97 +83,133 @@ export function applySpectrumTick(
   };
 }
 
-export interface AppState {
-  ws: WsClient | null;
-  wsState: string;
+export interface ShellState {
   lang: string;
   speedUnit: string;
+  activeViewId: string;
+}
+
+export interface TransportState {
+  ws: WsClient | null;
+  wsState: string;
+  pendingPayload: unknown | null;
+  renderQueued: boolean;
+  lastRenderTsMs: number;
+  minRenderIntervalMs: number;
+  hasReceivedPayload: boolean;
+  payloadError: string | null;
+}
+
+export interface RealtimeState {
   clients: AdaptedClient[];
   selectedClientId: string | null;
-  spectrumPlot: SpectrumChart | null;
-  spectra: { clients: Record<string, SpectrumClientData> };
   speedMps: number | null;
   rotationalSpeeds: RotationalSpeeds | null;
-  activeViewId: string;
+  loggingStatus: LoggingStatusPayload;
+  locationOptions: LocationOption[];
+  locationCodes: string[];
+  sensorsSettingsSignature: string;
+}
+
+export interface HistoryState {
   runs: HistoryEntry[];
   deleteAllRunsInFlight: boolean;
   expandedRunId: string | null;
   runDetailsById: Record<string, RunDetail>;
-  loggingStatus: LoggingStatusPayload;
-  locationOptions: LocationOption[];
+}
+
+export interface SettingsState {
   vehicleSettings: VehicleSettings;
   cars: CarRecord[];
   activeCarId: string | null;
   speedSource: SpeedSourceKind;
   manualSpeedKph: number | null;
   gpsFallbackActive: boolean;
+}
+
+export interface SpectrumState {
+  spectrumPlot: SpectrumChart | null;
+  spectra: { clients: Record<string, SpectrumClientData> };
   chartBands: ChartBand[];
-  pendingPayload: unknown | null;
-  renderQueued: boolean;
-  lastRenderTsMs: number;
-  minRenderIntervalMs: number;
-  sensorsSettingsSignature: string;
-  locationCodes: string[];
   hasSpectrumData: boolean;
-  hasReceivedPayload: boolean;
-  payloadError: string | null;
+}
+
+export interface AppState {
+  shell: ShellState;
+  transport: TransportState;
+  realtime: RealtimeState;
+  history: HistoryState;
+  settings: SettingsState;
+  spectrum: SpectrumState;
 }
 
 export function createAppState(): AppState {
   return {
-    ws: null,
-    wsState: "connecting",
-    lang: "en",
-    speedUnit: "kmh",
-    clients: [],
-    selectedClientId: null,
-    spectrumPlot: null,
-    spectra: { clients: {} },
-    speedMps: null,
-    rotationalSpeeds: null,
-    activeViewId: "dashboardView",
-    runs: [],
-    deleteAllRunsInFlight: false,
-    expandedRunId: null,
-    runDetailsById: {},
-    loggingStatus: {
-      enabled: false,
-      run_id: null,
-      write_error: null,
-      analysis_in_progress: false,
+    shell: {
+      lang: "en",
+      speedUnit: "kmh",
+      activeViewId: "dashboardView",
     },
-    locationOptions: [],
-    vehicleSettings: {
-      tire_width_mm: 285.0,
-      tire_aspect_pct: 30.0,
-      rim_in: 21.0,
-      final_drive_ratio: 3.08,
-      current_gear_ratio: 0.64,
-      wheel_bandwidth_pct: 5.0,
-      driveshaft_bandwidth_pct: 4.5,
-      engine_bandwidth_pct: 5.2,
-      speed_uncertainty_pct: 1.0,
-      tire_diameter_uncertainty_pct: 1.0,
-      final_drive_uncertainty_pct: 0.1,
-      gear_uncertainty_pct: 0.2,
-      min_abs_band_hz: 0.2,
-      max_band_half_width_pct: 6.0,
-      tire_deflection_factor: 0.97,
+    transport: {
+      ws: null,
+      wsState: "connecting",
+      pendingPayload: null,
+      renderQueued: false,
+      lastRenderTsMs: 0,
+      minRenderIntervalMs: 100,
+      hasReceivedPayload: false,
+      payloadError: null,
     },
-    cars: [],
-    activeCarId: null,
-    speedSource: "gps",
-    manualSpeedKph: null,
-    gpsFallbackActive: false,
-    chartBands: [],
-    pendingPayload: null,
-    renderQueued: false,
-    lastRenderTsMs: 0,
-    minRenderIntervalMs: 100,
-    sensorsSettingsSignature: "",
-    locationCodes: defaultLocationCodes.slice(),
-    hasSpectrumData: false,
-    hasReceivedPayload: false,
-    payloadError: null,
+    realtime: {
+      clients: [],
+      selectedClientId: null,
+      speedMps: null,
+      rotationalSpeeds: null,
+      loggingStatus: {
+        enabled: false,
+        run_id: null,
+        write_error: null,
+        analysis_in_progress: false,
+      },
+      locationOptions: [],
+      locationCodes: defaultLocationCodes.slice(),
+      sensorsSettingsSignature: "",
+    },
+    history: {
+      runs: [],
+      deleteAllRunsInFlight: false,
+      expandedRunId: null,
+      runDetailsById: {},
+    },
+    settings: {
+      vehicleSettings: {
+        tire_width_mm: 285.0,
+        tire_aspect_pct: 30.0,
+        rim_in: 21.0,
+        final_drive_ratio: 3.08,
+        current_gear_ratio: 0.64,
+        wheel_bandwidth_pct: 5.0,
+        driveshaft_bandwidth_pct: 4.5,
+        engine_bandwidth_pct: 5.2,
+        speed_uncertainty_pct: 1.0,
+        tire_diameter_uncertainty_pct: 1.0,
+        final_drive_uncertainty_pct: 0.1,
+        gear_uncertainty_pct: 0.2,
+        min_abs_band_hz: 0.2,
+        max_band_half_width_pct: 6.0,
+        tire_deflection_factor: 0.97,
+      },
+      cars: [],
+      activeCarId: null,
+      speedSource: "gps",
+      manualSpeedKph: null,
+      gpsFallbackActive: false,
+    },
+    spectrum: {
+      spectrumPlot: null,
+      spectra: { clients: {} },
+      chartBands: [],
+      hasSpectrumData: false,
+    },
   };
 }

--- a/apps/ui/src/app/views/dom_helpers.ts
+++ b/apps/ui/src/app/views/dom_helpers.ts
@@ -1,0 +1,13 @@
+export function renderTableEmptyRow(
+  textHtml: string,
+  colspan: number,
+): string {
+  return `<tr><td colspan="${colspan}">${textHtml}</td></tr>`;
+}
+
+export function renderStatusGridRow(
+  labelHtml: string,
+  valueHtml: string,
+): string {
+  return `<div class="update-status-row"><span class="update-label">${labelHtml}</span><span>${valueHtml}</span></div>`;
+}

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../api/types";
 import type { RunDetail } from "../ui_app_state";
 import { heatColor, normalizeUnit } from "../features/heat_utils";
+import { renderTableEmptyRow } from "./dom_helpers";
 
 type LocationIntensityRow = HistoryInsightsPayload["sensor_intensity_by_location"][number];
 
@@ -273,7 +274,7 @@ export function renderHistoryEmptyState(
   container: HTMLElement,
   text: string,
 ): void {
-  container.innerHTML = `<tr><td colspan="4">${text}</td></tr>`;
+  container.innerHTML = renderTableEmptyRow(text, 4);
 }
 
 export function renderHistoryTable(

--- a/apps/ui/src/app/views/realtime_sensor_table_view.ts
+++ b/apps/ui/src/app/views/realtime_sensor_table_view.ts
@@ -1,5 +1,6 @@
 import type { LocationOption } from "../../api/types";
 import type { AdaptedClient } from "../../server_payload";
+import { renderTableEmptyRow } from "./dom_helpers";
 
 export interface RealtimeSensorTableViewParams {
   clients: AdaptedClient[];
@@ -39,7 +40,10 @@ export function renderRealtimeSensorTable(
 ): void {
   const { clients, locationOptions, locationCodeForClient, t, escapeHtml } = params;
   if (!clients.length) {
-    container.innerHTML = `<tr><td colspan="5">${escapeHtml(t("settings.sensors.no_sensors"))}</td></tr>`;
+    container.innerHTML = renderTableEmptyRow(
+      escapeHtml(t("settings.sensors.no_sensors")),
+      5,
+    );
     return;
   }
 

--- a/apps/ui/src/app/views/settings_car_list_view.ts
+++ b/apps/ui/src/app/views/settings_car_list_view.ts
@@ -1,4 +1,5 @@
 import type { CarRecord } from "../../api/types";
+import { renderTableEmptyRow } from "./dom_helpers";
 
 export interface SettingsCarListViewParams {
   cars: CarRecord[];
@@ -19,7 +20,10 @@ export function renderSettingsCarList(
 ): void {
   const { cars, activeCarId, t, escapeHtml, fmt } = params;
   if (!cars.length) {
-    container.innerHTML = `<tr><td colspan="7">${escapeHtml(t("settings.car.no_cars"))}</td></tr>`;
+    container.innerHTML = renderTableEmptyRow(
+      escapeHtml(t("settings.car.no_cars")),
+      7,
+    );
     return;
   }
 

--- a/apps/ui/src/app/views/update_status_view.ts
+++ b/apps/ui/src/app/views/update_status_view.ts
@@ -1,5 +1,6 @@
 import type { HealthStatusPayload, UpdateStatusPayload } from "../../api/types";
 import type { UiDomElements } from "../ui_dom_registry";
+import { renderStatusGridRow } from "./dom_helpers";
 
 const STATE_VARIANT: Readonly<Record<string, string>> = {
   idle: "muted",
@@ -58,6 +59,152 @@ function formatHealthReason(
   return key ? t(key) : reason;
 }
 
+function renderStateHeaderRow(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  const { t, escapeHtml } = deps;
+  const pill = `<span class="pill pill--${STATE_VARIANT[status.state] || "muted"}">${escapeHtml(t(`settings.update.state.${status.state}`))}</span>`;
+  const phase = status.state === "idle"
+    ? ""
+    : ` <span class="subtle">${escapeHtml(t(`settings.update.phase.${status.phase}`))}</span>`;
+  return renderStatusGridRow(
+    escapeHtml(t("settings.update.status")),
+    `${pill}${phase}`,
+  );
+}
+
+function renderLifecycleRows(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  const { t, escapeHtml } = deps;
+  const rows: string[] = [];
+  if (status.ssid) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.ssid_label")), escapeHtml(status.ssid)));
+  if (status.started_at) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.started_at")), escapeHtml(formatTimestamp(status.started_at))));
+  if (status.phase_started_at && status.state !== "idle") rows.push(renderStatusGridRow(escapeHtml(t("settings.update.phase_started_at")), escapeHtml(formatTimestamp(status.phase_started_at))));
+  if (status.state !== "idle" && status.phase_elapsed_s != null) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.phase_elapsed")), escapeHtml(formatDuration(status.phase_elapsed_s))));
+  if (status.finished_at) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.finished_at")), escapeHtml(formatTimestamp(status.finished_at))));
+  if (status.last_success_at) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.last_success")), escapeHtml(formatTimestamp(status.last_success_at))));
+  return rows.join("");
+}
+
+function renderRuntimeRows(
+  status: UpdateStatusPayload,
+  showRuntimeAssetsCheck: boolean,
+  deps: UpdateStatusViewDeps,
+): string {
+  const { t, escapeHtml } = deps;
+  const rows: string[] = [];
+  if (status.runtime?.version && status.runtime.version !== "unknown") rows.push(renderStatusGridRow(escapeHtml(t("settings.update.runtime_version")), escapeHtml(status.runtime.version)));
+  if (status.runtime?.commit) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.runtime_commit")), escapeHtml(status.runtime.commit.slice(0, 12))));
+  if (!status.runtime?.static_assets_hash) return rows.join("");
+  rows.push(renderStatusGridRow(escapeHtml(t("settings.update.runtime_assets")), escapeHtml(status.runtime.static_assets_hash.slice(0, 12))));
+  if (showRuntimeAssetsCheck) {
+    rows.push(renderStatusGridRow(
+      escapeHtml(t("settings.update.runtime_assets_check")),
+      escapeHtml(t(status.runtime.assets_verified ? "settings.update.runtime_assets_ok" : "settings.update.runtime_assets_bad")),
+    ));
+  }
+  return rows.join("");
+}
+
+function renderStateGrid(
+  status: UpdateStatusPayload,
+  showRuntimeAssetsCheck: boolean,
+  deps: UpdateStatusViewDeps,
+): string {
+  return `<div class="update-status-grid">${renderStateHeaderRow(status, deps)}${renderLifecycleRows(status, deps)}${renderRuntimeRows(status, showRuntimeAssetsCheck, deps)}</div>`;
+}
+
+function renderHealthSummaryRows(
+  health: HealthStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  const { t, escapeHtml } = deps;
+  const pill = `<span class="pill pill--${HEALTH_VARIANT[health.status]}${health.persistence.write_error ? " pill--bad" : ""}">${escapeHtml(t(`settings.update.health.state.${health.status}`))}</span>`;
+  const rows = [
+    renderStatusGridRow(escapeHtml(t("settings.update.health.label")), pill),
+    renderStatusGridRow(escapeHtml(t("settings.update.health.processing_state")), escapeHtml(health.processing_state)),
+  ];
+  if (health.processing_failures > 0) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.processing_failures")), escapeHtml(health.processing_failures)));
+  if (health.degradation_reasons.length) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.reasons")), escapeHtml(health.degradation_reasons.map((reason) => formatHealthReason(reason, t)).join(", "))));
+  return rows.join("");
+}
+
+function renderHealthDataLossRows(
+  health: HealthStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  if (health.data_loss.affected_clients <= 0) return "";
+  const { t, escapeHtml } = deps;
+  return [
+    renderStatusGridRow(escapeHtml(t("settings.update.health.affected_clients")), escapeHtml(`${health.data_loss.affected_clients}/${health.data_loss.tracked_clients}`)),
+    renderStatusGridRow(
+      escapeHtml(t("settings.update.health.data_loss")),
+      escapeHtml([
+        `frames=${health.data_loss.frames_dropped}`,
+        `queue=${health.data_loss.queue_overflow_drops}`,
+        `server=${health.data_loss.server_queue_drops}`,
+        `parse=${health.data_loss.parse_errors}`,
+      ].join(", ")),
+    ),
+  ].join("");
+}
+
+function renderHealthPersistenceRows(
+  health: HealthStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  const analysisQueueDepth = health.persistence.analysis_queue_depth ?? 0;
+  if (!health.persistence.analysis_in_progress && !health.persistence.write_error && analysisQueueDepth <= 0) return "";
+  const { t, escapeHtml } = deps;
+  const rows = [
+    renderStatusGridRow(
+      escapeHtml(t("settings.update.health.persistence")),
+      escapeHtml(health.persistence.write_error || t("settings.update.health.persistence_ok")),
+    ),
+  ];
+  if (health.persistence.analysis_in_progress) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.analysis")), escapeHtml(t("settings.update.health.analysis_in_progress"))));
+  if (health.persistence.analysis_active_run_id) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.analysis_run")), escapeHtml(health.persistence.analysis_active_run_id)));
+  if (health.persistence.analysis_started_at) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.analysis_started_at")), escapeHtml(formatTimestamp(health.persistence.analysis_started_at))));
+  if (health.persistence.analysis_elapsed_s != null) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.analysis_elapsed")), escapeHtml(formatDuration(health.persistence.analysis_elapsed_s))));
+  if (analysisQueueDepth > 0) rows.push(renderStatusGridRow(escapeHtml(t("settings.update.health.analysis_queue_depth")), escapeHtml(String(analysisQueueDepth))));
+  return rows.join("");
+}
+
+function renderHealthGrid(
+  health: HealthStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  return `<div class="update-status-grid" style="margin-top:1rem;">${renderHealthSummaryRows(health, deps)}${renderHealthDataLossRows(health, deps)}${renderHealthPersistenceRows(health, deps)}</div>`;
+}
+
+function renderIssuesList(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  if (!status.issues.length) return "";
+  const { t, escapeHtml } = deps;
+  const items = status.issues.map((issue) => {
+    const detail = issue.detail
+      ? `<div class="issue-detail subtle">${escapeHtml(issue.detail)}</div>`
+      : "";
+    return `<li class="issue-item"><span class="issue-phase">[${escapeHtml(issue.phase)}]</span> <span class="issue-message">${escapeHtml(issue.message)}</span>${detail}</li>`;
+  }).join("");
+  return `<div class="update-issues" style="margin-top:1rem;"><strong>${escapeHtml(t("settings.update.issues"))}</strong><ul class="issue-list">${items}</ul></div>`;
+}
+
+function renderLogTail(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): string {
+  if (!status.log_tail.length) return "";
+  const { t, escapeHtml } = deps;
+  const logBody = status.log_tail.map((line) => `${escapeHtml(line)}\n`).join("");
+  return `<details class="update-log" style="margin-top:1rem;"><summary>${escapeHtml(t("settings.update.log"))}</summary><pre class="log-pre" style="max-height:15rem;overflow:auto;font-size:0.75rem;background:var(--bg-secondary,#1a1a2e);padding:0.5rem;border-radius:0.25rem;">${logBody}</pre></details>`;
+}
+
 export function syncUpdateControls(
   els: Pick<UiDomElements, "updateStartBtn" | "updateCancelBtn" | "updateSsidInput" | "updatePasswordInput">,
   status: UpdateStatusPayload,
@@ -80,201 +227,18 @@ export function renderUpdateStatusPanel(
   health: HealthStatusPayload,
   deps: UpdateStatusViewDeps,
 ): void {
-  const { t, escapeHtml } = deps;
-  const isRunning = status.state === "running";
-  const isIdle = status.state === "idle";
-  const analysisQueueDepth = health.persistence.analysis_queue_depth ?? 0;
   const hasAssetRelatedIssue = status.issues.some((issue) =>
     ASSET_ISSUE_RE.test(`${issue.message} ${issue.detail}`),
   );
   const showRuntimeAssetsCheck = status.state !== "failed" || hasAssetRelatedIssue;
-
-  if (isIdle && !status.last_success_at && !status.issues.length && health.status === "ok") {
+  if (status.state === "idle" && !status.last_success_at && !status.issues.length && health.status === "ok") {
     panel.innerHTML = "";
     return;
   }
-
-  const stateKey = `settings.update.state.${status.state}`;
-  const phaseKey = `settings.update.phase.${status.phase}`;
-
-  let html = `<div class="update-status-grid">`;
-  html += `<div class="update-status-row">`;
-  html += `<span class="update-label">${escapeHtml(t("settings.update.status"))}</span>`;
-  html += `<span class="pill pill--${STATE_VARIANT[status.state] || "muted"}">${escapeHtml(t(stateKey))}</span>`;
-  if (!isIdle) {
-    html += ` <span class="subtle">${escapeHtml(t(phaseKey))}</span>`;
-  }
-  html += `</div>`;
-
-  if (status.ssid) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.ssid_label"))}</span>`;
-    html += `<span>${escapeHtml(status.ssid)}</span>`;
-    html += `</div>`;
-  }
-  if (status.started_at) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.started_at"))}</span>`;
-    html += `<span>${escapeHtml(formatTimestamp(status.started_at))}</span>`;
-    html += `</div>`;
-  }
-  if (status.phase_started_at && !isIdle) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.phase_started_at"))}</span>`;
-    html += `<span>${escapeHtml(formatTimestamp(status.phase_started_at))}</span>`;
-    html += `</div>`;
-  }
-  if (!isIdle && status.phase_elapsed_s !== null && status.phase_elapsed_s !== undefined) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.phase_elapsed"))}</span>`;
-    html += `<span>${escapeHtml(formatDuration(status.phase_elapsed_s))}</span>`;
-    html += `</div>`;
-  }
-  if (status.finished_at) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.finished_at"))}</span>`;
-    html += `<span>${escapeHtml(formatTimestamp(status.finished_at))}</span>`;
-    html += `</div>`;
-  }
-  if (status.last_success_at) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.last_success"))}</span>`;
-    html += `<span>${escapeHtml(formatTimestamp(status.last_success_at))}</span>`;
-    html += `</div>`;
-  }
-  if (status.runtime?.version && status.runtime.version !== "unknown") {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_version"))}</span>`;
-    html += `<span>${escapeHtml(status.runtime.version)}</span>`;
-    html += `</div>`;
-  }
-  if (status.runtime?.commit) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_commit"))}</span>`;
-    html += `<span>${escapeHtml(status.runtime.commit.slice(0, 12))}</span>`;
-    html += `</div>`;
-  }
-  if (status.runtime?.static_assets_hash) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_assets"))}</span>`;
-    html += `<span>${escapeHtml(status.runtime.static_assets_hash.slice(0, 12))}</span>`;
-    html += `</div>`;
-    if (showRuntimeAssetsCheck) {
-      html += `<div class="update-status-row">`;
-      html += `<span class="update-label">${escapeHtml(t("settings.update.runtime_assets_check"))}</span>`;
-      html += `<span>${escapeHtml(t(status.runtime.assets_verified ? "settings.update.runtime_assets_ok" : "settings.update.runtime_assets_bad"))}</span>`;
-      html += `</div>`;
-    }
-  }
-  html += `</div>`;
-
-  html += `<div class="update-status-grid" style="margin-top:1rem;">`;
-  html += `<div class="update-status-row">`;
-  html += `<span class="update-label">${escapeHtml(t("settings.update.health.label"))}</span>`;
-  html += `<span class="pill pill--${HEALTH_VARIANT[health.status]}${health.persistence.write_error ? " pill--bad" : ""}">${escapeHtml(t(`settings.update.health.state.${health.status}`))}</span>`;
-  html += `</div>`;
-  html += `<div class="update-status-row">`;
-  html += `<span class="update-label">${escapeHtml(t("settings.update.health.processing_state"))}</span>`;
-  html += `<span>${escapeHtml(health.processing_state)}</span>`;
-  html += `</div>`;
-
-  if (health.processing_failures > 0) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.health.processing_failures"))}</span>`;
-    html += `<span>${escapeHtml(health.processing_failures)}</span>`;
-    html += `</div>`;
-  }
-
-  if (health.degradation_reasons.length) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.health.reasons"))}</span>`;
-    html += `<span>${escapeHtml(health.degradation_reasons.map((reason) => formatHealthReason(reason, t)).join(", "))}</span>`;
-    html += `</div>`;
-  }
-
-  if (health.data_loss.affected_clients > 0) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.health.affected_clients"))}</span>`;
-    html += `<span>${escapeHtml(`${health.data_loss.affected_clients}/${health.data_loss.tracked_clients}`)}</span>`;
-    html += `</div>`;
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.health.data_loss"))}</span>`;
-    html += `<span>${escapeHtml([
-      `frames=${health.data_loss.frames_dropped}`,
-      `queue=${health.data_loss.queue_overflow_drops}`,
-      `server=${health.data_loss.server_queue_drops}`,
-      `parse=${health.data_loss.parse_errors}`,
-    ].join(", "))}</span>`;
-    html += `</div>`;
-  }
-
-  if (health.persistence.analysis_in_progress || health.persistence.write_error || analysisQueueDepth > 0) {
-    html += `<div class="update-status-row">`;
-    html += `<span class="update-label">${escapeHtml(t("settings.update.health.persistence"))}</span>`;
-    html += `<span>${escapeHtml(
-      health.persistence.write_error
-        ? health.persistence.write_error
-        : t("settings.update.health.persistence_ok"),
-    )}</span>`;
-    html += `</div>`;
-    if (health.persistence.analysis_in_progress) {
-      html += `<div class="update-status-row">`;
-      html += `<span class="update-label">${escapeHtml(t("settings.update.health.analysis"))}</span>`;
-      html += `<span>${escapeHtml(t("settings.update.health.analysis_in_progress"))}</span>`;
-      html += `</div>`;
-      if (health.persistence.analysis_active_run_id) {
-        html += `<div class="update-status-row">`;
-        html += `<span class="update-label">${escapeHtml(t("settings.update.health.analysis_run"))}</span>`;
-        html += `<span>${escapeHtml(health.persistence.analysis_active_run_id)}</span>`;
-        html += `</div>`;
-      }
-      if (health.persistence.analysis_started_at) {
-        html += `<div class="update-status-row">`;
-        html += `<span class="update-label">${escapeHtml(t("settings.update.health.analysis_started_at"))}</span>`;
-        html += `<span>${escapeHtml(formatTimestamp(health.persistence.analysis_started_at))}</span>`;
-        html += `</div>`;
-      }
-      if (health.persistence.analysis_elapsed_s !== null && health.persistence.analysis_elapsed_s !== undefined) {
-        html += `<div class="update-status-row">`;
-        html += `<span class="update-label">${escapeHtml(t("settings.update.health.analysis_elapsed"))}</span>`;
-        html += `<span>${escapeHtml(formatDuration(health.persistence.analysis_elapsed_s))}</span>`;
-        html += `</div>`;
-      }
-    }
-    if (analysisQueueDepth > 0) {
-      html += `<div class="update-status-row">`;
-      html += `<span class="update-label">${escapeHtml(t("settings.update.health.analysis_queue_depth"))}</span>`;
-      html += `<span>${escapeHtml(String(analysisQueueDepth))}</span>`;
-      html += `</div>`;
-    }
-  }
-  html += `</div>`;
-
-  if (status.issues.length) {
-    html += `<div class="update-issues" style="margin-top:1rem;">`;
-    html += `<strong>${escapeHtml(t("settings.update.issues"))}</strong>`;
-    html += `<ul class="issue-list">`;
-    for (const issue of status.issues) {
-      html += `<li class="issue-item">`;
-      html += `<span class="issue-phase">[${escapeHtml(issue.phase)}]</span> `;
-      html += `<span class="issue-message">${escapeHtml(issue.message)}</span>`;
-      if (issue.detail) {
-        html += `<div class="issue-detail subtle">${escapeHtml(issue.detail)}</div>`;
-      }
-      html += `</li>`;
-    }
-    html += `</ul></div>`;
-  }
-
-  if (status.log_tail.length) {
-    html += `<details class="update-log" style="margin-top:1rem;">`;
-    html += `<summary>${escapeHtml(t("settings.update.log"))}</summary>`;
-    html += `<pre class="log-pre" style="max-height:15rem;overflow:auto;font-size:0.75rem;background:var(--bg-secondary,#1a1a2e);padding:0.5rem;border-radius:0.25rem;">`;
-    for (const line of status.log_tail) {
-      html += escapeHtml(line) + "\n";
-    }
-    html += `</pre></details>`;
-  }
-
-  panel.innerHTML = html;
+  panel.innerHTML = [
+    renderStateGrid(status, showRuntimeAssetsCheck, deps),
+    renderHealthGrid(health, deps),
+    renderIssuesList(status, deps),
+    renderLogTail(status, deps),
+  ].join("");
 }

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+import { runDemoMode } from "../src/app/demo_mode";
+import { adaptServerPayload } from "../src/server_payload";
+
+test.describe("runDemoMode", () => {
+  test.beforeEach(() => {
+    (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
+      typeof globalThis;
+  });
+
+  test("emits a schema-valid websocket payload", () => {
+    const selectedClientId = "aabbcc001122";
+    const state = {
+      transport: {
+        wsState: "disconnected",
+        hasReceivedPayload: false,
+      },
+    };
+    let renderWsStateCalls = 0;
+    let adaptedPayload:
+      | ReturnType<typeof adaptServerPayload>
+      | undefined;
+
+    runDemoMode({
+      state,
+      renderWsState: () => {
+        renderWsStateCalls += 1;
+      },
+      applyPayload: (payload) => {
+        adaptedPayload = adaptServerPayload(payload);
+      },
+    });
+
+    expect(renderWsStateCalls).toBe(1);
+    expect(state.transport.wsState).toBe("connected");
+    expect(state.transport.hasReceivedPayload).toBe(true);
+    expect(adaptedPayload).toBeDefined();
+    expect(adaptedPayload?.clients).toHaveLength(5);
+    expect(adaptedPayload?.spectra?.clients[selectedClientId]).toMatchObject({
+      freq: expect.any(Array),
+      combined: expect.any(Array),
+      strength_metrics: expect.objectContaining({
+        vibration_strength_db: expect.any(Number),
+      }),
+    });
+  });
+});

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -91,8 +91,8 @@ function testTranslation(key: string, vars?: Record<string, unknown>): string {
 }
 
 function ensureRunDetail(state: ReturnType<typeof createAppState>, runId: string): RunDetail {
-  if (!state.runDetailsById[runId]) {
-    state.runDetailsById[runId] = {
+  if (!state.history.runDetailsById[runId]) {
+    state.history.runDetailsById[runId] = {
       preview: null,
       previewLoading: false,
       previewError: "",
@@ -103,7 +103,7 @@ function ensureRunDetail(state: ReturnType<typeof createAppState>, runId: string
       pdfError: "",
     };
   }
-  return state.runDetailsById[runId];
+  return state.history.runDetailsById[runId];
 }
 
 test.beforeEach(() => {
@@ -126,7 +126,7 @@ test("history list module refreshes runs and renders table state", async () => {
   }) as typeof fetch;
 
   const module = createHistoryListModule({
-    state,
+    history: state.history,
     els,
     t: testTranslation,
     escapeHtml: (value) => String(value ?? ""),
@@ -135,7 +135,7 @@ test("history list module refreshes runs and renders table state", async () => {
     formatInt: (value) => String(value),
     ensureRunDetail: (runId) => ensureRunDetail(state, runId),
     collapseExpandedRun: () => {
-      state.expandedRunId = null;
+      state.history.expandedRunId = null;
     },
   });
 
@@ -145,7 +145,7 @@ test("history list module refreshes runs and renders table state", async () => {
     globalThis.fetch = originalFetch;
   }
 
-  expect(state.runs).toHaveLength(1);
+  expect(state.history.runs).toHaveLength(1);
   expect(historySummary.textContent).toContain("history.available_count");
   expect(historyTableBody.innerHTML).toContain("run-001");
   expect(deleteAllRunsBtn.disabled).toBe(false);
@@ -153,7 +153,7 @@ test("history list module refreshes runs and renders table state", async () => {
 
 test("history detail module loads preview and reloads expanded run on language change", async () => {
   const state = createAppState();
-  state.expandedRunId = null;
+  state.history.expandedRunId = null;
   const { els } = createHistoryElements();
   const originalFetch = globalThis.fetch;
   const requests: string[] = [];
@@ -171,16 +171,17 @@ test("history detail module loads preview and reloads expanded run on language c
 
   let renderCalls = 0;
   const module = createHistoryDetailModule({
-    state,
+    history: state.history,
+    getLanguage: () => state.shell.lang,
     els,
     t: testTranslation,
     escapeHtml: (value) => String(value ?? ""),
     ensureRunDetail: (runId) => ensureRunDetail(state, runId),
     collapseExpandedRun: () => {
-      const previous = state.expandedRunId;
-      state.expandedRunId = null;
+      const previous = state.history.expandedRunId;
+      state.history.expandedRunId = null;
       if (previous) {
-        delete state.runDetailsById[previous];
+        delete state.history.runDetailsById[previous];
       }
     },
     renderHistoryTable: () => {
@@ -190,14 +191,14 @@ test("history detail module loads preview and reloads expanded run on language c
 
   try {
     module.toggleRunDetails("run-001");
-    await expect.poll(() => state.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(1);
+    await expect.poll(() => state.history.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(1);
     await module.loadRunInsights("run-001", true);
-    expect(state.runDetailsById["run-001"]?.insights?.sensor_count_used).toBe(1);
+    expect(state.history.runDetailsById["run-001"]?.insights?.sensor_count_used).toBe(1);
 
-    state.lang = "nl";
+    state.shell.lang = "nl";
     module.reloadExpandedRunOnLanguageChange();
-    await expect.poll(() => state.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(2);
-    await expect.poll(() => state.runDetailsById["run-001"]?.insights?.sensor_count_used ?? null).toBe(2);
+    await expect.poll(() => state.history.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(2);
+    await expect.poll(() => state.history.runDetailsById["run-001"]?.insights?.sensor_count_used ?? null).toBe(2);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -227,13 +228,14 @@ test("history detail module treats analyzing insights responses as not-yet-avail
 
   let renderCalls = 0;
   const module = createHistoryDetailModule({
-    state,
+    history: state.history,
+    getLanguage: () => state.shell.lang,
     els,
     t: testTranslation,
     escapeHtml: (value) => String(value ?? ""),
     ensureRunDetail: (runId) => ensureRunDetail(state, runId),
     collapseExpandedRun: () => {
-      state.expandedRunId = null;
+      state.history.expandedRunId = null;
     },
     renderHistoryTable: () => {
       renderCalls += 1;
@@ -247,10 +249,10 @@ test("history detail module treats analyzing insights responses as not-yet-avail
     globalThis.fetch = originalFetch;
   }
 
-  expect(state.runDetailsById["run-001"]?.preview).toBeNull();
-  expect(state.runDetailsById["run-001"]?.previewError).toBe("");
-  expect(state.runDetailsById["run-001"]?.insights).toBeNull();
-  expect(state.runDetailsById["run-001"]?.insightsError).toBe("");
+  expect(state.history.runDetailsById["run-001"]?.preview).toBeNull();
+  expect(state.history.runDetailsById["run-001"]?.previewError).toBe("");
+  expect(state.history.runDetailsById["run-001"]?.insights).toBeNull();
+  expect(state.history.runDetailsById["run-001"]?.insightsError).toBe("");
   expect(renderCalls).toBeGreaterThanOrEqual(4);
   expect(requests).toEqual([
     "/api/history/run-001/insights?lang=en",
@@ -334,11 +336,11 @@ test("downloadBlobFile downloads with decoded filename and revokes the blob URL"
 
 test("history download/delete module reports partial delete failures without detail-loading deps", async () => {
   const state = createAppState();
-  state.runs = [
+  state.history.runs = [
     { run_id: "run-001", start_time_utc: "2026-01-01T00:00:00Z", sample_count: 42 },
     { run_id: "run-002", start_time_utc: "2026-01-01T00:10:00Z", sample_count: 84 },
   ];
-  state.expandedRunId = "run-001";
+  state.history.expandedRunId = "run-001";
   ensureRunDetail(state, "run-001");
   ensureRunDetail(state, "run-002");
 
@@ -368,14 +370,15 @@ test("history download/delete module reports partial delete failures without det
   let renderCalls = 0;
   let refreshCalls = 0;
   const module = createHistoryDownloadDeleteModule({
-    state,
+    history: state.history,
+    getLanguage: () => state.shell.lang,
     t: testTranslation,
     ensureRunDetail: (runId) => ensureRunDetail(state, runId),
     collapseExpandedRun: () => {
-      const previous = state.expandedRunId;
-      state.expandedRunId = null;
+      const previous = state.history.expandedRunId;
+      state.history.expandedRunId = null;
       if (previous) {
-        delete state.runDetailsById[previous];
+        delete state.history.runDetailsById[previous];
       }
     },
     renderHistoryTable: () => {
@@ -398,8 +401,8 @@ test("history download/delete module reports partial delete failures without det
   }
 
   expect(deleteRequests).toEqual(["/api/history/run-001", "/api/history/run-002"]);
-  expect(state.deleteAllRunsInFlight).toBe(false);
-  expect(state.expandedRunId).toBeNull();
+  expect(state.history.deleteAllRunsInFlight).toBe(false);
+  expect(state.history.expandedRunId).toBeNull();
   expect(renderCalls).toBe(1);
   expect(refreshCalls).toBe(1);
   expect(alerts).toHaveLength(1);

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -214,7 +214,7 @@ test.describe("createUiShellNavigationModule", () => {
     const { els, dashboardView, historyView, dashboardButton, historyButton } = createShellDeps();
     let resizeCalls = 0;
     const module = createUiShellNavigationModule({
-      state,
+      shell: state.shell,
       els,
       onDashboardViewActivated: () => {
         resizeCalls += 1;
@@ -222,7 +222,7 @@ test.describe("createUiShellNavigationModule", () => {
     });
 
     module.setActiveView("historyView");
-    expect(state.activeViewId).toBe("historyView");
+    expect(state.shell.activeViewId).toBe("historyView");
     expect(historyView.hidden).toBe(false);
     expect(dashboardView.hidden).toBe(true);
     expect(historyButton.classList.contains("active")).toBe(true);
@@ -231,7 +231,7 @@ test.describe("createUiShellNavigationModule", () => {
     expect(resizeCalls).toBe(0);
 
     module.setActiveView("missingView");
-    expect(state.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(dashboardView.hidden).toBe(false);
     expect(dashboardButton.classList.contains("active")).toBe(true);
     expect(resizeCalls).toBe(1);
@@ -240,13 +240,13 @@ test.describe("createUiShellNavigationModule", () => {
   test("bindHandlers supports keyboard navigation", () => {
     const state = createAppState();
     const { els, historyButton } = createShellDeps();
-    const module = createUiShellNavigationModule({ state, els });
+    const module = createUiShellNavigationModule({ shell: state.shell, els });
 
     module.bindHandlers();
     const event = historyButton.triggerKeydown("ArrowLeft");
 
     expect(event.defaultPrevented).toBe(true);
-    expect(state.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
   });
 });
 
@@ -276,7 +276,7 @@ test.describe("createUiShellPreferencesModule", () => {
     const applyLanguageCalls: boolean[] = [];
     let renderSpeedReadoutCalls = 0;
     const module = createUiShellPreferencesModule({
-      state,
+      shell: state.shell,
       els,
       t: (key) => key,
       normalizeLanguage: (lang) => lang,
@@ -295,8 +295,8 @@ test.describe("createUiShellPreferencesModule", () => {
     }
 
     expect(requests).toEqual(["/api/settings/language", "/api/settings/speed-unit"]);
-    expect(state.lang).toBe("nl");
-    expect(state.speedUnit).toBe("mps");
+    expect(state.shell.lang).toBe("nl");
+    expect(state.shell.speedUnit).toBe("mps");
     expect(speedUnitSelect.value).toBe("mps");
     expect(applyLanguageCalls).toEqual([true]);
     expect(renderSpeedReadoutCalls).toBe(1);
@@ -319,7 +319,7 @@ test.describe("createUiShellPreferencesModule", () => {
 
     let renderSpeedReadoutCalls = 0;
     const module = createUiShellPreferencesModule({
-      state,
+      shell: state.shell,
       els,
       t: (key) => key,
       normalizeLanguage: (lang) => lang,
@@ -332,7 +332,7 @@ test.describe("createUiShellPreferencesModule", () => {
     try {
       module.bindHandlers();
       speedUnitSelect.triggerChange("mps");
-      await expect.poll(() => state.speedUnit).toBe("mps");
+      await expect.poll(() => state.shell.speedUnit).toBe("mps");
       await expect.poll(() => renderSpeedReadoutCalls).toBe(1);
     } finally {
       globalThis.fetch = originalFetch;
@@ -345,7 +345,7 @@ test.describe("createUiShellPreferencesModule", () => {
         body: JSON.stringify({ speed_unit: "mps" }),
       },
     ]);
-    expect(state.speedUnit).toBe("mps");
+    expect(state.shell.speedUnit).toBe("mps");
     expect(renderSpeedReadoutCalls).toBe(1);
   });
 });
@@ -353,10 +353,13 @@ test.describe("createUiShellPreferencesModule", () => {
 test.describe("createUiShellStatusModule", () => {
   test("renders websocket state without bootstrap wiring", () => {
     const state = createAppState();
-    state.wsState = "stale";
+    state.transport.wsState = "stale";
     const { els, linkState, connectionBanner, appShellWrap } = createShellDeps();
     const module = createUiShellStatusModule({
-      state,
+      shell: state.shell,
+      transport: state.transport,
+      realtime: state.realtime,
+      settings: state.settings,
       els,
       t: (key) => key,
       setPillState: (el, variant, text) => {
@@ -377,15 +380,18 @@ test.describe("createUiShellStatusModule", () => {
 
   test("renders speed override and car-selection warning", () => {
     const state = createAppState();
-    state.speedMps = 12;
-    state.speedSource = "manual";
-    state.manualSpeedKph = 43.2;
-    state.speedUnit = "kmh";
-    state.cars = [];
-    state.activeCarId = null;
+    state.realtime.speedMps = 12;
+    state.settings.speedSource = "manual";
+    state.settings.manualSpeedKph = 43.2;
+    state.shell.speedUnit = "kmh";
+    state.settings.cars = [];
+    state.settings.activeCarId = null;
     const { els, speed, carSelectionBanner } = createShellDeps();
     const module = createUiShellStatusModule({
-      state,
+      shell: state.shell,
+      transport: state.transport,
+      realtime: state.realtime,
+      settings: state.settings,
       els,
       t: testTranslation,
       setPillState: () => {},


### PR DESCRIPTION
Closes #1169

## Summary

This PR fixes the remaining frontend architecture problems described in #1169 without changing the project's framework-free approach. The main goal is to stop treating the dashboard as one giant mutable `AppState` bag and instead make state ownership explicit at the feature level. In the same pass, it breaks the largest remaining string-builder view into smaller sections, extracts repeated DOM helpers, and preserves the existing UX rather than redesigning it.

Before this change, the runtime, realtime feature, history feature, and settings feature all shared the same mutable state object. That made it easy for a module to reach across feature boundaries and read or mutate fields it did not really own. The issue body called out the history table path as a major offender, but after re-auditing the live tree the sharper root cause was broader: the whole app still depended on a single state bag, and `renderUpdateStatusPanel()` was the standout rendering hotspot that had grown beyond what was comfortable to maintain.

## Implementation approach

I kept the existing vanilla TypeScript / direct-DOM model intact and made the smallest architectural change that fixes the coupling problem at the root. Instead of introducing a framework, store library, reducer layer, or compatibility shim, `ui_app_state.ts` now defines nested feature-scoped stores inside the top-level app state factory:

- `shell`
- `transport`
- `realtime`
- `history`
- `settings`
- `spectrum`

That change preserves one creation path for the UI while replacing the old "everyone gets everything" dependency shape. The refactor then updates each feature and runtime collaborator to depend on the store slice it actually owns plus explicit getter callbacks for the few cross-feature reads that still matter.

## Main code changes

### 1. Feature-scoped state ownership

`apps/ui/src/app/ui_app_state.ts` is now the single place that defines the nested store shape. Realtime state owns the connected clients, location options, logging status, and selection metadata. History state owns runs, expanded detail state, and cached detail payloads. Settings state owns cars, analysis settings, speed source settings, and related in-flight flags. Shell, transport, and spectrum state own their existing concerns in the same way.

`apps/ui/src/app/app_feature_bundle.ts` now wires those store slices into features instead of handing them the entire app state. The same ownership cleanup continues through the feature modules:

- `realtime_feature.ts` now works with `RealtimeState` plus `getLanguage()`
- `history_feature.ts`, `history_list_module.ts`, `history_detail_module.ts`, and `history_download_delete_module.ts` now work with `HistoryState` plus `getLanguage()` where needed
- `settings_feature.ts`, `settings_analysis_module.ts`, `settings_speed_source_module.ts`, and `settings_gps_status_module.ts` now work with `SettingsState` plus `getSpeedUnit()` where needed

That removes the direct feature-to-feature mutation path that #1169 called out. Features can still read what they need across boundaries, but those reads now happen through explicit callbacks instead of via an unconstrained shared object reference.

### 2. Runtime wiring updated to the new store boundaries

The runtime layer was updated in the same style so the feature split is real end to end, not just type reshuffling. `ui_live_transport_controller.ts`, `ui_shell_controller.ts`, `ui_shell_navigation_module.ts`, `ui_shell_preferences_module.ts`, `ui_shell_status_module.ts`, and `ui_spectrum_controller.ts` now consume only the nested store slices they actually use.

This is especially important for transport and shell code because they sit at the center of most updates. The branch keeps the behavior the same, but it narrows each module's surface area enough that future changes do not need full-app-state awareness by default.

### 3. Shared DOM helpers and smaller view sections

To address the repeated HTML patterns in the issue, this PR adds `apps/ui/src/app/views/dom_helpers.ts`. Right now it intentionally stays small and focused: it centralizes the repeated empty-table row markup and the repeated status-grid row markup that was duplicated across several views.

The helper is then used by:

- `history_table_view.ts`
- `realtime_sensor_table_view.ts`
- `settings_car_list_view.ts`
- `update_status_view.ts`

`apps/ui/src/app/views/update_status_view.ts` is the main rendering cleanup in this PR. Rather than one long function appending HTML for every case, it is now decomposed into section-level helpers for state, runtime, health, issues, and log rendering. This keeps the existing HTML output model and styling hooks, but it makes the view much easier to inspect and change without re-reading a 190-line builder.

I deliberately did not force a deeper rewrite of `renderHistoryTable()` because the current history table path was already more decomposed than the issue body implied. The better bounded fix was to reuse shared helpers there and spend the complexity budget on the update-status renderer and state ownership seams.

### 4. Demo-mode schema follow-up discovered during validation

While running local visual validation, I found a real regression that was tightly coupled to this work: demo mode was emitting a websocket payload that no longer satisfied the generated schema because `selected_client_id` and `rotational_speeds` are required top-level fields now. That caused the local visual flow to fall into the `Payload error` state instead of rendering the demo dashboard.

`apps/ui/src/app/demo_mode.ts` now includes those required fields, and `apps/ui/tests/demo_mode.spec.ts` was added to lock that contract down by passing the emitted payload through `adaptServerPayload()`. This was a useful follow-up because it turned an implicit visual assumption into an explicit contract test.

## Risks, tradeoffs, and scope boundaries

The main tradeoff here is that the UI still uses mutable objects; the fix is scoped to ownership and dependency narrowing, not to a full reactive rewrite. That is intentional. The project does not need React, Redux, or a custom event framework to solve the current maintainability pain. The new store boundaries make the current approach much safer without introducing a second architecture problem.

I also avoided adding compatibility layers so modules continue to use the current contracts directly. The issue asked for better boundaries, and the cleanest way to get them was to update callers rather than preserve the old full-state shape behind adapters.

## Validation

I validated the branch locally with:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/demo_mode.spec.ts tests/history_feature_modules.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts tests/smoke.bootstrap.spec.ts tests/smoke.history.spec.ts tests/smoke.settings.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`
- `export PATH="$HOME/.local/bin:$PATH" && make lint`

The focused Playwright module/demo suite passed with `48 passed`, and the targeted smoke suite passed with `14 passed`.

I also attempted the required local Docker smoke via `docker compose up -d`, but this environment still has no reachable Docker daemon/socket, so that validation remains environment-blocked and should be covered again by GitHub CI.

For completeness, I also ran the local visual spec during development. That run exposed the real demo-payload schema bug that is fixed in this PR. The remaining screenshot mismatches reflect existing backend-less local baseline drift rather than a new code path failure in this branch.
