### PR TITLE
Fix #1211: add startup run retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - **Structured observability** — Application file logs now use structured JSON,
   HTTP responses echo `X-Request-ID`, and successful settings writes emit
   `settings_change` audit events with before/after values.
+- **Automatic startup run retention** — The server now prunes terminal
+  (`complete` / `error`) runs older than `logging.run_retention_days`
+  (default `7`) during HistoryDB startup maintenance, keeping long-lived Pi
+  deployments from accumulating unbounded local run history.
 
 ## Unreleased — Engineering Hardening Pass
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -73,6 +73,10 @@ packet. `processing.client_ttl_seconds` is the longer retention/eviction window
 for keeping stale clients and their metadata available after they stop sending
 traffic.
 
+For persisted run history on Pi-class devices, `logging.run_retention_days`
+controls how many days of terminal (`complete` / `error`) runs are kept before
+startup maintenance prunes them automatically. The default is `7`.
+
 ## Environment variables
 
 Prefer YAML config for normal runtime settings. The backend also supports a

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -4,6 +4,7 @@ import logging
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
@@ -205,6 +206,82 @@ def test_recover_stale_recording_runs_marks_error(tmp_path: Path) -> None:
     assert run is not None
     assert run.status.value == "error"
     assert "Recovered stale recording during startup at" in str(run.error_message)
+
+
+def test_prune_terminal_runs_older_than_days_deletes_only_old_terminal_runs(
+    tmp_path: Path,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-old-complete", "2026-01-01T00:00:00Z", _metadata("run-old-complete"))
+    db.store_analysis(
+        "run-old-complete",
+        make_persisted_analysis(_analysis("run-old-complete", score=10)),
+    )
+    db.create_run("run-old-error", "2026-01-01T00:00:00Z", _metadata("run-old-error"))
+    db.store_analysis_error("run-old-error", "failed")
+    db.create_run("run-recent-complete", "2026-01-01T00:00:00Z", _metadata("run-recent-complete"))
+    db.store_analysis(
+        "run-recent-complete",
+        make_persisted_analysis(_analysis("run-recent-complete", score=20)),
+    )
+    db.create_run("run-recording", "2026-01-01T00:00:00Z", _metadata("run-recording"))
+    db.create_run("run-analyzing", "2026-01-01T00:00:00Z", _metadata("run-analyzing"))
+    db.finalize_run("run-analyzing", "2026-01-01T00:01:00Z")
+
+    old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+    recent_timestamp = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    with db._cursor() as cur:
+        cur.execute(
+            "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (old_timestamp, old_timestamp, "run-old-complete"),
+        )
+        cur.execute(
+            "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (old_timestamp, old_timestamp, "run-old-error"),
+        )
+        cur.execute(
+            "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (recent_timestamp, recent_timestamp, "run-recent-complete"),
+        )
+        cur.execute(
+            "UPDATE runs SET created_at = ? WHERE run_id = ?",
+            (old_timestamp, "run-recording"),
+        )
+        cur.execute(
+            "UPDATE runs SET created_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (old_timestamp, old_timestamp, "run-analyzing"),
+        )
+
+    pruned = db.prune_terminal_runs_older_than_days(7)
+
+    assert pruned == 2
+    assert db.get_run("run-old-complete") is None
+    assert db.get_run("run-old-error") is None
+    assert db.get_run("run-recent-complete") is not None
+    assert db.get_run("run-recording") is not None
+    assert db.get_run("run-analyzing") is not None
+
+
+def test_prune_terminal_runs_older_than_days_cascades_samples(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    db.create_run("run-prune", "2026-01-01T00:00:00Z", _metadata("run-prune"))
+    db.append_samples("run-prune", [SensorFrame.from_dict({"i": i}) for i in range(3)])
+    db.store_analysis("run-prune", make_persisted_analysis(_analysis("run-prune", score=9)))
+
+    old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+    with db._cursor() as cur:
+        cur.execute(
+            "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (old_timestamp, old_timestamp, "run-prune"),
+        )
+
+    pruned = db.prune_terminal_runs_older_than_days(7)
+
+    assert pruned == 1
+    assert db.get_run("run-prune") is None
+    with db._cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-prune",))
+        assert cur.fetchone()[0] == 0
 
 
 def test_create_run_does_not_auto_recover_recording(tmp_path: Path) -> None:

--- a/apps/server/tests/app/test_config.py
+++ b/apps/server/tests/app/test_config.py
@@ -37,6 +37,14 @@ def test_logging_no_data_timeout_defaults_and_allows_override(cfg_path: Path) ->
     assert cfg.logging.no_data_timeout_s == 30.0
 
 
+def test_logging_run_retention_days_defaults_and_allows_override(cfg_path: Path) -> None:
+    cfg = _write_and_load(cfg_path, {})
+    assert cfg.logging.run_retention_days == 7
+
+    cfg = _write_and_load(cfg_path, {"logging": {"run_retention_days": 21}})
+    assert cfg.logging.run_retention_days == 21
+
+
 def test_dev_and_docker_configs_equivalent() -> None:
     """config.dev.yaml and config.docker.yaml share core settings but Docker
     intentionally overrides environment-specific options (GPS disabled because

--- a/apps/server/tests/app/test_config_validation.py
+++ b/apps/server/tests/app/test_config_validation.py
@@ -183,6 +183,7 @@ class TestLoggingConfigValidation:
             "no_data_timeout_s": 15.0,
             "history_db_path": Path("/tmp/history.db"),
             "persist_history_db": True,
+            "run_retention_days": 7,
             "shutdown_analysis_timeout_s": 30.0,
             "app_log_path": Path("/tmp/app.log"),
         }
@@ -205,6 +206,10 @@ class TestLoggingConfigValidation:
     def test_negative_shutdown_timeout_clamped(self) -> None:
         cfg = self._make(shutdown_analysis_timeout_s=-1.0)
         assert cfg.shutdown_analysis_timeout_s >= 0
+
+    def test_non_positive_run_retention_days_clamped(self) -> None:
+        cfg = self._make(run_retention_days=0)
+        assert cfg.run_retention_days >= 1
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/app/test_container.py
+++ b/apps/server/tests/app/test_container.py
@@ -11,9 +11,11 @@ def test_create_history_db_skips_stale_recovery_when_quick_check_marked_corrupte
     monkeypatch,
 ) -> None:
     recovered = {"called": False}
+    pruned = {"called": False}
     fake_db = SimpleNamespace(
         corruption_detected=True,
         recover_stale_recording_runs=lambda: recovered.__setitem__("called", True),
+        prune_terminal_runs_older_than_days=lambda _days: pruned.__setitem__("called", True),
     )
 
     def _fake_history_db(_path: Path, *, corruption_reporter=None):
@@ -22,7 +24,7 @@ def test_create_history_db_skips_stale_recovery_when_quick_check_marked_corrupte
 
     monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
     config = SimpleNamespace(
-        logging=SimpleNamespace(history_db_path=tmp_path / "history.db"),
+        logging=SimpleNamespace(history_db_path=tmp_path / "history.db", run_retention_days=7),
     )
 
     result = container_module.create_history_db(
@@ -32,3 +34,74 @@ def test_create_history_db_skips_stale_recovery_when_quick_check_marked_corrupte
 
     assert result is fake_db
     assert recovered["called"] is False
+    assert pruned["called"] is False
+
+
+def test_create_history_db_prunes_old_terminal_runs_on_startup(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, int | None]] = []
+
+    def _recover() -> int:
+        calls.append(("recover", None))
+        return 0
+
+    def _prune(days: int) -> int:
+        calls.append(("prune", days))
+        return 2
+
+    fake_db = SimpleNamespace(
+        corruption_detected=False,
+        recover_stale_recording_runs=_recover,
+        prune_terminal_runs_older_than_days=_prune,
+    )
+
+    def _fake_history_db(_path: Path, *, corruption_reporter=None):
+        assert corruption_reporter is not None
+        return fake_db
+
+    monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
+    config = SimpleNamespace(
+        logging=SimpleNamespace(history_db_path=tmp_path / "history.db", run_retention_days=14),
+    )
+
+    result = container_module.create_history_db(
+        config,
+        corruption_reporter=lambda _details: None,
+    )
+
+    assert result is fake_db
+    assert calls == [("recover", None), ("prune", 14)]
+
+
+def test_create_history_db_continues_when_retention_prune_fails(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    fake_db = SimpleNamespace(
+        corruption_detected=False,
+        recover_stale_recording_runs=lambda: 0,
+        prune_terminal_runs_older_than_days=lambda _days: (_ for _ in ()).throw(
+            RuntimeError("prune failed")
+        ),
+    )
+
+    def _fake_history_db(_path: Path, *, corruption_reporter=None):
+        assert corruption_reporter is not None
+        return fake_db
+
+    monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
+    config = SimpleNamespace(
+        logging=SimpleNamespace(history_db_path=tmp_path / "history.db", run_retention_days=7),
+    )
+
+    with caplog.at_level("WARNING"):
+        result = container_module.create_history_db(
+            config,
+            corruption_reporter=lambda _details: None,
+        )
+
+    assert result is fake_db
+    assert "Failed to prune terminal runs older than 7 day(s)" in caplog.text

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from contextlib import AbstractContextManager
+from datetime import UTC, datetime, timedelta
 
 from vibesensor.adapters.persistence.history_db._samples import V2_INSERT_SQL, sample_to_v2_row
 from vibesensor.domain.run_status import RunStatus, is_run_deletable, transition_run
@@ -242,5 +243,20 @@ class _HistoryDBRunLifecycleMixin:
             cur.execute(
                 "UPDATE runs SET status = 'error', error_message = ? WHERE status = 'recording'",
                 (f"Recovered stale recording during startup at {now}",),
+            )
+            return int(cur.rowcount)
+
+    def prune_terminal_runs_older_than_days(self, retention_days: int) -> int:
+        if retention_days < 1:
+            raise ValueError("retention_days must be at least 1")
+        cutoff_utc = (datetime.now(UTC) - timedelta(days=retention_days)).isoformat()
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM runs
+                WHERE status IN ('complete', 'error')
+                  AND COALESCE(analysis_completed_at, end_time_utc, created_at) < ?
+                """,
+                (cutoff_utc,),
             )
             return int(cur.rowcount)

--- a/apps/server/vibesensor/app/config_defaults.py
+++ b/apps/server/vibesensor/app/config_defaults.py
@@ -41,6 +41,7 @@ DEFAULT_CONFIG: JsonObject = {
         "metrics_log_hz": 4,
         "no_data_timeout_s": 15.0,
         "persist_history_db": True,
+        "run_retention_days": 7,
         "shutdown_analysis_timeout_s": 30,
         "app_log_path": "data/app.log",
     },

--- a/apps/server/vibesensor/app/config_loader.py
+++ b/apps/server/vibesensor/app/config_loader.py
@@ -194,6 +194,10 @@ def load_config(config_path: Path | None = None) -> AppConfig:
                 path,
             ),
             persist_history_db=bool(logging_cfg["persist_history_db"]),
+            run_retention_days=_coerce_int(
+                logging_cfg["run_retention_days"],
+                "logging.run_retention_days",
+            ),
             shutdown_analysis_timeout_s=_coerce_float(
                 logging_cfg["shutdown_analysis_timeout_s"],
                 "logging.shutdown_analysis_timeout_s",

--- a/apps/server/vibesensor/app/config_schema.py
+++ b/apps/server/vibesensor/app/config_schema.py
@@ -163,6 +163,7 @@ class LoggingConfig:
     no_data_timeout_s: float
     history_db_path: Path
     persist_history_db: bool
+    run_retention_days: int
     shutdown_analysis_timeout_s: float
     app_log_path: Path | None
 
@@ -181,6 +182,14 @@ class LoggingConfig:
                 self.no_data_timeout_s,
             )
             object.__setattr__(self, "no_data_timeout_s", 15.0)
+        if not isinstance(self.run_retention_days, int) or self.run_retention_days < 1:
+            clamped = max(1, int(self.run_retention_days or 7))
+            LOGGER.warning(
+                "logging.run_retention_days=%r is invalid — clamped to %s",
+                self.run_retention_days,
+                clamped,
+            )
+            object.__setattr__(self, "run_retention_days", clamped)
         if (
             not isinstance(self.shutdown_analysis_timeout_s, NUMERIC_TYPES)
             or self.shutdown_analysis_timeout_s < 0

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -68,14 +68,15 @@ def create_history_db(
     *,
     corruption_reporter: Callable[[str], None] | None = None,
 ) -> HistoryDB:
-    """Create and initialise the HistoryDB, recovering any stale runs."""
+    """Create and initialise the HistoryDB, recovering stale runs and pruning old ones."""
     history_db = HistoryDB(
         config.logging.history_db_path,
         corruption_reporter=corruption_reporter,
     )
     if history_db.corruption_detected:
         LOGGER.error(
-            "History DB corruption detected at startup; skipping stale-run recovery and "
+            "History DB corruption detected at startup; skipping stale-run recovery, "
+            "retention pruning, and "
             "continuing with writes disabled until the DB is repaired.",
         )
         return history_db
@@ -87,6 +88,23 @@ def create_history_db(
         raise
     if recovered_runs:
         LOGGER.warning("Recovered %d stale recording run(s) on startup", recovered_runs)
+    try:
+        pruned_runs = history_db.prune_terminal_runs_older_than_days(
+            config.logging.run_retention_days,
+        )
+    except Exception:
+        LOGGER.warning(
+            "Failed to prune terminal runs older than %d day(s) during startup maintenance",
+            config.logging.run_retention_days,
+            exc_info=True,
+        )
+    else:
+        if pruned_runs:
+            LOGGER.info(
+                "Pruned %d terminal run(s) older than %d day(s) during startup maintenance",
+                pruned_runs,
+                config.logging.run_retention_days,
+            )
     return history_db
 
 

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -1,4 +1,4 @@
-# History DB Schema (v10)
+# History DB Schema (v11)
 
 The VibeSensor server stores run history, samples, analysis results,
 application settings and client names in a single SQLite file located at
@@ -20,7 +20,7 @@ splits internal responsibilities across focused modules:
 - `__init__.py`: shared SQLite connection/lock/cursor ownership, schema
   initialization/migrations, settings snapshot persistence, and client-name persistence.
 - `_run_lifecycle.py`: run creation/finalization, sample appends, analysis writes, delete
-  flows, and stale-recording recovery.
+  flows, stale-recording recovery, and startup retention pruning for old terminal runs.
 - `_sample_io.py`: batched sample reads and keyset-pagination helpers.
 - `_queries.py`: run listing/detail queries, metadata reads, health reads, and integrity
   checks.
@@ -115,13 +115,14 @@ creates the current tables first, then checks the stored integer version:
 
 | Stored version | Action |
 |----------------|--------|
-| `0` on a fresh DB | Create all tables, stamp `user_version = 10` |
+| `0` on a fresh DB | Create all tables, stamp `user_version = 11` |
 | `0` with a legacy `schema_meta` table present | Raise `RuntimeError` directing the user to delete the incompatible DB |
-| `10` | No action needed |
-| `9` | Migrate `settings_kv` → `settings_snapshot` single-row table |
-| `8` | Chain migrate: add `case_id` column (v8→v9), then `settings_kv` → `settings_snapshot` (v9→v10) |
+| `11` | No action needed |
+| `10` | Migrate stored persisted-analysis payloads to stamp the current schema version (v10→v11) |
+| `9` | Migrate `settings_kv` → `settings_snapshot` single-row table, then stamp persisted-analysis payload version (v9→v10→v11) |
+| `8` | Chain migrate: add `case_id` column (v8→v9), then `settings_kv` → `settings_snapshot` (v9→v10), then stamp persisted-analysis payload version (v10→v11) |
 | Older unsupported values (for example `1` or `4`) | Raise `RuntimeError` directing the user to delete the database file |
-| Newer than `10` | Raise `RuntimeError` (downgrade not supported) |
+| Newer than `11` | Raise `RuntimeError` (downgrade not supported) |
 
 ### Schema versioning policy
 
@@ -150,3 +151,13 @@ For a 30-minute run at 4 Hz × 4 sensors (~28,800 samples):
 | Write speed | Slower (JSON serialize per row) | Faster (typed bind params) |
 | Read speed | Slower (JSON parse per row) | Faster (direct column access) |
 | Queryable | No (opaque blobs) | Yes (indexed typed columns) |
+
+## Startup retention policy
+
+On startup, `create_history_db()` first recovers stale `recording` rows into
+`error`, then prunes `complete` and `error` runs older than
+`logging.run_retention_days` (default `7`). The prune cutoff uses the run's
+terminal timestamp (`analysis_completed_at`, then `end_time_utc`, then
+`created_at`) so active `recording` / `analyzing` runs are never deleted by the
+automatic policy. Sample rows are removed automatically through the existing
+`ON DELETE CASCADE` foreign key on `samples_v2`.

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -27,6 +27,11 @@ map. The response also includes operational metrics:
 - `tick_duration_s` / `max_tick_duration_s` / `tick_count` — processing loop timing
 - `db_last_write_duration_s` / `db_max_write_duration_s` — DB write latency
 
+Run-history retention is enforced during startup maintenance. By default the Pi
+prunes `complete` and `error` runs older than `logging.run_retention_days: 7`.
+Raise or lower that value in the server config when the device needs a longer
+or shorter local-history window.
+
 ## Diagnose high dropped frames
 
 1. Confirm the health endpoint responds and inspect connected clients.


### PR DESCRIPTION
## Summary

This PR fixes issue #1211 by adding an automatic run-retention policy for long-lived Pi deployments. The underlying problem was not a total lack of resource management, but a narrower missing maintenance step: the server already warned about low disk space, handled persistence failures, exposed storage degradation through health state, and allowed manual history deletion, but it never cleaned up old run history on its own. That meant `complete` and `error` runs could accumulate indefinitely on a device that stays in service for weeks or months, even though the codebase already had the pieces needed to recover stale active runs and to delete terminal runs safely.

The implementation here keeps the scope tightly aligned with that verified gap. Instead of introducing a second storage-management subsystem, a quota engine, or a new background service, the retention policy is wired into the existing HistoryDB startup-maintenance path. On startup, the server still recovers stale `recording` runs first, then prunes only terminal runs older than a configurable number of days. The new config surface is `logging.run_retention_days`, with a default of `7`, so Pi images and standard deployments pick up a bounded history window automatically while still allowing operators to tune the retention window in YAML when needed.

## Implementation approach

I kept the retention logic adjacent to the startup code that already owns HistoryDB consistency fixes. `create_history_db()` already performs startup-only database work before the rest of the runtime is assembled, so it was the cleanest place to add automatic pruning without widening unrelated runtime contracts or spreading storage policy across multiple layers. The HistoryDB facade remains the public owner of DB lifecycle behavior, and the actual prune query lives in `_run_lifecycle.py` alongside stale-recording recovery and delete flows.

The pruning rule is deliberately conservative. It only deletes runs whose status is already terminal (`complete` or `error`), and it computes age using the run’s terminal timestamp by checking `analysis_completed_at`, then `end_time_utc`, then `created_at`. That avoids deleting active `recording` or `analyzing` runs and avoids pruning a long run merely because it was created earlier than it finished. Sample rows continue to be removed through the existing foreign-key cascade on `samples_v2`, so there is no duplicate cleanup path for child rows.

I also made startup pruning best-effort rather than fatal. If stale-run recovery fails, startup still treats that as a hard error because it indicates a deeper database-maintenance problem in an existing consistency path. If retention pruning fails, the server logs a warning and continues booting. That tradeoff preserves availability while still surfacing that startup maintenance did not complete. For a long-running Pi deployment, failing open on the retention pass is safer than refusing to start the whole service because a non-essential cleanup query could not run.

## Main code changes

In the backend config layer, `LoggingConfig` now includes `run_retention_days`, the default config adds `logging.run_retention_days: 7`, and the config loader parses and validates the new key through the same typed config flow as the rest of the logging settings. Validation clamps invalid direct-construction values to a safe minimum, matching the existing pattern used elsewhere in the schema layer.

In HistoryDB lifecycle code, I added `prune_terminal_runs_older_than_days(retention_days: int) -> int`. The method computes the UTC cutoff at call time and issues a single delete against terminal runs older than that cutoff. The SQL uses `COALESCE(analysis_completed_at, end_time_utc, created_at)` to compare terminal age consistently, and it relies on existing `ON DELETE CASCADE` behavior to clean out associated sample rows.

In startup wiring, `create_history_db()` now does three things in order: instantiate HistoryDB, skip write-side maintenance entirely if quick-check corruption was already detected, recover stale recording runs, and then run the new terminal-run prune step using `config.logging.run_retention_days`. Successful pruning emits an info log when it actually deletes rows; prune failures emit a warning with exception details and do not abort startup.

## Tests and documentation

The test coverage was expanded in the narrow areas this change touches. `test_history_db_lifecycle.py` now verifies that old `complete` and `error` runs are pruned while `recording`, `analyzing`, and newer complete runs are preserved, and it separately verifies that pruning a terminal run also removes its samples. `test_container.py` now verifies that corrupted databases still skip all startup write maintenance, that startup calls stale recovery before retention pruning, and that prune failures are logged without breaking startup. Config tests were updated to cover the new default and an override, and config-validation tests now cover clamping of non-positive retention values.

Documentation was updated in the places that directly describe runtime storage behavior. `apps/server/README.md` now points operators to `logging.run_retention_days` in the main configuration section. `docs/history_db_schema.md` documents the startup retention behavior, explains that it only targets terminal runs, and also fixes the schema-version text in that document so it matches the current code again. `docs/operational-runbooks.md` now mentions the new startup retention window and how to tune it. `CHANGELOG.md` also records the operator-facing impact of the new retention policy.

## Validation

I validated the change in progressively broader layers:

- `pytest -q apps/server/tests/app/test_config.py apps/server/tests/app/test_config_validation.py apps/server/tests/app/test_container.py apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py`
- `make docs-lint`
- `python3 tools/tests/run_ci_parallel.py --skip-bootstrap --skip-npm-ci --job backend-quality --job backend-typecheck --job backend-tests`

All of those passed locally.

I also retried the required Docker smoke path with `docker compose build --pull && docker compose up -d`, but this environment still cannot reach a Docker daemon socket and fails with `docker.errors.DockerException` / `FileNotFoundError` against the Unix socket path. I’m calling that out explicitly because it is an environment limitation here, not a skipped validation step.

## Risks, tradeoffs, and follow-ups

The main intentional tradeoff is choosing age-based startup pruning instead of a storage-quota system. That keeps the fix aligned with the actual verified issue and avoids a more invasive quota/eviction framework that would need a lot more policy surface and operator semantics. If we later need capacity-aware pruning on top of this, the new retention path provides a bounded baseline without preventing a more advanced policy later.

Another important choice is that pruning only happens at startup, not continuously in the background. That is enough to solve the issue with a small blast radius, but it means a device that never restarts will not prune old runs until its next reboot or service restart. That feels like the right tradeoff for this issue because it reuses an existing maintenance phase and avoids adding a long-running scheduler just to delete historical rows.
