### PR TITLE
Clarify test layout and smoke marker guidance

### DIFF
--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -8,6 +8,7 @@ subsystems is caught early.
 
 from __future__ import annotations
 
+import pytest
 from test_support import (
     ALL_WHEEL_SENSORS,
     make_fault_samples,
@@ -27,6 +28,8 @@ from vibesensor.adapters.pdf.mapping import (
 )
 from vibesensor.adapters.pdf.report_data import ReportTemplateData
 from vibesensor.use_cases.diagnostics import RunAnalysis
+
+pytestmark = pytest.mark.smoke
 
 
 def _make_small_dataset() -> tuple[dict, list[dict]]:

--- a/apps/server/tests/integration/test_contract_persistence_analysis.py
+++ b/apps/server/tests/integration/test_contract_persistence_analysis.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from test_support import (
     ALL_WHEEL_SENSORS,
     make_fault_samples,
@@ -21,6 +22,8 @@ from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
+
+pytestmark = pytest.mark.smoke
 
 
 def _create_populated_db(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,56 +15,44 @@ The test tree is feature-based. Most directories mirror the backend package or m
 
 ```text
 apps/server/tests/
-├── conftest.py
 ├── _paths.py
+├── conftest.py
 ├── test_support/
-├── analysis/
-├── api/
+├── adapters/
 ├── app/
-├── car_library/
-├── config/
-├── diagnostics/
 ├── domain/
-├── gps/
-├── history/
-├── hotspot/
 ├── hygiene/
+├── infra/
 ├── integration/
-├── metrics_log/
-├── processing/
-├── protocol/
-├── report/
-├── update/
-└── websocket/
+├── shared/
+└── use_cases/
 ```
+
+Older flat roots such as `analysis/`, `api/`, `config/`, `gps/`, `history/`,
+`hotspot/`, `metrics_log/`, `processing/`, `protocol/`, `report/`, `update/`,
+and `websocket/` were consolidated into the mirrored tree above. Do not create
+new top-level flat roots; use the matching mirrored area unless the test is
+intentionally cross-cutting.
 
 ## Where tests belong
 
 | If you change... | Start with... |
 |---|---|
-| `vibesensor/analysis/*` | `apps/server/tests/analysis/` |
-| `vibesensor/report/*`, `report_i18n.py` | `apps/server/tests/report/` |
-| `vibesensor/routes/*` | `apps/server/tests/api/` |
-| `vibesensor/app/runtime_state.py`, `vibesensor/adapters/http/dependencies.py`, `vibesensor/infra/runtime/*`, `worker_pool.py` | `apps/server/tests/infra/runtime/` and `apps/server/tests/adapters/http/` |
-| `vibesensor/adapters/persistence/history_db/*`, `vibesensor/use_cases/history/*` | `apps/server/tests/adapters/persistence/history_db/` and `apps/server/tests/use_cases/history/` |
-| `vibesensor/update/*` | `apps/server/tests/update/` |
-| `vibesensor/processing/*` | `apps/server/tests/processing/` |
-| `vibesensor/ws_hub.py`, `ws_schema_export.py` | `apps/server/tests/websocket/` |
-| `vibesensor/config.py`, `settings_store.py`, `constants.py` | `apps/server/tests/config/` |
-| `vibesensor/shared/order_bands.py` | `apps/server/tests/use_cases/diagnostics/` |
-| `vibesensor/domain/*`, `vibesensor/boundaries/*`, `vibesensor/shared/types/{run_schema,car_config,sensor_config,speed_source_config,settings_snapshot,settings_types}.py`, `json_utils.py`, `registry.py` | `apps/server/tests/domain/` |
-| `vibesensor/shared/boundaries/*`, `vibesensor/shared/types/sensor_frame.py` | `apps/server/tests/shared/` |
-| `vibesensor/gps_speed.py` | `apps/server/tests/gps/` |
-| `vibesensor/protocol.py`, `udp_*.py` | `apps/server/tests/protocol/` |
-| `vibesensor/metrics_log/*` | `apps/server/tests/metrics_log/` |
-| `vibesensor/car_library.py` and related data | `apps/server/tests/car_library/` |
-| `vibesensor/hotspot/*` | `apps/server/tests/hotspot/` |
-| `vibesensor/locations.py` | `apps/server/tests/analysis/` |
+| `vibesensor/adapters/http/*` | `apps/server/tests/adapters/http/` |
+| `vibesensor/adapters/{hotspot,pdf,persistence,simulator,udp,websocket}/*` | the matching `apps/server/tests/adapters/.../` directory |
+| `vibesensor/app/*` | `apps/server/tests/app/` |
+| `vibesensor/domain/*` | `apps/server/tests/domain/` |
+| `vibesensor/infra/{config,processing,runtime,workers}/*` | the matching `apps/server/tests/infra/.../` directory |
+| `vibesensor/shared/boundaries/*`, `vibesensor/shared/types/sensor_frame.py`, shared helper utilities | `apps/server/tests/shared/` |
+| Shared types and metadata contracts used across the domain boundary (`run_schema`, `car_config`, `sensor_config`, `speed_source_config`, `settings_snapshot`, `settings_types`) | `apps/server/tests/domain/` or `apps/server/tests/shared/` depending on the ownership boundary under test |
+| `vibesensor/use_cases/{diagnostics,history,run,updates}/*` | the matching `apps/server/tests/use_cases/.../` directory |
 
 Use cross-cutting directories when a test is intentionally broader than one package boundary:
 
 - `apps/server/tests/integration/`: scenario, pipeline, multi-module behavior, and bug-fix regressions spanning multiple subsystems.
 - `apps/server/tests/hygiene/`: architecture guards and repo hygiene.
+
+Those two directories are the intentional flat exceptions to the mirrored tree.
 
 Regression tests live alongside the feature they primarily test. Cross-cutting
 regressions that span multiple subsystems go in `integration/`.
@@ -82,7 +70,8 @@ Contract bridge tests live in `apps/server/tests/integration/` and validate that
 | `test_contract_analysis_report.py` | `summarize_run_data()` → `prepare_report_input()` → `map_summary()` |
 | `test_contract_persistence_analysis.py` | `HistoryDB` write → read → `summarize_run_data()` |
 
-These tests run in standard CI (no special markers). They use minimal synthetic data and complete in under 5 seconds.
+These tests are marked `smoke`, run in standard CI, use minimal synthetic data,
+and complete in under 5 seconds.
 
 ## Running tests
 
@@ -223,6 +212,10 @@ The default CI-parity suite now mirrors these blocking GitHub checks:
 3. Reuse shared helpers only when multiple files need the same setup or assertions.
 4. Import `SERVER_ROOT` and `REPO_ROOT` from `_paths.py` instead of using fragile parent traversals.
 
+Cached helpers such as `@lru_cache` are acceptable when they memoize immutable
+test data. If a test monkeypatches the underlying file, path, or other cached
+state, clear the cache in that test before asserting on the changed behavior.
+
 ## Markers
 
 | Marker | Meaning |
@@ -230,3 +223,14 @@ The default CI-parity suite now mirrors these blocking GitHub checks:
 | `e2e` | Docker-based end-to-end tests |
 | `long_sim` | Longer simulated-run tests |
 | `smoke` | Minimal critical-path checks |
+
+Use markers sparingly:
+
+- `@pytest.mark.smoke`: fast, deterministic, high-signal checks for critical
+  paths such as schema/contract bridges or minimal end-to-end behavior.
+- `@pytest.mark.long_sim`: slower simulated-run tests that intentionally trade
+  speed for more scenario coverage.
+- `@pytest.mark.e2e`: Docker-backed end-to-end tests.
+
+Do not mark every fast unit test as `smoke`; keep it a compact slice that is
+useful for quick feedback.


### PR DESCRIPTION
## Summary

This PR resolves the remaining actionable part of #1202 by bringing the testing guide back in sync with the real test tree and modestly expanding the repo’s `smoke` marker coverage in a place that already fits the marker definition. The live issue correctly downgraded the original report: fixture inconsistency is already refuted, the suite is already pytest-native, and the repository already uses a custom marker scheme (`smoke`, `long_sim`, `e2e`). The real gaps were lower risk and mostly about clarity: the human-facing testing guide still described the old flat directory layout, the “where tests belong” table still pointed contributors at directories that no longer exist, and the marker section did not explain when to use the current marker scheme.

Rather than trying to refactor test directories that are already mostly mirrored, or mechanically add markers across a large swath of tests, I kept the fix narrow. The documentation now reflects the current mirrored tree and explicitly explains that `integration/` and `hygiene/` are the intentional flat cross-cutting exceptions. I also marked the two existing contract-bridge integration modules as `smoke`, since the guide already describes them as fast, deterministic, critical-path checks that complete in under five seconds.

Closes #1202.

## Problem being solved

The issue body identified three remaining low-priority concerns after the original audit was re-checked: marker coverage is thin, some legacy flat test directories create ambiguity, and cached helper patterns deserve awareness even though no concrete order-dependency failures were found.

After reading the current repo state, the most important finding was that `docs/testing.md` had drifted from reality. Its layout diagram still showed legacy roots such as `analysis/`, `api/`, `config/`, `gps/`, `history/`, `hotspot/`, `metrics_log/`, `processing/`, `protocol/`, `report/`, `update/`, and `websocket/`, while the actual `apps/server/tests/` tree now primarily uses the mirrored `adapters/`, `app/`, `domain/`, `infra/`, `shared/`, and `use_cases/` structure. The “Where tests belong” table had the same drift and would actively misdirect someone adding a new test today.

The issue’s marker point was also directionally right, but only in a low-priority sense. The project already defines custom markers in `apps/server/pyproject.toml`, and those markers are used consistently where they exist. What was missing was clearer guidance on when to apply them and a slightly broader use of `smoke` on some obviously high-signal, fast-running tests.

Finally, I checked the cached-helper concern. The only test-side `@lru_cache` usage I found was in `apps/server/tests/adapters/pdf/test_report_i18n.py`, where cached JSON loaders are used for immutable translation data and the relevant monkeypatched tests already clear the production translation cache explicitly. That is not a real defect, but it is worth documenting as a pattern: if a test monkeypatches cached state, clear the cache before asserting on the changed behavior.

## Implementation approach

I treated this as a “documentation plus tiny annotation” issue rather than a code-refactor issue. The test layout itself is already in better shape than the original report claimed, so renaming directories or shuffling files around would have added churn without solving a real problem.

The first part of the change updates `docs/testing.md` so it reflects the actual current test tree, the current ownership boundaries, and the intended exceptions. The second part adds `@pytest.mark.smoke` to two existing integration modules that are already documented as fast contract-bridge checks. This increases the usefulness of `pytest -m smoke` without turning the marker into a generic label for every quick test in the repository.

## Main changes by area

In `docs/testing.md`, I replaced the stale top-level layout diagram with the mirrored tree that exists today under `apps/server/tests/`. I also added a note explaining that the older flat roots were consolidated and should not be reintroduced, unless a test is intentionally cross-cutting.

I updated the “Where tests belong” table so it now points to the current mirrored directories, including the `adapters/`, `infra/`, `shared/`, and `use_cases/` branches. I kept `integration/` and `hygiene/` explicitly documented as the flat cross-cutting exceptions rather than implying they are leftovers.

The contract-bridge section now states that those tests are `smoke`-marked, run in standard CI, use minimal synthetic data, and complete quickly. The marker section now explains when to use `smoke`, `long_sim`, and `e2e`, and it explicitly says not to mark every fast unit test as `smoke`.

I also added a short cached-helper note to the guide so contributors know that memoized test helpers are acceptable for immutable data, but caches should be cleared when a test monkeypatches the underlying state.

On the test side, `apps/server/tests/integration/test_contract_analysis_report.py` and `apps/server/tests/integration/test_contract_persistence_analysis.py` now carry `pytestmark = pytest.mark.smoke`. These modules were the cleanest candidates because the guide already treats them as fast critical-path contract checks, and the focused validation confirmed they still run comfortably under the promised threshold.

## Schema, contract, config, and docs impact

There are no runtime contract, schema, or configuration changes in this PR. The only code-side behavior change is test selection metadata via the added `smoke` markers. The main user-visible effect is that the testing guide is now accurate again and the smoke slice covers two more high-signal contract-bridge modules.

## Validation performed

I ran focused validation against the two newly marked test modules:

- `python -m pytest -q apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_contract_persistence_analysis.py`
- Result: `9 passed`

I then ran the relevant repo validation for this docs-and-tests change:

- `make docs-lint`
- `make lint`

Those passed cleanly. I also did a review pass on the working diff to verify that the guide now matches the current test tree and that the smoke markers were applied to an appropriate pair of fast, deterministic modules.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here was whether to do a larger structural cleanup. I intentionally did not move or rename any test directories, because the actual repository has already mostly converged on the mirrored structure the issue wanted. The remaining flat roots, `integration/` and `hygiene/`, are cross-cutting by design and should stay that way.

I also chose not to inflate marker coverage just for the sake of numbers. Adding `smoke` to every quick test would make the marker less useful. Marking the two documented contract-bridge modules is a better incremental improvement because they are already fast, deterministic, and strategically important.

## Follow-ups / out of scope

This PR does not attempt a full audit of every possible smoke-marker candidate, and it does not rewrite older test filenames or perform large directory moves. If a future issue wants a broader smoke suite curation pass, that can build on the now-correct guidance in `docs/testing.md`. For #1202, the important work is done: the guide matches the real tree again, the intentional flat exceptions are clearly documented, cached-helper awareness is captured, and smoke coverage is slightly less sparse in a high-signal area.
