### PR TITLE
Fix #1194 control UDP error handling

### DIFF
--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.adapters.udp.protocol import HelloMessage, parse_cmd
-from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
+from vibesensor.adapters.udp.protocol import HelloMessage, pack_ack, parse_cmd
+from vibesensor.adapters.udp.udp_control_tx import ControlDatagramProtocol, UDPControlPlane
 from vibesensor.infra.runtime.registry import ClientRegistry
 
 
@@ -49,3 +50,27 @@ def test_send_identify_accepts_hex_and_mac_client_ids(
 
     cmd = parse_cmd(payload)
     assert cmd.client_id.hex() == client_hex
+
+
+def test_control_datagram_unexpected_exception_is_logged_and_counted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client_hex = "aabbccddeeff"
+    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    protocol = ControlDatagramProtocol(registry)
+    packet = pack_ack(bytes.fromhex(client_hex), cmd_seq=7, status=0)
+
+    def boom(_: bytes) -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("vibesensor.adapters.udp.udp_control_tx.parse_ack", boom)
+
+    with caplog.at_level(logging.WARNING):
+        protocol.datagram_received(packet, ("127.0.0.1", 9001))
+
+    record = registry.get(client_hex)
+    assert record is not None
+    assert record.parse_errors == 1
+    assert "Unexpected error processing control datagram" in caplog.text

--- a/apps/server/vibesensor/adapters/udp/udp_control_tx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_control_tx.py
@@ -64,6 +64,16 @@ class ControlDatagramProtocol(asyncio.DatagramProtocol):
             client_id = extract_client_id_hex(data)
             LOGGER.debug("Control parse error from %s (client=%s): %s", addr, client_id, exc)
             registry.note_parse_error(client_id)
+        except Exception:
+            client_id = extract_client_id_hex(data)
+            LOGGER.warning(
+                "Unexpected error processing control datagram from %s (client=%s); "
+                "dropping packet to keep listener alive.",
+                addr,
+                client_id,
+                exc_info=True,
+            )
+            registry.note_parse_error(client_id)
 
 
 class UDPControlPlane:


### PR DESCRIPTION
Closes #1194.

## Summary

This PR fixes the single remaining actionable defect in #1194: the control UDP receive path handled `ProtocolError` for malformed control packets but let other unexpected exceptions propagate out of `datagram_received()`. In practice the risk is low because the parser already validates the binary format carefully, but if an unanticipated runtime error did escape that callback, the control listener could stop handling incoming HELLO and ACK traffic. The fix is intentionally narrow. I did not reopen the other seven claims from the issue because the issue body already documents that they were verified as refuted, already fixed, or negligible in the current codebase.

## Problem being solved

The control-side UDP handler lives in `apps/server/vibesensor/adapters/udp/udp_control_tx.py` inside `ControlDatagramProtocol.datagram_received()`. That callback handles three message types relevant to the control socket: HELLO messages, ACK messages, and DATA_ACK frames that are intentionally ignored on this path. Before this change, the callback wrapped that handling in a `try/except ProtocolError` block. That meant malformed control packets were accounted for and converted into debug logs plus parse-error counters, but any other exception raised during parsing or registry updates would bubble out of the callback.

That asymmetry mattered because the data receive path already has a more defensive shape. `udp_data_rx.py` explicitly catches unexpected exceptions in the ingestion/processing path so one bad packet or one surprising runtime failure does not take down the long-lived consumer loop. The issue correctly identified that the control side did not have an equivalent boundary guard. Even if the practical likelihood is small, the right place to contain that class of failure is the protocol callback itself, where the system can drop the offending datagram, surface the failure in logs and counters, and keep the listener alive for subsequent packets.

## Implementation approach

I kept the fix inside the existing control datagram protocol rather than adding any new helpers, wrappers, or indirection. The issue is not that the control stack lacks architecture; it is simply missing one top-level resilience guard at the transport boundary. Because of that, the strongest implementation is the smallest one.

`ControlDatagramProtocol.datagram_received()` still behaves the same way for expected cases:

- empty payloads are ignored
- HELLO packets are parsed and fed into `registry.update_from_hello()`
- ACK packets are parsed, logged, and fed into `registry.update_from_ack()`
- DATA_ACK packets are ignored on the control path
- `ProtocolError` remains a debug-level parse failure that increments `parse_errors`

The only behavior change is a new `except Exception` block after the specific `ProtocolError` handler. When an unexpected exception occurs, the handler now extracts the client ID from the raw datagram if available, logs a warning with `exc_info=True`, increments the registry parse-error counter for that client, and drops the packet. The important outcome is that the callback returns normally instead of letting the exception escape.

I deliberately kept this as a broad transport-boundary catch even though the repo generally discourages broad exception handling. This is one of the places where a broad catch is the correct design: the callback is an ingress boundary for untrusted network data and long-lived listener uptime matters more than propagating a surprise exception into the event loop. The implementation still surfaces the failure explicitly via warning logs and counters, so it is not a silent fallback.

## Main code changes by area

### Control UDP handler

In `apps/server/vibesensor/adapters/udp/udp_control_tx.py`, `ControlDatagramProtocol.datagram_received()` now has an additional `except Exception` branch after the existing `except ProtocolError` branch.

That new branch does three things:

1. extracts a client ID from the raw datagram when possible using the existing `extract_client_id_hex()` helper
2. writes a warning log that includes the sender address, the client ID, and traceback information
3. records a parse error against the client via `registry.note_parse_error()` before dropping the packet

No changes were made to outbound command sending, command sequencing, socket startup, or shutdown. The fix is intentionally scoped only to the inbound control receive callback.

### Regression coverage

In `apps/server/tests/adapters/udp/test_udp_control_tx.py`, I added a focused regression test that exercises the exact failure mode the issue describes. The test builds a valid ACK packet, monkeypatches `parse_ack()` to raise `RuntimeError`, calls `datagram_received()` directly, and then asserts three things:

- the callback does not re-raise the unexpected exception
- the registry records one parse error for the packet's client
- the warning log message was emitted

This is a stronger regression test than simply asserting a broad catch exists in source, because it validates the observable behavior we actually need: listener survival, instrumentation, and explicit logging.

## Validation performed

I validated the change at three levels.

First, I ran focused UDP adapter tests covering both the control and data receiver surfaces:

- `python -m pytest -q apps/server/tests/adapters/udp/test_udp_control_tx.py apps/server/tests/adapters/udp/test_udp_data_rx.py`

That targeted run passed with `12 passed`.

Second, I reran the full backend validation gate used throughout this backlog run:

- `make lint`
- `make typecheck-backend`
- `python -m pytest -q --tb=short apps/server/tests`

That broader pass succeeded with `5718 passed, 5 skipped, 1 xpassed`.

Third, per repository policy for backend changes, I reran the local runtime smoke path. Docker is still unavailable in this environment, so I used the established native fallback with `vibesensor-server` plus `vibesensor-sim`, but pointed the server at a temporary config file and temporary SQLite database so the smoke run would not mutate `apps/server/data/history.db`. `/api/health` reported ready, the simulator drove three connected clients, and `/api/clients` returned all clients to disconnected after the simulator stopped.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is intentional: this PR only fixes the confirmed remaining bug from #1194. I did not broaden the change into control-plane refactors, shared UDP exception helpers, or re-triage of the other claims from the issue because the issue text itself already narrows the remaining scope to this one low-severity resilience gap.

I also chose to count the unexpected failure as a parse error rather than inventing a new metric category. That keeps observability aligned with the existing counter surface and avoids adding new API or health-model surface area for a single narrow issue.

Out of scope for this PR: changing protocol parser internals, adding new control-plane metrics, or touching unrelated run-lifecycle behaviors such as recorder transitions, buffer resize semantics, or settings snapshots. Those areas were reviewed in the issue and are intentionally left alone here.
