### PR TITLE
Add developer setup troubleshooting FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,3 +156,34 @@ drift.
 - Port confusion: production-style access is usually `http://127.0.0.1`, while native dev often uses `http://127.0.0.1:8000`.
 - UI contract drift: follow [apps/ui/README.md#contract-sync](apps/ui/README.md#contract-sync) for the generated HTTP/WS/constants sync flow and rerun `npm run sync:contracts`.
 - Slow or failing end-to-end runs: check Docker status and the operational runbook before debugging application logic.
+
+### Developer setup troubleshooting
+
+- `make doctor` fails on Python or Node: switch to the versions pinned in
+  [.python-version](.python-version) and [.nvmrc](.nvmrc), then rerun
+  `make doctor` before bootstrapping. A doctor `WARN` on Docker or PlatformIO
+  only means those optional workflow paths are unavailable; the native Python +
+  Vite path can still be usable.
+- `vibesensor-server`, `vibesensor-config-preflight`, or other `vibesensor-*`
+  commands are missing after `pip install -e`: activate the same environment you
+  installed into before running repo commands. If you use a local `.venv`, run
+  `source .venv/bin/activate` first; otherwise, make sure the installing
+  interpreter's script directory is on your `PATH` and rerun
+  `python3 -m pip install -e "./apps/server[dev]"`.
+- Backend bootstrap looks half-installed or editable installs behave strangely:
+  avoid mixing global and virtualenv installs. Recreate the environment you
+  intend to use, then rerun either `make setup` or the native bootstrap flow in
+  [README.md#native-python--vite-recommended-for-backend-or-ui-iteration](README.md#native-python--vite-recommended-for-backend-or-ui-iteration).
+- `npm --prefix apps/ui ci` or `npm --prefix apps/ui run dev` fails right after a
+  Node version switch: confirm `node --version` matches `.nvmrc`, delete
+  `apps/ui/node_modules`, and rerun `npm --prefix apps/ui ci` instead of
+  `npm install`.
+- `docker compose` fails before the app starts: check `docker info` and
+  `docker compose version` before debugging the repo itself. If the daemon is
+  not reachable or your user lacks Docker permissions, fix that first and then
+  retry the commands from [README.md#docker-dev-mode-source-mounted-hot-reload](README.md#docker-dev-mode-source-mounted-hot-reload).
+- The Vite UI loads but `/api` or `/ws` requests fail: keep
+  `vibesensor-server --reload --config apps/server/config.dev.yaml` running on
+  `:8000`, then run `npm --prefix apps/ui run dev` and open
+  `http://127.0.0.1:5173`. The backend listener on `http://127.0.0.1:8000` is
+  the API server, not the Vite dev server.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ static UI build instead of the dev server, run `python tools/build_ui_static.py`
 and skip `npm --prefix apps/ui run dev`, then open http://localhost:8000.
 
 Use [CONTRIBUTING.md](CONTRIBUTING.md) for the full validation, CI reproduction,
-and workflow guidance.
+developer troubleshooting, and workflow guidance.
 
 The simulator supports interactive commands — type `help` to see options like
 `list`, `set <sensor> profile <name>`, `pulse`, `pause`, `resume`.


### PR DESCRIPTION
## Summary

Closes #1204.

This PR adds the missing developer-facing troubleshooting guidance that the issue identified without rewriting or duplicating the setup instructions that are already in good shape. After re-checking the live docs, the core onboarding story was stronger than the original issue description implied: the repository already has clear quick-start paths in `README.md`, contributor workflow guidance in `CONTRIBUTING.md`, and a `make doctor` prerequisite check. The real gap was narrower and more practical: once a developer had chosen a setup path, there was no short FAQ for the common setup failures that happen before meaningful coding starts.

The fix stays intentionally small. I expanded `CONTRIBUTING.md` with a new `Developer setup troubleshooting` subsection and made one small README wording change so contributors can discover that new guidance directly from the quick-start flow.

## Problem being solved

The issue was not a missing bootstrap command or a broken setup guide. It was a missing bridge between the existing setup commands and the kinds of problems new contributors actually hit while trying to use them.

Before this change, the documentation told developers how to get started, but it did not give them a focused place to look when the expected setup path failed in routine, non-product ways. For example, a contributor could run into a Python or Node version mismatch, install backend entry points into the wrong environment, switch Node versions and end up with stale `node_modules`, or discover that Docker itself was unavailable before any repository code was actually involved. Those are not product runtime problems, and they are not really validation-workflow questions either. They are onboarding and local-environment troubleshooting questions.

The repository already had an `Operational Troubleshooting` section in `README.md`, but that guidance is aimed at runtime behavior and deployment-style checks. It covers things like hotspot access, simulator connectivity, and dropped frames rather than local developer bootstrap issues. The contributor guide also had a short `Common failure cases` list, but it was limited to a few workflow topics and did not cover the setup-phase problems called out by the issue.

This PR fills that specific gap.

## Implementation approach

I chose to put the new guidance in `CONTRIBUTING.md` rather than in `README.md` or an operational runbook. That was the main design decision in this fix.

`README.md` is still the right place for the high-level quick-start paths: Docker quick check, Docker dev mode, native Python + Vite, and the simulator flow. It is the first-stop orientation document, and it should stay concise enough that a new contributor can choose a workflow quickly. Moving a large troubleshooting FAQ into that file would mix user-facing entry guidance with maintenance-heavy local-environment advice.

`docs/operational-runbooks.md` was also the wrong home because its scope is operational and runtime-focused. The issue itself already recognized that the missing guidance was developer-specific rather than production-specific.

That left `CONTRIBUTING.md` as the smallest complete home for the change. It already contains the contributor workflow, validation expectations, CI reproduction pointers, and a `Common failure cases` section. Expanding that guide with a dedicated setup troubleshooting subsection keeps the new material near the existing contributor workflow, avoids adding a brand-new doc, and preserves a clean separation between onboarding troubleshooting and runtime troubleshooting.

I also updated the README pointer near the native quick-start section so it now explicitly says `CONTRIBUTING.md` covers developer troubleshooting in addition to validation and workflow guidance. That small sentence change makes the new section easier to discover without turning the README into the troubleshooting document itself.

## Main documentation changes by area

### `CONTRIBUTING.md`

The main change is a new `Developer setup troubleshooting` subsection placed directly after the existing `Common failure cases` section.

The new guidance covers the most useful setup-stage problems without repeating the entire bootstrap flow:

- what to do when `make doctor` fails on Python or Node, and how to interpret warnings about optional Docker or PlatformIO paths
- what it usually means when `vibesensor-*` console scripts are missing after `pip install -e`, including the common environment-activation / PATH mismatch problem
- how to recover when editable installs look half-broken because global and virtualenv installs have been mixed together
- how to repair the frontend path after a Node version switch by verifying `.nvmrc`, clearing `apps/ui/node_modules`, and rerunning `npm ci`
- how to recognize Docker daemon or permission problems as environment issues instead of repo issues
- how to interpret the native-dev split between the backend on `:8000` and the Vite dev server on `:5173` when API or WebSocket calls fail

The wording follows the existing contributor-guide style: direct bullets, short symptom-first wording, concrete commands, and links back to the canonical setup sections when a larger reset or bootstrap rerun is needed.

### `README.md`

The README change is intentionally tiny. The native quick-start section already pointed readers to `CONTRIBUTING.md` for validation, CI reproduction, and workflow guidance. I expanded that sentence so it also mentions developer troubleshooting. That keeps the quick-start flow intact while making the new contributor FAQ discoverable from the place where most first-time developers will start.

## Why this scope is intentionally small

This PR does not add a new standalone troubleshooting document, and it does not try to turn the contributor guide into a full platform support manual.

The goal here was not to document every possible machine-specific problem. It was to cover the repeatable, repo-adjacent failure modes that new contributors are most likely to hit and that the repository can reasonably help them diagnose. That is why the new section focuses on pinned versions, environment activation, editable-install consistency, Docker workflow availability, Node dependency resets, and the native dev server split.

## Validation

This was a documentation-only change, so I ran the validation that matters for documentation correctness:

- `make docs-lint`

That passed successfully and verified that the new local markdown links and anchors are valid and that the docs stack stayed consistent.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is placement: some developers may initially expect all troubleshooting content to live in the main README. I think the contributor guide is the better long-term home because it keeps the README readable while still giving developers a focused place for setup problems. The small README pointer change is there to reduce discoverability risk.

I also kept the section intentionally limited to developer setup troubleshooting. I did not move or expand the operational runbook, and I did not duplicate the existing bootstrap instructions from the README or component-specific READMEs. If future onboarding issues show recurring problems outside this set, the contributor troubleshooting section can grow incrementally from here.
