### PR TITLE
Fix vibration strength peak validation

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -96,16 +96,15 @@ def test_floor_rms_peak_index_out_of_range_ignored() -> None:
 # -- peak_band_rms_amp_g ----------------------------------------------------
 
 
-def test_band_rms_center_out_of_range_returns_zero() -> None:
-    assert (
+@pytest.mark.parametrize("center_idx", [-1, 5])
+def test_band_rms_center_out_of_range_raises(center_idx: int) -> None:
+    with pytest.raises(ValueError, match="center_idx"):
         peak_band_rms_amp_g(
             freq_hz=[10.0],
             combined_spectrum_amp_g=[1.0],
-            center_idx=5,
+            center_idx=center_idx,
             bandwidth_hz=1.0,
         )
-        == 0.0
-    )
 
 
 def test_band_rms_single_bin() -> None:
@@ -129,6 +128,19 @@ def test_band_rms_multiple_bins() -> None:
     )
     # Center 10 Hz ± 1.5 Hz → bins 9, 10, 11 → values 1.0, 2.0, 1.0
     expected = sqrt((1.0 + 4.0 + 1.0) / 3)
+    assert result == pytest.approx(expected)
+
+
+def test_band_rms_last_bin_uses_available_neighbors() -> None:
+    freq = [8.0, 9.0, 10.0, 11.0, 12.0]
+    values = [0.0, 1.0, 2.0, 1.0, 2.0]
+    result = peak_band_rms_amp_g(
+        freq_hz=freq,
+        combined_spectrum_amp_g=values,
+        center_idx=4,
+        bandwidth_hz=1.5,
+    )
+    expected = sqrt((1.0 + 4.0) / 2)
     assert result == pytest.approx(expected)
 
 

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
@@ -91,6 +91,15 @@ class TestComputeVibrationStrengthBoundaries:
         assert result["top_peaks"][0]["hz"] == 10.0
         assert "strength_bucket" in result
 
+    def test_first_interior_candidate_with_stronger_left_neighbor_is_not_reported(self) -> None:
+        result = compute_vibration_strength_db(
+            freq_hz=[0.0, 1.0, 2.0],
+            combined_spectrum_amp_g_values=[10.0, 6.0, 1.0],
+        )
+        assert result["top_peaks"] == []
+        assert result["vibration_strength_db"] == 0.0
+        assert result["peak_amp_g"] == 0.0
+
     def test_large_spectrum(self) -> None:
         """Large spectrum (1000 bins) should complete without issues."""
         freq = [float(i) for i in range(1000)]

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -230,10 +230,15 @@ def peak_band_rms_amp_g(
     center_idx: int,
     bandwidth_hz: float,
 ) -> float:
-    """Return the RMS amplitude in g of bins within *bandwidth_hz* of *center_idx*."""
+    """Return the RMS amplitude in g of bins within *bandwidth_hz* of *center_idx*.
+
+    Raises ``ValueError`` when *center_idx* is outside the aligned spectrum.
+    """
     freq, amps = _aligned_float_arrays(freq_hz, combined_spectrum_amp_g)
     if not (0 <= center_idx < freq.size):
-        return 0.0
+        raise ValueError(
+            f"center_idx {center_idx} out of range for aligned spectrum size {freq.size}"
+        )
     center_hz = float(freq[center_idx])
     band = amps[np.abs(freq - center_hz) <= bandwidth_hz]
     if band.size == 0:
@@ -245,9 +250,7 @@ def _local_maxima_indexes(values: npt.NDArray[np.float64], threshold: float) -> 
     maxima: list[int] = []
     if values.size > 2:
         interior = values[1:-1]
-        mask = (interior >= threshold) & (interior >= values[2:])
-        if interior.size > 1:
-            mask[1:] &= interior[1:] > values[1:-2]
+        mask = (interior >= threshold) & (interior > values[:-2]) & (interior >= values[2:])
         maxima.extend((np.flatnonzero(mask) + 1).tolist())
     if values.size > 1:
         last_val = float(values[-1])
@@ -266,7 +269,8 @@ def vibration_strength_db_scalar(
     """Compute vibration strength in dB: ``20*log10((peak+eps)/(floor+eps))``.
 
     *epsilon_g* defaults to ``max(1e-9, floor * 0.05)`` to avoid log(0)
-    and to set a meaningful dynamic range floor.
+    and to set a meaningful dynamic range floor. Non-finite or negative inputs
+    are clamped to ``0.0`` before epsilon is applied.
     """
     _floor_raw = float(floor_amp_g)
     _band_raw = float(peak_band_rms_amp_g)
@@ -312,6 +316,11 @@ def compute_vibration_strength_db(
     )
 
     local_maxima = _local_maxima_indexes(combined, threshold)
+    invalid_idx = next((idx for idx in local_maxima if not (0 <= idx < freq.size)), None)
+    if invalid_idx is not None:
+        raise ValueError(
+            f"peak index {invalid_idx} out of range for aligned spectrum size {freq.size}"
+        )
     peak_indexes = [int(idx) for idx in local_maxima[: max(1, top_n)]]
 
     floor_strength = strength_floor_amp_g(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -77,6 +77,8 @@ and complete in under 5 seconds.
 
 Four tiers: `make test-changed` for a fast changed-file heuristic, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `act -W .github/workflows/ci.yml` (required before finalizing) to run the real GitHub workflow locally in Docker.
 
+Main local tiers:
+
 ```bash
 # Changed-file heuristic (current branch vs origin/main, fallback to main)
 make test-changed
@@ -92,22 +94,24 @@ make test-all
 
 # Required pre-finalization gate — real GitHub workflow via act (requires Docker)
 act -W .github/workflows/ci.yml
+```
 
-# Single feature area
+Focused feature-area and fuzzing runs:
+
+```bash
 pytest -q apps/server/tests/adapters/pdf/
 pytest -q apps/server/tests/use_cases/history/
 pytest -q apps/server/tests/use_cases/updates/
-python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100
-
-# Cross-cutting scopes
 pytest -q apps/server/tests/integration/
+python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100
+```
 
-# Focused CI job groups
+Focused CI job groups and full-stack validation:
+
+```bash
 python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests
 python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
 python3 tools/tests/run_ci_parallel.py --job release-smoke
-
-# Full-stack (Docker-backed)
 make test-full-suite
 ```
 

--- a/tools/dev/fuzz_analysis_engine.py
+++ b/tools/dev/fuzz_analysis_engine.py
@@ -166,7 +166,9 @@ def _coerce_include_samples(case: Mapping[str, object], override: bool | None) -
 
 def _metadata_strategy(st: Any) -> Any:
     positive_int = st.integers(min_value=32, max_value=6400)
-    positive_float = st.floats(min_value=0.05, max_value=2.0, allow_nan=False, allow_infinity=False)
+    positive_float = st.floats(
+        min_value=0.05, max_value=2.0, allow_nan=False, allow_infinity=False
+    )
     settings_float = st.floats(
         min_value=0.1,
         max_value=10.0,
@@ -482,7 +484,9 @@ def _materialize_samples(
                 continue
             dominance = 1.0
             if fault_kind != "none" and not diffuse_excitation:
-                dominance = 1.65 if sensor_index == 0 else (0.55 + (sensor_index * 0.12))
+                dominance = (
+                    1.65 if sensor_index == 0 else (0.55 + (sensor_index * 0.12))
+                )
 
             base_amp_g = max(1e-6, floor_amp_g * (1.2 + (sensor_index * 0.18)))
             fault_amp_g = max(1e-6, base_fault_amp_g * dominance)
@@ -546,7 +550,8 @@ def _materialize_samples(
                     else "missing"
                 ),
                 "gear": float(metadata.get("current_gear_ratio") or 0.0) or None,
-                "final_drive_ratio": float(metadata.get("final_drive_ratio") or 0.0) or None,
+                "final_drive_ratio": float(metadata.get("final_drive_ratio") or 0.0)
+                or None,
                 "accel_x_g": round(base_amp_g * (0.8 + accel_scale), 6),
                 "accel_y_g": round(base_amp_g * (0.6 + (accel_scale * 0.5)), 6),
                 "accel_z_g": round(1.0 + base_amp_g * (0.4 + accel_scale), 6),
@@ -573,7 +578,9 @@ def _validate_summary(
     TypeAdapter(AnalysisSummary).validate_python(summary)
     summary_rows = summary.get("rows")
     if summary_rows != expected_rows:
-        raise AssertionError(f"summary rows {summary_rows!r} != expected {expected_rows}")
+        raise AssertionError(
+            f"summary rows {summary_rows!r} != expected {expected_rows}"
+        )
     if summary.get("findings") is None:
         raise AssertionError("summary findings missing")
     if summary.get("run_suitability") is None:
@@ -620,10 +627,12 @@ def main() -> int:
     try:
         from hypothesis import HealthCheck, Phase, given, settings
         from hypothesis import strategies as st
-    except ImportError as exc:  # pragma: no cover - exercised only in missing-dev-deps envs
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - exercised only in missing-dev-deps envs
         raise SystemExit(
             "Missing Hypothesis. Install backend dev dependencies first with "
-            "`python3 -m pip install -e \"./apps/server[dev]\"`."
+            '`python3 -m pip install -e "./apps/server[dev]"`.'
         ) from exc
 
     from pydantic import TypeAdapter

--- a/tools/dev/fuzz_processing_pipeline.py
+++ b/tools/dev/fuzz_processing_pipeline.py
@@ -157,19 +157,32 @@ def _strength_case_strategy(st: Any) -> Any:
             )
         )
         freq_step_hz = draw(
-            st.floats(min_value=0.1, max_value=12.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=0.1, max_value=12.0, allow_nan=False, allow_infinity=False
+            )
         )
         start_hz = draw(
-            st.floats(min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False
+            )
         )
-        center_idx = draw(st.integers(min_value=0, max_value=max(0, min(lengths or [0]) - 1)))
+        center_idx = draw(
+            st.integers(min_value=0, max_value=max(0, min(lengths or [0]) - 1))
+        )
         bandwidth_hz = draw(
-            st.floats(min_value=0.05, max_value=8.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=0.05, max_value=8.0, allow_nan=False, allow_infinity=False
+            )
         )
         epsilon_g = draw(
             st.one_of(
                 st.none(),
-                st.floats(min_value=1e-12, max_value=0.1, allow_nan=False, allow_infinity=False),
+                st.floats(
+                    min_value=1e-12,
+                    max_value=0.1,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
             )
         )
         return {
@@ -191,7 +204,9 @@ def _fft_case_strategy(st: Any) -> Any:
         sample_rate_hz = draw(st.integers(min_value=32, max_value=4096))
         fft_n = draw(st.sampled_from((32, 64, 128, 256, 512)))
         spectrum_min_hz = draw(
-            st.floats(min_value=0.0, max_value=40.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=0.0, max_value=40.0, allow_nan=False, allow_infinity=False
+            )
         )
         max_band_hz = max(float(sample_rate_hz) / 2.0, spectrum_min_hz + 1.0)
         spectrum_max_hz = draw(
@@ -206,7 +221,9 @@ def _fft_case_strategy(st: Any) -> Any:
         spike_col = draw(st.integers(min_value=0, max_value=fft_n - 1))
         spike_axis = draw(st.integers(min_value=0, max_value=2))
         dc_offset = draw(
-            st.floats(min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False
+            )
         )
         base_block = draw(
             st.lists(
@@ -225,7 +242,9 @@ def _fft_case_strategy(st: Any) -> Any:
             )
         )
         spike_value = draw(
-            st.floats(min_value=-64.0, max_value=64.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=-64.0, max_value=64.0, allow_nan=False, allow_infinity=False
+            )
         )
         return {
             "sample_rate_hz": sample_rate_hz,
@@ -251,7 +270,9 @@ def _processor_case_strategy(st: Any) -> Any:
         waveform_display_hz = draw(st.integers(min_value=1, max_value=120))
         fft_n = draw(st.sampled_from((32, 64, 128, 256)))
         spectrum_min_hz = draw(
-            st.floats(min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False)
+            st.floats(
+                min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False
+            )
         )
         spectrum_max_hz = draw(
             st.floats(
@@ -264,7 +285,12 @@ def _processor_case_strategy(st: Any) -> Any:
         accel_scale = draw(
             st.one_of(
                 st.none(),
-                st.floats(min_value=1e-5, max_value=0.05, allow_nan=False, allow_infinity=False),
+                st.floats(
+                    min_value=1e-5,
+                    max_value=0.05,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
             )
         )
         clients = draw(
@@ -386,8 +412,12 @@ def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> None:
             ),
         )
         if combined:
-            assert all(np.isfinite(combined)), "combined spectrum contains non-finite values"
-            assert all(value >= 0.0 for value in combined), "combined spectrum contains negatives"
+            assert all(np.isfinite(combined)), (
+                "combined spectrum contains non-finite values"
+            )
+            assert all(value >= 0.0 for value in combined), (
+                "combined spectrum contains negatives"
+            )
 
         floor_amp = noise_floor_amp_p20_g(combined_spectrum_amp_g=combined)
         assert np.isfinite(floor_amp) and floor_amp >= 0.0
@@ -429,7 +459,9 @@ def _run_strength_target(config: FuzzConfig, *, duration_s: float) -> None:
             for peak in metrics["top_peaks"]
             if isinstance(peak, Mapping) and "vibration_strength_db" in peak
         ]
-        assert _is_sorted_desc(peak_strengths), "strength peaks not sorted by descending dB"
+        assert _is_sorted_desc(peak_strengths), (
+            "strength peaks not sorted by descending dB"
+        )
         _json_no_nan(metrics)
 
     try:
@@ -537,7 +569,9 @@ def _run_fft_target(config: FuzzConfig, *, duration_s: float) -> None:
             assert axis_payload["amp"].shape == combined_amp.shape
             assert np.all(np.isfinite(axis_payload["amp"]))
             TypeAdapter(list[AxisPeak]).validate_python(result["axis_peaks"][axis])
-        TypeAdapter(VibrationStrengthMetrics).validate_python(result["strength_metrics"])
+        TypeAdapter(VibrationStrengthMetrics).validate_python(
+            result["strength_metrics"]
+        )
         _json_no_nan(current_output)
 
     try:
@@ -619,7 +653,9 @@ def _run_processor_target(config: FuzzConfig, *, duration_s: float) -> None:
 
         clients_raw = case["clients"]
         chunks_raw = case["chunks"]
-        if not isinstance(clients_raw, Sequence) or not isinstance(chunks_raw, Sequence):
+        if not isinstance(clients_raw, Sequence) or not isinstance(
+            chunks_raw, Sequence
+        ):
             raise TypeError("processor case must contain sequence clients and chunks")
         clients = [str(client_id) for client_id in clients_raw]
         for chunk in chunks_raw:
@@ -634,7 +670,9 @@ def _run_processor_target(config: FuzzConfig, *, duration_s: float) -> None:
                     if isinstance(chunk.get("sample_rate_hz"), int)
                     else None
                 ),
-                t0_us=int(chunk["t0_us"]) if isinstance(chunk.get("t0_us"), int) else None,
+                t0_us=int(chunk["t0_us"])
+                if isinstance(chunk.get("t0_us"), int)
+                else None,
             )
 
         metrics_by_client: dict[str, ClientMetrics] = {}
@@ -739,10 +777,12 @@ def main() -> int:
 
     try:
         import hypothesis  # noqa: F401
-    except ImportError as exc:  # pragma: no cover - only exercised in missing-dev-deps envs
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - only exercised in missing-dev-deps envs
         raise SystemExit(
             "Missing Hypothesis. Install backend dev dependencies first with "
-            "`python3 -m pip install -e \"./apps/server[dev]\"`."
+            '`python3 -m pip install -e "./apps/server[dev]"`.'
         ) from exc
 
     targets: list[TargetName]


### PR DESCRIPTION
Closes #1263.

## Summary

This PR fixes the reproducible correctness problem in `apps/server/vibesensor/vibration_strength.py` where the first interior spectrum bin could be reported as a peak even when the bin immediately to its left was larger. That bug was real on current `main` and was easy to reproduce end to end with a three-bin spectrum such as `[10, 6, 1]`, which incorrectly surfaced the middle bin as a vibration-strength peak. In the same area, the helper that computes band RMS around a peak index silently returned `0.0` for invalid indexes, which made invalid caller state look like a weak-but-valid measurement instead of an explicit error.

The implementation here keeps the fix narrow. It corrects the peak comparison logic, replaces the silent invalid-index fallback with explicit validation, adds regression coverage for the specific false-positive case plus boundary index handling, and preserves the repo’s existing intentional behavior that allows a strong last-bin peak. I also had to absorb a few no-op lint/doc hygiene updates outside the core module because the current branch could not pass `make lint` otherwise under the repo’s own toolchain.

## Problem being solved

Issue `#1263` grouped several concerns around peak detection, dB guard behavior, and validation in the vibration-strength pipeline. I re-verified each claim against the current code before changing anything. Two problems were clearly live and directly actionable.

First, `_local_maxima_indexes()` only enforced the left-neighbor comparison for interior candidates after the first one. The first interior candidate was checked against the threshold and the right neighbor, but not against the value on its left. That meant a non-peak could survive if it happened to sit at index `1` and still cleared the threshold. Because `compute_vibration_strength_db()` uses those local maxima directly, the bug leaked into the public vibration-strength result rather than being limited to a private helper.

Second, `peak_band_rms_amp_g()` returned `0.0` when `center_idx` was outside the aligned spectrum length. In practice that made invalid caller state indistinguishable from a very weak real signal. Since the helper is used to turn peak indexes into reportable amplitude and dB values, surfacing an explicit error is safer than silently flattening the result.

Other items from the issue body were reviewed as part of the same pass. In particular, the current `vibration_strength_db_scalar()` implementation already clamps non-finite and negative inputs before applying the canonical epsilon floor, and existing behavior for constant spectra already stays finite in the public pipeline. I therefore did not rewrite the dB formula or the broader peak-selection policy beyond the confirmed defect.

## Implementation approach

The guiding approach was to fix only the current root cause, keep externally intentional behavior stable, and add regression coverage that proves the branch still honors those boundaries.

In `vibration_strength.py`, the local-maxima mask now applies the left-neighbor comparison to every interior candidate, including the first one. That removes the false-positive path without changing the repo’s deliberate handling of the final spectrum bin. The last-bin branch remains intact because existing regression tests explicitly require a clear peak at the last frequency bin to remain detectable.

I also changed `peak_band_rms_amp_g()` so invalid `center_idx` values raise `ValueError` instead of returning `0.0`. That makes misuse visible immediately and aligns better with the repo’s preference for explicit failures over silent defensive fallbacks. To keep the public pipeline honest, `compute_vibration_strength_db()` now performs an explicit peak-index validation step before it uses local-maxima indexes for downstream band-RMS and frequency lookups.

Finally, I clarified the `vibration_strength_db_scalar()` docstring to document the existing clamp-and-epsilon behavior. This does not alter the canonical dB definition; it makes the current near-zero-floor handling easier to understand when reading the code.

## Main code changes by area

### Core vibration-strength logic

`apps/server/vibesensor/vibration_strength.py`

The core changes are all in the canonical vibration-strength module:

- fixed the interior local-maxima mask so the first interior candidate must also beat its left neighbor;
- changed `peak_band_rms_amp_g()` to raise `ValueError` on invalid aligned-spectrum indexes;
- added a defensive validation in `compute_vibration_strength_db()` before any peak-index-based access;
- documented the existing dB scalar input clamping behavior.

### Regression coverage

`apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py`

I added a focused regression that proves a stronger left neighbor suppresses the first interior candidate, preventing the old false-positive peak from reappearing through the public pipeline.

`apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`

I replaced the old out-of-range expectation with explicit `ValueError` coverage for invalid `center_idx` values and added a boundary-focused test showing that the last bin still computes a valid RMS using the bins that actually exist around it.

These new tests complement the existing core regression that already requires a last-bin peak to stay visible in `compute_vibration_strength_db()`.

### Lint/doc unblock work

`tools/dev/fuzz_analysis_engine.py`, `tools/dev/fuzz_processing_pipeline.py`, and `docs/testing.md`

While validating the branch, `make lint` failed on current baseline issues unrelated to `#1263`: two fuzz harnesses needed repo-standard Ruff formatting, and `docs/testing.md` contained an oversized command block that tripped `docs_lint`. I applied Ruff’s no-op formatter output to the scripts and split the large testing command block into smaller sections without changing the documented commands. These changes were necessary to get the standard repo validation gate green on this branch.

## Validation

I validated in layers:

- focused regression suite: `python3 -m pytest -q apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py apps/server/tests/use_cases/diagnostics/test_vibration_math_coverage.py` (`68 passed`);
- targeted lint on touched files with `ruff check` and `ruff format --check`;
- full repo-standard local gate in a session venv: `make lint`, `make typecheck-backend`, and `make test-changed`.

The final broad run passed with backend static guards, docs lint, schema export checks, mypy (`323` files), and the changed-file test runner, including the full backend pytest suite (`5770 passed, 5 skipped, 1 xpassed`).

## Risks, tradeoffs, and follow-ups

The main behavioral change is that invalid `peak_band_rms_amp_g()` indexes now raise instead of quietly collapsing to zero. I think that is the right tradeoff: this helper sits close enough to reportable metrics that silent coercion is more dangerous than an explicit failure. The branch keeps that change safe by validating peak indexes before the public vibration-strength pipeline uses them.

I intentionally did not rewrite the broader peak algorithm, remove last-bin peak handling, or change the canonical dB formula. Those would have widened scope beyond the confirmed current defect and would have risked breaking existing behavior that the repo already tests for explicitly.

If we want to go further later, the next logical follow-up would be a separate pass over the sibling peak-selection code in `infra/processing/fft.py`, because it has related but not identical fallback behavior. I left that alone here to keep `#1263` bounded to the canonical vibration-strength path.
