### PR TITLE
Refresh stale docs and changelog coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased — Documentation, DX, and Observability Alignment
+
+### Improvements
+
+- **Performance and runtime hardening follow-through** — Recent merged work now
+  reflected here includes broadcast/registry hot-path improvements, stricter
+  locking on runtime-critical paths, SQLite persistence hardening, migration
+  rollback safety, and more explicit UDP/update error handling.
+- **Short-run and operator feedback polish** — Added the short-run suitability
+  warning, normalized settings update verbs, and unified frontend error
+  notifications so API/UI error handling and operator messages stay coherent.
+- **Docs and test-map refresh** — Documented key HTTP routes in OpenAPI, froze
+  recorder run context for more reliable tests, clarified test layout and smoke
+  markers, reused shared boundary decoders, added the developer troubleshooting
+  FAQ, and polished the local development inner loop.
+- **CI and dependency reproducibility** — CI now reuses cached E2E images,
+  captures failure artifacts for slower suites, gates long jobs behind fast
+  prerequisites, runs `pip check`, uses Dependabot for backend/frontend/actions
+  dependencies, and keeps the backend build requirement for `setuptools`
+  explicitly bounded.
+- **Structured observability** — Application file logs now use structured JSON,
+  HTTP responses echo `X-Request-ID`, and successful settings writes emit
+  `settings_change` audit events with before/after values.
+
 ## Unreleased — Engineering Hardening Pass
 
 ### Breaking changes

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -73,6 +73,32 @@ packet. `processing.client_ttl_seconds` is the longer retention/eviction window
 for keeping stale clients and their metadata available after they stop sending
 traffic.
 
+## Environment variables
+
+Prefer YAML config for normal runtime settings. The backend also supports a
+small set of `VIBESENSOR_*` environment overrides for packaging, service, and
+debug workflows:
+
+- `VIBESENSOR_CONFIG_PATH`: alternate config path used by the app factory and
+  the hotspot/systemd launch path.
+- `VIBESENSOR_SERVE_STATIC=0`: disable mounting bundled UI static files for
+  API-only runs, backend tests, or release validation helpers.
+- `VIBESENSOR_DISABLE_AUTO_APP=1`: prevent import-time FastAPI app creation;
+  mainly useful for tests, CLI entrypoints, and release validation subprocesses.
+- `VIBESENSOR_WS_DEBUG=1`: enable dev-only WebSocket payload-size debug logs.
+
+Updater and release tooling also expose focused overrides:
+
+- `VIBESENSOR_FIRMWARE_CACHE_DIR`
+- `VIBESENSOR_FIRMWARE_REPO`
+- `VIBESENSOR_FIRMWARE_CHANNEL`
+- `VIBESENSOR_FIRMWARE_PINNED_TAG`
+- `VIBESENSOR_SERVER_REPO`
+- `VIBESENSOR_UPDATE_STATE_PATH`
+
+Those update-related variables are intended for controlled packaging, staging,
+or recovery scenarios rather than day-to-day dashboard use.
+
 Common runtime files under `apps/server/data/` include:
 
 - `history.db`: persisted run history and settings.

--- a/docs/design_language.md
+++ b/docs/design_language.md
@@ -64,7 +64,7 @@ Automatic on touch/coarse-pointer tablet-ish viewports (`pointer: coarse` + `max
 - Heat coloring per location using report-consistent p95 intensity metric over a 10-second rolling window.
 - Event pulse: glow ring + brief blink animation on new vibration events.
 - Tapping the car map does nothing for now.
-- Location taxonomy: reuses the report location codes from `apps/server/vibesensor/locations.py`.
+- Location taxonomy: reuses the report location codes from `apps/server/vibesensor/shared/locations.py`.
 
 ## Do / Don't
 - Do use existing tokens and classes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -94,9 +94,9 @@ make test-all
 act -W .github/workflows/ci.yml
 
 # Single feature area
-pytest -q apps/server/tests/report/
-pytest -q apps/server/tests/history/
-pytest -q apps/server/tests/update/
+pytest -q apps/server/tests/adapters/pdf/
+pytest -q apps/server/tests/use_cases/history/
+pytest -q apps/server/tests/use_cases/updates/
 
 # Cross-cutting scopes
 pytest -q apps/server/tests/integration/
@@ -198,7 +198,10 @@ cd apps/server && python -m pytest -q --cov=vibesensor --cov-report=term-missing
 Coverage guidance:
 
 - Treat coverage as a risk-finding tool, not the only quality signal.
-- High-risk backend areas such as `analysis/`, `processing/`, `history_db/`, and `update/` should stay above the repo-wide baseline whenever practical.
+- High-risk backend areas such as `use_cases/diagnostics/`,
+  `infra/processing/`, `adapters/persistence/history_db/`, and
+  `use_cases/updates/` should stay above the repo-wide baseline whenever
+  practical.
 
 The default CI-parity suite now mirrors these blocking GitHub checks:
 

--- a/docs/time_alignment.md
+++ b/docs/time_alignment.md
@@ -110,7 +110,7 @@ here.
 
 ```bash
 # Focused alignment tests (29 tests, <1 s):
-python -m pytest apps/server/tests/processing/test_time_alignment.py -v
+python -m pytest apps/server/tests/infra/processing/test_time_alignment.py -v
 
 # Full backend suite:
 pytest -q apps/server/tests


### PR DESCRIPTION
## Summary

This PR resolves the remaining documentation drift from `#1209` without rewriting large sections of the docs that were already correct. The issue assessment was mostly right that there were stale paths in the test/docs guidance and that the changelog had fallen behind recent merged work, but it also mixed those real problems with some claims that no longer matched the repository. The goal here was to update the parts that were genuinely stale, keep the intentional historical references that still add context, and document the real `VIBESENSOR_*` environment variables that are relevant to current backend workflows.

In practice, this change refreshes stale backend test-path examples in `docs/testing.md`, fixes an outdated backend path in `docs/design_language.md`, fixes the matching stale test path in `docs/time_alignment.md`, adds a concise environment-variable section to `apps/server/README.md`, and adds grouped changelog coverage for the recent merged hardening work already present on `main`.

## Problem being solved

The main problem was not “all docs are stale,” but rather that a few highly visible navigation and maintenance touchpoints had drifted just enough to send contributors to the wrong place. `docs/testing.md` still had single-feature pytest examples using the old flat roots (`apps/server/tests/report/`, `history/`, `update/`) even though the repo has long since standardized on the mirrored ownership tree. The same file also still described high-risk areas using old backend names like `analysis/` and `update/`, which no longer line up with the package layout described elsewhere in the repo.

There were also smaller but real path drifts outside the exact issue text. `docs/design_language.md` still referenced `apps/server/vibesensor/locations.py`, while the actual shared module is `apps/server/vibesensor/shared/locations.py`. `docs/time_alignment.md` still pointed at `apps/server/tests/processing/test_time_alignment.py`, even though the mirrored path is now `apps/server/tests/infra/processing/test_time_alignment.py`.

Separately, the issue was right that user-facing docs did not explain the real `VIBESENSOR_*` environment variables. The commonly cited examples from the issue (`VS_ENV`, `VS_DATA_DIR`, `VS_LOG_LEVEL`) do not exist, but the backend does expose real environment-based overrides for config path selection, static-file serving, auto-app creation, WebSocket debug logging, and updater/release overrides. Those needed a documented home.

Finally, the changelog had not kept pace with the recent merged hardening work on `main`. Rather than trying to force every merged PR into a one-bullet-per-PR format, I treated the existing changelog as thematic and added one new grouped unreleased section that summarizes the recent performance, runtime, CI, dependency, documentation, and observability improvements already merged.

## Implementation approach

I kept the update intentionally documentation-first and validation-light:

1. Re-scan the exact stale path patterns from the issue instead of rewriting docs from memory.
2. Preserve intentional historical references where they still serve as migration context.
3. Add only the environment variables that are real and operationally meaningful.
4. Update the changelog in the same thematic style it already uses, rather than introducing a second format for recent work.

That approach matters because this issue is about trust in documentation. Overcorrecting by deleting useful historical notes or inventing a new changelog structure would solve one kind of drift by creating another.

## Main documentation changes by area

### `docs/testing.md`

This file had the clearest path drift. I updated the “Single feature area” examples from the old flat roots to the current mirrored locations:

- `apps/server/tests/adapters/pdf/`
- `apps/server/tests/use_cases/history/`
- `apps/server/tests/use_cases/updates/`

I also updated the “high-risk backend areas” guidance to use the current ownership boundaries:

- `use_cases/diagnostics/`
- `infra/processing/`
- `adapters/persistence/history_db/`
- `use_cases/updates/`

I deliberately left the “Older flat roots such as … were consolidated …” paragraph intact because that text is historical context, not drift. It explains why contributors might still encounter those names in older references and directs them toward the current mirrored structure.

### `docs/design_language.md` and `docs/time_alignment.md`

These were small but real fixes:

- `docs/design_language.md` now points at `apps/server/vibesensor/shared/locations.py`.
- `docs/time_alignment.md` now uses the current mirrored test path under `apps/server/tests/infra/processing/`.

These are low-risk updates, but they matter because they are the kind of “just one wrong path” drift that wastes time when someone follows the docs literally.

### `apps/server/README.md`

I added a new environment-variable section that documents the actual `VIBESENSOR_*` overrides that current backend workflows use. The section intentionally distinguishes between normal YAML-based configuration and focused environment overrides for packaging, service, debug, release, and updater scenarios.

That keeps the README honest: YAML remains the primary runtime configuration path, but the important environment hooks are now discoverable instead of living only in code, systemd units, Dockerfiles, and test helpers.

### `CHANGELOG.md`

I added a new unreleased section, `Documentation, DX, and Observability Alignment`, to catch the recent merged work that had not yet been summarized in the changelog. The bullets are grouped by theme rather than individual PR number:

- runtime/performance hardening,
- operator-feedback and API/UI polish,
- test/doc/DX refresh,
- CI and dependency reproducibility,
- structured observability.

This keeps the changelog readable while still acknowledging the recent engineering work already on `main`.

## Validation

Because this is a documentation-only change set, I validated it with the repo’s documentation gate instead of rerunning backend runtime suites that are unaffected by these edits:

- `make docs-lint`

I also rescanned the specific stale-path patterns that triggered the issue to confirm they no longer appear in the touched docs:

- old `apps/server/tests/report|history|update` examples,
- the old `vibesensor/locations.py` reference,
- the old `apps/server/tests/processing/test_time_alignment.py` path.

That gave me both the general repo docs validation and the issue-specific confirmation that the targeted drift is actually gone.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that the new changelog section summarizes recent work thematically instead of exhaustively listing every merged PR. I chose that because it matches the existing changelog style and makes the document more maintainable. If the repo later wants strict per-PR release-note bookkeeping, that should be a deliberate formatting decision applied consistently across the whole changelog, not just this slice.

I also intentionally did **not** document every internal or test-only environment variable found anywhere in the codebase. The README now covers the meaningful backend-facing overrides without turning into a dump of every temporary test harness knob.

Out of scope for this PR:

- rewriting already-correct architecture docs,
- changing the generated protocol docs,
- adding a new changelog automation workflow,
- reworking the broader docs information architecture.

Closes #1209.
