### PR TITLE
Harden FFT spectrum edge handling

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_extended.py
+++ b/apps/server/tests/infra/processing/test_processing_extended.py
@@ -225,6 +225,45 @@ def test_multi_spectrum_payload_compares_freq_axes_without_np_asarray(
     assert result["freq"]
 
 
+def test_multi_spectrum_payload_reuses_shared_freq_conversion_for_matching_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vibesensor.infra.processing.fft import float_list as real_float_list
+
+    proc = _make_processor(sample_rate_hz=200, fft_n=128, spectrum_max_hz=100)
+    samples = _random_samples(300)
+
+    proc.ingest("c1", samples, sample_rate_hz=200)
+    proc.ingest("c2", samples, sample_rate_hz=200)
+    proc.ingest("c3", samples, sample_rate_hz=320)
+    proc.compute_metrics("c1", sample_rate_hz=200)
+    proc.compute_metrics("c2", sample_rate_hz=200)
+    proc.compute_metrics("c3", sample_rate_hz=320)
+
+    proc.spectrum_payload("c1")
+    proc.spectrum_payload("c2")
+    proc.spectrum_payload("c3")
+
+    calls: list[int] = []
+
+    def _counting_float_list(values: np.ndarray | list[float]) -> list[float]:
+        calls.append(len(values))
+        return real_float_list(values)
+
+    monkeypatch.setattr(
+        "vibesensor.infra.processing.payload.float_list",
+        _counting_float_list,
+    )
+
+    result = proc.multi_spectrum_payload(["c1", "c2", "c3"])
+
+    assert result["freq"] == []
+    assert len(calls) == 2
+    assert result["clients"]["c1"]["freq"]
+    assert result["clients"]["c2"]["freq"]
+    assert result["clients"]["c3"]["freq"]
+
+
 # -- compute_metrics -----------------------------------------------------------
 
 

--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -69,6 +69,12 @@ class TestMedfilt3:
         assert result[1, 3] == pytest.approx(0.0)
         assert result[2, 2] == pytest.approx(0.0)
 
+    def test_all_nan_block_is_sanitized_to_zero(self) -> None:
+        block = np.full((3, 5), float("nan"), dtype=np.float32)
+        result = medfilt3(block)
+        assert np.all(np.isfinite(result))
+        assert np.all(result == 0.0)
+
 
 class TestSmoothSpectrum:
     """Tests for the sliding-average spectrum smoother."""
@@ -98,6 +104,14 @@ class TestSmoothSpectrum:
         result_4 = smooth_spectrum(amps, bins=4)
         result_5 = smooth_spectrum(amps, bins=5)
         np.testing.assert_allclose(result_4, result_5)
+
+    def test_nan_input_is_sanitized_before_smoothing(self) -> None:
+        amps = np.array([1.0, np.nan, 3.0], dtype=np.float32)
+        result = smooth_spectrum(amps, bins=3)
+        np.testing.assert_allclose(
+            result,
+            np.array([2.0 / 3.0, 4.0 / 3.0, 2.0], dtype=np.float32),
+        )
 
 
 class TestNoiseFloor:
@@ -257,3 +271,20 @@ class TestComputeFftSpectrum:
             "axis_peaks",
         }
         assert set(result.keys()) == expected_keys
+
+    def test_zero_length_fft_block_returns_empty_result(self) -> None:
+        result = compute_fft_spectrum(
+            np.empty((3, 0), dtype=np.float32),
+            256,
+            fft_window=np.empty((0,), dtype=np.float32),
+            fft_scale=1.0,
+            freq_slice=np.empty((0,), dtype=np.float32),
+            valid_idx=np.empty((0,), dtype=np.intp),
+        )
+        assert result["freq_slice"].size == 0
+        assert result["combined_amp"].size == 0
+        assert result["strength_metrics"]["vibration_strength_db"] == 0.0
+        assert result["strength_metrics"]["top_peaks"] == []
+        for axis in ("x", "y", "z"):
+            assert result["spectrum_by_axis"][axis]["amp"].size == 0
+            assert result["axis_peaks"][axis] == []

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -31,6 +31,35 @@ FloatArray: TypeAlias = npt.NDArray[np.float32]
 IntIndexArray: TypeAlias = npt.NDArray[np.intp]
 
 
+def _sanitize_float_array(values: FloatArray) -> FloatArray:
+    return np.nan_to_num(
+        values,
+        copy=True,
+        nan=0.0,
+        posinf=0.0,
+        neginf=0.0,
+    ).astype(np.float32, copy=False)
+
+
+def _empty_fft_spectrum_result(freq_slice: FloatArray) -> FftSpectrumResult:
+    empty_amp = np.empty(0, dtype=np.float32)
+    spectrum_by_axis: SpectrumByAxis = {}
+    axis_peaks: dict[Axis, list[AxisPeak]] = {}
+    for axis in AXES:
+        spectrum_by_axis[axis] = {
+            "freq": freq_slice,
+            "amp": empty_amp.copy(),
+        }
+        axis_peaks[axis] = []
+    return {
+        "freq_slice": freq_slice,
+        "spectrum_by_axis": spectrum_by_axis,
+        "combined_amp": empty_amp,
+        "strength_metrics": empty_vibration_strength_metrics(),
+        "axis_peaks": axis_peaks,
+    }
+
+
 def medfilt3(block: FloatArray) -> FloatArray:
     """Apply a 3-point median filter per-row (per-axis).
 
@@ -88,23 +117,24 @@ def medfilt3(block: FloatArray) -> FloatArray:
 
     all_invalid = ~left_valid & ~mid_valid & ~right_valid
     center[all_invalid] = np.nan
-    return filtered
+    return _sanitize_float_array(filtered)
 
 
 def smooth_spectrum(amps: FloatArray, bins: int = 5) -> FloatArray:
     """Smooth a spectrum using a sliding-average convolution kernel."""
     if amps.size == 0:
         return amps
+    sanitized = _sanitize_float_array(amps)
     width = max(1, int(bins))
     if width <= 1:
-        return amps.astype(np.float32, copy=True)
+        return sanitized
     if (width % 2) == 0:
         width += 1
-    if amps.size < width:
-        return amps.astype(np.float32, copy=True)
+    if sanitized.size < width:
+        return sanitized
     kernel = np.ones(width, dtype=np.float32) / np.float32(width)
     half = width // 2
-    padded = np.pad(amps, (half, half), mode="edge")
+    padded = np.pad(sanitized, (half, half), mode="edge")
     return np.convolve(padded, kernel, mode="valid").astype(np.float32)
 
 
@@ -247,6 +277,8 @@ def compute_fft_spectrum(
         raise ValueError(
             f"fft_block column count {fft_block.shape[1]} does not match fft_window length {fft_n}",
         )
+    if fft_n == 0:
+        return _empty_fft_spectrum_result(freq_slice)
     if spike_filter_enabled:
         fft_block = medfilt3(fft_block)
     fft_block = fft_block - np.mean(fft_block, axis=1, keepdims=True)

--- a/apps/server/vibesensor/infra/processing/payload.py
+++ b/apps/server/vibesensor/infra/processing/payload.py
@@ -288,10 +288,15 @@ def build_multi_spectrum_payload(
 
     # When all clients share the same frequency axis, emit a single
     # top-level "freq" and omit per-client "freq" to reduce payload size.
+    shared_freq_list: list[float]
     if mismatch_ids:
-        for cid, freq_arr in per_client_freq.items():
-            clients[cid]["freq"] = float_list(freq_arr)
-        shared_freq_list: list[float] = []
+        shared_freq_list = float_list(shared_freq) if shared_freq is not None else []
+        mismatch_set = set(mismatch_ids)
+        for cid in clients:
+            clients[cid]["freq"] = (
+                float_list(per_client_freq[cid]) if cid in mismatch_set else shared_freq_list
+            )
+        shared_freq_list = []
     else:
         shared_freq_list = float_list(shared_freq) if shared_freq is not None else []
 


### PR DESCRIPTION
Closes #1264.

## Summary

This PR hardens the FFT/spectrum-processing path against non-finite input, adds an explicit zero-length FFT fast path, and removes redundant frequency-axis conversion work from the multi-client mismatch payload builder. The changes stay intentionally narrow: they fix the currently reproducible defects in `apps/server/vibesensor/infra/processing/fft.py` and `apps/server/vibesensor/infra/processing/payload.py`, then lock the behavior down with focused regressions in the processing test suite.

I re-verified the issue body against current `main` before changing anything. That audit showed that some of the “empty-data guards are missing everywhere” framing was stale: several helpers already do the right thing for empty arrays today (`noise_floor`, `smooth_spectrum` short inputs, `top_peaks`, `combined_spectrum_amp_g`, and the downstream vibration-strength math). The real live defects were more specific than that summary suggested. `medfilt3()` still left NaNs behind in all-NaN windows and on untouched edge samples, `smooth_spectrum()` still propagated NaNs through convolution, `compute_fft_spectrum()` still raised on a zero-length `(3, 0)` block paired with an empty FFT window, and `build_multi_spectrum_payload()` still re-converted every client frequency axis to Python lists whenever even one client mismatched the shared axis.

## Problem being solved

The FFT path is a core runtime surface, so small correctness bugs cascade quickly. If non-finite values survive the spike filter, they flow into detrending, FFT amplitude extraction, peak selection, and eventually payload shaping. Likewise, a zero-length FFT block should not raise a low-level NumPy error when the rest of the processing stack already has “empty result” semantics. The payload issue is more about waste than wrong answers: in the mismatch case the builder must still expose per-client frequency axes, but it does not need to pay the cost of converting the same shared axis repeatedly for clients that still match one another.

The issue body also called out a broader “quadratic serialization” problem. On current code, the actionable problem is not that per-client frequency data can be omitted entirely in mismatch mode — the existing API expects those client payloads to carry `freq` when the top-level shared axis is blank. The real opportunity is to reuse one shared conversion for the clients that still match the primary axis and only do extra conversions for the truly mismatched clients.

## Implementation approach

The guiding principle here was to harden the pure helpers rather than layering defensive cleanup elsewhere. The FFT helper module is explicitly stateless and testable, so this is the right place to normalize non-finite inputs and define empty-result behavior.

I added a small private `_sanitize_float_array()` helper in `fft.py` and used it in the two functions where non-finite propagation mattered most: `medfilt3()` and `smooth_spectrum()`. For the spike filter, that means the function still performs its median-of-three logic but now returns a finite array even when every value in a window is invalid or when untouched edge samples are NaN. For the smoother, the input is sanitized before edge padding and convolution, which keeps `np.convolve()` from turning a single NaN into an all-NaN smoothed spectrum.

For the empty-FFT case, I did not try to special-case NumPy errors deeper in the pipeline. Instead, `compute_fft_spectrum()` now recognizes a zero-length FFT window after shape validation and returns an explicit empty result through a private `_empty_fft_spectrum_result()` helper. That helper preserves the existing result shape, including empty arrays for each axis and empty strength metrics, so callers get a stable payload contract instead of a crash.

In `payload.py`, the mismatch path now computes one shared frequency list for the clients that still align with the original shared axis, then only calls `float_list()` again for client IDs that actually diverged. This preserves the current payload contract — every client still gets its own `freq` when the top-level shared frequency list is blank — while removing redundant conversion work.

## Main code changes by area

### FFT helper hardening

`apps/server/vibesensor/infra/processing/fft.py`

The main logic changes are here:

- added `_sanitize_float_array()` for centralized NaN/Inf cleanup;
- made `medfilt3()` return sanitized finite output rather than leaking NaNs from all-invalid windows or untouched edges;
- made `smooth_spectrum()` sanitize input before padding/convolution;
- added `_empty_fft_spectrum_result()` and used it when `compute_fft_spectrum()` receives a zero-length FFT window/block.

These changes intentionally leave the overall FFT algorithm, windowing, and peak-selection policy unchanged.

### Multi-client payload optimization

`apps/server/vibesensor/infra/processing/payload.py`

The mismatch branch in `build_multi_spectrum_payload()` now distinguishes between clients that still match the shared axis and clients that truly need independent conversion. Matching clients reuse one converted list; mismatched clients still get individually converted lists, preserving the current payload shape.

### Regression coverage

`apps/server/tests/infra/processing/test_processing_fft.py`

Added focused unit coverage for:

- all-NaN `medfilt3()` input producing finite zeros;
- NaN input to `smooth_spectrum()` being sanitized before smoothing;
- zero-length FFT blocks returning an empty result instead of raising.

`apps/server/tests/infra/processing/test_processing_extended.py`

Added a multi-client payload regression that primes per-client spectrum caches, monkeypatches `float_list()`, and proves mismatch-mode payload building now reuses one shared frequency conversion for matching clients instead of converting every client axis separately.

## Validation

I validated in two layers.

First, I ran a focused regression slice that directly covers the touched helpers and the nearby processing invariants:

- `python3 -m pytest -q apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/infra/processing/test_report_signal_filtering_regressions.py apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py`

That run passed with `71 passed`.

Second, I ran the broader repo-standard local gate in the session virtualenv:

- `make lint`
- `make typecheck-backend`
- `make test-changed`

The final broad pass was green. It covered the repo’s standard backend hygiene/static-guard checks, docs lint, schema export checks, mypy across the backend package, and the changed-file test runner. `make test-changed` selected the infra/processing path and passed with `432 passed`.

## Risks, tradeoffs, and follow-ups

The biggest tradeoff here is that sanitizing `medfilt3()` and `smooth_spectrum()` turns non-finite values into zeros instead of preserving a distinction between “missing” and “silent.” I think that is the correct choice at this layer because downstream FFT, peak, and payload code expects finite numeric arrays, not tri-state signal semantics. If we ever need richer missing-data semantics, that should be modeled explicitly above these pure numeric helpers rather than by letting NaNs leak through the spectral path.

I also intentionally did not rewrite the broader FFT pipeline, add caching for every possible frequency-array consumer, or change the public payload contract in mismatch mode. Those would all widen scope beyond the confirmed current defects. The current fix only removes redundant work while preserving the existing API shape.

A reasonable follow-up later would be a more systematic pass over payload caching for multi-client spectrum views if profiling shows that spectrum broadcast still dominates runtime under heavy fan-out. That felt out of scope for `#1264`; the goal here was to fix the reproducible inefficiency without inventing a new caching layer.
