### PR TITLE
Improve developer onboarding workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,14 +20,22 @@ Primary references:
 
 ## Local setup
 
+Before the first bootstrap, run `make doctor` if you want a quick prerequisite
+check against the pinned Python/Node versions and the optional Docker/firmware
+tooling. Run bare `make` any time you want the current repo command menu.
+
 ### Docker path
 
-Follow the [Quick Start](README.md#docker-fastest) in the README.
+Use [README.md#docker-quick-product-check](README.md#docker-quick-product-check)
+for a production-style container quick check, or
+[README.md#docker-dev-mode-source-mounted-hot-reload](README.md#docker-dev-mode-source-mounted-hot-reload)
+for the source-mounted backend-reload + Vite dev-server flow.
 
 ### Native backend path
 
-Start with [README.md#native-python](README.md#native-python) for the native
-bootstrap commands.
+Start with
+[README.md#native-python--vite-recommended-for-backend-or-ui-iteration](README.md#native-python--vite-recommended-for-backend-or-ui-iteration)
+for the native bootstrap commands.
 
 If you're iterating on the dashboard itself, use
 [apps/ui/README.md](apps/ui/README.md) for the frontend dev-server, build, and

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
-.PHONY: setup format lint typecheck-backend typecheck ui-typecheck test test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
+.DEFAULT_GOAL := help
+.PHONY: help doctor setup format lint typecheck-backend typecheck ui-typecheck test test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
 CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job backend-tests
 
-setup:
+help: ## Show the available make targets and what each one does
+	@awk 'BEGIN {FS = ":.*## "; printf "Available targets:\n"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+doctor: ## Check pinned tool versions and local workflow availability
+	python3 tools/dev/check_prerequisites.py
+
+setup: ## Install backend dev dependencies and UI node_modules
 	python3 -m pip install --upgrade pip
 	python3 -m pip install -e "./apps/server[dev]"
 	cd apps/ui && npm ci
 
-format:
+format: ## Run Ruff formatter over backend and tooling files
 	ruff format $(LINT_TARGETS)
 
-lint:
+lint: ## Run repo hygiene, static guards, docs lint, and contract drift checks
 	ruff check $(LINT_TARGETS)
 	ruff format --check $(LINT_TARGETS)
 	python3 tools/dev/check_hygiene.py
@@ -23,43 +30,45 @@ lint:
 	python3 -m vibesensor.cli.ws_schema_export --check
 	python3 -m vibesensor.cli.http_api_schema_export --check
 
-typecheck-backend:
+typecheck-backend: ## Run backend mypy checks
 	PYTHON=$(CURDIR)/.venv/bin/python; \
 	if [ ! -x "$$PYTHON" ]; then PYTHON=python3; fi; \
 	cd apps/server && "$$PYTHON" -m mypy --config-file pyproject.toml
 
+typecheck: ## Run backend and UI type checks
 typecheck: typecheck-backend ui-typecheck
 
-test:
+test: ## Run the fast backend pytest suite
 	python3 -m pytest -q apps/server/tests
 
-test-ci-lite:
+test-ci-lite: ## Run the non-Docker blocking CI subset locally
 	python3 tools/tests/run_ci_parallel.py $(CI_LITE_JOBS)
 
-test-all:
+test-all: ## Run the broader local CI runner, including Docker jobs when available
 	python3 tools/tests/run_ci_parallel.py
 
-test-full-suite:
+test-full-suite: ## Run the full Docker-backed end-to-end suite locally
 	python3 tools/tests/run_e2e_parallel.py --shards 1
 
-sync-contracts:
+sync-contracts: ## Regenerate shared frontend HTTP/WS/contracts artifacts
 	cd apps/ui && npm run sync:contracts
 
+regen-contracts: ## Sync contracts and rebuild the contract reference doc
 regen-contracts: sync-contracts
 	python3 tools/config/generate_contract_reference_doc.py
 
-coverage:  ## COV_OPTS="--cov-report=html:../../artifacts/coverage/html" or "--cov-fail-under=80"
+coverage: ## Run backend coverage with optional COV_OPTS overrides
 	cd apps/server && python3 -m pytest -q --cov=vibesensor --cov-report=term-missing:skip-covered $(COV_OPTS) tests
 
-smoke:
+smoke: ## Run simulator and websocket smoke checks against a local server
 	vibesensor-sim --count 3 --duration 20 --server-host 127.0.0.1 --no-auto-server
 	vibesensor-ws-smoke --uri ws://127.0.0.1:8000/ws --min-clients 3 --timeout 35
 
-loc:
+loc: ## Run the repo lines-of-code budget check
 	python3 tools/dev/loc_check.py
 
-docs-lint:
+docs-lint: ## Run docs lint without the broader lint suite
 	python3 tools/dev/docs_lint.py
 
-ui-typecheck:
+ui-typecheck: ## Run UI contract freshness checks and TypeScript type checking
 	cd apps/ui && npm run check:contracts && npm run typecheck

--- a/README.md
+++ b/README.md
@@ -84,9 +84,20 @@ Each component has its own README with setup instructions and details.
 
 See [docs/README.md](docs/README.md) for the complete documentation index.
 
+## Prerequisites
+
+- Python `3.11.x` for the native backend, local tooling, and simulator (`.python-version`)
+- Node `22.x` plus `npm` for the UI build and dev server (`.nvmrc`)
+- Docker plus Docker Compose for the Docker quick-start and Docker dev mode
+- PlatformIO `6.x` only when you are working on firmware
+
+Run `make doctor` after cloning to validate the pinned toolchain and see which
+workflow paths are available on your machine. Run bare `make` to list the
+supported repo commands.
+
 ## Quick Start
 
-### Docker (fastest)
+### Docker (quick product check)
 
 ```bash
 git clone https://github.com/Skamba/VibeSensor.git
@@ -103,7 +114,22 @@ vibesensor-sim --count 5 --server-host 127.0.0.1
 
 Open http://localhost:8000.
 
-### Native Python
+If you want source-mounted hot-reload instead of a production-style container
+build, use the Docker dev mode below.
+
+### Docker dev mode (source-mounted hot reload)
+
+```bash
+git clone https://github.com/Skamba/VibeSensor.git
+cd VibeSensor
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+Open http://127.0.0.1:5173 for the Vite dev server with HMR. The backend keeps
+running on http://127.0.0.1:8000 with `vibesensor-server --reload`, so Python
+changes hot-reload without rebuilding the image.
+
+### Native Python + Vite (recommended for backend or UI iteration)
 
 ```bash
 python3 -m pip install -e "./apps/server[dev]"
@@ -198,6 +224,9 @@ Full field layout: [docs/protocol.md](docs/protocol.md).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full validation workflow
 (lint, type checking, test suites, and CI job reproduction).
+
+Run bare `make` to see the repo command menu, and use `make doctor` before your
+first bootstrap if you want a quick prerequisite check.
 
 Tests are organized in feature-based subdirectories under `apps/server/tests/`
 mirroring source modules. See [docs/testing.md](docs/testing.md) for the full

--- a/apps/server/tests/hygiene/test_ci_command_parity.py
+++ b/apps/server/tests/hygiene/test_ci_command_parity.py
@@ -1,0 +1,24 @@
+"""Guard: local CI-parallel runner commands stay aligned with ci.yml."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from tests._paths import REPO_ROOT
+
+_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "check_hygiene.py"
+
+
+def _load_check_hygiene_module():
+    spec = importlib.util.spec_from_file_location("check_hygiene_local", _CHECK_HYGIENE)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_HYGIENE}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_runner_commands_match_ci_yml() -> None:
+    module = _load_check_hygiene_module()
+    assert module.check_ci_command_sync() == []

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -1,0 +1,99 @@
+"""Guards for the local CI-parallel runner bootstrap behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+from tests._paths import REPO_ROOT
+
+_CI_PARALLEL = REPO_ROOT / "tools" / "tests" / "run_ci_parallel.py"
+
+
+def _load_ci_parallel_module():
+    spec = importlib.util.spec_from_file_location("ci_parallel_local_for_tests", _CI_PARALLEL)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CI_PARALLEL}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bootstrap_marks_ui_lock_hash_after_shared_npm_ci(monkeypatch, tmp_path: Path) -> None:
+    module = _load_ci_parallel_module()
+    ui_dir = tmp_path / "apps" / "ui"
+    ui_dir.mkdir(parents=True)
+    package_lock = ui_dir / "package-lock.json"
+    package_lock.write_text('{"lockfileVersion": 3}\n', encoding="utf-8")
+
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "LOG_DIR", tmp_path / "logs")
+    module.LOG_DIR.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(module, "UI_DIR", ui_dir)
+    monkeypatch.setattr(module, "UI_NODE_MODULES", ui_dir / "node_modules")
+    monkeypatch.setattr(module, "UI_LOCK_FILE", package_lock)
+    monkeypatch.setattr(module, "UI_LOCK_HASH_FILE", ui_dir / ".npm-ci-lock.sha256")
+    monkeypatch.setattr(module, "_run_step", lambda step, log_file: 0)
+
+    result = module._run_bootstrap(
+        module._bootstrap_steps("python3", True, include_platformio=False)
+    )
+
+    assert result == 0
+    assert (
+        module.UI_LOCK_HASH_FILE.read_text(encoding="utf-8").strip()
+        == hashlib.sha256(package_lock.read_bytes()).hexdigest()
+    )
+
+
+def test_main_refuses_skip_bootstrap_when_release_smoke_would_race_ui_jobs(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    module = _load_ci_parallel_module()
+    ui_dir = tmp_path / "apps" / "ui"
+    ui_dir.mkdir(parents=True)
+    (ui_dir / "package-lock.json").write_text('{"lockfileVersion": 3}\n', encoding="utf-8")
+    (ui_dir / "node_modules").mkdir()
+
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(module, "UI_DIR", ui_dir)
+    monkeypatch.setattr(module, "UI_NODE_MODULES", ui_dir / "node_modules")
+    monkeypatch.setattr(module, "UI_LOCK_FILE", ui_dir / "package-lock.json")
+    monkeypatch.setattr(module, "UI_LOCK_HASH_FILE", ui_dir / ".npm-ci-lock.sha256")
+    monkeypatch.setattr(
+        module,
+        "_job_steps",
+        lambda python_cmd: {
+            "frontend-typecheck": [],
+            "ui-smoke": [],
+            "release-smoke": [],
+        },
+    )
+
+    def _unexpected_bootstrap(_steps):
+        raise AssertionError("bootstrap should not run when the race guard exits early")
+
+    monkeypatch.setattr(module, "_run_bootstrap", _unexpected_bootstrap)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            "run_ci_parallel.py",
+            "--skip-bootstrap",
+            "--job",
+            "frontend-typecheck",
+            "--job",
+            "ui-smoke",
+            "--job",
+            "release-smoke",
+        ],
+    )
+
+    result = module.main()
+    output = capsys.readouterr().out
+
+    assert result == 2
+    assert "release-smoke would trigger npm ci inside apps/ui" in output

--- a/apps/server/tests/use_cases/updates/test_run_release_smoke.py
+++ b/apps/server/tests/use_cases/updates/test_run_release_smoke.py
@@ -80,3 +80,47 @@ def test_run_release_smoke_can_reuse_existing_wheel_and_skip_ui_build(
         command for command in commands if command[0][-1] == str(existing_wheel.resolve())
     )
     assert pip_install_command[0][-1] == str(existing_wheel.resolve())
+
+
+def test_build_server_wheel_uses_builder_venv(monkeypatch, tmp_path: Path) -> None:
+    module, _repo_root = _load_release_smoke_runner()
+    repo_root = tmp_path / "repo"
+    dist_dir = repo_root / "apps" / "server" / "dist"
+    dist_dir.mkdir(parents=True)
+    built_wheel = dist_dir / "vibesensor-2025.6.15-py3-none-any.whl"
+    commands: list[tuple[list[str], Path, dict[str, str] | None]] = []
+    builder_venv = tmp_path / "builder-venv"
+
+    class _FakeTempDir:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self) -> str:
+            return str(builder_venv)
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def _fake_run(cmd: list[str], *, cwd: Path, env=None) -> None:
+        commands.append((list(cmd), cwd, env))
+        if cmd[1:4] == ["-m", "build", "--wheel"]:
+            built_wheel.parent.mkdir(parents=True, exist_ok=True)
+            built_wheel.write_text("wheel", encoding="utf-8")
+
+    monkeypatch.setattr(module.tempfile, "TemporaryDirectory", _FakeTempDir)
+    monkeypatch.setattr(module.venv.EnvBuilder, "create", lambda self, path: None)
+    monkeypatch.setattr(module, "_venv_python", lambda path: Path(path) / "bin" / "python")
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    wheel_path = module._build_server_wheel(repo_root)
+
+    assert wheel_path == built_wheel
+    expected_python = str(builder_venv / "bin" / "python")
+    assert commands == [
+        (
+            [expected_python, "-m", "pip", "install", "--upgrade", "pip", "build"],
+            repo_root,
+            None,
+        ),
+        ([expected_python, "-m", "build", "--wheel", "apps/server/"], repo_root, None),
+    ]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,29 @@
+services:
+  vibesensor-server:
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    environment:
+      PYTHONPATH: /workspace/apps/server
+    command:
+      - vibesensor-server
+      - --reload
+      - --config
+      - /workspace/apps/server/config.docker.yaml
+
+  vibesensor-ui-dev:
+    image: node:22-slim
+    network_mode: host
+    working_dir: /workspace/apps/ui
+    depends_on:
+      - vibesensor-server
+    volumes:
+      - .:/workspace
+      - vibesensor-ui-node_modules:/workspace/apps/ui/node_modules
+    command:
+      - sh
+      - -lc
+      - npm ci && npm run dev -- --host 0.0.0.0 --port 5173
+
+volumes:
+  vibesensor-ui-node_modules:

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -1,11 +1,16 @@
-"""Repository hygiene checks: line endings (LF-only), path indirection, and CI job sync."""
+"""Repository hygiene checks: line endings, path indirection, and CI/local-runner sync."""
 
 from __future__ import annotations
 
+import importlib.util
 import re
+import shlex
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+
+import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -81,8 +86,191 @@ def check_path_indirections() -> tuple[list[str], list[str]]:
     return pointer_files, python_path_hacks
 
 
-_CI_JOB_RE = re.compile(r"^  (\w[\w-]*):\s*$")
-_PARALLEL_JOB_RE = re.compile(r'"([^"]+)":\s*\[')
+_MIRRORED_UI_INSTALL_JOBS = ("frontend-typecheck", "ui-smoke")
+_MIRRORED_BACKEND_INSTALL_JOBS = (
+    "backend-quality",
+    "backend-typecheck",
+    "backend-tests",
+    "e2e",
+)
+_FIRMWARE_INSTALL_JOB = "firmware-native-tests"
+
+
+def _load_ci_workflow() -> dict[str, object]:
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text())
+    return workflow if isinstance(workflow, dict) else {}
+
+
+def _load_ci_parallel_module():
+    module_path = ROOT / "tools" / "tests" / "run_ci_parallel.py"
+    spec = importlib.util.spec_from_file_location("ci_parallel_local", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _normalize_python_token(token: str) -> str:
+    return "python" if Path(token).name.startswith("python") else token
+
+
+def _normalize_tokenized_command(tokens: list[str]) -> str:
+    if not tokens:
+        return ""
+    normalized = list(tokens)
+    normalized[0] = _normalize_python_token(normalized[0])
+    return shlex.join(normalized)
+
+
+def _normalize_shell_command(command: str) -> str:
+    tokens = shlex.split(command)
+    if "&&" not in tokens:
+        return _normalize_tokenized_command(tokens)
+
+    parts: list[str] = []
+    current: list[str] = []
+    for token in tokens:
+        if token == "&&":
+            if current:
+                parts.append(_normalize_tokenized_command(current))
+                current = []
+            continue
+        current.append(token)
+    if current:
+        parts.append(_normalize_tokenized_command(current))
+    return " && ".join(parts)
+
+
+def _normalize_env(env: Mapping[str, object] | None) -> str:
+    if not env:
+        return ""
+    parts = [f"{key}={env[key]}" for key in sorted(env)]
+    return f"env {' '.join(parts)} "
+
+
+def _normalize_ci_step_commands(step: Mapping[str, object]) -> list[str]:
+    run = step.get("run")
+    if not isinstance(run, str):
+        return []
+    working_directory = step.get("working-directory")
+    cwd_prefix = ""
+    if isinstance(working_directory, str) and working_directory:
+        cwd_prefix = f"cd {working_directory} && "
+    env_prefix = _normalize_env(
+        step.get("env") if isinstance(step.get("env"), Mapping) else None
+    )
+    lines = [raw_line.strip() for raw_line in run.splitlines() if raw_line.strip()]
+    line_cwd_prefix = ""
+    if lines and lines[0].startswith("cd ") and "&&" not in lines[0] and len(lines) > 1:
+        line_cwd_prefix = f"{_normalize_shell_command(lines[0])} && "
+        lines = lines[1:]
+
+    commands: list[str] = []
+    for line in lines:
+        commands.append(
+            f"{cwd_prefix}{line_cwd_prefix}{env_prefix}{_normalize_shell_command(line)}"
+        )
+    return commands
+
+
+def _ci_run_steps_by_job() -> dict[str, list[dict[str, object]]]:
+    workflow = _load_ci_workflow()
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, Mapping):
+        return {}
+
+    result: dict[str, list[dict[str, object]]] = {}
+    for job_name, job_body in jobs.items():
+        if not isinstance(job_name, str) or not isinstance(job_body, Mapping):
+            continue
+        raw_steps = job_body.get("steps")
+        if not isinstance(raw_steps, list):
+            continue
+        normalized_steps: list[dict[str, object]] = []
+        for raw_step in raw_steps:
+            if not isinstance(raw_step, Mapping):
+                continue
+            run = raw_step.get("run")
+            if not isinstance(run, str):
+                continue
+            normalized_steps.append(
+                {
+                    "name": raw_step.get("name", ""),
+                    "commands": _normalize_ci_step_commands(raw_step),
+                }
+            )
+        result[job_name] = normalized_steps
+    return result
+
+
+def _normalize_local_step(step) -> str:
+    cwd_prefix = ""
+    if step.cwd != ROOT:
+        cwd_prefix = f"cd {step.cwd.relative_to(ROOT).as_posix()} && "
+    env_prefix = _normalize_env(step.env)
+    return f"{cwd_prefix}{env_prefix}{_normalize_tokenized_command(step.cmd)}"
+
+
+def _local_runner_commands() -> tuple[dict[str, list[str]], list[str], list[str]]:
+    ci_parallel = _load_ci_parallel_module()
+    common_bootstrap = [
+        _normalize_local_step(step)
+        for step in ci_parallel._bootstrap_steps(  # type: ignore[attr-defined]
+            sys.executable,
+            True,
+            include_platformio=False,
+        )
+    ]
+    firmware_bootstrap = [
+        _normalize_local_step(step)
+        for step in ci_parallel._bootstrap_steps(  # type: ignore[attr-defined]
+            sys.executable,
+            True,
+            include_platformio=True,
+        )
+    ]
+    job_steps = {
+        name: [_normalize_local_step(step) for step in steps]
+        for name, steps in ci_parallel._job_steps(sys.executable).items()  # type: ignore[attr-defined]
+    }
+    return job_steps, common_bootstrap, firmware_bootstrap
+
+
+def _pip_install_markers(commands: list[str]) -> set[str]:
+    markers: set[str] = set()
+    for command in commands:
+        tokens = shlex.split(command)
+        if len(tokens) < 5:
+            continue
+        if tokens[1:4] != ["-m", "pip", "install"]:
+            continue
+        args = tokens[4:]
+        i = 0
+        while i < len(args):
+            token = args[i]
+            if token == "--upgrade" and i + 1 < len(args):
+                markers.add(f"{token} {args[i + 1]}")
+                i += 2
+                continue
+            if token == "-e" and i + 1 < len(args):
+                markers.add(f"{token} {args[i + 1]}")
+                i += 2
+                continue
+            if not token.startswith("-"):
+                markers.add(token)
+            i += 1
+    return markers
+
+
+def _ci_step_named(steps: list[dict[str, object]], name: str) -> list[str]:
+    for step in steps:
+        if step.get("name") == name:
+            commands = step.get("commands")
+            if isinstance(commands, list):
+                return [str(command) for command in commands]
+    return []
 
 
 def check_ci_job_sync() -> list[str]:
@@ -93,21 +281,8 @@ def check_ci_job_sync() -> list[str]:
     if not ci_yml.exists() or not parallel_py.exists():
         return errors
 
-    ci_jobs: set[str] = set()
-    in_jobs = False
-    for line in ci_yml.read_text().splitlines():
-        if line.rstrip() == "jobs:":
-            in_jobs = True
-            continue
-        if in_jobs:
-            m = _CI_JOB_RE.match(line)
-            if m:
-                ci_jobs.add(m.group(1))
-
-    parallel_jobs: set[str] = set()
-    py_text = parallel_py.read_text()
-    for m in _PARALLEL_JOB_RE.finditer(py_text):
-        parallel_jobs.add(m.group(1))
+    ci_jobs = set(_ci_run_steps_by_job())
+    parallel_jobs = set(_local_runner_commands()[0])
 
     only_ci = ci_jobs - parallel_jobs
     only_parallel = parallel_jobs - ci_jobs
@@ -115,6 +290,65 @@ def check_ci_job_sync() -> list[str]:
         errors.append(f"CI jobs not mirrored in run_ci_parallel.py: {sorted(only_ci)}")
     if only_parallel:
         errors.append(f"run_ci_parallel.py jobs not in ci.yml: {sorted(only_parallel)}")
+    return errors
+
+
+def check_ci_command_sync() -> list[str]:
+    """Verify mirrored CI run commands stay aligned with run_ci_parallel.py."""
+    ci_steps = _ci_run_steps_by_job()
+    local_jobs, common_bootstrap, firmware_bootstrap = _local_runner_commands()
+    errors: list[str] = []
+
+    common_backend_markers = _pip_install_markers(common_bootstrap[:2])
+    for job_name in _MIRRORED_BACKEND_INSTALL_JOBS:
+        install_commands = _ci_step_named(
+            ci_steps.get(job_name, []), "Install dependencies"
+        )
+        if _pip_install_markers(install_commands) != common_backend_markers:
+            errors.append(
+                f"{job_name} install commands drifted from local bootstrap: "
+                f"ci={install_commands!r} local={common_bootstrap[:2]!r}"
+            )
+
+    ui_bootstrap_commands = common_bootstrap[2:]
+    for job_name in _MIRRORED_UI_INSTALL_JOBS:
+        install_commands = _ci_step_named(
+            ci_steps.get(job_name, []), "Install UI dependencies"
+        )
+        if install_commands != ui_bootstrap_commands:
+            errors.append(
+                f"{job_name} UI install commands drifted from local bootstrap: "
+                f"ci={install_commands!r} local={ui_bootstrap_commands!r}"
+            )
+
+    firmware_install_commands = _ci_step_named(
+        ci_steps.get(_FIRMWARE_INSTALL_JOB, []),
+        "Install dependencies",
+    )
+    if _pip_install_markers(firmware_install_commands) != _pip_install_markers(
+        firmware_bootstrap[:3]
+    ):
+        errors.append(
+            f"{_FIRMWARE_INSTALL_JOB} install commands drifted from local bootstrap: "
+            f"ci={firmware_install_commands!r} local={firmware_bootstrap[:3]!r}"
+        )
+
+    install_step_names = {"Install dependencies", "Install UI dependencies"}
+    for job_name, steps in ci_steps.items():
+        expected_commands: list[str] = []
+        for step in steps:
+            if step.get("name") in install_step_names:
+                continue
+            commands = step.get("commands")
+            if isinstance(commands, list):
+                expected_commands.extend(str(command) for command in commands)
+        local_commands = local_jobs.get(job_name, [])
+        if expected_commands != local_commands:
+            errors.append(
+                f"{job_name} run commands drifted from run_ci_parallel.py: "
+                f"ci={expected_commands!r} local={local_commands!r}"
+            )
+
     return errors
 
 
@@ -152,6 +386,15 @@ def main() -> int:
         failures += 1
     else:
         print("CI job names in sync between ci.yml and run_ci_parallel.py.")
+
+    ci_command_sync_errors = check_ci_command_sync()
+    if ci_command_sync_errors:
+        print("CI command sync drift detected:")
+        for item in ci_command_sync_errors:
+            print(f"  - {item}")
+        failures += 1
+    else:
+        print("CI commands in sync between ci.yml and run_ci_parallel.py.")
 
     return 1 if failures else 0
 

--- a/tools/dev/check_prerequisites.py
+++ b/tools/dev/check_prerequisites.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Check local development prerequisites and workflow availability."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str
+    message: str
+
+
+def _read_required_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _which(command: str) -> str | None:
+    return shutil.which(command)
+
+
+def _run(command: list[str]) -> tuple[bool, str]:
+    proc = subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    output = (proc.stdout or "").strip()
+    return proc.returncode == 0, output
+
+
+def _first_line(text: str) -> str:
+    return text.splitlines()[0].strip() if text else ""
+
+
+def _check_python(expected_major_minor: str) -> CheckResult:
+    if _which("python3") is None:
+        return CheckResult(
+            "python3",
+            "FAIL",
+            f"missing (expected {expected_major_minor}.x from .python-version)",
+        )
+    ok, output = _run(
+        [
+            "python3",
+            "-c",
+            "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')",
+        ]
+    )
+    if not ok:
+        return CheckResult(
+            "python3", "FAIL", f"unable to read version: {_first_line(output)}"
+        )
+    actual = output.strip()
+    if not actual.startswith(f"{expected_major_minor}."):
+        return CheckResult(
+            "python3",
+            "FAIL",
+            f"found {actual}; expected {expected_major_minor}.x (see .python-version)",
+        )
+    return CheckResult("python3", "OK", f"{actual} (matches .python-version)")
+
+
+def _check_node(expected_major: str) -> CheckResult:
+    if _which("node") is None:
+        return CheckResult(
+            "node", "FAIL", f"missing (expected {expected_major}.x from .nvmrc)"
+        )
+    ok, output = _run(["node", "--version"])
+    if not ok:
+        return CheckResult(
+            "node", "FAIL", f"unable to read version: {_first_line(output)}"
+        )
+    actual = output.lstrip("v").strip()
+    if not actual.startswith(f"{expected_major}."):
+        return CheckResult(
+            "node",
+            "FAIL",
+            f"found {actual}; expected {expected_major}.x (see .nvmrc)",
+        )
+    return CheckResult("node", "OK", f"v{actual} (matches .nvmrc)")
+
+
+def _check_npm() -> CheckResult:
+    if _which("npm") is None:
+        return CheckResult("npm", "FAIL", "missing")
+    ok, output = _run(["npm", "--version"])
+    if not ok:
+        return CheckResult(
+            "npm", "FAIL", f"unable to read version: {_first_line(output)}"
+        )
+    return CheckResult("npm", "OK", output.strip())
+
+
+def _check_docker() -> list[CheckResult]:
+    results: list[CheckResult] = []
+    if _which("docker") is None:
+        return [
+            CheckResult(
+                "docker", "WARN", "missing (Docker quick-start/dev mode unavailable)"
+            ),
+            CheckResult(
+                "docker compose", "WARN", "unavailable because docker is missing"
+            ),
+        ]
+
+    results.append(CheckResult("docker", "OK", "installed"))
+
+    compose_ok, compose_output = _run(["docker", "compose", "version"])
+    if compose_ok:
+        results.append(CheckResult("docker compose", "OK", _first_line(compose_output)))
+    else:
+        legacy_ok, legacy_output = _run(["docker-compose", "version"])
+        if legacy_ok:
+            results.append(
+                CheckResult("docker compose", "OK", _first_line(legacy_output))
+            )
+        else:
+            results.append(
+                CheckResult(
+                    "docker compose",
+                    "WARN",
+                    f"unavailable: {_first_line(compose_output or legacy_output)}",
+                )
+            )
+
+    daemon_ok, daemon_output = _run(["docker", "info"])
+    if daemon_ok:
+        results.append(CheckResult("docker daemon", "OK", "reachable"))
+    else:
+        results.append(
+            CheckResult(
+                "docker daemon",
+                "WARN",
+                f"not reachable: {_first_line(daemon_output)}",
+            )
+        )
+    return results
+
+
+def _check_platformio() -> CheckResult:
+    if _which("pio") is None:
+        return CheckResult(
+            "platformio", "WARN", "missing (only needed for firmware work)"
+        )
+    ok, output = _run(["pio", "--version"])
+    if not ok:
+        return CheckResult(
+            "platformio", "WARN", f"installed but unhealthy: {_first_line(output)}"
+        )
+    match = re.search(r"\bversion\s+([0-9.]+)", output, re.IGNORECASE)
+    version = match.group(1) if match else _first_line(output)
+    return CheckResult("platformio", "OK", version)
+
+
+def _print_section(title: str, results: list[CheckResult]) -> None:
+    print(title)
+    for result in results:
+        print(f"  [{result.status}] {result.name}: {result.message}")
+
+
+def main() -> int:
+    expected_python = _read_required_text(ROOT / ".python-version")
+    expected_node = _read_required_text(ROOT / ".nvmrc")
+
+    core_results = [
+        _check_python(expected_python),
+        _check_node(expected_node),
+        _check_npm(),
+    ]
+    docker_results = _check_docker()
+    firmware_results = [_check_platformio()]
+
+    _print_section("Core development prerequisites:", core_results)
+    print()
+    _print_section("Docker workflow availability:", docker_results)
+    print()
+    _print_section("Firmware workflow availability:", firmware_results)
+    print()
+
+    core_failures = [result for result in core_results if result.status == "FAIL"]
+    warnings = [
+        result
+        for result in [*core_results, *docker_results, *firmware_results]
+        if result.status == "WARN"
+    ]
+
+    if core_failures:
+        print(
+            "doctor failed: fix the core development prerequisites above before continuing."
+        )
+        return 1
+
+    if warnings:
+        print(
+            "doctor passed with warnings: the native Python + Vite workflow is available, but some optional paths are not ready."
+        )
+        return 0
+
+    print("doctor passed: the native and Docker development workflows are ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -9,6 +9,7 @@ below to match.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shlex
 import subprocess
@@ -20,6 +21,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci_local"
+UI_DIR = ROOT / "apps" / "ui"
+UI_NODE_MODULES = UI_DIR / "node_modules"
+UI_LOCK_FILE = UI_DIR / "package-lock.json"
+UI_LOCK_HASH_FILE = UI_DIR / ".npm-ci-lock.sha256"
 PRINT_LOCK = threading.Lock()
 RESULT_LOCK = threading.Lock()
 
@@ -49,6 +54,37 @@ def _emit(line: str) -> None:
 
 def _format_cmd(cmd: list[str]) -> str:
     return shlex.join(cmd)
+
+
+def _ui_lock_hash() -> str:
+    # Keep this hash rule aligned with tools/build_ui_static.py.
+    return hashlib.sha256(UI_LOCK_FILE.read_bytes()).hexdigest()
+
+
+def _ui_lock_hash_is_current() -> bool:
+    if not UI_LOCK_HASH_FILE.exists():
+        return False
+    return UI_LOCK_HASH_FILE.read_text(encoding="utf-8").strip() == _ui_lock_hash()
+
+
+def _mark_ui_lock_hash_current() -> None:
+    UI_LOCK_HASH_FILE.write_text(f"{_ui_lock_hash()}\n", encoding="utf-8")
+
+
+def _should_run_ui_npm_ci(skip_npm_ci: bool) -> bool:
+    return not skip_npm_ci and (
+        not UI_NODE_MODULES.exists() or not _ui_lock_hash_is_current()
+    )
+
+
+def _shared_ui_workspace_would_race(
+    selected_jobs: list[str], *, skip_bootstrap: bool, skip_npm_ci: bool
+) -> bool:
+    if not skip_bootstrap or "release-smoke" not in selected_jobs:
+        return False
+    if "frontend-typecheck" not in selected_jobs and "ui-smoke" not in selected_jobs:
+        return False
+    return _should_run_ui_npm_ci(skip_npm_ci)
 
 
 def _run_step(step: Step, log_file) -> int:
@@ -107,7 +143,12 @@ def _run_job(name: str, steps: list[Step], results: dict[str, JobResult]) -> Non
         )
 
 
-def _bootstrap_steps(python_cmd: str, run_npm_ci: bool) -> list[Step]:
+def _bootstrap_steps(
+    python_cmd: str,
+    run_npm_ci: bool,
+    *,
+    include_platformio: bool,
+) -> list[Step]:
     steps = [
         Step(
             "python deps: pip upgrade",
@@ -118,6 +159,13 @@ def _bootstrap_steps(python_cmd: str, run_npm_ci: bool) -> list[Step]:
             [python_cmd, "-m", "pip", "install", "-e", "./apps/server[dev]"],
         ),
     ]
+    if include_platformio:
+        steps.append(
+            Step(
+                "python deps: platformio",
+                [python_cmd, "-m", "pip", "install", "platformio>=6,<7"],
+            )
+        )
     if run_npm_ci:
         steps.append(Step("ui deps: npm ci", ["npm", "ci"], cwd=ROOT / "apps" / "ui"))
     return steps
@@ -126,45 +174,43 @@ def _bootstrap_steps(python_cmd: str, run_npm_ci: bool) -> list[Step]:
 def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
     return {
         "backend-quality": [
-            Step("lint + quality checks", ["make", "lint"]),
+            Step("Backend quality checks", ["make", "lint"]),
         ],
         "backend-typecheck": [
-            Step("mypy", ["make", "typecheck-backend"]),
+            Step(
+                "Mypy backend enforced coverage",
+                [python_cmd, "-m", "mypy", "--config-file", "pyproject.toml"],
+                cwd=ROOT / "apps" / "server",
+                env={"MYPYPATH": "."},
+            ),
         ],
         "frontend-typecheck": [
-            Step("ui contract sync + typecheck", ["make", "ui-typecheck"]),
+            Step(
+                "UI contract sync check",
+                ["npm", "run", "check:contracts"],
+                cwd=ROOT / "apps" / "ui",
+            ),
+            Step("UI typecheck", ["npm", "run", "typecheck"], cwd=ROOT / "apps" / "ui"),
         ],
         "ui-smoke": [
             Step(
-                "playwright install chromium",
+                "Install Playwright Chromium",
                 ["npx", "playwright", "install", "chromium"],
                 cwd=ROOT / "apps" / "ui",
             ),
-            Step("ui smoke", ["npm", "run", "test:smoke"], cwd=ROOT / "apps" / "ui"),
+            Step(
+                "UI smoke tests", ["npm", "run", "test:smoke"], cwd=ROOT / "apps" / "ui"
+            ),
         ],
         "release-smoke": [
             Step(
-                "release smoke",
-                [python_cmd, "tools/tests/run_release_smoke.py", "--skip-npm-ci"],
+                "Release smoke validation",
+                [python_cmd, "tools/tests/run_release_smoke.py"],
             ),
         ],
         "firmware-native-tests": [
             Step(
-                "platformio core version",
-                [
-                    python_cmd,
-                    "-c",
-                    (
-                        "import re, subprocess, sys; "
-                        "proc = subprocess.run(['pio', '--version'], capture_output=True, text=True); "
-                        "output = (proc.stdout or '') + (proc.stderr or ''); "
-                        "sys.stdout.write(output); "
-                        "sys.exit(0 if proc.returncode == 0 and re.search(r'\\bversion\\s+6\\.', output) else 1)"
-                    ),
-                ],
-            ),
-            Step(
-                "firmware protocol fixture check",
+                "Verify firmware protocol fixtures",
                 [
                     python_cmd,
                     "tools/firmware/generate_protocol_contract_fixtures.py",
@@ -172,14 +218,14 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                 ],
             ),
             Step(
-                "firmware native tests",
+                "Firmware native tests",
                 ["pio", "test", "-e", "native"],
                 cwd=ROOT / "firmware" / "esp",
             ),
         ],
         "backend-tests": [
             Step(
-                "backend tests",
+                "Backend tests",
                 [
                     python_cmd,
                     "-m",
@@ -192,7 +238,7 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
         ],
         "e2e": [
             Step(
-                "docker-backed e2e suite",
+                "Docker-backed e2e suite (skip already-owned checks)",
                 [
                     python_cmd,
                     "tools/tests/run_e2e_parallel.py",
@@ -219,6 +265,8 @@ def _run_bootstrap(steps: list[Step]) -> int:
                     f"[bootstrap] fail at '{step.label}' (exit {rc}) after {elapsed:.1f}s; log: {bootstrap_log}"
                 )
                 return rc
+            if step.label == "ui deps: npm ci":
+                _mark_ui_lock_hash_current()
             _emit(f"[bootstrap] ok '{step.label}' in {elapsed:.1f}s")
     _emit("[bootstrap] success")
     return 0
@@ -261,16 +309,6 @@ def main() -> int:
     python_cmd = sys.executable
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
-    run_npm_ci = (
-        not args.skip_npm_ci and not (ROOT / "apps" / "ui" / "node_modules").exists()
-    )
-    bootstrap_steps = (
-        [] if args.skip_bootstrap else _bootstrap_steps(python_cmd, run_npm_ci)
-    )
-    bootstrap_rc = _run_bootstrap(bootstrap_steps)
-    if bootstrap_rc != 0:
-        return bootstrap_rc
-
     all_jobs = _job_steps(python_cmd)
     selected_jobs = (
         args.job
@@ -286,6 +324,33 @@ def main() -> int:
             "e2e",
         ]
     )
+
+    if _shared_ui_workspace_would_race(
+        selected_jobs,
+        skip_bootstrap=args.skip_bootstrap,
+        skip_npm_ci=args.skip_npm_ci,
+    ):
+        _emit(
+            "[ci-local] refusing to run shared UI jobs with --skip-bootstrap: "
+            "release-smoke would trigger npm ci inside apps/ui while other UI jobs "
+            "use the same workspace. Re-run without --skip-bootstrap, or refresh "
+            "apps/ui/.npm-ci-lock.sha256 before using --skip-bootstrap."
+        )
+        return 2
+
+    run_npm_ci = _should_run_ui_npm_ci(args.skip_npm_ci)
+    bootstrap_steps = (
+        []
+        if args.skip_bootstrap
+        else _bootstrap_steps(
+            python_cmd,
+            run_npm_ci,
+            include_platformio="firmware-native-tests" in selected_jobs,
+        )
+    )
+    bootstrap_rc = _run_bootstrap(bootstrap_steps)
+    if bootstrap_rc != 0:
+        return bootstrap_rc
 
     started = time.monotonic()
     results: dict[str, JobResult] = {}

--- a/tools/tests/run_release_smoke.py
+++ b/tools/tests/run_release_smoke.py
@@ -28,12 +28,20 @@ def _resolve_repo_path(repo_root: Path, raw_path: str) -> Path:
 def _build_server_wheel(repo_root: Path) -> Path:
     dist_dir = repo_root / "apps" / "server" / "dist"
     shutil.rmtree(dist_dir, ignore_errors=True)
-    python_cmd = sys.executable
-    _run(
-        [python_cmd, "-m", "pip", "install", "--upgrade", "pip", "build"],
-        cwd=repo_root,
-    )
-    _run([python_cmd, "-m", "build", "--wheel", "apps/server/"], cwd=repo_root)
+    with tempfile.TemporaryDirectory(
+        prefix="vibesensor-build-wheel-venv-"
+    ) as venv_text:
+        venv_dir = Path(venv_text)
+        venv.EnvBuilder(with_pip=True).create(venv_dir)
+        build_python = _venv_python(venv_dir)
+        _run(
+            [str(build_python), "-m", "pip", "install", "--upgrade", "pip", "build"],
+            cwd=repo_root,
+        )
+        _run(
+            [str(build_python), "-m", "build", "--wheel", "apps/server/"],
+            cwd=repo_root,
+        )
     wheels = sorted(dist_dir.glob("*.whl"))
     if not wheels:
         raise RuntimeError(f"No wheel produced in {dist_dir}")


### PR DESCRIPTION
Closes #1170

## Summary

This PR improves the first-run and day-to-day developer workflow in the areas called out by `#1170`: Makefile discoverability, onboarding prerequisites, Docker dev mode, and CI/local-runner drift detection. The repo had grown a solid set of commands and checks, but too much of that workflow was still implicit knowledge. Running bare `make` unexpectedly executed `setup`, the README jumped from clone straight into commands without first telling contributors which tools and versions they needed, Docker Compose only offered a production-style container path, and the local CI mirror only guaranteed that job names matched GitHub Actions, not that the commands inside those jobs still lined up.

The implementation keeps the fix bounded rather than turning into a tooling rewrite. It adds a self-documenting command surface, a lightweight prerequisite doctor, a source-mounted Docker dev override, command-level CI parity checks, and a couple of small local-runner hardening fixes that were discovered while validating the main work.

## What changed

The `Makefile` now defaults to a `help` target instead of falling through to `setup`. Every existing target in the file now has a `##` description so the default output acts as a real command menu rather than requiring maintainers to inspect the file directly. I also added a `doctor` target that runs a new `tools/dev/check_prerequisites.py` script. The script validates the pinned Python and Node versions from `.python-version` and `.nvmrc`, checks that `npm` is present, and reports Docker / Docker Compose / Docker daemon availability and PlatformIO availability in a way that matches how the repo is actually used. Missing or mismatched core tools fail the check, while optional workflow paths show up as warnings so native backend and UI work are not blocked just because Docker or firmware tooling is unavailable on a given machine.

For Docker-based iteration, there is now a new `docker-compose.dev.yml` override. The base `docker-compose.yml` remains the production-style quick product check, while the dev override mounts the repository into the container workspace, runs `vibesensor-server --reload` against the Docker config, and starts a separate Vite development service for the UI. That gives Docker users a documented source-mounted path with backend reload plus frontend HMR instead of needing a full image rebuild for every edit.

The documentation was updated to match the new workflow split. `README.md` now starts the quick-start section with an explicit prerequisites list, points readers at `make doctor`, distinguishes the production-style Docker quick check from the new Docker dev mode, and keeps the native Python + Vite path as the recommended route for backend or UI iteration. `CONTRIBUTING.md` was updated to point contributors at the new setup paths, explain when `make doctor` is useful, and link to the correct README anchors for Docker quick-check, Docker dev mode, and native iteration. The existing validation workflow sections in `CONTRIBUTING.md` were already directionally correct, so the change there was mostly about discoverability and routing instead of rewriting the guidance wholesale.

On the CI parity side, `tools/dev/check_hygiene.py` now goes beyond job-name matching and verifies the mirrored job commands in `tools/tests/run_ci_parallel.py` against the `run:` steps in `.github/workflows/ci.yml`. The normalization logic handles multi-line `run` blocks, `cd ...` setup lines, shell chaining, and job-scoped environment prefixes so the comparison stays stable without being naïvely string-equal. I added `apps/server/tests/hygiene/test_ci_command_parity.py` so this behavior stays guarded in pytest as well as through `make lint`.

While validating that parity work, I found two adjacent local-runner problems that were tightly coupled to the issue’s “trust the local CI mirror” goal. First, the shared-workspace local runner could still trigger a second `npm ci` inside `release-smoke` while `frontend-typecheck` or `ui-smoke` were using the same `apps/ui/node_modules` tree. GitHub Actions isolates those jobs, but the local helper does not, which made the mirror look flaky even when the mirrored commands were correct. `tools/tests/run_ci_parallel.py` now tracks the same UI lock-hash marker used by `tools/build_ui_static.py` and refuses the one `--skip-bootstrap` combination that would recreate that race in a shared workspace. Second, `tools/tests/run_release_smoke.py` previously installed `build` into the host Python before producing the wheel, which breaks on PEP 668 “externally managed” environments. That script now creates a temporary builder venv for the wheel build step, then continues to use a separate temporary venv for the actual smoke validation. Those fixes stay small, but they make the local runner materially more reliable on real contributor machines.

## Validation

I validated the change set in layers, starting with focused tooling regressions and then moving out to the broader DX flows the issue is trying to improve.

- `python3 -m pytest -q apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/use_cases/updates/test_run_release_smoke.py`
- `make lint`
- bare `make` to confirm the new help menu and target descriptions
- `make doctor`
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config`
- `python3 tools/tests/run_release_smoke.py`
- `python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke --job release-smoke --skip-bootstrap`

Those checks all passed on the final tree. The last command is important because it is the exact local runner combination that originally exposed the shared-workspace UI dependency race. After the runner hardening, that three-job subset completed successfully with `frontend-typecheck`, `ui-smoke`, and `release-smoke` all green in one run.

One limitation remains honest and unchanged from earlier issues in this backlog: the Docker daemon is not reachable in this environment, so I could not fully boot the dev override locally. I did run the full compose config validation and `make doctor` reports that exact condition as a warning rather than hiding it. The Docker dev path is therefore configuration-validated here, while the packaged release path and mirrored local runner path were fully executed.

## Risks, tradeoffs, and out-of-scope notes

I kept the fix intentionally scoped. The CI parity logic still mirrors commands from the Python helper instead of generating the helper from YAML, because full generation would be a larger design shift than this issue needs. The Docker dev mode is a new override file, not a full profile matrix or devcontainer setup. The prerequisite doctor is meant to answer “can I start working?” quickly.

I also avoided rolling broader Docker / dependency hygiene work into this PR. For example, I did not use this issue to tackle image dependency trimming, Python/Node version source unification across every container, or CI cache restructuring. Those concerns are real, but they belong in the next queued backlog item rather than being silently folded into the onboarding fix.

Overall, this PR makes the intended development paths much easier to discover, makes the local CI mirror more trustworthy, and leaves the repo with a clearer distinction between quick product checks, source-mounted Docker iteration, and native backend/UI development.
