### PR TITLE
Clarify enforced backend layer dependency DAG

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,14 @@ Domain model (scope: behavioral rules only; see `docs/domain-model.md` for the f
 - Consumers import from `vibesensor.domain`, not from individual module files.
 - Boundary decoders/serializers live under `apps/server/vibesensor/shared/boundaries/`; do not rebuild payload-driven business logic in report/history/runtime consumers.
 - Factories that build domain objects from already-typed internal metadata, snapshots, or computed state belong on domain objects (or the owning use-case), not in `shared/boundaries/`.
+- Backend layer dependency DAG is enforced by `tools/dev/verify_backend_static_guards.py::_check_layer_boundaries()`:
+  - `domain` imports no inner project layers
+  - `shared` may import `domain`
+  - `use_cases` may import `domain` and `shared`
+  - `infra` may import `domain` and `shared`
+  - `adapters` may import `domain`, `shared`, `infra`, and `use_cases`
+  - `app` may import all backend layers
+- Treat `shared -> domain` and `infra -> domain` as intentional current architecture, not violations. The disallowed direction for this issue family is outer-layer leakage back inward, such as `use_cases -> adapters` or `domain -> shared/infra/adapters`.
 
 Commands
 - Other AI guidance and docs should reference this list instead of repeating it.

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -50,6 +50,18 @@ This file is the repo map, not a workflow or policy guide. Use `.github/copilot-
 - `apps/ui/src/app/features/`: UI feature workflows for settings, realtime, history, updates, cars, and ESP flash.
 - `apps/ui/src/app/views/`: DOM renderers and event-target decoders.
 
+## Backend layer dependency DAG
+
+- Import-direction enforcement lives in `tools/dev/verify_backend_static_guards.py::_check_layer_boundaries()`.
+- Current allowed dependency directions are:
+  - `domain` -> none
+  - `shared` -> `domain`
+  - `use_cases` -> `domain`, `shared`
+  - `infra` -> `domain`, `shared`
+  - `adapters` -> `domain`, `shared`, `infra`, `use_cases`
+  - `app` -> all backend layers
+- `shared -> domain` and `infra -> domain` are intentional in the current architecture. Questions in the `#1271` family should focus on disallowed inward leakage such as `use_cases -> adapters` or `domain -> outer layers`, not these permitted edges.
+
 ## Test layout
 
 - `apps/server/tests/` mirrors the backend package layout with `app/`, `shared/`, `domain/`, `use_cases/`, `adapters/`, and `infra/` subtrees.


### PR DESCRIPTION
Closes #1271

## Summary

This PR resolves `#1271` by clarifying the backend layer dependency rules that are already enforced in the repository, rather than by forcing structural code changes that current `main` does not need. After reconciling the issue body against the live codebase, the main conclusion was that the issue describes an older or less formalized architecture state than the one that exists today. The backend already has an explicit import-direction DAG in `tools/dev/verify_backend_static_guards.py`, and that static guard already runs in the normal lint path. The examples called out in the issue as violations — especially `shared -> domain`, `infra -> domain`, and adapter imports of use-case services — are not currently bugs. They are allowed edges in the architecture that the codebase enforces.

Because of that, the smallest correct fix was not a risky refactor of already-compliant code. The real gap was that the canonical guidance did not state the layer DAG clearly enough for humans or future automation to immediately distinguish allowed edges from true boundary violations. This change makes that rule explicit in the two canonical guidance locations: `.github/copilot-instructions.md` and `docs/ai/repo-map.md`.

## Problem being solved

Issue `#1271` frames the backend as if it still has broad layer-boundary drift:

- `shared/` importing `domain/`
- `infra/` depending on domain objects
- adapters depending on multiple `use_cases` modules
- `use_cases` leaking back into adapters
- persistence and transport concerns sitting in the wrong architectural layer

On current `main`, those claims do not all map to live defects. During the audit for this PR, I checked the current implementation, the current static architecture guard, and the current repository guidance. The results were consistent:

- `use_cases` does not currently import `vibesensor.adapters`.
- The backend static guard already enforces a layer DAG.
- That DAG explicitly allows `shared -> domain`.
- That DAG explicitly allows `infra -> domain`.
- That DAG explicitly allows `adapters -> use_cases`.

In other words, the issue was no longer useful as a literal code-change checklist. The actual risk was architectural misunderstanding: a contributor reading only the stale issue text could easily conclude that some currently legal and intentionally designed dependencies should be removed. That would create churn, not improvement. This PR solves that ambiguity by publishing the actual rule where developers and future agents are meant to look first.

## Chosen implementation approach

The approach here was:

1. Audit the issue claims against the current code and current guardrails.
2. Confirm whether any live import-direction violations still exist.
3. If the code is already compliant, fix the guidance gap instead of fabricating code churn.

I explicitly chose not to “fix” the code paths mentioned in the issue body because doing so would have been counterproductive. Removing `shared -> domain` or `infra -> domain` imports would not align the codebase with its actual architecture; it would fight the architecture that the repo documents and enforces in tooling. Likewise, the issue’s concern about adapters importing multiple use-case modules is not itself a live bug under the current layering rules.

Instead, this PR documents the enforced backend dependency DAG in the canonical AI guidance file and in the repo map, and calls out the most important interpretive rule for this issue family: `shared -> domain` and `infra -> domain` are intentional today, while the real prohibited direction is outer-layer leakage back inward, such as `use_cases -> adapters` or `domain -> outer layers`.

## Main changes by area

This PR changes two documentation/guidance files.

### `.github/copilot-instructions.md`

I added an explicit backend layer dependency DAG under the domain-model guidance area, mirroring the allowed import directions already enforced by the static guard.

I also added a short interpretation note that `shared -> domain` and `infra -> domain` are intentional in the current architecture, and that the real problem pattern for issue `#1271`-style work is inward leakage from outer layers back into inner layers.

### `docs/ai/repo-map.md`

I added a dedicated “Backend layer dependency DAG” section that points readers at the enforcement point in `tools/dev/verify_backend_static_guards.py::_check_layer_boundaries()` and restates the allowed dependency directions. This keeps the navigation-oriented repo map aligned with the canonical architectural guidance and with the real static guard used in lint/CI.

## What I verified before making this change

Before deciding on a docs/guidance fix, I verified that `use_cases` does not import `vibesensor.adapters`, reviewed `tools/dev/verify_backend_static_guards.py` to confirm the currently enforced DAG, and spot-checked current `shared/` and `infra/` imports from `vibesensor.domain` against that rule. I also confirmed the repo guidance did not surface the DAG clearly enough, which is why the stale issue text remained plausible. That audit is why this PR stays narrow and documentation-focused.

## Schema, contract, config, and runtime impact

There are no schema, API contract, config, or runtime behavior changes in this PR.

The backend architecture was already compliant with the enforced DAG before this diff. This PR improves the clarity of the canonical guidance so future work is compared against the actual rules instead of an outdated mental model.

## Validation performed

I ran:

- `make lint`
- `make typecheck-backend`

`make lint` is the important validation step for this issue because it runs the backend static guards, including the layer-boundary check, and also runs docs lint. `make typecheck-backend` remained green as a broader backend sanity check.

Both commands passed on the final diff.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is choosing explicit guidance over structural refactoring. That is the correct tradeoff because the repository already has the structural rule in code. Changing implementation to satisfy a stale issue narrative would risk unnecessary churn or even moving the code away from the intended architecture.

Another consideration is documentation drift. By putting the DAG in both the canonical guidance file and the repo map, this PR improves discoverability but also creates two places that must stay aligned. That is acceptable here because the repo map is the navigation index and the copilot instructions own architectural invariants; both now point back to the same enforcement script.

## Out of scope and follow-up

This PR does not attempt a broader architecture rewrite, introduce a DI framework, or move classes between layers. The narrower claim is that on current `main`, the live backend already complies with the enforced layer DAG, and the missing piece was clarity about what that DAG actually allows.

If a future issue uncovers a concrete current violation of `use_cases -> adapters`, `domain -> outer layers`, or another disallowed edge, that should be fixed as a targeted code change backed by the existing guardrails. For this issue, the correct fix is to align the human guidance with the architecture the repository already enforces.
