### PR TITLE
Polish local development inner loop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,10 +27,12 @@ Domain model (scope: behavioral rules only; see `docs/domain-model.md` for the f
 
 Commands
 - Other AI guidance and docs should reference this list instead of repeating it.
+- `make setup`
 - `python -m pip install -e "./apps/server[dev]"`
 - `make lint`
 - `make typecheck-backend`
 - `make docs-lint`
+- `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
 - `act -j backend-quality -W .github/workflows/ci.yml` (run a single CI job locally via `act`; requires Docker)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,13 @@ recommended live-dev path is `vibesensor-server --reload --config
 apps/server/config.dev.yaml` plus `npm --prefix apps/ui run dev`, then open
 `http://127.0.0.1:5173`.
 
+If you want the browser to open automatically on local desktop workflows, use
+`npm --prefix apps/ui run dev:open` instead of `npm --prefix apps/ui run dev`.
+
 ## Hooks and local safeguards
 
-Enable versioned hooks if you want local guardrails:
+`make setup` enables the versioned repo hooks automatically. If you skipped that
+bootstrap path or want to re-enable them manually, run:
 
 ```bash
 git config core.hooksPath .githooks
@@ -59,6 +63,10 @@ Current hook behavior:
 - If a hook blocks you unexpectedly, use the commands below directly and then investigate instead of guessing.
 
 ## Validation workflow
+
+Use `make test-changed` as a heuristic shortcut for the files changed on your
+current branch when you want a fast first pass. It is not a replacement for the
+broader tiers below before merge.
 
 Three tiers: use `make test` during iteration, `make test-ci-lite` for the
 non-Docker blocking-CI subset, and `make test-all` when you want the broader
@@ -75,6 +83,7 @@ Additional local-only convenience commands:
 | Goal | Command |
 |---|---|
 | Fast backend tests | `make test` |
+| Changed-file heuristic | `make test-changed` |
 | Non-Docker CI subset | `make test-ci-lite` |
 | Full local CI runner | `make test-all` |
 | Coverage view | `make coverage` |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup format lint typecheck-backend typecheck ui-typecheck test test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup format lint typecheck-backend typecheck ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
 CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job backend-tests
@@ -14,6 +14,7 @@ setup: ## Install backend dev dependencies and UI node_modules
 	python3 -m pip install --upgrade pip
 	python3 -m pip install -e "./apps/server[dev]"
 	cd apps/ui && npm ci
+	git config --local core.hooksPath .githooks
 
 format: ## Run Ruff formatter over backend and tooling files
 	ruff format $(LINT_TARGETS)
@@ -40,6 +41,9 @@ typecheck: typecheck-backend ui-typecheck
 
 test: ## Run the fast backend pytest suite
 	python3 -m pytest -q apps/server/tests
+
+test-changed: ## Run heuristic checks for files changed vs origin/main
+	python3 tools/tests/run_changed.py $(if $(BASE_REF),--base-ref $(BASE_REF),)
 
 test-ci-lite: ## Run the non-Docker blocking CI subset locally
 	python3 tools/tests/run_ci_parallel.py $(CI_LITE_JOBS)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ run log format. Synthetic analysis scenarios live in
 
 ## Developer Safeguards
 
-Enable versioned local hooks:
+`make setup` enables the versioned local hooks automatically. If you skipped
+that bootstrap flow or want to re-enable them manually, run:
 
 ```bash
 git config core.hooksPath .githooks

--- a/apps/server/tests/hygiene/test_run_changed.py
+++ b/apps/server/tests/hygiene/test_run_changed.py
@@ -1,0 +1,113 @@
+"""Guard the heuristic changed-file test runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+from tests._paths import REPO_ROOT
+
+_RUN_CHANGED = REPO_ROOT / "tools" / "tests" / "run_changed.py"
+
+
+def _load_run_changed_module():
+    spec = importlib.util.spec_from_file_location("run_changed_local_for_tests", _RUN_CHANGED)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_RUN_CHANGED}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plan_commands_maps_backend_source_to_mirrored_test_dir() -> None:
+    module = _load_run_changed_module()
+
+    commands = module._plan_commands(("apps/server/vibesensor/shared/boundaries/finding.py",))
+
+    assert commands == (
+        module.PlannedCommand(
+            "pytest",
+            ("python3", "-m", "pytest", "-q", "apps/server/tests/shared"),
+        ),
+    )
+
+
+def test_plan_commands_uses_changed_test_file_directly() -> None:
+    module = _load_run_changed_module()
+
+    commands = module._plan_commands(
+        ("apps/server/tests/shared/boundaries/test_finding_roundtrip.py",)
+    )
+
+    assert commands == (
+        module.PlannedCommand(
+            "pytest",
+            (
+                "python3",
+                "-m",
+                "pytest",
+                "-q",
+                "apps/server/tests/shared/boundaries/test_finding_roundtrip.py",
+            ),
+        ),
+    )
+
+
+def test_plan_commands_combines_docs_ui_and_hygiene_checks() -> None:
+    module = _load_run_changed_module()
+
+    commands = module._plan_commands(("README.md", "apps/ui/package.json", "Makefile"))
+
+    assert commands == (
+        module.PlannedCommand("docs-lint", ("make", "docs-lint")),
+        module.PlannedCommand("ui-typecheck", ("make", "ui-typecheck")),
+        module.PlannedCommand(
+            "pytest",
+            ("python3", "-m", "pytest", "-q", "apps/server/tests/hygiene"),
+        ),
+    )
+
+
+def test_plan_commands_falls_back_to_make_test_for_unmapped_backend_changes() -> None:
+    module = _load_run_changed_module()
+
+    commands = module._plan_commands(("apps/server/vibesensor/_version.py",))
+
+    assert commands == (module.PlannedCommand("backend-tests", ("make", "test")),)
+
+
+def test_changed_files_includes_committed_and_worktree_changes(monkeypatch) -> None:
+    module = _load_run_changed_module()
+    outputs = {
+        ("merge-base", "origin/main", "HEAD"): "abc123",
+        ("diff", "--name-only", "abc123..HEAD"): "docs/testing.md\n",
+        ("diff", "--name-only", "--cached"): "Makefile\n",
+        ("diff", "--name-only"): "CONTRIBUTING.md\n",
+        ("ls-files", "--others", "--exclude-standard"): "tools/tests/run_changed.py\n",
+    }
+
+    monkeypatch.setattr(module, "_git_output", lambda *args: outputs.get(args, ""))
+
+    assert module._changed_files("origin/main") == (
+        "CONTRIBUTING.md",
+        "Makefile",
+        "docs/testing.md",
+        "tools/tests/run_changed.py",
+    )
+
+
+def test_changed_files_exits_cleanly_when_merge_base_is_missing(monkeypatch) -> None:
+    module = _load_run_changed_module()
+
+    def _raise_on_merge_base(*args: str) -> str:
+        if args == ("merge-base", "origin/main", "HEAD"):
+            raise subprocess.CalledProcessError(128, ("git", *args))
+        return ""
+
+    monkeypatch.setattr(module, "_git_output", _raise_on_merge_base)
+
+    with pytest.raises(SystemExit, match="Unable to find a common ancestor"):
+        module._changed_files("origin/main")

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -18,6 +18,7 @@ server over HTTP (REST) and WebSocket (live data).
 cd apps/ui
 npm ci
 npm run dev          # Dev server on http://localhost:5173
+npm run dev:open     # Same dev server, but opens the browser on local desktops
 npm run build        # Production build to dist/
 npm run typecheck    # Type check without emitting
 ```

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -9,6 +9,7 @@
     "pretypecheck": "npm run sync:contracts",
     "prebuild": "npm run sync:contracts",
     "dev": "vite --host 0.0.0.0 --port 5173",
+    "dev:open": "vite --host 0.0.0.0 --port 5173 --open",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4173",
     "typecheck": "tsc --noEmit",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,9 +75,12 @@ and complete in under 5 seconds.
 
 ## Running tests
 
-Four tiers: `make test` for fast iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `act -W .github/workflows/ci.yml` (required before finalizing) to run the real GitHub workflow locally in Docker.
+Four tiers: `make test-changed` for a fast changed-file heuristic, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `act -W .github/workflows/ci.yml` (required before finalizing) to run the real GitHub workflow locally in Docker.
 
 ```bash
+# Changed-file heuristic (current branch vs origin/main, fallback to main)
+make test-changed
+
 # Fast iteration — backend unit tests
 make test
 

--- a/tools/tests/run_changed.py
+++ b/tools/tests/run_changed.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Run fast, heuristic checks for files changed in the current branch."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).resolve().parents[2]
+BACKEND_TESTS_ROOT = PurePosixPath("apps/server/tests")
+BACKEND_SOURCE_ROOT = PurePosixPath("apps/server/vibesensor")
+DOC_FILES = {
+    "README.md",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md",
+    ".github/copilot-instructions.md",
+}
+HYGIENE_TRIGGER_PATHS = {
+    "Makefile",
+    ".python-version",
+    ".nvmrc",
+    "docker-compose.yml",
+    "docker-compose.dev.yml",
+}
+HYGIENE_TRIGGER_PREFIXES = (".githooks/", ".github/", "tools/")
+
+
+@dataclass(frozen=True)
+class PlannedCommand:
+    label: str
+    argv: tuple[str, ...]
+
+
+def _git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+
+
+def _git_has_ref(ref: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            cwd=ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _resolve_base_ref(requested: str | None) -> str:
+    candidates = [requested] if requested else ["origin/main", "main"]
+    for candidate in candidates:
+        if candidate and _git_has_ref(candidate):
+            return candidate
+    raise SystemExit(
+        "No base ref found. Fetch origin/main or rerun with --base-ref <ref> (for example main)."
+    )
+
+
+def _changed_files(base_ref: str) -> tuple[str, ...]:
+    try:
+        merge_base = _git_output("merge-base", base_ref, "HEAD")
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"Unable to find a common ancestor between {base_ref} and HEAD. "
+            "Fetch the latest history or rerun with --base-ref <ref>."
+        ) from exc
+    committed = {
+        line
+        for line in _git_output(
+            "diff", "--name-only", f"{merge_base}..HEAD"
+        ).splitlines()
+        if line.strip()
+    }
+    staged = {
+        line
+        for line in _git_output("diff", "--name-only", "--cached").splitlines()
+        if line.strip()
+    }
+    unstaged = {
+        line for line in _git_output("diff", "--name-only").splitlines() if line.strip()
+    }
+    untracked = {
+        line
+        for line in _git_output(
+            "ls-files", "--others", "--exclude-standard"
+        ).splitlines()
+        if line.strip()
+    }
+    return tuple(sorted(committed | staged | unstaged | untracked))
+
+
+def _is_markdown_path(path: str) -> bool:
+    return path.endswith(".md") or path in DOC_FILES or path.startswith("docs/")
+
+
+def _test_target_for_changed_test(path: str) -> str:
+    candidate = PurePosixPath(path)
+    if candidate.name.startswith("test_") and candidate.suffix == ".py":
+        return candidate.as_posix()
+    return candidate.parent.as_posix()
+
+
+def _mirrored_backend_test_target(path: str) -> str | None:
+    source_path = PurePosixPath(path)
+    try:
+        relative = source_path.relative_to(BACKEND_SOURCE_ROOT)
+    except ValueError:
+        return None
+    if not relative.parts:
+        return None
+    candidate = BACKEND_TESTS_ROOT / relative.parts[0]
+    if (ROOT / candidate).is_dir():
+        return candidate.as_posix()
+    return None
+
+
+def _plan_commands(changed_files: tuple[str, ...]) -> tuple[PlannedCommand, ...]:
+    docs_changed = False
+    ui_changed = False
+    backend_fallback = False
+    pytest_targets: set[str] = set()
+
+    for path in changed_files:
+        normalized = PurePosixPath(path).as_posix()
+        if _is_markdown_path(normalized):
+            docs_changed = True
+            continue
+
+        if normalized.startswith("apps/server/tests/"):
+            pytest_targets.add(_test_target_for_changed_test(normalized))
+            continue
+
+        if normalized.startswith("apps/server/vibesensor/"):
+            mirrored_target = _mirrored_backend_test_target(normalized)
+            if mirrored_target is not None:
+                pytest_targets.add(mirrored_target)
+            else:
+                backend_fallback = True
+            continue
+
+        if normalized.startswith("apps/ui/"):
+            ui_changed = True
+            continue
+
+        if normalized in HYGIENE_TRIGGER_PATHS or normalized.startswith(
+            HYGIENE_TRIGGER_PREFIXES
+        ):
+            pytest_targets.add("apps/server/tests/hygiene")
+            continue
+
+        if normalized.startswith("apps/server/"):
+            backend_fallback = True
+
+    commands: list[PlannedCommand] = []
+    if docs_changed:
+        commands.append(PlannedCommand("docs-lint", ("make", "docs-lint")))
+    if ui_changed:
+        commands.append(PlannedCommand("ui-typecheck", ("make", "ui-typecheck")))
+    if backend_fallback:
+        commands.append(PlannedCommand("backend-tests", ("make", "test")))
+    elif pytest_targets:
+        commands.append(
+            PlannedCommand(
+                "pytest",
+                ("python3", "-m", "pytest", "-q", *tuple(sorted(pytest_targets))),
+            )
+        )
+    return tuple(commands)
+
+
+def _run_planned_commands(commands: tuple[PlannedCommand, ...]) -> int:
+    for command in commands:
+        print(f"[test-changed] {command.label}: {shlex.join(command.argv)}")
+        completed = subprocess.run(command.argv, cwd=ROOT, check=False)
+        if completed.returncode != 0:
+            return completed.returncode
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        help="Git ref to diff against (default: origin/main, falling back to main).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the selected commands without running them.",
+    )
+    args = parser.parse_args()
+
+    base_ref = _resolve_base_ref(args.base_ref)
+    changed_files = _changed_files(base_ref)
+    if not changed_files:
+        print(f"[test-changed] No changed files detected vs {base_ref}.")
+        return 0
+
+    print(f"[test-changed] Changed files vs {base_ref}:")
+    for path in changed_files:
+        print(f"  - {path}")
+
+    commands = _plan_commands(changed_files)
+    if not commands:
+        print("[test-changed] No mapped checks for the current diff.")
+        return 0
+
+    if args.dry_run:
+        for command in commands:
+            print(f"[test-changed] {command.label}: {shlex.join(command.argv)}")
+        return 0
+
+    return _run_planned_commands(commands)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #1205.

This PR tightens the local development inner loop in three focused ways without over-building new tooling or forcing behavior that does not fit every workflow. After re-checking the live repo, the issue was again only partially accurate: the project already had versioned git hooks in `.githooks/`, multiple useful local test tiers, and backend hot reload. The real missing pieces were smaller and more practical:

1. the existing hooks were optional enough that many developers would never enable them,
2. there was no built-in “test what I changed” shortcut for a focused branch, and
3. browser auto-open existed only as a suggestion in the issue, not as a safe, opt-in local convenience.

This PR addresses those concrete gaps while preserving the repo’s existing preference for explicit workflows and reversible local tooling.

## Problem being solved

The issue was not asking for a brand-new development system. Most of the original complaints were already refuted by the current codebase: the backend can already hot-reload, Docker dev mode already mounts the repo instead of rebuilding for every edit, and the Makefile already has useful local test tiers.

The remaining DX problems were about discoverability and convenience rather than missing core capability.

First, the repo already had versioned pre-commit and pre-push hooks, but they were only enabled if a developer explicitly ran `git config core.hooksPath .githooks`. That meant the hooks existed, but not in a way that naturally helped a new contributor who followed the normal setup flow.

Second, the repo already had broad commands like `make test`, `make test-ci-lite`, and `make test-all`, plus focused pytest path examples in `docs/testing.md`, but there was still no single shortcut for “run the fastest relevant checks for the files I changed on this branch.”

Third, the issue suggested browser auto-open as a minor polish item. I did not think `server.open: true` in Vite was the right global default for this repo because the same UI tooling is used in Docker, remote, and headless flows. A better fit is to offer browser auto-open as an opt-in convenience for local desktop workflows while keeping the default dev server behavior explicit and predictable.

## Implementation approach

I intentionally kept this fix small and composable.

I did not add a large pre-commit framework, I did not build an overly clever changed-test dependency tracker, and I did not change Vite to auto-open the browser in every environment. Instead, I extended the existing repo patterns:

- reuse the existing `.githooks/` directory instead of introducing a new hook system,
- add a lightweight changed-file runner that maps repo paths to already-existing validation commands and mirrored test directories,
- expose browser auto-open as a separate UI script instead of changing the default dev-server contract.

That approach keeps the behavior easy to understand and easy to bypass when someone wants the explicit commands directly.

## Main changes by area

### `Makefile`

Two developer entry points changed here.

First, `make setup` now runs `git config --local core.hooksPath .githooks` after installing backend and UI dependencies. This turns the existing repo-managed hooks into part of the standard bootstrap path instead of a separate optional step.

Second, the Makefile now exposes `make test-changed`, which runs `python3 tools/tests/run_changed.py`. This makes the new shortcut discoverable through `make` and keeps it aligned with the repo’s existing command surface.

### `tools/tests/run_changed.py`

This is the main new DX helper.

The script compares the current branch against `origin/main`, falling back to `main` when needed, and now includes committed, staged, unstaged, and untracked files so it is useful before a commit exists. From there it selects a conservative set of checks:

- markdown and doc changes trigger `make docs-lint`
- UI source/config changes trigger `make ui-typecheck`
- changed backend test files run directly or by parent directory when the changed file is a helper
- changed backend source files map to the mirrored backend test area (for example `apps/server/vibesensor/shared/...` maps to `apps/server/tests/shared`)
- repo tooling, hook, and Makefile changes map to `apps/server/tests/hygiene`
- backend files that cannot be mapped safely fall back to `make test`

I also hardened the script so `git merge-base` failures produce a clear user-facing error instead of an uncaught stack trace.

This helper is intentionally heuristic rather than “smart.” It is for fast first-pass iteration, not as a replacement for broader validation before merge.

### `apps/server/tests/hygiene/test_run_changed.py`

I added focused hygiene coverage for the new script. The tests verify:

- mirrored backend source paths resolve to the right test area,
- changed test files are run directly,
- mixed docs/UI/tooling changes combine the expected commands,
- unmapped backend changes fall back to `make test`, and
- merge-base failures exit cleanly with a useful message.

That keeps the shortcut behavior explicit and makes later refactors safer.

### UI and docs

For the browser convenience item, I added `npm run dev:open` to `apps/ui/package.json` instead of changing the default `dev` script or Vite server behavior globally. This gives local desktop users the convenience they want without surprising Docker or remote workflows.

I then updated the relevant docs so the new behavior is discoverable and consistent:

- `CONTRIBUTING.md` now explains that `make setup` auto-enables the repo hooks, documents `make test-changed`, and points at `npm run dev:open` as an optional desktop workflow
- `README.md` updates the developer safeguards wording so the hook behavior matches reality
- `apps/ui/README.md` documents the new `dev:open` script
- `docs/testing.md` includes `make test-changed` in the fast-iteration command set
- `.github/copilot-instructions.md` adds `make setup` and `make test-changed` to the canonical command list

## Validation

I validated both the new helper itself and the broader workflow impact.

Focused checks:

- `python3 -m pytest -q apps/server/tests/hygiene/test_run_changed.py`
- `make test-changed BASE_REF=cba42c12c0940766f20744eb2dec5c22af9c0ef7`

The `make test-changed` run on this branch correctly selected docs lint, UI typecheck, and hygiene pytest coverage from the actual changed files.

Broader local validation:

- `make test-ci-lite`

That completed successfully in the session venv, covering backend quality, backend typecheck, frontend typecheck, UI smoke, release smoke, and backend tests.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that `make test-changed` is deliberately heuristic. It does not try to infer exact transitive test dependencies, and it will fall back to broader commands when a safe narrow mapping is not obvious.

I also chose not to make browser auto-open the default Vite behavior. The separate `dev:open` script gives local desktop users the convenience without changing the contract for everyone else.

Finally, I did not introduce a pre-commit framework like `pre-commit` or husky in this PR. The repo already had working versioned hooks; the missing step was making them part of normal setup rather than optional tribal knowledge.
