### PR TITLE
Improve CI efficiency workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
 
   ui-smoke:
     name: UI smoke tests
+    needs:
+      - frontend-typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -109,6 +111,10 @@ jobs:
 
   release-smoke:
     name: Release smoke
+    needs:
+      - backend-quality
+      - backend-typecheck
+      - frontend-typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -135,6 +141,8 @@ jobs:
 
   firmware-native-tests:
     name: Firmware native tests
+    needs:
+      - backend-quality
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -158,6 +166,9 @@ jobs:
 
   backend-tests:
     name: Backend tests
+    needs:
+      - backend-quality
+      - backend-typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -167,13 +178,30 @@ jobs:
           fetch-depth: 1
 
       - uses: ./.github/actions/setup-backend
+
+      - name: Prepare backend test artifacts
+        run: |
+          mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests
         run: |
-          python -m pytest -q --tb=short apps/server/tests
+          python -m pytest -q --tb=short --junitxml artifacts/ai/logs/ci/backend-tests.xml apps/server/tests
+
+      - name: Upload backend test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-artifacts
+          path: artifacts/ai/logs/ci/
+          if-no-files-found: ignore
+          retention-days: 7
 
   e2e:
     name: E2E (docker)
+    needs:
+      - backend-quality
+      - backend-typecheck
+      - frontend-typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -183,7 +211,28 @@ jobs:
           fetch-depth: 1
 
       - uses: ./.github/actions/setup-backend
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Prebuild cached E2E image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/server/Dockerfile
+          tags: vibesensor-full-suite:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Docker-backed e2e suite (skip already-owned checks)
         run: |
           python3 tools/tests/run_e2e_parallel.py --fast-e2e
+
+      - name: Upload e2e failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-artifacts
+          path: artifacts/ai/logs/e2e_parallel/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/apps/server/tests/hygiene/test_run_e2e_parallel.py
+++ b/apps/server/tests/hygiene/test_run_e2e_parallel.py
@@ -1,0 +1,88 @@
+"""Guard docker-backed e2e image preparation behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from tests._paths import REPO_ROOT
+
+_RUN_E2E_PARALLEL = REPO_ROOT / "tools" / "tests" / "run_e2e_parallel.py"
+
+
+def _load_run_e2e_parallel_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_e2e_parallel_local_for_tests", _RUN_E2E_PARALLEL
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_RUN_E2E_PARALLEL}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prepare_image_builds_by_default(monkeypatch) -> None:
+    module = _load_run_e2e_parallel_module()
+    built_images: list[str] = []
+
+    monkeypatch.setattr(module, "_build_image", lambda image: built_images.append(image) or 0)
+
+    assert module._prepare_image("vibesensor-full-suite", env={}) == 0
+    assert built_images == ["vibesensor-full-suite"]
+
+
+def test_prepare_image_reuses_prebuilt_image_when_skip_requested(monkeypatch) -> None:
+    module = _load_run_e2e_parallel_module()
+    emitted: list[str] = []
+
+    def _unexpected_build(_image: str) -> int:
+        raise AssertionError("skip-build mode should not rebuild the docker image")
+
+    monkeypatch.setattr(module, "_build_image", _unexpected_build)
+    monkeypatch.setattr(
+        module,
+        "_docker_image_exists",
+        lambda image: image == "vibesensor-full-suite",
+    )
+    monkeypatch.setattr(module, "_emit", emitted.append)
+
+    assert (
+        module._prepare_image(
+            "vibesensor-full-suite",
+            env={module._SKIP_BUILD_ENV: "true"},
+        )
+        == 0
+    )
+    assert any("reusing prebuilt docker image" in line for line in emitted)
+
+
+def test_prepare_image_reuses_prebuilt_image_in_github_actions(monkeypatch) -> None:
+    module = _load_run_e2e_parallel_module()
+    emitted: list[str] = []
+
+    def _unexpected_build(_image: str) -> int:
+        raise AssertionError("GitHub Actions should reuse the prebuilt docker image")
+
+    monkeypatch.setattr(module, "_build_image", _unexpected_build)
+    monkeypatch.setattr(module, "_docker_image_exists", lambda _image: True)
+    monkeypatch.setattr(module, "_emit", emitted.append)
+
+    assert module._prepare_image("vibesensor-full-suite", env={"GITHUB_ACTIONS": "true"}) == 0
+    assert any("reusing prebuilt docker image" in line for line in emitted)
+
+
+def test_prepare_image_exits_cleanly_when_skip_requested_but_image_is_missing(
+    monkeypatch,
+) -> None:
+    module = _load_run_e2e_parallel_module()
+    emitted: list[str] = []
+
+    def _unexpected_build(_image: str) -> int:
+        raise AssertionError("skip-build mode should not rebuild missing images")
+
+    monkeypatch.setattr(module, "_build_image", _unexpected_build)
+    monkeypatch.setattr(module, "_docker_image_exists", lambda _image: False)
+    monkeypatch.setattr(module, "_emit", emitted.append)
+
+    assert module._prepare_image("missing-image", env={module._SKIP_BUILD_ENV: "1"}) == 2
+    assert any("missing-image" in line for line in emitted)

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -225,6 +225,10 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
         ],
         "backend-tests": [
             Step(
+                "Prepare backend test artifacts",
+                ["mkdir", "-p", "artifacts/ai/logs/ci"],
+            ),
+            Step(
                 "Backend tests",
                 [
                     python_cmd,
@@ -232,6 +236,8 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                     "pytest",
                     "-q",
                     "--tb=short",
+                    "--junitxml",
+                    "artifacts/ai/logs/ci/backend-tests.xml",
                     "apps/server/tests",
                 ],
             ),

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import URLError
@@ -51,6 +52,7 @@ def collect_test_ids(pytest_args: list[str]) -> list[str]:
 ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "e2e_parallel"
 PRINT_LOCK = threading.Lock()
+_SKIP_BUILD_ENV = "VIBESENSOR_E2E_SKIP_BUILD"
 
 
 @dataclass(frozen=True)
@@ -176,6 +178,49 @@ def _build_image(image: str) -> int:
     cmd = ["docker", "build", "-f", "apps/server/Dockerfile", "-t", image, "."]
     _emit(f"[e2e-parallel] building docker image once: {shlex.join(cmd)}")
     return _run(cmd, log_path=LOG_DIR / "docker-build.log")
+
+
+def _skip_build_requested(env: Mapping[str, str] | None = None) -> bool:
+    source = os.environ if env is None else env
+    return source.get(_SKIP_BUILD_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _running_in_github_actions(env: Mapping[str, str] | None = None) -> bool:
+    source = os.environ if env is None else env
+    return source.get("GITHUB_ACTIONS", "").strip().lower() == "true"
+
+
+def _docker_image_exists(image: str) -> bool:
+    result = subprocess.run(
+        ["docker", "image", "inspect", image],
+        cwd=str(ROOT),
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def _prepare_image(image: str, *, env: Mapping[str, str] | None = None) -> int:
+    image_exists = _docker_image_exists(image)
+    if image_exists and (_skip_build_requested(env) or _running_in_github_actions(env)):
+        _emit(f"[e2e-parallel] reusing prebuilt docker image: {image}")
+        return 0
+
+    if _skip_build_requested(env):
+        _emit(
+            f"[e2e-parallel] {_SKIP_BUILD_ENV} requested skipping the docker build, "
+            f"but image {image!r} is not present locally"
+        )
+        return 2
+
+    build_rc = _build_image(image)
+    if build_rc != 0:
+        _emit(
+            f"[e2e-parallel] docker build failed (exit {build_rc}); "
+            f"log={LOG_DIR / 'docker-build.log'}"
+        )
+    return build_rc
 
 
 def _api_snapshot(base_url: str, path: str) -> str:
@@ -426,12 +471,8 @@ def main() -> int:
         f"across {num_shards} shards (min requested: {args.shards})"
     )
 
-    build_rc = _build_image(args.docker_image)
+    build_rc = _prepare_image(args.docker_image)
     if build_rc != 0:
-        _emit(
-            f"[e2e-parallel] docker build failed (exit {build_rc}); "
-            f"log={LOG_DIR / 'docker-build.log'}"
-        )
         return build_rc
 
     pid = str(os.getpid())


### PR DESCRIPTION
## Summary

This PR closes #1206 by tightening the parts of the CI workflow that were still genuinely inefficient in the current repository state, while deliberately avoiding broader churn where the issue description had drifted from reality.

When I scoped the issue against the live codebase, two of the headline claims were already stale: the workflow was already running its jobs in parallel, and backend tests were already using `pytest-xdist` through the shared `pyproject.toml` configuration. That meant the smallest complete fix was not “rewrite CI from scratch,” but rather to improve the places where the current pipeline was still paying avoidable costs: expensive jobs that started before cheap prerequisite failures were known, a Docker-backed e2e job that rebuilt the same image layers every run, and failure paths that did not preserve enough structured artifacts for quick diagnosis.

The result is a focused workflow update that keeps local/GitHub parity intact, preserves the repo’s existing shared setup patterns, and improves both CI efficiency and failure debuggability.

## What changed

### 1. Slower jobs now wait for fast prerequisite checks

The workflow now uses `needs:` to gate the heavier jobs behind the fastest checks that provide meaningful signal first.

`ui-smoke` now depends on `frontend-typecheck`, which prevents Playwright work from starting when the UI is already failing at the type or contract layer.

`backend-tests` now depends on `backend-quality` and `backend-typecheck`, so expensive pytest runs do not start when lint, hygiene, schema-sync, config preflight, or mypy has already failed.

`release-smoke` now depends on the relevant backend and frontend gates, and `firmware-native-tests` now depends on `backend-quality` so obvious repo-wide guard failures stop earlier. The Docker-backed `e2e` job also waits for the fast backend/frontend checks before launching the most expensive integration path.

This is intentionally a modest fast-fail layer rather than a wholesale restructuring of the workflow graph. The tradeoff is a small amount of additional sequencing on green runs, but the benefit is that obviously broken pull requests stop burning runner minutes on slow follow-on jobs.

### 2. The e2e job now reuses a cached prebuilt Docker image in GitHub Actions

The most meaningful remaining runtime inefficiency in the workflow was the e2e path. Before this change, the `e2e` job always invoked `tools/tests/run_e2e_parallel.py`, and that script always performed a fresh `docker build` before running the sharded suite. That meant the job paid for `npm ci`, UI bundling, and the server package install even when the relevant image layers were unchanged.

The workflow now sets up Docker Buildx and prebuilds the e2e image with `docker/build-push-action`, using GitHub Actions cache storage via `cache-from: type=gha` and `cache-to: type=gha,mode=max`, and loading the tagged image into the local daemon for the test step.

On the script side, `run_e2e_parallel.py` gained an image-preparation path that checks whether it is running inside GitHub Actions and whether the requested image is already present locally. When both conditions are true, it reuses the prebuilt image instead of rebuilding it. Local development behavior stays safe: outside GitHub Actions, the script still builds the image itself unless an explicit skip-build override is requested. This keeps local runs self-contained and avoids accidentally reusing stale images on developer machines.

That split was important. I wanted the CI workflow to get the caching win, but I did not want to quietly change local semantics in a way that would make the script depend on undocumented local prebuild steps.

### 3. CI now preserves useful failure artifacts

The workflow now emits and uploads artifacts from the two jobs where failure forensics matter most.

For `backend-tests`, the job now creates `artifacts/ai/logs/ci/` and writes a JUnit XML report there with `pytest --junitxml`. If the job fails, GitHub Actions uploads that directory as a short-lived artifact so the failure surface is not limited to console output.

For `e2e`, the workflow now uploads `artifacts/ai/logs/e2e_parallel/` on failure. That directory already contains the sharded e2e logs and Docker build log written by the runner script, so this change mainly makes those diagnostics visible in the Actions UI instead of being stranded in the runner filesystem.

Both upload steps use `if: failure()` and `if-no-files-found: ignore`, which keeps successful runs lean and avoids turning missing-path edge cases into secondary failures.

### 4. Local CI runner parity and hygiene coverage were updated in lockstep

This repository already enforces strong parity between `.github/workflows/ci.yml` and `tools/tests/run_ci_parallel.py`, so I updated the mirrored local runner instead of leaving CI-only drift behind.

`run_ci_parallel.py` now creates the backend artifact directory and runs the same JUnit-producing pytest command as the workflow. I also added `apps/server/tests/hygiene/test_run_e2e_parallel.py` to pin the new image-preparation behavior, including the GitHub Actions reuse path and the explicit skip-build safeguard.

That keeps the existing hygiene checks honest: the repo can continue to verify that CI job commands and local mirrored commands stay aligned instead of silently diverging over time.

## Validation

I validated this change set with both focused and broader local checks:

- `python -m pytest -q apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_docker_ci_hygiene.py`
- `make lint`
- `make typecheck-backend`
- `make test-ci-lite`

The broader `make test-ci-lite` run was especially useful here because it exercised the updated local CI runner command path rather than only the targeted hygiene tests.

## Risks and out-of-scope items

The main tradeoff is that `needs:` introduces some deliberate sequencing for slower jobs. I think that is justified because the gated jobs are the expensive ones, and the prerequisite checks are the fastest, highest-signal failures in the workflow.

I intentionally did **not** add broad path-based workflow skipping in this PR. The issue text called that out, but the current workflow still relies on the always-on quality path for docs and hygiene coverage, so safe selective skipping needs a more careful scope than this issue warranted.

If we want to optimize further later, the next logical follow-up would be a dedicated change-scope mechanism that preserves required docs and hygiene checks while skipping only truly irrelevant heavy jobs.
