### PR TITLE
Add regressions for history async offloading

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_async_offloading.py
+++ b/apps/server/tests/use_cases/history/test_history_async_offloading.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+from dataclasses import dataclass, field
+
+import pytest
+
+from vibesensor.domain import RunStatus
+from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.use_cases.history.exports import HistoryExportService
+from vibesensor.use_cases.history.helpers import async_require_run
+from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
+from vibesensor.use_cases.history.runs import HistoryRunService
+
+
+def _stored_run(run_id: str = "run-1") -> StoredHistoryRun:
+    return StoredHistoryRun(
+        run_id=run_id,
+        status=RunStatus.COMPLETE,
+        start_time_utc="2026-01-01T00:00:00Z",
+        end_time_utc="2026-01-01T00:01:00Z",
+        metadata=RunMetadata.from_dict(
+            {
+                "run_id": run_id,
+                "start_time_utc": "2026-01-01T00:00:00Z",
+                "sensor_model": "fixture-sensor",
+                "raw_sample_rate_hz": 800,
+                "sample_rate_hz": 800,
+                "feature_interval_s": 1.0,
+                "source": "test",
+            }
+        ),
+        created_at="2026-01-01T00:00:00Z",
+        sample_count=3,
+    )
+
+
+@dataclass
+class _HistoryDbStub:
+    run: StoredHistoryRun | None = None
+    runs: list[HistoryRunListEntry] | None = None
+    get_run_calls: list[str] = field(default_factory=list)
+    get_run_thread_id: int | None = None
+    list_runs_calls: int = 0
+    list_runs_thread_id: int | None = None
+
+    def get_run(self, run_id: str) -> StoredHistoryRun | None:
+        self.get_run_calls.append(run_id)
+        self.get_run_thread_id = threading.get_ident()
+        if self.run is None:
+            return None
+        return self.run
+
+    def list_runs(self) -> list[HistoryRunListEntry]:
+        self.list_runs_calls += 1
+        self.list_runs_thread_id = threading.get_ident()
+        return list(self.runs or [])
+
+
+@pytest.mark.asyncio
+async def test_async_require_run_offloads_lookup_to_worker_thread() -> None:
+    history_db = _HistoryDbStub(run=_stored_run())
+    main_thread_id = threading.main_thread().ident
+    assert main_thread_id is not None
+
+    run = await async_require_run(history_db, "run-1")
+
+    assert run.run_id == "run-1"
+    assert history_db.get_run_calls == ["run-1"]
+    assert history_db.get_run_thread_id is not None
+    assert history_db.get_run_thread_id != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_history_run_service_list_runs_offloads_lookup_to_worker_thread() -> None:
+    expected = [
+        HistoryRunListEntry(
+            run_id="run-1",
+            status=RunStatus.COMPLETE,
+            start_time_utc="2026-01-01T00:00:00Z",
+            end_time_utc="2026-01-01T00:01:00Z",
+            created_at="2026-01-01T00:01:00Z",
+            sample_count=3,
+        )
+    ]
+    history_db = _HistoryDbStub(runs=expected)
+    service = HistoryRunService(history_db)
+    main_thread_id = threading.main_thread().ident
+    assert main_thread_id is not None
+
+    runs = await service.list_runs()
+
+    assert runs == expected
+    assert history_db.list_runs_calls == 1
+    assert history_db.list_runs_thread_id is not None
+    assert history_db.list_runs_thread_id != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_export_service_build_export_context_offloads_csv_spooling_to_worker_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history_db = _HistoryDbStub(run=_stored_run("run/1"))
+    service = HistoryExportService(history_db)
+    spool = tempfile.SpooledTemporaryFile[bytes]()
+    captured: dict[str, object] = {}
+    main_thread_id = threading.main_thread().ident
+    assert main_thread_id is not None
+
+    def _fake_build_raw_csv_spool(
+        self: HistoryExportService,
+        run_id: str,
+    ) -> tuple[tempfile.SpooledTemporaryFile[bytes], int]:
+        captured["self"] = self
+        captured["run_id"] = run_id
+        captured["thread_id"] = threading.get_ident()
+        return spool, 7
+
+    monkeypatch.setattr(HistoryExportService, "_build_raw_csv_spool", _fake_build_raw_csv_spool)
+
+    context = await service.build_export_context("run/1")
+    try:
+        assert context.run_id == "run/1"
+        assert context.safe_name == "run_1"
+        assert context.sample_count == 7
+        assert context.raw_csv_spool is spool
+        assert history_db.get_run_calls == ["run/1"]
+        assert captured["self"] is service
+        assert captured["run_id"] == "run/1"
+        assert captured["thread_id"] != main_thread_id
+    finally:
+        spool.close()
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_get_or_build_offloads_pdf_generation_to_worker_thread() -> None:
+    cache = HistoryReportPdfCache()
+    captured: dict[str, object] = {}
+    main_thread_id = threading.main_thread().ident
+    assert main_thread_id is not None
+
+    def _build_pdf() -> bytes:
+        captured["thread_id"] = threading.get_ident()
+        return b"%PDF-1.7"
+
+    pdf = await cache.get_or_build(
+        ("run-1", "en", None, 1, "{}", "none"),
+        _build_pdf,
+        run_id="run-1",
+    )
+
+    assert pdf == b"%PDF-1.7"
+    assert captured["thread_id"] != main_thread_id


### PR DESCRIPTION
Closes #1270

## Summary

This PR resolves `#1270` by adding focused regression coverage around the async history/report paths that were called out in the issue, after first reconciling the issue body against the current `main` branch. The key outcome of that reconciliation is that most of the issue description is now historical rather than current: the codebase already bounds the UDP ingest queue, already tracks and cancels the relevant worker tasks through runtime lifecycle management, and already offloads the blocking history/report operations to worker threads with `asyncio.to_thread()`. Because of that, the correct fix on today’s code is not a risky production refactor. The real gap is that we did not have direct regression tests proving that those blocking operations continue to run off the event-loop thread.

This change therefore adds a new focused backend test module, `apps/server/tests/use_cases/history/test_history_async_offloading.py`, that locks in the current concurrency contract for the history helper, history run service, export service, and report PDF cache. The new tests verify actual worker-thread execution rather than only checking that `asyncio.to_thread()` was invoked as an API call. That distinction matters: a guardrail PR for an async architecture issue should protect the behavior that keeps the event loop responsive, not merely assert that a helper function name appeared in the call path.

## Problem being solved

Issue `#1270` describes a broad set of async/concurrency problems: blocking I/O happening in the event loop, task lifecycle leaks, and missing backpressure. On an older revision of the codebase, some or all of those concerns may well have been live. On current `main`, however, the situation is materially better:

- The history/report paths already offload blocking work with `asyncio.to_thread()`.
- The UDP ingest queue is already bounded and drop-metered instead of unbounded.
- The UDP consumer task is already tracked and cancelled by lifecycle code rather than being left orphaned.
- Recent updater cancellation hardening from `#1268` already removed one concurrency-related stale claim from the issue body.

That meant a direct implementation from the issue text would have pushed this PR toward churn without a live bug to justify it. Instead, the actual risk today is regression risk: if somebody later inlines one of these blocking operations back onto the event loop, or weakens the offloading boundary in the name of simplification, we would have very little targeted coverage to catch it quickly. This PR closes that gap.

## Chosen implementation approach

The approach here is deliberately narrow and behavior-focused:

1. Reconcile the issue against current code first.
2. Keep the existing production design if it is already correct.
3. Add tests that verify the concurrency contract at the behavior level.

I chose not to modify production modules because the code already does the right thing in the areas I validated. I also chose not to stop at a superficial “calls `to_thread()`” assertion. The first test draft used patched `asyncio.to_thread()` helpers to capture arguments, which was enough to show intent but not enough to prove non-blocking execution. I replaced that with stronger tests that record the actual thread identity of the blocking work and assert that it does not run on the main event-loop thread. That makes the regression coverage much more meaningful for the class of issue this ticket is about.

## Main code changes by area

The full repo diff is one new test module:

- `apps/server/tests/use_cases/history/test_history_async_offloading.py`

That module adds four focused async tests:

- `async_require_run()` now has regression coverage proving the underlying run lookup executes on a worker thread rather than on the main thread.
- `HistoryRunService.list_runs()` now has matching coverage for the list operation.
- `HistoryExportService.build_export_context()` now has coverage proving the blocking CSV spool builder runs on a worker thread while still returning the expected export metadata and spool object.
- `HistoryReportPdfCache.get_or_build()` now has coverage proving PDF generation runs on a worker thread instead of synchronously on the event loop thread.

To keep the tests honest, the helpers in the new file use lightweight stubs that record thread identifiers when their blocking methods are executed. The assertions then compare those identifiers against the main thread identifier. This gives us a concrete behavioral signal that the offloading boundary still exists.

One subtle but important improvement during implementation was removing the earlier fake `to_thread()` interception pattern. That earlier version could only prove that the code path *called* a `to_thread` wrapper. It could not prove that the blocking work actually ran away from the event loop. The final version fixes that weakness and makes the tests match the real concurrency property we care about.

## Schema, contract, config, and documentation impact

There are no schema, storage, API contract, configuration, or documentation changes in this PR.

That is intentional. The issue was resolved without changing production behavior, so there was no reason to touch runtime contracts, generated frontend artifacts, or human-facing docs. The value here is preserving an existing behavior guarantee that was previously under-tested.

## Validation performed

I validated this change in several layers.

Focused validation:

- `pytest -q apps/server/tests/use_cases/history/test_history_async_offloading.py`

Broader async/concurrency-related validation:

- `pytest -q apps/server/tests/use_cases/history/ apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/adapters/udp/ apps/server/tests/infra/runtime/test_runtime.py`

Repository-standard validation:

- `make lint`
- `make typecheck-backend`
- `make test-changed`

All of the above passed on the final diff. Since there are no production-code changes in this PR, additional runtime smoke beyond those suites was not necessary to establish that the current behavior remains intact.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is choosing a guardrail-only fix instead of forcing code motion to better match an issue description that is no longer fully current. Refactoring already-correct async code merely to “touch” production files would add surface area without improving behavior.

Another consideration was test brittleness. Threading tests can become flaky if they depend on thread names, timing windows, or scheduler races. These tests intentionally avoid that. They do not assume a particular worker-thread name and they do not require timing-sensitive coordination. They only assert that the blocking function’s recorded thread identifier differs from the main thread identifier, which is the stable concurrency guarantee we actually need.

## Follow-ups and out-of-scope items

This PR does not claim that every sentence in `#1270` maps one-to-one to a current bug. Instead, it resolves the issue on today’s codebase by verifying the live async guarantees that were most relevant to the ticket and most worth protecting against regression.

If future investigation finds a new concrete concurrency defect in recorder sequencing, runtime shutdown, or backpressure handling, that should land as its own narrowly scoped follow-up issue with a reproduction grounded in current `main`. For this ticket, the most accurate and safest completion is to preserve the already-correct behavior with strong regression coverage.
