### PR TITLE
Replace modal UI alerts with shared banner

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -48,6 +48,7 @@
 
       <div id="carSelectionBanner" class="connection-banner connection-banner--warn" hidden aria-live="assertive" role="alert"></div>
       <div id="connectionBanner" class="connection-banner" hidden aria-live="assertive" role="alert"></div>
+      <div id="appErrorBanner" class="connection-banner app-error-banner" hidden aria-live="assertive" role="alert"></div>
 
       <section id="dashboardView" class="view active" role="tabpanel" aria-labelledby="tab-dashboard">
         <div class="dashboard-grid">

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -22,6 +22,7 @@ export interface AppFeatureBundleDeps {
   els: UiDomElements;
   t: (key: string, vars?: Record<string, unknown>) => string;
   escapeHtml: (value: unknown) => string;
+  showError: (message: string) => void;
   fmt: (n: number, digits?: number) => string;
   fmtTs: (iso: string) => string;
   formatInt: (value: number) => string;
@@ -43,6 +44,7 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     els,
     t,
     escapeHtml,
+    showError: deps.showError,
     fmt,
     fmtTs,
     formatInt,
@@ -54,6 +56,7 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     els,
     t,
     escapeHtml,
+    showError: deps.showError,
     formatInt,
     setPillState: deps.setPillState,
     setStatValue: deps.setStatValue,
@@ -67,6 +70,7 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     els,
     t,
     escapeHtml,
+    showError: deps.showError,
     fmt,
     renderSpectrum: deps.renderSpectrum,
     renderSpeedReadout: deps.renderSpeedReadout,
@@ -77,12 +81,13 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     els,
     t,
     escapeHtml,
+    showError: deps.showError,
     fmt,
     addCarFromWizard: settings.addCarFromWizard,
   });
 
-  const update = createUpdateFeature({ els, t, escapeHtml });
-  const espFlash = createEspFlashFeature({ els, t, escapeHtml });
+  const update = createUpdateFeature({ els, t, escapeHtml, showError: deps.showError });
+  const espFlash = createEspFlashFeature({ els, t, escapeHtml, showError: deps.showError });
 
   return {
     history,

--- a/apps/ui/src/app/feature_deps_base.ts
+++ b/apps/ui/src/app/feature_deps_base.ts
@@ -11,4 +11,5 @@ export interface FeatureDepsBase {
   els: UiDomElements;
   t: (key: string, vars?: Record<string, unknown>) => string;
   escapeHtml: (value: unknown) => string;
+  showError: (message: string) => void;
 }

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -145,7 +145,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
       nextLogIndex = 0;
       restartPolling();
     } catch (err) {
-      window.alert(`${t("settings.esp_flash.start_failed")}\n${err instanceof Error ? err.message : String(err)}`);
+      ctx.showError(`${t("settings.esp_flash.start_failed")}\n${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/apps/ui/src/app/features/history_download_delete_module.ts
+++ b/apps/ui/src/app/features/history_download_delete_module.ts
@@ -49,6 +49,7 @@ export interface HistoryDownloadDeleteModuleDeps {
   history: HistoryState;
   getLanguage: () => string;
   t: (key: string, vars?: Record<string, unknown>) => string;
+  showError: (message: string) => void;
   ensureRunDetail: (runId: string) => RunDetail;
   collapseExpandedRun: () => void;
   renderHistoryTable: () => void;
@@ -75,7 +76,7 @@ export function createHistoryDownloadDeleteModule(
     try {
       await deleteHistoryRunApi(runId);
     } catch (err) {
-      window.alert(err instanceof Error ? err.message : t("history.delete_failed"));
+      ctx.showError(err instanceof Error ? err.message : t("history.delete_failed"));
       return;
     }
     if (history.expandedRunId === runId) {
@@ -114,7 +115,7 @@ export function createHistoryDownloadDeleteModule(
     await ctx.refreshHistory();
     if (failed > 0) {
       const summary = t("history.delete_all_partial", { deleted, total: names.length, failed });
-      window.alert(firstError ? `${summary}\n${firstError}` : summary);
+      ctx.showError(firstError ? `${summary}\n${firstError}` : summary);
     }
   }
 

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -80,6 +80,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     history,
     getLanguage: ctx.getLanguage,
     t: ctx.t,
+    showError: ctx.showError,
     ensureRunDetail,
     collapseExpandedRun,
     renderHistoryTable: () => listModule.renderHistoryTable(),

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -205,7 +205,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     try {
       await setClientLocationApi(clientId, locationCode);
     } catch (err) {
-      window.alert(err instanceof Error ? err.message : t("actions.set_location_failed"));
+      ctx.showError(err instanceof Error ? err.message : t("actions.set_location_failed"));
       return;
     }
     const client = realtime.clients.find((c) => c.id === clientId);
@@ -227,7 +227,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     try {
       await removeClientApi(clientId);
     } catch (err) {
-      window.alert(err instanceof Error ? err.message : t("actions.remove_client_failed"));
+      ctx.showError(err instanceof Error ? err.message : t("actions.remove_client_failed"));
       return;
     }
     const prevSelected = realtime.selectedClientId;

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -97,7 +97,7 @@ export function createSettingsAnalysisModule(ctx: SettingsAnalysisModuleDeps): S
     const validUncertainty = speedUncertainty >= 0 && speedUncertainty <= 20 && tireDiameterUncertainty >= 0 && tireDiameterUncertainty <= 20 && finalDriveUncertainty >= 0 && finalDriveUncertainty <= 10 && gearUncertainty >= 0 && gearUncertainty <= 20;
     const validBandLimits = minAbsBandHz >= 0 && minAbsBandHz <= 10 && maxBandHalfWidth > 0 && maxBandHalfWidth <= 25;
     if (!validBandwidths || !validUncertainty || !validBandLimits) {
-      window.alert(t("settings.validation_error"));
+      ctx.showError(t("settings.validation_error"));
       return;
     }
     const payload: AnalysisSettingsRequest = {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -55,7 +55,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   let handlersBound = false;
 
   function showSettingsSaveError(error: unknown): void {
-    window.alert(error instanceof Error ? error.message : t("settings.save_failed"));
+    ctx.showError(error instanceof Error ? error.message : t("settings.save_failed"));
   }
 
   function hasValidActiveCar(): boolean {
@@ -77,6 +77,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     els,
     t,
     escapeHtml,
+    showError: ctx.showError,
     settings,
     renderSpectrum: ctx.renderSpectrum,
     hasValidActiveCar,
@@ -87,6 +88,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     els,
     t,
     escapeHtml,
+    showError: ctx.showError,
     settings,
     renderSpeedReadout: ctx.renderSpeedReadout,
     onSaveError: showSettingsSaveError,
@@ -95,6 +97,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     els,
     t,
     escapeHtml,
+    showError: ctx.showError,
     settings,
     getSpeedUnit: ctx.getSpeedUnit,
     fmt,
@@ -129,7 +132,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
       renderCarList();
       ctx.renderSpectrum();
     } catch (_err) {
-      window.alert(t("settings.car.activate_failed"));
+      ctx.showError(t("settings.car.activate_failed"));
     }
   }
 
@@ -145,7 +148,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
       renderCarList();
       ctx.renderSpectrum();
     } catch (_err) {
-      window.alert(t("settings.car.delete_failed"));
+      ctx.showError(t("settings.car.delete_failed"));
     }
   }
 

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -80,9 +80,9 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("409")) {
-        window.alert(t("settings.update.already_running"));
+        ctx.showError(t("settings.update.already_running"));
       } else {
-        window.alert(`${t("settings.update.start_failed")}\n${msg}`);
+        ctx.showError(`${t("settings.update.start_failed")}\n${msg}`);
       }
     }
   }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -8,6 +8,10 @@ import {
   type UiShellNavigationModule,
 } from "./ui_shell_navigation_module";
 import {
+  createUiShellNotificationModule,
+  type UiShellNotificationModule,
+} from "./ui_shell_notification_module";
+import {
   createUiShellPreferencesModule,
   type UiShellPreferencesModule,
 } from "./ui_shell_preferences_module";
@@ -27,6 +31,8 @@ export class UiShellController {
   private readonly els: UiDomElements;
 
   private readonly navigation: UiShellNavigationModule;
+
+  private readonly notifications: UiShellNotificationModule;
 
   private readonly preferences: UiShellPreferencesModule;
 
@@ -48,6 +54,9 @@ export class UiShellController {
         this.state.spectrum.spectrumPlot?.resize();
       },
     });
+    this.notifications = createUiShellNotificationModule({
+      els: this.els,
+    });
     this.status = createUiShellStatusModule({
       shell: this.state.shell,
       transport: this.state.transport,
@@ -64,6 +73,7 @@ export class UiShellController {
       normalizeLanguage: (lang) => I18N.normalizeLang(lang),
       applyLanguage: (forceReloadInsights = false) => this.applyLanguage(forceReloadInsights),
       renderSpeedReadout: () => this.status.renderSpeedReadout(),
+      showError: (message) => this.showError(message),
     });
   }
 
@@ -102,6 +112,10 @@ export class UiShellController {
     if (!el) return;
     el.className = `pill pill--${variant}`;
     el.textContent = text;
+  }
+
+  showError(message: string): void {
+    this.notifications.showError(message);
   }
 
   renderSpeedReadout(): void {

--- a/apps/ui/src/app/runtime/ui_shell_notification_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_notification_module.ts
@@ -1,0 +1,54 @@
+import type { UiDomElements } from "../ui_dom_registry";
+
+const ERROR_BANNER_VISIBLE_MS = 8_000;
+
+export interface UiShellNotificationModuleDeps {
+  els: UiDomElements;
+}
+
+export interface UiShellNotificationModule {
+  showError(message: string): void;
+  clearError(): void;
+}
+
+export function createUiShellNotificationModule(
+  ctx: UiShellNotificationModuleDeps,
+): UiShellNotificationModule {
+  let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearPendingTimer(): void {
+    if (clearTimer === null) return;
+    clearTimeout(clearTimer);
+    clearTimer = null;
+  }
+
+  function clearError(): void {
+    clearPendingTimer();
+    const banner = ctx.els.appErrorBanner;
+    if (!banner) return;
+    banner.hidden = true;
+    banner.textContent = "";
+    banner.className = "connection-banner app-error-banner";
+  }
+
+  function showError(message: string): void {
+    clearPendingTimer();
+    const banner = ctx.els.appErrorBanner;
+    if (!banner) {
+      console.warn("UI error banner unavailable", message);
+      return;
+    }
+    banner.hidden = false;
+    banner.textContent = message;
+    banner.className = "connection-banner connection-banner--bad app-error-banner";
+    clearTimer = setTimeout(() => {
+      clearTimer = null;
+      clearError();
+    }, ERROR_BANNER_VISIBLE_MS);
+  }
+
+  return {
+    showError,
+    clearError,
+  };
+}

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -14,6 +14,7 @@ export interface UiShellPreferencesModuleDeps {
   normalizeLanguage: (lang: string) => string;
   applyLanguage: (forceReloadInsights?: boolean) => void;
   renderSpeedReadout: () => void;
+  showError: (message: string) => void;
 }
 
 export interface UiShellPreferencesModule {
@@ -70,7 +71,7 @@ export function createUiShellPreferencesModule(
       if (els.languageSelect) {
         els.languageSelect.value = previousLang;
       }
-      window.alert(error instanceof Error ? error.message : ctx.t("settings.save_failed"));
+      ctx.showError(error instanceof Error ? error.message : ctx.t("settings.save_failed"));
     }
   }
 
@@ -88,7 +89,7 @@ export function createUiShellPreferencesModule(
       if (els.speedUnitSelect) {
         els.speedUnitSelect.value = previousUnit;
       }
-      window.alert(error instanceof Error ? error.message : ctx.t("settings.save_failed"));
+      ctx.showError(error instanceof Error ? error.message : ctx.t("settings.save_failed"));
     }
   }
 

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -54,6 +54,7 @@ export class UiAppRuntime {
       els: this.els,
       t: (key, vars) => this.shell.t(key, vars),
       escapeHtml,
+      showError: (message) => this.shell.showError(message),
       fmt,
       fmtTs,
       formatInt: (value) => this.shell.localFormatInt(value),

--- a/apps/ui/src/app/ui_dom_registry.ts
+++ b/apps/ui/src/app/ui_dom_registry.ts
@@ -81,6 +81,7 @@ export interface UiDomElements {
   staleTimeoutInput: HTMLInputElement | null;
 
   connectionBanner: HTMLElement | null;
+  appErrorBanner: HTMLElement | null;
   appShellWrap: HTMLElement | null;
   rotationalAssumptions: HTMLElement | null;
   rotationalAssumptionsBody: HTMLElement | null;
@@ -187,6 +188,7 @@ export function createUiDomRegistry(): UiDomElements {
     gpsFallbackPanel: el("gpsFallbackPanel"),
     staleTimeoutInput: inputEl("staleTimeoutInput"),
     connectionBanner: el("connectionBanner"),
+    appErrorBanner: el("appErrorBanner"),
     appShellWrap: document.querySelector<HTMLElement>(".wrap"),
 
     rotationalAssumptions: el("rotationalAssumptions"),

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -313,6 +313,12 @@ input:focus-visible,
   border-bottom-color: var(--border);
 }
 
+.app-error-banner {
+  white-space: pre-line;
+  justify-content: flex-start;
+  text-align: left;
+}
+
 .connection-banner::before {
   content: '⚠';
   font-size: 1rem;

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -168,6 +168,7 @@ function createDeps() {
     espFlashCancelBtn,
     t: (key: string) => key,
     escapeHtml: (value: unknown) => String(value ?? ""),
+    showError: () => {},
   };
 }
 
@@ -268,6 +269,7 @@ function createUpdateDeps() {
     updateCancelBtn,
     t: (key: string) => key,
     escapeHtml: (value: unknown) => String(value ?? ""),
+    showError: () => {},
   };
 }
 
@@ -275,7 +277,6 @@ test.describe("createEspFlashFeature polling", () => {
   test.beforeEach(() => {
     (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
       typeof globalThis;
-    window.alert = (() => {}) as typeof window.alert;
   });
 
   test("start replaces the previous poll timeout instead of creating a second chain", async () => {
@@ -387,7 +388,6 @@ test.describe("createUpdateFeature polling", () => {
   test.beforeEach(() => {
     (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
       typeof globalThis;
-    window.alert = (() => {}) as typeof window.alert;
   });
 
   test("start replaces the previous update poll timeout instead of creating a second chain", async () => {

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -346,9 +346,8 @@ test("history download/delete module reports partial delete failures without det
 
   const originalFetch = globalThis.fetch;
   const originalConfirm = window.confirm;
-  const originalAlert = window.alert;
   const deleteRequests: string[] = [];
-  const alerts: string[] = [];
+  const errors: string[] = [];
 
   globalThis.fetch = (async (input: string | URL | RequestInfo, init?: RequestInit) => {
     const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
@@ -363,9 +362,6 @@ test("history download/delete module reports partial delete failures without det
     throw new Error(`Unexpected request: ${url}`);
   }) as typeof fetch;
   window.confirm = (() => true) as typeof window.confirm;
-  window.alert = ((message?: string) => {
-    alerts.push(String(message ?? ""));
-  }) as typeof window.alert;
 
   let renderCalls = 0;
   let refreshCalls = 0;
@@ -373,6 +369,9 @@ test("history download/delete module reports partial delete failures without det
     history: state.history,
     getLanguage: () => state.shell.lang,
     t: testTranslation,
+    showError: (message) => {
+      errors.push(message);
+    },
     ensureRunDetail: (runId) => ensureRunDetail(state, runId),
     collapseExpandedRun: () => {
       const previous = state.history.expandedRunId;
@@ -397,7 +396,6 @@ test("history download/delete module reports partial delete failures without det
   } finally {
     globalThis.fetch = originalFetch;
     window.confirm = originalConfirm;
-    window.alert = originalAlert;
   }
 
   expect(deleteRequests).toEqual(["/api/history/run-001", "/api/history/run-002"]);
@@ -405,7 +403,7 @@ test("history download/delete module reports partial delete failures without det
   expect(state.history.expandedRunId).toBeNull();
   expect(renderCalls).toBe(1);
   expect(refreshCalls).toBe(1);
-  expect(alerts).toHaveLength(1);
-  expect(alerts[0]).toContain("history.delete_all_partial");
-  expect(alerts[0]).toContain("delete failed");
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain("history.delete_all_partial");
+  expect(errors[0]).toContain("delete failed");
 });

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -150,12 +150,6 @@ test("assigning a sensor location preserves the original sensor name", async ({ 
 });
 
 test("failed speed-source save reverts the UI and shows an error", async ({ page }) => {
-  let dialogMessage = "";
-  page.on("dialog", async (dialog) => {
-    dialogMessage = dialog.message();
-    await dialog.accept();
-  });
-
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
       "GET /api/settings/language": { language: "en" },
@@ -179,19 +173,14 @@ test("failed speed-source save reverts the UI and shows an error", async ({ page
   await page.locator("#manualSpeedInput").fill("45");
   await page.locator("#saveSpeedSourceBtn").click();
 
-  await expect.poll(() => dialogMessage).toContain("Speed source save failed");
+  await expect(page.locator("#appErrorBanner")).toBeVisible();
+  await expect(page.locator("#appErrorBanner")).toContainText("Speed source save failed");
   await expect(page.locator('input[name="speedSourceRadio"][value="gps"]')).toBeChecked();
   await expect(page.locator('input[name="speedSourceRadio"][value="manual"]')).not.toBeChecked();
   await expect(page.locator("#manualSpeedInput")).toHaveValue("");
 });
 
 test("failed language save reverts the selector and shows an error", async ({ page }) => {
-  let dialogMessage = "";
-  page.on("dialog", async (dialog) => {
-    dialogMessage = dialog.message();
-    await dialog.accept();
-  });
-
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
       "GET /api/settings/language": { language: "en" },
@@ -210,7 +199,8 @@ test("failed language save reverts the selector and shows an error", async ({ pa
   await page.goto("/");
   await page.locator("#languageSelect").selectOption("nl");
 
-  await expect.poll(() => dialogMessage).toContain("Language save failed");
+  await expect(page.locator("#appErrorBanner")).toBeVisible();
+  await expect(page.locator("#appErrorBanner")).toContainText("Language save failed");
   await expect(page.locator("#languageSelect")).toHaveValue("en");
   await expect(page.locator("#tab-settings")).toContainText("Settings");
 });

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_SHELL_VIEW_ID,
   createUiShellNavigationModule,
 } from "../src/app/runtime/ui_shell_navigation_module";
+import { createUiShellNotificationModule } from "../src/app/runtime/ui_shell_notification_module";
 import { createUiShellPreferencesModule } from "../src/app/runtime/ui_shell_preferences_module";
 import { createUiShellStatusModule } from "../src/app/runtime/ui_shell_status_module";
 
@@ -153,6 +154,7 @@ function createShellDeps(overrides?: Partial<UiDomElements>): {
   speed: HTMLElement;
   linkState: HTMLElement;
   connectionBanner: HTMLElement;
+  appErrorBanner: HTMLElement;
   carSelectionBanner: HTMLElement;
   appShellWrap: HTMLElement;
 } {
@@ -165,6 +167,7 @@ function createShellDeps(overrides?: Partial<UiDomElements>): {
   const speed = createTextElement();
   const linkState = createTextElement();
   const connectionBanner = createTextElement();
+  const appErrorBanner = createTextElement();
   const carSelectionBanner = createTextElement();
   const appShellWrap = createTextElement();
 
@@ -176,6 +179,7 @@ function createShellDeps(overrides?: Partial<UiDomElements>): {
     speed,
     linkState,
     connectionBanner,
+    appErrorBanner,
     carSelectionBanner,
     appShellWrap,
     ...overrides,
@@ -192,6 +196,7 @@ function createShellDeps(overrides?: Partial<UiDomElements>): {
     speed,
     linkState,
     connectionBanner,
+    appErrorBanner,
     carSelectionBanner,
     appShellWrap,
   };
@@ -286,6 +291,7 @@ test.describe("createUiShellPreferencesModule", () => {
       renderSpeedReadout: () => {
         renderSpeedReadoutCalls += 1;
       },
+      showError: () => {},
     });
 
     try {
@@ -327,6 +333,7 @@ test.describe("createUiShellPreferencesModule", () => {
       renderSpeedReadout: () => {
         renderSpeedReadoutCalls += 1;
       },
+      showError: () => {},
     });
 
     try {
@@ -347,6 +354,58 @@ test.describe("createUiShellPreferencesModule", () => {
     ]);
     expect(state.shell.speedUnit).toBe("mps");
     expect(renderSpeedReadoutCalls).toBe(1);
+  });
+
+  test("save failure restores the previous value and reports via showError", async () => {
+    const state = createAppState();
+    const { els, speedUnitSelect } = createShellDeps();
+    const originalFetch = globalThis.fetch;
+    const errors: string[] = [];
+    globalThis.fetch = (async () => {
+      throw new Error("save failed");
+    }) as typeof fetch;
+
+    const module = createUiShellPreferencesModule({
+      shell: state.shell,
+      els,
+      t: (key) => key,
+      normalizeLanguage: (lang) => lang,
+      applyLanguage: () => {},
+      renderSpeedReadout: () => {},
+      showError: (message) => {
+        errors.push(message);
+      },
+    });
+
+    try {
+      module.bindHandlers();
+      speedUnitSelect.triggerChange("mps");
+      await expect.poll(() => errors).toEqual(["save failed"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(state.shell.speedUnit).toBe("kmh");
+    expect(speedUnitSelect.value).toBe("kmh");
+  });
+});
+
+test.describe("createUiShellNotificationModule", () => {
+  test("shows and clears the shared error banner", () => {
+    const { els, appErrorBanner } = createShellDeps();
+    const module = createUiShellNotificationModule({ els });
+
+    module.showError("save failed");
+
+    expect(appErrorBanner.hidden).toBe(false);
+    expect(appErrorBanner.textContent).toBe("save failed");
+    expect(appErrorBanner.className).toBe("connection-banner connection-banner--bad app-error-banner");
+
+    module.clearError();
+
+    expect(appErrorBanner.hidden).toBe(true);
+    expect(appErrorBanner.textContent).toBe("");
+    expect(appErrorBanner.className).toBe("connection-banner app-error-banner");
   });
 });
 


### PR DESCRIPTION
## Summary

This PR resolves the concrete, user-facing part of `#1198`: the frontend still had a scattered set of blocking `window.alert()` error paths even though most of the rest of the UI already communicates state through shell banners, pills, inline status text, and disabled controls. That inconsistency showed up in settings persistence failures, car-management actions, sensor-location changes, history delete flows, update start failures, and ESP flash start failures.

Rather than leaving those code paths as modal browser dialogs, this change moves them onto a shared shell-level error banner so error reporting uses one consistent presentation pattern across the app.

I intentionally kept the scope narrow. During investigation I re-verified the issue’s own claim triage: the broader “frontend resilience” concerns were mostly overstated. Strict TypeScript, schema validation, reconnect behavior, defensive chart rendering, and disconnected-state indicators are already in place. The only worthwhile fix here was the remaining alert-vs-banner inconsistency. I did **not** try to redesign loading state management across the whole UI or chase the theoretical settings/WebSocket race described in the issue, because that would have turned a low-risk consistency cleanup into a much broader refactor without evidence of a real functional bug.

## Implementation approach

The design goal was to remove modal alert dialogs without adding a new global singleton or duplicating notification logic across feature modules. The cleanest fit for the current architecture was:

1. add one reusable error-notification surface at the shell level,
2. expose it through the existing dependency-injection flow,
3. replace the existing `window.alert()` error branches with calls to that shared callback.

This keeps route/data behavior unchanged and only standardizes how frontend errors are presented to the user. It also preserves the current split between the shell runtime and individual feature modules instead of hard-coding DOM manipulation into each feature.

## Main code changes by area

### 1. Shell-level shared notification banner

I added a new top-level `#appErrorBanner` element in `apps/ui/index.html`, next to the other shell banners already used for connection state and active-car warnings. Styling reuses the existing banner language in `app.css` rather than inventing a separate toast design system. The only additional CSS is a small `app-error-banner` class so multi-line messages render cleanly with `white-space: pre-line` and left-aligned text.

I then added `ui_shell_notification_module.ts`, a small runtime module responsible for showing and clearing that shared error banner. It handles timer cleanup and auto-hides the banner after a short interval so the app does not accumulate stale error messages in the shell.

### 2. Shared dependency plumbing

To avoid importing a shell DOM helper directly into every feature, I extended the existing dependency-injection shape with a single `showError(message: string)` callback:

- `FeatureDepsBase`
- `AppFeatureBundleDeps`
- `UiShellController`
- `UiShellPreferencesModule`
- `UiAppRuntime`

That means features keep using injected capabilities instead of reaching across layers, and the banner behavior stays owned by the shell runtime where it belongs.

### 3. Replacing modal alert paths

The remaining modal alert flows now use the shared banner instead:

- `ui_shell_preferences_module.ts` for persisted language and speed-unit save failures
- `settings_feature.ts` for shared settings-save errors and car activate/delete failures
- `settings_analysis_module.ts` for invalid analysis-setting input
- `realtime_feature.ts` for sensor location assignment and client removal failures
- `history_download_delete_module.ts` for delete-run and partial delete-all failures
- `update_feature.ts` for update start failures and already-running conflicts
- `esp_flash_feature.ts` for flash start failures

The important point is that the underlying behavior is unchanged: the same errors are still surfaced, the same save-revert logic still runs, and the same strings are shown. Only the presentation changed from browser dialogs to the shared in-app banner.

## Tests and validation

I updated the focused frontend tests to reflect the new contract rather than the old alert-dialog behavior:

- `ui_shell_runtime_modules.spec.ts`
  - adds coverage for the new notification module
  - adds a preferences failure-path test that verifies save failures report through `showError`
- `history_feature_modules.spec.ts`
  - now asserts that partial delete-all failures are reported through the injected error callback
- `esp_flash_feature.spec.ts`
  - updates the lightweight feature deps used in polling tests so they carry the new `showError` callback
- `smoke.settings.spec.ts`
  - replaces old dialog expectations with assertions against the new `#appErrorBanner`

Local validation performed:

`cd apps/ui && npm run typecheck && npm run build && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/history_feature_modules.spec.ts tests/esp_flash_feature.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`

Result: `19 passed`

Broader frontend smoke validation:

`cd apps/ui && npm run test:smoke`

Result: `16 passed`

I also ran a focused code-review pass over the final diff after the tests were green, and it did not find any material issues.

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that this is a banner-based notification, not a blocking confirmation dialog. That is intentional. These flows are all error-reporting paths after a user action, not high-risk destructive confirmations. The confirmation dialogs that actually gate destructive actions, such as delete confirmations, remain unchanged. Only the post-failure reporting path changed.

I also kept the banner implementation intentionally small. I did not add a new generalized toast queue, prioritization system, or per-feature notification state. There is only one shared transient banner because that is enough to solve the real inconsistency without adding unnecessary UI framework code.

Finally, I chose not to tackle the theoretical settings/WebSocket interleaving concern in this PR. The issue itself already notes that the risk is largely mitigated by server-side locking and infrequent user-triggered changes. There was no evidence that this was causing an actual user-visible failure, so I kept this change focused on the confirmed inconsistency.

## Out of scope

This PR does **not** attempt to unify every loading and error idiom in the app. History detail panels still use inline error text where that makes sense for row-local state, and status areas like update/flash/logging still use pills where they are already working well. The goal here was not to flatten every UX pattern into one component, but to remove the remaining browser-modal outliers and align them with the shell-level messaging style the rest of the app already uses.

No API contracts, schemas, or backend code changed in this PR.

Closes #1198
