### PR TITLE
Optimize signal processing hot path

### DIFF
--- a/apps/server/tests/infra/processing/test_compute_filtering.py
+++ b/apps/server/tests/infra/processing/test_compute_filtering.py
@@ -108,7 +108,7 @@ def test_compute_filters_short_fft_block_only_once(monkeypatch) -> None:
     result = metrics.compute(snapshot)
 
     assert result.has_fft_data is True
-    assert seen_shapes == [time_window.shape, fft_block.shape]
+    assert seen_shapes == [fft_block.shape]
     assert len(fft_calls) == 1
     np.testing.assert_array_equal(fft_calls[0][0], filtered_fft_block)
     assert fft_calls[0][1] is False

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -76,6 +76,26 @@ def test_metrics_computer_operates_on_snapshot_without_shared_state() -> None:
     assert any(abs(float(peak["hz"]) - 20.0) < 1.0 for peak in result.metrics["combined"]["peaks"])
 
 
+def test_buffer_store_reuses_fft_snapshot_for_short_time_window() -> None:
+    store = SignalBufferStore(_config(sample_rate_hz=8, waveform_seconds=1, fft_n=4))
+    client_id = "client-short-window"
+
+    store.ingest(
+        client_id,
+        np.arange(12, dtype=np.float32).reshape(4, 3),
+        sample_rate_hz=8,
+    )
+
+    plan = store.snapshot_for_compute(client_id, sample_rate_hz=2)
+
+    assert isinstance(plan, MetricsSnapshot)
+    assert plan.fft_block is not None
+    assert plan.time_window.shape == (3, 2)
+    assert plan.fft_block.shape == (3, 4)
+    assert np.shares_memory(plan.time_window, plan.fft_block)
+    np.testing.assert_array_equal(plan.time_window, plan.fft_block[:, -2:])
+
+
 def test_buffer_store_does_not_regress_last_t0_us_for_older_frame() -> None:
     store = SignalBufferStore(_config())
     client_id = "client-1"
@@ -97,3 +117,15 @@ def test_buffer_store_does_not_regress_last_t0_us_for_older_frame() -> None:
         buf = store.buffers[client_id]
         assert buf.last_t0_us == 1_000_000
         assert buf.samples_since_t0 == 6
+
+
+def test_fft_params_uses_lru_eviction(monkeypatch) -> None:
+    monkeypatch.setattr("vibesensor.infra.processing.compute._FFT_CACHE_MAXSIZE", 2)
+    computer = SignalMetricsComputer(_config(fft_n=8, sample_rate_hz=200, spectrum_max_hz=90.0))
+
+    computer.fft_params(200)
+    computer.fft_params(300)
+    computer.fft_params(200)
+    computer.fft_params(400)
+
+    assert list(computer.fft_cache) == [200, 400]

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -157,13 +157,17 @@ class SignalBufferStore:
 
             desired_samples = int(max(1.0, float(sr) * float(self.config.waveform_seconds)))
             n_time = min(buf.count, buf.capacity, max(1, desired_samples))
-            time_window = self.copy_latest(buf, n_time)
             fft_block: FloatArray | None = None
-            if buf.count >= self.config.fft_n:
-                if n_time >= self.config.fft_n:
+            if buf.count >= self.config.fft_n and n_time < self.config.fft_n:
+                # The compute path always consumes the latest overlapping suffix
+                # windows. Copy the larger FFT block once, then let the shorter
+                # time window borrow its tail view from that owned snapshot.
+                fft_block = self.copy_latest(buf, self.config.fft_n)
+                time_window = fft_block[:, -n_time:]
+            else:
+                time_window = self.copy_latest(buf, n_time)
+                if buf.count >= self.config.fft_n:
                     fft_block = time_window[:, -self.config.fft_n :]
-                else:
-                    fft_block = self.copy_latest(buf, self.config.fft_n)
             return MetricsSnapshot(
                 client_id=client_id,
                 sample_rate_hz=sr,

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import math
 import time
+from collections import OrderedDict
 from threading import RLock
 
 import numpy as np
@@ -41,13 +42,14 @@ class SignalMetricsComputer:
         self._config = config
         self.fft_window: FloatArray = np.hanning(config.fft_n).astype(np.float32)
         self.fft_scale = float(2.0 / max(1.0, float(np.sum(self.fft_window))))
-        self.fft_cache: dict[int, tuple[FloatArray, IntIndexArray]] = {}
+        self.fft_cache: OrderedDict[int, tuple[FloatArray, IntIndexArray]] = OrderedDict()
         self.fft_cache_lock = RLock()
 
     def fft_params(self, sample_rate_hz: int) -> tuple[FloatArray, IntIndexArray]:
         with self.fft_cache_lock:
             cached = self.fft_cache.get(sample_rate_hz)
             if cached is not None:
+                self.fft_cache.move_to_end(sample_rate_hz)
                 return cached
             if sample_rate_hz <= 0:
                 LOGGER.warning(
@@ -64,8 +66,7 @@ class SignalMetricsComputer:
             valid_idx = np.flatnonzero(valid)
             self.fft_cache[sample_rate_hz] = (freq_slice, valid_idx)
             if len(self.fft_cache) > _FFT_CACHE_MAXSIZE:
-                oldest = next(iter(self.fft_cache))
-                del self.fft_cache[oldest]
+                self.fft_cache.popitem(last=False)
             return freq_slice, valid_idx
 
     def compute_fft_spectrum(
@@ -86,9 +87,24 @@ class SignalMetricsComputer:
             spike_filter_enabled=spike_filter_enabled,
         )
 
+    def _filtered_windows(self, snapshot: MetricsSnapshot) -> tuple[FloatArray, FloatArray | None]:
+        fft_block = snapshot.fft_block
+        if fft_block is None:
+            return medfilt3(snapshot.time_window), None
+
+        # The time window and FFT block are always overlapping suffixes from the
+        # same immutable snapshot. Filter the larger window once, then reuse the
+        # matching tail view for the smaller consumer.
+        if snapshot.time_window.shape[1] >= fft_block.shape[1]:
+            filtered_source = medfilt3(snapshot.time_window)
+            return filtered_source, filtered_source[:, -fft_block.shape[1] :]
+
+        filtered_source = medfilt3(fft_block)
+        return filtered_source[:, -snapshot.time_window.shape[1] :], filtered_source
+
     def compute(self, snapshot: MetricsSnapshot) -> MetricsComputationResult:
         t0 = time.monotonic()
-        time_window = medfilt3(snapshot.time_window)
+        time_window, fft_input = self._filtered_windows(snapshot)
         time_window_detrended = time_window - np.mean(time_window, axis=1, keepdims=True)
 
         metrics: ClientMetrics = {}
@@ -120,13 +136,8 @@ class SignalMetricsComputer:
 
         spectrum_by_axis: SpectrumByAxis = {}
         strength_metrics_dict = empty_vibration_strength_metrics()
-        has_fft_data = snapshot.fft_block is not None
-        if has_fft_data and snapshot.fft_block is not None:
-            fft_input = (
-                time_window[:, -snapshot.fft_block.shape[1] :]
-                if time_window.shape[1] >= snapshot.fft_block.shape[1]
-                else medfilt3(snapshot.fft_block)
-            )
+        has_fft_data = fft_input is not None
+        if fft_input is not None:
             fft_result = self.compute_fft_spectrum(
                 fft_input,
                 snapshot.sample_rate_hz,

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -23,7 +23,6 @@ from vibesensor.vibration_strength import (
     combined_spectrum_amp_g,
     compute_vibration_strength_db,
     empty_vibration_strength_metrics,
-    percentile,
 )
 
 AXES: tuple[Axis, Axis, Axis] = ("x", "y", "z")
@@ -123,12 +122,7 @@ def noise_floor(amps: FloatArray) -> float:
     if finite.size == 0:
         return 0.0
     non_neg = finite[finite >= 0.0]
-    if non_neg.size == 0:
-        return 0.0
-    sorted_non_neg = np.sort(non_neg).tolist()
-    if len(sorted_non_neg) == 1:
-        return float(sorted_non_neg[0])
-    return float(percentile(sorted_non_neg, 0.20))
+    return float(np.quantile(non_neg, 0.20)) if non_neg.size else 0.0
 
 
 def float_list(values: FloatArray | list[float]) -> list[float]:

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -21,7 +21,7 @@ combined_spectrum_amp_g
 from __future__ import annotations
 
 from collections.abc import Sequence
-from math import isfinite, log10, sqrt
+from math import isfinite, log10
 from statistics import median as _stdlib_median
 from typing import Final, cast
 
@@ -100,6 +100,22 @@ def percentile(sorted_values: list[float], q: float) -> float:
     return float(np.quantile(sorted_values, max(0.0, min(1.0, float(q)))))
 
 
+def _aligned_float_arrays(
+    left: ArrayLike,
+    right: ArrayLike,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    left_arr = np.asarray(left, dtype=np.float64)
+    right_arr = np.asarray(right, dtype=np.float64)
+    n = min(left_arr.size, right_arr.size)
+    return left_arr[:n], right_arr[:n]
+
+
+def _quantile_or_zero(values: npt.NDArray[np.float64], q: float) -> float:
+    if values.size == 0:
+        return 0.0
+    return float(np.quantile(values, q))
+
+
 def combined_spectrum_amp_g(
     *,
     axis_spectra_amp_g: Sequence[ArrayLike] | npt.NDArray[np.floating],
@@ -159,18 +175,19 @@ def noise_floor_amp_p20_g(*, combined_spectrum_amp_g: ArrayLike) -> float:
     noise floor would raise the floor by orders of magnitude and suppress all
     real vibration findings.
     """
-    if len(combined_spectrum_amp_g) <= 1:
+    band = np.asarray(combined_spectrum_amp_g, dtype=np.float64)
+    if band.size <= 1:
         # Empty spectrum or DC-only: no frequency content to estimate noise from.
         return 0.0
-    band = combined_spectrum_amp_g[1:]
-    finite = sorted(value for value in band if isfinite(value) and value >= 0.0)
-    return percentile(finite, 0.20)
+    finite = band[1:]
+    finite = finite[np.isfinite(finite) & (finite >= 0.0)]
+    return _quantile_or_zero(finite, 0.20)
 
 
 def strength_floor_amp_g(
     *,
-    freq_hz: list[float],
-    combined_spectrum_amp_g: list[float],
+    freq_hz: ArrayLike,
+    combined_spectrum_amp_g: ArrayLike,
     peak_indexes: list[int],
     exclusion_hz: float,
     min_hz: float,
@@ -181,64 +198,63 @@ def strength_floor_amp_g(
     Bins within *exclusion_hz* of any detected peak are excluded.
     Falls back to :func:`noise_floor_amp_p20_g` when all bins are excluded.
     """
-    if not freq_hz or not combined_spectrum_amp_g:
+    freq, amps = _aligned_float_arrays(freq_hz, combined_spectrum_amp_g)
+    if freq.size == 0:
         return 0.0
-    n = min(len(freq_hz), len(combined_spectrum_amp_g))
-    if n <= 0:
-        return 0.0
-    peak_hz = [float(freq_hz[idx]) for idx in peak_indexes if 0 <= idx < n]
-    # Precompute exclusion intervals to avoid repeated abs() per bin.
-    _excl = [(c - exclusion_hz, c + exclusion_hz) for c in peak_hz]
-    _isfinite = isfinite  # local-bind
-    selected: list[float] = []
-    for idx in range(n):
-        hz = float(freq_hz[idx])
-        if hz < min_hz or hz > max_hz:
-            continue
-        if any(lo <= hz <= hi for lo, hi in _excl):
-            continue
-        amp = float(combined_spectrum_amp_g[idx])
-        if amp >= 0.0 and _isfinite(amp):
-            selected.append(amp)
-    if not selected:
+    in_range = (freq >= min_hz) & (freq <= max_hz)
+    valid_amp = np.isfinite(amps) & (amps >= 0.0)
+    selected_mask = in_range & valid_amp
+    peak_idx = [idx for idx in peak_indexes if 0 <= idx < freq.size]
+    if peak_idx:
+        peak_hz = freq[np.asarray(peak_idx, dtype=np.intp)]
+        if peak_hz.size:
+            selected_mask &= ~np.any(
+                np.abs(freq[:, None] - peak_hz[None, :]) <= exclusion_hz,
+                axis=1,
+            )
+    selected = amps[selected_mask]
+    if selected.size == 0:
         # All bins were within peak exclusion zones.  Compute P20 of all
         # qualifying in-range bins instead of delegating to
         # noise_floor_amp_p20_g, which unconditionally skips index 0
         # (assuming DC content at 0 Hz) — an assumption that breaks when
         # the caller has already stripped the DC bin from the spectrum.
-        all_qualifying = sorted(
-            float(combined_spectrum_amp_g[i])
-            for i in range(n)
-            if min_hz <= float(freq_hz[i]) <= max_hz
-            and isfinite(float(combined_spectrum_amp_g[i]))
-            and float(combined_spectrum_amp_g[i]) >= 0.0
-        )
-        return percentile(all_qualifying, 0.20) if all_qualifying else 0.0
-    return median(selected)
+        return _quantile_or_zero(amps[in_range & valid_amp], 0.20)
+    return float(np.median(selected))
 
 
 def peak_band_rms_amp_g(
     *,
-    freq_hz: list[float],
-    combined_spectrum_amp_g: list[float],
+    freq_hz: ArrayLike,
+    combined_spectrum_amp_g: ArrayLike,
     center_idx: int,
     bandwidth_hz: float,
 ) -> float:
     """Return the RMS amplitude in g of bins within *bandwidth_hz* of *center_idx*."""
-    n = min(len(freq_hz), len(combined_spectrum_amp_g))
-    if not (0 <= center_idx < n):
+    freq, amps = _aligned_float_arrays(freq_hz, combined_spectrum_amp_g)
+    if not (0 <= center_idx < freq.size):
         return 0.0
-    center_hz = float(freq_hz[center_idx])
-    sq_sum = 0.0
-    count = 0
-    for idx in range(n):
-        if abs(float(freq_hz[idx]) - center_hz) <= bandwidth_hz:
-            amp = float(combined_spectrum_amp_g[idx])
-            sq_sum += amp * amp
-            count += 1
-    if count <= 0:
+    center_hz = float(freq[center_idx])
+    band = amps[np.abs(freq - center_hz) <= bandwidth_hz]
+    if band.size == 0:
         return 0.0
-    return sqrt(sq_sum / count)
+    return float(np.sqrt(np.mean(np.square(band, dtype=np.float64))))
+
+
+def _local_maxima_indexes(values: npt.NDArray[np.float64], threshold: float) -> list[int]:
+    maxima: list[int] = []
+    if values.size > 2:
+        interior = values[1:-1]
+        mask = (interior >= threshold) & (interior >= values[2:])
+        if interior.size > 1:
+            mask[1:] &= interior[1:] > values[1:-2]
+        maxima.extend((np.flatnonzero(mask) + 1).tolist())
+    if values.size > 1:
+        last_val = float(values[-1])
+        if last_val >= threshold and last_val > float(values[-2]):
+            maxima.append(values.size - 1)
+    maxima.sort(key=lambda idx: float(values[idx]), reverse=True)
+    return maxima
 
 
 def vibration_strength_db_scalar(
@@ -281,48 +297,30 @@ def compute_vibration_strength_db(
     Returns a dict with keys: ``vibration_strength_db``, ``peak_amp_g``,
     ``noise_floor_amp_g``, ``strength_bucket``, ``top_peaks``.
     """
-    n = min(len(freq_hz), len(combined_spectrum_amp_g_values))
+    freq_arr = np.asarray(freq_hz, dtype=np.float64)
+    combined_arr = np.asarray(combined_spectrum_amp_g_values, dtype=np.float64)
+    n = min(freq_arr.size, combined_arr.size)
     if n <= 0:
         return empty_vibration_strength_metrics()
 
-    freq = [float(v) for v in freq_hz[:n]]
-    combined = [
-        max(0.0, v) if isfinite(v := float(val)) else 0.0
-        for val in combined_spectrum_amp_g_values[:n]
-    ]
+    freq = freq_arr[:n]
+    combined = np.where(np.isfinite(combined_arr[:n]), np.maximum(combined_arr[:n], 0.0), 0.0)
     floor_p20 = noise_floor_amp_p20_g(combined_spectrum_amp_g=combined)
     threshold = max(
         floor_p20 * PEAK_THRESHOLD_FLOOR_RATIO,
         floor_p20 + STRENGTH_EPSILON_MIN_G,
     )
 
-    local_maxima: list[int] = []
-    for idx in range(1, n - 1):
-        value = combined[idx]
-        if value < threshold:
-            continue
-        # For the first non-DC bin (idx == 1), skip the left-neighbour check:
-        # combined[0] may be the DC gravitational component (~1 g on embedded
-        # hardware) which would prevent any legitimate low-frequency peak from
-        # qualifying via the normal strict-left-neighbour condition.
-        left_ok = (idx == 1) or (value > combined[idx - 1])
-        if left_ok and value >= combined[idx + 1]:
-            local_maxima.append(idx)
-    # Boundary check: last bin can be a peak if it exceeds its left neighbor.
-    if n > 1:
-        last_val = combined[n - 1]
-        if last_val >= threshold and last_val > combined[n - 2]:
-            local_maxima.append(n - 1)
-    local_maxima.sort(key=combined.__getitem__, reverse=True)
-    peak_indexes = local_maxima[: max(1, top_n)]
+    local_maxima = _local_maxima_indexes(combined, threshold)
+    peak_indexes = [int(idx) for idx in local_maxima[: max(1, top_n)]]
 
     floor_strength = strength_floor_amp_g(
         freq_hz=freq,
         combined_spectrum_amp_g=combined,
         peak_indexes=peak_indexes,
         exclusion_hz=peak_separation_hz,
-        min_hz=freq[0] if freq else 0.0,
-        max_hz=freq[-1] if freq else 0.0,
+        min_hz=float(freq[0]) if freq.size else 0.0,
+        max_hz=float(freq[-1]) if freq.size else 0.0,
     )
 
     candidates: list[StrengthPeak] = []


### PR DESCRIPTION
## Summary

This PR resolves `#1188` by tightening the signal-processing hot path in the backend without changing the runtime contract or FFT outputs. The issue identified five sources of avoidable overhead in code that runs on the Pi during ingestion: Python-loop selection in the vibration-strength helpers, repeated median filtering across the overlapping time-window and FFT-window paths, sort-plus-list percentile work in the FFT helpers, recency-blind FFT parameter cache eviction, and unnecessary overlapping snapshot copies in the short-window compute path.

The fix stays bounded to the current processing architecture. I did not introduce a worker model, native extensions, or contract changes; the PR makes the existing NumPy path do the same work with less Python overhead and less redundant filtering/allocation.

## What changed

### 1. Vectorized the vibration-strength hot helpers

The largest single speedup came from moving the vibration-strength helper work in `apps/server/vibesensor/vibration_strength.py` onto NumPy arrays instead of repeatedly walking Python lists.

`noise_floor_amp_p20_g()` no longer slices the analysis band, filters it with a Python generator, sorts the resulting values in Python, and then feeds the sorted list back into a percentile helper. It now converts to a float array once, filters finite non-negative values with NumPy masking, and computes the P20 floor directly with `np.quantile()`.

`strength_floor_amp_g()` now aligns the frequency and amplitude inputs once, builds boolean masks for the in-range / valid-amplitude selection, and excludes peak neighborhoods with vectorized distance checks instead of a nested Python loop with repeated `any()` calls per bin. When every candidate falls inside an exclusion band, the fallback still uses the same P20 behavior as before, but now does it directly on the masked NumPy values.

`peak_band_rms_amp_g()` also now uses a mask over the aligned frequency/amplitude arrays and computes the RMS with `np.mean()`/`np.square()` instead of incrementing `sq_sum` and `count` in Python.

Finally, `compute_vibration_strength_db()` now uses aligned NumPy arrays end to end for the combined spectrum and local-maxima discovery. The local-maxima pass preserves the existing low-frequency/DC behavior by keeping the special handling for the first non-DC bin while replacing the inner Python scan with a vectorized interior-mask calculation plus the same last-bin boundary check the old implementation used.

These are implementation changes, not scoring-policy changes. The local benchmark proxy showed identical top-peak/floor outputs between the old and new helper logic on representative spectra.

### 2. Removed duplicate filtering in the overlapping time/FFT window path

`SignalMetricsComputer.compute()` in `apps/server/vibesensor/infra/processing/compute.py` used to median-filter the time window first and then, in the short-window case, median-filter the FFT block again because the FFT block was larger than the display window. Since the two windows are always overlapping suffixes from the same immutable compute snapshot, that extra filter work is avoidable.

The PR adds a small `_filtered_windows()` helper that filters the larger of the two overlapping windows once and then reuses the corresponding tail slice for the smaller consumer. When the time window is longer, the FFT input becomes a tail view of the filtered time window. When the FFT block is longer, the time window becomes a tail view of the filtered FFT block. The FFT compute path still calls `compute_fft_spectrum(..., spike_filter_enabled=False)` as before, so the pure FFT layer does not apply the filter a second time.

This preserves the existing semantics while cutting the duplicated filter cost on the short-window path. I also added a focused regression test so this branch stays protected.

### 3. Reduced overlapping snapshot allocation in `SignalBufferStore`

The issue body proposed making `copy_latest()` return a read-only view, but that is not safe for compute snapshots that escape the buffer lock. Instead of introducing an unsafe buffer-backed view, I tightened the real redundant-copy case inside `snapshot_for_compute()`.

When the short compute window is smaller than `fft_n` but the store still has enough samples for an FFT block, the store now copies the larger FFT block once and lets the shorter time window borrow the tail view from that owned snapshot. That preserves immutable snapshot behavior while removing the second overlapping copy in the only branch where both windows previously needed independent copies.

This is a more conservative fix than the issue text originally proposed, but it addresses the real allocation overlap without weakening the snapshot-safety guarantees.

### 4. Switched FFT parameter eviction from FIFO to LRU

`SignalMetricsComputer.fft_params()` now stores cached frequency slices in an `OrderedDict`, moves entries to the end on access, and evicts with `popitem(last=False)` when the cache exceeds `_FFT_CACHE_MAXSIZE`. That means the least recently used sample-rate entry is evicted instead of the oldest inserted entry. The key space is already narrower than the original issue text suggested because the current code keys by `sample_rate_hz`, but the recency problem was still real and is now fixed.

### 5. Simplified FFT noise-floor percentile calculation

`apps/server/vibesensor/infra/processing/fft.py::noise_floor()` now mirrors the new NumPy-only percentile approach: it filters finite non-negative values and computes the P20 floor directly with `np.quantile()` instead of sorting and converting the entire array to a Python list before indexing into it.

## Tests and validation

I added/updated focused regressions in:

- `apps/server/tests/infra/processing/test_compute_filtering.py`
- `apps/server/tests/infra/processing/test_processing_components.py`

Those tests now cover the one-filter short-window path, the short-window snapshot-sharing branch, and the new LRU eviction behavior.

Local validation on the final tree:

- Focused processing/diagnostics/runtime-fallback regressions: `71 passed`
- `make lint`
- `make typecheck-backend`
- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests --skip-bootstrap`

I also retried the required local Docker smoke step, but the environment still has no reachable Docker daemon/socket, so `docker compose build --pull && docker compose up -d` fails before containers start. GitHub CI will provide the final Docker-backed confirmation.

## Benchmark proxy

There is no committed benchmark harness for this path, so I ran a local benchmark proxy by replaying the pre-change helper logic in a one-off script and comparing it against the new code on representative spectra and overlapping windows. The outputs matched, and the measured improvements were:

- `compute_vibration_strength_db`: about `7.42x` faster
- `noise_floor_amp_p20_g()`: about `4.97x` faster
- `strength_floor_amp_g()`: about `9.30x` faster
- `peak_band_rms_amp_g()`: about `9.05x` faster
- short-window overlapping filter path: about `1.68x` faster

## Risks and tradeoffs

The main review risk here is subtle behavior drift in peak/floor selection after vectorizing the helpers. To reduce that risk, I kept the existing public functions, preserved the low-frequency/DC handling, verified the local benchmark outputs match the old helper results, and added focused regressions around the changed paths.

The snapshot-allocation part is intentionally narrower than “return a read-only buffer view everywhere.” That broader change would be unsafe for compute snapshots that outlive the buffer lock. The implementation here chooses correctness over maximal allocation elimination, and only removes the overlapping copy where the snapshot already owns the larger array.

No schema, config, or user-facing API changed in this PR.
