### PR TITLE
Fix #1192 SQLite persistence hardening

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
@@ -10,6 +10,10 @@ from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.types.run_schema import RunMetadata
 
 
+class _AbortTxn(BaseException):
+    pass
+
+
 def _metadata(run_id: str) -> RunMetadata:
     return RunMetadata.from_dict(
         {
@@ -43,6 +47,59 @@ def test_history_db_read_errors_clear_read_transaction(tmp_path: Path) -> None:
             with db._cursor(commit=False) as cur:
                 cur.execute("SELECT * FROM missing_table")
         assert not db._read_conn.in_transaction
+    finally:
+        db.close()
+
+
+def test_history_db_read_base_exception_clears_read_transaction(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    try:
+        db.create_run("run-read-abort", "2026-01-01T00:00:00Z", _metadata("run-read-abort"))
+        assert db._read_conn is not None
+        with pytest.raises(_AbortTxn):
+            with db._cursor(commit=False) as cur:
+                cur.execute("SELECT * FROM runs WHERE run_id = ?", ("run-read-abort",))
+                raise _AbortTxn
+        assert not db._read_conn.in_transaction
+        assert [run.run_id for run in db.list_runs()] == ["run-read-abort"]
+    finally:
+        db.close()
+
+
+def test_history_db_write_cursor_base_exception_rolls_back(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    try:
+        db.create_run("run-write-cursor", "2026-01-01T00:00:00Z", _metadata("run-write-cursor"))
+        with pytest.raises(_AbortTxn):
+            with db._cursor() as cur:
+                cur.execute(
+                    "UPDATE runs SET sample_count = 7 WHERE run_id = ?",
+                    ("run-write-cursor",),
+                )
+                raise _AbortTxn
+        assert not db._conn.in_transaction
+        run = db.get_run("run-write-cursor")
+        assert run is not None
+        assert run.sample_count == 0
+    finally:
+        db.close()
+
+
+def test_history_db_write_transaction_base_exception_rolls_back(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    try:
+        db.create_run("run-write-tx", "2026-01-01T00:00:00Z", _metadata("run-write-tx"))
+        with pytest.raises(_AbortTxn):
+            with db.write_transaction_cursor() as cur:
+                cur.execute(
+                    "UPDATE runs SET sample_count = 9 WHERE run_id = ?",
+                    ("run-write-tx",),
+                )
+                raise _AbortTxn
+        assert not db._conn.in_transaction
+        run = db.get_run("run-write-tx")
+        assert run is not None
+        assert run.sample_count == 0
     finally:
         db.close()
 

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -289,6 +289,8 @@ def test_startup_quick_check_logs_corruption(
         db._run_startup_quick_check()
     assert "quick_check reported corruption" in caplog.text
     assert "row 7 missing from index" in caplog.text
+    assert db.corruption_detected is True
+    assert db.corruption_details == "row 7 missing from index"
     db.close()
 
 
@@ -316,6 +318,43 @@ def test_startup_quick_check_reports_corruption_via_callback(
     monkeypatch.setattr(db, "_cursor", _fake_cursor)
     db._run_startup_quick_check()
     assert reported == ["row 7 missing from index"]
+    assert db.corruption_detected is True
+    db.close()
+
+
+def test_startup_quick_check_blocks_future_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-corrupt", "2026-01-01T00:00:00Z", _metadata("run-corrupt"))
+
+    class _FakeCursor:
+        def execute(self, sql: str) -> None:
+            assert sql == "PRAGMA quick_check"
+
+        def fetchall(self) -> list[tuple[str]]:
+            return [("row 7 missing from index",)]
+
+    original_cursor = db._cursor
+
+    @contextmanager
+    def _fake_cursor(*, commit: bool = True):
+        yield _FakeCursor()
+
+    monkeypatch.setattr(db, "_cursor", _fake_cursor)
+    db._run_startup_quick_check()
+    monkeypatch.setattr(db, "_cursor", original_cursor)
+
+    with pytest.raises(sqlite3.DatabaseError, match="Writes are disabled"):
+        db.append_samples("run-corrupt", [SensorFrame.from_dict({"i": 1})])
+    with pytest.raises(sqlite3.DatabaseError, match="Writes are disabled"):
+        db.finalize_run("run-corrupt", "2026-01-01T00:10:00Z")
+
+    run = db.get_run("run-corrupt")
+    assert run is not None
+    assert run.sample_count == 0
+    assert run.status.value == "recording"
     db.close()
 
 

--- a/apps/server/tests/app/test_container.py
+++ b/apps/server/tests/app/test_container.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from vibesensor.app import container as container_module
+
+
+def test_create_history_db_skips_stale_recovery_when_quick_check_marked_corrupted(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    recovered = {"called": False}
+    fake_db = SimpleNamespace(
+        corruption_detected=True,
+        recover_stale_recording_runs=lambda: recovered.__setitem__("called", True),
+    )
+
+    def _fake_history_db(_path: Path, *, corruption_reporter=None):
+        assert corruption_reporter is not None
+        return fake_db
+
+    monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
+    config = SimpleNamespace(
+        logging=SimpleNamespace(history_db_path=tmp_path / "history.db"),
+    )
+
+    result = container_module.create_history_db(
+        config,
+        corruption_reporter=lambda _details: None,
+    )
+
+    assert result is fake_db
+    assert recovered["called"] is False

--- a/apps/server/tests/use_cases/run/test_recorder_runtime.py
+++ b/apps/server/tests/use_cases/run/test_recorder_runtime.py
@@ -110,7 +110,7 @@ async def test_runtime_auto_stop_uses_to_thread(
 
 
 @pytest.mark.asyncio
-async def test_runtime_tick_holds_lock_during_build_and_append(
+async def test_runtime_tick_releases_lock_before_build_and_append(
     make_logger,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -139,5 +139,5 @@ async def test_runtime_tick_holds_lock_during_build_and_append(
     with pytest.raises(_StopLoop):
         await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
 
-    assert build_lock_owned == [True]
-    assert append_lock_owned == [True]
+    assert build_lock_owned == [False]
+    assert append_lock_owned == [False]

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -45,6 +45,7 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
     ) -> None:
         self.db_path = db_path
         self._corruption_reporter = corruption_reporter
+        self._corruption_details: str | None = None
         self._lock = RLock()
         self._read_lock = RLock()
         db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -101,12 +102,14 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
         with lock:
             if conn is None:
                 raise RuntimeError("HistoryDB is closed")
+            if commit:
+                self._assert_write_allowed()
             cur = conn.cursor()
             try:
                 yield cur
                 if commit:
                     conn.commit()
-            except sqlite3.Error:
+            except BaseException:
                 if conn.in_transaction:
                     conn.rollback()
                 raise
@@ -119,16 +122,40 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
         with self._lock:
             if self._conn is None:
                 raise RuntimeError("HistoryDB is closed")
+            self._assert_write_allowed()
             cur = self._conn.cursor()
             try:
                 cur.execute("BEGIN IMMEDIATE")
                 yield cur
                 self._conn.commit()
-            except sqlite3.Error:
-                self._conn.rollback()
+            except BaseException:
+                if self._conn.in_transaction:
+                    self._conn.rollback()
                 raise
             finally:
                 cur.close()
+
+    @property
+    def corruption_detected(self) -> bool:
+        return self._corruption_details is not None
+
+    @property
+    def corruption_details(self) -> str | None:
+        return self._corruption_details
+
+    def _assert_write_allowed(self) -> None:
+        if self._corruption_details is None:
+            return
+        raise sqlite3.DatabaseError(
+            "History DB quick_check reported corruption for "
+            f"{self.db_path}: {self._corruption_details}. Writes are disabled until "
+            "the database is repaired or replaced."
+        )
+
+    def _mark_corrupted(self, details: str) -> None:
+        self._corruption_details = details
+        if self._corruption_reporter is not None:
+            self._corruption_reporter(details)
 
     # -- schema ---------------------------------------------------------------
 
@@ -242,12 +269,12 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
             )
             raise
         if problems:
-            if self._corruption_reporter is not None:
-                self._corruption_reporter("; ".join(problems))
+            details = "; ".join(problems)
+            self._mark_corrupted(details)
             LOGGER.critical(
                 "History DB quick_check reported corruption for %s: %s",
                 self.db_path,
-                "; ".join(problems),
+                details,
             )
 
     # -- settings_snapshot persistence -----------------------------------------

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -73,6 +73,12 @@ def create_history_db(
         config.logging.history_db_path,
         corruption_reporter=corruption_reporter,
     )
+    if history_db.corruption_detected:
+        LOGGER.error(
+            "History DB corruption detected at startup; skipping stale-run recovery and "
+            "continuing with writes disabled until the DB is repaired.",
+        )
+        return history_db
     try:
         recovered_runs = history_db.recover_stale_recording_runs()
     except Exception:

--- a/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
@@ -67,25 +67,25 @@ def _flush_active_run_tick(
         if snapshot is None:
             return None, False
         live_start_mono_s = recorder._live_start_mono_s
-        timestamp_utc = utc_now_iso()
-        live_rows = recorder._sample_flush.build_sample_records(
-            run_id=snapshot.run_id,
-            t_s=max(0.0, time.monotonic() - live_start_mono_s),
-            timestamp_utc=timestamp_utc,
+    timestamp_utc = utc_now_iso()
+    live_rows = recorder._sample_flush.build_sample_records(
+        run_id=snapshot.run_id,
+        t_s=max(0.0, time.monotonic() - live_start_mono_s),
+        timestamp_utc=timestamp_utc,
+    )
+    if not isinstance(live_rows, list):
+        logger.warning(
+            "Metrics logger sample builder returned %s instead of list; dropping tick.",
+            type(live_rows).__name__,
         )
-        if not isinstance(live_rows, list):
-            logger.warning(
-                "Metrics logger sample builder returned %s instead of list; dropping tick.",
-                type(live_rows).__name__,
-            )
-            live_rows = []
-        no_data_timeout = recorder._sample_flush.append_records(
-            snapshot.run_id,
-            snapshot.start_time_utc,
-            snapshot.start_mono_s,
-            prebuilt_rows=live_rows,
-        )
-        return snapshot.run_id, no_data_timeout
+        live_rows = []
+    no_data_timeout = recorder._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        live_start_mono_s,
+        prebuilt_rows=live_rows,
+    )
+    return snapshot.run_id, no_data_timeout
 
 
 async def run_loop(recorder: RunRecorder, *, logger: logging.Logger) -> None:


### PR DESCRIPTION
Fixes #1192.

## Summary

This PR hardens the SQLite persistence path in three places that the issue identified as real defects, while deliberately not broadening the fix into the two concerns that the issue already scoped down as overstated. The main result is that startup corruption detection now behaves like a real circuit breaker instead of a log-only warning, transactional cursor helpers always roll back before re-raising unexpected failures, and the periodic recorder flush no longer keeps `recorder._lock` held across synchronous database work.

The change is intentionally conservative. I did not alter the schema, switch persistence strategies, or add new recovery mechanisms. Instead, I tightened the existing `HistoryDB` behavior so it fails safe, let the app continue booting in a degraded read-only state when corruption is already known, and reduced lock hold time in the live recorder path without changing the append/write protocol itself.

## Problem Being Solved

The first confirmed bug was in `HistoryDB._run_startup_quick_check()`. Before this PR, a failing `PRAGMA quick_check` only logged a critical error and called the existing corruption reporter callback. The `HistoryDB` instance still came up fully writable, which meant later `create_run`, `append_samples`, `finalize_run`, and similar writes could continue mutating a database that startup had already identified as corrupted.

The second confirmed bug was in the cursor context managers. Both `_cursor()` and `write_transaction_cursor()` only rolled back on `sqlite3.Error`. That meant non-SQLite failures raised inside the transaction body, including `BaseException` subclasses such as `KeyboardInterrupt` or `SystemExit`, could bypass rollback and leave a transaction open or half-applied.

The third confirmed bug was in `_flush_active_run_tick()`. The runtime tick held `recorder._lock` while building sample rows and then following the append path all the way into synchronous SQLite I/O. That unnecessarily serialized unrelated recorder operations behind disk latency.

## Implementation Approach

### 1. Make corruption detection a write circuit breaker

`HistoryDB` now stores corruption details internally when startup quick check finds problems. I added `_corruption_details`, `corruption_detected`, and `corruption_details`, plus a small `_assert_write_allowed()` helper that raises a clear `sqlite3.DatabaseError` explaining that writes are disabled until the database is repaired or replaced.

That helper is enforced centrally in both write-capable cursor helpers instead of being duplicated across individual persistence methods. As a result, the protection now applies consistently to all normal write flows that already depend on `_cursor(commit=True)` or `write_transaction_cursor()`, including run lifecycle changes, sample appends, and settings/client-name persistence.

I also kept the existing corruption reporter path intact rather than inventing a second health mechanism. The runtime already wires `HistoryDB(..., corruption_reporter=health_state.mark_db_corrupted)`, and the health snapshot path already exposes the corruption fields. This PR makes that existing plumbing meaningful by ensuring startup corruption actually changes the persistence behavior.

### 2. Let startup continue in degraded read-only mode

Once writes are blocked after corruption detection, the next startup behavior matters. `create_history_db()` previously always called `recover_stale_recording_runs()` immediately after constructing `HistoryDB`. That recovery path is a write operation, so after enabling the circuit breaker it would have failed startup outright on an already-corrupted database.

To preserve the degraded-health behavior instead of turning corruption into a total boot failure, `create_history_db()` now checks `history_db.corruption_detected` and skips stale-run recovery when the DB is already known bad. The app can still start, the health endpoint can still report the corruption state, and operators now get a functioning service surface that is read-only instead of a server that keeps writing into corruption or crashes during bootstrap.

### 3. Roll back on `BaseException`, then re-raise

Both transaction helpers now catch `BaseException` rather than only `sqlite3.Error`, roll back when the connection is still in a transaction, and then re-raise the original failure. This preserves the repository’s exception-discipline goal: programming bugs still propagate and are not silently swallowed, but they no longer skip cleanup.

I intentionally did not add broad fallback logging or silent recovery here. The behavior is still fail-fast; it is just fail-fast after leaving the database connection in a clean state.

### 4. Release the recorder lock before synchronous DB work

`_flush_active_run_tick()` still snapshots the active run state and the live-start monotonic timestamp while `recorder._lock` is held, which preserves the repository’s static guard and the intended snapshot invariant. The expensive work now happens after the lock is released: timestamp generation, sample-row building, and the append path into `HistoryDB`.

I also made sure the same captured `live_start_mono_s` value is used consistently for both `t_s` calculation and the later append call, so the tick carries one coherent start-time snapshot through the whole flush.

## Tests and Validation

I extended the focused persistence and runtime coverage instead of relying only on existing broad tests.

`test_history_db_connections.py` now verifies that read cursors, normal write cursors, and explicit write transactions all roll back cleanly on a custom `BaseException` subclass while preserving connection usability.

`test_history_db_lifecycle.py` now verifies that startup corruption sets the new corruption state, exposes the stored details, and blocks subsequent writes with a clear database error.

`test_container.py` was added to cover the startup orchestration change, specifically that `create_history_db()` skips stale-run recovery when quick check has already marked the database corrupted.

`test_recorder_runtime.py` now asserts the opposite of the old behavior: the recorder lock must not be owned during sample building or append work.

Validation run locally:

- `python -m pytest -q` on the focused issue tests: `51 passed`
- `make lint`
- `make typecheck-backend`
- `python -m pytest -q --tb=short apps/server/tests` → `5710 passed, 5 skipped, 1 xpassed`

I reran the full backend validation after a small review follow-up in the recorder tick path to make sure the final committed state, not just the initial patch, was green.

For runtime smoke, the documented Docker path still could not run in this environment because the Docker daemon socket is unavailable. I repeated the repo’s native fallback instead: started `vibesensor-server` with `apps/server/config.dev.yaml`, confirmed `/api/health` reported `ready`, ran `vibesensor-sim` with 3 clients, verified connected clients rose to 3 during the burst, then verified connected clients aged back down to 0 after the simulator stopped and the stale timeout elapsed.

## Risks, Tradeoffs, and Out-of-Scope Items

The main tradeoff is that a corrupted history database now becomes intentionally read-only instead of “best effort.” That is the safer behavior and matches the issue’s goal, but it means operators must repair or replace the DB instead of hoping writes keep working.

I did not add automatic corruption repair, new health schemas, or any refactor of the mixin structure. I also did not change WAL/read-connection behavior beyond rollback cleanup because the issue’s own verification already showed the claimed read-after-write hazard was overstated.
