### PR TITLE
Normalize update HTTP error handling

### DIFF
--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -154,6 +154,30 @@ async def test_identify_client_normalizes_client_id_before_registry_and_control_
 
 
 @pytest.mark.asyncio
+async def test_set_client_location_maps_registry_conflict_to_409() -> None:
+    from vibesensor.adapters.http.clients import create_client_routes
+
+    class ConflictRegistry:
+        def get(self, _client_id: str) -> object:
+            return object()
+
+        def set_location(self, _client_id: str, _location: str) -> None:
+            raise ValueError("Location 'front_left_wheel' already assigned to other sensor")
+
+    registry = ConflictRegistry()
+    control_plane = MagicMock()
+    settings_store = MagicMock()
+    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
+    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+
+    with pytest.raises(HTTPException) as exc_info:
+        request = type("Req", (), {"location_code": "front_left_wheel"})()
+        await endpoint("aa:bb:cc:dd:ee:ff", request)
+    assert exc_info.value.status_code == 409
+    assert "already assigned" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
 async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected(
     tmp_path: Path,
     monkeypatch,

--- a/apps/server/tests/adapters/http/test_helpers_exception_handling.py
+++ b/apps/server/tests/adapters/http/test_helpers_exception_handling.py
@@ -8,16 +8,32 @@ from fastapi import HTTPException
 from vibesensor.adapters.http._helpers import domain_errors_to_http
 from vibesensor.shared.exceptions import (
     ConfigurationError,
+    ProtocolError,
+    UpdateError,
     VibeSensorError,
 )
 
 
 def test_configuration_error_caught_as_vibesensor_error() -> None:
-    """ConfigurationError (no longer a ValueError) is caught by the VibeSensorError handler."""
+    """ConfigurationError maps to HTTP 400."""
     with pytest.raises(HTTPException) as exc_info:
         with domain_errors_to_http(catch_value_error=400):
             raise ConfigurationError("bad config")
-    assert exc_info.value.status_code == 500
+    assert exc_info.value.status_code == 400
+
+
+def test_protocol_error_maps_to_400() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        with domain_errors_to_http():
+            raise ProtocolError("bad packet")
+    assert exc_info.value.status_code == 400
+
+
+def test_update_error_conflict_maps_to_409() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        with domain_errors_to_http():
+            raise UpdateError("busy", status="conflict")
+    assert exc_info.value.status_code == 409
 
 
 def test_plain_value_error_still_caught() -> None:

--- a/apps/server/tests/adapters/http/test_update_endpoints.py
+++ b/apps/server/tests/adapters/http/test_update_endpoints.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from vibesensor.adapters.http.updates import create_update_routes
+from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.firmware.esp_flash_types import (
     EspFlashHistoryEntry,
     EspFlashState,
@@ -87,9 +88,9 @@ def test_start_update_returns_started_response(update_client) -> None:
     state.update_manager.start.assert_called_once_with("GarageNet", "secret123")
 
 
-def test_start_update_maps_value_error_to_400(update_client) -> None:
+def test_start_update_maps_configuration_error_to_400(update_client) -> None:
     client, state = update_client
-    state.update_manager.start.side_effect = ValueError("SSID must be 1-64 characters")
+    state.update_manager.start.side_effect = ConfigurationError("SSID must be 1-64 characters")
 
     response = client.post("/api/update/start", json={"ssid": "x", "password": ""})
 
@@ -97,9 +98,12 @@ def test_start_update_maps_value_error_to_400(update_client) -> None:
     assert response.json()["detail"] == "SSID must be 1-64 characters"
 
 
-def test_start_update_maps_runtime_error_to_409(update_client) -> None:
+def test_start_update_maps_update_conflict_to_409(update_client) -> None:
     client, state = update_client
-    state.update_manager.start.side_effect = RuntimeError("Update already in progress")
+    state.update_manager.start.side_effect = UpdateError(
+        "Update already in progress",
+        status="conflict",
+    )
 
     response = client.post("/api/update/start", json={"ssid": "GarageNet", "password": ""})
 
@@ -169,9 +173,9 @@ def test_start_esp_flash_rejects_missing_port_when_auto_detect_disabled(update_c
     assert "port is required when auto_detect is False" in str(response.json())
 
 
-def test_start_esp_flash_maps_value_error_to_400(update_client) -> None:
+def test_start_esp_flash_maps_configuration_error_to_400(update_client) -> None:
     client, state = update_client
-    state.esp_flash_manager.start.side_effect = ValueError(
+    state.esp_flash_manager.start.side_effect = ConfigurationError(
         "port is required when auto_detect is False"
     )
 
@@ -181,9 +185,12 @@ def test_start_esp_flash_maps_value_error_to_400(update_client) -> None:
     assert response.json()["detail"] == "port is required when auto_detect is False"
 
 
-def test_start_esp_flash_maps_runtime_error_to_409(update_client) -> None:
+def test_start_esp_flash_maps_update_conflict_to_409(update_client) -> None:
     client, state = update_client
-    state.esp_flash_manager.start.side_effect = RuntimeError("Flash already in progress")
+    state.esp_flash_manager.start.side_effect = UpdateError(
+        "Flash already in progress",
+        status="conflict",
+    )
 
     response = client.post("/api/esp-flash/start", json={"port": None, "auto_detect": True})
 

--- a/apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from test_support import response_payload
 
 from vibesensor.adapters.http.updates import create_update_routes
+from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.firmware.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.firmware.esp_flash_types import (
     FlashCommandRunner,
@@ -340,7 +341,7 @@ async def test_single_job_lock_and_cancel(tmp_path: Path) -> None:
     mgr, _ = _build_manager(cache_dir, runner=_FakeRunner(hang=True))
 
     mgr.start(port=None, auto_detect=True)
-    with pytest.raises(RuntimeError, match="already in progress"):
+    with pytest.raises(UpdateError, match="already in progress"):
         mgr.start(port="/dev/ttyUSB0", auto_detect=False)
     assert mgr.cancel() is True
     assert mgr._task is not None
@@ -506,8 +507,8 @@ def test_esp_flash_start_request_requires_port_when_not_auto_detect() -> None:
 
 
 @pytest.mark.asyncio
-async def test_esp_flash_start_returns_400_on_value_error() -> None:
-    """start_esp_flash must map ValueError from esp_flash_manager.start → 400."""
+async def test_esp_flash_start_returns_400_on_configuration_error() -> None:
+    """start_esp_flash must map ConfigurationError from esp_flash_manager.start → 400."""
     from unittest.mock import MagicMock
 
     from vibesensor.adapters.http.updates import create_update_routes
@@ -517,7 +518,7 @@ async def test_esp_flash_start_returns_400_on_value_error() -> None:
             return []
 
         def start(self, **_):
-            raise ValueError("port is required when auto_detect is False")
+            raise ConfigurationError("port is required when auto_detect is False")
 
         def cancel(self):
             return False

--- a/apps/server/tests/use_cases/updates/test_update_manager_core.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_core.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from _update_manager_test_helpers import FakeRunner, cancel_task, mock_which
 
+from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.models import UpdatePhase, UpdateState
 
@@ -24,16 +25,16 @@ class TestUpdateManager:
 
     def test_start_validates_ssid(self) -> None:
         manager, _ = self.make_manager()
-        with pytest.raises(ValueError, match="SSID"):
+        with pytest.raises(ConfigurationError, match="SSID"):
             manager.start("", "pw")
-        with pytest.raises(ValueError, match="SSID"):
+        with pytest.raises(ConfigurationError, match="SSID"):
             manager.start("   ", "pw")
-        with pytest.raises(ValueError, match="SSID"):
+        with pytest.raises(ConfigurationError, match="SSID"):
             manager.start("x" * 65, "pw")
 
     def test_start_validates_password_length(self) -> None:
         manager, _ = self.make_manager()
-        with pytest.raises(ValueError, match="Password"):
+        with pytest.raises(ConfigurationError, match="Password"):
             manager.start("TestNet", "p" * 129)
 
     @pytest.mark.asyncio
@@ -55,7 +56,7 @@ class TestUpdateManager:
         with patch("shutil.which", mock_which):
             manager.start("TestNet", "pass123")
             assert manager.status.state == UpdateState.running
-            with pytest.raises(RuntimeError, match="already in progress"):
+            with pytest.raises(UpdateError, match="already in progress"):
                 manager.start("OtherNet", "pass456")
 
         manager.cancel()

--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -10,9 +10,12 @@ from fastapi import HTTPException
 from vibesensor.domain import normalize_sensor_id
 from vibesensor.shared.exceptions import (
     AnalysisNotReadyError,
+    ConfigurationError,
     DataCorruptError,
     ProcessingError,
+    ProtocolError,
     RunNotFoundError,
+    UpdateError,
     VibeSensorError,
 )
 from vibesensor.use_cases.history.helpers import async_require_run, safe_filename
@@ -50,6 +53,13 @@ def domain_errors_to_http(
             status_code=status_map.get(exc.status, 409),
             detail=str(exc),
         ) from exc
+    except ConfigurationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ProtocolError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except UpdateError as exc:
+        status_code = 409 if exc.status == "conflict" else 500
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
     except DataCorruptError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except ProcessingError as exc:

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException
 
-from vibesensor.adapters.http._helpers import normalize_client_id_or_400
+from vibesensor.adapters.http._helpers import domain_errors_to_http, normalize_client_id_or_400
 from vibesensor.adapters.http.models import (
     ClientLocationsResponse,
     ClientsResponse,
@@ -83,10 +83,8 @@ def create_client_routes(
             if label is None:
                 raise HTTPException(status_code=400, detail="Unknown location_code")
 
-            try:
+            with domain_errors_to_http(catch_value_error=409):
                 registry.set_location(normalized_client_id, code)
-            except ValueError as exc:
-                raise HTTPException(status_code=409, detail=str(exc)) from exc
 
             registry.set_name(normalized_client_id, label)
         else:

--- a/apps/server/vibesensor/adapters/http/updates.py
+++ b/apps/server/vibesensor/adapters/http/updates.py
@@ -43,7 +43,7 @@ def create_update_routes(
 
     @router.post("/api/update/start", response_model=UpdateStartResponse)
     async def start_update(req: UpdateStartRequest) -> UpdateStartResponse:
-        with domain_errors_to_http(catch_value_error=400, catch_runtime_error=409):
+        with domain_errors_to_http():
             update_manager.start(req.ssid, req.password)
         return UpdateStartResponse(status="started", ssid=req.ssid)
 
@@ -60,7 +60,7 @@ def create_update_routes(
 
     @router.post("/api/esp-flash/start", response_model=EspFlashStartResponse)
     async def start_esp_flash(req: EspFlashStartRequest) -> EspFlashStartResponse:
-        with domain_errors_to_http(catch_value_error=400, catch_runtime_error=409):
+        with domain_errors_to_http():
             job_id = esp_flash_manager.start(port=req.port, auto_detect=req.auto_detect)
         return EspFlashStartResponse(status="started", job_id=job_id)
 

--- a/apps/server/vibesensor/shared/exceptions.py
+++ b/apps/server/vibesensor/shared/exceptions.py
@@ -59,6 +59,10 @@ class ProtocolError(VibeSensorError):
 class UpdateError(VibeSensorError):
     """OTA update system failure."""
 
+    def __init__(self, message: str, *, status: str = "error") -> None:
+        super().__init__(message)
+        self.status = status
+
 
 class RunNotFoundError(VibeSensorError):
     """Requested run does not exist in the history database."""

--- a/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_manager.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_manager.py
@@ -10,6 +10,7 @@ import sys
 import time
 from pathlib import Path
 
+from vibesensor.shared.exceptions import UpdateError
 from vibesensor.use_cases.updates.firmware.esp_flash_runner import SubprocessFlashCommandRunner
 from vibesensor.use_cases.updates.firmware.esp_flash_types import (
     EspFlashHistoryEntry,
@@ -86,7 +87,7 @@ class EspFlashManager:
 
     def start(self, *, port: str | None, auto_detect: bool) -> int:
         if self._task is not None and not self._task.done():
-            raise RuntimeError("Flash already in progress")
+            raise UpdateError("Flash already in progress", status="conflict")
         self._job_counter += 1
         self._logs = []
         self._cancel_event.clear()

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.models import (
@@ -104,11 +105,11 @@ class UpdateManager:
     def start(self, ssid: str, password: str) -> None:
         ssid = ssid.strip()
         if not ssid or len(ssid) > 64:
-            raise ValueError("SSID must be 1-64 characters")
+            raise ConfigurationError("SSID must be 1-64 characters")
         if password and len(password) > 128:
-            raise ValueError("Password must be at most 128 characters")
+            raise ConfigurationError("Password must be at most 128 characters")
         if self._task is not None and not self._task.done():
-            raise RuntimeError("Update already in progress")
+            raise UpdateError("Update already in progress", status="conflict")
         self._cancel_event.clear()
         self._tracker.start_job(ssid)
         self._status = self._tracker.status


### PR DESCRIPTION
## Summary

This change fixes the user-visible part of `#1197`: route-facing update workflows were still mixing raw stdlib exceptions with the repo’s domain exception hierarchy, and `domain_errors_to_http()` did not explicitly understand several domain error categories that those routes can raise. The result was inconsistent HTTP responses across closely related endpoints and unnecessary ad-hoc translation logic in a few handlers.

The patch normalizes the update start and ESP flash start paths around domain exceptions, teaches the shared HTTP mapper how to classify those errors consistently, and removes one remaining hand-rolled client-location conflict mapping in favor of the shared helper.

I intentionally did **not** change the negative dB behavior or add a PDF timeout in this PR. I re-verified both claims directly against the live code while working this issue. Negative values from `vibration_strength_db_scalar()` are part of the repository’s tested canonical dB calculation and already flow into the existing low-strength bucket behavior; clamping them here would be a broader product/output contract change rather than a narrow error-handling fix. PDF generation timeout handling is a separate low-priority design concern, but it is not tightly coupled to the route-mapping inconsistency fixed in this patch and would need more deliberate design than a quick wrapper around `asyncio.to_thread(...)`.

## Implementation approach

The main design goal was to make the HTTP boundary behave consistently without introducing compatibility shims or duplicating mapping logic in more routes. Rather than adding more ad-hoc `HTTPException` branches, I tightened the contract between the update/flash use cases and the shared HTTP translation layer:

1. raise domain exceptions from the relevant business logic,
2. make the shared HTTP mapper understand those exceptions explicitly,
3. keep the route handlers thin and let them delegate translation through one path.

That approach keeps the fix narrow, improves future maintainability in the touched area, and avoids spreading more route-specific exception policy into endpoint functions.

## Main code changes by area

### 1. Shared exception taxonomy

`UpdateError` now carries an optional `status` field. This is intentionally small: I did not build a new hierarchy of specialized subclasses just for this issue. The new field gives the HTTP layer enough structured information to distinguish conflict-style failures (for example, “already running”) from generic update failures without forcing callers back into string matching or stdlib exception classes.

### 2. Shared HTTP exception mapping

`domain_errors_to_http()` now explicitly maps:

- `ConfigurationError` to HTTP `400`
- `ProtocolError` to HTTP `400`
- `UpdateError(status="conflict")` to HTTP `409`
- other `UpdateError` instances to HTTP `500`

This change closes the gap where domain-specific update/config/protocol failures were previously falling through the generic domain branch and surfacing as less useful responses. The existing generic domain handling and optional stdlib hooks remain in place for untouched callers elsewhere in the codebase.

### 3. Update workflow use case

`UpdateManager.start()` no longer uses raw `ValueError` or `RuntimeError` for route-facing validation/conflict states. Invalid SSID/password input now raises `ConfigurationError`, and “update already in progress” now raises `UpdateError(..., status="conflict")`.

That makes the updater facade align with the project’s purpose-built exception model and gives the route layer enough information to return stable, intention-revealing status codes.

### 4. ESP flash workflow use case

`EspFlashManager.start()` now reports a concurrent flash attempt via `UpdateError(..., status="conflict")` instead of `RuntimeError`. This keeps the update and flash entry points behaviorally aligned and removes another case where concurrency state leaked through a generic stdlib exception.

### 5. HTTP routes

`adapters/http/updates.py` now relies on plain `domain_errors_to_http()` for the start-update and start-ESP-flash endpoints instead of separately wiring `catch_value_error` / `catch_runtime_error`. The routes become thinner, and the exception policy is now centralized in the shared mapper instead of duplicated per endpoint.

`adapters/http/clients.py` also now routes client-location conflicts through `domain_errors_to_http(catch_value_error=409)` instead of using a bespoke `try/except HTTPException` conversion at the route. That keeps the remaining legacy stdlib-conflict case on the same translation path as the rest of the HTTP surface until the deeper registry/domain layer is normalized in a future change.

## Tests and validation

I updated focused tests at each touched layer:

- helper-level HTTP mapping tests for `ConfigurationError`, `ProtocolError`, and conflict-style `UpdateError`
- update endpoint tests that now assert the new domain exceptions map to the expected response codes
- update manager core tests that expect domain exceptions instead of stdlib exceptions
- ESP flash manager tests for conflict behavior
- client API tests that verify the shared mapper produces the expected `409` on location conflicts

Focused coverage passed:

`python -m pytest -q apps/server/tests/adapters/http/test_helpers_exception_handling.py apps/server/tests/adapters/http/test_update_endpoints.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/use_cases/updates/test_update_manager_core.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py`

Result: `65 passed`

Broader backend validation also passed:

- `make lint`
- `make typecheck-backend`
- `python -m pytest -q --tb=short apps/server/tests`

Result: `5722 passed, 5 skipped, 1 xpassed`

Because Docker is not available in this local environment, I also ran the required native runtime smoke fallback with a temporary config/database and temporary ports. That verified `/api/health`, `/api/update/status`, and `/api/esp-flash/status`, exercised a simulator connection during runtime, confirmed clients disconnected after the simulator stopped, and verified clean server shutdown.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is that `UpdateError.status` is intentionally modest. It solves the concrete conflict-vs-generic distinction needed by the current HTTP surface without over-designing a large status taxonomy or subclass tree ahead of real additional consumers.

I also considered clamping negative dB values here to satisfy the issue body literally, but that would have changed a tested repository invariant in `vibration_strength_db_scalar()` and would likely need coordinated work across report text, UI presentation, and boundary contracts. That is too broad for a safe error-handling patch.

Similarly, I did not add a naive PDF timeout around the report generation thread. A superficial timeout wrapper would not truly cancel a worker already running inside `to_thread`, so that needs a more careful design if it becomes worth doing.

## Out of scope

No schema, API contract export, or documentation files changed in this PR because the HTTP surface behavior is preserved semantically while only the exception taxonomy and status mapping become more consistent.

This PR therefore resolves the concrete route-facing inconsistency in `#1197` without broadening into unrelated product-level behavior changes.

Refs #1197
