### PR TITLE
Extract shared UI polling and car wizard views

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -56,8 +56,8 @@ It regenerates:
 | `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport, payload adaptation, and throttled live-session rendering |
 | `app/runtime/ui_spectrum_controller.ts` | Spectrum chart lifecycle, overlays, order-band calculation, and animation |
 | `app/app_feature_bundle.ts` | Feature composition for dashboard, realtime, settings, cars, history, update, and ESP flash flows |
-| `app/features/` | Feature owners for state changes, API calls, polling loops, and delegated UI event wiring |
-| `app/views/` | Focused DOM rendering and event-target decoding for settings, realtime, history, and update panels |
+| `app/features/` | Feature owners for state changes, API calls, shared polling control, and delegated UI event wiring |
+| `app/views/` | Focused DOM rendering and event-target decoding for settings, cars wizard, realtime, history, and update panels |
 | `api.ts` | REST API client with typed request/response interfaces |
 | `ws.ts` | WebSocket client with auto-reconnect and stale detection |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |

--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -1,10 +1,35 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
-import { getCarLibraryBrands, getCarLibraryModels, getCarLibraryTypes } from "../../api";
-import type { CarLibraryModel, CarLibraryGearbox, CarLibraryTireOption, CarLibraryVariant } from "../../api";
+import {
+  getCarLibraryBrands,
+  getCarLibraryModels,
+  getCarLibraryTypes,
+} from "../../api";
+import type {
+  CarLibraryGearbox,
+  CarLibraryModel,
+  CarLibraryTireOption,
+  CarLibraryVariant,
+} from "../../api";
+import {
+  renderWizardBrandOptions,
+  renderWizardGearboxOptions,
+  renderWizardMessage,
+  renderWizardModelOptions,
+  renderWizardTireOptions,
+  renderWizardTypeOptions,
+  renderWizardVariantOptions,
+  syncCarWizardStepState,
+  writeCarWizardTireInputs,
+} from "../views/car_wizard_view";
 
 export interface CarsFeatureDeps extends FeatureDepsBase {
   fmt: (n: number, digits?: number) => string;
-  addCarFromWizard: (name: string, carType: string, aspects: Record<string, number>, variant?: string) => Promise<void>;
+  addCarFromWizard: (
+    name: string,
+    carType: string,
+    aspects: Record<string, number>,
+    variant?: string,
+  ) => Promise<void>;
 }
 
 export interface CarsFeature {
@@ -23,13 +48,19 @@ interface WizardState {
 }
 
 /** Resolve effective gearboxes for the selected variant (or base model fallback). */
-function resolveGearboxes(model: CarLibraryModel | null, variant: CarLibraryVariant | null): CarLibraryGearbox[] {
+function resolveGearboxes(
+  model: CarLibraryModel | null,
+  variant: CarLibraryVariant | null,
+): CarLibraryGearbox[] {
   if (variant?.gearboxes && variant.gearboxes.length > 0) return variant.gearboxes;
   return model?.gearboxes || [];
 }
 
 /** Resolve effective tire options for the selected variant (or base model fallback). */
-function resolveTireOptions(model: CarLibraryModel | null, variant: CarLibraryVariant | null): CarLibraryTireOption[] {
+function resolveTireOptions(
+  model: CarLibraryModel | null,
+  variant: CarLibraryVariant | null,
+): CarLibraryTireOption[] {
   if (variant?.tire_options && variant.tire_options.length > 0) return variant.tire_options;
   return model?.tire_options || [];
 }
@@ -46,7 +77,17 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
     selectedGearbox: null,
     selectedTire: null,
   };
-  const WIZARD_STEP_COUNT = 5;
+
+  function bindWizardOptionButtons(
+    container: HTMLElement,
+    onSelect: (button: HTMLButtonElement) => void,
+  ): void {
+    container.querySelectorAll<HTMLButtonElement>(".wiz-opt").forEach((button) => {
+      button.addEventListener("click", () => {
+        onSelect(button);
+      });
+    });
+  }
 
   function resetWizardState(): void {
     wizState.step = 0;
@@ -69,23 +110,18 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
     if (els.addCarWizard) els.addCarWizard.hidden = true;
   }
 
-  function buildWizardCarName(brand: string, model: string, variant: CarLibraryVariant | null): string {
+  function buildWizardCarName(
+    brand: string,
+    model: string,
+    variant: CarLibraryVariant | null,
+  ): string {
     const variantSuffix = variant ? ` ${variant.name}` : "";
     if (brand) return `${brand} ${model || "Custom"}${variantSuffix}`;
     return (model || "Custom Car") + variantSuffix;
   }
 
   function loadWizardStep(): void {
-    for (let i = 0; i < WIZARD_STEP_COUNT; i++) {
-      const stepEl = document.getElementById(`wizardStep${i}`);
-      if (stepEl) stepEl.classList.toggle("active", i === wizState.step);
-    }
-    document.querySelectorAll(".wizard-step-dot").forEach((dot) => {
-      const s = Number(dot.getAttribute("data-step"));
-      dot.classList.toggle("active", s === wizState.step);
-      dot.classList.toggle("done", s < wizState.step);
-    });
-    if (els.wizardBackBtn) els.wizardBackBtn.style.display = wizState.step > 0 ? "" : "none";
+    syncCarWizardStepState(els, wizState.step);
     if (wizState.step === 0) void loadBrandStep();
     else if (wizState.step === 1) void loadTypeStep();
     else if (wizState.step === 2) void loadModelStep();
@@ -94,152 +130,147 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
   }
 
   async function loadBrandStep(): Promise<void> {
-    const container = document.getElementById("wizardBrandList");
+    const container = els.wizardBrandList;
     if (!container) return;
-    container.innerHTML = `<em>${escapeHtml(t("settings.wizard.loading"))}</em>`;
+    container.innerHTML = renderWizardMessage(t("settings.wizard.loading"), escapeHtml);
     try {
       const data = await getCarLibraryBrands();
-      container.innerHTML = (data.brands || []).map((b) => `<button type="button" class="wiz-opt" data-value="${escapeHtml(b)}">${escapeHtml(b)}</button>`).join("");
-      container.querySelectorAll(".wiz-opt").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          wizState.brand = btn.getAttribute("data-value") || "";
-          wizState.step = 1;
-          loadWizardStep();
-        });
+      container.innerHTML = renderWizardBrandOptions(data.brands || [], escapeHtml);
+      bindWizardOptionButtons(container, (button) => {
+        const value = button.dataset.value || "";
+        if (!value) return;
+        wizState.brand = value;
+        wizState.step = 1;
+        loadWizardStep();
       });
-    } catch (_err) {
-      container.innerHTML = `<em>${escapeHtml(t("settings.wizard.load_failed_brands"))}</em>`;
+    } catch {
+      container.innerHTML = renderWizardMessage(t("settings.wizard.load_failed_brands"), escapeHtml);
     }
   }
 
   async function loadTypeStep(): Promise<void> {
-    const container = document.getElementById("wizardTypeList");
+    const container = els.wizardTypeList;
     if (!container) return;
-    container.innerHTML = `<em>${escapeHtml(t("settings.wizard.loading"))}</em>`;
+    container.innerHTML = renderWizardMessage(t("settings.wizard.loading"), escapeHtml);
     try {
       const data = await getCarLibraryTypes(wizState.brand);
-      container.innerHTML = (data.types || []).map((t2) => `<button type="button" class="wiz-opt" data-value="${escapeHtml(t2)}">${escapeHtml(t2)}</button>`).join("");
-      container.querySelectorAll(".wiz-opt").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          wizState.carType = btn.getAttribute("data-value") || "";
-          wizState.step = 2;
-          loadWizardStep();
-        });
+      container.innerHTML = renderWizardTypeOptions(data.types || [], escapeHtml);
+      bindWizardOptionButtons(container, (button) => {
+        const value = button.dataset.value || "";
+        if (!value) return;
+        wizState.carType = value;
+        wizState.step = 2;
+        loadWizardStep();
       });
-    } catch (_err) {
-      container.innerHTML = `<em>${escapeHtml(t("settings.wizard.load_failed_types"))}</em>`;
+    } catch {
+      container.innerHTML = renderWizardMessage(t("settings.wizard.load_failed_types"), escapeHtml);
     }
   }
 
   async function loadModelStep(): Promise<void> {
-    const container = document.getElementById("wizardModelList");
+    const container = els.wizardModelList;
     if (!container) return;
-    container.innerHTML = `<em>${escapeHtml(t("settings.wizard.loading"))}</em>`;
+    container.innerHTML = renderWizardMessage(t("settings.wizard.loading"), escapeHtml);
     try {
       const data = await getCarLibraryModels(wizState.brand, wizState.carType);
       const models: CarLibraryModel[] = data.models || [];
-      container.innerHTML = models.map((m, idx) => {
-        const tireStr = `${m.tire_width_mm}/${m.tire_aspect_pct}R${m.rim_in}`;
-        return `<button type="button" class="wiz-opt" data-idx="${idx}"><span>${escapeHtml(m.model)}</span><span class="wiz-opt-detail">${escapeHtml(tireStr)}</span></button>`;
-      }).join("");
-      container.querySelectorAll(".wiz-opt").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          const idx = Number(btn.getAttribute("data-idx"));
-          wizState.selectedModel = models[idx] || null;
-          wizState.model = wizState.selectedModel?.model || "";
-          wizState.selectedVariant = null;
-          wizState.selectedTire = null;
-          wizState.step = 3;
-          loadWizardStep();
-        });
+      container.innerHTML = renderWizardModelOptions(models, escapeHtml);
+      bindWizardOptionButtons(container, (button) => {
+        const idx = Number(button.dataset.idx);
+        wizState.selectedModel = models[idx] || null;
+        wizState.model = wizState.selectedModel?.model || "";
+        wizState.selectedVariant = null;
+        wizState.selectedTire = null;
+        wizState.step = 3;
+        loadWizardStep();
       });
-    } catch (_err) {
-      container.innerHTML = `<em>${escapeHtml(t("settings.wizard.load_failed_models"))}</em>`;
+    } catch {
+      container.innerHTML = renderWizardMessage(t("settings.wizard.load_failed_models"), escapeHtml);
     }
   }
 
   function loadVariantStep(): void {
-    const container = document.getElementById("wizardVariantList");
+    const container = els.wizardVariantList;
     if (!container) return;
     const variants: CarLibraryVariant[] = wizState.selectedModel?.variants || [];
     if (!variants.length) {
-      // No variants defined (custom model) – skip to gearbox step
       wizState.step = 4;
       loadWizardStep();
       return;
     }
-    container.innerHTML = variants.map((v, idx) => {
-      const detail = [v.drivetrain, v.engine].filter(Boolean).join(" · ");
-      return `<button type="button" class="wiz-opt" data-idx="${idx}"><span>${escapeHtml(v.name)}</span><span class="wiz-opt-detail">${escapeHtml(detail)}</span></button>`;
-    }).join("");
-    container.querySelectorAll(".wiz-opt").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const idx = Number(btn.getAttribute("data-idx"));
-        wizState.selectedVariant = variants[idx] || null;
-        wizState.selectedTire = null;
-        wizState.step = 4;
-        loadWizardStep();
-      });
+    container.innerHTML = renderWizardVariantOptions(variants, escapeHtml);
+    bindWizardOptionButtons(container, (button) => {
+      const idx = Number(button.dataset.idx);
+      wizState.selectedVariant = variants[idx] || null;
+      wizState.selectedTire = null;
+      wizState.step = 4;
+      loadWizardStep();
     });
   }
 
   function loadGearboxStep(): void {
-    const tireContainer = document.getElementById("wizardTireList");
+    const tireContainer = els.wizardTireList;
     if (tireContainer) {
       const tireOptions = resolveTireOptions(wizState.selectedModel, wizState.selectedVariant);
       if (tireOptions.length > 0) {
-        tireContainer.innerHTML = tireOptions.map((to, idx) => `<button type="button" class="wiz-opt${idx === 0 ? " selected" : ""}" data-tire-idx="${idx}"><span>${escapeHtml(to.name)}</span><span class="wiz-opt-detail">${to.tire_width_mm}/${to.tire_aspect_pct}R${to.rim_in}</span></button>`).join("");
+        tireContainer.innerHTML = renderWizardTireOptions(tireOptions, escapeHtml);
         const defaultTire = tireOptions[0];
         wizState.selectedTire = defaultTire;
-        updateWizTireInputs(defaultTire);
-        tireContainer.querySelectorAll(".wiz-opt").forEach((btn) => {
-          btn.addEventListener("click", () => {
-            const idx = Number(btn.getAttribute("data-tire-idx"));
-            wizState.selectedTire = tireOptions[idx] || defaultTire;
-            updateWizTireInputs(wizState.selectedTire);
-            tireContainer.querySelectorAll(".wiz-opt").forEach((b) => b.classList.remove("selected"));
-            btn.classList.add("selected");
+        writeCarWizardTireInputs(els, defaultTire);
+        bindWizardOptionButtons(tireContainer, (button) => {
+          const idx = Number(button.dataset.tireIdx);
+          wizState.selectedTire = tireOptions[idx] || defaultTire;
+          writeCarWizardTireInputs(els, wizState.selectedTire);
+          tireContainer.querySelectorAll(".wiz-opt").forEach((candidate) => {
+            candidate.classList.remove("selected");
           });
+          button.classList.add("selected");
         });
-      } else tireContainer.innerHTML = "";
+      } else {
+        tireContainer.innerHTML = "";
+      }
     }
 
-    const container = document.getElementById("wizardGearboxList");
+    const container = els.wizardGearboxList;
     if (!container) return;
     const gearboxes = resolveGearboxes(wizState.selectedModel, wizState.selectedVariant);
     if (!gearboxes.length) {
-      container.innerHTML = `<em>${escapeHtml(t("settings.wizard.no_gearboxes"))}</em>`;
+      container.innerHTML = renderWizardMessage(t("settings.wizard.no_gearboxes"), escapeHtml);
       return;
     }
-    container.innerHTML = gearboxes.map((gb, idx) => `<button type="button" class="wiz-opt" data-idx="${idx}"><span>${escapeHtml(gb.name)}</span><span class="wiz-opt-detail">FD: ${ctx.fmt(gb.final_drive_ratio, 2)} · Top Gear: ${ctx.fmt(gb.top_gear_ratio, 2)}</span></button>`).join("");
-    container.querySelectorAll(".wiz-opt").forEach((btn) => {
-      btn.addEventListener("click", async () => {
-        const idx = Number(btn.getAttribute("data-idx"));
-        const gb = gearboxes[idx];
-        if (!gb) return;
+    container.innerHTML = renderWizardGearboxOptions(gearboxes, {
+      escapeHtml,
+      fmt: ctx.fmt,
+    });
+    bindWizardOptionButtons(container, (button) => {
+      void (async () => {
+        const idx = Number(button.dataset.idx);
+        const gearbox = gearboxes[idx];
+        if (!gearbox) return;
         const tire = wizState.selectedTire || wizState.selectedModel;
         if (!tire) return;
-        const carName = buildWizardCarName(wizState.brand, wizState.model, wizState.selectedVariant);
+        wizState.selectedGearbox = gearbox;
+        const carName = buildWizardCarName(
+          wizState.brand,
+          wizState.model,
+          wizState.selectedVariant,
+        );
         const variantName = wizState.selectedVariant?.name;
-        await ctx.addCarFromWizard(carName, wizState.carType, {
-          tire_width_mm: tire.tire_width_mm,
-          tire_aspect_pct: tire.tire_aspect_pct,
-          rim_in: tire.rim_in,
-          final_drive_ratio: gb.final_drive_ratio,
-          current_gear_ratio: gb.top_gear_ratio,
-        }, variantName);
+        await ctx.addCarFromWizard(
+          carName,
+          wizState.carType,
+          {
+            tire_width_mm: tire.tire_width_mm,
+            tire_aspect_pct: tire.tire_aspect_pct,
+            rim_in: tire.rim_in,
+            final_drive_ratio: gearbox.final_drive_ratio,
+            current_gear_ratio: gearbox.top_gear_ratio,
+          },
+          variantName,
+        );
         closeWizard();
-      });
+      })();
     });
-  }
-
-  function updateWizTireInputs(tire: CarLibraryTireOption): void {
-    const tw = document.getElementById("wizTireWidth") as HTMLInputElement | null;
-    const ta = document.getElementById("wizTireAspect") as HTMLInputElement | null;
-    const ri = document.getElementById("wizRim") as HTMLInputElement | null;
-    if (tw) tw.value = String(tire.tire_width_mm);
-    if (ta) ta.value = String(tire.tire_aspect_pct);
-    if (ri) ri.value = String(tire.rim_in);
   }
 
   function bindWizardHandlers(): void {
@@ -249,56 +280,64 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
       els.wizardBackBtn.addEventListener("click", () => {
         if (wizState.step > 0) {
           wizState.step -= 1;
-          // Skip variant step when going back from gearbox if there are no variants to show
-          if (wizState.step === 3 && (!wizState.selectedModel || !(wizState.selectedModel.variants?.length))) {
+          if (
+            wizState.step === 3
+            && (!wizState.selectedModel || !(wizState.selectedModel.variants?.length))
+          ) {
             wizState.step = 2;
           }
           loadWizardStep();
         }
       });
     }
-    document.getElementById("wizardCustomBrandBtn")?.addEventListener("click", () => {
-      const input = document.getElementById("wizardCustomBrand") as HTMLInputElement | null;
-      const val = input?.value?.trim();
-      if (!val) return;
-      wizState.brand = val;
+    els.wizardCustomBrandBtn?.addEventListener("click", () => {
+      const value = els.wizardCustomBrandInput?.value?.trim();
+      if (!value) return;
+      wizState.brand = value;
       wizState.step = 1;
       loadWizardStep();
     });
-    document.getElementById("wizardCustomTypeBtn")?.addEventListener("click", () => {
-      const input = document.getElementById("wizardCustomType") as HTMLInputElement | null;
-      const val = input?.value?.trim();
-      if (!val) return;
-      wizState.carType = val;
+    els.wizardCustomTypeBtn?.addEventListener("click", () => {
+      const value = els.wizardCustomTypeInput?.value?.trim();
+      if (!value) return;
+      wizState.carType = value;
       wizState.step = 2;
       loadWizardStep();
     });
-    document.getElementById("wizardCustomModelBtn")?.addEventListener("click", () => {
-      const input = document.getElementById("wizardCustomModel") as HTMLInputElement | null;
-      const val = input?.value?.trim();
-      if (!val) return;
-      wizState.model = val;
+    els.wizardCustomModelBtn?.addEventListener("click", () => {
+      const value = els.wizardCustomModelInput?.value?.trim();
+      if (!value) return;
+      wizState.model = value;
       wizState.selectedModel = null;
       wizState.selectedVariant = null;
       wizState.step = 4;
       loadWizardStep();
     });
-    document.getElementById("wizardManualAddBtn")?.addEventListener("click", async () => {
-      const tw = Number((document.getElementById("wizTireWidth") as HTMLInputElement | null)?.value);
-      const ta = Number((document.getElementById("wizTireAspect") as HTMLInputElement | null)?.value);
-      const ri = Number((document.getElementById("wizRim") as HTMLInputElement | null)?.value);
-      const fd = Number((document.getElementById("wizFinalDrive") as HTMLInputElement | null)?.value);
-      const gr = Number((document.getElementById("wizGearRatio") as HTMLInputElement | null)?.value);
+    els.wizardManualAddBtn?.addEventListener("click", async () => {
+      const tw = Number(els.wizTireWidthInput?.value);
+      const ta = Number(els.wizTireAspectInput?.value);
+      const ri = Number(els.wizRimInput?.value);
+      const fd = Number(els.wizFinalDriveInput?.value);
+      const gr = Number(els.wizGearRatioInput?.value);
       if (!(tw > 0 && ta > 0 && ri > 0 && fd > 0 && gr > 0)) return;
-      const name = buildWizardCarName(wizState.brand, wizState.model, wizState.selectedVariant);
+      const name = buildWizardCarName(
+        wizState.brand,
+        wizState.model,
+        wizState.selectedVariant,
+      );
       const variantName = wizState.selectedVariant?.name;
-      await ctx.addCarFromWizard(name, wizState.carType || "Custom", {
-        tire_width_mm: tw,
-        tire_aspect_pct: ta,
-        rim_in: ri,
-        final_drive_ratio: fd,
-        current_gear_ratio: gr,
-      }, variantName);
+      await ctx.addCarFromWizard(
+        name,
+        wizState.carType || "Custom",
+        {
+          tire_width_mm: tw,
+          tire_aspect_pct: ta,
+          rim_in: ri,
+          final_drive_ratio: fd,
+          current_gear_ratio: gr,
+        },
+        variantName,
+      );
       closeWizard();
     });
   }

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,6 +1,7 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { EspFlashStatusPayload } from "../../api/types";
+import { createPollingController } from "./polling_controller";
 import {
   cancelEspFlash,
   getEspFlashHistory,
@@ -29,9 +30,6 @@ const STATE_TO_VARIANT: Readonly<Record<string, string>> = {
 
 export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature {
   const { els, t, escapeHtml } = ctx;
-  let pollTimer: ReturnType<typeof setTimeout> | null = null;
-  let pollGeneration = 0;
-  let pollingActive = false;
   let nextLogIndex = 0;
 
   async function refreshPorts(): Promise<void> {
@@ -104,36 +102,16 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
     els.espFlashHistoryPanel.innerHTML = `<ul>${rows.join("")}</ul>`;
   }
 
-  function clearPollTimer(): void {
-    if (pollTimer === null) return;
-    clearTimeout(pollTimer);
-    pollTimer = null;
-  }
-
-  function schedulePoll(delayMs: number, generation: number): void {
-    if (!pollingActive || generation !== pollGeneration) return;
-    clearPollTimer();
-    pollTimer = setTimeout(() => void poll(generation), delayMs);
-  }
-
-  async function poll(generation: number = pollGeneration): Promise<void> {
-    try {
+  const polling = createPollingController({
+    poll: async () => {
       const status = await getEspFlashStatus();
       renderStatus(status);
       await refreshLogs(status);
       await refreshHistory();
-      schedulePoll(status.state === "running" ? POLL_ACTIVE_MS : POLL_IDLE_MS, generation);
-    } catch {
-      schedulePoll(POLL_ACTIVE_MS, generation);
-    }
-  }
-
-  function restartPolling(): void {
-    if (!pollingActive) return;
-    pollGeneration += 1;
-    clearPollTimer();
-    void poll(pollGeneration);
-  }
+      return status.state === "running" ? POLL_ACTIVE_MS : POLL_IDLE_MS;
+    },
+    onErrorDelayMs: POLL_ACTIVE_MS,
+  });
 
   async function onStart(): Promise<void> {
     const selected = els.espFlashPortSelect?.value || "__auto__";
@@ -143,7 +121,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
       await startEspFlash(port, autoDetect);
       if (els.espFlashLogPanel) els.espFlashLogPanel.textContent = "";
       nextLogIndex = 0;
-      restartPolling();
+      polling.restart();
     } catch (err) {
       ctx.showError(`${t("settings.esp_flash.start_failed")}\n${err instanceof Error ? err.message : String(err)}`);
     }
@@ -155,7 +133,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
     } catch {
       // Cancel request may fail if the job already finished; poll to sync state.
     }
-    restartPolling();
+    polling.restart();
   }
 
   function bindHandlers(): void {
@@ -165,17 +143,12 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
   }
 
   function startPolling(): void {
-    if (pollingActive) return;
-    pollingActive = true;
     void refreshPorts();
-    restartPolling();
+    polling.start();
   }
 
   function stopPolling(): void {
-    if (!pollingActive && pollTimer === null) return;
-    pollingActive = false;
-    pollGeneration += 1;
-    clearPollTimer();
+    polling.stop();
   }
 
   return { bindHandlers, startPolling, stopPolling };

--- a/apps/ui/src/app/features/polling_controller.ts
+++ b/apps/ui/src/app/features/polling_controller.ts
@@ -1,0 +1,67 @@
+export interface PollingController {
+  start(): void;
+  stop(): void;
+  restart(): void;
+}
+
+export interface PollingControllerOptions {
+  poll: () => Promise<number>;
+  onErrorDelayMs: number;
+}
+
+export function createPollingController(
+  options: PollingControllerOptions,
+): PollingController {
+  const { poll, onErrorDelayMs } = options;
+
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollGeneration = 0;
+  let pollingActive = false;
+
+  function clearPollTimer(): void {
+    if (pollTimer === null) return;
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+
+  function schedulePoll(delayMs: number, generation: number): void {
+    if (!pollingActive || generation !== pollGeneration) return;
+    clearPollTimer();
+    pollTimer = setTimeout(() => void runPoll(generation), delayMs);
+  }
+
+  async function runPoll(generation: number = pollGeneration): Promise<void> {
+    try {
+      const delayMs = await poll();
+      schedulePoll(delayMs, generation);
+    } catch {
+      schedulePoll(onErrorDelayMs, generation);
+    }
+  }
+
+  function restart(): void {
+    if (!pollingActive) return;
+    pollGeneration += 1;
+    clearPollTimer();
+    void runPoll(pollGeneration);
+  }
+
+  function start(): void {
+    if (pollingActive) return;
+    pollingActive = true;
+    restart();
+  }
+
+  function stop(): void {
+    if (!pollingActive && pollTimer === null) return;
+    pollingActive = false;
+    pollGeneration += 1;
+    clearPollTimer();
+  }
+
+  return {
+    start,
+    stop,
+    restart,
+  };
+}

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -2,6 +2,7 @@ import type { SpeedSourceStatusPayload } from "../../api/types";
 import { getSpeedSourceStatus } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
+import { createPollingController } from "./polling_controller";
 
 const GPS_POLL_FAST = 2_000;
 const GPS_POLL_SLOW = 10_000;
@@ -26,7 +27,6 @@ export interface SettingsGpsStatusModule {
 
 export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps): SettingsGpsStatusModule {
   const { settings, els, t, fmt } = ctx;
-  let gpsPollTimer: ReturnType<typeof setTimeout> | null = null;
 
   function connectionStateLabel(connectionState: string): string {
     const key = CONNECTION_STATE_I18N[connectionState];
@@ -87,8 +87,8 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
     }
   }
 
-  async function pollGpsStatus(): Promise<void> {
-    try {
+  const polling = createPollingController({
+    poll: async () => {
       const status = await getSpeedSourceStatus();
       settings.gpsFallbackActive = status.fallback_active
         || (
@@ -99,23 +99,17 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
         );
       renderGpsStatus(status);
       ctx.renderSpeedReadout();
-      const interval = status.connection_state === "connected" ? GPS_POLL_FAST : GPS_POLL_SLOW;
-      gpsPollTimer = setTimeout(() => void pollGpsStatus(), interval);
-    } catch {
-      gpsPollTimer = setTimeout(() => void pollGpsStatus(), GPS_POLL_SLOW);
-    }
-  }
+      return status.connection_state === "connected" ? GPS_POLL_FAST : GPS_POLL_SLOW;
+    },
+    onErrorDelayMs: GPS_POLL_SLOW,
+  });
 
   function startGpsStatusPolling(): void {
-    if (gpsPollTimer !== null) return;
-    void pollGpsStatus();
+    polling.start();
   }
 
   function stopGpsStatusPolling(): void {
-    if (gpsPollTimer !== null) {
-      clearTimeout(gpsPollTimer);
-      gpsPollTimer = null;
-    }
+    polling.stop();
   }
 
   return {

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -1,6 +1,7 @@
 import type { HealthStatusPayload, UpdateStatusPayload } from "../../api/types";
 import { getHealthStatus, getUpdateStatus, startUpdate, cancelUpdate } from "../../api/settings";
 import type { FeatureDepsBase } from "../feature_deps_base";
+import { createPollingController } from "./polling_controller";
 import {
   renderUpdateStatusPanel,
   syncUpdateControls,
@@ -20,9 +21,6 @@ const POLL_INTERVAL_RUNNING = 2_000;
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   const { els, t, escapeHtml } = ctx;
 
-  let pollTimer: ReturnType<typeof setTimeout> | null = null;
-  let pollGeneration = 0;
-  let pollingActive = false;
   let passwordVisible = false;
 
   function renderStatus(status: UpdateStatusPayload, health: HealthStatusPayload): void {
@@ -32,35 +30,14 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     renderUpdateStatusPanel(panel, status, health, { t, escapeHtml });
   }
 
-  function clearPollTimer(): void {
-    if (pollTimer === null) return;
-    clearTimeout(pollTimer);
-    pollTimer = null;
-  }
-
-  function schedulePoll(delayMs: number, generation: number): void {
-    if (!pollingActive || generation !== pollGeneration) return;
-    clearPollTimer();
-    pollTimer = setTimeout(() => void pollStatus(generation), delayMs);
-  }
-
-  async function pollStatus(generation: number = pollGeneration): Promise<void> {
-    try {
+  const polling = createPollingController({
+    poll: async () => {
       const [status, health] = await Promise.all([getUpdateStatus(), getHealthStatus()]);
       renderStatus(status, health);
-      const interval = status.state === "running" ? POLL_INTERVAL_RUNNING : POLL_INTERVAL_IDLE;
-      schedulePoll(interval, generation);
-    } catch {
-      schedulePoll(POLL_INTERVAL_RUNNING, generation);
-    }
-  }
-
-  function restartPolling(): void {
-    if (!pollingActive) return;
-    pollGeneration += 1;
-    clearPollTimer();
-    void pollStatus(pollGeneration);
-  }
+      return status.state === "running" ? POLL_INTERVAL_RUNNING : POLL_INTERVAL_IDLE;
+    },
+    onErrorDelayMs: POLL_INTERVAL_RUNNING,
+  });
 
   async function handleStart(): Promise<void> {
     const ssid = els.updateSsidInput?.value?.trim() ?? "";
@@ -76,7 +53,7 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       if (els.updatePasswordInput) {
         els.updatePasswordInput.value = "";
       }
-      restartPolling();
+      polling.restart();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("409")) {
@@ -90,7 +67,7 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   async function handleCancel(): Promise<void> {
     try {
       await cancelUpdate();
-      restartPolling();
+      polling.restart();
     } catch {
       /* ignore */
     }
@@ -116,16 +93,11 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   }
 
   function startPolling(): void {
-    if (pollingActive) return;
-    pollingActive = true;
-    restartPolling();
+    polling.start();
   }
 
   function stopPolling(): void {
-    if (!pollingActive && pollTimer === null) return;
-    pollingActive = false;
-    pollGeneration += 1;
-    clearPollTimer();
+    polling.stop();
   }
 
   return {

--- a/apps/ui/src/app/ui_dom_registry.ts
+++ b/apps/ui/src/app/ui_dom_registry.ts
@@ -50,6 +50,26 @@ export interface UiDomElements {
   addCarWizard: HTMLElement | null;
   wizardCloseBtn: HTMLButtonElement | null;
   wizardBackBtn: HTMLButtonElement | null;
+  wizardSteps: Array<HTMLElement | null>;
+  wizardStepDots: HTMLElement[];
+  wizardBrandList: HTMLElement | null;
+  wizardTypeList: HTMLElement | null;
+  wizardModelList: HTMLElement | null;
+  wizardVariantList: HTMLElement | null;
+  wizardTireList: HTMLElement | null;
+  wizardGearboxList: HTMLElement | null;
+  wizardCustomBrandInput: HTMLInputElement | null;
+  wizardCustomBrandBtn: HTMLButtonElement | null;
+  wizardCustomTypeInput: HTMLInputElement | null;
+  wizardCustomTypeBtn: HTMLButtonElement | null;
+  wizardCustomModelInput: HTMLInputElement | null;
+  wizardCustomModelBtn: HTMLButtonElement | null;
+  wizardManualAddBtn: HTMLButtonElement | null;
+  wizTireWidthInput: HTMLInputElement | null;
+  wizTireAspectInput: HTMLInputElement | null;
+  wizRimInput: HTMLInputElement | null;
+  wizFinalDriveInput: HTMLInputElement | null;
+  wizGearRatioInput: HTMLInputElement | null;
   speedSourceRadios: HTMLInputElement[];
   manualSpeedInput: HTMLInputElement | null;
   saveSpeedSourceBtn: HTMLButtonElement | null;
@@ -156,6 +176,26 @@ export function createUiDomRegistry(): UiDomElements {
     addCarWizard: el("addCarWizard"),
     wizardCloseBtn: btnEl("wizardCloseBtn"),
     wizardBackBtn: btnEl("wizardBackBtn"),
+    wizardSteps: [0, 1, 2, 3, 4].map((index) => el(`wizardStep${index}`)),
+    wizardStepDots: Array.from(document.querySelectorAll<HTMLElement>(".wizard-step-dot")),
+    wizardBrandList: el("wizardBrandList"),
+    wizardTypeList: el("wizardTypeList"),
+    wizardModelList: el("wizardModelList"),
+    wizardVariantList: el("wizardVariantList"),
+    wizardTireList: el("wizardTireList"),
+    wizardGearboxList: el("wizardGearboxList"),
+    wizardCustomBrandInput: inputEl("wizardCustomBrand"),
+    wizardCustomBrandBtn: btnEl("wizardCustomBrandBtn"),
+    wizardCustomTypeInput: inputEl("wizardCustomType"),
+    wizardCustomTypeBtn: btnEl("wizardCustomTypeBtn"),
+    wizardCustomModelInput: inputEl("wizardCustomModel"),
+    wizardCustomModelBtn: btnEl("wizardCustomModelBtn"),
+    wizardManualAddBtn: btnEl("wizardManualAddBtn"),
+    wizTireWidthInput: inputEl("wizTireWidth"),
+    wizTireAspectInput: inputEl("wizTireAspect"),
+    wizRimInput: inputEl("wizRim"),
+    wizFinalDriveInput: inputEl("wizFinalDrive"),
+    wizGearRatioInput: inputEl("wizGearRatio"),
     speedSourceRadios: Array.from(
       document.querySelectorAll<HTMLInputElement>('input[name="speedSourceRadio"]'),
     ),

--- a/apps/ui/src/app/views/car_wizard_view.ts
+++ b/apps/ui/src/app/views/car_wizard_view.ts
@@ -1,0 +1,156 @@
+import type {
+  CarLibraryGearbox,
+  CarLibraryModel,
+  CarLibraryTireOption,
+  CarLibraryVariant,
+} from "../../api/types";
+import type { UiDomElements } from "../ui_dom_registry";
+
+type EscapeHtml = (value: unknown) => string;
+type FormatNumber = (value: number, digits?: number) => string;
+
+interface WizardOptionSpec {
+  dataAttribute: string;
+  value: string;
+  label: string;
+  detail?: string;
+  selected?: boolean;
+}
+
+function renderWizardOptions(
+  options: WizardOptionSpec[],
+  escapeHtml: EscapeHtml,
+): string {
+  return options
+    .map((option) => {
+      const detail = option.detail
+        ? `<span class="wiz-opt-detail">${escapeHtml(option.detail)}</span>`
+        : "";
+      return `<button type="button" class="wiz-opt${option.selected ? " selected" : ""}" data-${option.dataAttribute}="${escapeHtml(option.value)}"><span>${escapeHtml(option.label)}</span>${detail}</button>`;
+    })
+    .join("");
+}
+
+export function renderWizardMessage(
+  message: string,
+  escapeHtml: EscapeHtml,
+): string {
+  return `<em>${escapeHtml(message)}</em>`;
+}
+
+export function renderWizardBrandOptions(
+  brands: string[],
+  escapeHtml: EscapeHtml,
+): string {
+  return renderWizardOptions(
+    brands.map((brand) => ({
+      dataAttribute: "value",
+      value: brand,
+      label: brand,
+    })),
+    escapeHtml,
+  );
+}
+
+export function renderWizardTypeOptions(
+  types: string[],
+  escapeHtml: EscapeHtml,
+): string {
+  return renderWizardOptions(
+    types.map((carType) => ({
+      dataAttribute: "value",
+      value: carType,
+      label: carType,
+    })),
+    escapeHtml,
+  );
+}
+
+export function renderWizardModelOptions(
+  models: CarLibraryModel[],
+  escapeHtml: EscapeHtml,
+): string {
+  return renderWizardOptions(
+    models.map((model, index) => ({
+      dataAttribute: "idx",
+      value: String(index),
+      label: model.model,
+      detail: `${model.tire_width_mm}/${model.tire_aspect_pct}R${model.rim_in}`,
+    })),
+    escapeHtml,
+  );
+}
+
+export function renderWizardVariantOptions(
+  variants: CarLibraryVariant[],
+  escapeHtml: EscapeHtml,
+): string {
+  return renderWizardOptions(
+    variants.map((variant, index) => ({
+      dataAttribute: "idx",
+      value: String(index),
+      label: variant.name,
+      detail: [variant.drivetrain, variant.engine].filter(Boolean).join(" · "),
+    })),
+    escapeHtml,
+  );
+}
+
+export function renderWizardTireOptions(
+  tireOptions: CarLibraryTireOption[],
+  escapeHtml: EscapeHtml,
+): string {
+  return renderWizardOptions(
+    tireOptions.map((tireOption, index) => ({
+      dataAttribute: "tire-idx",
+      value: String(index),
+      label: tireOption.name,
+      detail: `${tireOption.tire_width_mm}/${tireOption.tire_aspect_pct}R${tireOption.rim_in}`,
+      selected: index === 0,
+    })),
+    escapeHtml,
+  );
+}
+
+export function renderWizardGearboxOptions(
+  gearboxes: CarLibraryGearbox[],
+  deps: { escapeHtml: EscapeHtml; fmt: FormatNumber },
+): string {
+  const { escapeHtml, fmt } = deps;
+  return renderWizardOptions(
+    gearboxes.map((gearbox, index) => ({
+      dataAttribute: "idx",
+      value: String(index),
+      label: gearbox.name,
+      detail: `FD: ${fmt(gearbox.final_drive_ratio, 2)} · Top Gear: ${fmt(gearbox.top_gear_ratio, 2)}`,
+    })),
+    escapeHtml,
+  );
+}
+
+export function syncCarWizardStepState(
+  els: Pick<UiDomElements, "wizardSteps" | "wizardStepDots" | "wizardBackBtn">,
+  step: number,
+): void {
+  els.wizardSteps.forEach((stepEl, index) => {
+    if (!stepEl) return;
+    stepEl.classList.toggle("active", index === step);
+  });
+  els.wizardStepDots.forEach((dot) => {
+    const dotStep = Number(dot.getAttribute("data-step"));
+    dot.classList.toggle("active", dotStep === step);
+    dot.classList.toggle("done", dotStep < step);
+  });
+  if (els.wizardBackBtn) {
+    els.wizardBackBtn.style.display = step > 0 ? "" : "none";
+  }
+}
+
+export function writeCarWizardTireInputs(
+  els: Pick<UiDomElements, "wizTireWidthInput" | "wizTireAspectInput" | "wizRimInput">,
+  tire: CarLibraryTireOption,
+): void {
+  if (els.wizTireWidthInput) els.wizTireWidthInput.value = String(tire.tire_width_mm);
+  if (els.wizTireAspectInput) els.wizTireAspectInput.value = String(tire.tire_aspect_pct);
+  if (els.wizRimInput) els.wizRimInput.value = String(tire.rim_in);
+}

--- a/apps/ui/tests/car_wizard_view.spec.ts
+++ b/apps/ui/tests/car_wizard_view.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  renderWizardGearboxOptions,
+  renderWizardModelOptions,
+  renderWizardTireOptions,
+  syncCarWizardStepState,
+  writeCarWizardTireInputs,
+} from "../src/app/views/car_wizard_view";
+
+type ClassListStub = {
+  add(name: string): void;
+  remove(name: string): void;
+  toggle(name: string, force?: boolean): void;
+  contains(name: string): boolean;
+};
+
+type ElementStub = HTMLElement & {
+  classList: ClassListStub;
+  getAttribute(name: string): string | null;
+};
+
+function createClassList(initial: string[] = []): ClassListStub {
+  const active = new Set(initial);
+  return {
+    add(name: string): void {
+      active.add(name);
+    },
+    remove(name: string): void {
+      active.delete(name);
+    },
+    toggle(name: string, force?: boolean): void {
+      if (typeof force === "boolean") {
+        if (force) active.add(name);
+        else active.delete(name);
+        return;
+      }
+      if (active.has(name)) active.delete(name);
+      else active.add(name);
+    },
+    contains(name: string): boolean {
+      return active.has(name);
+    },
+  };
+}
+
+function createElement(attributes: Record<string, string> = {}): ElementStub {
+  return {
+    classList: createClassList(),
+    getAttribute(name: string): string | null {
+      return attributes[name] ?? null;
+    },
+  } as unknown as ElementStub;
+}
+
+function createInput(): HTMLInputElement {
+  return {
+    value: "",
+  } as unknown as HTMLInputElement;
+}
+
+test.describe("car wizard view helpers", () => {
+  test("syncCarWizardStepState updates step, dot, and back-button state", () => {
+    const wizardSteps = Array.from({ length: 5 }, () => createElement());
+    const wizardStepDots = Array.from({ length: 5 }, (_, index) =>
+      createElement({ "data-step": String(index) }));
+    const wizardBackBtn = {
+      style: { display: "" },
+    } as unknown as HTMLButtonElement;
+
+    syncCarWizardStepState({ wizardSteps, wizardStepDots, wizardBackBtn }, 3);
+
+    expect(wizardSteps[3].classList.contains("active")).toBe(true);
+    expect(wizardSteps[2].classList.contains("active")).toBe(false);
+    expect(wizardStepDots[3].classList.contains("active")).toBe(true);
+    expect(wizardStepDots[2].classList.contains("done")).toBe(true);
+    expect(wizardBackBtn.style.display).toBe("");
+
+    syncCarWizardStepState({ wizardSteps, wizardStepDots, wizardBackBtn }, 0);
+    expect(wizardSteps[0].classList.contains("active")).toBe(true);
+    expect(wizardStepDots[0].classList.contains("active")).toBe(true);
+    expect(wizardStepDots[1].classList.contains("done")).toBe(false);
+    expect(wizardBackBtn.style.display).toBe("none");
+  });
+
+  test("render helpers produce the expected wizard option markup", () => {
+    const escapeHtml = (value: unknown) => String(value ?? "");
+    const fmt = (value: number, digits = 0) => Number(value).toFixed(digits);
+    const models: Parameters<typeof renderWizardModelOptions>[0] = [{
+      model: "Roadster",
+      tire_width_mm: 245,
+      tire_aspect_pct: 40,
+      rim_in: 18,
+      variants: [],
+      gearboxes: [],
+      tire_options: [],
+    }];
+    const tireOptions: Parameters<typeof renderWizardTireOptions>[0] = [{
+      name: "Sport",
+      tire_width_mm: 245,
+      tire_aspect_pct: 40,
+      rim_in: 18,
+    }];
+    const gearboxes: Parameters<typeof renderWizardGearboxOptions>[0] = [{
+      name: "6-speed",
+      final_drive_ratio: 3.91,
+      top_gear_ratio: 0.82,
+    }];
+
+    expect(renderWizardModelOptions(models, escapeHtml)).toContain('data-idx="0"');
+    expect(renderWizardModelOptions(models, escapeHtml)).toContain("245/40R18");
+    expect(renderWizardTireOptions(tireOptions, escapeHtml)).toContain("selected");
+    expect(renderWizardGearboxOptions(gearboxes, { escapeHtml, fmt })).toContain("FD: 3.91");
+    expect(renderWizardGearboxOptions(gearboxes, { escapeHtml, fmt })).toContain("Top Gear: 0.82");
+  });
+
+  test("writeCarWizardTireInputs syncs the selected tire dimensions into manual inputs", () => {
+    const els: Parameters<typeof writeCarWizardTireInputs>[0] = {
+      wizTireWidthInput: createInput(),
+      wizTireAspectInput: createInput(),
+      wizRimInput: createInput(),
+    };
+    const tire: Parameters<typeof writeCarWizardTireInputs>[1] = {
+      name: "Touring",
+      tire_width_mm: 225,
+      tire_aspect_pct: 50,
+      rim_in: 17,
+    };
+
+    writeCarWizardTireInputs(els, tire);
+
+    expect(els.wizTireWidthInput?.value).toBe("225");
+    expect(els.wizTireAspectInput?.value).toBe("50");
+    expect(els.wizRimInput?.value).toBe("17");
+  });
+});

--- a/apps/ui/tests/polling_controller.spec.ts
+++ b/apps/ui/tests/polling_controller.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+
+import { createPollingController } from "../src/app/features/polling_controller";
+
+type TimerHarness = {
+  pendingDelays(): number[];
+  restore(): void;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function installTimerHarness(): TimerHarness {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let nextId = 1;
+  const active = new Map<number, number>();
+
+  globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
+    const id = nextId;
+    nextId += 1;
+    active.set(id, Number(delay ?? 0));
+    void handler;
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  globalThis.clearTimeout = ((timeoutId?: ReturnType<typeof setTimeout>) => {
+    if (typeof timeoutId !== "number") return;
+    active.delete(timeoutId);
+  }) as typeof clearTimeout;
+
+  return {
+    pendingDelays(): number[] {
+      return Array.from(active.values()).sort((left, right) => left - right);
+    },
+    restore(): void {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
+}
+
+async function flushAsyncWork(rounds = 12): Promise<void> {
+  for (let index = 0; index < rounds; index += 1) {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+test.describe("createPollingController", () => {
+  test("restart replaces the previous timer instead of keeping two poll chains alive", async () => {
+    const timers = installTimerHarness();
+    let pollCalls = 0;
+    const controller = createPollingController({
+      poll: async () => {
+        pollCalls += 1;
+        return 500;
+      },
+      onErrorDelayMs: 2_000,
+    });
+
+    try {
+      controller.start();
+      await flushAsyncWork();
+      expect(pollCalls).toBe(1);
+      expect(timers.pendingDelays()).toEqual([500]);
+
+      controller.restart();
+      await flushAsyncWork();
+      expect(pollCalls).toBe(2);
+      expect(timers.pendingDelays()).toEqual([500]);
+    } finally {
+      timers.restore();
+    }
+  });
+
+  test("stop prevents an in-flight poll from reviving the loop", async () => {
+    const timers = installTimerHarness();
+    const pollDeferred = createDeferred<number>();
+    let pollCalls = 0;
+    const controller = createPollingController({
+      poll: async () => {
+        pollCalls += 1;
+        if (pollCalls === 1) {
+          return pollDeferred.promise;
+        }
+        return 750;
+      },
+      onErrorDelayMs: 2_000,
+    });
+
+    try {
+      controller.start();
+      await flushAsyncWork();
+      expect(pollCalls).toBe(1);
+      expect(timers.pendingDelays()).toEqual([]);
+
+      controller.stop();
+      pollDeferred.resolve(750);
+      await flushAsyncWork();
+      expect(timers.pendingDelays()).toEqual([]);
+    } finally {
+      timers.restore();
+    }
+  });
+
+  test("errors schedule the configured retry delay", async () => {
+    const timers = installTimerHarness();
+    const controller = createPollingController({
+      poll: async () => {
+        throw new Error("temporary failure");
+      },
+      onErrorDelayMs: 3_000,
+    });
+
+    try {
+      controller.start();
+      await flushAsyncWork();
+      expect(timers.pendingDelays()).toEqual([3_000]);
+    } finally {
+      timers.restore();
+    }
+  });
+});

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -47,8 +47,8 @@ This file is the repo map, not a workflow or policy guide. Use `.github/copilot-
 - `shared/`: cross-cutting ports, model/payload types, JSON helpers, boundary codecs, split constant modules under `shared/constants/`, and small package-level helpers such as `shared/_data_files.py`, `shared/sensor_units.py`, and `shared/run_context_warning.py`. Key stable owners include `shared/types/persisted_analysis.py`, `shared/types/analysis_views.py`, `shared/types/history_analysis_contracts.py`, `shared/types/run_schema.py`, `shared/types/car_config.py`, `shared/types/speed_source_config.py`, and the codec/projection modules under `shared/boundaries/` such as `settings_snapshot_codec.py`.
 - `domain/`: domain model package for classification, ranking, lifecycle, and query logic. See `docs/domain-model.md` for the domain object graph.
 - `apps/ui/src/app/runtime/`: UI composition root and runtime controllers.
-- `apps/ui/src/app/features/`: UI feature workflows for settings, realtime, history, updates, cars, and ESP flash.
-- `apps/ui/src/app/views/`: DOM renderers and event-target decoders.
+- `apps/ui/src/app/features/`: UI feature workflows for settings, realtime, history, updates, cars, and ESP flash, plus the shared polling controller used by long-running status features.
+- `apps/ui/src/app/views/`: DOM renderers and event-target decoders, including the car wizard view helpers.
 
 ## Backend layer dependency DAG
 


### PR DESCRIPTION
Closes #1275

## Summary

This PR addresses the live frontend architecture debt behind `#1275` without pretending the whole issue body still justifies a framework-scale rewrite. After auditing the current `apps/ui` code, the strongest real problems were narrower than the ticket suggested:

- the same timer / generation / active-flag polling lifecycle was duplicated across the update, ESP flash, and GPS status features
- `cars_feature.ts` still mixed feature orchestration with global DOM lookups, wizard step-progress mutations, manual input reads, and inline wizard option rendering

Other parts of the issue were already stale or overstated on current `main`. UI feature code already imports HTTP contract types through `src/api/types.ts` instead of importing the generated OpenAPI file directly, and the large view modules named in the ticket (`history_table_view.ts` and `update_status_view.ts`) are already split into smaller helper render functions.

The concrete fix here is therefore two-part:

1. extract a shared frontend polling controller and migrate the three long-running polling features to it
2. move the car wizard’s rendering and DOM-boundary concerns behind a dedicated view module plus explicit `UiDomElements` entries so `cars_feature.ts` no longer reaches into the global document for wizard containers and inputs

## Problem being solved

The issue describes several symptoms of frontend architectural drift: duplicated polling state machines, direct DOM manipulation, generated-contract coupling, oversized mixed render functions, and missing component boundaries. Those concerns do not all have equal weight in the current codebase.

The audit showed that the polling problem is very real. `update_feature.ts` and `esp_flash_feature.ts` were carrying nearly identical polling lifecycle code, and `settings_gps_status_module.ts` had a simpler variant that still implemented its own timer loop separately. The shared pattern was the important part: timer reference, active flag, generation/cancellation protection, explicit restart after user-triggered mutations, and retry scheduling on transient failures.

The audit also showed that `cars_feature.ts` was the main remaining direct-DOM outlier. It still handled wizard step activation, step-dot state, container selection, loading/error placeholders, option-button HTML construction, tire input synchronization, and manual add form reads in the same feature module. That made the file harder to test, harder to scan, and more tightly coupled to raw document structure than the rest of the UI.

By contrast, two of the bigger claims in the issue were already outdated:

- generated HTTP contract types are already wrapped by `apps/ui/src/api/types.ts`
- `history_table_view.ts` and `update_status_view.ts` already use focused helper renderers instead of one giant monolithic render function

So the right fix was not “add a frontend framework” or “invent a generic component system.” The right fix was to tighten the two live structural seams that actually exist today.

## Implementation approach

I kept the change set intentionally small and behavior-preserving.

### Shared polling controller

I added `apps/ui/src/app/features/polling_controller.ts` as the single owner of the polling lifecycle that had previously been copied across multiple files. The controller owns:

- the current timeout handle
- the polling generation token used to invalidate stale in-flight work
- active/inactive lifecycle
- restart semantics after user actions
- fallback scheduling after transient polling failures

Then I migrated:

- `update_feature.ts`
- `esp_flash_feature.ts`
- `settings_gps_status_module.ts`

to use the shared controller instead of locally implementing their own timer/generation loops.

This gives the UI one authoritative polling behavior instead of three near-copies. It also upgrades GPS status polling to the same stale-generation protection already used by the update and ESP flash features.

### Car wizard view and DOM registry boundary

I added `apps/ui/src/app/views/car_wizard_view.ts` and moved the wizard-specific DOM/rendering helpers there:

- step-progress synchronization
- loading / message rendering
- brand, type, model, variant, tire, and gearbox option rendering
- tire-input synchronization for the manual add flow

I also expanded `UiDomElements` and `createUiDomRegistry()` with explicit wizard nodes for:

- wizard step containers and dots
- wizard list containers
- custom brand / type / model inputs and buttons
- manual tire / drivetrain inputs

That lets `cars_feature.ts` work through injected DOM references instead of repeatedly calling `document.getElementById(...)` throughout the wizard flow.

The result is that `cars_feature.ts` now looks more like a true feature orchestrator:

- it owns wizard state transitions
- it calls API functions
- it delegates rendering details to the view layer
- it reads DOM through the central registry instead of global document lookups

That is the boundary that was actually worth adding here.

## Code changes by area

### `apps/ui/src/app/features/`

- added `polling_controller.ts`
- updated `update_feature.ts` to use the shared controller
- updated `esp_flash_feature.ts` to use the shared controller
- updated `settings_gps_status_module.ts` to use the shared controller
- refactored `cars_feature.ts` to depend on registry/view helpers instead of global document access

### `apps/ui/src/app/views/`

- added `car_wizard_view.ts` for wizard-specific DOM rendering and step UI sync helpers

### `apps/ui/src/app/ui_dom_registry.ts`

- added explicit wizard element fields so car-wizard code can consume injected DOM references instead of reaching into the global document

### Tests

- added `tests/polling_controller.spec.ts`
- added `tests/car_wizard_view.spec.ts`
- kept existing `esp_flash_feature.spec.ts` polling coverage green, which now also validates the refactored update/ESP features on top of the shared controller

### Docs

- updated `apps/ui/README.md`
- updated `docs/ai/repo-map.md`

Both now mention the new shared polling/controller split and the car-wizard view seam so the package layout description matches the live code.

## Validation

I validated the change with the existing frontend toolchain and focused Playwright coverage:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/polling_controller.spec.ts tests/car_wizard_view.spec.ts tests/esp_flash_feature.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts tests/smoke.cars.spec.ts tests/smoke.settings.spec.ts --workers=1`

These checks cover:

- TypeScript integrity across the refactor
- production build output
- shared polling lifecycle behavior
- car-wizard helper behavior
- preserved update/ESP polling behavior
- browser-level cars/settings flows touched by the new boundaries

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this PR intentionally does **not** solve every claim listed in `#1275`. That is by design. The audit showed that some parts of the ticket were already fixed or no longer the highest-value targets.

I also did not introduce a generic lifecycle registry or component system. The current app structure already has workable feature factories and runtime composition. What it lacked was a shared polling primitive and a cleaner boundary around the most DOM-heavy wizard flow. Those are now in place.

If future UI work finds another repeated lifecycle pattern that deserves a shared abstraction, we can add it from concrete evidence. For this issue, the honest maintainable win was to standardize polling behavior and pull the car wizard toward the same feature/view split the rest of the UI already follows.
