### PR TITLE
Harden history DB backup cleanup and indexes

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import vibesensor.adapters.persistence.history_db as history_db_module
+from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db._schema import SCHEMA_VERSION
+
+
+def _query_plan_details(db_path: Path, sql: str) -> list[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return [str(row[3]) for row in conn.execute(f"EXPLAIN QUERY PLAN {sql}")]
+    finally:
+        conn.close()
+
+
+def test_history_db_status_created_at_queries_use_composite_index(tmp_path: Path) -> None:
+    db_path = tmp_path / "history.db"
+    db = HistoryDB(db_path)
+    db.close()
+
+    latest_recording_plan = _query_plan_details(
+        db_path,
+        "SELECT run_id FROM runs WHERE status = 'recording' ORDER BY created_at DESC LIMIT 1",
+    )
+    analyzing_runs_plan = _query_plan_details(
+        db_path,
+        "SELECT run_id FROM runs WHERE status = 'analyzing' ORDER BY created_at ASC LIMIT 1000",
+    )
+
+    assert any("idx_runs_status_created_at" in detail for detail in latest_recording_plan)
+    assert any("idx_runs_status_created_at" in detail for detail in analyzing_runs_plan)
+    assert all("USE TEMP B-TREE FOR ORDER BY" not in detail for detail in latest_recording_plan)
+    assert all("USE TEMP B-TREE FOR ORDER BY" not in detail for detail in analyzing_runs_plan)
+
+
+def test_history_db_migration_backup_cleans_up_temp_file_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    created_temp_paths: list[Path] = []
+    closed_backup_connections: list[bool] = []
+
+    class _FailingBackupConnection:
+        def execute(self, _sql: str) -> None:
+            raise OSError("backup prep failed")
+
+        def close(self) -> None:
+            closed_backup_connections.append(True)
+
+    def _fake_connect(
+        path: str | Path,
+        *args: object,
+        **kwargs: object,
+    ) -> _FailingBackupConnection:
+        del args, kwargs
+        created_temp_paths.append(Path(path))
+        return _FailingBackupConnection()
+
+    monkeypatch.setattr(history_db_module.sqlite3, "connect", _fake_connect)
+
+    try:
+        with pytest.raises(OSError, match="backup prep failed"):
+            db._create_migration_backup(SCHEMA_VERSION)
+    finally:
+        db.close()
+
+    assert closed_backup_connections == [True]
+    assert len(created_temp_paths) == 1
+    assert not created_temp_paths[0].exists()
+    assert not list(tmp_path.glob(f"history.bak-v{SCHEMA_VERSION}.*.tmp"))

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -270,12 +270,16 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
         temp_path = Path(temp_path_text)
         backup_conn = sqlite3.connect(temp_path)
         try:
-            backup_conn.execute("PRAGMA journal_mode=DELETE")
-            self._conn.backup(backup_conn)
-        finally:
-            backup_conn.close()
-            Path(temp_path_text).chmod(0o600)
-        temp_path.replace(backup_path)
+            try:
+                backup_conn.execute("PRAGMA journal_mode=DELETE")
+                self._conn.backup(backup_conn)
+            finally:
+                backup_conn.close()
+            temp_path.chmod(0o600)
+            temp_path.replace(backup_path)
+        except BaseException:
+            temp_path.unlink(missing_ok=True)
+            raise
         LOGGER.warning(
             "Created pre-migration backup for %s at %s",
             self.db_path,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
@@ -61,6 +61,7 @@ CREATE INDEX IF NOT EXISTS idx_samples_v2_run_time ON samples_v2(run_id, t_s);
 
 CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
 CREATE INDEX IF NOT EXISTS idx_runs_created_at ON runs(created_at);
+CREATE INDEX IF NOT EXISTS idx_runs_status_created_at ON runs(status, created_at);
 
 CREATE TABLE IF NOT EXISTS settings_snapshot (
     id          INTEGER PRIMARY KEY CHECK(id = 1),


### PR DESCRIPTION
## Summary

This PR fixes the live persistence defects still present behind issue `#1269` on current `main`, without pulling in the stale parts of the original issue body that no longer match the codebase.

Before changing anything, I reconciled the issue text against the current `HistoryDB` implementation. That mattered here because several headline claims are already outdated. The persistence layer is no longer a single all-in-one file: `HistoryDB` remains the public entry point, but query logic, run lifecycle handling, sample I/O, schema constants, and sample row helpers already live in focused sibling modules. The `check_same_thread=False` concern is also no longer a live bug in the way the issue describes, because the write and read connections are guarded by explicit `RLock` instances and the current tests already cover thread-safe append/read behavior. The basic `runs(status)` and `runs(created_at)` indexes also already exist. What still remained real after that reconciliation were two narrower defects: migration backup failures could leave orphaned temporary backup files behind, and the actual history queries that filter by `status` and order by `created_at` were still forcing SQLite to build a temporary B-tree because the schema lacked a composite index matching the query pattern.

## Problem

The first live issue was in `HistoryDB._create_migration_backup()`. The code already closed the temporary SQLite connection in a `finally` block, but if any part of backup preparation or finalization failed after the temporary file had been created, the temp file itself could be left behind in the database directory. That does not corrupt the live database, but it creates avoidable filesystem junk in the exact code path that is supposed to make schema migration safer and more recoverable.

The second live issue was query-shape specific. Current history queries such as `latest_recording_run_id()` and `list_analyzing_runs()` filter on `status` and then order by `created_at`. With only separate indexes on `status` and `created_at`, SQLite chose `idx_runs_status` and then emitted `USE TEMP B-TREE FOR ORDER BY` for those queries. I verified that directly with `EXPLAIN QUERY PLAN` against the current schema before changing anything. So while the issue body’s broader “missing indexes” claim is overstated on current `main`, there was still a real indexing gap on the exact query pattern the history layer uses today.

## Implementation approach

I kept the fix intentionally small and local to the persistence layer.

In `apps/server/vibesensor/adapters/persistence/history_db/_schema.py`, I added `CREATE INDEX IF NOT EXISTS idx_runs_status_created_at ON runs(status, created_at);`. That index matches the live query pattern rather than adding speculative indexes for columns that are not actually queried in the current code path. I verified the effect before implementing it by running `EXPLAIN QUERY PLAN` against the existing schema and again against a scratch schema with the new index added. Before the change, SQLite used `idx_runs_status` and built a temp B-tree for sorting. With the composite index present, the planner switched to `idx_runs_status_created_at` and the temporary sort step disappeared for both the “latest recording run” and “list analyzing runs” queries.

In `apps/server/vibesensor/adapters/persistence/history_db/__init__.py`, I tightened `_create_migration_backup()` so that the temporary backup file is always removed if backup creation fails after the temp path has been allocated. The structure matters here: the temporary SQLite connection still closes reliably first, and only then does the outer failure path unlink the temp file and re-raise the original exception. That keeps the success path unchanged while preventing orphaned `history.bak-v*.tmp` files on failure.

I did not expand the PR into broader refactors or speculative concurrency work because the current code does not justify that scope. The locking model, module split, and baseline schema are all already significantly better than the issue description suggests, so the right fix here is the smallest complete one that addresses the remaining live defects.

## Tests and validation

I added a focused regression module at `apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py`.

The first new test proves the schema change at the query-planner level. It creates a fresh `HistoryDB`, inspects `EXPLAIN QUERY PLAN` for the two real status-ordered history queries, and asserts that they use `idx_runs_status_created_at` without falling back to `USE TEMP B-TREE FOR ORDER BY`. That keeps the test grounded in the real performance problem instead of only checking that an index name exists in schema text.

The second new test exercises the backup cleanup failure path. It patches the temporary backup connection used by `_create_migration_backup()` so setup fails after the temp file has been created, then asserts that the temporary connection is still closed and the temporary backup file is removed. That locks in the bugfix directly.

Local validation for this PR included:

- focused persistence tests:
  - `apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py`
  - relevant schema migration and connection tests
- the full `apps/server/tests/adapters/persistence/history_db/` suite
- `make lint`
- `make typecheck-backend`
- `make test-changed`
- a native `vibesensor-server` + `vibesensor-sim` smoke run using `apps/server/config.dev.yaml`

The native smoke passed cleanly: the backend started successfully on the updated history DB schema, `/api/health` stayed healthy, `processing_failures` remained `0`, and ingestion counters increased during simulator traffic and settled again after the simulator stopped.

## Risks, tradeoffs, and scope boundaries

The new composite index is additive and uses `CREATE INDEX IF NOT EXISTS`, so it is safe for both fresh and existing databases. Because `SCHEMA_SQL` is executed during startup, the index is created without needing a separate schema-version bump or a new explicit migration step. I kept the index narrowly targeted to the queries we actually run today instead of adding speculative secondary indexes for fields like `case_id` that are not used as runtime query predicates in the current persistence layer.

The backup cleanup change is also deliberately conservative. It does not alter when backups are taken or how migration rollback works; it only guarantees that failed attempts do not leave temporary files behind.

I intentionally did not attempt to solve the stale parts of the original issue body in this PR. I did not replace the SQLite threading model, add migration locking, or perform a larger module decomposition because the current codebase has already moved on in those areas, and forcing unrelated churn into this issue would make the diff broader without improving the live behavior we actually observed.

Closes #1269.
