### PR TITLE
Reuse shared boundary decoder coercions

### DIFF
--- a/apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py
+++ b/apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.finding import finding_from_payload
+from vibesensor.shared.boundaries.vibration_origin import location_hotspot_from_payload
+
+
+def test_location_hotspot_from_payload_drops_non_finite_numeric_values() -> None:
+    hotspot = location_hotspot_from_payload(
+        {
+            "location": "front-left",
+            "dominance_ratio": float("nan"),
+            "localization_confidence": float("inf"),
+            "location_count": float("-inf"),
+        }
+    )
+
+    assert hotspot.strongest_location == "front-left"
+    assert hotspot.dominance_ratio is None
+    assert hotspot.localization_confidence is None
+    assert hotspot.location_count is None
+
+
+def test_finding_from_payload_drops_non_finite_boundary_numbers() -> None:
+    finding = finding_from_payload(
+        {
+            "finding_id": "F-boundary-numbers",
+            "suspected_source": "wheel/tire",
+            "confidence": float("nan"),
+            "ranking_score": float("inf"),
+            "dominance_ratio": float("-inf"),
+            "phase_evidence": {"cruise_fraction": float("nan")},
+            "evidence_metrics": {"vibration_strength_db": float("inf")},
+            "location_hotspot": {
+                "location": "front-left",
+                "dominance_ratio": float("nan"),
+                "localization_confidence": float("inf"),
+                "location_count": float("-inf"),
+            },
+        }
+    )
+
+    assert finding.confidence is None
+    assert finding.ranking_score == 0.0
+    assert finding.dominance_ratio is None
+    assert finding.cruise_fraction == 0.0
+    assert finding.vibration_strength_db is None
+    assert finding.location is not None
+    assert finding.location.dominance_ratio is None
+    assert finding.location.localization_confidence is None
+    assert finding.location.location_count is None

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -28,6 +28,7 @@ from vibesensor.shared.boundaries.vibration_origin import (
     location_hotspot_from_payload,
     vibration_origin_from_payload,
 )
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.types.history_analysis_contracts import payload_value_from_json
 
@@ -117,13 +118,7 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
         v = payload.get(key)
         return str(v) if v is not None else ""
 
-    conf_raw = payload.get("confidence")
-    confidence: float | None = None
-    if conf_raw is not None:
-        try:
-            confidence = coerce_float(conf_raw)
-        except (TypeError, ValueError):
-            pass
+    confidence = _as_float(payload.get("confidence"))
 
     freq_raw = payload.get("frequency_hz") or payload.get("frequency_hz_or_order")
     frequency_hz: float | None = None
@@ -139,30 +134,14 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     band = payload.get("strongest_speed_band")
 
     # Evidence / ranking fields
-    ranking_raw = payload.get("ranking_score")
-    ranking_score = 0.0
-    if ranking_raw is not None:
-        try:
-            ranking_score = coerce_float(ranking_raw)
-        except (TypeError, ValueError):
-            pass
-
-    dominance_raw = payload.get("dominance_ratio")
-    dominance_ratio: float | None = None
-    if dominance_raw is not None:
-        try:
-            dominance_ratio = coerce_float(dominance_raw)
-        except (TypeError, ValueError):
-            pass
+    ranking_score = _as_float(payload.get("ranking_score")) or 0.0
+    dominance_ratio = _as_float(payload.get("dominance_ratio"))
 
     phase_ev = payload.get("phase_evidence")
     cruise_fraction = 0.0
     phases_detected: tuple[str, ...] = ()
     if isinstance(phase_ev, dict):
-        try:
-            cruise_fraction = float(phase_ev.get("cruise_fraction", 0.0))
-        except (TypeError, ValueError):
-            pass
+        cruise_fraction = _as_float(phase_ev.get("cruise_fraction")) or 0.0
         raw_phases_detected = phase_ev.get("phases_detected")
         if isinstance(raw_phases_detected, list):
             phases_detected = tuple(
@@ -173,12 +152,7 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     vib_db: float | None = None
     ev_metrics = payload.get("evidence_metrics")
     if isinstance(ev_metrics, dict):
-        raw_db = ev_metrics.get("vibration_strength_db")
-        if raw_db is not None:
-            try:
-                vib_db = float(raw_db)
-            except (TypeError, ValueError):
-                pass
+        vib_db = _as_float(ev_metrics.get("vibration_strength_db"))
 
     # Build domain value objects from nested dicts when available
     evidence: FindingEvidence | None = None

--- a/apps/server/vibesensor/shared/boundaries/vibration_origin.py
+++ b/apps/server/vibesensor/shared/boundaries/vibration_origin.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from vibesensor.domain import Finding, VibrationSource, coerce_float, coerce_int
+from vibesensor.domain import Finding, VibrationSource
 from vibesensor.domain.location_hotspot import LocationHotspot
 from vibesensor.domain.vibration_origin import VibrationOrigin
 from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.shared.json_utils import as_int_or_none as _as_int
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.types.history_analysis_contracts import (
     SuspectedVibrationOriginPayload as SuspectedVibrationOrigin,
@@ -28,38 +29,14 @@ def location_hotspot_from_payload(payload: dict[str, object]) -> LocationHotspot
     if second_loc and second_loc not in alt_strings:
         alt_strings.append(second_loc)
 
-    dom_raw = payload.get("dominance_ratio")
-    dominance_ratio: float | None = None
-    if dom_raw is not None:
-        try:
-            dominance_ratio = coerce_float(dom_raw)
-        except (TypeError, ValueError):
-            pass
-
-    loc_conf_raw = payload.get("localization_confidence")
-    localization_confidence: float | None = None
-    if loc_conf_raw is not None:
-        try:
-            localization_confidence = coerce_float(loc_conf_raw)
-        except (TypeError, ValueError):
-            pass
-
-    loc_count_raw = payload.get("location_count")
-    loc_count: int | None = None
-    if loc_count_raw is not None:
-        try:
-            loc_count = coerce_int(loc_count_raw)
-        except (TypeError, ValueError):
-            pass
-
     return LocationHotspot(
         strongest_location=str(payload.get("top_location", payload.get("location", "")) or ""),
-        dominance_ratio=dominance_ratio,
-        localization_confidence=localization_confidence,
+        dominance_ratio=_as_float(payload.get("dominance_ratio")),
+        localization_confidence=_as_float(payload.get("localization_confidence")),
         weak_spatial_separation=bool(payload.get("weak_spatial_separation", False)),
         ambiguous=bool(payload.get("ambiguous_location", payload.get("ambiguous", False))),
         alternative_locations=tuple(alt_strings),
-        location_count=loc_count,
+        location_count=_as_int(payload.get("location_count")),
     )
 
 


### PR DESCRIPTION
## Summary

Closes #1203.

This PR resolves the only concrete remaining item in the issue’s audit: a small cluster of repeated optional numeric coercion blocks inside the boundary decoder layer. After re-checking the live code, I found that the meaningful remaining repetition was limited to a few `try`/`except` blocks in `shared/boundaries/finding.py` and `shared/boundaries/vibration_origin.py` that were all doing the same job: accept an untrusted payload value, attempt to coerce it to an optional number, and quietly drop invalid values.

The repository already had shared helpers that express exactly that intent: `as_float_or_none()` and `as_int_or_none()` in `apps/server/vibesensor/shared/json_utils.py`. This change reuses those helpers in the matching decoder paths, keeps the one intentional exception explicit, and adds a focused regression test that documents the resulting boundary behavior for non-finite numbers.

## Problem being solved

The remaining code-quality issue here was not a missing framework or a broad architectural flaw. It was a small amount of repeated boundary-local numeric parsing code that made two things harder than necessary.

First, the decoder logic was noisier than it needed to be. Several fields in `finding_from_payload()` and `location_hotspot_from_payload()` followed the same repetitive pattern: read a raw object from a mapping, initialize a local variable, attempt `coerce_float()` or `coerce_int()`, and swallow `TypeError` / `ValueError` on failure. That pattern obscured the actual meaning of the code, which is simply “decode an optional numeric field if possible, otherwise treat it as absent.”

Second, the repetition made it easier for small sanitization differences to creep in over time. The shared JSON utility helpers already reject non-finite values such as `NaN` and `Inf`, while the open-coded coercion paths were only handling conversion failures. That meant boundary code that looked structurally identical could still diverge in edge-case behavior depending on which local coercion style it used.

This PR fixes that by standardizing the plain optional-number paths on the existing shared helpers instead of keeping several boundary-local copies of the same coercion pattern.

## Implementation approach

I intentionally kept this solution narrow. I did not introduce a generic decoder base class, a new abstraction layer, or any cross-cutting “framework” for all boundary modules. The issue itself already established that the decoder modules are intentionally separate by boundary type, and the repo guidance strongly favors extending existing helpers over inventing parallel infrastructure. A full abstraction would have added more surface area than value for a small code-style issue.

Instead, I used the existing helpers only where the semantics already matched the code being replaced. That keeps the refactor easy to reason about and avoids rewriting decoders whose logic is intentionally more specialized.

The main explicit exception is the `frequency_hz` / `frequency_hz_or_order` handling in `finding_from_payload()`. That path is not just “optional float or none.” It also preserves a non-numeric order label when the payload carries a textual order descriptor instead of a numeric frequency. I left that logic intact so the refactor does not accidentally collapse an intentional boundary contract into generic number parsing.

## Main code changes by area

### `apps/server/vibesensor/shared/boundaries/vibration_origin.py`

`location_hotspot_from_payload()` previously had three separate local coercion blocks for `dominance_ratio`, `localization_confidence`, and `location_count`. Each one read a raw field, initialized a local variable to `None`, tried to coerce it, and ignored conversion errors.

Those blocks now use the shared helpers directly:

- `dominance_ratio` uses `as_float_or_none()`
- `localization_confidence` uses `as_float_or_none()`
- `location_count` uses `as_int_or_none()`

No other hotspot behavior changed. The location alias handling, ambiguity flags, and alternative-location normalization remain as before.

### `apps/server/vibesensor/shared/boundaries/finding.py`

`finding_from_payload()` had the same repetitive pattern for several plain optional numeric fields. These now reuse `as_float_or_none()` where that helper exactly matches the decoder’s intent:

- top-level `confidence`
- top-level `ranking_score`
- top-level `dominance_ratio`
- nested `phase_evidence.cruise_fraction`
- nested `evidence_metrics.vibration_strength_db`

For the fields that have defaults rather than remaining optional, the decoder still preserves those defaults after coercion. In practice that means invalid or non-finite values now sanitize to the existing default path instead of leaking further into domain construction.

I deliberately did not rewrite the `frequency_hz` fallback branch, because that code carries real business meaning: numeric values should become `frequency_hz`, while non-numeric payloads can still populate the order-label path.

## Tests and validation

I added a focused regression module: `apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py`.

That test covers the safety-sensitive behavior introduced by consolidating on the shared helpers. It verifies that non-finite values provided through boundary payloads do not survive as `NaN` / `Inf` in decoded results. Instead:

- optional numeric fields become `None`
- defaulted numeric fields continue through their established `0.0` fallback path
- nested hotspot numeric fields are sanitized consistently with the top-level decoder fields

This is important because the refactor is not only about reducing repetition; it also makes the sanitization policy explicit and test-backed.

I also ran the surrounding validation that should catch accidental contract drift or typing mistakes in this area:

- `python -m pytest -q apps/server/tests/shared/boundaries` → `95 passed`
- `make lint`
- `make typecheck-backend`

The boundary suite exercises the existing roundtrip, equivalence, legacy-alias, projection, and schema-surface coverage around these decoders, so this gives good confidence that the refactor preserved expected behavior for valid payloads while intentionally tightening non-finite edge cases.

## Contracts, schema, config, and docs

There are no API schema, config, or user-facing documentation changes in this PR.

The refactor stays entirely within backend boundary decoding internals and does not change the shape of persisted or transported payloads. Because the contract surface is unchanged, there was no need to regenerate frontend contracts or update README guidance.

## Risks, tradeoffs, and edge cases considered

The main tradeoff in this PR is that some previously repeated coercion blocks now inherit the shared helper’s stricter handling of non-finite values. That is an intentional improvement. Boundary decoders should normalize bad numeric payloads into safe absent/default values rather than propagate `NaN` / `Inf` deeper into domain objects.

I made that behavior explicit in tests because it is the one meaningful semantic change hidden inside what would otherwise look like a pure cleanup diff.

I also kept the scope intentionally limited. I did not attempt to abstract all boundary modules into a common decoder pattern, because the current architecture benefits from per-boundary independence and the issue did not justify a larger structural rewrite. This PR removes the real low-risk duplication without adding indirection.

## Out of scope / follow-up

I consider the remaining structural similarity across `shared/boundaries/` modules to be an intentional architectural pattern rather than a defect. If future growth introduces substantially more repeated decoder machinery, that would be the right time to revisit whether a common helper layer should expand. For the current codebase, the smallest complete fix is to reuse the existing shared numeric helpers where they already fit.
