### PR TITLE
Add short-run suitability warning

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1215,6 +1215,10 @@
     "en": "Analysis sampling",
     "nl": "Analysebemonstering"
   },
+  "SUITABILITY_CHECK_RUN_DURATION": {
+    "en": "Run duration",
+    "nl": "Ritduur"
+  },
   "SUITABILITY_CHECK_FRAME_INTEGRITY": {
     "en": "Frame integrity",
     "nl": "Frame-integriteit"
@@ -1234,6 +1238,10 @@
   "SUITABILITY_CHECK_SPEED_VARIATION": {
     "en": "Speed variation",
     "nl": "Snelheidsvariatie"
+  },
+  "SUITABILITY_RUN_DURATION_WARNING": {
+    "en": "Very short run analyzed. Confidence may be limited.",
+    "nl": "Zeer korte rit geanalyseerd. De betrouwbaarheid kan beperkt zijn."
   },
   "SUITABILITY_FRAME_INTEGRITY_PASS": {
     "en": "No dropped frames or queue overflows detected.",

--- a/apps/server/tests/shared/boundaries/test_run_suitability.py
+++ b/apps/server/tests/shared/boundaries/test_run_suitability.py
@@ -26,6 +26,7 @@ def test_run_suitability_payload_projects_domain_checks() -> None:
     suitability = RunSuitability(
         checks=(
             SuitabilityCheck(check_key="speed_profile", state="warn"),
+            SuitabilityCheck(check_key="SUITABILITY_CHECK_RUN_DURATION", state="warn"),
             SuitabilityCheck(check_key="steady_cruise", state="pass"),
         )
     )
@@ -36,7 +37,9 @@ def test_run_suitability_payload_projects_domain_checks() -> None:
     assert payload[0]["check_key"] == "speed_profile"
     assert payload[0]["state"] == "warn"
     assert "explanation" in payload[0]
-    assert payload[1]["check_key"] == "steady_cruise"
+    assert payload[1]["check_key"] == "SUITABILITY_CHECK_RUN_DURATION"
+    assert payload[1]["explanation"] == {"_i18n_key": "SUITABILITY_RUN_DURATION_WARNING"}
+    assert payload[2]["check_key"] == "steady_cruise"
 
 
 def test_run_suitability_payload_handles_none() -> None:

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -8,14 +8,19 @@ from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
 
 
-def _run_metadata(run_id: str, *, language: str = "en") -> RunMetadata:
+def _run_metadata(
+    run_id: str,
+    *,
+    language: str = "en",
+    raw_sample_rate_hz: int = 800,
+) -> RunMetadata:
     return RunMetadata.from_dict(
         {
             "run_id": run_id,
             "start_time_utc": "2025-01-01T00:00:00Z",
             "sensor_model": "fixture-sensor",
-            "raw_sample_rate_hz": 800,
-            "sample_rate_hz": 800,
+            "raw_sample_rate_hz": raw_sample_rate_hz,
+            "sample_rate_hz": raw_sample_rate_hz,
             "feature_interval_s": 1.0,
             "language": language,
         }
@@ -51,7 +56,7 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
 
     summary = build_post_analysis_summary(
         run_id="run-ok",
-        metadata=_run_metadata("run-ok", language="nl"),
+        metadata=_run_metadata("run-ok", language="nl", raw_sample_rate_hz=1),
         samples=[{"t_s": 1.0, "vibration_strength_db": 10.0}],
         language="nl",
         total_sample_count=3,
@@ -96,7 +101,7 @@ def test_build_post_analysis_summary_adds_stride_warning(
 
     summary = build_post_analysis_summary(
         run_id="run-stride",
-        metadata=_run_metadata("run-stride"),
+        metadata=_run_metadata("run-stride", raw_sample_rate_hz=1),
         samples=[{"t_s": 1.0, "vibration_strength_db": 10.0}],
         language="en",
         total_sample_count=5,
@@ -111,5 +116,49 @@ def test_build_post_analysis_summary_adds_stride_warning(
             "check": "SUITABILITY_CHECK_ANALYSIS_SAMPLING",
             "state": "warn",
             "explanation": "stride=3",
+        }
+    ]
+
+
+def test_build_post_analysis_summary_adds_short_run_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRunAnalysis:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def summarize(self):
+            return SimpleNamespace(
+                diagnostic_case=SimpleNamespace(case_id="case-3"),
+            )
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.diagnostics.RunAnalysis",
+        FakeRunAnalysis,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+        lambda _result: {},
+    )
+    monkeypatch.setattr(
+        "vibesensor.report_i18n.tr",
+        lambda _language, key, **_kwargs: key,
+    )
+
+    summary = build_post_analysis_summary(
+        run_id="run-short",
+        metadata=_run_metadata("run-short", raw_sample_rate_hz=800),
+        samples=[{"t_s": 1.0, "vibration_strength_db": 10.0}],
+        language="en",
+        total_sample_count=100,
+        stride=1,
+    )
+
+    assert summary["run_suitability"] == [
+        {
+            "check_key": "SUITABILITY_CHECK_RUN_DURATION",
+            "check": "SUITABILITY_CHECK_RUN_DURATION",
+            "state": "warn",
+            "explanation": "SUITABILITY_RUN_DURATION_WARNING",
         }
     ]

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1215,6 +1215,10 @@
     "en": "Analysis sampling",
     "nl": "Analysebemonstering"
   },
+  "SUITABILITY_CHECK_RUN_DURATION": {
+    "en": "Run duration",
+    "nl": "Ritduur"
+  },
   "SUITABILITY_CHECK_FRAME_INTEGRITY": {
     "en": "Frame integrity",
     "nl": "Frame-integriteit"
@@ -1234,6 +1238,10 @@
   "SUITABILITY_CHECK_SPEED_VARIATION": {
     "en": "Speed variation",
     "nl": "Snelheidsvariatie"
+  },
+  "SUITABILITY_RUN_DURATION_WARNING": {
+    "en": "Very short run analyzed. Confidence may be limited.",
+    "nl": "Zeer korte rit geanalyseerd. De betrouwbaarheid kan beperkt zijn."
   },
   "SUITABILITY_FRAME_INTEGRITY_PASS": {
     "en": "No dropped frames or queue overflows detected.",

--- a/apps/server/vibesensor/domain/run_suitability.py
+++ b/apps/server/vibesensor/domain/run_suitability.py
@@ -87,6 +87,8 @@ class SuitabilityCheck:
             if stride:
                 return _i18n_ref("SUITABILITY_ANALYSIS_SAMPLING_STRIDE_WARNING", stride=stride)
             return ""
+        if self.check_key == "SUITABILITY_CHECK_RUN_DURATION":
+            return _i18n_ref("SUITABILITY_RUN_DURATION_WARNING")
         return ""
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -18,6 +18,8 @@ from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
+_MIN_POST_ANALYSIS_DURATION_S = 1.0
+
 
 def build_post_analysis_summary(
     *,
@@ -50,6 +52,22 @@ def build_post_analysis_summary(
     }
     summary_payload["analysis_metadata"] = payload_object_from_json(analysis_metadata)
 
+    sample_rate_hz = _post_analysis_sample_rate_hz(metadata)
+    if sample_rate_hz is not None and total_sample_count < max(
+        1, int(sample_rate_hz * _MIN_POST_ANALYSIS_DURATION_S)
+    ):
+        short_run_check = SuitabilityCheck(
+            check_key="SUITABILITY_CHECK_RUN_DURATION",
+            state="warn",
+        )
+        explanation = tr(language, "SUITABILITY_RUN_DURATION_WARNING")
+        _append_run_suitability_warning(
+            summary_payload=summary_payload,
+            check_key=short_run_check.check_key,
+            state=short_run_check.state,
+            explanation=explanation,
+        )
+
     if stride > 1:
         stride_check = SuitabilityCheck(
             check_key="SUITABILITY_CHECK_ANALYSIS_SAMPLING",
@@ -61,16 +79,47 @@ def build_post_analysis_summary(
             "SUITABILITY_ANALYSIS_SAMPLING_STRIDE_WARNING",
             stride=str(stride),
         )
-        run_suitability = summary_payload.get("run_suitability")
-        if not isinstance(run_suitability, list):
-            run_suitability = []
-            summary_payload["run_suitability"] = run_suitability
-        warning_payload: RunSuitabilityCheck = {
-            "check_key": stride_check.check_key,
-            "check": stride_check.check_key,
-            "state": stride_check.state,
-            "explanation": explanation,
-        }
-        run_suitability.append(warning_payload)
+        _append_run_suitability_warning(
+            summary_payload=summary_payload,
+            check_key=stride_check.check_key,
+            state=stride_check.state,
+            explanation=explanation,
+        )
 
     return persisted_analysis_from_summary(summary_payload)
+
+
+def _append_run_suitability_warning(
+    *,
+    summary_payload: object,
+    check_key: str,
+    state: str,
+    explanation: str,
+) -> None:
+    summary_payload_dict = cast(dict[str, object], summary_payload)
+    run_suitability = summary_payload_dict.get("run_suitability")
+    if not isinstance(run_suitability, list):
+        run_suitability_list: list[RunSuitabilityCheck] = []
+        summary_payload_dict["run_suitability"] = run_suitability_list
+        run_suitability = run_suitability_list
+    else:
+        run_suitability = cast(list[RunSuitabilityCheck], run_suitability)
+    warning_payload: RunSuitabilityCheck = {
+        "check_key": check_key,
+        "check": check_key,
+        "state": state,
+        "explanation": explanation,
+    }
+    run_suitability.append(warning_payload)
+
+
+def _post_analysis_sample_rate_hz(metadata: RunMetadata) -> int | None:
+    raw_sample_rate_hz = metadata.raw_sample_rate_hz
+    if raw_sample_rate_hz is not None and raw_sample_rate_hz > 0:
+        return raw_sample_rate_hz
+    extra_sample_rate_hz = metadata.extras.get("sample_rate_hz")
+    if isinstance(extra_sample_rate_hz, int) and extra_sample_rate_hz > 0:
+        return extra_sample_rate_hz
+    if isinstance(extra_sample_rate_hz, float) and extra_sample_rate_hz > 0:
+        return int(extra_sample_rate_hz)
+    return None


### PR DESCRIPTION
Closes #1195.

## Summary

This PR addresses the one surviving claim in #1195: the post-analysis pipeline did not have any explicit minimum-duration guard for very short runs. The current code already handled the other three claims correctly, so I kept the change tightly scoped to the remaining gap. Instead of introducing a hard skip that would prevent persisted analysis from being produced at all, this change adds an explicit low-confidence suitability warning when a run is too short to support normal diagnostic confidence.

I chose the warning path because it matches the issue’s suggested remediation options while preserving the current behavior of the post-analysis pipeline. The pipeline can still summarize the run, but it now tells downstream consumers and the user-facing report that the run duration itself is a caution signal. That gives us a smaller, behavior-safe fix than adding a new early-return path through the analysis workflow.

## Problem Being Solved

Before this change, `build_post_analysis_summary()` would run diagnostics on completed recordings regardless of how little data had been captured. In practice, the rest of the system already had several soft quality signals, and the issue body correctly noted that this was not a correctness bug. The real gap was that a run with an extremely small sample count could still produce a full summary without any explicit warning that the run duration itself was too short for strong FFT resolution or stable statistical confidence.

That meant a very short capture could look more trustworthy than it really was, especially once it had been serialized into persisted analysis and later rendered by report or history consumers. The right fix here is not to redesign post-analysis, but to make the short-run concern visible in the same suitability channel that already carries other caution-level diagnostic context.

## Implementation Approach

The implementation adds a short-run suitability warning at summary-build time, after the diagnostics result has already been converted into the standard summary payload and before the payload is persisted. That placement matters for two reasons.

First, it keeps the change close to the existing post-analysis summary assembly logic instead of duplicating duration checks elsewhere in loaders, workers, or HTTP adapters. Second, it ensures the warning becomes part of the persisted summary contract, so the same caution survives later reads and projections rather than existing only as an ephemeral runtime decision.

I used a one-second threshold derived from the run’s effective sample rate and `total_sample_count`. The code first resolves the sample rate from typed metadata, preferring `raw_sample_rate_hz` and falling back to `metadata.extras["sample_rate_hz"]` when needed. If the run contains fewer than roughly one second of samples, the summary gets an additional `run_suitability` item with the new check key `SUITABILITY_CHECK_RUN_DURATION` and warning state `warn`.

This keeps the change explicit and easy to reason about. There is no new parallel gate, no hidden early abort, and no speculative configuration knob. The summary simply records that this run should be interpreted with caution because of duration.

## Main Code Changes

In `apps/server/vibesensor/use_cases/run/post_analysis_summary.py`, the summary builder now calculates whether the total sample count is below the short-run threshold and appends a warning when that condition is met. I also added a small helper to resolve the effective sample rate from typed run metadata, and I reused the same summary-payload mutation path that already appends other analysis-related warnings such as stride-based sampling warnings.

In `apps/server/vibesensor/domain/run_suitability.py`, the domain-side `SuitabilityCheck.explanation_i18n_ref()` method now recognizes `SUITABILITY_CHECK_RUN_DURATION` and maps it to a stable i18n reference. That keeps explanation ownership in the domain layer rather than rebuilding a special-case explanation elsewhere.

In `apps/server/data/report_i18n.json`, I added the new user-facing strings for the check label and the warning explanation in both English and Dutch. Because this repository packages runtime JSON data into the Python package, I also synced the mirrored packaged copy at `apps/server/vibesensor/data/report_i18n.json` so the hygiene test and installed runtime data stay aligned.

## Tests and Validation

I expanded the focused post-analysis tests to cover both the new behavior and the existing non-short-run behavior. The summary tests now verify that a short run gets the expected `SUITABILITY_CHECK_RUN_DURATION` warning while existing analysis metadata and stride-warning behavior still work. I also updated the boundary projection test so a domain `RunSuitability` containing the new check still serializes with the expected explanation payload.

After the focused tests passed, I ran the broader backend validation gate:

- `make lint`
- `make typecheck-backend`
- `python -m pytest -q --tb=short apps/server/tests`

The final full-suite result was `5719 passed, 5 skipped, 1 xpassed`.

I also ran the required native smoke fallback because Docker is not available in this environment. For that check I started `vibesensor-server` with a temp config and temp SQLite DB on isolated ports, verified `/api/health` returned `status=ok` and `startup_state=ready`, ran `vibesensor-sim` with three clients, confirmed `/api/clients` showed `CONNECTED_DURING 3`, waited for the simulator to stop, and then confirmed the API returned `CONNECTED_AFTER 0` before shutting the temp server down cleanly.

## Risks, Tradeoffs, and Edge Cases

The key tradeoff is that this PR intentionally does **not** hard-block short runs. A hard minimum-duration gate would be more aggressive, but it would also change pipeline behavior more substantially by preventing persisted post-analysis output from being generated at all for those runs. Given the issue severity, the existing use of soft suitability signals, and the repository preference for small behavior-safe fixes, I think the warning-based approach is the stronger choice here.

Another edge case is sample-rate availability. The new warning only triggers when the code can resolve a positive effective sample rate from run metadata. That is deliberate: if the sample rate is missing or malformed, we should not invent a duration threshold from bad data. In those cases the pipeline behaves exactly as it did before, which is safer than adding guesswork.

The warning is also additive rather than replacing other suitability checks. A short run can still carry stride-related or other caution signals, and all of them will remain visible to downstream consumers.

## Out of Scope

This PR does not redesign the post-analysis worker, change loader downsampling, alter success-path timing logs, or add a configurable duration threshold. Those claims were already refuted by the issue’s verification notes, and the current change keeps scope aligned with the one remaining gap.
