### PR TITLE
Validate history and car identifiers at HTTP boundaries

### DIFF
--- a/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
+++ b/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
+from vibesensor.cli.http_api_schema_export import export_schema
+from vibesensor.shared.types.car_config import CarsSnapshot
+
+
+def _history_test_client() -> tuple[TestClient, MagicMock, MagicMock, MagicMock]:
+    from vibesensor.adapters.http.history import create_history_routes
+
+    run_service = MagicMock()
+    run_service.get_run = AsyncMock()
+    run_service.get_insights = AsyncMock()
+    run_service.delete_run = AsyncMock()
+
+    report_service = MagicMock()
+    report_service.build_pdf = AsyncMock()
+
+    export_service = MagicMock()
+    export_service.build_export = AsyncMock()
+
+    app = FastAPI()
+    app.include_router(
+        create_history_routes(
+            run_service=run_service,
+            report_service=report_service,
+            export_service=export_service,
+        )
+    )
+    return TestClient(app), run_service, report_service, export_service
+
+
+def _settings_test_client() -> tuple[TestClient, MagicMock]:
+    from vibesensor.adapters.http.settings import create_settings_routes
+
+    settings_store = MagicMock()
+    settings_store.get_cars.return_value = CarsSnapshot(
+        cars=[
+            {
+                "id": "car-1",
+                "name": "Test Car",
+                "type": "sedan",
+                "aspects": {"tire_width_mm": 225.0},
+            }
+        ],
+        active_car_id="car-1",
+    )
+    gps_monitor = MagicMock()
+    gps_monitor.status_snapshot.return_value = SpeedSourceStatusSnapshot(
+        gps_enabled=True,
+        connection_state="connected",
+        device="/dev/ttyUSB0",
+        fix_mode=3,
+        fix_dimension="3d",
+        speed_confidence="high",
+        epx_m=1.0,
+        epy_m=1.0,
+        epv_m=1.0,
+        last_update_age_s=0.5,
+        raw_speed_kmh=48.0,
+        effective_speed_kmh=48.0,
+        last_error=None,
+        reconnect_delay_s=None,
+        fallback_active=False,
+        speed_source="gps",
+        stale_timeout_s=8.0,
+    )
+
+    app = FastAPI()
+    app.include_router(create_settings_routes(settings_store, gps_monitor))
+    return TestClient(app), settings_store
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "service_attr"),
+    [
+        ("GET", "/api/history/bad%20id", "get_run"),
+        ("GET", "/api/history/bad%20id/insights", "get_insights"),
+        ("DELETE", "/api/history/bad%20id", "delete_run"),
+        ("GET", "/api/history/bad%20id/report.pdf", "build_pdf"),
+        ("GET", "/api/history/bad%20id/export", "build_export"),
+    ],
+)
+def test_history_routes_reject_invalid_run_ids_before_reaching_services(
+    method: str,
+    path: str,
+    service_attr: str,
+) -> None:
+    client, run_service, report_service, export_service = _history_test_client()
+
+    response = client.request(method, path)
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid run identifier"}
+    getattr(run_service, service_attr, AsyncMock()).assert_not_called()
+    getattr(report_service, service_attr, AsyncMock()).assert_not_called()
+    getattr(export_service, service_attr, AsyncMock()).assert_not_called()
+
+
+def test_settings_routes_reject_invalid_car_id_in_active_car_request() -> None:
+    client, settings_store = _settings_test_client()
+
+    response = client.put("/api/settings/cars/active", json={"car_id": "bad id"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid car identifier"}
+    settings_store.set_active_car.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload", "store_attr"),
+    [
+        ("PUT", "/api/settings/cars/bad%20id", {"name": "Updated"}, "update_car"),
+        ("DELETE", "/api/settings/cars/bad%20id", None, "delete_car"),
+    ],
+)
+def test_settings_routes_reject_invalid_car_path_ids_before_store_calls(
+    method: str,
+    path: str,
+    payload: dict[str, object] | None,
+    store_attr: str,
+) -> None:
+    client, settings_store = _settings_test_client()
+
+    response = client.request(method, path, json=payload)
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid car identifier"}
+    settings_store.get_cars.assert_not_called()
+    getattr(settings_store, store_attr).assert_not_called()
+
+
+def test_export_schema_documents_invalid_identifier_responses() -> None:
+    schema_dict = json.loads(export_schema())
+
+    history_paths = [
+        ("/api/history/{run_id}", "get"),
+        ("/api/history/{run_id}", "delete"),
+        ("/api/history/{run_id}/insights", "get"),
+        ("/api/history/{run_id}/report.pdf", "get"),
+        ("/api/history/{run_id}/export", "get"),
+    ]
+    for path, method in history_paths:
+        assert schema_dict["paths"][path][method]["responses"]["400"]["description"] == (
+            "Invalid run identifier."
+        )
+
+    assert (
+        schema_dict["paths"]["/api/settings/cars/active"]["put"]["responses"]["400"]["description"]
+        == "Invalid car identifier."
+    )
+    assert (
+        schema_dict["paths"]["/api/settings/cars/{car_id}"]["put"]["responses"]["400"][
+            "description"
+        ]
+        == "Invalid car identifier."
+    )
+    assert (
+        schema_dict["paths"]["/api/settings/cars/{car_id}"]["delete"]["responses"]["400"][
+            "description"
+        ]
+        == "Invalid car identifier or the requested deletion violates current settings constraints."
+    )

--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any, TypeAlias
@@ -25,12 +26,16 @@ __all__ = [
     "OpenAPIResponses",
     "async_require_run",
     "domain_errors_to_http",
+    "normalize_car_id_or_400",
     "normalize_client_id_or_400",
     "normalize_mac_or_400",
+    "normalize_run_id_or_400",
     "safe_filename",
 ]
 
 OpenAPIResponses: TypeAlias = dict[int | str, dict[str, Any]]
+_CAR_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+_RUN_ID_RE = re.compile(r"^[!-~]{1,128}$")
 
 
 @contextmanager
@@ -86,6 +91,20 @@ def normalize_client_id_or_400(client_id: str) -> str:
         return normalize_sensor_id(client_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Invalid sensor identifier") from exc
+
+
+def normalize_run_id_or_400(run_id: str) -> str:
+    """Validate a history run identifier or raise HTTP 400."""
+    if _RUN_ID_RE.fullmatch(run_id):
+        return run_id
+    raise HTTPException(status_code=400, detail="Invalid run identifier")
+
+
+def normalize_car_id_or_400(car_id: str) -> str:
+    """Validate a car configuration identifier or raise HTTP 400."""
+    if _CAR_ID_RE.fullmatch(car_id):
+        return car_id
+    raise HTTPException(status_code=400, detail="Invalid car identifier")
 
 
 def normalize_mac_or_400(mac: str) -> str:

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
-from vibesensor.adapters.http._helpers import OpenAPIResponses, domain_errors_to_http
+from vibesensor.adapters.http._helpers import (
+    OpenAPIResponses,
+    domain_errors_to_http,
+    normalize_run_id_or_400,
+)
 from vibesensor.adapters.http.models import (
     DeleteHistoryRunResponse,
     HistoryInsightsAnalyzingResponse,
@@ -25,6 +29,10 @@ if TYPE_CHECKING:
 
 _RUN_NOT_FOUND_RESPONSE: OpenAPIResponses = {
     404: {"description": "Requested run was not found."},
+}
+
+_INVALID_RUN_ID_RESPONSE: OpenAPIResponses = {
+    400: {"description": "Invalid run identifier."},
 }
 
 _RUN_LOAD_ERROR_RESPONSE: OpenAPIResponses = {
@@ -79,17 +87,22 @@ def create_history_routes(
         response_model=HistoryRunResponse,
         response_model_exclude_unset=True,
         response_model_exclude_none=True,
-        responses={**_RUN_NOT_FOUND_RESPONSE, **_RUN_LOAD_ERROR_RESPONSE},
+        responses={
+            **_INVALID_RUN_ID_RESPONSE,
+            **_RUN_NOT_FOUND_RESPONSE,
+            **_RUN_LOAD_ERROR_RESPONSE,
+        },
     )
     async def get_history_run(run_id: str) -> HistoryRunResponse:
         """Return full metadata and analysis payloads for a single recorded run."""
+        run_id = normalize_run_id_or_400(run_id)
         with domain_errors_to_http():
             return await run_service.get_run(run_id)
 
     @router.get(
         "/api/history/{run_id}/insights",
         response_model=HistoryInsightsResponse,
-        responses=_HISTORY_INSIGHTS_RESPONSES,
+        responses={**_INVALID_RUN_ID_RESPONSE, **_HISTORY_INSIGHTS_RESPONSES},
     )
     async def get_history_insights(
         run_id: str,
@@ -101,6 +114,7 @@ def create_history_routes(
         ),
     ) -> HistoryInsightsResponse | JSONResponse:
         """Return localized post-analysis findings, or a 202 while analysis is still running."""
+        run_id = normalize_run_id_or_400(run_id)
         with domain_errors_to_http():
             result = await run_service.get_insights(run_id, requested_lang=lang)
         if result is None:
@@ -114,10 +128,11 @@ def create_history_routes(
     @router.delete(
         "/api/history/{run_id}",
         response_model=DeleteHistoryRunResponse,
-        responses=_RUN_NOT_FOUND_RESPONSE,
+        responses={**_INVALID_RUN_ID_RESPONSE, **_RUN_NOT_FOUND_RESPONSE},
     )
     async def delete_history_run(run_id: str) -> DeleteHistoryRunResponse:
         """Delete a persisted run and its derived artifacts from history storage."""
+        run_id = normalize_run_id_or_400(run_id)
         with domain_errors_to_http():
             return await run_service.delete_run(run_id)
 
@@ -126,7 +141,7 @@ def create_history_routes(
     @router.get(
         "/api/history/{run_id}/report.pdf",
         response_class=Response,
-        responses=_REPORT_RESPONSES,
+        responses={**_INVALID_RUN_ID_RESPONSE, **_REPORT_RESPONSES},
     )
     async def download_history_report_pdf(
         run_id: str,
@@ -139,6 +154,7 @@ def create_history_routes(
         ),
     ) -> Response:
         """Build and download the PDF diagnostic report for a persisted run."""
+        run_id = normalize_run_id_or_400(run_id)
         with domain_errors_to_http():
             pdf = await report_service.build_pdf(run_id, lang)
         pdf_headers = {
@@ -155,10 +171,11 @@ def create_history_routes(
     @router.get(
         "/api/history/{run_id}/export",
         response_class=StreamingResponse,
-        responses=_EXPORT_RESPONSES,
+        responses={**_INVALID_RUN_ID_RESPONSE, **_EXPORT_RESPONSES},
     )
     async def export_history_run(run_id: str) -> StreamingResponse:
         """Build and stream the ZIP export bundle for a persisted run."""
+        run_id = normalize_run_id_or_400(run_id)
         with domain_errors_to_http():
             export = await export_service.build_export(run_id)
         return StreamingResponse(

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException
 from vibesensor.adapters.http._helpers import (
     OpenAPIResponses,
     domain_errors_to_http,
+    normalize_car_id_or_400,
     normalize_mac_or_400,
 )
 from vibesensor.adapters.http.models import (
@@ -48,11 +49,17 @@ if TYPE_CHECKING:
     from vibesensor.infra.config.settings_store import SettingsStore
 
 _CAR_NOT_FOUND_RESPONSES: OpenAPIResponses = {
+    400: {"description": "Invalid car identifier."},
     404: {"description": "Requested car profile was not found."},
 }
 
 _DELETE_CAR_RESPONSES: OpenAPIResponses = {
-    400: {"description": "The requested deletion violates current settings constraints."},
+    400: {
+        "description": (
+            "Invalid car identifier or the requested deletion violates "
+            "current settings constraints."
+        )
+    },
     404: {"description": "Requested car profile was not found."},
 }
 
@@ -224,7 +231,7 @@ def create_settings_routes(
     )
     async def set_active_car(req: ActiveCarRequest) -> CarsResponse:
         """Select which saved car profile should drive current analysis settings."""
-        car_id = req.car_id
+        car_id = normalize_car_id_or_400(req.car_id)
         with domain_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(settings_store.set_active_car, car_id)
         return _cars_response(result)
@@ -236,6 +243,7 @@ def create_settings_routes(
     )
     async def update_car(car_id: str, req: CarUpsertRequest) -> CarsResponse:
         """Update an existing car profile while preserving unspecified fields."""
+        car_id = normalize_car_id_or_400(car_id)
         payload = _car_upsert_payload(req)
         with domain_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(
@@ -252,6 +260,7 @@ def create_settings_routes(
     )
     async def delete_car(car_id: str) -> CarsResponse:
         """Delete a saved car profile when that removal keeps settings state valid."""
+        car_id = normalize_car_id_or_400(car_id)
         # Existence check first so unknown-car yields 404 while business-logic
         # errors (e.g. "cannot delete the last car") propagate as 400.
         cars_snapshot = await asyncio.to_thread(settings_store.get_cars)

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -7135,6 +7135,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid run identifier."
+          },
           "404": {
             "description": "Requested run was not found."
           },
@@ -7179,6 +7182,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid run identifier."
+          },
           "404": {
             "description": "Requested run was not found."
           },
@@ -7220,6 +7226,9 @@
         "responses": {
           "200": {
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid run identifier."
           },
           "404": {
             "description": "Requested run was not found."
@@ -7298,6 +7307,9 @@
             },
             "description": "Analysis is still running for the requested run."
           },
+          "400": {
+            "description": "Invalid run identifier."
+          },
           "404": {
             "description": "Requested run was not found."
           },
@@ -7353,6 +7365,9 @@
         "responses": {
           "200": {
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid run identifier."
           },
           "404": {
             "description": "Requested run was not found."
@@ -7595,6 +7610,9 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "description": "Invalid car identifier."
+          },
           "404": {
             "description": "Requested car profile was not found."
           },
@@ -7642,7 +7660,7 @@
             "description": "Successful Response"
           },
           "400": {
-            "description": "The requested deletion violates current settings constraints."
+            "description": "Invalid car identifier or the requested deletion violates current settings constraints."
           },
           "404": {
             "description": "Requested car profile was not found."
@@ -7697,6 +7715,9 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid car identifier."
           },
           "404": {
             "description": "Requested car profile was not found."

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -2824,6 +2824,10 @@ export interface operations {
           "application/json": components["schemas"]["HistoryRunResponse"];
         };
       };
+      /** @description Invalid run identifier. */
+      400: {
+        content: never;
+      };
       /** @description Requested run was not found. */
       404: {
         content: never;
@@ -2857,6 +2861,10 @@ export interface operations {
           "application/json": components["schemas"]["DeleteHistoryRunResponse"];
         };
       };
+      /** @description Invalid run identifier. */
+      400: {
+        content: never;
+      };
       /** @description Requested run was not found. */
       404: {
         content: never;
@@ -2882,6 +2890,10 @@ export interface operations {
     responses: {
       /** @description Successful Response */
       200: {
+        content: never;
+      };
+      /** @description Invalid run identifier. */
+      400: {
         content: never;
       };
       /** @description Requested run was not found. */
@@ -2927,6 +2939,10 @@ export interface operations {
           "application/json": components["schemas"]["HistoryInsightsAnalyzingResponse"];
         };
       };
+      /** @description Invalid run identifier. */
+      400: {
+        content: never;
+      };
       /** @description Requested run was not found. */
       404: {
         content: never;
@@ -2962,6 +2978,10 @@ export interface operations {
     responses: {
       /** @description Successful Response */
       200: {
+        content: never;
+      };
+      /** @description Invalid run identifier. */
+      400: {
         content: never;
       };
       /** @description Requested run was not found. */
@@ -3121,6 +3141,10 @@ export interface operations {
           "application/json": components["schemas"]["CarsResponse"];
         };
       };
+      /** @description Invalid car identifier. */
+      400: {
+        content: never;
+      };
       /** @description Requested car profile was not found. */
       404: {
         content: never;
@@ -3155,6 +3179,10 @@ export interface operations {
           "application/json": components["schemas"]["CarsResponse"];
         };
       };
+      /** @description Invalid car identifier. */
+      400: {
+        content: never;
+      };
       /** @description Requested car profile was not found. */
       404: {
         content: never;
@@ -3184,7 +3212,7 @@ export interface operations {
           "application/json": components["schemas"]["CarsResponse"];
         };
       };
-      /** @description The requested deletion violates current settings constraints. */
+      /** @description Invalid car identifier or the requested deletion violates current settings constraints. */
       400: {
         content: never;
       };


### PR DESCRIPTION
Closes #1273

## Summary

This PR addresses the live API-contract defect behind `#1273` without turning the issue’s much broader checklist into a cross-cutting rewrite of stable HTTP and WebSocket behavior. After reconciling the issue body against current `main`, the real problem turned out to be narrower and more concrete: several HTTP routes were still accepting obviously invalid string identifiers at the API boundary and only failing later in the history/settings layers, usually as “not found” style outcomes. That made the contract less predictable than it should be, because malformed identifiers were not being rejected consistently before they reached service or store logic.

The fix in this PR is to validate those identifiers explicitly at the HTTP boundary, document the resulting `400` responses in the exported OpenAPI contract, and add focused regression coverage around both the live route behavior and the generated schema surface.

## Problem being solved

Issue `#1273` lists a wide set of possible contract-quality concerns: inconsistent status codes, path parameter validation gaps, response-shape inconsistencies, health payload overexposure, missing WebSocket runtime validation, extra-field handling, nested optionals in history payloads, and the lack of a cross-cutting validation framework.

On current `main`, most of that list is either stale, already intentionally designed, or too broad to fix safely as part of a focused issue-sized change:

- The detailed `/api/health` payload is an active contract, not dead internals. The UI update status view renders several of those fields today, and release smoke validation also checks them.
- WebSocket schema versioning already exists where it matters: outbound server payloads include `schema_version`, the UI validates the generated schema, and inbound client messages are intentionally small and tolerant of unknown keys.
- The `response_model_exclude_unset` / `response_model_exclude_none` concern is already narrowly scoped to the history run endpoint and has focused tests around the omitted optional fields.
- The “missing cross-cutting validation framework” claim is real only in the abstract; building a new framework here would be a much larger architectural change than the live defect required.

The concrete live gap was simpler: history `run_id` values and car identifiers were not always being validated explicitly at the route boundary. That allowed invalid identifiers to propagate into downstream logic instead of failing fast with a clear `400 Bad Request`.

## Chosen implementation approach

I took an audit-first, root-cause-oriented approach:

1. Reconcile the issue body against current route code, models, generated contracts, UI consumers, updater health checks, and tests.
2. Keep only the live, low-risk defect in scope.
3. Fix that defect at the HTTP boundary rather than deeper in the service or persistence layers.
4. Update the generated contract artifacts so the documented API matches the live route behavior.

That led to a deliberately narrow fix set:

- add shared identifier validators in the HTTP helper layer
- apply them to history run routes and car-ID routes before service/store calls
- document the new `400` responses in the exported OpenAPI/UI contract
- add focused regression coverage

I explicitly did **not** rewrite `/api/health`, replace the current WebSocket validation pattern, or change response serialization policy, because those parts of the issue body do not line up with the current behavior or the current consumers of those contracts.

## Main code changes by area

### `apps/server/vibesensor/adapters/http/_helpers.py`

Added shared helper functions for HTTP-boundary identifier validation:

- `normalize_run_id_or_400()`
- `normalize_car_id_or_400()`

These keep the existing route-layer pattern where malformed path/body identifiers are rejected with `HTTPException(status_code=400, ...)` instead of silently flowing into deeper logic.

The run-ID validator is intentionally a little broader than the car-ID validator. During implementation I hit an existing history-export regression test that uses punctuation-bearing run IDs and relies on later filename sanitization via `safe_filename()`. The final validator therefore rejects whitespace/control-style garbage while preserving printable punctuation-bearing run IDs that the current history/report flow already supports.

### `apps/server/vibesensor/adapters/http/history.py`

Applied `normalize_run_id_or_400()` consistently across the history route family:

- `GET /api/history/{run_id}`
- `GET /api/history/{run_id}/insights`
- `DELETE /api/history/{run_id}`
- `GET /api/history/{run_id}/report.pdf`
- `GET /api/history/{run_id}/export`

I also added explicit `400` response documentation for these endpoints so the OpenAPI contract now reflects the live invalid-identifier behavior.

### `apps/server/vibesensor/adapters/http/settings.py`

Applied `normalize_car_id_or_400()` to the car-identifier entry points:

- `PUT /api/settings/cars/active`
- `PUT /api/settings/cars/{car_id}`
- `DELETE /api/settings/cars/{car_id}`

The delete route’s `400` description was widened to cover both malformed identifiers and the existing business-logic constraint failures (for example, attempts to delete the last car).

### Generated contract artifacts

Regenerated:

- `apps/ui/src/contracts/http_api_schema.json`
- `apps/ui/src/generated/http_api_contracts.ts`

These updates are intentionally small: they document the new `400` responses for the affected history and car routes so frontend and other contract consumers see the same behavior that the live server now enforces.

### Focused regression coverage

Added `apps/server/tests/adapters/http/test_api_path_identifier_validation.py`, which covers two important surfaces:

1. real HTTP route behavior returning `400` before downstream history/settings services are called
2. exported OpenAPI documentation including the new `400` responses

This keeps the change locked to the contract boundary instead of testing only helper internals.

## Validation performed

Focused tests:

- `pytest -q apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/adapters/http/test_settings_endpoints.py`
- `pytest -q apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py`

Broader repo validation:

- `make typecheck-backend`
- `cd apps/ui && npm run typecheck && npm run build`
- `make lint`
- `make test-changed`

`make test-changed` exercised:

- UI contract freshness + UI typecheck
- adapter-focused backend pytest selection

and completed successfully with:

- `1242 passed`

Native runtime smoke:

- started `vibesensor-server --config apps/server/config.dev.yaml`
- confirmed `GET /api/health` returned a healthy payload
- confirmed invalid history and car identifiers now return live `400` responses

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is intentionally **not** treating every bullet in `#1273` as still live. I think that is the correct engineering choice. The current `/api/health` detail fields are already consumed by the UI and updater flow, so stripping them here would be a wider contract change than the issue’s live defect justified. Likewise, the WebSocket and response-shape concerns are already constrained by current generated contracts, runtime parsing, and focused tests.

The run-ID validation is also intentionally not reduced to a very tight UUID-only rule. Current history/report behavior already supports printable punctuation-bearing run IDs, and existing export/report code sanitizes those IDs only when constructing filenames. The final validator preserves that compatibility while still rejecting malformed whitespace/control-style input at the HTTP boundary.

If we later want a bigger API-contract simplification effort, that should be a dedicated change set with coordinated updates across backend routes, UI consumers, release validation, and any generated client expectations. This PR stays intentionally smaller: it fixes the live invalid-identifier boundary gap, aligns the generated API contract with runtime behavior, and leaves the current intentionally consumed health/WebSocket contracts alone.
