### PR TITLE
Tighten dependency reproducibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /apps/server
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - CI
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /apps/ui
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - CI
+      - dependencies
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
 
       - uses: ./.github/actions/setup-backend
 
+      - name: Validate dependency consistency
+        run: |
+          python -m pip check
+
       - name: Backend quality checks
         run: make lint
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -54,6 +54,15 @@ For native backend iteration, run `vibesensor-server --reload --config
 apps/server/config.dev.yaml` from the repo root so Python changes hot-reload
 while the Vite dev server proxies browser traffic to `http://127.0.0.1:8000`.
 
+## Dependency management
+
+Backend Python dependencies are declared in `apps/server/pyproject.toml` with
+bounded version ranges and installed through the editable package flow (`python
+-m pip install -e "./apps/server[dev]"`). The repo currently validates that
+model with CI `pip check` plus automated Dependabot update PRs rather than
+maintaining a second checked-in Python lockfile workflow alongside the editable
+install path.
+
 ## Configuration
 
 Configuration is YAML-based. Run `vibesensor-config-preflight --dump-defaults` to see all available keys with defaults. Use `apps/server/config.dev.yaml` or `apps/server/config.docker.yaml` for local overrides.

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68,<83", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py
+++ b/apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py
@@ -1,0 +1,24 @@
+"""Guard dependency reproducibility metadata and automation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from tests._paths import REPO_ROOT
+
+_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "check_hygiene.py"
+
+
+def _load_check_hygiene_module():
+    spec = importlib.util.spec_from_file_location("check_hygiene_dependency_local", _CHECK_HYGIENE)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_HYGIENE}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dependency_reproducibility_hygiene() -> None:
+    module = _load_check_hygiene_module()
+    assert module.check_dependency_reproducibility_hygiene() == []

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -155,6 +155,21 @@ def _project_dependency_spec(requirement_name: str) -> str | None:
     return None
 
 
+def _build_system_requirement_spec(requirement_name: str) -> str | None:
+    pyproject = _load_server_pyproject()
+    build_system = pyproject.get("build-system")
+    if not isinstance(build_system, Mapping):
+        return None
+    requires = build_system.get("requires")
+    if not isinstance(requires, list):
+        return None
+    prefix = f"{requirement_name}>="
+    for requirement in requires:
+        if isinstance(requirement, str) and requirement.startswith(prefix):
+            return requirement
+    return None
+
+
 def _lower_bound_major(requirement_spec: str) -> int | None:
     match = re.search(r">=?\s*([0-9]+)", requirement_spec)
     return int(match.group(1)) if match else None
@@ -619,6 +634,75 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
     return errors
 
 
+def check_dependency_reproducibility_hygiene() -> list[str]:
+    errors: list[str] = []
+
+    release_fetcher = (
+        ROOT
+        / "apps"
+        / "server"
+        / "vibesensor"
+        / "use_cases"
+        / "updates"
+        / "releases"
+        / "release_fetcher.py"
+    ).read_text(encoding="utf-8")
+    packaging_spec = _project_dependency_spec("packaging")
+    if (
+        "from packaging.version import Version" in release_fetcher
+        and packaging_spec is None
+    ):
+        errors.append(
+            "apps/server/pyproject.toml must declare packaging when release_fetcher imports packaging.version.Version."
+        )
+
+    setuptools_spec = _build_system_requirement_spec("setuptools")
+    if setuptools_spec is None:
+        errors.append(
+            "apps/server/pyproject.toml build-system requires must declare setuptools."
+        )
+    elif "<" not in setuptools_spec:
+        errors.append(
+            f"apps/server/pyproject.toml build-system setuptools requirement must include an upper bound; found {setuptools_spec!r}."
+        )
+
+    dependabot_path = ROOT / ".github" / "dependabot.yml"
+    if not dependabot_path.exists():
+        errors.append(
+            "Missing .github/dependabot.yml for automated dependency updates."
+        )
+        return errors
+
+    dependabot = _load_yaml_mapping(dependabot_path)
+    raw_updates = dependabot.get("updates")
+    if not isinstance(raw_updates, list):
+        errors.append(".github/dependabot.yml must define an updates list.")
+        return errors
+
+    configured_updates: set[tuple[str, str]] = set()
+    for item in raw_updates:
+        if not isinstance(item, Mapping):
+            continue
+        ecosystem = item.get("package-ecosystem")
+        directory = item.get("directory")
+        if isinstance(ecosystem, str) and isinstance(directory, str):
+            configured_updates.add((ecosystem, directory))
+
+    required_updates = {
+        ("pip", "/apps/server"),
+        ("npm", "/apps/ui"),
+        ("github-actions", "/"),
+    }
+    missing_updates = sorted(required_updates - configured_updates)
+    if missing_updates:
+        errors.append(
+            ".github/dependabot.yml is missing required update entries: "
+            f"{missing_updates}"
+        )
+
+    return errors
+
+
 def main() -> int:
     failures = 0
 
@@ -671,6 +755,15 @@ def main() -> int:
         failures += 1
     else:
         print("Docker/CI dependency hygiene checks passed.")
+
+    dependency_repro_errors = check_dependency_reproducibility_hygiene()
+    if dependency_repro_errors:
+        print("Dependency reproducibility hygiene drift detected:")
+        for item in dependency_repro_errors:
+            print(f"  - {item}")
+        failures += 1
+    else:
+        print("Dependency reproducibility hygiene checks passed.")
 
     return 1 if failures else 0
 

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -174,6 +174,10 @@ def _bootstrap_steps(
 def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
     return {
         "backend-quality": [
+            Step(
+                "Validate dependency consistency",
+                [python_cmd, "-m", "pip", "check"],
+            ),
             Step("Backend quality checks", ["make", "lint"]),
         ],
         "backend-typecheck": [


### PR DESCRIPTION
## Summary

This PR closes #1207 by tightening dependency reproducibility around the backend’s existing `pyproject.toml` + editable-install workflow instead of introducing a second dependency-management regime that the repo does not currently use.

When I scoped the issue against the live repository, one of the headline claims had already gone stale: `packaging` is already declared explicitly in `apps/server/pyproject.toml`, and the updater release fetcher imports it from there. The remaining live gaps were different from the original report: there was still no Dependabot configuration, CI was not running `pip check`, the build-system requirement for `setuptools` had no upper bound, and the repository did not clearly explain whether the lack of a checked-in Python lockfile was intentional or simply unfinished.

Rather than layer a brand-new Python lockfile toolchain on top of a repo that already standardizes on direct `pyproject.toml` dependency declarations and editable installs, this PR strengthens the current model and makes its guardrails explicit.

## Problem being solved

The backend currently depends on bounded runtime and dev dependency ranges in `apps/server/pyproject.toml`, and all of the documented bootstrap flows install from that package definition with `python -m pip install -e "./apps/server[dev]"`. That means reproducibility in practice depends on two things: keeping metadata, CI, and automation aligned around the same package definition, and catching resolver drift early when dependency ecosystems move.

Before this change, the repository had a few weak spots in that flow.

First, CI would verify lint, type checks, schema drift, and tests, but it would not run `pip check`, so a dependency conflict could still be resolved into the environment without an explicit consistency check.

Second, there was no Dependabot configuration at all, so bounded dependency ranges existed but there was no automated repository-native mechanism to surface update pressure for Python, Node, or GitHub Actions dependencies.

Third, the build-system requirement for `setuptools` had only a lower bound. That left the backend package open to an unreviewed future setuptools major release even though the rest of the repo already follows bounded-range dependency discipline.

Finally, the backend documentation did not explain that the repo intentionally uses bounded `pyproject.toml` metadata plus editable installs, rather than a checked-in Python lockfile. Without that explanation, the absence of a lockfile looked like an oversight rather than an explicit tooling choice.

## Implementation approach

I kept the change set focused on improving the existing model instead of replacing it.

A full Python lockfile workflow would have required choosing and documenting new tooling, updating the shared backend setup action, deciding how Docker builds should consume the lock, and reconciling all of that with the repo’s direct editable-install commands. That is a much broader shift than this issue required, and it would have created a second source of truth unless adopted end to end.

Instead, this PR makes the current source of truth stronger: `apps/server/pyproject.toml` remains the dependency authority, CI now validates the installed environment explicitly, Dependabot now surfaces updates automatically, and new hygiene checks keep the metadata and automation from drifting.

## Main code changes by area

### 1. CI and local runner dependency validation

The `backend-quality` job in `.github/workflows/ci.yml` now runs `python -m pip check` immediately after the shared backend setup action and before `make lint`.

That change is mirrored in `tools/tests/run_ci_parallel.py`, where the local CI-equivalent runner now performs the same dependency-consistency check before the broader backend-quality step. This keeps the local runner and GitHub workflow aligned with the same command shape, which matters because the repo already enforces command parity between `ci.yml` and `run_ci_parallel.py`.

The practical effect is simple: if the backend install resolves to an internally inconsistent environment, CI now says so directly instead of relying on later failures to reveal it indirectly.

### 2. Dependabot automation

This PR adds `.github/dependabot.yml` and enables weekly updates for three surfaces:

- Python dependencies in `/apps/server`
- npm dependencies in `/apps/ui`
- GitHub Actions workflow dependencies at the repo root

That keeps the fix aligned with the actual monorepo shape instead of treating the issue as backend-only in a way that would still leave update automation absent elsewhere.

The config is intentionally small: weekly cadence, standard labels, and a modest open-PR limit so the repo gets update visibility without turning dependency maintenance into constant noise.

### 3. Build-system dependency bound

`apps/server/pyproject.toml` now bounds the build backend as `setuptools>=68,<83`.

The point here is not to freeze setuptools indefinitely. It is to align the build-system requirement with the same reviewed-range practice already used for runtime dependencies, so the next major setuptools jump becomes an explicit decision instead of an invisible background upgrade.

That upper bound also works well with the new Dependabot config: when the ecosystem moves past the current reviewed major, the repository will get a concrete update proposal instead of silently absorbing the change.

### 4. Documentation and hygiene guards

`apps/server/README.md` now has a short dependency-management section explaining that the backend uses bounded `pyproject.toml` dependencies plus editable installs, and that CI `pip check` and Dependabot are the repo’s reproducibility guardrails instead of a second checked-in Python lockfile workflow.

I also added a new `check_dependency_reproducibility_hygiene()` rule to `tools/dev/check_hygiene.py`, along with `apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py`.

That guard verifies three things that matter to this issue:

- `packaging` stays declared while `release_fetcher.py` imports `packaging.version.Version`
- the setuptools build requirement keeps an explicit upper bound
- `.github/dependabot.yml` continues to include the expected pip, npm, and GitHub Actions update entries

This keeps the fix from regressing quietly after the issue is merged.

## Validation

I validated the change in the same editable-install model the repo already uses:

- `python -m pip install -e "./apps/server[dev]"`
- `python -m pytest -q apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_docker_ci_hygiene.py`
- `make lint`
- `make typecheck-backend`
- `make test-ci-lite`

The broader `make test-ci-lite` run was important here because it exercised the updated local CI-equivalent runner, including the new `pip check` step inside `backend-quality`, rather than only validating the targeted hygiene guard.

## Risks, tradeoffs, and out-of-scope items

The main deliberate non-change is that this PR does **not** introduce a checked-in Python lockfile. I think that is the right call for this repo right now because the current workflow is built around direct editable installs from `pyproject.toml`, and adding a lockfile without also redesigning the shared backend setup, Docker build path, and developer bootstrap instructions would create a second dependency source of truth.

Instead, this PR makes the current model explicit and safer.

Likewise, I did not add a license-audit tool in this change. That could be a legitimate future enhancement, but it is a separate policy decision from the consistency and update-automation gaps this issue was really exposing.

With those boundaries, the result is a small but durable improvement: the current dependency model is clearer, better checked, and better automated than it was before.
