### PR TITLE
Guard buffer store snapshots after eviction

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.buffer_store import (
+    MAX_CLIENT_SAMPLE_RATE_HZ,
+    SignalBufferStore,
+)
+from vibesensor.infra.processing.compute import SignalMetricsComputer
+from vibesensor.infra.processing.models import CachedMetricsHit, MetricsSnapshot, ProcessorConfig
+
+
+def _config(**overrides: object) -> ProcessorConfig:
+    base = {
+        "sample_rate_hz": 200,
+        "waveform_seconds": 2,
+        "waveform_display_hz": 50,
+        "fft_n": 128,
+        "spectrum_min_hz": 0.0,
+        "spectrum_max_hz": 100.0,
+        "accel_scale_g_per_lsb": None,
+    }
+    base.update(overrides)
+    return ProcessorConfig(**base)
+
+
+def test_snapshot_for_compute_clamps_excessive_sample_rate_override() -> None:
+    store = SignalBufferStore(_config())
+    client_id = "sensor-1"
+
+    store.ingest(client_id, np.ones((256, 3), dtype=np.float32), sample_rate_hz=200)
+
+    plan = store.snapshot_for_compute(client_id, sample_rate_hz=250_000)
+
+    assert isinstance(plan, MetricsSnapshot)
+    assert plan.sample_rate_hz == MAX_CLIENT_SAMPLE_RATE_HZ
+    assert store.buffers[client_id].sample_rate_hz == MAX_CLIENT_SAMPLE_RATE_HZ
+
+
+def test_stale_result_is_rejected_after_buffer_eviction_and_recreation() -> None:
+    config = _config()
+    store = SignalBufferStore(config)
+    computer = SignalMetricsComputer(config)
+    client_id = "sensor-2"
+
+    old_samples = np.random.default_rng(0).standard_normal((256, 3)).astype(np.float32)
+    new_samples = (np.random.default_rng(1).standard_normal((256, 3)) * 10.0).astype(np.float32)
+
+    store.ingest(client_id, old_samples, sample_rate_hz=200)
+    plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+
+    assert isinstance(plan, MetricsSnapshot)
+    stale_result = computer.compute(plan)
+
+    store.evict_clients(set())
+    store.ingest(client_id, new_samples, sample_rate_hz=200)
+    recreated_epoch = store.buffers[client_id].buffer_epoch
+
+    assert recreated_epoch != stale_result.buffer_epoch
+
+    store.store_metrics_result(stale_result)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.buffer_epoch == recreated_epoch
+        assert buf.latest_metrics == {}
+        assert buf.compute_generation == -1
+
+    next_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(next_plan, MetricsSnapshot)
+    assert not isinstance(next_plan, CachedMetricsHit)

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -39,6 +39,7 @@ class SignalBufferStore:
         self.config = config
         self.buffers: dict[str, ClientBuffer] = {}
         self._client_locks: dict[str, RLock] = {}
+        self._next_buffer_epoch = 0
         self.lock = RLock()
         self.stats = ProcessorStats()
 
@@ -91,18 +92,10 @@ class SignalBufferStore:
                 )
                 return
             if sample_rate_hz is not None and sample_rate_hz > 0:
-                requested_rate = int(sample_rate_hz)
-                clamped_rate = max(1, min(MAX_CLIENT_SAMPLE_RATE_HZ, requested_rate))
-                if clamped_rate != requested_rate:
-                    LOGGER.warning(
-                        "Clamped client sample_rate_hz from %d to %d to bound buffer growth",
-                        requested_rate,
-                        clamped_rate,
-                    )
-                buf.sample_rate_hz = clamped_rate
-                self._resize_buffer_unlocked(
+                self._apply_sample_rate_override_unlocked(
                     buf,
-                    buf.sample_rate_hz * self.config.waveform_seconds,
+                    sample_rate_hz,
+                    resize_buffer=True,
                 )
             now_mono = clock()
             buf.last_ingest_mono_s = now_mono
@@ -150,7 +143,11 @@ class SignalBufferStore:
             if buf is None or buf.count == 0:
                 return None
             if sample_rate_hz is not None and sample_rate_hz > 0:
-                buf.sample_rate_hz = int(sample_rate_hz)
+                self._apply_sample_rate_override_unlocked(
+                    buf,
+                    sample_rate_hz,
+                    resize_buffer=False,
+                )
             sr = buf.sample_rate_hz or self.config.sample_rate_hz
             if buf.compute_generation == buf.ingest_generation and buf.compute_sample_rate_hz == sr:
                 return CachedMetricsHit(metrics=buf.latest_metrics)
@@ -172,6 +169,7 @@ class SignalBufferStore:
                 client_id=client_id,
                 sample_rate_hz=sr,
                 ingest_generation=buf.ingest_generation,
+                buffer_epoch=buf.buffer_epoch,
                 time_window=time_window,
                 fft_block=fft_block,
             )
@@ -179,7 +177,11 @@ class SignalBufferStore:
     def store_metrics_result(self, result: MetricsComputationResult) -> ClientMetrics:
         """Commit a compute result back into shared state and update stats."""
         with self.locked_client_buffer(result.client_id) as buf:
-            if buf is not None and result.ingest_generation >= buf.compute_generation:
+            if (
+                buf is not None
+                and result.buffer_epoch == buf.buffer_epoch
+                and result.ingest_generation >= buf.compute_generation
+            ):
                 buf.latest_metrics = result.metrics
                 buf.compute_generation = result.ingest_generation
                 buf.compute_sample_rate_hz = result.sample_rate_hz
@@ -326,7 +328,12 @@ class SignalBufferStore:
         buf = self.buffers.get(client_id)
         if buf is None:
             data: FloatArray = np.zeros((3, self.config.max_samples), dtype=np.float32)
-            buf = ClientBuffer(data=data, capacity=self.config.max_samples)
+            buf = ClientBuffer(
+                data=data,
+                capacity=self.config.max_samples,
+                buffer_epoch=self._next_buffer_epoch,
+            )
+            self._next_buffer_epoch += 1
             self.buffers[client_id] = buf
             self._client_locks[client_id] = RLock()
         return buf
@@ -398,6 +405,30 @@ class SignalBufferStore:
         buf.capacity = new_capacity
         buf.write_idx = latest.shape[1] % new_capacity
         buf.count = min(latest.shape[1], new_capacity)
+
+    def _apply_sample_rate_override_unlocked(
+        self,
+        buf: ClientBuffer,
+        sample_rate_hz: int,
+        *,
+        resize_buffer: bool,
+    ) -> None:
+        requested_rate = int(sample_rate_hz)
+        clamped_rate = max(1, min(MAX_CLIENT_SAMPLE_RATE_HZ, requested_rate))
+        if clamped_rate != requested_rate:
+            LOGGER.warning(
+                "Clamped client sample_rate_hz from %d to %d to bound buffer growth",
+                requested_rate,
+                clamped_rate,
+            )
+        if clamped_rate == buf.sample_rate_hz:
+            return
+        buf.sample_rate_hz = clamped_rate
+        if resize_buffer:
+            self._resize_buffer_unlocked(
+                buf,
+                clamped_rate * self.config.waveform_seconds,
+            )
 
     def copy_latest(self, buf: ClientBuffer, n: int) -> FloatArray:
         if n <= 0 or buf.count == 0:

--- a/apps/server/vibesensor/infra/processing/buffers.py
+++ b/apps/server/vibesensor/infra/processing/buffers.py
@@ -22,6 +22,7 @@ class ClientBuffer:
 
     data: np.ndarray
     capacity: int
+    buffer_epoch: int = 0
     write_idx: int = 0
     count: int = 0
     sample_rate_hz: int = 0

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -167,6 +167,7 @@ class SignalMetricsComputer:
             client_id=snapshot.client_id,
             sample_rate_hz=snapshot.sample_rate_hz,
             ingest_generation=snapshot.ingest_generation,
+            buffer_epoch=snapshot.buffer_epoch,
             metrics=metrics,
             spectrum_by_axis=spectrum_by_axis,
             strength_metrics=strength_metrics_dict,

--- a/apps/server/vibesensor/infra/processing/models.py
+++ b/apps/server/vibesensor/infra/processing/models.py
@@ -75,6 +75,7 @@ class MetricsSnapshot:
     ingest_generation: int
     time_window: FloatArray
     fft_block: FloatArray | None
+    buffer_epoch: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,6 +90,7 @@ class MetricsComputationResult:
     strength_metrics: VibrationStrengthMetrics
     has_fft_data: bool
     duration_s: float
+    buffer_epoch: int = 0
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

Closes #1265.

This PR fixes the two concrete buffer-store defects that are still reproducible on current `main`, while deliberately not broadening into adjacent runtime work that belongs to later backlog items.

When I reconciled the issue body against the live code, several claims turned out to be stale on current `main`: `write_idx` access is already serialized by per-client locks, zero-capacity resize is already guarded by `max(1, ...)`, and the compute cache already invalidates correctly when the stored sample rate changes. The two defects that *did* reproduce were narrower but still important:

First, `SignalBufferStore.snapshot_for_compute()` accepted arbitrary positive `sample_rate_hz` overrides and wrote them directly into `buf.sample_rate_hz`, bypassing the ingest-side clamp to `MAX_CLIENT_SAMPLE_RATE_HZ`. That meant the compute path could end up using unrealistic rates such as `999999`, even though ingest correctly bounded the same field.

Second, compute results were guarded only by `ingest_generation` when written back into shared state. That allowed a stale compute result captured from an old buffer instance to be committed into a newly recreated buffer after `evict_clients()` removed the original one and fresh data arrived for the same client ID. In that situation, the recreated buffer could incorrectly look cache-hot and return a `CachedMetricsHit` backed by metrics from the detached, older buffer.

## Implementation approach

The fix keeps the existing architecture intact and targets the root causes directly.

I did **not** change the overall buffer locking strategy, compute scheduling model, or runtime processing-loop state. Those areas are either already protected, already handled, or belong to follow-up issues. Instead, this PR focuses on buffer identity and sample-rate normalization inside the processing subsystem.

## Main code changes

### 1. Add buffer identity alongside generation counters

The core stale-result bug existed because `ingest_generation` alone is not sufficient to identify *which buffer instance* produced a compute snapshot. A newly recreated buffer starts its own generations again, so generation numbers from a detached buffer can collide semantically with a new live buffer.

To fix that, `ClientBuffer` now carries a `buffer_epoch`, and `SignalBufferStore` now assigns a monotonically increasing epoch each time it creates a fresh per-client buffer in `_get_or_create_unlocked()`.

That epoch is then threaded through the immutable compute pipeline:

- `MetricsSnapshot` now includes `buffer_epoch`
- `MetricsComputationResult` now includes `buffer_epoch`
- `SignalMetricsComputer.compute()` passes the snapshot epoch through unchanged

Finally, `SignalBufferStore.store_metrics_result()` now requires both of the following before committing a result:

- the result epoch matches the current buffer epoch
- the result ingest generation is not older than the last committed compute generation

This preserves the existing “same buffer, newer or equal generation wins” behavior, while rejecting stale results from detached buffer instances after eviction/recreation.

### 2. Share sample-rate normalization between ingest and compute snapshot paths

The sample-rate bug was simpler: ingest already normalized oversized rates, but `snapshot_for_compute()` did not.

This PR extracts the rate normalization logic into `_apply_sample_rate_override_unlocked()`, which:

- coerces the requested rate to `int`
- clamps it to `MAX_CLIENT_SAMPLE_RATE_HZ`
- logs the same warning when clamping happens
- optionally resizes the buffer when the caller is the ingest path

`ingest()` now uses this helper with `resize_buffer=True`, preserving its current behavior.

`snapshot_for_compute()` now uses the same helper with `resize_buffer=False`, so compute-side overrides can no longer write out-of-bounds sample rates into buffer state.

That keeps the semantics consistent without changing the current decision that snapshot-time overrides should update the stored sample rate but not resize the buffer immediately.

## Tests and regression coverage

I added a new focused test module: `apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py`.

It covers the two confirmed current failures directly:

- `test_snapshot_for_compute_clamps_excessive_sample_rate_override()` verifies that compute-side overrides now clamp to `MAX_CLIENT_SAMPLE_RATE_HZ` the same way ingest already does
- `test_stale_result_is_rejected_after_buffer_eviction_and_recreation()` reproduces the old stale-result path by taking a snapshot, computing from it, evicting the client, recreating the buffer with fresh data, and then attempting to store the stale result. The test asserts that the recreated buffer keeps empty metrics, leaves `compute_generation` unset, and returns a fresh `MetricsSnapshot` rather than an incorrect cached hit

I also kept the existing nearby processing tests green so this change remains compatible with the current snapshot/compute contract.

## What this PR intentionally does not change

I intentionally did not fold in broader architectural work from the issue body that is either stale or better handled separately:

- no write-index lock redesign
- no zero-capacity resize change (already guarded)
- no runtime `ProcessingLoopState` synchronization work
- no ring-buffer redesign or memory-pooling refactor
- no async offloading refactor for every NumPy conversion on the UDP path

Those would expand the scope significantly and are not required to fix the two live defects reproduced on current `main`.

## Validation

Local validation completed successfully:

- `pytest -q apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_processing_extended.py`
- `pytest -q apps/server/tests/infra/processing/`
- `make lint`
- `make typecheck-backend`
- `make test-changed`

I also performed runtime validation.

The repository instructions prefer Docker Compose runtime verification, but that was blocked in this environment because the Docker daemon socket was unavailable (`docker.errors.DockerException` while fetching the server API version). Rather than stop at unit tests, I ran the documented native fallback flow instead:

- started `vibesensor-server --reload --config apps/server/config.dev.yaml`
- confirmed `http://127.0.0.1:8000/api/health` returned `200` with `status: ok`
- ran `vibesensor-sim --count 3 --duration 10 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
- confirmed the server saw 3 clients and that `intake_stats.total_ingested_samples` reached `24000`
- polled `/api/health` again after the simulator stopped and verified the ingestion counter stayed flat, confirming the stream went idle cleanly

## Risks and tradeoffs

The main tradeoff here is that the PR narrows the issue to the defects that are demonstrably real today instead of trying to satisfy every statement in the original issue body literally. I think that is the safer and more maintainable choice.

The `buffer_epoch` change is intentionally small and internal to the processing subsystem. It does not alter external HTTP/WebSocket contracts, and it avoids a riskier behavioral change such as refusing all stale same-buffer results. The sample-rate normalization change similarly follows existing ingest behavior rather than inventing a second policy.
