### PR TITLE
Fix WebSocket selection race during broadcast

### DIFF
--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -182,6 +182,98 @@ async def test_payload_error_does_not_block_other_clients() -> None:
 
 
 @pytest.mark.asyncio
+async def test_broadcast_uses_latest_selection_when_selection_changes_during_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub = WebSocketHub()
+    ws = _make_ws()
+    await hub.add(ws, "client_a")
+    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
+    selection_swapped = False
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        nonlocal selection_swapped
+        if not selection_swapped:
+            selection_swapped = True
+            await hub.update_selected_client(ws, "client_b")
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+
+    await hub.broadcast(payload_builder)
+
+    assert _sent_json(ws) == {"selected": "client_b"}
+    assert [call.args[0] for call in payload_builder.call_args_list] == [
+        "client_a",
+        "client_b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_reuses_lazy_payload_for_connections_converging_on_same_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub = WebSocketHub()
+    ws1 = _make_ws()
+    ws2 = _make_ws()
+    await hub.add(ws1, "client_a")
+    await hub.add(ws2, "client_c")
+    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
+    selection_swapped = False
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        nonlocal selection_swapped
+        if not selection_swapped:
+            selection_swapped = True
+            await hub.update_selected_client(ws1, "client_b")
+            await hub.update_selected_client(ws2, "client_b")
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+
+    await hub.broadcast(payload_builder)
+
+    assert _sent_json(ws1) == {"selected": "client_b"}
+    assert _sent_json(ws2) == {"selected": "client_b"}
+    assert [call.args[0] for call in payload_builder.call_args_list] == [
+        "client_a",
+        "client_c",
+        "client_b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_payload_error_affected_count_uses_updated_selection(
+    caplog,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hub = WebSocketHub()
+    ws = _make_ws()
+    await hub.add(ws, "client_a")
+    selection_swapped = False
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        nonlocal selection_swapped
+        if not selection_swapped:
+            selection_swapped = True
+            await hub.update_selected_client(ws, "client_b")
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+
+    def selective_builder(client_id):
+        if client_id == "client_b":
+            raise RuntimeError("cannot build for client_b")
+        return {"selected": client_id}
+
+    with caplog.at_level(logging.ERROR, logger="vibesensor.adapters.websocket.hub"):
+        await hub.broadcast(selective_builder)
+
+    assert _sent_json(ws) == {"error": "payload_build_failed"}
+    assert any("1 connection(s)" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_payload_error_logged_at_error_level(caplog) -> None:
     """Payload build failures must be logged at ERROR level with client id."""
     hub = WebSocketHub()

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -136,6 +136,17 @@ class WebSocketHub:
                 and current.connection_id == conn.connection_id,
             )
 
+    async def _current_selected_client_id(
+        self,
+        conn: _WSConnectionSnapshot,
+    ) -> tuple[bool, str | None]:
+        """Return the live selected client for *conn* when the connection is still current."""
+        async with self._lock:
+            current = self._connections.get(id(conn.websocket))
+            if current is None or current.closing or current.connection_id != conn.connection_id:
+                return False, None
+            return True, current.selected_client_id
+
     async def _mark_snapshot_closing(self, conn: _WSConnectionSnapshot) -> bool:
         """Mark *conn* as closing if it is still the active registered connection."""
         async with self._lock:
@@ -233,10 +244,73 @@ class WebSocketHub:
             )
             return selected_client_id, _ERROR_PAYLOAD, True, None
 
+    async def _build_payload_text(
+        self,
+        selected_client_id: str | None,
+        payload_builder: Callable[[str | None], LiveWsPayload],
+        payload_cache: dict[str | None, str],
+        failed_client_ids: set[str | None],
+        debug_info: dict[str | None, bool] | None,
+    ) -> str:
+        """Build and serialize payload text for *selected_client_id* once for the tick."""
+        raw_payload = self._build_raw_payload(
+            selected_client_id,
+            payload_builder,
+            failed_client_ids,
+        )
+        if raw_payload is None:
+            payload_cache[selected_client_id] = _ERROR_PAYLOAD
+            return _ERROR_PAYLOAD
+        _selected_client_id, text, failed, has_freq = await asyncio.to_thread(
+            self._serialize_payload,
+            selected_client_id,
+            raw_payload,
+            capture_debug=debug_info is not None,
+        )
+        payload_cache[selected_client_id] = text
+        if failed:
+            failed_client_ids.add(selected_client_id)
+        if debug_info is not None and has_freq is not None:
+            debug_info[selected_client_id] = has_freq
+        return text
+
+    async def _get_or_build_payload_text(
+        self,
+        selected_client_id: str | None,
+        payload_builder: Callable[[str | None], LiveWsPayload],
+        payload_cache: dict[str | None, str],
+        pending_payload_tasks: dict[str | None, asyncio.Task[str]],
+        failed_client_ids: set[str | None],
+        debug_info: dict[str | None, bool] | None,
+    ) -> str:
+        """Return cached payload text or build it once for the current tick."""
+        cached = payload_cache.get(selected_client_id)
+        if cached is not None:
+            return cached
+        task = pending_payload_tasks.get(selected_client_id)
+        if task is None:
+            task = asyncio.create_task(
+                self._build_payload_text(
+                    selected_client_id,
+                    payload_builder,
+                    payload_cache,
+                    failed_client_ids,
+                    debug_info,
+                )
+            )
+            pending_payload_tasks[selected_client_id] = task
+        try:
+            return await task
+        finally:
+            if pending_payload_tasks.get(selected_client_id) is task and task.done():
+                pending_payload_tasks.pop(selected_client_id, None)
+
     async def _send_conn(
         self,
         conn: _WSConnectionSnapshot,
         payload_text: str,
+        *,
+        selected_client_id: str | None,
     ) -> _WSConnectionSnapshot | None:
         """Send the appropriate payload to *conn*, return the WebSocket on failure."""
         if not await self._is_snapshot_current(conn):
@@ -254,12 +328,54 @@ class WebSocketHub:
                 LOGGER.warning(
                     "WebSocket broadcast send failed (selected_client=%r); "
                     "connection will be removed.",
-                    conn.selected_client_id,
+                    selected_client_id,
                     exc_info=True,
                 )
             if await self._mark_snapshot_closing(conn):
                 return conn
             return None
+
+    async def _send_current_conn(
+        self,
+        conn: _WSConnectionSnapshot,
+        payload_builder: Callable[[str | None], LiveWsPayload],
+        payload_cache: dict[str | None, str],
+        pending_payload_tasks: dict[str | None, asyncio.Task[str]],
+        failed_client_ids: set[str | None],
+        sent_selected_client_ids: dict[int, str | None],
+        debug_info: dict[str | None, bool] | None,
+    ) -> _WSConnectionSnapshot | None:
+        """Send a payload built for the connection's current selection."""
+        is_current, selected_client_id = await self._current_selected_client_id(conn)
+        if not is_current:
+            return None
+        payload_text = await self._get_or_build_payload_text(
+            selected_client_id,
+            payload_builder,
+            payload_cache,
+            pending_payload_tasks,
+            failed_client_ids,
+            debug_info,
+        )
+        still_current, latest_selected_client_id = await self._current_selected_client_id(conn)
+        if not still_current:
+            return None
+        if latest_selected_client_id != selected_client_id:
+            selected_client_id = latest_selected_client_id
+            payload_text = await self._get_or_build_payload_text(
+                selected_client_id,
+                payload_builder,
+                payload_cache,
+                pending_payload_tasks,
+                failed_client_ids,
+                debug_info,
+            )
+        sent_selected_client_ids[conn.connection_id] = selected_client_id
+        return await self._send_conn(
+            conn,
+            payload_text,
+            selected_client_id=selected_client_id,
+        )
 
     async def broadcast(
         self,
@@ -268,14 +384,16 @@ class WebSocketHub:
         """Broadcast a live metric payload to all connected WebSocket clients.
 
         Calls *payload_builder* at most once per unique ``selected_client_id``
-        across all connections (results are cached per tick).  Connections that
+        observed during the tick (results are cached per tick). Connections that
         fail or time out during send are removed from the hub automatically.
         """
         conns = await self._snapshot()
         if not conns:
             return
         payload_cache: dict[str | None, str] = {}
+        pending_payload_tasks: dict[str | None, asyncio.Task[str]] = {}
         failed_client_ids: set[str | None] = set()
+        sent_selected_client_ids: dict[int, str | None] = {}
         # Collect debug inspection data during build (avoids redundant json.loads later).
         debug_info: dict[str | None, bool] | None = {} if _ws_debug_enabled() else None
         unique_selected_ids = list(dict.fromkeys(conn.selected_client_id for conn in conns))
@@ -313,9 +431,14 @@ class WebSocketHub:
 
         dead_ws = await asyncio.gather(
             *(
-                self._send_conn(
+                self._send_current_conn(
                     conn,
-                    payload_cache[conn.selected_client_id],
+                    payload_builder,
+                    payload_cache,
+                    pending_payload_tasks,
+                    failed_client_ids,
+                    sent_selected_client_ids,
+                    debug_info,
                 )
                 for conn in conns
             ),
@@ -327,7 +450,11 @@ class WebSocketHub:
                 await self._remove_snapshot(conn)
         if failed_client_ids:
             # Count how many connections were affected by build failures.
-            affected = sum(1 for c in conns if c.selected_client_id in failed_client_ids)
+            affected = sum(
+                1
+                for selected_client_id in sent_selected_client_ids.values()
+                if selected_client_id in failed_client_ids
+            )
             LOGGER.error(
                 "Payload build failed for %d client id(s) (%s); "
                 "%d connection(s) received error payloads.",


### PR DESCRIPTION
## Summary

Closes #1267.

This PR fixes the real current defect behind the WebSocket broadcast issue on `main`: a client that changed its selected sensor after the hub snapshotted active connections for a broadcast tick could still receive a payload built for the stale snapshot selection during that tick. After reconciling the issue against the current codebase, the live bug surface proved narrower than the issue body and centered on the send-time selection race inside `WebSocketHub.broadcast()`.

The fix keeps the current per-selection broadcast optimization, but moves the connection-specific decision to the point where the payload is actually sent. Instead of always using the `selected_client_id` captured in the initial connection snapshot, the hub now resolves each connection’s current selected client immediately before send, lazily builds and caches any newly needed payload text once per unique updated selection within the tick, and rechecks the selection one more time before the final send so a mid-build selection change does not fall back to the stale snapshot payload. The result is that the connection sees a payload consistent with its latest selection state for the current broadcast tick without regressing the per-selection cache behavior.

## Problem being solved

Before this change, `WebSocketHub.broadcast()` took a snapshot of active connections, built payloads once per unique `selected_client_id` seen in that snapshot, serialized them, and then sent `payload_cache[conn.selected_client_id]` for each snapshotted connection. That structure was efficient, but it assumed the selection state recorded in the snapshot remained valid through the full build and send phase.

That assumption is not always true. Selection changes arrive through the WebSocket endpoint itself via `update_selected_client()`, and those updates can happen after the broadcast snapshot is taken but before the connection is actually sent its payload. The hub already protected against stale connection identity by checking `connection_id` before send, but it did not protect against stale selection state. In practice that meant a client could switch to a new selected sensor and still receive one broadcast tick for the old selection.

While investigating, I also verified that several claims in the original issue body do not describe current `main` behavior. `WsBroadcastService` does not cache `selected_client_id` in its shared payload; it overlays that value per `build_payload()` call, so selection changes do not require shared-payload cache invalidation there. GPS speed is resolved fresh on each shared payload build, the realtime sensor table uses a single `innerHTML` assignment, the current `spectrum_animation.ts` path does not use the claimed hot-loop `Float64Array` allocations, and existing WebSocket tests already covered send-failure cleanup. That let this PR stay tightly scoped to the confirmed backend race instead of broadening into speculative cleanup.

## Implementation approach

In `apps/server/vibesensor/adapters/websocket/hub.py`, the hub now has a small helper to read the current selected client for a snapshotted connection while still verifying that the same live connection is registered. Broadcast still performs the same initial snapshot and still prebuilds payloads for the unique selections present in that snapshot. The important change is what happens during send.

A new lazy payload-resolution path now handles any selection changes that happened after the snapshot. If the current selected client for a connection is not already present in the per-tick payload cache, the hub builds and serializes that payload on demand. That lazy path is itself cached: multiple connections converging on the same new selection during the same tick share a single payload build rather than triggering duplicate work. This preserves the original optimization goal of building once per unique selection observed during the tick, even when the set of selections shifts after the initial snapshot.

The send path also performs one more selection recheck before the final `send_text()` call. That keeps the fix targeted at the real race window that triggered this issue: selection may change while payload text is being prepared, so the hub needs to confirm that it is still about to send the correct selection-specific payload. If the selection changed again, the hub resolves the updated payload from the same cache-aware lazy path before sending.

I also tightened the error summary accounting so payload-build failures are counted against the selection that was actually used at send time rather than only the selection from the original snapshot. That keeps failure logs accurate even if a lazy build fails for a selection that only appeared after the snapshot.

## Tests and validation

The main regression coverage lives in `apps/server/tests/adapters/websocket/test_ws_hub.py`.

The first new test proves the real bug: if a connection changes selection during the serialization phase of a broadcast tick, the hub now sends the payload for the updated selection instead of the stale snapshot selection.

The second new test verifies that when multiple connections converge on the same updated selection mid-tick, the hub only performs one lazy payload build for that new selection.

The third new test covers the coupled logging path and verifies that payload-build failure accounting still reports the correct affected connection count when the failure happens on an updated selection rather than the snapshot selection.

In addition to those focused regressions, I ran:

- `pytest -q apps/server/tests/adapters/websocket/test_ws_hub.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py`
- `pytest -q apps/server/tests/adapters/websocket/ apps/server/tests/adapters/http/test_api_ws_health_and_clients.py`
- `make lint`
- `make typecheck-backend`
- `make test-changed`

Because Docker is still unavailable in this environment, I could not use the repository’s preferred Compose-based runtime validation. I confirmed the same external blocker as earlier in the run: `docker compose` fails while fetching the Docker server API version because the daemon socket is unavailable. To avoid skipping runtime coverage, I used the same native fallback validation pattern that already worked for earlier issues in this run. I started `vibesensor-server --reload --config apps/server/config.dev.yaml`, streamed three simulated clients with `vibesensor-sim`, connected a live WebSocket client, changed `selected_client_id` over the socket, and verified that the stream reflected the new selection. After the simulator stopped, `/api/health` remained `ok`, `processing_failures` stayed at `0`, and `total_ingested_samples` settled at `24000` without continuing to increase.

## Risks, tradeoffs, and follow-ups

The biggest tradeoff here is that the hub now does a little more coordination during send to favor correctness when selection changes race with broadcast. That added logic stays local to the hub and still caches payload text per unique selection, so the fix does not introduce a second transport path or abandon the existing optimization model.

I did not broaden this PR into frontend animation, table rendering, or WebSocket schema work because those claims were not the live current bug behind the issue after code reconciliation. If later work finds new measurable frontend bottlenecks or a separate contract mismatch, that should land as its own focused change set rather than being mixed into this concurrency fix.
