### PR TITLE
Fix #1193 migration safety and rollback resilience

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "fastapi>=0.111,<1",
   "uvicorn[standard]>=0.30,<1",
   "numpy>=1.26,<2",
+  "packaging>=24,<25",
   "PyYAML>=6,<7",
   "reportlab>=4,<5",
   "websockets>=12,<16",

--- a/apps/server/tests/adapters/persistence/history_db/test_schema_migration.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_schema_migration.py
@@ -232,6 +232,104 @@ CREATE TABLE client_names (
     conn.close()
 
 
+def _create_v10_database(
+    db_path: Path,
+    *,
+    analysis_json: str | None = None,
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """\
+PRAGMA user_version = 10;
+
+CREATE TABLE runs (
+    run_id                  TEXT PRIMARY KEY,
+    case_id                 TEXT,
+    status                  TEXT NOT NULL DEFAULT 'recording'
+                            CHECK (status IN ('recording', 'analyzing', 'complete', 'error')),
+    start_time_utc          TEXT NOT NULL,
+    end_time_utc            TEXT,
+    metadata_json           TEXT NOT NULL,
+    analysis_json           TEXT,
+    error_message           TEXT,
+    sample_count            INTEGER NOT NULL DEFAULT 0,
+    created_at              TEXT NOT NULL,
+    analysis_started_at     TEXT,
+    analysis_completed_at   TEXT
+);
+
+CREATE TABLE samples_v2 (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id                TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+    timestamp_utc         TEXT,
+    t_s                   REAL,
+    client_id             TEXT,
+    client_name           TEXT,
+    location              TEXT,
+    sample_rate_hz        INTEGER,
+    speed_kmh             REAL,
+    gps_speed_kmh         REAL,
+    speed_source          TEXT,
+    engine_rpm            REAL,
+    engine_rpm_source     TEXT,
+    gear                  REAL,
+    final_drive_ratio     REAL,
+    accel_x_g             REAL,
+    accel_y_g             REAL,
+    accel_z_g             REAL,
+    dominant_freq_hz      REAL,
+    dominant_axis         TEXT,
+    vibration_strength_db REAL,
+    strength_bucket       TEXT,
+    strength_peak_amp_g   REAL,
+    strength_floor_amp_g  REAL,
+    frames_dropped_total  INTEGER DEFAULT 0,
+    queue_overflow_drops  INTEGER DEFAULT 0,
+    top_peaks             TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_samples_v2_run_id ON samples_v2(run_id);
+CREATE INDEX IF NOT EXISTS idx_samples_v2_run_time ON samples_v2(run_id, t_s);
+
+CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+CREATE INDEX IF NOT EXISTS idx_runs_created_at ON runs(created_at);
+
+CREATE TABLE settings_snapshot (
+    id          INTEGER PRIMARY KEY CHECK(id = 1),
+    value_json  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE TABLE client_names (
+    client_id   TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+"""
+    )
+    if analysis_json is not None:
+        conn.execute(
+            "INSERT INTO runs ("
+            "run_id, case_id, status, start_time_utc, end_time_utc, metadata_json, "
+            "analysis_json, created_at, analysis_started_at, analysis_completed_at"
+            ") "
+            "VALUES (?, ?, 'complete', ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "legacy-run",
+                "case-1",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:05:00Z",
+                '{"source":"legacy"}',
+                analysis_json,
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:05:01Z",
+                "2026-01-01T00:05:02Z",
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
 # -- HistoryDB integration tests ---------------------------------------------
 
 
@@ -395,7 +493,7 @@ def test_historydb_migrates_v9_empty_settings_kv(tmp_path: Path) -> None:
 
 
 def test_historydb_v8_migrates_through_v9_to_v10(tmp_path: Path) -> None:
-    """v8 databases chain-migrate through v9 (case_id) to v10 (settings_snapshot)."""
+    """v8 databases chain-migrate through v9/v10 to current schema."""
     db_path = tmp_path / "history.db"
     _create_v8_database(db_path, analysis_json='{"findings": [], "top_causes": [], "warnings": []}')
 
@@ -415,6 +513,93 @@ def test_historydb_v8_migrates_through_v9_to_v10(tmp_path: Path) -> None:
     assert "settings_snapshot" in tables
     assert "settings_kv" not in tables
     db.close()
+
+
+def test_historydb_v8_chain_migration_creates_step_backups(tmp_path: Path) -> None:
+    db_path = tmp_path / "history.db"
+    _create_v8_database(db_path, analysis_json='{"findings": [], "top_causes": [], "warnings": []}')
+
+    db = HistoryDB(db_path)
+    db.close()
+
+    backup_versions = {
+        8: tmp_path / "history.bak-v8",
+        9: tmp_path / "history.bak-v9",
+        10: tmp_path / "history.bak-v10",
+    }
+    for version, backup_path in backup_versions.items():
+        assert backup_path.exists()
+        conn = sqlite3.connect(str(backup_path))
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == version
+        finally:
+            conn.close()
+
+
+def test_historydb_migrates_v10_analysis_json_to_versioned_storage(tmp_path: Path) -> None:
+    db_path = tmp_path / "history.db"
+    _create_v10_database(
+        db_path,
+        analysis_json='{"findings": [], "top_causes": [], "warnings": []}',
+    )
+
+    db = HistoryDB(db_path)
+    try:
+        run = db.get_run("legacy-run")
+        assert run is not None
+        assert run.analysis == {"findings": [], "top_causes": [], "warnings": []}
+    finally:
+        db.close()
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        analysis_json = conn.execute(
+            "SELECT analysis_json FROM runs WHERE run_id = ?",
+            ("legacy-run",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    backup = tmp_path / "history.bak-v10"
+    assert version == SCHEMA_VERSION
+    assert '"_schema_version": 1' in analysis_json
+    assert backup.exists()
+
+
+def test_historydb_restores_backup_when_v10_migration_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "history.db"
+    _create_v10_database(
+        db_path,
+        analysis_json='{"findings": [], "top_causes": [], "warnings": []}',
+    )
+
+    def _broken(self: HistoryDB) -> None:
+        with self._cursor() as cur:
+            cur.execute("UPDATE runs SET analysis_json = NULL WHERE run_id = ?", ("legacy-run",))
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(HistoryDB, "_migrate_v10_to_v11_persisted_analysis_version", _broken)
+
+    with pytest.raises(RuntimeError, match="restored backup"):
+        HistoryDB(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        analysis_json = conn.execute(
+            "SELECT analysis_json FROM runs WHERE run_id = ?",
+            ("legacy-run",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert version == 10
+    assert analysis_json == '{"findings": [], "top_causes": [], "warnings": []}'
+    assert (tmp_path / "history.bak-v10").exists()
 
 
 def test_historydb_newer_version_raises(tmp_path: Path) -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
@@ -153,10 +153,29 @@ def test_store_analysis_persists_summary_directly(
     raw = row[0]
     # No envelope — summary stored directly
     assert '"summary"' not in raw
+    assert '"_schema_version": 1' in raw
     assert '"lang"' in raw
     run = db.get_run("r1")
     assert run is not None
     assert run.analysis == {"lang": "en", "findings": []}
+    db.close()
+
+
+def test_get_run_marks_unknown_analysis_storage_version_corrupt(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
+    db.finalize_run("r1", "2026-01-01T00:01:00Z")
+
+    with db._cursor() as cur:
+        cur.execute(
+            "UPDATE runs SET analysis_json = ? WHERE run_id = ?",
+            ('{"_schema_version": 99, "findings": []}', "r1"),
+        )
+
+    run = db.get_run("r1")
+    assert run is not None
+    assert run.analysis is None
+    assert run.analysis_corrupt is True
     db.close()
 
 

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -106,6 +106,26 @@ async def test_snapshot_for_rollback_writes_checksum_metadata(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_snapshot_for_rollback_keeps_latest_previous_wheel_as_secondary_fallback(
+    tmp_path: Path,
+) -> None:
+    installer, _commands, _tracker = _make_installer(tmp_path)
+    rollback_dir = tmp_path / "rollback"
+    rollback_dir.mkdir()
+    _build_fake_wheel(rollback_dir / "vibesensor-2025.6.12-py3-none-any.whl", version="2025.6.12")
+    _build_fake_wheel(rollback_dir / "vibesensor-2025.6.13-py3-none-any.whl", version="2025.6.13")
+
+    with patch("vibesensor.__version__", "2025.6.14"):
+        assert await installer.snapshot_for_rollback() is True
+
+    wheels = sorted(path.name for path in rollback_dir.glob("vibesensor-*.whl"))
+    assert wheels == [
+        "vibesensor-2025.6.13-py3-none-any.whl",
+        "vibesensor-2025.6.14-py3-none-any.whl",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_snapshot_for_rollback_fails_when_metadata_write_fails(tmp_path: Path) -> None:
     installer, _commands, tracker = _make_installer(tmp_path)
     rollback_dir = tmp_path / "rollback"
@@ -180,6 +200,61 @@ async def test_rollback_without_metadata_uses_valid_newest_wheel(tmp_path: Path)
     assert any(
         "Rollback metadata missing; falling back to newest rollback wheel without checksum pin"
         in line
+        for line in tracker.status.log_tail
+    )
+
+
+@pytest.mark.asyncio
+async def test_rollback_missing_primary_wheel_uses_secondary_fallback(tmp_path: Path) -> None:
+    installer, commands, tracker = _make_installer(tmp_path)
+    rollback_dir = tmp_path / "rollback"
+    rollback_dir.mkdir()
+    older_wheel = rollback_dir / "vibesensor-2025.6.13-py3-none-any.whl"
+    _build_fake_wheel(older_wheel, version="2025.6.13")
+    (rollback_dir / "rollback_snapshot.json").write_text(
+        json.dumps(
+            {
+                "version": "2025.6.14",
+                "wheel_name": "vibesensor-2025.6.14-py3-none-any.whl",
+                "sha256": "1" * 64,
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    commands.set_response("from vibesensor import __version__", 0, "2025.6.13\n", "")
+
+    assert await installer.rollback() is True
+    assert any(str(older_wheel) in " ".join(call[0]) for call in commands.calls)
+    assert any("Using fallback rollback wheel" in line for line in tracker.status.log_tail)
+
+
+@pytest.mark.asyncio
+async def test_rollback_invalid_primary_wheel_uses_secondary_fallback(tmp_path: Path) -> None:
+    installer, commands, tracker = _make_installer(tmp_path)
+    rollback_dir = tmp_path / "rollback"
+    rollback_dir.mkdir()
+    newer_wheel = rollback_dir / "vibesensor-2025.6.14-py3-none-any.whl"
+    older_wheel = rollback_dir / "vibesensor-2025.6.13-py3-none-any.whl"
+    _build_fake_wheel(newer_wheel, version="2025.6.14")
+    _build_fake_wheel(older_wheel, version="2025.6.13")
+    (rollback_dir / "rollback_snapshot.json").write_text(
+        json.dumps(
+            {
+                "version": "2025.6.14",
+                "wheel_name": newer_wheel.name,
+                "sha256": "0" * 64,
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    commands.set_response("from vibesensor import __version__", 0, "2025.6.13\n", "")
+
+    assert await installer.rollback() is True
+    assert any(str(older_wheel) in " ".join(call[0]) for call in commands.calls)
+    assert any(
+        "Primary rollback snapshot could not be used; trying older rollback wheel" in line
         for line in tracker.status.log_tail
     )
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -7,7 +7,10 @@ sample-I/O, and query helpers live in focused sibling modules.
 from __future__ import annotations
 
 import logging
+import os
+import shutil
 import sqlite3
+import tempfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -24,6 +27,7 @@ from vibesensor.shared.boundaries.settings_snapshot_codec import settings_snapsh
 from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import is_json_object
+from vibesensor.shared.types.persisted_analysis import PERSISTED_ANALYSIS_SCHEMA_VERSION
 from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload
 
 # Re-export for public API.
@@ -32,6 +36,8 @@ __all__ = ["HistoryDB"]
 LOGGER = logging.getLogger(__name__)
 
 _CASE_ID_MIGRATION_SOURCE_VERSION = 8
+_SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION = 9
+_PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION = 10
 
 
 class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDBQueryMixin):
@@ -163,9 +169,7 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
         with self._cursor() as cur:
             cur.executescript(SCHEMA_SQL)
 
-        with self._cursor(commit=False) as cur:
-            cur.execute("PRAGMA user_version")
-            version = cur.fetchone()[0]
+        version = self._schema_version()
 
         if version == 0:
             # Check for legacy schema_meta table (pre-v5 databases).
@@ -191,18 +195,109 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
                 f"History DB schema version {version} is newer than "
                 f"supported {SCHEMA_VERSION}. Cannot downgrade.",
             )
-        if version == _CASE_ID_MIGRATION_SOURCE_VERSION:
-            self._migrate_v8_to_v9_case_id()
-            version = 9
-        if version == 9:
-            self._migrate_v9_to_v10_settings_table()
-            return
-        msg = (
-            f"Database schema v{version} is incompatible with "
-            f"current v{SCHEMA_VERSION}. "
-            f"Delete the database file at {self.db_path} to recreate it."
+        while version < SCHEMA_VERSION:
+            migration = self._migration_step(version)
+            if migration is None:
+                msg = (
+                    f"Database schema v{version} is incompatible with "
+                    f"current v{SCHEMA_VERSION}. "
+                    f"Delete the database file at {self.db_path} to recreate it."
+                )
+                raise RuntimeError(msg)
+            next_version, handler = migration
+            backup_path = self._create_migration_backup(version)
+            try:
+                handler()
+                actual_version = self._schema_version()
+                if actual_version != next_version:
+                    raise RuntimeError(
+                        "History DB migration "
+                        f"v{version}→v{next_version} completed without updating "
+                        f"PRAGMA user_version (found v{actual_version})"
+                    )
+            except BaseException as exc:
+                self._restore_migration_backup(backup_path)
+                raise RuntimeError(
+                    "History DB migration "
+                    f"v{version}→v{next_version} failed; restored backup from {backup_path}"
+                ) from exc
+            version = next_version
+
+    def _schema_version(self) -> int:
+        with self._cursor(commit=False) as cur:
+            cur.execute("PRAGMA user_version")
+            row = cur.fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def _migration_step(self, version: int) -> tuple[int, Callable[[], None]] | None:
+        steps: tuple[tuple[int, int, Callable[[], None]], ...] = (
+            (
+                _CASE_ID_MIGRATION_SOURCE_VERSION,
+                _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION,
+                self._migrate_v8_to_v9_case_id,
+            ),
+            (
+                _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION,
+                _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION,
+                self._migrate_v9_to_v10_settings_table,
+            ),
+            (
+                _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION,
+                SCHEMA_VERSION,
+                self._migrate_v10_to_v11_persisted_analysis_version,
+            ),
         )
-        raise RuntimeError(msg)
+        for from_version, to_version, handler in steps:
+            if from_version == version:
+                return to_version, handler
+        return None
+
+    def _migration_backup_path(self, version: int) -> Path:
+        return self.db_path.with_suffix(f".bak-v{version}")
+
+    def _create_migration_backup(self, version: int) -> Path:
+        if self._conn is None:
+            raise RuntimeError("HistoryDB is closed")
+        if str(self.db_path) == ":memory:":
+            raise RuntimeError("Cannot create migration backup for in-memory HistoryDB")
+        backup_path = self._migration_backup_path(version)
+        fd, temp_path_text = tempfile.mkstemp(
+            prefix=f"{backup_path.name}.",
+            suffix=".tmp",
+            dir=backup_path.parent,
+        )
+        os.close(fd)
+        temp_path = Path(temp_path_text)
+        backup_conn = sqlite3.connect(temp_path)
+        try:
+            backup_conn.execute("PRAGMA journal_mode=DELETE")
+            self._conn.backup(backup_conn)
+        finally:
+            backup_conn.close()
+            Path(temp_path_text).chmod(0o600)
+        temp_path.replace(backup_path)
+        LOGGER.warning(
+            "Created pre-migration backup for %s at %s",
+            self.db_path,
+            backup_path,
+        )
+        return backup_path
+
+    def _restore_migration_backup(self, backup_path: Path) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+        if self._read_conn is not None:
+            self._read_conn.close()
+            self._read_conn = None
+        Path(f"{self.db_path}-wal").unlink(missing_ok=True)
+        Path(f"{self.db_path}-shm").unlink(missing_ok=True)
+        shutil.copy2(backup_path, self.db_path)
+        LOGGER.error(
+            "Restored History DB backup after migration failure: %s -> %s",
+            backup_path,
+            self.db_path,
+        )
 
     @staticmethod
     def _has_runs_column(cur: sqlite3.Cursor, column_name: str) -> bool:
@@ -254,6 +349,31 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
                 "WHERE key = 'settings_snapshot'"
             )
             cur.execute("DROP TABLE IF EXISTS settings_kv")
+            cur.execute(
+                f"PRAGMA user_version = {_PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION}"
+            )
+
+    def _migrate_v10_to_v11_persisted_analysis_version(self) -> None:
+        LOGGER.info("Migrating history DB at %s from schema v10 to v11", self.db_path)
+        with self._cursor() as cur:
+            cur.execute("SELECT run_id, analysis_json FROM runs WHERE analysis_json IS NOT NULL")
+            updates: list[tuple[str, str]] = []
+            for run_id, analysis_json in cur.fetchall():
+                parsed_analysis = safe_json_loads(
+                    analysis_json,
+                    context=f"run {run_id} analysis during schema migration",
+                )
+                if not is_json_object(parsed_analysis):
+                    continue
+                if parsed_analysis.get("_schema_version") == PERSISTED_ANALYSIS_SCHEMA_VERSION:
+                    continue
+                parsed_analysis["_schema_version"] = PERSISTED_ANALYSIS_SCHEMA_VERSION
+                updates.append((safe_json_dumps(parsed_analysis), str(run_id)))
+            if updates:
+                cur.executemany(
+                    "UPDATE runs SET analysis_json = ? WHERE run_id = ?",
+                    updates,
+                )
             cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
     def _run_startup_quick_check(self) -> None:

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -121,7 +121,15 @@ class _HistoryDBQueryMixin:
         if analysis_json:
             parsed_analysis = safe_json_loads(analysis_json, context=f"run {run_id} analysis")
             if is_json_object(parsed_analysis):
-                analysis = PersistedAnalysis.from_json_object(parsed_analysis)
+                try:
+                    analysis = PersistedAnalysis.from_storage_json_object(parsed_analysis)
+                except ValueError:
+                    LOGGER.warning(
+                        "get_run: analysis for run %s used an unsupported storage schema version",
+                        run_id,
+                        exc_info=True,
+                    )
+                    analysis_corrupt = True
             else:
                 analysis_corrupt = True
         return StoredHistoryRun(

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -196,7 +196,7 @@ class _HistoryDBRunLifecycleMixin:
                 "analysis_completed_at = ?, end_time_utc = COALESCE(end_time_utc, ?) "
                 "WHERE run_id = ?",
                 (
-                    safe_json_dumps(summary_payload),
+                    safe_json_dumps(analysis.to_storage_json_object()),
                     now,
                     now,
                     run_id,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
@@ -7,7 +7,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS runs (

--- a/apps/server/vibesensor/shared/types/persisted_analysis.py
+++ b/apps/server/vibesensor/shared/types/persisted_analysis.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 
 from vibesensor.shared.types.json_types import JsonObject
 
+PERSISTED_ANALYSIS_SCHEMA_VERSION = 1
+_STORAGE_SCHEMA_VERSION_KEY = "_schema_version"
+
 
 @dataclass(frozen=True, slots=True)
 class PersistedAnalysis(Mapping[str, object]):
@@ -19,8 +22,21 @@ class PersistedAnalysis(Mapping[str, object]):
     def from_json_object(cls, payload: JsonObject) -> PersistedAnalysis:
         return cls(_payload=deepcopy(payload))
 
+    @classmethod
+    def from_storage_json_object(cls, payload: JsonObject) -> PersistedAnalysis:
+        normalized = deepcopy(payload)
+        raw_version = normalized.pop(_STORAGE_SCHEMA_VERSION_KEY, 0)
+        if raw_version not in (0, PERSISTED_ANALYSIS_SCHEMA_VERSION):
+            raise ValueError(f"Unsupported persisted analysis schema version: {raw_version!r}")
+        return cls(_payload=normalized)
+
     def to_json_object(self) -> JsonObject:
         return deepcopy(self._payload)
+
+    def to_storage_json_object(self) -> JsonObject:
+        payload = self.to_json_object()
+        payload[_STORAGE_SCHEMA_VERSION_KEY] = PERSISTED_ANALYSIS_SCHEMA_VERSION
+        return payload
 
     def __getitem__(self, key: str) -> object:
         return self._payload[key]

--- a/apps/server/vibesensor/use_cases/updates/installer.py
+++ b/apps/server/vibesensor/use_cases/updates/installer.py
@@ -164,36 +164,56 @@ class UpdateInstaller:
             self._tracker.add_issue("installing", "No rollback wheel available")
             return False
 
-        wheel: Path
+        wheel: Path | None = None
         expected_version = ""
-        expected_sha256: str | None = None
+        candidates: list[tuple[Path, str, str | None]] = []
         if metadata is not None:
-            wheel = self._config.rollback_dir / metadata.wheel_name
-            expected_version = metadata.version
-            expected_sha256 = metadata.sha256
-            if not wheel.is_file():
-                self._tracker.add_issue(
-                    "installing",
-                    "Rollback snapshot wheel is missing",
-                    f"metadata expected {wheel}",
-                )
-                return False
+            primary_wheel = self._config.rollback_dir / metadata.wheel_name
+            candidates.append((primary_wheel, metadata.version, metadata.sha256))
+            for fallback_wheel in rollback_wheels:
+                if fallback_wheel.name == metadata.wheel_name:
+                    continue
+                wheel_parts = fallback_wheel.stem.split("-")
+                fallback_version = wheel_parts[1] if len(wheel_parts) >= 2 else ""
+                candidates.append((fallback_wheel, fallback_version, None))
         else:
-            wheel = rollback_wheels[0]
-            wheel_parts = wheel.stem.split("-")
-            expected_version = wheel_parts[1] if len(wheel_parts) >= 2 else ""
             self._tracker.log(
                 "Rollback metadata missing; falling back to newest "
                 "rollback wheel without checksum pin",
             )
+            for fallback_wheel in rollback_wheels:
+                wheel_parts = fallback_wheel.stem.split("-")
+                fallback_version = wheel_parts[1] if len(wheel_parts) >= 2 else ""
+                candidates.append((fallback_wheel, fallback_version, None))
 
-        if not self._wheel_validator.validate_wheel(
-            wheel,
-            phase="installing",
-            context="Rollback wheel",
-            fatal=False,
-            expected_sha256=expected_sha256,
-        ):
+        for idx, (candidate_wheel, candidate_version, candidate_sha256) in enumerate(candidates):
+            if not candidate_wheel.is_file():
+                if idx == 0 and metadata is not None:
+                    self._tracker.add_issue(
+                        "installing",
+                        "Rollback snapshot wheel is missing",
+                        f"metadata expected {candidate_wheel}",
+                    )
+                continue
+            context = "Rollback wheel" if idx == 0 else "Fallback rollback wheel"
+            if not self._wheel_validator.validate_wheel(
+                candidate_wheel,
+                phase="installing",
+                context=context,
+                fatal=False,
+                expected_sha256=candidate_sha256,
+            ):
+                if idx == 0 and len(candidates) > 1:
+                    self._tracker.log(
+                        "Primary rollback snapshot could not be used; trying older rollback wheel"
+                    )
+                continue
+            if idx > 0:
+                self._tracker.log(f"Using fallback rollback wheel {candidate_wheel.name}")
+            wheel = candidate_wheel
+            expected_version = candidate_version
+            break
+        if wheel is None:
             return False
 
         venv_python = reinstall_python_executable(self._config.repo)

--- a/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.request import Request, urlopen
 
+from packaging.version import Version
+
 from vibesensor.shared.constants.github import GITHUB_REPO
 from vibesensor.shared.types.json_types import JsonValue, is_json_array, is_json_object
 
@@ -304,8 +306,6 @@ class ServerReleaseFetcher(GitHubAPIClient):
         # Guard against suggesting downgrades: compare versions so that only
         # genuinely newer releases are reported.
         try:
-            from packaging.version import Version
-
             if Version(release.version) <= Version(current_version):
                 LOGGER.info(
                     "Latest release %s is not newer than current %s; skipping",
@@ -313,9 +313,8 @@ class ServerReleaseFetcher(GitHubAPIClient):
                     current_version,
                 )
                 return None
-        except (ImportError, ValueError):
-            # If packaging is unavailable or versions are unparseable,
-            # fall through and treat any difference as an update.
+        except ValueError:
+            # If versions are unparseable, fall through and treat any difference as an update.
             LOGGER.warning(
                 "Could not compare versions %r vs %r; treating as update",
                 release.version,

--- a/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
@@ -13,6 +13,7 @@ from vibesensor.use_cases.updates.status import UpdateStatusTracker
 __all__ = ["RollbackSnapshotMetadata", "RollbackSnapshotStore"]
 
 _ROLLBACK_METADATA_FILE = "rollback_snapshot.json"
+_ROLLBACK_WHEEL_KEEP_LIMIT = 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,8 +72,16 @@ class RollbackSnapshotStore:
         )
 
     def prune_wheels(self, *, keep_name: str) -> None:
-        for old_wheel in self.rollback_wheels():
-            if old_wheel.name != keep_name:
+        wheels = self.rollback_wheels()
+        keep_names = {keep_name}
+        for old_wheel in wheels:
+            if old_wheel.name == keep_name:
+                continue
+            if len(keep_names) >= _ROLLBACK_WHEEL_KEEP_LIMIT:
+                break
+            keep_names.add(old_wheel.name)
+        for old_wheel in wheels:
+            if old_wheel.name not in keep_names:
                 old_wheel.unlink(missing_ok=True)
 
     def load_metadata(self) -> RollbackSnapshotMetadata | None:


### PR DESCRIPTION
Closes #1193.

## Summary

This PR hardens the migration and update path around the concrete risks called out in #1193: the inline schema-upgrade ladder in `HistoryDB`, the absence of pre-migration backups, the single retained rollback wheel, unversioned persisted-analysis storage, and the optional `packaging` dependency used for release version comparison. The scope stays intentionally narrow. I did not introduce a second migration framework, API versioning, or config-version infrastructure because the issue itself distinguishes those as lower-priority maturity gaps rather than active bugs. Instead, this change focuses on the parts that can lose data, leave a device without a viable rollback artifact, or silently accept persistence formats that have become incompatible.

## Problem

Before this change, schema upgrades in `apps/server/vibesensor/adapters/persistence/history_db/__init__.py` were expressed as a hardcoded `if/elif` ladder that explicitly knew about `v8 -> v9` and `v9 -> v10`. Older versions failed with a runtime error instructing the operator to delete the database. That was already brittle from a maintenance perspective, but the more serious problem was safety: upgrades executed directly against the live SQLite file with no backup and no restore path. A mid-migration failure could leave the database in a partially mutated state.

The updater had a related resilience gap. Rollback wheel pruning effectively reduced the retained rollback set to a single artifact. If that wheel was missing or invalid when rollback was needed, there was no second local candidate to try. Persisted analysis had a different versioning issue: `analysis_json` rows were stored as plain JSON objects without any storage schema marker, so the read path had no reliable way to tell whether it understood the format it was decoding. Finally, the release fetcher treated `packaging` as optional even though it was the only robust version comparison path.

## Implementation approach

I kept the migration implementation in the existing `HistoryDB` module rather than introducing dynamic migration discovery or a separate package. The goal here was to remove the hardcoded inline chain and add failure safety without adding infrastructure that the rest of the codebase does not need yet. The resulting structure is a small ordered migration-step runner that makes future schema bumps additive and testable while preserving the current module boundaries.

The migration runner now executes explicit version-to-version steps in order until the database reaches `SCHEMA_VERSION = 11`. Before each step, it creates a backup of the current SQLite file using SQLite's backup API. If a migration step raises, the code restores the original database from that backup and then re-raises the failure. This gives the code a bounded rollback mechanism for migration failures without relying on “delete the DB and start over.” I kept the backups version-specific so operators and tests can tell which pre-step state was preserved.

## Main code changes

### History DB migration safety

`HistoryDB._ensure_schema()` now relies on an ordered migration list instead of a hand-written inline version ladder. The schema version moved from `10` to `11`. Existing `v8 -> v9` and `v9 -> v10` steps were preserved, and a new `v10 -> v11` step was added.

That new `v10 -> v11` migration updates legacy `runs.analysis_json` rows by adding a storage-only persisted-analysis schema marker. The storage marker is `"_schema_version": 1`. It exists only in persisted JSON; the in-memory `PersistedAnalysis` object does not grow extra public behavior for this. The migration only rewrites rows that already have analysis payloads, and the tests cover the expected backfill behavior.

### Persisted analysis storage versioning

`apps/server/vibesensor/shared/types/persisted_analysis.py` now exposes storage-specific encode/decode helpers. Writes use `to_storage_json_object()`, which emits the `_schema_version` field. Reads use `from_storage_json_object()`, which strips the storage-only marker and reconstructs the same in-memory representation as before.

The query layer now treats unsupported storage schema versions as corrupt data rather than silently accepting them. That behavior is intentional: if persisted analysis evolves in a way the current server does not understand, the record should be surfaced as corrupted instead of producing an incorrectly decoded analysis object.

### Updater rollback resilience

`rollback_snapshot.py` now retains two rollback wheels instead of pruning to one. In `installer.py`, rollback no longer assumes the snapshot's primary wheel is the only candidate. If the current snapshot wheel is missing or fails validation before install, the installer can fall back to the older retained wheel. This is still deliberately bounded; I did not expand retention into a general history or artifact registry because the issue only calls for removing the single-slot fragility.

### Release comparison dependency hygiene

`apps/server/pyproject.toml` now explicitly depends on `packaging>=24,<25`. `release_fetcher.py` imports `packaging.version.Version` directly at module scope and only treats malformed version strings as comparison failures. That removes the previous “best effort if installed” behavior and makes runtime expectations explicit.

## Tests and validation

I added focused coverage in three main areas.

`apps/server/tests/adapters/persistence/history_db/test_schema_migration.py` now verifies that migrating an older database creates step backups, that the `v10 -> v11` migration backfills persisted-analysis schema markers, and that a raised migration failure restores the original database from backup.

`apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py` now checks that stored `analysis_json` includes `_schema_version: 1` and that unsupported persisted-analysis storage versions are surfaced as corrupt on read.

`apps/server/tests/use_cases/updates/test_update_installer_verification.py` now covers retaining a secondary rollback wheel and using it when the primary retained wheel is missing or invalid.

Validation ran at both targeted and broader levels:

- `pytest -q apps/server/tests/adapters/persistence/history_db/test_schema_migration.py apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/releases/test_release_fetcher.py`
- `make lint`
- `make typecheck-backend`
- `python -m pytest -q --tb=short apps/server/tests`

The full backend suite passed locally with `5717 passed, 5 skipped, 1 xpassed`.

Per repo policy, I also reran the runtime smoke path. Docker is not available in this environment, so I used the native fallback with `vibesensor-server` plus `vibesensor-sim`, but pointed the server at a temporary config and temporary SQLite file so the smoke run would not mutate `apps/server/data/history.db`. `/api/health` reported ready, the simulator drove three live clients, and `/api/clients` returned all clients to disconnected after the simulator stopped.

## Risks, tradeoffs, and out-of-scope items

The biggest tradeoff here is that migration orchestration remains code-local rather than becoming a standalone discovery-based framework. I believe that is the right balance for this repository today: it eliminates the hardcoded inline chain and adds backup/restore safety without introducing a second layer of infrastructure to maintain.

I also kept persisted-analysis versioning intentionally storage-only. That lets us protect on-disk compatibility and add future migration hooks without widening the public domain surface unnecessarily.

Out of scope for this PR: HTTP API versioning, Pi OS A/B upgrade strategy, and config-file version fields. Those concerns remain valid as future infrastructure improvements, but they are not required to close the concrete data-safety and rollback-resilience bugs in #1193.
