### PR TITLE
Return frozen registry snapshots

### DIFF
--- a/apps/server/tests/infra/runtime/test_registry_thread_safety.py
+++ b/apps/server/tests/infra/runtime/test_registry_thread_safety.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from vibesensor.adapters.udp.protocol import HelloMessage
+from vibesensor.infra.runtime.registry import ClientRecordSnapshot, ClientRegistry
+
+
+def _make_registry_with_client() -> tuple[ClientRegistry, str]:
+    registry = ClientRegistry()
+    client_id = "aabbccddeeff"
+    registry.update_from_hello(
+        HelloMessage(
+            client_id=bytes.fromhex(client_id),
+            control_port=9010,
+            sample_rate_hz=800,
+            name="node-1",
+            firmware_version="fw-1",
+            frame_samples=200,
+        ),
+        ("10.4.0.2", 9010),
+        now=1.0,
+        now_mono=1.0,
+    )
+    return registry, client_id
+
+
+def test_registry_get_returns_frozen_snapshot() -> None:
+    registry, client_id = _make_registry_with_client()
+
+    record = registry.get(client_id)
+
+    assert isinstance(record, ClientRecordSnapshot)
+    assert record is not None
+    assert record.control_addr == ("10.4.0.2", 9010)
+    with pytest.raises(FrozenInstanceError):
+        record.name = "mutated"
+
+
+def test_registry_get_returns_point_in_time_snapshot() -> None:
+    registry, client_id = _make_registry_with_client()
+
+    first = registry.get(client_id)
+    assert first is not None
+
+    registry.set_name(client_id, "renamed-node")
+    registry.set_location(client_id, "front-left")
+
+    second = registry.get(client_id)
+    assert second is not None
+
+    assert first.name == "node-1"
+    assert first.location_code == ""
+    assert second.name == "renamed-node"
+    assert second.location_code == "front-left"

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -28,7 +28,13 @@ from vibesensor.shared.types.payload_types import ClientMetrics
 
 LOGGER = logging.getLogger(__name__)
 
-__all__ = ["ClientRecord", "ClientRegistry", "ClientSnapshot", "DataUpdateResult"]
+__all__ = [
+    "ClientRecord",
+    "ClientRecordSnapshot",
+    "ClientRegistry",
+    "ClientSnapshot",
+    "DataUpdateResult",
+]
 
 
 def _resolve_now_wall(now: float | None) -> float:
@@ -95,6 +101,65 @@ class ClientRecord:
         if len(self._seen_seqs) > window_size:
             cutoff = self._seen_seqs_max - window_size + 1
             self._seen_seqs = {s for s in self._seen_seqs if s >= cutoff}
+
+
+@dataclass(frozen=True, slots=True)
+class ClientRecordSnapshot:
+    """Immutable point-in-time view returned by :meth:`ClientRegistry.get`."""
+
+    client_id: str
+    name: str
+    firmware_version: str = ""
+    sample_rate_hz: int = 0
+    frame_samples: int = 0
+    last_seen: float = 0.0
+    last_seen_mono: float = 0.0
+    location_code: str = ""
+    data_addr: tuple[str, int] | None = None
+    control_addr: tuple[str, int] | None = None
+    frames_total: int = 0
+    frames_dropped: int = 0
+    queue_overflow_drops: int = 0
+    server_queue_drops: int = 0
+    parse_errors: int = 0
+    last_seq: int | None = None
+    last_ack_cmd_seq: int | None = None
+    last_ack_status: int | None = None
+    reset_count: int = 0
+    last_reset_time: float | None = None
+    last_t0_us: int | None = None
+    timing_jitter_us_ema: float = 0.0
+    timing_drift_us_total: float = 0.0
+    duplicates_received: int = 0
+
+
+def _snapshot_record(record: ClientRecord) -> ClientRecordSnapshot:
+    return ClientRecordSnapshot(
+        client_id=record.client_id,
+        name=record.name,
+        firmware_version=record.firmware_version,
+        sample_rate_hz=record.sample_rate_hz,
+        frame_samples=record.frame_samples,
+        last_seen=record.last_seen,
+        last_seen_mono=record.last_seen_mono,
+        location_code=record.location_code,
+        data_addr=record.data_addr,
+        control_addr=record.control_addr,
+        frames_total=record.frames_total,
+        frames_dropped=record.frames_dropped,
+        queue_overflow_drops=record.queue_overflow_drops,
+        server_queue_drops=record.server_queue_drops,
+        parse_errors=record.parse_errors,
+        last_seq=record.last_seq,
+        last_ack_cmd_seq=record.last_ack_cmd_seq,
+        last_ack_status=record.last_ack_status,
+        reset_count=record.reset_count,
+        last_reset_time=record.last_reset_time,
+        last_t0_us=record.last_t0_us,
+        timing_jitter_us_ema=record.timing_jitter_us_ema,
+        timing_drift_us_total=record.timing_drift_us_total,
+        duplicates_received=record.duplicates_received,
+    )
 
 
 class ClientRegistry:
@@ -289,13 +354,17 @@ class ClientRegistry:
         had_name = self._metadata.discard_name(normalized)
         return had_client or had_name
 
-    def get(self, client_id: str) -> ClientRecord | None:
+    def get(self, client_id: str) -> ClientRecordSnapshot | None:
+        """Return an immutable point-in-time snapshot for *client_id*."""
         try:
             normalized = _normalize_client_id(client_id)
         except ValueError:
             return None
         with self._lock:
-            return self._clients.get(normalized)
+            record = self._clients.get(normalized)
+            if record is None:
+                return None
+            return _snapshot_record(record)
 
     def active_client_ids(
         self,

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -127,14 +127,29 @@ class SignalSource(Protocol):
 class TrackedClient(Protocol):
     """Minimal active-client view consumed by recording helpers."""
 
-    client_id: str
-    name: str
-    firmware_version: str
-    sample_rate_hz: int
-    location_code: str
-    frames_total: int
-    frames_dropped: int
-    queue_overflow_drops: int
+    @property
+    def client_id(self) -> str: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def firmware_version(self) -> str: ...
+
+    @property
+    def sample_rate_hz(self) -> int: ...
+
+    @property
+    def location_code(self) -> str: ...
+
+    @property
+    def frames_total(self) -> int: ...
+
+    @property
+    def frames_dropped(self) -> int: ...
+
+    @property
+    def queue_overflow_drops(self) -> int: ...
 
 
 class ClientTracker(Protocol):


### PR DESCRIPTION
Closes #1190.

## Summary

This PR fixes the one concurrency bug from #1190 that is still real on the current tree: `ClientRegistry.get()` returned the live mutable `ClientRecord`, which meant callers could read or mutate registry-owned state after the registry lock had already been released. The issue body originally grouped that with `RuntimeHealthState`, `GPSTransportState`, and earlier WebSocket concerns, so I started by re-auditing the live runtime code before changing anything. That audit confirmed the registry leak was real and active, while the other claims were either defensive-only or already stale after the runtime cleanups that landed in earlier issues. I kept the implementation bounded to the actual active race surface rather than adding speculative locking to unrelated code.

The fix changes `ClientRegistry.get()` to return a frozen `ClientRecordSnapshot` instead of the live `ClientRecord`. The snapshot carries the same public runtime fields that current callers read today, including control/data addresses, counters, timing metadata, reset information, and command-ack tracking, but it does not expose the registry’s private dedup window internals. With that change, callers still get the data they need, but they cannot mutate registry-owned state outside the lock or accidentally hold onto a reference that changes under them.

## Problem

The registry already uses an `RLock` to protect updates from HELLO/DATA/ACK traffic and metadata changes, but `get()` broke that encapsulation. It normalized the client ID, entered the lock, and then returned the actual object stored in `_clients`. That meant the protection stopped at the dictionary lookup rather than at the object boundary. Callers like the UDP control plane, UDP data receiver, recording helpers, and HTTP client routes only read fields today, but they were all reading through a shared mutable reference whose lifetime extended beyond the lock. In other words, the registry was internally synchronized but still leaking unsynchronized mutable state through a public method.

The rest of the issue needed a narrower reading. `RuntimeHealthState` is still mutable and lock-free, but its writes remain part of single-threaded bootstrap and event-loop health reporting rather than a cross-thread race. `GPSTransportState` already uses immutable snapshot replacement, so readers see whole-state swaps instead of torn updates. The earlier `WsBroadcastService` and WebSocket connection-removal concerns were already addressed or based on incorrect call-chain assumptions. Because of that, broad locking changes would have been noise instead of a root-cause fix.

## Implementation

The core code change is in `apps/server/vibesensor/infra/runtime/registry.py`.

I introduced a frozen `ClientRecordSnapshot` dataclass that mirrors the public runtime-facing fields from `ClientRecord`. It intentionally excludes the private dedup bookkeeping fields because callers should never observe or depend on them. A small `_snapshot_record()` helper now copies the live record into that frozen value, and `ClientRegistry.get()` returns that snapshot. The rest of the registry’s internal update paths still operate on the mutable `ClientRecord` instances behind the lock, so the change stays at the boundary where mutable state escapes.

That boundary change surfaced one typing seam in `apps/server/vibesensor/shared/ports.py`. The `TrackedClient` protocol previously declared plain writable attributes. That was fine when the concrete implementation was the mutable `ClientRecord`, but a frozen snapshot is read-only by design. To keep the protocol aligned with how consumers actually use it, I converted `TrackedClient` to a read-only property protocol. Existing concrete types with dataclass fields still satisfy it structurally, while the protocol now models the intended contract more accurately: recording and runtime consumers need read access to client state, not permission to mutate it.

I deliberately did not change the broader runtime-health and GPS modules in this PR. The audit showed those claims do not represent active thread-safety bugs on the current tree, so locking them here would add complexity without closing a real defect. This keeps the PR small, reviewable, and directly tied to the confirmed registry leak.

## Tests and validation

I added a new focused module at `apps/server/tests/infra/runtime/test_registry_thread_safety.py` rather than extending the existing large registry omnibus. The new tests lock in the behavior change directly:

- `test_registry_get_returns_frozen_snapshot` verifies that `get()` now returns a `ClientRecordSnapshot` and that attempts to mutate it raise `FrozenInstanceError`.
- `test_registry_get_returns_point_in_time_snapshot` verifies that a previously returned snapshot does not change when the registry later updates the same client’s name and location.

Beyond those new focused tests, I ran the existing caller surfaces that rely on `registry.get()` so the snapshot contract was exercised where it matters:

- `pytest -q apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/infra/runtime/test_registry_thread_safety.py apps/server/tests/adapters/udp/test_udp_control_tx.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/infra/processing/test_sample_builder.py apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_recorder_runtime.py apps/server/tests/integration/test_exception_discipline.py apps/server/tests/integration/test_refactor_contract_regressions.py`
- `pytest -q apps/server/tests/infra/runtime/test_registry_thread_safety.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_recorder_runtime.py`
- `make lint`
- `make typecheck-backend`
- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests --skip-bootstrap`

All of those passed locally.

I also retried the required Docker validation with `docker compose build --pull`, but this environment still cannot reach a Docker daemon/socket, so local Docker smoke remains blocked exactly as it was for the preceding backend issues. GitHub CI will need to provide the final containerized signal again.

## Risks and tradeoffs

The main tradeoff is a small copy cost when `ClientRegistry.get()` is called. I accepted that because the goal here is to stop leaking mutable registry-owned state, and the callers already treat the result as a read model. Returning a frozen snapshot makes the contract explicit and makes the concurrency boundary easy to reason about. I considered expanding the fix into defensive locking for `RuntimeHealthState` or `GPSTransportState`, but the live audit showed that would be speculative hardening rather than a real bug fix. Keeping the PR bounded makes it clearer why each change exists and reduces the chance of introducing unrelated runtime behavior changes.
