### PR TITLE
Rebalance fast E2E shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Docker-backed e2e suite (skip already-owned checks)
         run: |
-          python3 tools/tests/run_e2e_parallel.py --fast-e2e
+          python3 tools/tests/run_e2e_parallel.py --fast-e2e --shards 6
 
       - name: Upload e2e failure artifacts
         if: failure()

--- a/apps/server/tests/hygiene/test_run_e2e_parallel.py
+++ b/apps/server/tests/hygiene/test_run_e2e_parallel.py
@@ -86,3 +86,12 @@ def test_prepare_image_exits_cleanly_when_skip_requested_but_image_is_missing(
 
     assert module._prepare_image("missing-image", env={module._SKIP_BUILD_ENV: "1"}) == 2
     assert any("missing-image" in line for line in emitted)
+
+
+def test_parse_args_defaults_to_six_shards(monkeypatch) -> None:
+    module = _load_run_e2e_parallel_module()
+    monkeypatch.setattr(module.sys, "argv", ["run_e2e_parallel.py"])
+
+    args = module._parse_args()
+
+    assert args.shards == 6

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -253,6 +253,8 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                     python_cmd,
                     "tools/tests/run_e2e_parallel.py",
                     "--fast-e2e",
+                    "--shards",
+                    "6",
                 ],
             ),
         ],

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -53,6 +53,7 @@ ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "e2e_parallel"
 PRINT_LOCK = threading.Lock()
 _SKIP_BUILD_ENV = "VIBESENSOR_E2E_SKIP_BUILD"
+_DEFAULT_MIN_SHARDS = 6
 
 
 @dataclass(frozen=True)
@@ -411,7 +412,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--shards",
         type=int,
-        default=2,
+        default=_DEFAULT_MIN_SHARDS,
         help="Minimum number of parallel shards (actual count may be higher for duration balance).",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

This PR rebalances the Docker-backed fast E2E runner by splitting the overloaded remainder shard into more parallel shards. The trigger for the change was the current GitHub Actions `E2E (docker)` job behavior: the latest green run collected 20 fast-E2E tests across 4 actual shards, and shard `4/4` took `86.7s` by itself while shards `1/4`, `2/4`, and `3/4` completed in `21.5s`, `13.5s`, and `13.3s`. In practice that means the whole E2E job is gated by one oversized remainder shard, even though the rest of the matrix is already well ahead of it.

The runner’s current configuration makes that outcome fairly easy to hit. `tools/tests/run_e2e_parallel.py` only requests a minimum of 2 shards by default, but the fast-E2E suite already has several tests that are treated as dedicated slow shards. In the current test set that produces 4 actual shards: three dedicated single-test shards and one remainder shard containing the other 17 tests. Using the existing estimation logic, that remainder shard carries roughly `51s` of estimated work, which lines up with the observed `86.7s` wall time in CI.

This PR raises the fast-E2E shard fanout to 6 and keeps that value explicit in the mirrored CI entrypoints. With the current collected fast-E2E suite, that takes the old one-big-remainder layout and spreads it across three remainder shards, producing a much flatter estimated plan of roughly `17.1s`, `8.9s`, `8.8s`, `18.0s`, `18.0s`, and `15.0s`. That is not a perfect duration model, but it is a materially better shape than one shard monopolizing nearly the entire job tail.

## Problem analysis

The root issue is not that the shard algorithm is completely broken. The existing duration-aware packing already does the right high-level thing: it gives very slow tests their own shards and greedily balances the rest. The problem is that the minimum shard target is now too low for the size and shape of the current fast-E2E suite. Once a few dedicated shards are carved out, the remaining tests still get packed into only one fallback shard, so the “balanced” part of the algorithm never gets enough bins to work with.

I verified that against both the live CI logs and the current local collection plan. The latest `E2E (docker)` job reported:

- 20 collected fast-E2E tests
- 4 actual shards
- shard `4/4` taking `86.7s`
- total wall time `86.7s`

I also ran the shard planner locally against the collected `e2e and not long_sim` set. With the previous minimum of 2 shards, the current planner produced these estimated loads:

- shard 1: `17.1s`
- shard 2: `8.9s`
- shard 3: `8.8s`
- shard 4: `51.0s`

When the minimum shard count is increased to 6, the same planner produces:

- shard 1: `17.1s`
- shard 2: `8.9s`
- shard 3: `8.8s`
- shard 4: `18.0s`
- shard 5: `18.0s`
- shard 6: `15.0s`

That directly addresses the problem the user called out: shard 4 is not “mysteriously” slow; it is structurally overloaded because it is effectively the only remainder bin.

## Implementation approach

I chose the smallest fix that changes the actual scheduling behavior without redesigning the shard algorithm or introducing speculative duration-hint churn. There are some stale duration hints in the runner for tests that have moved between files over time, but refreshing those would require guessing fresh weights for renamed or restructured tests, and it still would not solve the broader issue that a minimum of 2 shards leaves too little room for the remainder to spread out.

Instead, this PR raises the minimum fast-E2E shard count to 6 in three aligned places:

1. `tools/tests/run_e2e_parallel.py` now defaults `--shards` to 6.
2. `.github/workflows/ci.yml` now explicitly invokes the fast-E2E runner with `--shards 6`.
3. `tools/tests/run_ci_parallel.py` mirrors that same explicit `--shards 6` invocation so local CI-parity runs stay aligned with the workflow.

That combination gives us two benefits. First, the GitHub workflow and the local CI-parity runner both document the intended shard fanout directly in the command line. Second, direct invocations of the runner that rely on its default behavior also pick up the safer shard count instead of silently falling back to the older, more imbalanced plan.

## Test coverage and safeguards

The code change itself is small, but I added a focused hygiene guard so the default does not regress quietly later. `apps/server/tests/hygiene/test_run_e2e_parallel.py` now verifies that the runner parses a default of 6 shards when `--shards` is not explicitly passed.

The repository already has command-parity hygiene that compares `.github/workflows/ci.yml` against `tools/tests/run_ci_parallel.py`, so once both mirrored entrypoints were updated, the existing parity guard continues to protect them from drifting apart. That means the explicit workflow/local-runner `--shards 6` change is now covered both by the existing command-sync checks and by the new default-value test.

## Validation

I validated the change with the narrow tests and the broader hygiene/typecheck gates that cover the touched surfaces:

- `pytest -q apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_job_parity.py`
- `make lint`
- `make typecheck-backend`

All of those passed locally.

I also reran the local shard-planning analysis against the current fast-E2E collection after the change. With the new default of 6, the planner now produces 6 actual shards instead of 4 and eliminates the single oversized remainder shard that previously dominated the job tail.

I did not run the Docker-backed E2E suite locally in this environment because this session still does not have access to a Docker daemon socket. That is the same environment limitation we hit earlier: local Docker-backed validation is not available here, so the final proof for the scheduling change is GitHub CI itself.

## Tradeoffs and follow-ups

The main tradeoff is that this increases the number of concurrent E2E shards, which means more parallel containers and more port allocations during the job. Given the current test volume and the existing per-shard isolated port ranges, that looks like an acceptable tradeoff for a materially shorter tail.

I intentionally did not try to refresh every duration hint in this PR. Some hints are still stale because test files moved, and we may want to revisit those with fresh measured timings later. But raising the minimum shard count already fixes the concrete imbalance the user observed, and it does so without baking in new guessed durations that might be wrong. If CI data still shows a persistent outlier after this shard-count increase, the next follow-up should be to refresh `_DURATION_HINTS` using current measured runtimes rather than historical values.
