### PR TITLE
Curate HTTP OpenAPI docs and versioning guidance

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -87,6 +87,18 @@ Current route groups:
 - `car_library.py`
 - `debug.py`
 
+### HTTP API schema export and versioning stance
+
+- Export the committed HTTP OpenAPI schema with `python -m vibesensor.cli.http_api_schema_export`.
+- The checked-in schema artifact lives at
+  `apps/ui/src/contracts/http_api_schema.json` and is kept in sync by CI
+  drift checks.
+- The current HTTP API intentionally remains a single unversioned `/api/*`
+  surface because the backend and bundled UI ship atomically.
+- If independent or third-party clients become a real compatibility concern,
+  introduce explicit path versioning starting at `/api/v1/` rather than adding
+  ad hoc compatibility shims to the current routes.
+
 ## Reports
 
 Generate a PDF from a saved run:

--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -278,3 +278,40 @@ def test_export_schema_uses_snake_case_settings_contract_fields(
     assert "speedUnit" not in speed_unit_request["properties"]
     assert "speed_unit" in speed_unit_response["properties"]
     assert "speedUnit" not in speed_unit_response["properties"]
+
+
+def test_export_schema_documents_key_endpoint_descriptions_and_error_responses(
+    schema_dict: dict[str, Any],
+) -> None:
+    health_route = schema_dict["paths"]["/api/health"]["get"]
+    set_client_location = schema_dict["paths"]["/api/clients/{client_id}/location"]["post"]
+    update_speed_source = schema_dict["paths"]["/api/settings/speed-source"]["put"]
+    history_insights = schema_dict["paths"]["/api/history/{run_id}/insights"]["get"]
+    update_start = schema_dict["paths"]["/api/update/start"]["post"]
+
+    assert health_route["tags"] == ["health"]
+    assert "runtime health snapshot" in health_route["description"]
+
+    assert set_client_location["tags"] == ["clients"]
+    assert "persist the updated mapping" in set_client_location["description"]
+    assert (
+        set_client_location["responses"]["409"]["description"]
+        == "Requested location is already assigned to another sensor."
+    )
+
+    assert update_speed_source["tags"] == ["settings"]
+    assert "preferred speed source" in update_speed_source["description"]
+    assert (
+        update_speed_source["responses"]["400"]["description"]
+        == "The requested speed-source configuration is invalid."
+    )
+
+    assert history_insights["tags"] == ["history"]
+    assert "post-analysis findings" in history_insights["description"]
+    assert history_insights["responses"]["422"]["description"] == (
+        "Insights are unavailable because analysis failed or produced unsupported persisted data."
+    )
+
+    assert update_start["tags"] == ["updates"]
+    assert "uplink Wi-Fi credentials" in update_start["description"]
+    assert update_start["responses"]["409"]["description"] == "An update job is already running."

--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -240,6 +240,23 @@ class TestSpeedSourceEndpoint:
         )
 
     @pytest.mark.asyncio
+    async def test_update_speed_source_maps_invalid_config_to_400(self, _settings_router) -> None:
+        router, state = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/speed-source", "PUT")
+        assert endpoint is not None
+
+        from vibesensor.adapters.http.models import SpeedSourceRequest
+
+        state.settings_store.update_speed_source.side_effect = ValueError(
+            "SpeedSourceConfig with speed_source=MANUAL requires manual_speed_kph"
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await endpoint(req=SpeedSourceRequest(speed_source="manual"))
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
     async def test_speed_source_status_response_shape(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/speed-source/status", "GET")

--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any, TypeAlias
 
 from fastapi import HTTPException
 
@@ -21,12 +22,15 @@ from vibesensor.shared.exceptions import (
 from vibesensor.use_cases.history.helpers import async_require_run, safe_filename
 
 __all__ = [
+    "OpenAPIResponses",
     "async_require_run",
     "domain_errors_to_http",
     "normalize_client_id_or_400",
     "normalize_mac_or_400",
     "safe_filename",
 ]
+
+OpenAPIResponses: TypeAlias = dict[int | str, dict[str, Any]]
 
 
 @contextmanager

--- a/apps/server/vibesensor/adapters/http/car_library.py
+++ b/apps/server/vibesensor/adapters/http/car_library.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query
 
+from vibesensor.adapters.http._helpers import OpenAPIResponses
 from vibesensor.adapters.http.models import (
     CarLibraryBrandsResponse,
     CarLibraryModelEntry,
     CarLibraryModelsResponse,
     CarLibraryTypesResponse,
 )
+
+_CAR_LIBRARY_NOT_FOUND_RESPONSES: OpenAPIResponses = {
+    404: {"description": "The requested brand or brand/type combination does not exist."},
+}
 
 
 def create_car_library_routes() -> APIRouter:
@@ -20,26 +25,39 @@ def create_car_library_routes() -> APIRouter:
         get_types_for_brand,
     )
 
-    router = APIRouter()
+    router = APIRouter(tags=["car-library"])
 
     @router.get("/api/car-library/brands", response_model=CarLibraryBrandsResponse)
     async def get_car_library_brands() -> CarLibraryBrandsResponse:
         """Return all available car manufacturer brands from the library."""
         return CarLibraryBrandsResponse(brands=get_brands())
 
-    @router.get("/api/car-library/types", response_model=CarLibraryTypesResponse)
+    @router.get(
+        "/api/car-library/types",
+        response_model=CarLibraryTypesResponse,
+        responses=_CAR_LIBRARY_NOT_FOUND_RESPONSES,
+    )
     async def get_car_library_types(
-        brand: str = Query(..., min_length=1),
+        brand: str = Query(..., min_length=1, description="Manufacturer brand to look up."),
     ) -> CarLibraryTypesResponse:
         """Return body types available for *brand*; 404 if the brand is unknown."""
         if brand not in get_brands():
             raise HTTPException(status_code=404, detail=f"Unknown brand: {brand!r}")
         return CarLibraryTypesResponse(types=get_types_for_brand(brand))
 
-    @router.get("/api/car-library/models", response_model=CarLibraryModelsResponse)
+    @router.get(
+        "/api/car-library/models",
+        response_model=CarLibraryModelsResponse,
+        responses=_CAR_LIBRARY_NOT_FOUND_RESPONSES,
+    )
     async def get_car_library_models(
-        brand: str = Query(..., min_length=1),
-        car_type: str = Query(..., min_length=1, alias="type"),
+        brand: str = Query(..., min_length=1, description="Manufacturer brand to look up."),
+        car_type: str = Query(
+            ...,
+            min_length=1,
+            alias="type",
+            description="Vehicle body type to look up for the selected brand.",
+        ),
     ) -> CarLibraryModelsResponse:
         """Return library entries for *brand* + *type*; 404 if the combination is unknown."""
         if brand not in get_brands():

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException
 
-from vibesensor.adapters.http._helpers import domain_errors_to_http, normalize_client_id_or_400
+from vibesensor.adapters.http._helpers import (
+    OpenAPIResponses,
+    domain_errors_to_http,
+    normalize_client_id_or_400,
+)
 from vibesensor.adapters.http.models import (
     ClientLocationsResponse,
     ClientsResponse,
@@ -28,6 +32,23 @@ if TYPE_CHECKING:
     from vibesensor.infra.processing.processor import SignalProcessor
     from vibesensor.infra.runtime.registry import ClientRegistry
 
+_IDENTIFY_CLIENT_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid sensor identifier."},
+    404: {"description": "Sensor not found."},
+    503: {"description": "Sensor is known but not currently reachable."},
+}
+
+_SET_CLIENT_LOCATION_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid sensor identifier or unknown location code."},
+    404: {"description": "Sensor not found."},
+    409: {"description": "Requested location is already assigned to another sensor."},
+}
+
+_REMOVE_CLIENT_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid sensor identifier."},
+    404: {"description": "Sensor not found."},
+}
+
 
 def create_client_routes(
     registry: ClientRegistry,
@@ -36,24 +57,31 @@ def create_client_routes(
     processor: SignalProcessor,
 ) -> APIRouter:
     """Create and return the client-management API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["clients"])
 
     @router.get("/api/clients", response_model=ClientsResponse)
     async def get_clients() -> ClientsResponse:
+        """List known sensor clients with live connection state and latest computed metrics."""
         active_ids = registry.active_client_ids()
         metrics = processor.all_latest_metrics(active_ids)
         return ClientsResponse(clients=snapshot_for_api(registry, metrics_by_client=metrics))
 
     @router.get("/api/client-locations", response_model=ClientLocationsResponse)
     async def get_client_locations() -> ClientLocationsResponse:
+        """List the supported sensor location codes that operators can assign to clients."""
         return ClientLocationsResponse(
             locations=[
                 LocationOptionResponse.model_validate(location) for location in all_locations()
             ]
         )
 
-    @router.post("/api/clients/{client_id}/identify", response_model=IdentifyResponse)
+    @router.post(
+        "/api/clients/{client_id}/identify",
+        response_model=IdentifyResponse,
+        responses=_IDENTIFY_CLIENT_RESPONSES,
+    )
     async def identify_client(client_id: str, req: IdentifyRequest) -> IdentifyResponse:
+        """Send a temporary identify/blink command so an operator can find a sensor physically."""
         normalized = normalize_client_id_or_400(client_id)
         # Distinguish "sensor never seen" (404) from "sensor known but not
         # currently connected" (503) so callers can react appropriately.
@@ -67,11 +95,13 @@ def create_client_routes(
     @router.post(
         "/api/clients/{client_id}/location",
         response_model=SetClientLocationResponse,
+        responses=_SET_CLIENT_LOCATION_RESPONSES,
     )
     async def set_client_location(
         client_id: str,
         req: SetLocationRequest,
     ) -> SetClientLocationResponse:
+        """Assign or clear the logical location for a sensor and persist the updated mapping."""
         normalized_client_id = normalize_client_id_or_400(client_id)
         if registry.get(normalized_client_id) is None:
             raise HTTPException(status_code=404, detail="Sensor not found")
@@ -103,8 +133,13 @@ def create_client_routes(
             name=name,
         )
 
-    @router.delete("/api/clients/{client_id}", response_model=RemoveClientResponse)
+    @router.delete(
+        "/api/clients/{client_id}",
+        response_model=RemoveClientResponse,
+        responses=_REMOVE_CLIENT_RESPONSES,
+    )
     async def remove_client(client_id: str) -> RemoveClientResponse:
+        """Remove a disconnected sensor from the runtime registry."""
         normalized_client_id = normalize_client_id_or_400(client_id)
         removed = registry.remove_client(normalized_client_id)
         if not removed:

--- a/apps/server/vibesensor/adapters/http/debug.py
+++ b/apps/server/vibesensor/adapters/http/debug.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, TypeGuard
 
 from fastapi import APIRouter, HTTPException, Query
 
-from vibesensor.adapters.http._helpers import normalize_client_id_or_400
+from vibesensor.adapters.http._helpers import OpenAPIResponses, normalize_client_id_or_400
 from vibesensor.shared.types.payload_types import (
     DebugSpectrumErrorPayload,
     DebugSpectrumPayload,
@@ -18,6 +18,11 @@ if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
 
 __all__ = ["create_debug_routes"]
+
+_DEBUG_SENSOR_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid sensor identifier."},
+    404: {"description": "No debug data is available for the requested sensor."},
+}
 
 
 def _is_debug_spectrum_error_payload(
@@ -46,9 +51,13 @@ def _is_raw_samples_payload(
 
 def create_debug_routes(processor: SignalProcessor) -> APIRouter:
     """Create and return the internal debug API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["debug"])
 
-    @router.get("/api/debug/spectrum/{client_id}", response_model=DebugSpectrumPayload)
+    @router.get(
+        "/api/debug/spectrum/{client_id}",
+        response_model=DebugSpectrumPayload,
+        responses=_DEBUG_SENSOR_RESPONSES,
+    )
     async def debug_spectrum(client_id: str) -> DebugSpectrumPayload:
         """Detailed spectrum debug info for independent verification."""
         normalized = normalize_client_id_or_400(client_id)
@@ -62,10 +71,19 @@ def create_debug_routes(processor: SignalProcessor) -> APIRouter:
             return result
         raise AssertionError("Unreachable debug spectrum payload state")
 
-    @router.get("/api/debug/raw-samples/{client_id}", response_model=RawSamplesPayload)
+    @router.get(
+        "/api/debug/raw-samples/{client_id}",
+        response_model=RawSamplesPayload,
+        responses=_DEBUG_SENSOR_RESPONSES,
+    )
     async def debug_raw_samples(
         client_id: str,
-        n: int = Query(default=2048, ge=1, le=6400),
+        n: int = Query(
+            default=2048,
+            ge=1,
+            le=6400,
+            description="Number of recent raw samples to return.",
+        ),
     ) -> RawSamplesPayload:
         """Raw time-domain samples in g for offline analysis."""
         normalized = normalize_client_id_or_400(client_id)

--- a/apps/server/vibesensor/adapters/http/health.py
+++ b/apps/server/vibesensor/adapters/http/health.py
@@ -25,10 +25,11 @@ def create_health_routes(
     run_recorder: RunRecorder,
 ) -> APIRouter:
     """Create and return the health-check API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["health"])
 
     @router.get("/api/health", response_model=HealthResponse)
     async def health() -> HealthResponse:
+        """Return the current runtime health snapshot for the server and sensor pipeline."""
         return HealthResponse.model_validate(
             build_system_health_snapshot(
                 loop_state,

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
-from vibesensor.adapters.http._helpers import domain_errors_to_http
+from vibesensor.adapters.http._helpers import OpenAPIResponses, domain_errors_to_http
 from vibesensor.adapters.http.models import (
     DeleteHistoryRunResponse,
     HistoryInsightsAnalyzingResponse,
@@ -23,6 +23,40 @@ if TYPE_CHECKING:
         HistoryRunServiceProtocol,
     )
 
+_RUN_NOT_FOUND_RESPONSE: OpenAPIResponses = {
+    404: {"description": "Requested run was not found."},
+}
+
+_RUN_LOAD_ERROR_RESPONSE: OpenAPIResponses = {
+    500: {"description": "Run data is corrupt or could not be processed."},
+}
+
+_HISTORY_INSIGHTS_RESPONSES: OpenAPIResponses = {
+    202: {
+        "model": HistoryInsightsAnalyzingResponse,
+        "description": "Analysis is still running for the requested run.",
+    },
+    404: {"description": "Requested run was not found."},
+    409: {"description": "Insights are not ready yet for the requested run."},
+    422: {
+        "description": (
+            "Insights are unavailable because analysis failed or produced "
+            "unsupported persisted data."
+        )
+    },
+    500: {"description": "Run data is corrupt or insights generation failed."},
+}
+
+_REPORT_RESPONSES: OpenAPIResponses = {
+    404: {"description": "Requested run was not found."},
+    500: {"description": "Report generation failed because the run data is corrupt or incomplete."},
+}
+
+_EXPORT_RESPONSES: OpenAPIResponses = {
+    404: {"description": "Requested run was not found."},
+    500: {"description": "Export generation failed because the run data is corrupt or incomplete."},
+}
+
 
 def create_history_routes(
     *,
@@ -31,12 +65,13 @@ def create_history_routes(
     export_service: HistoryExportServiceProtocol,
 ) -> APIRouter:
     """Create and return the run-history / report API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["history"])
 
     # -- history CRUD ----------------------------------------------------------
 
     @router.get("/api/history", response_model=HistoryListResponse)
     async def get_history() -> HistoryListResponse:
+        """List all persisted recording runs available in history storage."""
         return HistoryListResponse(runs=await run_service.list_runs())
 
     @router.get(
@@ -44,20 +79,28 @@ def create_history_routes(
         response_model=HistoryRunResponse,
         response_model_exclude_unset=True,
         response_model_exclude_none=True,
+        responses={**_RUN_NOT_FOUND_RESPONSE, **_RUN_LOAD_ERROR_RESPONSE},
     )
     async def get_history_run(run_id: str) -> HistoryRunResponse:
+        """Return full metadata and analysis payloads for a single recorded run."""
         with domain_errors_to_http():
             return await run_service.get_run(run_id)
 
     @router.get(
         "/api/history/{run_id}/insights",
         response_model=HistoryInsightsResponse,
-        responses={202: {"model": HistoryInsightsAnalyzingResponse}},
+        responses=_HISTORY_INSIGHTS_RESPONSES,
     )
     async def get_history_insights(
         run_id: str,
-        lang: str | None = Query(default=None),
+        lang: str | None = Query(
+            default=None,
+            description=(
+                "Optional language override for localized insights text (for example 'en' or 'nl')."
+            ),
+        ),
     ) -> HistoryInsightsResponse | JSONResponse:
+        """Return localized post-analysis findings, or a 202 while analysis is still running."""
         with domain_errors_to_http():
             result = await run_service.get_insights(run_id, requested_lang=lang)
         if result is None:
@@ -68,18 +111,34 @@ def create_history_routes(
             )
         return result
 
-    @router.delete("/api/history/{run_id}", response_model=DeleteHistoryRunResponse)
+    @router.delete(
+        "/api/history/{run_id}",
+        response_model=DeleteHistoryRunResponse,
+        responses=_RUN_NOT_FOUND_RESPONSE,
+    )
     async def delete_history_run(run_id: str) -> DeleteHistoryRunResponse:
+        """Delete a persisted run and its derived artifacts from history storage."""
         with domain_errors_to_http():
             return await run_service.delete_run(run_id)
 
     # -- report PDF ------------------------------------------------------------
 
-    @router.get("/api/history/{run_id}/report.pdf", response_class=Response)
+    @router.get(
+        "/api/history/{run_id}/report.pdf",
+        response_class=Response,
+        responses=_REPORT_RESPONSES,
+    )
     async def download_history_report_pdf(
         run_id: str,
-        lang: str | None = Query(default=None),
+        lang: str | None = Query(
+            default=None,
+            description=(
+                "Optional language override for the generated PDF report "
+                "(for example 'en' or 'nl')."
+            ),
+        ),
     ) -> Response:
+        """Build and download the PDF diagnostic report for a persisted run."""
         with domain_errors_to_http():
             pdf = await report_service.build_pdf(run_id, lang)
         pdf_headers = {
@@ -93,8 +152,13 @@ def create_history_routes(
 
     # -- CSV/ZIP export --------------------------------------------------------
 
-    @router.get("/api/history/{run_id}/export", response_class=StreamingResponse)
+    @router.get(
+        "/api/history/{run_id}/export",
+        response_class=StreamingResponse,
+        responses=_EXPORT_RESPONSES,
+    )
     async def export_history_run(run_id: str) -> StreamingResponse:
+        """Build and stream the ZIP export bundle for a persisted run."""
         with domain_errors_to_http():
             export = await export_service.build_export(run_id)
         return StreamingResponse(

--- a/apps/server/vibesensor/adapters/http/recording.py
+++ b/apps/server/vibesensor/adapters/http/recording.py
@@ -32,18 +32,21 @@ def create_recording_routes(
     run_recorder: RunRecorder,
 ) -> APIRouter:
     """Create and return the run-recording / logging API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["recording"])
 
     @router.get("/api/recording/status", response_model=RecordingStatusResponse)
     async def get_logging_status() -> RecordingStatusResponse:
+        """Return the current recording state, counters, and last completed run details."""
         return _recording_status_response(run_recorder.status())
 
     @router.post("/api/recording/start", response_model=RecordingStatusResponse)
     async def start_logging() -> RecordingStatusResponse:
+        """Start recording a new run and return the updated recorder status snapshot."""
         return _recording_status_response(run_recorder.start_recording())
 
     @router.post("/api/recording/stop", response_model=RecordingStatusResponse)
     async def stop_logging() -> RecordingStatusResponse:
+        """Stop the active recording and return the updated recorder status snapshot."""
         return _recording_status_response(run_recorder.stop_recording())
 
     return router

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException
 
-from vibesensor.adapters.http._helpers import domain_errors_to_http, normalize_mac_or_400
+from vibesensor.adapters.http._helpers import (
+    OpenAPIResponses,
+    domain_errors_to_http,
+    normalize_mac_or_400,
+)
 from vibesensor.adapters.http.models import (
     ActiveCarRequest,
     AnalysisSettingsRequest,
@@ -43,13 +47,47 @@ if TYPE_CHECKING:
     from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
     from vibesensor.infra.config.settings_store import SettingsStore
 
+_CAR_NOT_FOUND_RESPONSES: OpenAPIResponses = {
+    404: {"description": "Requested car profile was not found."},
+}
+
+_DELETE_CAR_RESPONSES: OpenAPIResponses = {
+    400: {"description": "The requested deletion violates current settings constraints."},
+    404: {"description": "Requested car profile was not found."},
+}
+
+_UPDATE_SPEED_SOURCE_RESPONSES: OpenAPIResponses = {
+    400: {"description": "The requested speed-source configuration is invalid."},
+}
+
+_UPDATE_SENSOR_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid sensor MAC address or sensor settings payload."},
+}
+
+_DELETE_SENSOR_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid sensor MAC address."},
+    404: {"description": "Sensor configuration not found for the given MAC address."},
+}
+
+_SET_LANGUAGE_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Unsupported language code."},
+}
+
+_SET_SPEED_UNIT_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Unsupported speed unit."},
+}
+
+_SET_ANALYSIS_SETTINGS_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Analysis settings are invalid or no active car is configured."},
+}
+
 
 def create_settings_routes(
     settings_store: SettingsStore,
     gps_monitor: GPSSpeedMonitor,
 ) -> APIRouter:
     """Create and return the device-settings API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["settings"])
 
     def _car_response(payload: CarConfigPayload) -> CarResponse:
         return CarResponse(
@@ -169,23 +207,35 @@ def create_settings_routes(
 
     @router.get("/api/settings/cars", response_model=CarsResponse)
     async def get_cars() -> CarsResponse:
+        """List all saved car profiles together with the currently active car ID."""
         return _cars_response(settings_store.get_cars())
 
     @router.post("/api/settings/cars", response_model=CarsResponse)
     async def add_car(req: CarUpsertRequest) -> CarsResponse:
+        """Create a new car profile from the provided partial settings payload."""
         payload = _car_upsert_payload(req)
         result = await asyncio.to_thread(settings_store.add_car, payload)
         return _cars_response(result)
 
-    @router.put("/api/settings/cars/active", response_model=CarsResponse)
+    @router.put(
+        "/api/settings/cars/active",
+        response_model=CarsResponse,
+        responses=_CAR_NOT_FOUND_RESPONSES,
+    )
     async def set_active_car(req: ActiveCarRequest) -> CarsResponse:
+        """Select which saved car profile should drive current analysis settings."""
         car_id = req.car_id
         with domain_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(settings_store.set_active_car, car_id)
         return _cars_response(result)
 
-    @router.put("/api/settings/cars/{car_id}", response_model=CarsResponse)
+    @router.put(
+        "/api/settings/cars/{car_id}",
+        response_model=CarsResponse,
+        responses=_CAR_NOT_FOUND_RESPONSES,
+    )
     async def update_car(car_id: str, req: CarUpsertRequest) -> CarsResponse:
+        """Update an existing car profile while preserving unspecified fields."""
         payload = _car_upsert_payload(req)
         with domain_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(
@@ -195,8 +245,13 @@ def create_settings_routes(
             )
         return _cars_response(result)
 
-    @router.delete("/api/settings/cars/{car_id}", response_model=CarsResponse)
+    @router.delete(
+        "/api/settings/cars/{car_id}",
+        response_model=CarsResponse,
+        responses=_DELETE_CAR_RESPONSES,
+    )
     async def delete_car(car_id: str) -> CarsResponse:
+        """Delete a saved car profile when that removal keeps settings state valid."""
         # Existence check first so unknown-car yields 404 while business-logic
         # errors (e.g. "cannot delete the last car") propagate as 400.
         cars_snapshot = await asyncio.to_thread(settings_store.get_cars)
@@ -210,22 +265,30 @@ def create_settings_routes(
 
     async def _apply_speed_source_update(req: SpeedSourceRequest) -> SpeedSourceResponse:
         payload = _speed_source_update_payload(req)
-        result = await asyncio.to_thread(
-            settings_store.update_speed_source,
-            payload,
-        )
+        with domain_errors_to_http(catch_value_error=400):
+            result = await asyncio.to_thread(
+                settings_store.update_speed_source,
+                payload,
+            )
         return _speed_source_response(result)
 
     @router.get("/api/settings/speed-source", response_model=SpeedSourceResponse)
     async def get_speed_source() -> SpeedSourceResponse:
+        """Return the persisted speed-source configuration used for order tracking."""
         return _speed_source_response(settings_store.get_speed_source())
 
-    @router.put("/api/settings/speed-source", response_model=SpeedSourceResponse)
+    @router.put(
+        "/api/settings/speed-source",
+        response_model=SpeedSourceResponse,
+        responses=_UPDATE_SPEED_SOURCE_RESPONSES,
+    )
     async def update_speed_source(req: SpeedSourceRequest) -> SpeedSourceResponse:
+        """Update the preferred speed source, manual fallback speed, and staleness timeout."""
         return await _apply_speed_source_update(req)
 
     @router.get("/api/settings/speed-source/status", response_model=SpeedSourceStatusResponse)
     async def get_speed_source_status() -> SpeedSourceStatusResponse:
+        """Return the live GPS connection state and effective speed-source status."""
         return _speed_source_status_response(gps_monitor.status_snapshot())
 
     # -- sensors ---------------------------------------------------------------
@@ -235,10 +298,16 @@ def create_settings_routes(
 
     @router.get("/api/settings/sensors", response_model=SensorsResponse)
     async def get_sensors() -> SensorsResponse:
+        """List persisted per-sensor settings keyed by normalized MAC address."""
         return _sensors_response()
 
-    @router.post("/api/settings/sensors/{mac}", response_model=SensorsResponse)
+    @router.post(
+        "/api/settings/sensors/{mac}",
+        response_model=SensorsResponse,
+        responses=_UPDATE_SENSOR_RESPONSES,
+    )
     async def update_sensor(mac: str, req: SensorRequest) -> SensorsResponse:
+        """Create or update persisted sensor metadata for a specific MAC address."""
         normalized_mac = normalize_mac_or_400(mac)
         payload = _sensor_update_payload(req)
         with domain_errors_to_http(catch_value_error=400):
@@ -249,8 +318,13 @@ def create_settings_routes(
             )
         return _sensors_response()
 
-    @router.delete("/api/settings/sensors/{mac}", response_model=SensorsResponse)
+    @router.delete(
+        "/api/settings/sensors/{mac}",
+        response_model=SensorsResponse,
+        responses=_DELETE_SENSOR_RESPONSES,
+    )
     async def delete_sensor(mac: str) -> SensorsResponse:
+        """Delete persisted sensor metadata for a specific MAC address."""
         normalized_mac = normalize_mac_or_400(mac)
         with domain_errors_to_http(catch_value_error=400):
             removed = await asyncio.to_thread(settings_store.remove_sensor, normalized_mac)
@@ -262,20 +336,32 @@ def create_settings_routes(
 
     @router.get("/api/settings/language", response_model=LanguageResponse)
     async def get_language() -> LanguageResponse:
+        """Return the currently selected dashboard language code."""
         return LanguageResponse(language=settings_store.language)
 
-    @router.put("/api/settings/language", response_model=LanguageResponse)
+    @router.put(
+        "/api/settings/language",
+        response_model=LanguageResponse,
+        responses=_SET_LANGUAGE_RESPONSES,
+    )
     async def set_language(req: LanguageRequest) -> LanguageResponse:
+        """Update the dashboard language used by the local UI."""
         with domain_errors_to_http(catch_value_error=400):
             language = await asyncio.to_thread(settings_store.set_language, req.language)
         return LanguageResponse(language=language)
 
     @router.get("/api/settings/speed-unit", response_model=SpeedUnitResponse)
     async def get_speed_unit() -> SpeedUnitResponse:
+        """Return the speed unit currently used for UI display and input."""
         return SpeedUnitResponse(speed_unit=settings_store.speed_unit)
 
-    @router.put("/api/settings/speed-unit", response_model=SpeedUnitResponse)
+    @router.put(
+        "/api/settings/speed-unit",
+        response_model=SpeedUnitResponse,
+        responses=_SET_SPEED_UNIT_RESPONSES,
+    )
     async def set_speed_unit(req: SpeedUnitRequest) -> SpeedUnitResponse:
+        """Update the speed unit used for UI display and manual speed entry."""
         with domain_errors_to_http(catch_value_error=400):
             unit = await asyncio.to_thread(settings_store.set_speed_unit, req.speed_unit)
         return SpeedUnitResponse(speed_unit=unit)
@@ -284,10 +370,16 @@ def create_settings_routes(
 
     @router.get("/api/settings/analysis", response_model=AnalysisSettingsResponse)
     async def get_analysis_settings() -> AnalysisSettingsResponse:
+        """Return the validated analysis settings derived from the active car profile."""
         return _analysis_settings_response()
 
-    @router.put("/api/settings/analysis", response_model=AnalysisSettingsResponse)
+    @router.put(
+        "/api/settings/analysis",
+        response_model=AnalysisSettingsResponse,
+        responses=_SET_ANALYSIS_SETTINGS_RESPONSES,
+    )
     async def set_analysis_settings(req: AnalysisSettingsRequest) -> AnalysisSettingsResponse:
+        """Update analysis-specific car aspects such as tire geometry and drivetrain ratios."""
         changes = _analysis_settings_payload(req)
         if changes:
             with domain_errors_to_http(catch_value_error=400):

--- a/apps/server/vibesensor/adapters/http/updates.py
+++ b/apps/server/vibesensor/adapters/http/updates.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Query
 
-from vibesensor.adapters.http._helpers import domain_errors_to_http
+from vibesensor.adapters.http._helpers import OpenAPIResponses, domain_errors_to_http
 from vibesensor.adapters.http.models import (
     EspFlashCancelResponse,
     EspFlashHistoryResponse,
@@ -27,57 +27,92 @@ if TYPE_CHECKING:
 
 __all__ = ["create_update_routes"]
 
+_UPDATE_START_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid Wi-Fi credentials or update request values."},
+    409: {"description": "An update job is already running."},
+    500: {"description": "The update process could not be started."},
+}
+
+_ESP_FLASH_START_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid flash settings or port selection."},
+    409: {"description": "An ESP flash job is already running."},
+    500: {"description": "The flash job could not be started."},
+}
+
 
 def create_update_routes(
     update_manager: UpdateManager,
     esp_flash_manager: EspFlashManager,
 ) -> APIRouter:
     """Create and return the OTA software/firmware update API routes."""
-    router = APIRouter()
+    router = APIRouter(tags=["updates"])
 
     # -- software update -------------------------------------------------------
 
     @router.get("/api/update/status", response_model=UpdateStatusResponse)
     async def get_update_status() -> UpdateStatusResponse:
+        """Return the current OTA software update job state, logs, and runtime details."""
         return UpdateStatusResponse.model_validate(update_manager.status.to_payload())
 
-    @router.post("/api/update/start", response_model=UpdateStartResponse)
+    @router.post(
+        "/api/update/start",
+        response_model=UpdateStartResponse,
+        responses=_UPDATE_START_RESPONSES,
+    )
     async def start_update(req: UpdateStartRequest) -> UpdateStartResponse:
+        """Start an OTA software update using the supplied uplink Wi-Fi credentials."""
         with domain_errors_to_http():
             update_manager.start(req.ssid, req.password)
         return UpdateStartResponse(status="started", ssid=req.ssid)
 
     @router.post("/api/update/cancel", response_model=UpdateCancelResponse)
     async def cancel_update() -> UpdateCancelResponse:
+        """Request cancellation of the active OTA software update job."""
         return UpdateCancelResponse(cancelled=update_manager.cancel())
 
     # -- ESP flash -------------------------------------------------------------
 
     @router.get("/api/esp-flash/ports", response_model=EspFlashPortsResponse)
     async def list_esp_flash_ports() -> EspFlashPortsResponse:
+        """List serial ports currently available for ESP32 firmware flashing."""
         ports = await esp_flash_manager.list_ports()
         return EspFlashPortsResponse.model_validate({"ports": ports})
 
-    @router.post("/api/esp-flash/start", response_model=EspFlashStartResponse)
+    @router.post(
+        "/api/esp-flash/start",
+        response_model=EspFlashStartResponse,
+        responses=_ESP_FLASH_START_RESPONSES,
+    )
     async def start_esp_flash(req: EspFlashStartRequest) -> EspFlashStartResponse:
+        """Start a new ESP32 firmware flash job with either auto-detect or an explicit port."""
         with domain_errors_to_http():
             job_id = esp_flash_manager.start(port=req.port, auto_detect=req.auto_detect)
         return EspFlashStartResponse(status="started", job_id=job_id)
 
     @router.get("/api/esp-flash/status", response_model=EspFlashStatusResponse)
     async def get_esp_flash_status() -> EspFlashStatusResponse:
+        """Return the current ESP32 flash job state and the selected serial port, if any."""
         return EspFlashStatusResponse.model_validate(esp_flash_manager.status.to_dict())
 
     @router.get("/api/esp-flash/logs", response_model=EspFlashLogsResponse)
-    async def get_esp_flash_logs(after: int = Query(default=0, ge=0)) -> EspFlashLogsResponse:
+    async def get_esp_flash_logs(
+        after: int = Query(
+            default=0,
+            ge=0,
+            description="Return log lines strictly after this zero-based index.",
+        ),
+    ) -> EspFlashLogsResponse:
+        """Return incremental ESP32 flash logs for polling clients."""
         return EspFlashLogsResponse.model_validate(esp_flash_manager.logs_since(after))
 
     @router.post("/api/esp-flash/cancel", response_model=EspFlashCancelResponse)
     async def cancel_esp_flash() -> EspFlashCancelResponse:
+        """Request cancellation of the active ESP32 flash job."""
         return EspFlashCancelResponse(cancelled=esp_flash_manager.cancel())
 
     @router.get("/api/esp-flash/history", response_model=EspFlashHistoryResponse)
     async def get_esp_flash_history() -> EspFlashHistoryResponse:
+        """List completed and failed ESP32 flash attempts kept in local history."""
         return EspFlashHistoryResponse.model_validate({"attempts": esp_flash_manager.history()})
 
     return router

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -6434,7 +6434,10 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Car Library Brands"
+        "summary": "Get Car Library Brands",
+        "tags": [
+          "car-library"
+        ]
       }
     },
     "/api/car-library/models": {
@@ -6443,20 +6446,24 @@
         "operationId": "get_car_library_models_api_car_library_models_get",
         "parameters": [
           {
+            "description": "Manufacturer brand to look up.",
             "in": "query",
             "name": "brand",
             "required": true,
             "schema": {
+              "description": "Manufacturer brand to look up.",
               "minLength": 1,
               "title": "Brand",
               "type": "string"
             }
           },
           {
+            "description": "Vehicle body type to look up for the selected brand.",
             "in": "query",
             "name": "type",
             "required": true,
             "schema": {
+              "description": "Vehicle body type to look up for the selected brand.",
               "minLength": 1,
               "title": "Type",
               "type": "string"
@@ -6474,6 +6481,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "The requested brand or brand/type combination does not exist."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6485,7 +6495,10 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Get Car Library Models"
+        "summary": "Get Car Library Models",
+        "tags": [
+          "car-library"
+        ]
       }
     },
     "/api/car-library/types": {
@@ -6494,10 +6507,12 @@
         "operationId": "get_car_library_types_api_car_library_types_get",
         "parameters": [
           {
+            "description": "Manufacturer brand to look up.",
             "in": "query",
             "name": "brand",
             "required": true,
             "schema": {
+              "description": "Manufacturer brand to look up.",
               "minLength": 1,
               "title": "Brand",
               "type": "string"
@@ -6515,6 +6530,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "The requested brand or brand/type combination does not exist."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6526,11 +6544,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Get Car Library Types"
+        "summary": "Get Car Library Types",
+        "tags": [
+          "car-library"
+        ]
       }
     },
     "/api/client-locations": {
       "get": {
+        "description": "List the supported sensor location codes that operators can assign to clients.",
         "operationId": "get_client_locations_api_client_locations_get",
         "responses": {
           "200": {
@@ -6544,11 +6566,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Client Locations"
+        "summary": "Get Client Locations",
+        "tags": [
+          "clients"
+        ]
       }
     },
     "/api/clients": {
       "get": {
+        "description": "List known sensor clients with live connection state and latest computed metrics.",
         "operationId": "get_clients_api_clients_get",
         "responses": {
           "200": {
@@ -6562,11 +6588,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Clients"
+        "summary": "Get Clients",
+        "tags": [
+          "clients"
+        ]
       }
     },
     "/api/clients/{client_id}": {
       "delete": {
+        "description": "Remove a disconnected sensor from the runtime registry.",
         "operationId": "remove_client_api_clients__client_id__delete",
         "parameters": [
           {
@@ -6590,6 +6620,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor identifier."
+          },
+          "404": {
+            "description": "Sensor not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6601,11 +6637,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Remove Client"
+        "summary": "Remove Client",
+        "tags": [
+          "clients"
+        ]
       }
     },
     "/api/clients/{client_id}/identify": {
       "post": {
+        "description": "Send a temporary identify/blink command so an operator can find a sensor physically.",
         "operationId": "identify_client_api_clients__client_id__identify_post",
         "parameters": [
           {
@@ -6639,6 +6679,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor identifier."
+          },
+          "404": {
+            "description": "Sensor not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6648,13 +6694,20 @@
               }
             },
             "description": "Validation Error"
+          },
+          "503": {
+            "description": "Sensor is known but not currently reachable."
           }
         },
-        "summary": "Identify Client"
+        "summary": "Identify Client",
+        "tags": [
+          "clients"
+        ]
       }
     },
     "/api/clients/{client_id}/location": {
       "post": {
+        "description": "Assign or clear the logical location for a sensor and persist the updated mapping.",
         "operationId": "set_client_location_api_clients__client_id__location_post",
         "parameters": [
           {
@@ -6688,6 +6741,15 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor identifier or unknown location code."
+          },
+          "404": {
+            "description": "Sensor not found."
+          },
+          "409": {
+            "description": "Requested location is already assigned to another sensor."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6699,7 +6761,10 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Set Client Location"
+        "summary": "Set Client Location",
+        "tags": [
+          "clients"
+        ]
       }
     },
     "/api/debug/raw-samples/{client_id}": {
@@ -6717,11 +6782,13 @@
             }
           },
           {
+            "description": "Number of recent raw samples to return.",
             "in": "query",
             "name": "n",
             "required": false,
             "schema": {
               "default": 2048,
+              "description": "Number of recent raw samples to return.",
               "maximum": 6400,
               "minimum": 1,
               "title": "N",
@@ -6740,6 +6807,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor identifier."
+          },
+          "404": {
+            "description": "No debug data is available for the requested sensor."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6751,7 +6824,10 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Debug Raw Samples"
+        "summary": "Debug Raw Samples",
+        "tags": [
+          "debug"
+        ]
       }
     },
     "/api/debug/spectrum/{client_id}": {
@@ -6780,6 +6856,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor identifier."
+          },
+          "404": {
+            "description": "No debug data is available for the requested sensor."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6791,11 +6873,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Debug Spectrum"
+        "summary": "Debug Spectrum",
+        "tags": [
+          "debug"
+        ]
       }
     },
     "/api/esp-flash/cancel": {
       "post": {
+        "description": "Request cancellation of the active ESP32 flash job.",
         "operationId": "cancel_esp_flash_api_esp_flash_cancel_post",
         "responses": {
           "200": {
@@ -6809,11 +6895,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Cancel Esp Flash"
+        "summary": "Cancel Esp Flash",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/esp-flash/history": {
       "get": {
+        "description": "List completed and failed ESP32 flash attempts kept in local history.",
         "operationId": "get_esp_flash_history_api_esp_flash_history_get",
         "responses": {
           "200": {
@@ -6827,19 +6917,25 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Esp Flash History"
+        "summary": "Get Esp Flash History",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/esp-flash/logs": {
       "get": {
+        "description": "Return incremental ESP32 flash logs for polling clients.",
         "operationId": "get_esp_flash_logs_api_esp_flash_logs_get",
         "parameters": [
           {
+            "description": "Return log lines strictly after this zero-based index.",
             "in": "query",
             "name": "after",
             "required": false,
             "schema": {
               "default": 0,
+              "description": "Return log lines strictly after this zero-based index.",
               "minimum": 0,
               "title": "After",
               "type": "integer"
@@ -6868,11 +6964,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Get Esp Flash Logs"
+        "summary": "Get Esp Flash Logs",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/esp-flash/ports": {
       "get": {
+        "description": "List serial ports currently available for ESP32 firmware flashing.",
         "operationId": "list_esp_flash_ports_api_esp_flash_ports_get",
         "responses": {
           "200": {
@@ -6886,11 +6986,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "List Esp Flash Ports"
+        "summary": "List Esp Flash Ports",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/esp-flash/start": {
       "post": {
+        "description": "Start a new ESP32 firmware flash job with either auto-detect or an explicit port.",
         "operationId": "start_esp_flash_api_esp_flash_start_post",
         "requestBody": {
           "content": {
@@ -6913,6 +7017,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid flash settings or port selection."
+          },
+          "409": {
+            "description": "An ESP flash job is already running."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -6922,13 +7032,20 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "description": "The flash job could not be started."
           }
         },
-        "summary": "Start Esp Flash"
+        "summary": "Start Esp Flash",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/esp-flash/status": {
       "get": {
+        "description": "Return the current ESP32 flash job state and the selected serial port, if any.",
         "operationId": "get_esp_flash_status_api_esp_flash_status_get",
         "responses": {
           "200": {
@@ -6942,11 +7059,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Esp Flash Status"
+        "summary": "Get Esp Flash Status",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/health": {
       "get": {
+        "description": "Return the current runtime health snapshot for the server and sensor pipeline.",
         "operationId": "health_api_health_get",
         "responses": {
           "200": {
@@ -6960,11 +7081,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Health"
+        "summary": "Health",
+        "tags": [
+          "health"
+        ]
       }
     },
     "/api/history": {
       "get": {
+        "description": "List all persisted recording runs available in history storage.",
         "operationId": "get_history_api_history_get",
         "responses": {
           "200": {
@@ -6978,11 +7103,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get History"
+        "summary": "Get History",
+        "tags": [
+          "history"
+        ]
       }
     },
     "/api/history/{run_id}": {
       "delete": {
+        "description": "Delete a persisted run and its derived artifacts from history storage.",
         "operationId": "delete_history_run_api_history__run_id__delete",
         "parameters": [
           {
@@ -7006,6 +7135,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Requested run was not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7017,9 +7149,13 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete History Run"
+        "summary": "Delete History Run",
+        "tags": [
+          "history"
+        ]
       },
       "get": {
+        "description": "Return full metadata and analysis payloads for a single recorded run.",
         "operationId": "get_history_run_api_history__run_id__get",
         "parameters": [
           {
@@ -7043,6 +7179,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Requested run was not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7052,13 +7191,20 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "description": "Run data is corrupt or could not be processed."
           }
         },
-        "summary": "Get History Run"
+        "summary": "Get History Run",
+        "tags": [
+          "history"
+        ]
       }
     },
     "/api/history/{run_id}/export": {
       "get": {
+        "description": "Build and stream the ZIP export bundle for a persisted run.",
         "operationId": "export_history_run_api_history__run_id__export_get",
         "parameters": [
           {
@@ -7075,6 +7221,9 @@
           "200": {
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Requested run was not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7084,13 +7233,20 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "description": "Export generation failed because the run data is corrupt or incomplete."
           }
         },
-        "summary": "Export History Run"
+        "summary": "Export History Run",
+        "tags": [
+          "history"
+        ]
       }
     },
     "/api/history/{run_id}/insights": {
       "get": {
+        "description": "Return localized post-analysis findings, or a 202 while analysis is still running.",
         "operationId": "get_history_insights_api_history__run_id__insights_get",
         "parameters": [
           {
@@ -7103,6 +7259,7 @@
             }
           },
           {
+            "description": "Optional language override for localized insights text (for example 'en' or 'nl').",
             "in": "query",
             "name": "lang",
             "required": false,
@@ -7115,6 +7272,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Optional language override for localized insights text (for example 'en' or 'nl').",
               "title": "Lang"
             }
           }
@@ -7138,24 +7296,30 @@
                 }
               }
             },
-            "description": "Accepted"
+            "description": "Analysis is still running for the requested run."
+          },
+          "404": {
+            "description": "Requested run was not found."
+          },
+          "409": {
+            "description": "Insights are not ready yet for the requested run."
           },
           "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
+            "description": "Insights are unavailable because analysis failed or produced unsupported persisted data."
+          },
+          "500": {
+            "description": "Run data is corrupt or insights generation failed."
           }
         },
-        "summary": "Get History Insights"
+        "summary": "Get History Insights",
+        "tags": [
+          "history"
+        ]
       }
     },
     "/api/history/{run_id}/report.pdf": {
       "get": {
+        "description": "Build and download the PDF diagnostic report for a persisted run.",
         "operationId": "download_history_report_pdf_api_history__run_id__report_pdf_get",
         "parameters": [
           {
@@ -7168,6 +7332,7 @@
             }
           },
           {
+            "description": "Optional language override for the generated PDF report (for example 'en' or 'nl').",
             "in": "query",
             "name": "lang",
             "required": false,
@@ -7180,6 +7345,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Optional language override for the generated PDF report (for example 'en' or 'nl').",
               "title": "Lang"
             }
           }
@@ -7187,6 +7353,9 @@
         "responses": {
           "200": {
             "description": "Successful Response"
+          },
+          "404": {
+            "description": "Requested run was not found."
           },
           "422": {
             "content": {
@@ -7197,13 +7366,20 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "description": "Report generation failed because the run data is corrupt or incomplete."
           }
         },
-        "summary": "Download History Report Pdf"
+        "summary": "Download History Report Pdf",
+        "tags": [
+          "history"
+        ]
       }
     },
     "/api/recording/start": {
       "post": {
+        "description": "Start recording a new run and return the updated recorder status snapshot.",
         "operationId": "start_logging_api_recording_start_post",
         "responses": {
           "200": {
@@ -7217,11 +7393,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Start Logging"
+        "summary": "Start Logging",
+        "tags": [
+          "recording"
+        ]
       }
     },
     "/api/recording/status": {
       "get": {
+        "description": "Return the current recording state, counters, and last completed run details.",
         "operationId": "get_logging_status_api_recording_status_get",
         "responses": {
           "200": {
@@ -7235,11 +7415,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Logging Status"
+        "summary": "Get Logging Status",
+        "tags": [
+          "recording"
+        ]
       }
     },
     "/api/recording/stop": {
       "post": {
+        "description": "Stop the active recording and return the updated recorder status snapshot.",
         "operationId": "stop_logging_api_recording_stop_post",
         "responses": {
           "200": {
@@ -7253,11 +7437,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Stop Logging"
+        "summary": "Stop Logging",
+        "tags": [
+          "recording"
+        ]
       }
     },
     "/api/settings/analysis": {
       "get": {
+        "description": "Return the validated analysis settings derived from the active car profile.",
         "operationId": "get_analysis_settings_api_settings_analysis_get",
         "responses": {
           "200": {
@@ -7271,9 +7459,13 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Analysis Settings"
+        "summary": "Get Analysis Settings",
+        "tags": [
+          "settings"
+        ]
       },
       "put": {
+        "description": "Update analysis-specific car aspects such as tire geometry and drivetrain ratios.",
         "operationId": "set_analysis_settings_api_settings_analysis_put",
         "requestBody": {
           "content": {
@@ -7296,6 +7488,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Analysis settings are invalid or no active car is configured."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7307,11 +7502,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Set Analysis Settings"
+        "summary": "Set Analysis Settings",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/cars": {
       "get": {
+        "description": "List all saved car profiles together with the currently active car ID.",
         "operationId": "get_cars_api_settings_cars_get",
         "responses": {
           "200": {
@@ -7325,9 +7524,13 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Cars"
+        "summary": "Get Cars",
+        "tags": [
+          "settings"
+        ]
       },
       "post": {
+        "description": "Create a new car profile from the provided partial settings payload.",
         "operationId": "add_car_api_settings_cars_post",
         "requestBody": {
           "content": {
@@ -7361,11 +7564,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Add Car"
+        "summary": "Add Car",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/cars/active": {
       "put": {
+        "description": "Select which saved car profile should drive current analysis settings.",
         "operationId": "set_active_car_api_settings_cars_active_put",
         "requestBody": {
           "content": {
@@ -7388,6 +7595,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Requested car profile was not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7399,11 +7609,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Set Active Car"
+        "summary": "Set Active Car",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/cars/{car_id}": {
       "delete": {
+        "description": "Delete a saved car profile when that removal keeps settings state valid.",
         "operationId": "delete_car_api_settings_cars__car_id__delete",
         "parameters": [
           {
@@ -7427,6 +7641,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "The requested deletion violates current settings constraints."
+          },
+          "404": {
+            "description": "Requested car profile was not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7438,9 +7658,13 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete Car"
+        "summary": "Delete Car",
+        "tags": [
+          "settings"
+        ]
       },
       "put": {
+        "description": "Update an existing car profile while preserving unspecified fields.",
         "operationId": "update_car_api_settings_cars__car_id__put",
         "parameters": [
           {
@@ -7474,6 +7698,9 @@
             },
             "description": "Successful Response"
           },
+          "404": {
+            "description": "Requested car profile was not found."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7485,11 +7712,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Update Car"
+        "summary": "Update Car",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/language": {
       "get": {
+        "description": "Return the currently selected dashboard language code.",
         "operationId": "get_language_api_settings_language_get",
         "responses": {
           "200": {
@@ -7503,9 +7734,13 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Language"
+        "summary": "Get Language",
+        "tags": [
+          "settings"
+        ]
       },
       "put": {
+        "description": "Update the dashboard language used by the local UI.",
         "operationId": "set_language_api_settings_language_put",
         "requestBody": {
           "content": {
@@ -7528,6 +7763,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Unsupported language code."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7539,11 +7777,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Set Language"
+        "summary": "Set Language",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/sensors": {
       "get": {
+        "description": "List persisted per-sensor settings keyed by normalized MAC address.",
         "operationId": "get_sensors_api_settings_sensors_get",
         "responses": {
           "200": {
@@ -7557,11 +7799,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Sensors"
+        "summary": "Get Sensors",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/sensors/{mac}": {
       "delete": {
+        "description": "Delete persisted sensor metadata for a specific MAC address.",
         "operationId": "delete_sensor_api_settings_sensors__mac__delete",
         "parameters": [
           {
@@ -7585,6 +7831,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor MAC address."
+          },
+          "404": {
+            "description": "Sensor configuration not found for the given MAC address."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7596,9 +7848,13 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete Sensor"
+        "summary": "Delete Sensor",
+        "tags": [
+          "settings"
+        ]
       },
       "post": {
+        "description": "Create or update persisted sensor metadata for a specific MAC address.",
         "operationId": "update_sensor_api_settings_sensors__mac__post",
         "parameters": [
           {
@@ -7632,6 +7888,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid sensor MAC address or sensor settings payload."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7643,11 +7902,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Update Sensor"
+        "summary": "Update Sensor",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/speed-source": {
       "get": {
+        "description": "Return the persisted speed-source configuration used for order tracking.",
         "operationId": "get_speed_source_api_settings_speed_source_get",
         "responses": {
           "200": {
@@ -7661,9 +7924,13 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Speed Source"
+        "summary": "Get Speed Source",
+        "tags": [
+          "settings"
+        ]
       },
       "put": {
+        "description": "Update the preferred speed source, manual fallback speed, and staleness timeout.",
         "operationId": "update_speed_source_api_settings_speed_source_put",
         "requestBody": {
           "content": {
@@ -7686,6 +7953,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "The requested speed-source configuration is invalid."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7697,11 +7967,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Update Speed Source"
+        "summary": "Update Speed Source",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/speed-source/status": {
       "get": {
+        "description": "Return the live GPS connection state and effective speed-source status.",
         "operationId": "get_speed_source_status_api_settings_speed_source_status_get",
         "responses": {
           "200": {
@@ -7715,11 +7989,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Speed Source Status"
+        "summary": "Get Speed Source Status",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/settings/speed-unit": {
       "get": {
+        "description": "Return the speed unit currently used for UI display and input.",
         "operationId": "get_speed_unit_api_settings_speed_unit_get",
         "responses": {
           "200": {
@@ -7733,9 +8011,13 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Speed Unit"
+        "summary": "Get Speed Unit",
+        "tags": [
+          "settings"
+        ]
       },
       "put": {
+        "description": "Update the speed unit used for UI display and manual speed entry.",
         "operationId": "set_speed_unit_api_settings_speed_unit_put",
         "requestBody": {
           "content": {
@@ -7758,6 +8040,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Unsupported speed unit."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7769,11 +8054,15 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Set Speed Unit"
+        "summary": "Set Speed Unit",
+        "tags": [
+          "settings"
+        ]
       }
     },
     "/api/update/cancel": {
       "post": {
+        "description": "Request cancellation of the active OTA software update job.",
         "operationId": "cancel_update_api_update_cancel_post",
         "responses": {
           "200": {
@@ -7787,11 +8076,15 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Cancel Update"
+        "summary": "Cancel Update",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/update/start": {
       "post": {
+        "description": "Start an OTA software update using the supplied uplink Wi-Fi credentials.",
         "operationId": "start_update_api_update_start_post",
         "requestBody": {
           "content": {
@@ -7814,6 +8107,12 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid Wi-Fi credentials or update request values."
+          },
+          "409": {
+            "description": "An update job is already running."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -7823,13 +8122,20 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "description": "The update process could not be started."
           }
         },
-        "summary": "Start Update"
+        "summary": "Start Update",
+        "tags": [
+          "updates"
+        ]
       }
     },
     "/api/update/status": {
       "get": {
+        "description": "Return the current OTA software update job state, logs, and runtime details.",
         "operationId": "get_update_status_api_update_status_get",
         "responses": {
           "200": {
@@ -7843,7 +8149,10 @@
             "description": "Successful Response"
           }
         },
-        "summary": "Get Update Status"
+        "summary": "Get Update Status",
+        "tags": [
+          "updates"
+        ]
       }
     }
   }

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -30,23 +30,38 @@ export interface paths {
     get: operations["get_car_library_types_api_car_library_types_get"];
   };
   "/api/client-locations": {
-    /** Get Client Locations */
+    /**
+     * Get Client Locations
+     * @description List the supported sensor location codes that operators can assign to clients.
+     */
     get: operations["get_client_locations_api_client_locations_get"];
   };
   "/api/clients": {
-    /** Get Clients */
+    /**
+     * Get Clients
+     * @description List known sensor clients with live connection state and latest computed metrics.
+     */
     get: operations["get_clients_api_clients_get"];
   };
   "/api/clients/{client_id}": {
-    /** Remove Client */
+    /**
+     * Remove Client
+     * @description Remove a disconnected sensor from the runtime registry.
+     */
     delete: operations["remove_client_api_clients__client_id__delete"];
   };
   "/api/clients/{client_id}/identify": {
-    /** Identify Client */
+    /**
+     * Identify Client
+     * @description Send a temporary identify/blink command so an operator can find a sensor physically.
+     */
     post: operations["identify_client_api_clients__client_id__identify_post"];
   };
   "/api/clients/{client_id}/location": {
-    /** Set Client Location */
+    /**
+     * Set Client Location
+     * @description Assign or clear the logical location for a sensor and persist the updated mapping.
+     */
     post: operations["set_client_location_api_clients__client_id__location_post"];
   };
   "/api/debug/raw-samples/{client_id}": {
@@ -64,131 +79,239 @@ export interface paths {
     get: operations["debug_spectrum_api_debug_spectrum__client_id__get"];
   };
   "/api/esp-flash/cancel": {
-    /** Cancel Esp Flash */
+    /**
+     * Cancel Esp Flash
+     * @description Request cancellation of the active ESP32 flash job.
+     */
     post: operations["cancel_esp_flash_api_esp_flash_cancel_post"];
   };
   "/api/esp-flash/history": {
-    /** Get Esp Flash History */
+    /**
+     * Get Esp Flash History
+     * @description List completed and failed ESP32 flash attempts kept in local history.
+     */
     get: operations["get_esp_flash_history_api_esp_flash_history_get"];
   };
   "/api/esp-flash/logs": {
-    /** Get Esp Flash Logs */
+    /**
+     * Get Esp Flash Logs
+     * @description Return incremental ESP32 flash logs for polling clients.
+     */
     get: operations["get_esp_flash_logs_api_esp_flash_logs_get"];
   };
   "/api/esp-flash/ports": {
-    /** List Esp Flash Ports */
+    /**
+     * List Esp Flash Ports
+     * @description List serial ports currently available for ESP32 firmware flashing.
+     */
     get: operations["list_esp_flash_ports_api_esp_flash_ports_get"];
   };
   "/api/esp-flash/start": {
-    /** Start Esp Flash */
+    /**
+     * Start Esp Flash
+     * @description Start a new ESP32 firmware flash job with either auto-detect or an explicit port.
+     */
     post: operations["start_esp_flash_api_esp_flash_start_post"];
   };
   "/api/esp-flash/status": {
-    /** Get Esp Flash Status */
+    /**
+     * Get Esp Flash Status
+     * @description Return the current ESP32 flash job state and the selected serial port, if any.
+     */
     get: operations["get_esp_flash_status_api_esp_flash_status_get"];
   };
   "/api/health": {
-    /** Health */
+    /**
+     * Health
+     * @description Return the current runtime health snapshot for the server and sensor pipeline.
+     */
     get: operations["health_api_health_get"];
   };
   "/api/history": {
-    /** Get History */
+    /**
+     * Get History
+     * @description List all persisted recording runs available in history storage.
+     */
     get: operations["get_history_api_history_get"];
   };
   "/api/history/{run_id}": {
-    /** Get History Run */
+    /**
+     * Get History Run
+     * @description Return full metadata and analysis payloads for a single recorded run.
+     */
     get: operations["get_history_run_api_history__run_id__get"];
-    /** Delete History Run */
+    /**
+     * Delete History Run
+     * @description Delete a persisted run and its derived artifacts from history storage.
+     */
     delete: operations["delete_history_run_api_history__run_id__delete"];
   };
   "/api/history/{run_id}/export": {
-    /** Export History Run */
+    /**
+     * Export History Run
+     * @description Build and stream the ZIP export bundle for a persisted run.
+     */
     get: operations["export_history_run_api_history__run_id__export_get"];
   };
   "/api/history/{run_id}/insights": {
-    /** Get History Insights */
+    /**
+     * Get History Insights
+     * @description Return localized post-analysis findings, or a 202 while analysis is still running.
+     */
     get: operations["get_history_insights_api_history__run_id__insights_get"];
   };
   "/api/history/{run_id}/report.pdf": {
-    /** Download History Report Pdf */
+    /**
+     * Download History Report Pdf
+     * @description Build and download the PDF diagnostic report for a persisted run.
+     */
     get: operations["download_history_report_pdf_api_history__run_id__report_pdf_get"];
   };
   "/api/recording/start": {
-    /** Start Logging */
+    /**
+     * Start Logging
+     * @description Start recording a new run and return the updated recorder status snapshot.
+     */
     post: operations["start_logging_api_recording_start_post"];
   };
   "/api/recording/status": {
-    /** Get Logging Status */
+    /**
+     * Get Logging Status
+     * @description Return the current recording state, counters, and last completed run details.
+     */
     get: operations["get_logging_status_api_recording_status_get"];
   };
   "/api/recording/stop": {
-    /** Stop Logging */
+    /**
+     * Stop Logging
+     * @description Stop the active recording and return the updated recorder status snapshot.
+     */
     post: operations["stop_logging_api_recording_stop_post"];
   };
   "/api/settings/analysis": {
-    /** Get Analysis Settings */
+    /**
+     * Get Analysis Settings
+     * @description Return the validated analysis settings derived from the active car profile.
+     */
     get: operations["get_analysis_settings_api_settings_analysis_get"];
-    /** Set Analysis Settings */
+    /**
+     * Set Analysis Settings
+     * @description Update analysis-specific car aspects such as tire geometry and drivetrain ratios.
+     */
     put: operations["set_analysis_settings_api_settings_analysis_put"];
   };
   "/api/settings/cars": {
-    /** Get Cars */
+    /**
+     * Get Cars
+     * @description List all saved car profiles together with the currently active car ID.
+     */
     get: operations["get_cars_api_settings_cars_get"];
-    /** Add Car */
+    /**
+     * Add Car
+     * @description Create a new car profile from the provided partial settings payload.
+     */
     post: operations["add_car_api_settings_cars_post"];
   };
   "/api/settings/cars/active": {
-    /** Set Active Car */
+    /**
+     * Set Active Car
+     * @description Select which saved car profile should drive current analysis settings.
+     */
     put: operations["set_active_car_api_settings_cars_active_put"];
   };
   "/api/settings/cars/{car_id}": {
-    /** Update Car */
+    /**
+     * Update Car
+     * @description Update an existing car profile while preserving unspecified fields.
+     */
     put: operations["update_car_api_settings_cars__car_id__put"];
-    /** Delete Car */
+    /**
+     * Delete Car
+     * @description Delete a saved car profile when that removal keeps settings state valid.
+     */
     delete: operations["delete_car_api_settings_cars__car_id__delete"];
   };
   "/api/settings/language": {
-    /** Get Language */
+    /**
+     * Get Language
+     * @description Return the currently selected dashboard language code.
+     */
     get: operations["get_language_api_settings_language_get"];
-    /** Set Language */
+    /**
+     * Set Language
+     * @description Update the dashboard language used by the local UI.
+     */
     put: operations["set_language_api_settings_language_put"];
   };
   "/api/settings/sensors": {
-    /** Get Sensors */
+    /**
+     * Get Sensors
+     * @description List persisted per-sensor settings keyed by normalized MAC address.
+     */
     get: operations["get_sensors_api_settings_sensors_get"];
   };
   "/api/settings/sensors/{mac}": {
-    /** Update Sensor */
+    /**
+     * Update Sensor
+     * @description Create or update persisted sensor metadata for a specific MAC address.
+     */
     post: operations["update_sensor_api_settings_sensors__mac__post"];
-    /** Delete Sensor */
+    /**
+     * Delete Sensor
+     * @description Delete persisted sensor metadata for a specific MAC address.
+     */
     delete: operations["delete_sensor_api_settings_sensors__mac__delete"];
   };
   "/api/settings/speed-source": {
-    /** Get Speed Source */
+    /**
+     * Get Speed Source
+     * @description Return the persisted speed-source configuration used for order tracking.
+     */
     get: operations["get_speed_source_api_settings_speed_source_get"];
-    /** Update Speed Source */
+    /**
+     * Update Speed Source
+     * @description Update the preferred speed source, manual fallback speed, and staleness timeout.
+     */
     put: operations["update_speed_source_api_settings_speed_source_put"];
   };
   "/api/settings/speed-source/status": {
-    /** Get Speed Source Status */
+    /**
+     * Get Speed Source Status
+     * @description Return the live GPS connection state and effective speed-source status.
+     */
     get: operations["get_speed_source_status_api_settings_speed_source_status_get"];
   };
   "/api/settings/speed-unit": {
-    /** Get Speed Unit */
+    /**
+     * Get Speed Unit
+     * @description Return the speed unit currently used for UI display and input.
+     */
     get: operations["get_speed_unit_api_settings_speed_unit_get"];
-    /** Set Speed Unit */
+    /**
+     * Set Speed Unit
+     * @description Update the speed unit used for UI display and manual speed entry.
+     */
     put: operations["set_speed_unit_api_settings_speed_unit_put"];
   };
   "/api/update/cancel": {
-    /** Cancel Update */
+    /**
+     * Cancel Update
+     * @description Request cancellation of the active OTA software update job.
+     */
     post: operations["cancel_update_api_update_cancel_post"];
   };
   "/api/update/start": {
-    /** Start Update */
+    /**
+     * Start Update
+     * @description Start an OTA software update using the supplied uplink Wi-Fi credentials.
+     */
     post: operations["start_update_api_update_start_post"];
   };
   "/api/update/status": {
-    /** Get Update Status */
+    /**
+     * Get Update Status
+     * @description Return the current OTA software update job state, logs, and runtime details.
+     */
     get: operations["get_update_status_api_update_status_get"];
   };
 }
@@ -2267,7 +2390,9 @@ export interface operations {
   get_car_library_models_api_car_library_models_get: {
     parameters: {
       query: {
+        /** @description Manufacturer brand to look up. */
         brand: string;
+        /** @description Vehicle body type to look up for the selected brand. */
         type: string;
       };
     };
@@ -2277,6 +2402,10 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["CarLibraryModelsResponse"];
         };
+      };
+      /** @description The requested brand or brand/type combination does not exist. */
+      404: {
+        content: never;
       };
       /** @description Validation Error */
       422: {
@@ -2293,6 +2422,7 @@ export interface operations {
   get_car_library_types_api_car_library_types_get: {
     parameters: {
       query: {
+        /** @description Manufacturer brand to look up. */
         brand: string;
       };
     };
@@ -2303,6 +2433,10 @@ export interface operations {
           "application/json": components["schemas"]["CarLibraryTypesResponse"];
         };
       };
+      /** @description The requested brand or brand/type combination does not exist. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2311,7 +2445,10 @@ export interface operations {
       };
     };
   };
-  /** Get Client Locations */
+  /**
+   * Get Client Locations
+   * @description List the supported sensor location codes that operators can assign to clients.
+   */
   get_client_locations_api_client_locations_get: {
     responses: {
       /** @description Successful Response */
@@ -2322,7 +2459,10 @@ export interface operations {
       };
     };
   };
-  /** Get Clients */
+  /**
+   * Get Clients
+   * @description List known sensor clients with live connection state and latest computed metrics.
+   */
   get_clients_api_clients_get: {
     responses: {
       /** @description Successful Response */
@@ -2333,7 +2473,10 @@ export interface operations {
       };
     };
   };
-  /** Remove Client */
+  /**
+   * Remove Client
+   * @description Remove a disconnected sensor from the runtime registry.
+   */
   remove_client_api_clients__client_id__delete: {
     parameters: {
       path: {
@@ -2347,6 +2490,14 @@ export interface operations {
           "application/json": components["schemas"]["RemoveClientResponse"];
         };
       };
+      /** @description Invalid sensor identifier. */
+      400: {
+        content: never;
+      };
+      /** @description Sensor not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2355,7 +2506,10 @@ export interface operations {
       };
     };
   };
-  /** Identify Client */
+  /**
+   * Identify Client
+   * @description Send a temporary identify/blink command so an operator can find a sensor physically.
+   */
   identify_client_api_clients__client_id__identify_post: {
     parameters: {
       path: {
@@ -2374,15 +2528,30 @@ export interface operations {
           "application/json": components["schemas"]["IdentifyResponse"];
         };
       };
+      /** @description Invalid sensor identifier. */
+      400: {
+        content: never;
+      };
+      /** @description Sensor not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Sensor is known but not currently reachable. */
+      503: {
+        content: never;
+      };
     };
   };
-  /** Set Client Location */
+  /**
+   * Set Client Location
+   * @description Assign or clear the logical location for a sensor and persist the updated mapping.
+   */
   set_client_location_api_clients__client_id__location_post: {
     parameters: {
       path: {
@@ -2401,6 +2570,18 @@ export interface operations {
           "application/json": components["schemas"]["SetClientLocationResponse"];
         };
       };
+      /** @description Invalid sensor identifier or unknown location code. */
+      400: {
+        content: never;
+      };
+      /** @description Sensor not found. */
+      404: {
+        content: never;
+      };
+      /** @description Requested location is already assigned to another sensor. */
+      409: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2416,6 +2597,7 @@ export interface operations {
   debug_raw_samples_api_debug_raw_samples__client_id__get: {
     parameters: {
       query?: {
+        /** @description Number of recent raw samples to return. */
         n?: number;
       };
       path: {
@@ -2428,6 +2610,14 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["RawSamplesPayload"];
         };
+      };
+      /** @description Invalid sensor identifier. */
+      400: {
+        content: never;
+      };
+      /** @description No debug data is available for the requested sensor. */
+      404: {
+        content: never;
       };
       /** @description Validation Error */
       422: {
@@ -2454,6 +2644,14 @@ export interface operations {
           "application/json": components["schemas"]["DebugSpectrumPayload"];
         };
       };
+      /** @description Invalid sensor identifier. */
+      400: {
+        content: never;
+      };
+      /** @description No debug data is available for the requested sensor. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2462,7 +2660,10 @@ export interface operations {
       };
     };
   };
-  /** Cancel Esp Flash */
+  /**
+   * Cancel Esp Flash
+   * @description Request cancellation of the active ESP32 flash job.
+   */
   cancel_esp_flash_api_esp_flash_cancel_post: {
     responses: {
       /** @description Successful Response */
@@ -2473,7 +2674,10 @@ export interface operations {
       };
     };
   };
-  /** Get Esp Flash History */
+  /**
+   * Get Esp Flash History
+   * @description List completed and failed ESP32 flash attempts kept in local history.
+   */
   get_esp_flash_history_api_esp_flash_history_get: {
     responses: {
       /** @description Successful Response */
@@ -2484,10 +2688,14 @@ export interface operations {
       };
     };
   };
-  /** Get Esp Flash Logs */
+  /**
+   * Get Esp Flash Logs
+   * @description Return incremental ESP32 flash logs for polling clients.
+   */
   get_esp_flash_logs_api_esp_flash_logs_get: {
     parameters: {
       query?: {
+        /** @description Return log lines strictly after this zero-based index. */
         after?: number;
       };
     };
@@ -2506,7 +2714,10 @@ export interface operations {
       };
     };
   };
-  /** List Esp Flash Ports */
+  /**
+   * List Esp Flash Ports
+   * @description List serial ports currently available for ESP32 firmware flashing.
+   */
   list_esp_flash_ports_api_esp_flash_ports_get: {
     responses: {
       /** @description Successful Response */
@@ -2517,7 +2728,10 @@ export interface operations {
       };
     };
   };
-  /** Start Esp Flash */
+  /**
+   * Start Esp Flash
+   * @description Start a new ESP32 firmware flash job with either auto-detect or an explicit port.
+   */
   start_esp_flash_api_esp_flash_start_post: {
     requestBody: {
       content: {
@@ -2531,15 +2745,30 @@ export interface operations {
           "application/json": components["schemas"]["EspFlashStartResponse"];
         };
       };
+      /** @description Invalid flash settings or port selection. */
+      400: {
+        content: never;
+      };
+      /** @description An ESP flash job is already running. */
+      409: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description The flash job could not be started. */
+      500: {
+        content: never;
+      };
     };
   };
-  /** Get Esp Flash Status */
+  /**
+   * Get Esp Flash Status
+   * @description Return the current ESP32 flash job state and the selected serial port, if any.
+   */
   get_esp_flash_status_api_esp_flash_status_get: {
     responses: {
       /** @description Successful Response */
@@ -2550,7 +2779,10 @@ export interface operations {
       };
     };
   };
-  /** Health */
+  /**
+   * Health
+   * @description Return the current runtime health snapshot for the server and sensor pipeline.
+   */
   health_api_health_get: {
     responses: {
       /** @description Successful Response */
@@ -2561,7 +2793,10 @@ export interface operations {
       };
     };
   };
-  /** Get History */
+  /**
+   * Get History
+   * @description List all persisted recording runs available in history storage.
+   */
   get_history_api_history_get: {
     responses: {
       /** @description Successful Response */
@@ -2572,7 +2807,10 @@ export interface operations {
       };
     };
   };
-  /** Get History Run */
+  /**
+   * Get History Run
+   * @description Return full metadata and analysis payloads for a single recorded run.
+   */
   get_history_run_api_history__run_id__get: {
     parameters: {
       path: {
@@ -2586,15 +2824,26 @@ export interface operations {
           "application/json": components["schemas"]["HistoryRunResponse"];
         };
       };
+      /** @description Requested run was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Run data is corrupt or could not be processed. */
+      500: {
+        content: never;
+      };
     };
   };
-  /** Delete History Run */
+  /**
+   * Delete History Run
+   * @description Delete a persisted run and its derived artifacts from history storage.
+   */
   delete_history_run_api_history__run_id__delete: {
     parameters: {
       path: {
@@ -2608,6 +2857,10 @@ export interface operations {
           "application/json": components["schemas"]["DeleteHistoryRunResponse"];
         };
       };
+      /** @description Requested run was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2616,7 +2869,10 @@ export interface operations {
       };
     };
   };
-  /** Export History Run */
+  /**
+   * Export History Run
+   * @description Build and stream the ZIP export bundle for a persisted run.
+   */
   export_history_run_api_history__run_id__export_get: {
     parameters: {
       path: {
@@ -2628,18 +2884,30 @@ export interface operations {
       200: {
         content: never;
       };
+      /** @description Requested run was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Export generation failed because the run data is corrupt or incomplete. */
+      500: {
+        content: never;
+      };
     };
   };
-  /** Get History Insights */
+  /**
+   * Get History Insights
+   * @description Return localized post-analysis findings, or a 202 while analysis is still running.
+   */
   get_history_insights_api_history__run_id__insights_get: {
     parameters: {
       query?: {
+        /** @description Optional language override for localized insights text (for example 'en' or 'nl'). */
         lang?: string | null;
       };
       path: {
@@ -2653,24 +2921,38 @@ export interface operations {
           "application/json": components["schemas"]["HistoryInsightsResponse"];
         };
       };
-      /** @description Accepted */
+      /** @description Analysis is still running for the requested run. */
       202: {
         content: {
           "application/json": components["schemas"]["HistoryInsightsAnalyzingResponse"];
         };
       };
-      /** @description Validation Error */
+      /** @description Requested run was not found. */
+      404: {
+        content: never;
+      };
+      /** @description Insights are not ready yet for the requested run. */
+      409: {
+        content: never;
+      };
+      /** @description Insights are unavailable because analysis failed or produced unsupported persisted data. */
       422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
+        content: never;
+      };
+      /** @description Run data is corrupt or insights generation failed. */
+      500: {
+        content: never;
       };
     };
   };
-  /** Download History Report Pdf */
+  /**
+   * Download History Report Pdf
+   * @description Build and download the PDF diagnostic report for a persisted run.
+   */
   download_history_report_pdf_api_history__run_id__report_pdf_get: {
     parameters: {
       query?: {
+        /** @description Optional language override for the generated PDF report (for example 'en' or 'nl'). */
         lang?: string | null;
       };
       path: {
@@ -2682,15 +2964,26 @@ export interface operations {
       200: {
         content: never;
       };
+      /** @description Requested run was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Report generation failed because the run data is corrupt or incomplete. */
+      500: {
+        content: never;
+      };
     };
   };
-  /** Start Logging */
+  /**
+   * Start Logging
+   * @description Start recording a new run and return the updated recorder status snapshot.
+   */
   start_logging_api_recording_start_post: {
     responses: {
       /** @description Successful Response */
@@ -2701,7 +2994,10 @@ export interface operations {
       };
     };
   };
-  /** Get Logging Status */
+  /**
+   * Get Logging Status
+   * @description Return the current recording state, counters, and last completed run details.
+   */
   get_logging_status_api_recording_status_get: {
     responses: {
       /** @description Successful Response */
@@ -2712,7 +3008,10 @@ export interface operations {
       };
     };
   };
-  /** Stop Logging */
+  /**
+   * Stop Logging
+   * @description Stop the active recording and return the updated recorder status snapshot.
+   */
   stop_logging_api_recording_stop_post: {
     responses: {
       /** @description Successful Response */
@@ -2723,7 +3022,10 @@ export interface operations {
       };
     };
   };
-  /** Get Analysis Settings */
+  /**
+   * Get Analysis Settings
+   * @description Return the validated analysis settings derived from the active car profile.
+   */
   get_analysis_settings_api_settings_analysis_get: {
     responses: {
       /** @description Successful Response */
@@ -2734,7 +3036,10 @@ export interface operations {
       };
     };
   };
-  /** Set Analysis Settings */
+  /**
+   * Set Analysis Settings
+   * @description Update analysis-specific car aspects such as tire geometry and drivetrain ratios.
+   */
   set_analysis_settings_api_settings_analysis_put: {
     requestBody: {
       content: {
@@ -2748,6 +3053,10 @@ export interface operations {
           "application/json": components["schemas"]["AnalysisSettingsResponse"];
         };
       };
+      /** @description Analysis settings are invalid or no active car is configured. */
+      400: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2756,7 +3065,10 @@ export interface operations {
       };
     };
   };
-  /** Get Cars */
+  /**
+   * Get Cars
+   * @description List all saved car profiles together with the currently active car ID.
+   */
   get_cars_api_settings_cars_get: {
     responses: {
       /** @description Successful Response */
@@ -2767,7 +3079,10 @@ export interface operations {
       };
     };
   };
-  /** Add Car */
+  /**
+   * Add Car
+   * @description Create a new car profile from the provided partial settings payload.
+   */
   add_car_api_settings_cars_post: {
     requestBody: {
       content: {
@@ -2789,7 +3104,10 @@ export interface operations {
       };
     };
   };
-  /** Set Active Car */
+  /**
+   * Set Active Car
+   * @description Select which saved car profile should drive current analysis settings.
+   */
   set_active_car_api_settings_cars_active_put: {
     requestBody: {
       content: {
@@ -2803,6 +3121,10 @@ export interface operations {
           "application/json": components["schemas"]["CarsResponse"];
         };
       };
+      /** @description Requested car profile was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2811,7 +3133,10 @@ export interface operations {
       };
     };
   };
-  /** Update Car */
+  /**
+   * Update Car
+   * @description Update an existing car profile while preserving unspecified fields.
+   */
   update_car_api_settings_cars__car_id__put: {
     parameters: {
       path: {
@@ -2830,6 +3155,10 @@ export interface operations {
           "application/json": components["schemas"]["CarsResponse"];
         };
       };
+      /** @description Requested car profile was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2838,7 +3167,10 @@ export interface operations {
       };
     };
   };
-  /** Delete Car */
+  /**
+   * Delete Car
+   * @description Delete a saved car profile when that removal keeps settings state valid.
+   */
   delete_car_api_settings_cars__car_id__delete: {
     parameters: {
       path: {
@@ -2852,6 +3184,14 @@ export interface operations {
           "application/json": components["schemas"]["CarsResponse"];
         };
       };
+      /** @description The requested deletion violates current settings constraints. */
+      400: {
+        content: never;
+      };
+      /** @description Requested car profile was not found. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2860,7 +3200,10 @@ export interface operations {
       };
     };
   };
-  /** Get Language */
+  /**
+   * Get Language
+   * @description Return the currently selected dashboard language code.
+   */
   get_language_api_settings_language_get: {
     responses: {
       /** @description Successful Response */
@@ -2871,7 +3214,10 @@ export interface operations {
       };
     };
   };
-  /** Set Language */
+  /**
+   * Set Language
+   * @description Update the dashboard language used by the local UI.
+   */
   set_language_api_settings_language_put: {
     requestBody: {
       content: {
@@ -2885,6 +3231,10 @@ export interface operations {
           "application/json": components["schemas"]["LanguageResponse"];
         };
       };
+      /** @description Unsupported language code. */
+      400: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2893,7 +3243,10 @@ export interface operations {
       };
     };
   };
-  /** Get Sensors */
+  /**
+   * Get Sensors
+   * @description List persisted per-sensor settings keyed by normalized MAC address.
+   */
   get_sensors_api_settings_sensors_get: {
     responses: {
       /** @description Successful Response */
@@ -2904,7 +3257,10 @@ export interface operations {
       };
     };
   };
-  /** Update Sensor */
+  /**
+   * Update Sensor
+   * @description Create or update persisted sensor metadata for a specific MAC address.
+   */
   update_sensor_api_settings_sensors__mac__post: {
     parameters: {
       path: {
@@ -2923,6 +3279,10 @@ export interface operations {
           "application/json": components["schemas"]["SensorsResponse"];
         };
       };
+      /** @description Invalid sensor MAC address or sensor settings payload. */
+      400: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2931,7 +3291,10 @@ export interface operations {
       };
     };
   };
-  /** Delete Sensor */
+  /**
+   * Delete Sensor
+   * @description Delete persisted sensor metadata for a specific MAC address.
+   */
   delete_sensor_api_settings_sensors__mac__delete: {
     parameters: {
       path: {
@@ -2945,6 +3308,14 @@ export interface operations {
           "application/json": components["schemas"]["SensorsResponse"];
         };
       };
+      /** @description Invalid sensor MAC address. */
+      400: {
+        content: never;
+      };
+      /** @description Sensor configuration not found for the given MAC address. */
+      404: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2953,7 +3324,10 @@ export interface operations {
       };
     };
   };
-  /** Get Speed Source */
+  /**
+   * Get Speed Source
+   * @description Return the persisted speed-source configuration used for order tracking.
+   */
   get_speed_source_api_settings_speed_source_get: {
     responses: {
       /** @description Successful Response */
@@ -2964,7 +3338,10 @@ export interface operations {
       };
     };
   };
-  /** Update Speed Source */
+  /**
+   * Update Speed Source
+   * @description Update the preferred speed source, manual fallback speed, and staleness timeout.
+   */
   update_speed_source_api_settings_speed_source_put: {
     requestBody: {
       content: {
@@ -2978,6 +3355,10 @@ export interface operations {
           "application/json": components["schemas"]["SpeedSourceResponse"];
         };
       };
+      /** @description The requested speed-source configuration is invalid. */
+      400: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -2986,7 +3367,10 @@ export interface operations {
       };
     };
   };
-  /** Get Speed Source Status */
+  /**
+   * Get Speed Source Status
+   * @description Return the live GPS connection state and effective speed-source status.
+   */
   get_speed_source_status_api_settings_speed_source_status_get: {
     responses: {
       /** @description Successful Response */
@@ -2997,7 +3381,10 @@ export interface operations {
       };
     };
   };
-  /** Get Speed Unit */
+  /**
+   * Get Speed Unit
+   * @description Return the speed unit currently used for UI display and input.
+   */
   get_speed_unit_api_settings_speed_unit_get: {
     responses: {
       /** @description Successful Response */
@@ -3008,7 +3395,10 @@ export interface operations {
       };
     };
   };
-  /** Set Speed Unit */
+  /**
+   * Set Speed Unit
+   * @description Update the speed unit used for UI display and manual speed entry.
+   */
   set_speed_unit_api_settings_speed_unit_put: {
     requestBody: {
       content: {
@@ -3022,6 +3412,10 @@ export interface operations {
           "application/json": components["schemas"]["SpeedUnitResponse"];
         };
       };
+      /** @description Unsupported speed unit. */
+      400: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
@@ -3030,7 +3424,10 @@ export interface operations {
       };
     };
   };
-  /** Cancel Update */
+  /**
+   * Cancel Update
+   * @description Request cancellation of the active OTA software update job.
+   */
   cancel_update_api_update_cancel_post: {
     responses: {
       /** @description Successful Response */
@@ -3041,7 +3438,10 @@ export interface operations {
       };
     };
   };
-  /** Start Update */
+  /**
+   * Start Update
+   * @description Start an OTA software update using the supplied uplink Wi-Fi credentials.
+   */
   start_update_api_update_start_post: {
     requestBody: {
       content: {
@@ -3055,15 +3455,30 @@ export interface operations {
           "application/json": components["schemas"]["UpdateStartResponse"];
         };
       };
+      /** @description Invalid Wi-Fi credentials or update request values. */
+      400: {
+        content: never;
+      };
+      /** @description An update job is already running. */
+      409: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description The update process could not be started. */
+      500: {
+        content: never;
+      };
     };
   };
-  /** Get Update Status */
+  /**
+   * Get Update Status
+   * @description Return the current OTA software update job state, logs, and runtime details.
+   */
   get_update_status_api_update_status_get: {
     responses: {
       /** @description Successful Response */


### PR DESCRIPTION
## Summary

Closes #1200.

This PR resolves the remaining confirmed scope of issue #1200 by improving the HTTP OpenAPI surface without overbuilding a full versioning mechanism. The issue’s own verification already narrowed the real gaps to two things: first, many FastAPI endpoints were technically present in the generated schema but were still weakly documented because they lacked route tags, endpoint descriptions, and curated runtime error-response metadata; second, the repository had no documented HTTP API versioning stance, even though the backend and bundled UI currently ship together and do not yet need simultaneous multi-version support.

The change set therefore stays deliberately documentation-first. It curates the generated OpenAPI document for the key HTTP route groups that new integrators or maintainers actually use, keeps the current unversioned `/api/*` contract in place, and documents how versioning should be introduced later if independent clients become a real requirement. While doing that work, I also fixed one tightly coupled runtime mismatch that the new docs would otherwise have exposed: `PUT /api/settings/speed-source` could let a settings-layer `ValueError` bubble out instead of being translated into the 400 response that the rest of the settings surface already uses.

## Problem Being Solved

Before this change, the project did already have a real HTTP schema export pipeline, a committed `http_api_schema.json`, and CI drift checks that fail when the committed schema falls out of sync. So the issue was never that OpenAPI generation was missing. The problem was quality and usability. A large portion of the route surface still depended on minimal auto-generated metadata, which meant the schema was functional but thin: route groups were not consistently tagged, many endpoints had no descriptive route text, and important operational error cases such as 404, 409, 422, or 503 were often not documented in the exported schema even though the handlers already surfaced them at runtime.

That created a poor experience for anyone reading the generated docs, integrating against the local API manually, or reviewing the contract for drift. It also left the versioning question undocumented, which makes future route work more ambiguous than it needs to be.

## Implementation Approach

I kept the implementation small and behavior-safe. Rather than redesigning the HTTP API or introducing `/api/v1` prematurely, I treated this as a curation pass over the existing route metadata layer.

The main route groups under `apps/server/vibesensor/adapters/http/` now declare explicit OpenAPI tags and endpoint descriptions across the health, clients, settings, history, recording, updates, debug, and car-library surfaces. For key routes, I also added curated `responses=` metadata so the generated schema documents the runtime errors that matter in practice. Examples include client identify and location assignment errors, history insight readiness and failure states, car and sensor settings errors, and update / ESP flash conflict conditions.

In parallel, I documented the repository’s current HTTP API versioning stance in `apps/server/README.md`: the product intentionally keeps a single unversioned `/api/*` surface while the backend and UI continue to ship atomically, and if independent or third-party clients ever create a genuine compatibility requirement, the preferred next step is explicit path versioning starting at `/api/v1/` rather than layering compatibility shims onto the current routes.

## Main Code Changes By Area

The route metadata work is spread across the existing HTTP route modules, not hidden in a separate schema layer. That keeps the documentation next to the live behavior it describes. Health, recording, and other straightforward routes gained descriptive text and route-group tags. The more important change was on the user-facing surfaces where runtime error semantics matter: clients, settings, history, updates, debug, and car-library endpoints now export clearer error-response docs for the existing behavior they already implement.

The only runtime behavior change in the PR is in `apps/server/vibesensor/adapters/http/settings.py`. While documenting the speed-source settings endpoint, I confirmed that invalid manual speed-source updates could still raise a `ValueError` from the settings layer. That made the OpenAPI docs impossible to document honestly as a 400-style validation failure unless the route actually mapped it. I aligned that endpoint with the rest of the settings surface by translating that `ValueError` to HTTP 400 via the existing route helper pattern. This is intentionally narrow and directly tied to the documentation goal.

I also added a small shared typing alias in `_helpers.py` for OpenAPI response-doc maps so the route constants stay mypy-clean without weakening types.

## Contract, Documentation, and Generated Artifact Changes

The committed HTTP schema artifact in `apps/ui/src/contracts/http_api_schema.json` was regenerated after the route metadata changes, and `apps/ui/src/generated/http_api_contracts.ts` was regenerated from that updated schema. This keeps the frontend-side generated contract in sync with the richer documentation surface.

On the human documentation side, `apps/server/README.md` now explicitly explains both how to export the committed HTTP schema and what the current versioning strategy is. That closes the \"no documented versioning stance\" part of the issue without pretending the project already supports multiple concurrent HTTP API versions.

## Tests and Validation

I added focused regression coverage in two places. `apps/server/tests/adapters/http/test_settings_endpoints.py` now verifies that invalid manual speed-source configuration maps to HTTP 400. `apps/server/tests/adapters/http/test_http_api_schema_export.py` now asserts that representative key endpoints export the new tags, descriptions, and curated error-response docs in the generated OpenAPI document.

Validation was then run at multiple levels. Focused HTTP adapter tests passed (`114 passed`). The broader repo gates passed in a session-local virtualenv: `make docs-lint`, `make lint`, and `make typecheck-backend`. The full backend suite also passed with `python3 -m pytest -q --tb=short apps/server/tests` (`5726 passed, 5 skipped, 1 xpassed`). Because the committed HTTP schema changed, I also ran `cd apps/ui && npm run typecheck && npm run build`, both of which succeeded after the contract refresh.

Finally, I ran a native runtime smoke using a temporary config and temporary history DB on isolated ports. That smoke confirmed `/api/health` returned a ready state, `/openapi.json` exposed the newly curated tags and response docs, and `PUT /api/settings/speed-source` with an invalid manual payload now returns HTTP 400 with the expected validation detail.

## Risks, Tradeoffs, and Out of Scope

The main tradeoff here is intentional restraint. I did not implement `/api/v1`, header-based version negotiation, multiple live API versions, autogenerated SDKs, or semantic compatibility analysis in CI, because the issue explicitly treats those as future or non-goal work. The current product architecture still supports a single co-deployed backend/UI contract, so documenting the present stance is the right step now.

The biggest risk with OpenAPI curation work is drift between documented and actual behavior. That is why I included both schema-export assertions and the small speed-source runtime alignment instead of only editing descriptions. The goal was to make the generated docs more useful while keeping them anchored to real runtime semantics.
