### PR TITLE
Fix #1191 locking hot paths

### DIFF
--- a/apps/server/tests/infra/processing/test_processing.py
+++ b/apps/server/tests/infra/processing/test_processing.py
@@ -168,6 +168,41 @@ def test_ingest_other_client_not_blocked_by_unrelated_client_lock() -> None:
     assert done.is_set()
 
 
+def test_evict_clients_does_not_wait_on_stale_client_lock() -> None:
+    processor = SignalProcessor(
+        sample_rate_hz=800,
+        waveform_seconds=8,
+        waveform_display_hz=100,
+        fft_n=1024,
+        spectrum_max_hz=200,
+    )
+    samples = np.zeros((10, 3), dtype=np.float32)
+    evicted = Event()
+
+    processor.ingest("keep", samples, sample_rate_hz=800)
+    processor.ingest("stale", samples, sample_rate_hz=800)
+    with processor._store.lock:
+        stale_lock = processor._store._client_locks["stale"]
+    stale_lock.acquire()
+
+    def _evict() -> None:
+        processor.evict_clients({"keep"})
+        evicted.set()
+
+    worker = Thread(target=_evict)
+    worker.start()
+    try:
+        assert evicted.wait(timeout=0.2)
+    finally:
+        stale_lock.release()
+
+    worker.join(timeout=1.0)
+    assert evicted.is_set()
+    assert "keep" in processor._store.buffers
+    assert "stale" not in processor._store.buffers
+    assert "stale" not in processor._store._client_locks
+
+
 def test_ingest_not_blocked_during_compute() -> None:
     """Regression: ingest must stay responsive while compute_metrics runs in a thread.
 

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -237,6 +237,35 @@ class TestProcessingLoopMismatchDetection:
         assert control_plane.broadcast_calls == 1
 
     @pytest.mark.asyncio
+    async def test_sync_clock_offloads_broadcast_to_thread(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        processor = _StubProcessor()
+        control_plane = _StubControlPlane()
+        loop, _state = _make_loop(processor=processor, control_plane=control_plane)
+        to_thread_calls: list[tuple[object | None, str]] = []
+
+        async def fake_to_thread(func, /, *args, **kwargs):
+            to_thread_calls.append(
+                (
+                    getattr(func, "__self__", None),
+                    getattr(func, "__name__", type(func).__name__),
+                ),
+            )
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "vibesensor.infra.runtime.processing_loop.asyncio.to_thread",
+            fake_to_thread,
+        )
+
+        await loop._run_tick(sync_clock=True)
+
+        assert to_thread_calls[0] == (control_plane, "broadcast_sync_clock")
+        assert control_plane.broadcast_calls == 1
+
+    @pytest.mark.asyncio
     async def test_sample_rate_mismatch_logged_once(self) -> None:
         """Sample-rate mismatch for a client is recorded in state exactly once."""
         mismatched = _StubRecord(sample_rate_hz=400, frame_samples=1024)

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -303,20 +303,14 @@ class SignalBufferStore:
             stale_ids = [
                 client_id for client_id in self.buffers if client_id not in keep_client_ids
             ]
-            stale_locks: list[RLock] = []
             for client_id in stale_ids:
-                client_lock = self._client_locks.get(client_id)
-                if client_lock is None:
-                    continue
-                client_lock.acquire()
-                stale_locks.append(client_lock)
-            try:
-                for client_id in stale_ids:
-                    self.buffers.pop(client_id, None)
-                    self._client_locks.pop(client_id, None)
-            finally:
-                for client_lock in reversed(stale_locks):
-                    client_lock.release()
+                # Detach stale client state under the store lock only. Threads
+                # already working with a stale client's buffer can finish
+                # against the detached objects, while new lookups will either
+                # see no buffer or create a fresh one without being blocked by
+                # eviction waiting on that stale client's lock.
+                self.buffers.pop(client_id, None)
+                self._client_locks.pop(client_id, None)
 
     def intake_stats(self) -> IntakeStatsPayload:
         with self.lock:

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -160,7 +160,7 @@ class ProcessingLoop:
         if sync_clock:
             try:
                 if self._control_plane is not None:
-                    self._control_plane.broadcast_sync_clock()
+                    await asyncio.to_thread(self._control_plane.broadcast_sync_clock)
             except Exception as exc:
                 raise ProcessingLoopError("sync_clock", exc) from exc
 


### PR DESCRIPTION
## Summary
- offload sync-clock broadcasting off the processing event loop via `asyncio.to_thread()`
- simplify stale-client eviction so it detaches stale buffers and locks without waiting on per-client locks
- add focused regressions for both concurrency fixes

## Testing
- python3 -m pytest -q apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/infra/processing/test_processing.py
- make lint
- make typecheck-backend
- python3 -m pytest -q --tb=short apps/server/tests
- native `vibesensor-server` + `vibesensor-sim` smoke on http://127.0.0.1:8000

Closes #1191
