### PR TITLE
Tighten analysis summary protocols and i18n types

### DIFF
--- a/apps/server/vibesensor/adapters/analysis_summary.py
+++ b/apps/server/vibesensor/adapters/analysis_summary.py
@@ -4,13 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import cast
 
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
-from vibesensor.shared.boundaries.analysis_summary import (
-    AnalysisResultLike,
-    analysis_result_to_summary,
-)
+from vibesensor.shared.boundaries.analysis_summary import analysis_result_to_summary
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.diagnostics import (
     AnalysisSampleInput,
@@ -37,7 +33,7 @@ def summarize_run_data(
         include_samples=include_samples,
         findings_builder=findings_builder,
     ).summarize()
-    return analysis_result_to_summary(cast(AnalysisResultLike, result))
+    return analysis_result_to_summary(result)
 
 
 def summarize_log(

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -48,6 +48,7 @@ from vibesensor.domain import (
 from vibesensor.report_i18n import human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
+from vibesensor.shared.types.json_types import JsonValue
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportFacts,
     PreparedReportInput,
@@ -188,7 +189,7 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
     if report_facts is None:
         raise ValueError("PreparedReportInput must include report_facts for report mapping")
 
-    def tr(key: str, **kw: object) -> str:
+    def tr(key: str, **kw: JsonValue) -> str:
         return str(_tr(lang, key, **kw))
 
     return _build_report_template_data(

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -11,6 +11,7 @@ from reportlab.lib.units import mm
 from vibesensor.adapters.pdf.report_data import FindingPresentation, ReportTemplateData
 from vibesensor.domain import LocationHotspotRow
 from vibesensor.report_i18n import tr as _tr
+from vibesensor.shared.types.json_types import JsonValue
 
 # ── Theme ────────────────────────────────────────────────────────────────────
 
@@ -273,7 +274,7 @@ class PdfRenderContext:
     ) -> PdfRenderContext:
         lang = data.lang
 
-        def default_tr(key: str, **kw: object) -> str:
+        def default_tr(key: str, **kw: JsonValue) -> str:
             result: str = _tr(lang, key, **kw)
             return result
 
@@ -293,5 +294,5 @@ class PdfRenderContext:
             text_fn=text_fn or default_text,
         )
 
-    def tr(self, key: str, **kw: object) -> str:
+    def tr(self, key: str, **kw: JsonValue) -> str:
         return self.tr_fn(key, **kw)

--- a/apps/server/vibesensor/report_i18n.py
+++ b/apps/server/vibesensor/report_i18n.py
@@ -9,7 +9,6 @@ import json
 import logging
 from collections.abc import Callable
 from functools import lru_cache
-from typing import Any
 
 from vibesensor.domain import VibrationSource
 from vibesensor.shared._data_files import resolve_static_data_file
@@ -38,7 +37,7 @@ def normalize_lang(lang: object) -> str:
     return "en"
 
 
-def tr(lang: object, key: str, **kwargs: Any) -> str:
+def tr(lang: object, key: str, **kwargs: JsonValue) -> str:
     """Look up translation *key* for *lang* and format with *kwargs*."""
     values = _load_translations().get(key)
     if values is None:

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -34,38 +34,94 @@ from vibesensor.shared.types.json_types import JsonObject
 
 
 class PreparedRunDataLike(Protocol):
-    run_id: str
-    duration_s: float
-    raw_sample_rate_hz: float | None
-    speed_breakdown: Sequence[SpeedBreakdownRowLike]
-    phase_speed_breakdown: Sequence[PhaseSpeedBreakdownRowLike]
-    phase_segments: Sequence[PhaseSegmentLike]
-    run_noise_baseline_g: float | None
-    speed_breakdown_skipped_reason: JsonObject | None
-    speed_stats_by_phase: Mapping[str, SpeedProfileSummary]
-    speed_values: list[float]
-    speed_non_null_pct: float
+    @property
+    def run_id(self) -> str: ...
+
+    @property
+    def duration_s(self) -> float: ...
+
+    @property
+    def raw_sample_rate_hz(self) -> float | None: ...
+
+    @property
+    def speed_breakdown(self) -> Sequence[SpeedBreakdownRowLike]: ...
+
+    @property
+    def phase_speed_breakdown(self) -> Sequence[PhaseSpeedBreakdownRowLike]: ...
+
+    @property
+    def phase_segments(self) -> Sequence[PhaseSegmentLike]: ...
+
+    @property
+    def run_noise_baseline_g(self) -> float | None: ...
+
+    @property
+    def speed_breakdown_skipped_reason(self) -> JsonObject | None: ...
+
+    @property
+    def speed_stats_by_phase(self) -> Mapping[str, SpeedProfileSummary]: ...
+
+    @property
+    def speed_values(self) -> list[float]: ...
+
+    @property
+    def speed_non_null_pct(self) -> float: ...
 
 
 class AnalysisResultLike(Protocol):
-    file_name: str
-    metadata: JsonObject
-    samples: Sequence[JsonObject]
-    language: str
-    include_samples: bool
-    prepared: PreparedRunDataLike
-    accel_stats: AccelStatisticsLike
-    reference_complete: bool
-    run_suitability: RunSuitability | None
-    most_likely_origin: VibrationOrigin | None
-    phase_timeline: Sequence[DrivingPhaseInterval]
-    sensor_locations: Sequence[str]
-    connected_locations: Collection[str]
-    sensor_intensity_by_location: Sequence[LocationIntensitySummary]
-    summary_speed_stats: SpeedProfileSummary
-    summary_phase_info: DrivingPhaseSummary
-    plot_data: PlotDataResultLike
-    test_run: TestRun
+    @property
+    def file_name(self) -> str: ...
+
+    @property
+    def metadata(self) -> JsonObject: ...
+
+    @property
+    def samples(self) -> Sequence[JsonObject]: ...
+
+    @property
+    def language(self) -> str: ...
+
+    @property
+    def include_samples(self) -> bool: ...
+
+    @property
+    def prepared(self) -> PreparedRunDataLike: ...
+
+    @property
+    def accel_stats(self) -> AccelStatisticsLike: ...
+
+    @property
+    def reference_complete(self) -> bool: ...
+
+    @property
+    def run_suitability(self) -> RunSuitability | None: ...
+
+    @property
+    def most_likely_origin(self) -> VibrationOrigin | None: ...
+
+    @property
+    def phase_timeline(self) -> Sequence[DrivingPhaseInterval]: ...
+
+    @property
+    def sensor_locations(self) -> Sequence[str]: ...
+
+    @property
+    def connected_locations(self) -> Collection[str]: ...
+
+    @property
+    def sensor_intensity_by_location(self) -> Sequence[LocationIntensitySummary]: ...
+
+    @property
+    def summary_speed_stats(self) -> SpeedProfileSummary: ...
+
+    @property
+    def summary_phase_info(self) -> DrivingPhaseSummary: ...
+
+    @property
+    def plot_data(self) -> PlotDataResultLike: ...
+
+    @property
+    def test_run(self) -> TestRun: ...
 
 
 def _amp_metric_values(accel_stats: AccelStatisticsLike) -> list[float]:

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from vibesensor.shared.boundaries.analysis_payload import RunSuitabilityCheck
-from vibesensor.shared.boundaries.analysis_summary import (
-    AnalysisResultLike,
-    analysis_result_to_summary,
-)
+from vibesensor.shared.boundaries.analysis_summary import analysis_result_to_summary
 from vibesensor.shared.boundaries.persisted_analysis_codec import (
     persisted_analysis_from_summary,
 )
@@ -42,8 +37,26 @@ def build_post_analysis_summary(
         file_name=run_id,
         include_samples=False,
     ).summarize()
-    summary_payload = analysis_result_to_summary(cast(AnalysisResultLike, result))
+    summary_payload = analysis_result_to_summary(result)
     summary_payload["case_id"] = result.diagnostic_case.case_id
+
+    def append_run_suitability_warning(
+        *,
+        check_key: str,
+        state: str,
+        explanation: str,
+    ) -> None:
+        run_suitability = summary_payload.get("run_suitability")
+        if run_suitability is None:
+            run_suitability = []
+            summary_payload["run_suitability"] = run_suitability
+        warning_payload: RunSuitabilityCheck = {
+            "check_key": check_key,
+            "check": check_key,
+            "state": state,
+            "explanation": explanation,
+        }
+        run_suitability.append(warning_payload)
 
     analysis_metadata: JsonObject = {
         "analyzed_sample_count": len(samples),
@@ -61,8 +74,7 @@ def build_post_analysis_summary(
             state="warn",
         )
         explanation = tr(language, "SUITABILITY_RUN_DURATION_WARNING")
-        _append_run_suitability_warning(
-            summary_payload=summary_payload,
+        append_run_suitability_warning(
             check_key=short_run_check.check_key,
             state=short_run_check.state,
             explanation=explanation,
@@ -79,38 +91,13 @@ def build_post_analysis_summary(
             "SUITABILITY_ANALYSIS_SAMPLING_STRIDE_WARNING",
             stride=str(stride),
         )
-        _append_run_suitability_warning(
-            summary_payload=summary_payload,
+        append_run_suitability_warning(
             check_key=stride_check.check_key,
             state=stride_check.state,
             explanation=explanation,
         )
 
     return persisted_analysis_from_summary(summary_payload)
-
-
-def _append_run_suitability_warning(
-    *,
-    summary_payload: object,
-    check_key: str,
-    state: str,
-    explanation: str,
-) -> None:
-    summary_payload_dict = cast(dict[str, object], summary_payload)
-    run_suitability = summary_payload_dict.get("run_suitability")
-    if not isinstance(run_suitability, list):
-        run_suitability_list: list[RunSuitabilityCheck] = []
-        summary_payload_dict["run_suitability"] = run_suitability_list
-        run_suitability = run_suitability_list
-    else:
-        run_suitability = cast(list[RunSuitabilityCheck], run_suitability)
-    warning_payload: RunSuitabilityCheck = {
-        "check_key": check_key,
-        "check": check_key,
-        "state": state,
-        "explanation": explanation,
-    }
-    run_suitability.append(warning_payload)
 
 
 def _post_analysis_sample_rate_hz(metadata: RunMetadata) -> int | None:


### PR DESCRIPTION
Closes #1272

## Summary

This PR resolves the live type-safety defects behind `#1272` without turning the issue’s broader, partially stale checklist into a risky repository-wide refactor. After reconciling the issue body against current `main`, the real problems turned out to be narrower and more concrete than the original ticket suggests. The most important one was in the analysis-summary boundary typing: the `AnalysisResultLike` and `PreparedRunDataLike` protocols were modeled as mutable attribute bags, while the real diagnostics result objects are frozen/read-only dataclasses. That mismatch is what forced `cast(AnalysisResultLike, ...)` at the call sites in `adapters/analysis_summary.py` and `use_cases/run/post_analysis_summary.py`.

The second live issue was the real translation path still typing `report_i18n.tr(**kwargs)` as `Any`, which erased useful type information for formatting parameters even though the values flowing through that path are JSON-compatible payload values. This PR fixes both problems. It makes the boundary protocols read-only so the concrete diagnostics objects conform structurally without casts, removes the cast-heavy call sites, and narrows the translation kwargs typing along the production translation/PDF wrapper path.

## Problem being solved

Issue `#1272` calls out a long list of possible type-safety problems: unsound casts, overly broad `Any`, erased payload types, codec asymmetry, and missing roundtrip guarantees. On current `main`, many of those claims are already stale or overbroad:

- `delete_run` already has a matching return type.
- Roundtrip coverage already exists in current tests.
- The vibration-strength serialization path already uses explicit coercion rather than silent unchecked conversion.
- Some of the broad payload-alias claims are not cheaply actionable because naive recursive tightening breaks FastAPI/Pydantic OpenAPI generation in the current stack.

The live root cause I was able to reproduce cleanly was this: boundary serializer functions accepted an `AnalysisResultLike` protocol whose members were declared as writable attributes, but the concrete `AnalysisResult` and `PreparedRunData` implementations are frozen/read-only dataclasses. Mypy therefore could not prove conformance, which is why the code had to use `cast(AnalysisResultLike, result)` to cross the boundary. That was the real unsoundness: the protocol shape was wrong for the concrete objects, and the cast was masking that design mismatch.

Separately, `report_i18n.tr()` still accepted `**kwargs: Any`, which meant callers lost static information exactly at the point where localized format arguments cross through the report/i18n layer.

## Chosen implementation approach

The approach was deliberately narrow and root-cause oriented:

1. Fix the boundary protocols so the real frozen diagnostics result objects structurally conform.
2. Remove the casts that only existed because the protocols were modeled incorrectly.
3. Narrow the translation kwargs type along the real production call chain.
4. Do not force recursive payload alias changes that break schema generation just to satisfy the issue text literally.

I explicitly did **not** attempt a repo-wide cast purge or a large-scale payload typing rewrite. During scoping I tested a straightforward recursive tightening of the shared/API payload aliases, and that broke FastAPI/Pydantic OpenAPI schema export. Since that would have turned a surgical type-safety fix into a contract-generation regression, I left that part out of this PR and focused on the live fixes that improve soundness without destabilizing the backend.

## Main code changes by area

### `shared/boundaries/analysis_summary.py`

`PreparedRunDataLike` and `AnalysisResultLike` now expose their members as read-only `@property` protocol members instead of writable plain attributes. This brings them into line with the surrounding summary-serialization contracts, which already use read-only structural protocols, and it matches the real frozen diagnostics dataclasses that implement these shapes.

This is the core fix. Once the protocols accurately reflected read-only access, the concrete diagnostics result objects could satisfy them structurally without any cast.

### `adapters/analysis_summary.py`

Removed the old `cast(AnalysisResultLike, result)` bridge and now pass the concrete diagnostics result directly into `analysis_result_to_summary()`.

### `use_cases/run/post_analysis_summary.py`

Removed the matching `cast(AnalysisResultLike, result)` call in the post-analysis persistence path. I also removed the old helper that took `summary_payload: object` and then cast it back to a mutable dict. Instead, the run-suitability warning append logic now stays local to `build_post_analysis_summary()` and mutates the already-typed local summary payload directly, without importing the boundary `AnalysisSummary` type into the use-case layer and without the previous object-erasure dance.

### `report_i18n.py`, `adapters/pdf/mapping.py`, and `adapters/pdf/pdf_style.py`

Narrowed `report_i18n.tr()` from `**kwargs: Any` to `**kwargs: JsonValue`, and aligned the real PDF wrapper helpers that forward those translation kwargs. This preserves the current runtime behavior while restoring useful static information across the actual formatting path that feeds report rendering and i18n resolution.

## What I verified during scoping

Before settling on this fix set, I checked the claims that would have pushed the work much broader:

- Existing roundtrip tests are already present for several relevant serialization paths.
- `delete_run` is not currently mismatched.
- The broad payload-alias complaint is not safe to “fix” naively because recursive alias tightening breaks `http_api_schema_export` in the current FastAPI/Pydantic setup.

That is why this PR intentionally fixes the live protocol/cast and `Any` issues without pretending the entire issue body still maps directly to today’s code.

## Schema, contract, config, and runtime impact

There are no intentional API shape, config, or runtime behavior changes in this PR.

The most important contract effect is internal typing correctness: the analysis-summary boundary protocols now describe the actual read-only access pattern of the concrete diagnostics result objects, and the translation formatting path now preserves JSON-compatible value typing instead of dropping to `Any`.

## Validation performed

Focused validation:

- `pytest -q apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_i18n_separation.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py`

Repository-standard validation:

- `make lint`
- `make typecheck-backend`
- `make test-changed`

`make test-changed` escalated to a full backend test run because the touched files are production backend modules. That completed successfully with:

- `5794 passed`
- `5 skipped`
- `1 xpassed`

This is especially important for this PR because it confirms the narrowed typing changes did not disturb summary building, report i18n, report mapping, static guards, or schema export.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is leaving the payload-alias portion of the issue body narrower than written. I believe that is the correct choice. A literal recursive tightening of those aliases is not a safe small fix in the current stack because it breaks OpenAPI generation, which is a worse regression than the type-precision gain would justify for this issue.

The narrower claim of this PR is more defensible: it removes the unsound cast pressure by making the protocols honest, and it replaces a real `Any` hole on the translation path with a typed JSON-compatible contract. Those changes improve type safety at the root cause without destabilizing runtime behavior or backend contracts.

If a later issue wants to revisit payload alias precision, it should do so with the current FastAPI/Pydantic schema generator constraints in mind and likely as a dedicated change set rather than as part of this cast/protocol cleanup.
