### PR TITLE
Fix exception masking in UDP and updater cleanup

### DIFF
--- a/apps/server/tests/adapters/http/test_request_observability.py
+++ b/apps/server/tests/adapters/http/test_request_observability.py
@@ -4,8 +4,9 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 from vibesensor.adapters.http.middleware import install_request_logging_middleware
 from vibesensor.adapters.http.settings import create_settings_routes
@@ -80,3 +81,52 @@ def test_unhandled_errors_still_echo_request_id(caplog: pytest.LogCaptureFixture
     assert response.headers[REQUEST_ID_HEADER] == "failing-request"
     failure_log = next(rec for rec in caplog.records if rec.message == "http_request_failed")
     assert failure_log.request_id == "failing-request"
+
+
+def test_http_exception_keeps_status_code_and_request_id(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+
+    @app.get("/teapot")
+    async def teapot() -> None:
+        raise HTTPException(status_code=418, detail="teapot")
+
+    with caplog.at_level(logging.INFO):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/teapot", headers={REQUEST_ID_HEADER: "teapot-request"})
+
+    assert response.status_code == 418
+    assert response.headers[REQUEST_ID_HEADER] == "teapot-request"
+    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    assert request_log.request_id == "teapot-request"
+    assert request_log.status_code == 418
+    assert all(rec.message != "http_request_failed" for rec in caplog.records)
+
+
+def test_request_validation_error_keeps_status_code_and_request_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+
+    class Payload(BaseModel):
+        value: int
+
+    @app.post("/items")
+    async def create_item(payload: Payload) -> dict[str, int]:
+        return {"value": payload.value}
+
+    with caplog.at_level(logging.INFO):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.post(
+                "/items",
+                json={"value": "bad"},
+                headers={REQUEST_ID_HEADER: "validation-request"},
+            )
+
+    assert response.status_code == 422
+    assert response.headers[REQUEST_ID_HEADER] == "validation-request"
+    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    assert request_log.request_id == "validation-request"
+    assert request_log.status_code == 422
+    assert all(rec.message != "http_request_failed" for rec in caplog.records)

--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -59,10 +59,9 @@ def test_send_identify_accepts_hex_and_mac_client_ids(
     assert cmd.client_id.hex() == client_hex
 
 
-def test_control_datagram_unexpected_exception_is_logged_and_counted(
+def test_control_datagram_programming_bug_propagates(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     client_hex = "aabbccddeeff"
     registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
@@ -73,6 +72,38 @@ def test_control_datagram_unexpected_exception_is_logged_and_counted(
         raise RuntimeError("boom")
 
     monkeypatch.setattr("vibesensor.adapters.udp.udp_control_tx.parse_ack", boom)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        protocol.datagram_received(packet, ("127.0.0.1", 9001))
+
+    assert registry.get(client_hex) is None
+
+
+def test_control_datagram_operational_error_is_logged_and_counted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client_hex = "aabbccddeeff"
+    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry.update_from_hello(
+        HelloMessage(
+            client_id=bytes.fromhex(client_hex),
+            control_port=9010,
+            sample_rate_hz=800,
+            name="node",
+            firmware_version="fw",
+        ),
+        ("127.0.0.1", 54000),
+        now=1.0,
+    )
+    protocol = ControlDatagramProtocol(registry)
+    packet = pack_ack(bytes.fromhex(client_hex), cmd_seq=7, status=0)
+
+    def raise_oserror(ack, now_ts):
+        raise OSError("socket boom")
+
+    monkeypatch.setattr(registry, "update_from_ack", raise_oserror)
 
     with caplog.at_level(logging.WARNING):
         protocol.datagram_received(packet, ("127.0.0.1", 9001))

--- a/apps/server/tests/adapters/udp/test_udp_data_rx.py
+++ b/apps/server/tests/adapters/udp/test_udp_data_rx.py
@@ -152,15 +152,11 @@ async def test_process_datagram_logs_client_id_on_error(fake_transport, drain_qu
 
 
 @pytest.mark.asyncio
-async def test_process_queue_survives_unexpected_exception_and_keeps_consuming(
+async def test_process_queue_propagates_unexpected_exception(
     fake_transport,
 ) -> None:
     registry = Mock()
-    registry.update_from_data.side_effect = [
-        RuntimeError("boom"),
-        DataUpdateResult(),
-    ]
-    registry.get.return_value = SimpleNamespace(sample_rate_hz=800)
+    registry.update_from_data.side_effect = RuntimeError("boom")
     processor = Mock()
     proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
     proto.connection_made(fake_transport)
@@ -169,17 +165,11 @@ async def test_process_queue_survives_unexpected_exception_and_keeps_consuming(
     pkt = pack_data(cid, seq=1, t0_us=100, samples=np.zeros((4, 3), dtype=np.int16))
 
     proto.datagram_received(pkt, ("127.0.0.1", 12345))
-    proto.datagram_received(pkt, ("127.0.0.1", 12345))
 
     consumer = asyncio.create_task(proto.process_queue())
-    await asyncio.wait_for(proto._queue.join(), timeout=1.0)
-    await asyncio.sleep(0)
-
-    assert processor.ingest.call_count == 1
-    assert not consumer.done()
-
-    consumer.cancel()
-    await asyncio.gather(consumer, return_exceptions=True)
+    with pytest.raises(RuntimeError, match="boom"):
+        await asyncio.wait_for(consumer, timeout=1.0)
+    assert processor.ingest.call_count == 0
 
 
 def test_process_datagram_parse_error_marks_registry_and_skips_ack(fake_transport) -> None:
@@ -193,6 +183,26 @@ def test_process_datagram_parse_error_marks_registry_and_skips_ack(fake_transpor
     registry.note_parse_error.assert_called_once()
     registry.update_from_data.assert_not_called()
     assert fake_transport.sent == []
+
+
+def test_process_datagram_parse_bug_propagates(
+    fake_transport,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = Mock()
+    processor = Mock()
+    proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
+    proto.connection_made(fake_transport)
+
+    def raise_runtime_error(_data: bytes):
+        raise RuntimeError("parse bug")
+
+    monkeypatch.setattr("vibesensor.adapters.udp.udp_data_rx.parse_data", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="parse bug"):
+        proto._process_datagram(b"\x02\x01", ("127.0.0.1", 12345))
+
+    registry.note_parse_error.assert_not_called()
 
 
 def test_process_datagram_reset_detected_flushes_buffer_before_ingest(fake_transport) -> None:

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -342,6 +342,73 @@ class TestUpdateManagerAsync:
             for issue in manager.status.issues
         )
 
+    async def test_cleanup_re_raises_runtime_details_bug_after_finishing_cleanup(
+        self,
+        tmp_path,
+    ) -> None:
+        manager, _runner, _ = setup_update_env(tmp_path)
+        manager.status.state = UpdateState.running
+        manager.status.phase = UpdatePhase.installing
+
+        with patch(
+            "vibesensor.use_cases.updates.manager.collect_runtime_details",
+            side_effect=TypeError("runtime bug"),
+        ):
+            with pytest.raises(TypeError, match="runtime bug"):
+                await manager._cleanup_after_update()
+
+        assert manager.status.finished_at is not None
+        assert manager.status.state == UpdateState.failed
+
+    async def test_cleanup_re_raises_wifi_diagnostics_bug_after_finishing_cleanup(
+        self,
+        tmp_path,
+    ) -> None:
+        manager, _runner, _ = setup_update_env(tmp_path)
+        manager.status.state = UpdateState.running
+        manager.status.phase = UpdatePhase.installing
+
+        with patch(
+            "vibesensor.use_cases.updates.manager.parse_wifi_diagnostics",
+            side_effect=TypeError("diagnostics bug"),
+        ):
+            with pytest.raises(TypeError, match="diagnostics bug"):
+                await manager._cleanup_after_update()
+
+        assert manager.status.finished_at is not None
+        assert manager.status.state == UpdateState.failed
+
+    async def test_run_update_preserves_cancelled_error_when_cleanup_bug_occurs(
+        self,
+        tmp_path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        manager, _runner, _ = setup_update_env(tmp_path)
+
+        with (
+            patch.object(
+                manager,
+                "_run_update_inner",
+                AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+            patch(
+                "vibesensor.use_cases.updates.manager.collect_runtime_details",
+                side_effect=TypeError("runtime bug"),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            manager.start("TestNet", "pass123")
+            assert manager.job_task is not None
+            with pytest.raises(asyncio.CancelledError):
+                await manager.job_task
+
+        assert manager.status.finished_at is not None
+        assert manager.status.state == UpdateState.failed
+        assert any(
+            rec.message == "Update cleanup interrupted during cancellation"
+            for rec in caplog.records
+        )
+
     async def test_check_update_failure_fails_update(self, tmp_path) -> None:
         manager, _runner, _ = setup_update_env(tmp_path)
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:

--- a/apps/server/vibesensor/adapters/udp/udp_control_tx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_control_tx.py
@@ -71,7 +71,7 @@ class ControlDatagramProtocol(asyncio.DatagramProtocol):
             client_id = extract_client_id_hex(data)
             LOGGER.debug("Control parse error from %s (client=%s): %s", addr, client_id, exc)
             registry.note_parse_error(client_id)
-        except Exception:
+        except (ValueError, KeyError, OSError):
             client_id = extract_client_id_hex(data)
             LOGGER.warning(
                 "Unexpected error processing control datagram from %s (client=%s); "

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -14,6 +14,7 @@ from typing import cast
 
 from vibesensor.adapters.udp.protocol import (
     MSG_DATA,
+    ProtocolError,
     extract_client_id_hex,
     pack_data_ack,
     parse_data,
@@ -92,20 +93,13 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
             data, addr = await self._queue.get()
             try:
                 self._process_datagram(data, addr)
-            except Exception:
-                LOGGER.warning(
-                    "Unexpected error processing UDP datagram from %s; "
-                    "dropping packet to keep consumer alive.",
-                    addr,
-                    exc_info=True,
-                )
             finally:
                 self._queue.task_done()
 
     def _process_datagram(self, data: bytes, addr: tuple[str, int]) -> None:
         try:
             msg = parse_data(data)
-        except Exception as exc:
+        except ProtocolError as exc:
             client_id = extract_client_id_hex(data)
             LOGGER.debug("DATA parse error from %s (client=%s): %s", addr, client_id, exc)
             self.registry.note_parse_error(client_id)

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -171,6 +171,7 @@ class UpdateManager:
         request_or_ssid: UpdateRequest | str,
         password: str | None = None,
     ) -> None:
+        cancelled = False
         try:
             await asyncio.wait_for(
                 self._run_update_inner(request_or_ssid, password),
@@ -181,6 +182,7 @@ class UpdateManager:
                 self._tracker.fail("timeout", f"Update timed out after {UPDATE_TIMEOUT_S}s")
                 self._tracker.log(f"Update timed out after {UPDATE_TIMEOUT_S}s")
         except asyncio.CancelledError:
+            cancelled = True
             if hasattr(self, "_tracker"):
                 self._tracker.fail("cancelled", "Update was cancelled")
                 self._tracker.log("Update cancelled")
@@ -190,7 +192,15 @@ class UpdateManager:
                 self._tracker.fail("unexpected", f"Unexpected error: {exc}")
             LOGGER.exception("update: unexpected error")
         finally:
-            await self._cleanup_after_update()
+            if cancelled:
+                try:
+                    await self._cleanup_after_update()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    LOGGER.warning("Update cleanup interrupted during cancellation", exc_info=True)
+            else:
+                await self._cleanup_after_update()
 
     async def _run_update_inner(
         self,
@@ -361,16 +371,10 @@ class UpdateManager:
                     )
                     LOGGER.warning("Cleanup hotspot restore failed", exc_info=True)
             tracker.clear_secrets()
-            try:
-                tracker.set_runtime(await asyncio.to_thread(collect_runtime_details, self._repo))
-                self._status = tracker.status
-            except Exception:
-                LOGGER.warning("Failed to collect runtime details", exc_info=True)
-            try:
-                diag_issues = await asyncio.to_thread(parse_wifi_diagnostics)
-                tracker.extend_issues(diag_issues)
-            except Exception:
-                LOGGER.debug("Failed to parse Wi-Fi diagnostics", exc_info=True)
+            tracker.set_runtime(await asyncio.to_thread(collect_runtime_details, self._repo))
+            self._status = tracker.status
+            diag_issues = await asyncio.to_thread(parse_wifi_diagnostics)
+            tracker.extend_issues(diag_issues)
             tracker.finish_cleanup()
             self._status = tracker.status
         except Exception:
@@ -378,6 +382,7 @@ class UpdateManager:
             tracker.finish_cleanup()
             self._status = tracker.status
             LOGGER.warning("Update cleanup interrupted", exc_info=True)
+            raise
 
     def _build_command_executor(self) -> UpdateCommandExecutor:
         return UpdateCommandExecutor(runner=self._runner, tracker=self._tracker)


### PR DESCRIPTION
## Summary

This PR fixes the live exception-discipline problems behind issue `#1268` without expanding into stale parts of the original issue body that no longer reproduce on current `main`.

I started by reconciling the issue description against the code that is actually shipping today. That changed the scope materially. The broad claims about literal bare `except:` blocks, HTTP middleware flattening handled `HTTPException` responses into `500`s, missing persistence retries, and settings rollback behavior were not live defects on refreshed `main`. The real remaining gaps were narrower and concentrated in three areas: the UDP data ingest path still swallowed unexpected bugs as recoverable packet drops, the UDP control datagram path still converted all unexpected processing failures into warning-only control errors, and updater cleanup still swallowed unexpected runtime-detail and Wi-Fi diagnostics failures after logging them. The fix in this PR targets those real behaviors directly, and the tests explicitly document the already-correct HTTP middleware behavior so the issue does not regress back into folklore later.

## Problem

The common failure mode across the affected code paths was that programmer errors and contract bugs were being treated as operational noise. In the UDP ingest loop, a broad `except Exception` in the queue consumer meant a real bug in datagram processing could be downgraded into “drop packet and keep going”, which hides defects and turns them into silent data loss. In the UDP control path, a similarly broad catch could turn unexpected registry or ack-processing bugs into warning logs and parse-error accounting instead of surfacing them for the runtime supervisor. In the updater, `_cleanup_after_update()` finished cleanup bookkeeping but swallowed unexpected failures from runtime detail collection and Wi-Fi diagnostics parsing, which made real cleanup bugs look like successful finalization.

That behavior makes the system look more resilient than it really is. The runtime stays alive, but important failures lose their original exception context and are much harder to diagnose.

## Implementation approach

The guiding principle here was to keep catching true operational and protocol failures, but stop converting programming bugs into success-shaped or warning-only outcomes.

In `apps/server/vibesensor/adapters/udp/udp_data_rx.py`, I removed the broad queue-consumer catch around `_process_datagram()`. Unexpected exceptions now propagate out of the consumer task instead of being logged as packet drops. That matches the runtime supervision model already used elsewhere: if the consumer has a real bug, the background-task failure should be visible rather than silently discarded. I also narrowed the datagram parse handler to `ProtocolError`, which is the expected failure contract for malformed data packets. Invalid payloads are still counted as parse errors and skipped, but unrelated bugs from deeper code no longer get misclassified as bad client input.

In `apps/server/vibesensor/adapters/udp/udp_control_tx.py`, I narrowed the control datagram catch path so only expected operational failures (`ValueError`, `KeyError`, and `OSError`) are converted into warning logs and parse-error accounting. That preserves the existing behavior for malformed or operationally bad control traffic, while letting true implementation bugs propagate instead of being mislabeled as another control warning.

In `apps/server/vibesensor/use_cases/updates/manager.py`, I changed cleanup so unexpected failures from `collect_runtime_details()` and `parse_wifi_diagnostics()` are no longer swallowed. Cleanup still finishes state bookkeeping, clears secrets, and marks the job finished, but unexpected cleanup bugs are re-raised so they are visible to the caller. During review, I found a subtle interaction bug in that change: if `_run_update()` was already propagating `CancelledError`, a cleanup exception could mask the cancellation in the `finally` block. I fixed that by preserving cancellation semantics in `_run_update()` and only suppressing cleanup exceptions in the specific case where they would otherwise replace an in-flight cancellation. Non-cancelled flows still surface cleanup bugs.

## Tests and validation

The test updates are intentionally split by behavior.

`apps/server/tests/adapters/udp/test_udp_data_rx.py` now checks that unexpected queue-consumer failures propagate instead of being silently dropped, while malformed protocol input still goes through the parse-error path. It also adds a regression proving that a parse bug from `parse_data()` is not misreported as a client parse error.

`apps/server/tests/adapters/udp/test_udp_control_tx.py` now distinguishes between operational control-plane failures and programming bugs. A real implementation bug in ack parsing now propagates, while expected operational failures in registry update handling are still logged and counted.

`apps/server/tests/use_cases/updates/test_update_manager_async.py` adds direct cleanup regressions for runtime-details and Wi-Fi-diagnostics failures, plus a task-lifecycle regression showing that cleanup bugs no longer mask `CancelledError` from `_run_update()`.

`apps/server/tests/adapters/http/test_request_observability.py` adds two regression tests that prove current middleware behavior for handled `HTTPException` and request validation failures is already correct: the original status code and request ID are preserved, and the middleware does not emit the unhandled-error log path. I kept these tests because the issue body claimed the opposite, and the repo benefits from locking in the behavior that already works.

Local validation for this PR included:

- focused issue tests for UDP, HTTP request observability, and update-manager cleanup
- broader UDP and updater pytest suites
- `make lint`
- `make typecheck-backend`
- `make test-changed`
- a native `vibesensor-server` + `vibesensor-sim` smoke run against `apps/server/config.dev.yaml`

The native smoke stayed healthy throughout: `/api/health` remained `ok`, `processing_failures` stayed at `0`, sample ingestion increased during simulator traffic, and intake counters settled after the simulator stopped.

## Risk, tradeoffs, and scope boundaries

The main intentional behavior change is that unexpected bugs in UDP handling are no longer treated as recoverable packet noise. That is stricter, but it is the right failure mode: these tasks are already supervised, and surfacing a real background-task failure is safer than silently continuing in a corrupted state. The control datagram path still catches expected operational issues, so this does not turn malformed network input into crashes.

For the updater, there is a tradeoff between “always finish cleanup” and “never hide cleanup bugs.” This change keeps the cleanup finalization path intact while surfacing unexpected cleanup failures, with a specific guard so task cancellation semantics remain correct. That gives us both better diagnosability and correct async behavior.

There are no schema, config, or documentation changes in this PR because the live fix did not require any contract or user-facing documentation updates. The broader parts of the original issue body that are already fixed or not applicable on current `main` were intentionally left untouched rather than force-fitting unrelated code churn into this issue.

Closes #1268.
