### PR TITLE
Freeze recorder run context during recording

### DIFF
--- a/apps/server/tests/adapters/udp/conftest.py
+++ b/apps/server/tests/adapters/udp/conftest.py
@@ -12,12 +12,13 @@ class FakeTransport:
 
     def __init__(self) -> None:
         self.sent: list[tuple[bytes, tuple[str, int]]] = []
+        self.closed = False
 
     def sendto(self, data: bytes, addr: tuple[str, int]) -> None:
         self.sent.append((data, addr))
 
     def close(self) -> None:
-        pass
+        self.closed = True
 
 
 @pytest.fixture

--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -74,3 +74,19 @@ def test_control_datagram_unexpected_exception_is_logged_and_counted(
     assert record is not None
     assert record.parse_errors == 1
     assert "Unexpected error processing control datagram" in caplog.text
+
+
+def test_close_closes_transport_once_and_clears_reference(tmp_path: Path, fake_transport) -> None:
+    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    plane = UDPControlPlane(registry=registry, bind_host="127.0.0.1", bind_port=9001)
+    plane.transport = fake_transport
+
+    plane.close()
+
+    assert fake_transport.closed is True
+    assert plane.transport is None
+
+    plane.close()
+
+    assert fake_transport.closed is True
+    assert plane.transport is None

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -216,7 +216,7 @@ def test_start_recording_rollover_flushes_first_pending_sample_batch(
     assert next_status.run_id != created_run_id
 
 
-def test_finalize_refreshes_run_metadata_from_latest_settings(
+def test_finalize_preserves_run_metadata_from_recording_start(
     make_logger,
     fake_history_db,
     mutable_fake_settings,
@@ -237,7 +237,10 @@ def test_finalize_refreshes_run_metadata_from_latest_settings(
     assert fake_history_db.updated_metadata
     updated_run_id, metadata = fake_history_db.updated_metadata[-1]
     assert updated_run_id == run_id
-    assert metadata.extras["tire_width_mm"] == 315.0
+    assert metadata.extras["tire_width_mm"] == 285.0
+    analysis_settings_snapshot = metadata.extras["analysis_settings_snapshot"]
+    assert isinstance(analysis_settings_snapshot, dict)
+    assert analysis_settings_snapshot["tire_width_mm"] == 285.0
 
 
 def test_append_records_surfaces_create_run_failure_in_status(

--- a/apps/server/tests/use_cases/run/test_run_context_temporal_isolation.py
+++ b/apps/server/tests/use_cases/run/test_run_context_temporal_isolation.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import CarSnapshot
+from vibesensor.use_cases.run._recorder_types import _build_run_metadata_record
+
+
+def test_recording_keeps_run_start_context_when_settings_change_mid_run(
+    make_logger,
+    mutable_fake_settings,
+    fake_gps_monitor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active_car_holder = [
+        CarSnapshot(
+            car_id="car-1",
+            name="Primary",
+            car_type="sedan",
+            aspects={
+                "tire_width_mm": 285.0,
+                "tire_aspect_pct": 30.0,
+                "rim_in": 21.0,
+                "final_drive_ratio": 3.08,
+                "current_gear_ratio": 0.64,
+            },
+        )
+    ]
+    monkeypatch.setattr(
+        mutable_fake_settings,
+        "active_car_snapshot",
+        lambda: active_car_holder[0],
+    )
+    fake_gps_monitor.override_speed_mps = 10.0
+
+    logger = make_logger(settings_store=mutable_fake_settings, gps_monitor=fake_gps_monitor)
+    logger.start_recording()
+    snapshot = logger._session_snapshot()
+    assert snapshot is not None
+
+    initial_rows = logger._sample_flush.build_sample_records(
+        run_id=snapshot.run_id,
+        t_s=1.0,
+        timestamp_utc="2026-02-16T12:00:00+00:00",
+    )
+
+    assert len(initial_rows) == 1
+    initial_row = initial_rows[0]
+    assert initial_row.final_drive_ratio == pytest.approx(3.08)
+    assert initial_row.gear == pytest.approx(0.64)
+    assert initial_row.engine_rpm is not None
+
+    mutable_fake_settings.values.update(
+        {
+            "tire_width_mm": 315.0,
+            "tire_aspect_pct": 35.0,
+            "rim_in": 20.0,
+            "final_drive_ratio": 4.1,
+            "current_gear_ratio": 0.95,
+        }
+    )
+    active_car_holder[0] = CarSnapshot(
+        car_id="car-2",
+        name="Changed",
+        car_type="hatchback",
+        aspects={
+            "tire_width_mm": 315.0,
+            "tire_aspect_pct": 35.0,
+            "rim_in": 20.0,
+            "final_drive_ratio": 4.1,
+            "current_gear_ratio": 0.95,
+        },
+    )
+
+    later_rows = logger._sample_flush.build_sample_records(
+        run_id=snapshot.run_id,
+        t_s=2.0,
+        timestamp_utc="2026-02-16T12:00:01+00:00",
+    )
+
+    assert len(later_rows) == 1
+    later_row = later_rows[0]
+    assert later_row.final_drive_ratio == pytest.approx(initial_row.final_drive_ratio)
+    assert later_row.gear == pytest.approx(initial_row.gear)
+    assert later_row.engine_rpm == pytest.approx(initial_row.engine_rpm)
+
+    metadata = _build_run_metadata_record(logger, snapshot.run_id, snapshot.start_time_utc)
+    assert metadata["tire_width_mm"] == pytest.approx(285.0)
+    analysis_settings_snapshot = metadata["analysis_settings_snapshot"]
+    assert isinstance(analysis_settings_snapshot, dict)
+    assert analysis_settings_snapshot["tire_width_mm"] == pytest.approx(285.0)
+    active_car_snapshot = metadata["active_car_snapshot"]
+    assert isinstance(active_car_snapshot, dict)
+    assert active_car_snapshot["id"] == "car-1"
+    assert active_car_snapshot["name"] == "Primary"

--- a/apps/server/vibesensor/use_cases/run/_recorder_types.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_types.py
@@ -51,21 +51,18 @@ def _build_run_metadata_record(
     run_id: str,
     start_time_utc: str,
 ) -> JsonObject:
+    run_context = recorder._run_context_snapshot(run_id)
     return build_run_metadata(
         run_id=run_id,
         start_time_utc=start_time_utc,
-        analysis_settings_snapshot=recorder._analysis_settings_snapshot(),
+        analysis_settings_snapshot=run_context.analysis_settings,
         sensor_model=recorder.sensor_model,
         firmware_version=firmware_version_for_run(recorder.registry),
         default_sample_rate_hz=recorder.default_sample_rate_hz,
         metrics_log_hz=recorder.metrics_log_hz,
         fft_window_size_samples=recorder.fft_window_size_samples,
         accel_scale_g_per_lsb=recorder.accel_scale_g_per_lsb,
-        active_car_snapshot=(
-            recorder._settings_store.active_car_snapshot()
-            if recorder._settings_store is not None
-            else None
-        ),
+        active_car_snapshot=run_context.car,
         language_provider=recorder._language_provider,
     )
 

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -27,6 +27,7 @@ from vibesensor.use_cases.run.persistence_writer import (
 )
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+from vibesensor.use_cases.run.run_context import build_run_context_snapshot
 from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator
 from vibesensor.use_cases.run.status_reporting import (
     RunRecorderStatusSnapshot,
@@ -37,6 +38,7 @@ from vibesensor.use_cases.run.status_reporting import (
 from . import _recorder_runtime, _recorder_types
 
 if TYPE_CHECKING:
+    from vibesensor.domain import RunContextSnapshot
     from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
     from vibesensor.shared.types.health_snapshot import RunRecorderHealthSnapshot
     from vibesensor.use_cases.run.lifecycle_state import ActiveRunSnapshot
@@ -80,6 +82,7 @@ class RunRecorder:
         self._history_db = history_db
         self._language_provider = language_provider
         self._live_start_mono_s = time.monotonic()
+        self._active_run_context: RunContextSnapshot | None = None
 
         self._lifecycle = RunLifecycleState(
             no_data_timeout_s=max(1.0, float(config.no_data_timeout_s)),
@@ -113,7 +116,7 @@ class RunRecorder:
             registry=self.registry,
             gps_monitor=self.gps_monitor,
             processor=self.processor,
-            analysis_settings_snapshot=self._analysis_settings_snapshot,
+            analysis_settings_snapshot=self._recording_analysis_settings_snapshot,
             default_sample_rate_hz=self.default_sample_rate_hz,
             lifecycle=self._lifecycle,
             persistence=self._persistence,
@@ -148,6 +151,31 @@ class RunRecorder:
     def _analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
         return _recorder_runtime.analysis_settings_snapshot(self._settings_store)
 
+    def _live_run_context_snapshot(self) -> RunContextSnapshot:
+        active_car_snapshot = (
+            self._settings_store.active_car_snapshot() if self._settings_store is not None else None
+        )
+        return build_run_context_snapshot(
+            analysis_settings_snapshot=self._analysis_settings_snapshot(),
+            active_car_snapshot=active_car_snapshot,
+        )
+
+    def _run_context_snapshot(self, run_id: str | None = None) -> RunContextSnapshot:
+        with self._lock:
+            current_run = self._lifecycle.current_run
+            active_run_context = self._active_run_context
+            if (
+                active_run_context is not None
+                and current_run is not None
+                and current_run.is_recording
+                and (run_id is None or current_run.run_id == run_id)
+            ):
+                return active_run_context
+        return self._live_run_context_snapshot()
+
+    def _recording_analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
+        return self._run_context_snapshot().analysis_settings
+
     def _session_snapshot(self) -> ActiveRunSnapshot | None:
         with self._lock:
             return self._lifecycle.snapshot()
@@ -158,13 +186,15 @@ class RunRecorder:
                 client_id,
                 reason="recording run start",
             )
+        run_context = self._live_run_context_snapshot()
         snapshot = self._lifecycle.start_new_run(
             run_id=uuid4().hex,
-            analysis_settings_snapshot=self._analysis_settings_snapshot(),
+            analysis_settings_snapshot=run_context.analysis_settings,
             start_time_utc=utc_now_iso(),
             start_mono_s=time.monotonic(),
             current_total=_recorder_runtime.active_frames_total(self.registry),
         )
+        self._active_run_context = run_context
         self._persistence.reset()
         self._live_start_mono_s = snapshot.start_mono_s
         return snapshot
@@ -258,6 +288,7 @@ class RunRecorder:
                     run_id,
                 )
             self._lifecycle.stop()
+            self._active_run_context = None
             self._persistence.reset()
             result = self.status()
         if run_id_to_analyze and self._history_db is not None:


### PR DESCRIPTION
## Summary

This PR resolves the remaining actionable part of #1201 by tightening the recorder’s frozen-at-start behavior and adding focused coverage around that contract. Manual verification showed that the temporal-isolation concern was more than a missing assertion: the recorder already captured an initial run snapshot in memory, yet some active recording paths were still consulting live settings after the run had started. That meant a settings or active-car change made mid-recording could leak into sample construction or finalized metadata even though the run was supposed to preserve the context from its start.

The recorder now preserves the active run context once at start and reuses it consistently while that run remains active. Alongside that behavior fix, this PR adds one small adapter-level cleanup regression for UDP control transport shutdown.

Closes #1201.

## Problem being solved

The issue was framed as a test coverage audit, and most of the original claims do not hold up against the current repository state. FFT known-signal coverage, migration tests, integration tests, boundary-condition coverage, and PDF tests all already exist. After reading the relevant code and tests on the current branch, the remaining meaningful work fell into two buckets.

The first bucket was adapter-level cleanup coverage. Existing deeper tests already verify cleanup behavior well, but adapter-level transport shutdown assertions were thinner in a few places. I addressed that with a very small UDP control-plane close regression rather than rewriting adapter tests wholesale.

The second bucket was temporal isolation of the run context. `RunRecorder._start_new_run_locked()` did create a frozen analysis snapshot at run start, but the sample-flush path and metadata builder were still using live settings accessors later in the run. In practice, that made the “frozen-at-start” guarantee incomplete. The issue described that gap as untested behavior, but the current implementation also needed a small correction so the new tests would validate the intended contract rather than lock in the drift.

## Implementation approach

The implementation centers on preserving a single frozen run-context snapshot for the active run and teaching the recorder paths that matter to consult that snapshot instead of live settings. I kept this inside the existing recorder orchestration rather than introducing new public abstractions or wider structural refactors.

`apps/server/vibesensor/use_cases/run/logger.py` now captures a full run-context snapshot at recording start. That snapshot includes both the analysis settings and the active car snapshot visible at the beginning of the run. The recorder keeps that frozen context for the active run and clears it when recording stops. A helper now returns the active run context when the requested run matches the currently recording run, and otherwise falls back to the live settings view used outside an active recording session.

That helper is now used in two important places. First, the `SampleFlushOrchestrator` receives analysis settings from the active run context instead of always reading the latest settings store values. Second, `_build_run_metadata_record()` now builds metadata from the active run context for the active run, including the frozen car snapshot, instead of pulling both pieces live at finalize time.

## Main code changes by area

In `logger.py`, I added the minimal machinery needed to cache and expose the active run context. The start path freezes that context exactly once when the run begins. The stop path clears it after finalization. This keeps the behavior local to the recorder and avoids changing unrelated consumers.

In `_recorder_types.py`, `_build_run_metadata_record()` now uses the recorder’s run-context helper. This matters because final metadata updates happen late in the run lifecycle, and that was one of the places where mid-run changes could previously bleed into persisted metadata. Using the recorder-owned run context closes that gap while preserving the existing metadata shape.

On the test side, `apps/server/tests/use_cases/run/test_metrics_log_helpers.py` no longer codifies the old behavior that refreshed finalized metadata from the latest settings. The updated expectation now matches the intended frozen-at-start contract.

I also added `apps/server/tests/use_cases/run/test_run_context_temporal_isolation.py`, a focused regression that mutates both settings and active-car context after recording starts and then verifies that sample records keep the original ratios, estimated engine RPM stays stable, and metadata generation for the active run keeps the original analysis and car snapshot.

Finally, `apps/server/tests/adapters/udp/test_udp_control_tx.py` now includes a cleanup regression proving that `UDPControlPlane.close()` closes the transport and clears the reference without leaving state behind. The shared UDP `FakeTransport` fixture was extended with a tiny `closed` flag so the test can assert teardown behavior directly.

## Schema, contract, config, and docs impact

There are no HTTP schema, frontend contract, or configuration changes in this PR. The persisted metadata shape remains the same; this change only makes the values more faithful to the run-start context they were already supposed to represent. No documentation updates were required.

## Validation performed

I first ran focused tests around the touched areas:

- `python -m pytest -q apps/server/tests/use_cases/run/test_run_context_temporal_isolation.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/adapters/udp/test_udp_control_tx.py`
- Result: `30 passed`

After that I ran the broader backend validation set used for backend changes in this repository:

- `make lint`
- `make typecheck-backend`
- `python -m pytest -q --tb=short apps/server/tests`

Those all passed cleanly. The full backend pytest run finished with `5728 passed, 5 skipped, 1 xpassed`. I also ran a high-signal code review pass on the working diff before preparing this PR, and it did not surface any material issues.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here was scope. I could have pushed this further into lifecycle-state refactoring, but that would have been larger than the issue warranted. Instead, I kept the freeze logic inside the recorder and used small helpers to route the right context to sample building and metadata finalization.

I also intentionally did not treat the “mock-heavy adapter tests” part of the issue as a reason to rewrite broad test areas. The repository already has substantial behavior-based coverage. This PR addresses a real behavior contract plus one small cleanup regression and leaves the broader style question alone.

A related edge case is active-car drift during a run. Because the same run-context snapshot now carries both analysis settings and the active car snapshot, later car changes no longer silently rewrite the recorded context for that run. That keeps future warning and history behavior aligned with what the operator actually had selected at recording start.

## Follow-ups / out of scope

This PR does not attempt to systematically replace every mock-heavy adapter test in the repository, and it does not add cleanup assertions to every transport or HTTP adapter. For #1201, the important work is done: the low-priority remaining gap was narrowed to a real frozen-context bug plus a small adapter cleanup hole, and both are now covered.
