### PR TITLE
Reduce runtime lock contention

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 import numpy as np
 
 from vibesensor.infra.processing.buffer_store import SignalBufferStore
@@ -117,6 +119,45 @@ def test_buffer_store_does_not_regress_last_t0_us_for_older_frame() -> None:
         buf = store.buffers[client_id]
         assert buf.last_t0_us == 1_000_000
         assert buf.samples_since_t0 == 6
+
+
+def test_buffer_store_evict_clients_does_not_hold_global_lock_while_waiting_on_client_lock() -> (
+    None
+):
+    store = SignalBufferStore(_config())
+    samples = np.ones((4, 3), dtype=np.float32)
+    store.ingest("keep", samples, sample_rate_hz=200)
+    store.ingest("evict", samples, sample_rate_hz=200)
+
+    with store.lock:
+        evict_lock = store._client_locks["evict"]
+        evict_lock.acquire()
+
+    finished = threading.Event()
+
+    def _run_evict() -> None:
+        store.evict_clients({"keep"})
+        finished.set()
+
+    thread = threading.Thread(target=_run_evict)
+    thread.start()
+    try:
+        for _ in range(50):
+            if store.lock.acquire(blocking=False):
+                store.lock.release()
+                break
+            threading.Event().wait(0.01)
+        else:
+            raise AssertionError(
+                "global store lock stayed held while eviction waited on client lock"
+            )
+    finally:
+        evict_lock.release()
+
+    thread.join(timeout=1.0)
+    assert finished.is_set()
+    assert "keep" in store.buffers
+    assert "evict" not in store.buffers
 
 
 def test_fft_params_uses_lru_eviction(monkeypatch) -> None:

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -232,9 +232,21 @@ class TestProcessingLoopMismatchDetection:
         control_plane = _StubControlPlane()
         loop, _state = _make_loop(processor=processor, control_plane=control_plane)
 
-        await loop._run_tick(sync_clock=True)
+        to_thread_calls: list[object] = []
+
+        async def fake_to_thread(func: object, /, *args: object, **kwargs: object) -> object:
+            to_thread_calls.append(func)
+            return func(*args, **kwargs)
+
+        with patch("asyncio.to_thread", fake_to_thread):
+            await loop._run_tick(sync_clock=True)
 
         assert control_plane.broadcast_calls == 1
+        assert len(to_thread_calls) == 2
+        assert getattr(to_thread_calls[0], "__self__", None) is control_plane
+        assert getattr(getattr(to_thread_calls[0], "__func__", None), "__name__", "") == (
+            "broadcast_sync_clock"
+        )
 
     @pytest.mark.asyncio
     async def test_sample_rate_mismatch_logged_once(self) -> None:

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -299,24 +299,21 @@ class SignalBufferStore:
             return result
 
     def evict_clients(self, keep_client_ids: set[str]) -> None:
+        stale_locks: list[RLock] = []
         with self.lock:
             stale_ids = [
                 client_id for client_id in self.buffers if client_id not in keep_client_ids
             ]
-            stale_locks: list[RLock] = []
             for client_id in stale_ids:
-                client_lock = self._client_locks.get(client_id)
-                if client_lock is None:
-                    continue
-                client_lock.acquire()
-                stale_locks.append(client_lock)
-            try:
-                for client_id in stale_ids:
-                    self.buffers.pop(client_id, None)
-                    self._client_locks.pop(client_id, None)
-            finally:
-                for client_lock in reversed(stale_locks):
-                    client_lock.release()
+                self.buffers.pop(client_id, None)
+                client_lock = self._client_locks.pop(client_id, None)
+                if client_lock is not None:
+                    stale_locks.append(client_lock)
+        # Wait out any in-flight users on the orphaned per-client locks without
+        # keeping the global store lock held across those waits.
+        for client_lock in stale_locks:
+            client_lock.acquire()
+            client_lock.release()
 
     def intake_stats(self) -> IntakeStatsPayload:
         with self.lock:

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -160,7 +160,7 @@ class ProcessingLoop:
         if sync_clock:
             try:
                 if self._control_plane is not None:
-                    self._control_plane.broadcast_sync_clock()
+                    await asyncio.to_thread(self._control_plane.broadcast_sync_clock)
             except Exception as exc:
                 raise ProcessingLoopError("sync_clock", exc) from exc
 


### PR DESCRIPTION
Closes #1191.

## Summary

This PR fixes the two still-real runtime locking problems from #1191: the processing loop was calling `broadcast_sync_clock()` synchronously on the async event loop, and `SignalBufferStore.evict_clients()` was keeping the global store lock held while it waited on per-client locks for stale clients. I started with a live code audit because the GitHub issue already noted that several of its original claims had gone stale. That audit held up: the `_live_start_mono_s` concern was already fixed, per-client buffer locking had already landed, and the `PostAnalysisWorker` thread-start path was real but negligible. The honest bounded fix was therefore limited to the processing-loop sync-clock call and stale-client eviction behavior.

The result is a small runtime-focused change set. `ProcessingLoop._run_tick()` now offloads sync-clock broadcasting through `asyncio.to_thread()`, matching the existing `compute_all` offload pattern in the same method. `SignalBufferStore.evict_clients()` now removes stale clients from the shared maps under the global lock and only then waits on the orphaned per-client locks, so the store no longer holds its global lock while blocked on stale-client cleanup. The tests were updated to cover both behaviors directly.

## Problem

The first issue lived in `apps/server/vibesensor/infra/runtime/processing_loop.py`. Every ~5 seconds, the tick loop decides whether it needs to sync clocks. Before this change, `_run_tick()` called `self._control_plane.broadcast_sync_clock()` directly inside the async tick. That method is synchronous and walks active registry clients while sending UDP packets. The operation is not huge, but it is still blocking work on the event loop thread. The code already uses `asyncio.to_thread()` later in the same method for `compute_all`, so sync-clock broadcasting stood out as the remaining synchronous hot-path call in the tick loop.

The second issue lived in `apps/server/vibesensor/infra/processing/buffer_store.py`. `evict_clients()` identified stale clients while holding the global store lock, then continued to hold that same lock while it acquired every stale client’s per-client `RLock`, removed the entries, and released the locks. That meant the global lock stayed live across all stale-client waits. Even though stale-client counts are usually small, the pattern amplified contention more than necessary and kept the shared store lock unavailable longer than needed.

The stale claims mattered here because they constrained scope. The older recorder `_live_start_mono_s` problem is already fixed, so there was no reason to reopen `RunRecorder`. Likewise, per-client buffer locking is already present in the buffer store, so this issue is not about reintroducing that work. Finally, the worker-thread creation path in `PostAnalysisWorker` still happens under a lock, but that path runs once per completed run rather than on the processing hot path, so changing it here would have been unrelated churn.

## Implementation

The processing-loop side is intentionally minimal. In `apps/server/vibesensor/infra/runtime/processing_loop.py`, the sync-clock branch now uses:

```python
await asyncio.to_thread(self._control_plane.broadcast_sync_clock)
```

That keeps the sequencing the same as before: sync-clock work still completes before registry reads, metric computation, and stale-client eviction proceed. The change only moves the blocking broadcaster call off the event loop thread, which is exactly the behavior this issue asked for.

The buffer-store change is in `apps/server/vibesensor/infra/processing/buffer_store.py`. The revised `evict_clients()` performs eviction in two phases:

1. While holding the global store lock, it computes the stale client IDs, removes those clients from `self.buffers`, and removes their per-client locks from `self._client_locks`, storing the removed locks in a temporary local list.
2. After releasing the global store lock, it acquires and immediately releases each orphaned per-client lock.

That second step is effectively a wait-for-in-flight-users barrier. Any code path that had already acquired a stale client lock before eviction can finish safely on the orphaned objects, while no new code path can discover those clients from the shared maps after step one. Most importantly, the global store lock is no longer held while eviction waits for those per-client lock users to drain.

I chose that structure instead of a broader lock-order refactor because it solves the actual contention problem without introducing a new global/per-client acquisition pattern. The store still removes shared-map state under the global lock, and it does not need to reacquire the global lock while holding a client lock. That keeps the change small and easy to reason about.

## Tests and validation

On the processing-loop side, `apps/server/tests/infra/runtime/test_processing_loop.py` now patches `asyncio.to_thread()` in `test_sync_clock_uses_control_plane_broadcaster` and asserts that the first offloaded function is the control-plane broadcaster. That verifies the new offload behavior directly instead of only asserting that the broadcaster was eventually called.

On the buffer-store side, `apps/server/tests/infra/processing/test_processing_components.py` gained a focused regression that pre-acquires a stale client lock, starts `evict_clients()` on another thread, and then asserts that the global store lock is still acquirable while eviction is blocked waiting on the stale client lock. That is the behavior the old implementation could not provide, and it directly guards the contention reduction this issue is about.

I validated the branch with:

- `pytest -q apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/infra/runtime/test_runtime.py`
- `make typecheck-backend`
- `make lint`
- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests --skip-bootstrap`

All of those passed locally.

As with the recent backend issues, I also retried the required Docker validation with `docker compose build --pull`, but this environment still cannot reach a Docker daemon/socket. So the local Docker smoke remains environment-blocked here, and GitHub CI will need to provide the final containerized signal again.

## Risks and tradeoffs

The main tradeoff is that sync-clock broadcasting now uses the same thread offload pattern as `compute_all`, which adds a small scheduling hop. That is intentional: the goal is to keep blocking registry/network work off the event loop, and the code already accepts the same pattern for metric computation.

For eviction, I avoided a more invasive redesign of the store’s lock helpers. The new orphaned-lock wait pattern is slightly more explicit than the previous in-lock cleanup, but it is also narrower and easier to verify. It reduces global-lock hold time without reopening the larger buffer-store architecture or changing eviction policy. That makes the PR a straightforward fix for the real contention surface rather than a speculative concurrency rewrite.
