### PR TITLE
Keep processing loop cleanup after compute failures

### DIFF
--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -14,6 +14,7 @@ from vibesensor.infra.runtime.processing_loop import (
     MAX_FATAL_BACKOFF_CYCLES,
     ProcessingHealth,
     ProcessingLoop,
+    ProcessingLoopError,
     ProcessingLoopState,
 )
 
@@ -47,6 +48,8 @@ class _StubProcessor:
         self._fail_count = fail_count
         self._call_count = 0
         self.compute_all_calls = 0
+        self.compute_call_args: list[tuple[list[str], dict[str, int]]] = []
+        self.evict_calls: list[set[str]] = []
 
     def clients_with_recent_data(self, client_ids: list[str], max_age_s: float = 3.0) -> list[str]:
         return list(client_ids)
@@ -58,12 +61,13 @@ class _StubProcessor:
     ) -> dict[str, Any]:
         self._call_count += 1
         self.compute_all_calls += 1
+        self.compute_call_args.append((list(client_ids), dict(sample_rates_hz or {})))
         if self._call_count <= self._fail_count:
             raise RuntimeError("stub compute_all failure")
         return {}
 
     def evict_clients(self, active: set[str]) -> None:
-        pass
+        self.evict_calls.append(set(active))
 
 
 class _StubControlPlane:
@@ -317,3 +321,71 @@ class TestProcessingLoopMismatchDetection:
         await loop._run_tick(sync_clock=False)
 
         assert len(state.frame_size_mismatch_logged) == 0
+
+
+class TestProcessingLoopCleanup:
+    @pytest.mark.asyncio
+    async def test_compute_all_failure_still_evicts_using_fresh_active_ids(self) -> None:
+        class _RefreshingRegistry(_StubRegistry):
+            def __init__(self) -> None:
+                super().__init__(
+                    clients={
+                        "stay": _StubRecord(sample_rate_hz=800, frame_samples=512),
+                        "drop": _StubRecord(sample_rate_hz=800, frame_samples=512),
+                    }
+                )
+                self._active_snapshots = [
+                    ["stay", "drop"],
+                    ["stay"],
+                ]
+
+            def active_client_ids(self) -> list[str]:
+                if self._active_snapshots:
+                    return self._active_snapshots.pop(0)
+                return ["stay"]
+
+        registry = _RefreshingRegistry()
+        processor = _StubProcessor(fail_count=1)
+        loop, _state = _make_loop(processor=processor, registry=registry)
+
+        with pytest.raises(ProcessingLoopError, match="stub compute_all failure") as exc_info:
+            await loop._run_tick(sync_clock=False)
+
+        assert exc_info.value.category == "compute_all"
+        assert processor.compute_call_args == [
+            (
+                ["stay", "drop"],
+                {"stay": 800, "drop": 800},
+            )
+        ]
+        assert processor.evict_calls == [{"stay"}]
+
+    @pytest.mark.asyncio
+    async def test_disappeared_client_is_skipped_before_compute_all(self) -> None:
+        class _DisappearingRegistry(_StubRegistry):
+            def __init__(self) -> None:
+                super().__init__(
+                    clients={
+                        "stay": _StubRecord(sample_rate_hz=800, frame_samples=512),
+                        "gone": _StubRecord(sample_rate_hz=400, frame_samples=256),
+                    }
+                )
+
+            def get(self, client_id: str) -> _StubRecord | None:
+                if client_id == "gone":
+                    return None
+                return super().get(client_id)
+
+        registry = _DisappearingRegistry()
+        processor = _StubProcessor()
+        loop, _state = _make_loop(processor=processor, registry=registry)
+
+        await loop._run_tick(sync_clock=False)
+
+        assert processor.compute_call_args == [
+            (
+                ["stay"],
+                {"stay": 800},
+            )
+        ]
+        assert processor.evict_calls == [{"stay", "gone"}]

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -175,6 +175,7 @@ class ProcessingLoop:
             raise ProcessingLoopError("ingress_state", exc) from exc
 
         sample_rates: dict[str, int] = {}
+        compute_client_ids: list[str] = []
         state = self.state
         for client_id in fresh_ids:
             try:
@@ -183,6 +184,7 @@ class ProcessingLoop:
                 raise ProcessingLoopError("registry_lookup", exc) from exc
             if record is None:
                 continue
+            compute_client_ids.append(client_id)
             sample_rates[client_id] = record.sample_rate_hz
             client_rate = int(record.sample_rate_hz or 0)
             if (
@@ -212,19 +214,30 @@ class ProcessingLoop:
                     self._fft_n,
                 )
 
+        compute_error: Exception | None = None
         try:
             await asyncio.to_thread(
                 self._processor.compute_all,
-                fresh_ids,
+                compute_client_ids,
                 sample_rates_hz=sample_rates,
             )
         except Exception as exc:
-            raise ProcessingLoopError("compute_all", exc) from exc
+            compute_error = exc
 
         try:
-            self._processor.evict_clients(set(active_ids))
+            self._processor.evict_clients(set(self._registry.active_client_ids()))
         except Exception as exc:
+            if compute_error is not None:
+                LOGGER.warning(
+                    "Processing loop cleanup also failed after compute_all failure; "
+                    "reporting compute_all as the primary error.",
+                    exc_info=True,
+                )
+                raise ProcessingLoopError("compute_all", compute_error) from compute_error
             raise ProcessingLoopError("publish_metrics", exc) from exc
+
+        if compute_error is not None:
+            raise ProcessingLoopError("compute_all", compute_error) from compute_error
 
     async def run(self) -> None:
         """~100 ms tick loop: evict stale clients, compute metrics, handle failures."""


### PR DESCRIPTION
## Summary

Closes #1266.

This PR fixes the two concrete processing-loop cleanup bugs that are still reproducible on current `main`, while deliberately not broadening into older or overstated claims from the issue body that no longer match the current implementation.

When I reconciled the issue against the live code, a few things became clear immediately. The current processing loop no longer has the old `IDLE/ACTIVE/ERROR/RECOVERY` state machine described in the issue text; it now tracks `OK`, `DEGRADED`, and `FATAL`. The runtime tests already cover several backoff and recovery paths, so the issue’s “zero test coverage” statement is stale. Likewise, the registry calls in this loop are in-memory `RLock`-guarded reads, not blocking I/O calls, so the broad “blocking registry calls stall the event loop” description does not accurately describe the current code.

The two behaviors that *did* reproduce on current `main` were both in `_run_tick()` cleanup and client selection logic:

1. If `processor.compute_all()` raised, `_run_tick()` raised `ProcessingLoopError("compute_all", ...)` before `processor.evict_clients()` ran at all.
2. If a client disappeared between the earlier `active_client_ids()` snapshot and the later `registry.get(client_id)` call, that missing client still remained in the list passed to `compute_all()`, but with no corresponding `sample_rates_hz` entry.

Those two gaps are small, real, and tightly connected, so this PR fixes them together.

## Problem being solved

The processing loop builds an initial list of active clients, filters it to “fresh” clients, then looks up per-client registry metadata before dispatching compute work. On current `main`, that flow assumed the set of clients stayed stable throughout the tick.

In practice, that assumption is too strong. A client can disappear between the first snapshot and the later metadata lookup. When that happened, the loop silently continued but still forwarded the disappeared client ID into `compute_all()`. That left the processing layer to deal with a client ID that no longer had matching registry metadata.

Separately, `_run_tick()` treated `compute_all()` as if it were the last meaningful operation in the tick. If `compute_all()` failed, buffer eviction never ran. That meant stale processor buffers could survive a failed tick even though the registry-side active-client set may already have changed.

These are correctness and cleanup issues, not architectural “big redesign” problems. The right fix is to make the tick resilient to client-set changes and to guarantee cleanup runs even when compute work fails.

## Implementation approach

I kept the existing processing-loop structure and corrected the failure/cleanup boundaries rather than introducing a new execution model.

The implementation follows two principles:

- only send still-valid clients into `compute_all()`
- always refresh the active-client snapshot for cleanup after the compute phase, even on failure

This keeps the loop behavior understandable and minimizes blast radius.

## Main code changes

### 1. Filter compute inputs to clients that still exist

In `apps/server/vibesensor/infra/runtime/processing_loop.py`, `_run_tick()` previously built `sample_rates` while iterating over `fresh_ids`, but still passed the original `fresh_ids` list to `compute_all()` even when `registry.get(client_id)` returned `None`.

This PR introduces a separate `compute_client_ids` list. A client is added to that list only if its registry snapshot still exists. The loop still gathers sample-rate and frame-size mismatch metadata exactly as before, but now `compute_all()` only receives the subset of clients that still have a current registry record.

That removes the stale/disappeared-client path without changing the general tick structure.

### 2. Always run eviction after the compute phase

The second change restructures the compute/cleanup boundary inside `_run_tick()`.

Instead of raising immediately on `compute_all()` failure, the loop now captures that exception, performs cleanup, and only then re-raises the categorized `ProcessingLoopError("compute_all", ...)`.

Cleanup itself now uses a **fresh** `active_client_ids()` call rather than the pre-compute snapshot captured earlier in the tick. That matters for two reasons:

- stale buffers are still evicted even when `compute_all()` fails
- eviction reflects the current post-compute registry state rather than the older snapshot taken at tick start

If cleanup also fails after a compute failure, the code logs that secondary cleanup problem but keeps the `compute_all` error as the primary reported failure. That keeps the top-level failure categorization stable while still surfacing the cleanup problem in logs.

## Tests

I extended `apps/server/tests/infra/runtime/test_processing_loop.py` with focused regressions that cover the two reproduced behaviors directly.

`test_compute_all_failure_still_evicts_using_fresh_active_ids()` verifies that:

- `compute_all()` can fail
- the loop still calls `evict_clients()`
- eviction uses a refreshed active-client snapshot rather than the older pre-compute list
- the raised error is still categorized as `compute_all`

`test_disappeared_client_is_skipped_before_compute_all()` verifies that when a client vanishes before registry metadata lookup, only the remaining valid clients are passed into `compute_all()`, along with the matching sample-rate metadata.

I kept the existing processing-loop backoff and mismatch tests green, which gives confidence that this change is a cleanup correction rather than a behavioral rewrite.

## What this PR intentionally does not change

This PR intentionally does **not** try to solve every statement in the issue body literally, because several of those statements no longer describe the current codebase.

In particular, this PR does not:

- add a new state-machine abstraction
- redesign registry locking
- add throughput metrics to `/api/health`
- retune backoff timing
- add a new disconnect subsystem
- change health snapshot assembly

Those would be materially larger changes, and they are not necessary to fix the two real current behaviors reproduced on `main`.

## Validation

Local validation completed successfully:

- `pytest -q apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/use_cases/test_system_health.py`
- `pytest -q apps/server/tests/infra/runtime/`
- `make lint`
- `make typecheck-backend`
- `make test-changed`

I also ran runtime validation.

As with the previous issue, the repository instructions prefer Docker Compose runtime verification, but that remains blocked in this environment because the Docker daemon socket is unavailable. Rather than stop at unit tests, I used the documented native runtime path:

- started `vibesensor-server --reload --config apps/server/config.dev.yaml`
- confirmed `/api/health` returned `status: ok`, `processing_state: ok`, and `processing_failures: 0`
- ran `vibesensor-sim --count 3 --duration 10 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
- confirmed the server saw 3 clients
- confirmed `total_ingested_samples` reached `24000`
- polled `/api/health` again after the simulator stopped and verified the ingestion counter stayed flat, confirming the stream went idle cleanly and the loop remained healthy

## Risks and tradeoffs

The main tradeoff is scope: I intentionally narrowed the issue to the runtime cleanup bugs that are actually live on current `main` instead of chasing stale issue text. I think that is the right engineering tradeoff here.

The code path still reports `compute_all` as the primary failure even if cleanup also fails afterward. That is deliberate: the compute failure is what triggered the degraded tick, and preserving that category avoids obscuring the original problem while still logging the cleanup failure for diagnosis.

Overall, this PR makes the tick loop more resilient to concurrent client-set changes and failed compute passes without rewriting the loop or changing its external contracts.
