### PR TITLE
Add request correlation and settings audit logs

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -80,6 +80,19 @@ Common runtime files under `apps/server/data/` include:
 - `clients.json`: persisted client metadata.
 - `report_i18n.json`: report translation data.
 
+## Observability
+
+When `logging.app_log_path` is configured, the backend writes structured JSON
+application logs instead of plain text. Each HTTP response now echoes an
+`X-Request-ID` header, and matching request-scoped log entries carry the same
+`request_id` field so operators can correlate a client-visible failure with the
+server log line that handled it.
+
+Successful settings writes also emit `settings_change` audit entries with
+before/after values for the changed setting or car profile. That gives a stable
+operator trail for configuration changes without adding a second persistence
+path.
+
 ## HTTP and WebSocket surface
 
 The API surface is implemented in `apps/server/vibesensor/adapters/http/` and assembled by `adapters/http/__init__.py`.

--- a/apps/server/tests/adapters/http/test_request_observability.py
+++ b/apps/server/tests/adapters/http/test_request_observability.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.http.middleware import install_request_logging_middleware
+from vibesensor.adapters.http.settings import create_settings_routes
+from vibesensor.infra.config.settings_store import SettingsStore
+from vibesensor.shared.structured_logging import REQUEST_ID_HEADER
+
+
+def test_request_logging_middleware_sets_response_header_and_logs_request(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+
+    @app.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    with caplog.at_level(logging.INFO, logger="vibesensor.adapters.http.middleware"):
+        with TestClient(app) as client:
+            response = client.get("/ping")
+
+    assert response.status_code == 200
+    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    assert response.headers[REQUEST_ID_HEADER] == request_log.request_id
+    assert request_log.method == "GET"
+    assert request_log.path == "/ping"
+    assert request_log.status_code == 200
+
+
+def test_request_id_flows_into_settings_audit_logs(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+    app.include_router(create_settings_routes(SettingsStore(), MagicMock()))
+
+    with caplog.at_level(logging.INFO):
+        with TestClient(app) as client:
+            response = client.put(
+                "/api/settings/language",
+                json={"language": "nl"},
+                headers={REQUEST_ID_HEADER: "client-req-42"},
+            )
+
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == "client-req-42"
+
+    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    audit_log = next(
+        rec
+        for rec in caplog.records
+        if rec.message == "settings_change"
+        and getattr(rec, "settings_action", None) == "set_language"
+    )
+    assert request_log.request_id == "client-req-42"
+    assert audit_log.request_id == "client-req-42"
+    assert audit_log.before == "en"
+    assert audit_log.after == "nl"
+
+
+def test_unhandled_errors_still_echo_request_id(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+
+    @app.get("/boom")
+    async def boom() -> dict[str, bool]:
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.INFO):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/boom", headers={REQUEST_ID_HEADER: "failing-request"})
+
+    assert response.status_code == 500
+    assert response.headers[REQUEST_ID_HEADER] == "failing-request"
+    failure_log = next(rec for rec in caplog.records if rec.message == "http_request_failed")
+    assert failure_log.request_id == "failing-request"

--- a/apps/server/tests/infra/config/test_settings_audit_logging.py
+++ b/apps/server/tests/infra/config/test_settings_audit_logging.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from vibesensor.infra.config.settings_store import SettingsStore
+
+
+def test_set_language_logs_audit_record(caplog: pytest.LogCaptureFixture) -> None:
+    store = SettingsStore()
+
+    with caplog.at_level(logging.INFO, logger="vibesensor.infra.config.settings_store"):
+        store.set_language("nl")
+
+    record = next(
+        rec
+        for rec in caplog.records
+        if rec.message == "settings_change"
+        and getattr(rec, "settings_action", None) == "set_language"
+    )
+    assert record.before == "en"
+    assert record.after == "nl"
+    assert getattr(record, "request_id", None) is None
+
+
+def test_add_car_logs_audit_record(caplog: pytest.LogCaptureFixture) -> None:
+    store = SettingsStore()
+
+    with caplog.at_level(logging.INFO, logger="vibesensor.infra.config.car_settings"):
+        created = store.add_car({"name": "Track Car", "type": "coupe"})
+
+    record = next(
+        rec
+        for rec in caplog.records
+        if rec.message == "settings_change" and getattr(rec, "settings_action", None) == "add_car"
+    )
+    assert record.before is None
+    assert record.after["id"] == created.cars[0]["id"]
+    assert record.after["name"] == "Track Car"
+    assert record.after["type"] == "coupe"
+    assert record.car_id == created.cars[0]["id"]

--- a/apps/server/tests/shared/test_structured_logging.py
+++ b/apps/server/tests/shared/test_structured_logging.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from vibesensor.shared.structured_logging import (
+    StructuredLogFormatter,
+    bind_request_id,
+    log_extra,
+    normalize_request_id,
+    reset_request_id,
+)
+
+
+def test_formatter_serializes_extra_fields_to_json() -> None:
+    formatter = StructuredLogFormatter()
+    record = logging.makeLogRecord(
+        {
+            "name": "vibesensor.test",
+            "levelno": logging.INFO,
+            "levelname": "INFO",
+            "msg": "settings_change",
+        }
+    )
+    record.event = "settings_change"
+    record.request_id = "req-123"
+    record.before = {"language": "en"}
+    record.after = {"language": "nl"}
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["message"] == "settings_change"
+    assert payload["logger"] == "vibesensor.test"
+    assert payload["event"] == "settings_change"
+    assert payload["request_id"] == "req-123"
+    assert payload["before"] == {"language": "en"}
+    assert payload["after"] == {"language": "nl"}
+
+
+def test_log_extra_includes_bound_request_id() -> None:
+    request_id, token = bind_request_id("  client/request-42 \n")
+    try:
+        extra = log_extra(event="http_request")
+    finally:
+        reset_request_id(token)
+
+    assert request_id == "client/request-42"
+    assert extra["request_id"] == "client/request-42"
+
+
+def test_normalize_request_id_falls_back_when_header_is_invalid() -> None:
+    request_id = normalize_request_id(" \n\t ")
+    assert request_id

--- a/apps/server/vibesensor/adapters/http/middleware.py
+++ b/apps/server/vibesensor/adapters/http/middleware.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from time import perf_counter
+
+from fastapi import FastAPI, Request
+from starlette.responses import PlainTextResponse, Response
+
+from vibesensor.shared.structured_logging import (
+    REQUEST_ID_HEADER,
+    bind_request_id,
+    current_request_id,
+    log_extra,
+    reset_request_id,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _attach_request_id(response: Response, request_id: str | None = None) -> Response:
+    resolved_request_id = request_id or current_request_id()
+    if resolved_request_id is not None:
+        response.headers[REQUEST_ID_HEADER] = resolved_request_id
+    return response
+
+
+def install_request_logging_middleware(app: FastAPI) -> None:
+    async def _request_logging_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        request_id, token = bind_request_id(request.headers.get(REQUEST_ID_HEADER))
+        request.state.request_id = request_id
+        started_at = perf_counter()
+        status_code = 500
+        request_failed = False
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return _attach_request_id(response, request_id)
+        except Exception:
+            request_failed = True
+            LOGGER.exception(
+                "http_request_failed",
+                extra=log_extra(
+                    event="http_request_failed",
+                    method=request.method,
+                    path=request.url.path,
+                    status_code=status_code,
+                    duration_ms=round((perf_counter() - started_at) * 1000.0, 3),
+                ),
+            )
+            return _attach_request_id(
+                PlainTextResponse("Internal Server Error", status_code=500),
+                request_id,
+            )
+        finally:
+            if not request_failed:
+                LOGGER.info(
+                    "http_request",
+                    extra=log_extra(
+                        event="http_request",
+                        method=request.method,
+                        path=request.url.path,
+                        status_code=status_code,
+                        duration_ms=round((perf_counter() - started_at) * 1000.0, 3),
+                    ),
+                )
+            reset_request_id(token)
+
+    app.middleware("http")(_request_logging_middleware)

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -21,11 +21,13 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from vibesensor.adapters.http import create_router
+from vibesensor.adapters.http.middleware import install_request_logging_middleware
 from vibesensor.adapters.udp.udp_data_rx import start_udp_data_receiver
 from vibesensor.app.container import build_runtime
 from vibesensor.app.runtime_state import AppRuntime
 from vibesensor.app.settings import load_config
 from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
+from vibesensor.shared.structured_logging import StructuredLogFormatter
 
 __all__ = ["create_app", "create_app_from_env", "main"]
 
@@ -60,7 +62,7 @@ def _setup_file_logging(log_path: Path | None) -> None:
             encoding="utf-8",
         )
         handler.setLevel(logging.INFO)
-        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s"))
+        handler.setFormatter(StructuredLogFormatter())
         logging.getLogger().addHandler(handler)
         LOGGER.info("File logging enabled: %s", log_path)
     except OSError:
@@ -116,6 +118,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     app = FastAPI(title="VibeSensor", lifespan=lifespan)
     app.state.runtime = runtime
+    install_request_logging_middleware(app)
     app.include_router(create_router(runtime.router))
     if os.getenv("VIBESENSOR_SERVE_STATIC", "1") == "1":
         static_dir = _PACKAGE_DIR / "static"

--- a/apps/server/vibesensor/infra/config/car_settings.py
+++ b/apps/server/vibesensor/infra/config/car_settings.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from vibesensor.domain import Car, CarSnapshot
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.types.car_config import (
     CarConfigUpdatePayload,
     CarsSnapshot,
@@ -32,6 +33,31 @@ _CarSettingsResultT = TypeVar("_CarSettingsResultT")
 def _clamp_str(value: object, maxlen: int) -> str:
     """Strip and truncate *value* to *maxlen* characters."""
     return str(value).strip()[:maxlen]
+
+
+def _car_payload(car: Car | None) -> dict[str, object] | None:
+    if car is None:
+        return None
+    return dict(car_to_persistence_dict(car))
+
+
+def _log_car_settings_change(
+    *,
+    action: str,
+    before: object,
+    after: object,
+    **fields: object,
+) -> None:
+    LOGGER.info(
+        "settings_change",
+        extra=log_extra(
+            event="settings_change",
+            settings_action=action,
+            before=before,
+            after=after,
+            **fields,
+        ),
+    )
 
 
 class CarSettingsMixin:
@@ -56,6 +82,7 @@ class CarSettingsMixin:
             snapshot: Callable[[], _CarSettingsSnapshotT],
             apply: Callable[[_CarSettingsSnapshotT], bool],
             restore: Callable[[_CarSettingsSnapshotT], None],
+            audit_log: Callable[[_CarSettingsSnapshotT], None] | None = None,
             after_persist: Callable[[], None] | None = None,
             result: Callable[[], _CarSettingsResultT],
         ) -> _CarSettingsResultT: ...
@@ -122,14 +149,24 @@ class CarSettingsMixin:
             snapshot=lambda: self._active_car_id,
             apply=_apply,
             restore=lambda previous: setattr(self, "_active_car_id", previous),
+            audit_log=lambda previous: _log_car_settings_change(
+                action="set_active_car",
+                before=previous,
+                after=self._active_car_id,
+                car_id=car_id,
+            ),
             after_persist=self._sync_analysis_settings,
             result=self._cars_snapshot_unlocked,
         )
 
     def add_car(self, car_data: CarConfigUpdatePayload) -> CarsSnapshot:
+        created_car_id: str | None = None
+
         def _apply(_previous: list[Car]) -> bool:
+            nonlocal created_car_id
             payload: dict[str, object] = dict(car_data)
-            payload["id"] = new_car_id()
+            created_car_id = new_car_id()
+            payload["id"] = created_car_id
             self._cars.append(Car.from_persisted_dict(payload))
             return True
 
@@ -137,6 +174,12 @@ class CarSettingsMixin:
             snapshot=lambda: list(self._cars),
             apply=_apply,
             restore=lambda previous: setattr(self, "_cars", previous),
+            audit_log=lambda _previous: _log_car_settings_change(
+                action="add_car",
+                before=None,
+                after=_car_payload(self._find_car(created_car_id)),
+                car_id=created_car_id,
+            ),
             after_persist=self._sync_analysis_settings,
             result=self._cars_snapshot_unlocked,
         )
@@ -184,6 +227,12 @@ class CarSettingsMixin:
             snapshot=lambda: list(self._cars),
             apply=_apply,
             restore=lambda previous: setattr(self, "_cars", previous),
+            audit_log=lambda previous: _log_car_settings_change(
+                action="update_car",
+                before=_car_payload(next((car for car in previous if car.id == car_id), None)),
+                after=_car_payload(self._find_car(car_id)),
+                car_id=car_id,
+            ),
             after_persist=self._sync_analysis_settings,
             result=self._cars_snapshot_unlocked,
         )
@@ -210,6 +259,17 @@ class CarSettingsMixin:
             snapshot=lambda: list(self._cars),
             apply=_apply,
             restore=lambda previous: setattr(self, "_cars", previous),
+            audit_log=lambda previous: _log_car_settings_change(
+                action="update_active_car_aspects",
+                before=(
+                    next(
+                        (dict(car.aspects) for car in previous if car.id == self._active_car_id),
+                        None,
+                    )
+                ),
+                after=self.active_car_aspects(),
+                car_id=self._active_car_id,
+            ),
             after_persist=self._sync_analysis_settings,
             result=lambda: self.active_car_aspects() or {},
         )
@@ -234,6 +294,13 @@ class CarSettingsMixin:
             snapshot=lambda: (list(self._cars), self._active_car_id),
             apply=_apply,
             restore=_restore,
+            audit_log=lambda previous: _log_car_settings_change(
+                action="delete_car",
+                before=_car_payload(next((car for car in previous[0] if car.id == car_id), None)),
+                after=None,
+                car_id=car_id,
+                active_car_id=self._active_car_id,
+            ),
             after_persist=self._sync_analysis_settings,
             result=self._cars_snapshot_unlocked,
         )

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -56,6 +56,7 @@ from vibesensor.shared.boundaries.settings_snapshot_codec import (
 )
 from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.shared.ports import SettingsSnapshotPersistence, SpeedSourceSync
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.types.car_config import car_to_persistence_dict
 from vibesensor.shared.types.sensor_config import (
     SensorConfig,
@@ -80,6 +81,19 @@ VALID_SPEED_UNITS: frozenset[str] = frozenset(get_args(SpeedUnitCode))
 
 _SettingsSnapshotT = TypeVar("_SettingsSnapshotT")
 _SettingsResultT = TypeVar("_SettingsResultT")
+
+
+def _log_settings_change(*, action: str, before: object, after: object, **fields: object) -> None:
+    LOGGER.info(
+        "settings_change",
+        extra=log_extra(
+            event="settings_change",
+            settings_action=action,
+            before=before,
+            after=after,
+            **fields,
+        ),
+    )
 
 
 class SettingsStore(CarSettingsMixin):
@@ -152,6 +166,7 @@ class SettingsStore(CarSettingsMixin):
         snapshot: Callable[[], _SettingsSnapshotT],
         apply: Callable[[_SettingsSnapshotT], bool],
         restore: Callable[[_SettingsSnapshotT], None],
+        audit_log: Callable[[_SettingsSnapshotT], None] | None = None,
         after_persist: Callable[[], None] | None = None,
         result: Callable[[], _SettingsResultT],
     ) -> _SettingsResultT:
@@ -165,6 +180,8 @@ class SettingsStore(CarSettingsMixin):
             except PersistenceError:
                 restore(previous)
                 raise
+            if audit_log is not None:
+                audit_log(previous)
             if after_persist is not None:
                 after_persist()
             return result()
@@ -254,6 +271,11 @@ class SettingsStore(CarSettingsMixin):
                 "_speed_cfg",
                 SpeedSourceConfig.from_dict(previous),
             ),
+            audit_log=lambda previous: _log_settings_change(
+                action="update_speed_source",
+                before=previous,
+                after=self._speed_cfg.to_dict(),
+            ),
             after_persist=self._sync_speed_source,
             result=self._speed_cfg.to_dict,
         )
@@ -291,6 +313,16 @@ class SettingsStore(CarSettingsMixin):
             snapshot=self._sensor_configs_snapshot_unlocked,
             apply=_apply,
             restore=lambda previous: setattr(self, "_sensors", previous),
+            audit_log=lambda previous: _log_settings_change(
+                action="set_sensor",
+                before=(
+                    previous_sensor.to_dict()
+                    if (previous_sensor := previous.get(sensor_id)) is not None
+                    else None
+                ),
+                after=self._sensors[sensor_id].to_dict(),
+                sensor_id=sensor_id,
+            ),
             result=lambda: {sensor_id: self._sensors[sensor_id].to_dict()},
         )
 
@@ -307,6 +339,16 @@ class SettingsStore(CarSettingsMixin):
             snapshot=self._sensor_configs_snapshot_unlocked,
             apply=_apply,
             restore=lambda previous: setattr(self, "_sensors", previous),
+            audit_log=lambda previous: _log_settings_change(
+                action="remove_sensor",
+                before=(
+                    previous_sensor.to_dict()
+                    if (previous_sensor := previous.get(sensor_id)) is not None
+                    else None
+                ),
+                after=None,
+                sensor_id=sensor_id,
+            ),
             result=lambda: removed,
         )
 
@@ -328,6 +370,11 @@ class SettingsStore(CarSettingsMixin):
             snapshot=lambda: self._language,
             apply=_apply,
             restore=lambda previous: setattr(self, "_language", previous),
+            audit_log=lambda previous: _log_settings_change(
+                action="set_language",
+                before=previous,
+                after=self._language,
+            ),
             result=lambda: self._language,
         )
 
@@ -349,5 +396,10 @@ class SettingsStore(CarSettingsMixin):
             snapshot=lambda: self._speed_unit,
             apply=_apply,
             restore=lambda previous: setattr(self, "_speed_unit", previous),
+            audit_log=lambda previous: _log_settings_change(
+                action="set_speed_unit",
+                before=previous,
+                after=self._speed_unit,
+            ),
             result=lambda: self._speed_unit,
         )

--- a/apps/server/vibesensor/shared/structured_logging.py
+++ b/apps/server/vibesensor/shared/structured_logging.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import logging
+import string
+from contextvars import ContextVar, Token
+from uuid import uuid4
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+_REQUEST_ID: ContextVar[str | None] = ContextVar("vibesensor_request_id", default=None)
+_ALLOWED_REQUEST_ID_CHARS = frozenset(string.ascii_letters + string.digits + "-._:/")
+_STANDARD_LOG_RECORD_FIELDS = frozenset(logging.makeLogRecord({}).__dict__) | {"message", "asctime"}
+
+
+def current_request_id() -> str | None:
+    return _REQUEST_ID.get()
+
+
+def normalize_request_id(raw_value: str | None) -> str:
+    if raw_value is None:
+        return uuid4().hex
+    candidate = "".join(ch for ch in raw_value.strip() if ch in _ALLOWED_REQUEST_ID_CHARS)[:64]
+    return candidate or uuid4().hex
+
+
+def bind_request_id(raw_value: str | None) -> tuple[str, Token[str | None]]:
+    request_id = normalize_request_id(raw_value)
+    return request_id, _REQUEST_ID.set(request_id)
+
+
+def reset_request_id(token: Token[str | None]) -> None:
+    _REQUEST_ID.reset(token)
+
+
+def log_extra(**fields: object) -> dict[str, object]:
+    extra = dict(fields)
+    request_id = current_request_id()
+    if request_id is not None:
+        extra["request_id"] = request_id
+    return extra
+
+
+def _json_compatible(value: object) -> JsonValue:
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_compatible(inner) for key, inner in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [_json_compatible(item) for item in value]
+    return str(value)
+
+
+class StructuredLogFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, JsonValue] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOG_RECORD_FIELDS:
+                continue
+            payload[key] = _json_compatible(value)
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True)

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -38,7 +38,11 @@ map. The response also includes operational metrics:
 docker compose logs --tail 100
 ```
 
-5. If the issue is on a Pi, also review systemd or journal output for the service and hotspot helpers.
+5. If file logging is enabled, use the `X-Request-ID` response header from the
+   failing HTTP call to find the matching structured JSON app-log entry; the
+   same `request_id` also appears on request-scoped `settings_change` audit
+   events.
+6. If the issue is on a Pi, also review systemd or journal output for the service and hotspot helpers.
 
 ## Diagnose stale or missing live updates
 


### PR DESCRIPTION
## Summary

This PR resolves the verified remaining observability gaps from `#1208` without broadening the issue into a larger telemetry platform rewrite. The issue report was correct that the backend still lacked structured application logging, request correlation IDs, and a settings change audit trail. It was not correct about the health endpoint being shallow, so this change deliberately leaves the existing health snapshot untouched and focuses on the gaps that were still real in the current codebase.

The core result is that backend file logs now emit structured JSON instead of plain text, every HTTP request handled through the FastAPI app gets a request ID that is echoed back via `X-Request-ID`, and successful settings mutations now emit explicit `settings_change` audit events with before/after values. That gives operators a concrete way to connect a user-visible request, the matching backend request log, and any persisted settings mutation that happened because of that request.

## Problem being solved

Before this change, `apps/server/vibesensor/app/bootstrap.py` attached a rotating file handler with the formatter `%(asctime)s %(levelname)-8s %(name)s: %(message)s`. That worked for human reading but not for reliable machine parsing or request-level correlation. The HTTP layer also had no request-context middleware, so there was no stable identifier to follow a request through log lines. On the settings side, the write paths inside `SettingsStore` and `CarSettingsMixin` persisted changes through `_update_with_rollback()` but never recorded what changed, what the old value was, or which request caused the mutation.

Those gaps made basic operator workflows harder than they needed to be. If a user changed language, edited a car profile, or updated a speed-source setting, there was no durable audit event to confirm the before/after transition. If a request failed, there was no response header that let the caller point directly at the matching backend log entry. The code already had meaningful operational health reporting in `/api/health`, so the right move was to improve correlation and auditability rather than bolt on unrelated new metrics.

## Implementation approach

I kept the implementation intentionally small and local to the existing seams:

1. Add a shared logging helper module rather than duplicating request-ID or formatter logic in the HTTP and config layers.
2. Install one lightweight HTTP middleware at app bootstrap to assign request IDs, log request summaries, and echo the header back to callers.
3. Reuse the existing rollback helper seam in settings persistence so successful mutations can be logged consistently after persistence succeeds.

This approach avoids inventing a second persistence path or a new “audit service” abstraction. It also preserves the repo’s current layering: HTTP stays responsible for request-scoped concerns, the shared helper owns cross-cutting logging mechanics, and the settings layer still owns the semantic meaning of what changed.

## Main code changes by area

### Shared structured logging helper

`apps/server/vibesensor/shared/structured_logging.py` is the new common helper. It centralizes:

- structured JSON log formatting for file logs,
- request ID normalization and context management,
- request-scoped log extras that automatically include the active request ID when present.

The formatter serializes common log metadata (`timestamp`, `level`, `logger`, `message`) plus any extra fields added by callers. That means existing loggers keep working, while request and settings audit events can add structured fields like `request_id`, `settings_action`, `before`, and `after` without custom per-handler formatting code.

### HTTP request correlation

`apps/server/vibesensor/adapters/http/middleware.py` adds request logging middleware that now runs for the FastAPI app from `bootstrap.py`. For each request it:

- assigns or normalizes an `X-Request-ID`,
- stores it in request-scoped context,
- logs a structured `http_request` event on successful responses,
- logs `http_request_failed` for unhandled failures,
- echoes the same `X-Request-ID` back to the client.

I also closed an important edge case here during review: unhandled `500` responses now still include the request ID. Without that, we would have logged the correlation ID server-side but failed to return it on the exact class of failures where operators need it most.

### Settings audit trail

`apps/server/vibesensor/infra/config/settings_store.py` and `apps/server/vibesensor/infra/config/car_settings.py` now emit structured `settings_change` events after persistence succeeds. The audit coverage includes:

- speed source updates,
- sensor set/remove,
- language changes,
- speed unit changes,
- active-car selection,
- car add/update/delete,
- active-car aspect updates.

The logs include `before` and `after` values for the changed item rather than dumping the entire settings snapshot for every mutation. That keeps the audit events specific enough to be useful without becoming noisy or overly coupled to unrelated state.

### Documentation

I updated `apps/server/README.md` and `docs/operational-runbooks.md` so operators know where to find the new behavior. The docs now call out that file logs are structured JSON when `logging.app_log_path` is configured, that HTTP responses echo `X-Request-ID`, and that successful settings writes emit `settings_change` audit events that can be correlated with request logs.

## Validation and tests

I added focused backend coverage instead of relying on only broad regression suites:

- `apps/server/tests/shared/test_structured_logging.py`
  - validates structured formatter output and request-ID helper behavior.
- `apps/server/tests/adapters/http/test_request_observability.py`
  - validates response-header echoing,
  - validates request/audit log correlation on a real settings route,
  - validates that unhandled `500` responses still return `X-Request-ID`.
- `apps/server/tests/infra/config/test_settings_audit_logging.py`
  - validates direct settings-store and car-profile audit logs.

I also reran the existing settings HTTP/store suites to make sure the new logging paths did not change endpoint behavior.

Local validation performed:

- `pytest -q apps/server/tests/shared/test_structured_logging.py apps/server/tests/infra/config/test_settings_audit_logging.py apps/server/tests/adapters/http/test_request_observability.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/infra/config/test_settings_store.py`
- `make lint`
- `make typecheck-backend`

For runtime validation, I exercised the backend with a real native smoke path using `vibesensor-server --config apps/server/config.dev.yaml` plus `vibesensor-sim`. During the run, `/api/clients` moved from `0` connected clients to `2`, and after the simulator stopped it returned to `0`, confirming the normal live-update path still behaved correctly. I also attempted the repo’s Docker compose smoke path, but the local environment did not have a reachable Docker daemon socket, so CI remains the place that will cover the containerized path in this session.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that the new audit trail is log-based rather than a second persisted audit database. That is intentional: the issue asked for an audit trail, and structured logs satisfy that need without adding a new storage system, migration surface, or retention policy. The request ID format is also deliberately simple and header-safe rather than adopting a heavier distributed tracing standard.

This PR does **not** try to add OS-level metrics, push alerting, or a diagnostic bundle exporter. Those were lower-priority gaps from the verified issue assessment, and they are intentionally left out to keep this change focused and reviewable.

Closes #1208.
