### PR TITLE
Centralize UI config tuning and restore preflight defaults

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -65,7 +65,7 @@ install path.
 
 ## Configuration
 
-Configuration is YAML-based. Run `vibesensor-config-preflight --dump-defaults` to see all available keys with defaults. Use `apps/server/config.dev.yaml` or `apps/server/config.docker.yaml` for local overrides.
+Configuration is YAML-based. Runtime defaults live in `vibesensor/app/config_defaults.py`, and `load_config()` applies precedence `DEFAULT_CONFIG -> selected YAML override file -> typed validation/clamping`. Run `vibesensor-config-preflight --dump-defaults` to see all available keys with defaults, or run `vibesensor-config-preflight apps/server/config.dev.yaml` / `apps/server/config.docker.yaml` to inspect a resolved override file.
 
 For live sensor presence, `processing.client_live_ttl_seconds` controls how long
 `/api/clients` and `/ws` keep reporting `connected: true` after the last

--- a/apps/server/tests/app/test_preflight_cli.py
+++ b/apps/server/tests/app/test_preflight_cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from vibesensor.cli.preflight import main
+
+
+def test_preflight_cli_dump_defaults(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight", "--dump-defaults"])
+
+    assert main() == 0
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["server"]["port"] == 80
+    assert payload["processing"]["sample_rate_hz"] == 800
+
+
+def test_preflight_cli_requires_config_without_dump_defaults(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight"])
+
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_preflight_cli_rejects_dump_defaults_with_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["vibesensor-config-preflight", "--dump-defaults", "apps/server/config.dev.yaml"],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_preflight_cli_prints_resolved_config(monkeypatch, capsys, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("server:\n  port: 8000\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight", str(config_path)])
+
+    assert main() == 0
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["config_path"] == str(config_path.resolve())
+    assert payload["server"]["port"] == 8000

--- a/apps/server/vibesensor/app/config_loader.py
+++ b/apps/server/vibesensor/app/config_loader.py
@@ -75,9 +75,9 @@ def _read_config_file(path: Path) -> JsonObject:
 def load_config(config_path: Path | None = None) -> AppConfig:
     """Load, validate, and return the application configuration.
 
-    Reads *config_path* (or the default ``config.yaml`` next to this module),
-    deep-merges with documented defaults, and returns a fully validated
-    ``AppConfig``.
+     Reads *config_path* (or the default ``config.yaml`` next to this module),
+    applies precedence ``DEFAULT_CONFIG -> YAML override file -> typed
+    validation/clamping``, and returns a fully validated ``AppConfig``.
     """
     path = config_path or (SERVER_DIR / "config.yaml")
     path = path.resolve()

--- a/apps/server/vibesensor/cli/preflight.py
+++ b/apps/server/vibesensor/cli/preflight.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from vibesensor.app.settings import AppConfig, load_config
+from vibesensor.app.settings import AppConfig, documented_default_config, load_config
 from vibesensor.shared.constants.ui import UI_HEAVY_PUSH_HZ, UI_PUSH_HZ
 
 
@@ -31,12 +31,25 @@ def summarize(cfg: AppConfig) -> dict[str, object]:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Validate and print resolved VibeSensor config")
-    parser.add_argument("config", type=Path, help="Path to config YAML")
-    return parser.parse_args()
+    parser.add_argument("config", type=Path, nargs="?", help="Path to config YAML")
+    parser.add_argument(
+        "--dump-defaults",
+        action="store_true",
+        help="Print the documented default config and exit",
+    )
+    args = parser.parse_args()
+    if args.dump_defaults and args.config is not None:
+        parser.error("--dump-defaults and config are mutually exclusive")
+    if not args.dump_defaults and args.config is None:
+        parser.error("config is required unless --dump-defaults is set")
+    return args
 
 
 def main() -> int:
     args = parse_args()
+    if args.dump_defaults:
+        print(json.dumps(documented_default_config(), indent=2, sort_keys=True))
+        return 0
     cfg = load_config(args.config)
     print(json.dumps(summarize(cfg), indent=2, sort_keys=True))
     return 0

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -60,6 +60,7 @@ It regenerates:
 | `app/views/` | Focused DOM rendering and event-target decoding for settings, cars wizard, realtime, history, and update panels |
 | `api.ts` | REST API client with typed request/response interfaces |
 | `ws.ts` | WebSocket client with auto-reconnect and stale detection |
+| `config.ts` | Centralized UI tuning constants for polling intervals, spectrum ranges, and history heatmap positions |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |
 | `spectrum.ts` | uPlot chart wrapper for interactive spectrum visualization |
 | `server_payload.ts` | Runtime WebSocket payload adaptation and schema-version guardrails around the generated WS types |

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,6 +1,9 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
-import type { UiDomElements } from "../ui_dom_registry";
 import type { EspFlashStatusPayload } from "../../api/types";
+import {
+  ESP_FLASH_POLL_ACTIVE_MS,
+  ESP_FLASH_POLL_IDLE_MS,
+} from "../../config";
+import type { FeatureDepsBase } from "../feature_deps_base";
 import { createPollingController } from "./polling_controller";
 import {
   cancelEspFlash,
@@ -18,9 +21,6 @@ export interface EspFlashFeature {
   startPolling(): void;
   stopPolling(): void;
 }
-
-const POLL_IDLE_MS = 4_000;
-const POLL_ACTIVE_MS = 1_000;
 
 const STATE_TO_VARIANT: Readonly<Record<string, string>> = {
   success: "ok",
@@ -108,9 +108,11 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
       renderStatus(status);
       await refreshLogs(status);
       await refreshHistory();
-      return status.state === "running" ? POLL_ACTIVE_MS : POLL_IDLE_MS;
+      return status.state === "running"
+        ? ESP_FLASH_POLL_ACTIVE_MS
+        : ESP_FLASH_POLL_IDLE_MS;
     },
-    onErrorDelayMs: POLL_ACTIVE_MS,
+    onErrorDelayMs: ESP_FLASH_POLL_ACTIVE_MS,
   });
 
   async function onStart(): Promise<void> {

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -1,11 +1,13 @@
 import type { SpeedSourceStatusPayload } from "../../api/types";
 import { getSpeedSourceStatus } from "../../api";
+import {
+  GPS_POLL_FAST_MS,
+  GPS_POLL_SLOW_MS,
+} from "../../config";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
 import { createPollingController } from "./polling_controller";
 
-const GPS_POLL_FAST = 2_000;
-const GPS_POLL_SLOW = 10_000;
 const CONNECTION_STATE_I18N: Record<string, string> = {
   disabled: "settings.speed.state_disabled",
   disconnected: "settings.speed.state_disconnected",
@@ -99,9 +101,11 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
         );
       renderGpsStatus(status);
       ctx.renderSpeedReadout();
-      return status.connection_state === "connected" ? GPS_POLL_FAST : GPS_POLL_SLOW;
+      return status.connection_state === "connected"
+        ? GPS_POLL_FAST_MS
+        : GPS_POLL_SLOW_MS;
     },
-    onErrorDelayMs: GPS_POLL_SLOW,
+    onErrorDelayMs: GPS_POLL_SLOW_MS,
   });
 
   function startGpsStatusPolling(): void {

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -1,5 +1,9 @@
 import type { HealthStatusPayload, UpdateStatusPayload } from "../../api/types";
 import { getHealthStatus, getUpdateStatus, startUpdate, cancelUpdate } from "../../api/settings";
+import {
+  UPDATE_POLL_INTERVAL_IDLE_MS,
+  UPDATE_POLL_INTERVAL_RUNNING_MS,
+} from "../../config";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import { createPollingController } from "./polling_controller";
 import {
@@ -14,9 +18,6 @@ export interface UpdateFeature {
   startPolling(): void;
   stopPolling(): void;
 }
-
-const POLL_INTERVAL_IDLE = 10_000;
-const POLL_INTERVAL_RUNNING = 2_000;
 
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   const { els, t, escapeHtml } = ctx;
@@ -34,9 +35,11 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     poll: async () => {
       const [status, health] = await Promise.all([getUpdateStatus(), getHealthStatus()]);
       renderStatus(status, health);
-      return status.state === "running" ? POLL_INTERVAL_RUNNING : POLL_INTERVAL_IDLE;
+      return status.state === "running"
+        ? UPDATE_POLL_INTERVAL_RUNNING_MS
+        : UPDATE_POLL_INTERVAL_IDLE_MS;
     },
-    onErrorDelayMs: POLL_INTERVAL_RUNNING,
+    onErrorDelayMs: UPDATE_POLL_INTERVAL_RUNNING_MS,
   });
 
   async function handleStart(): Promise<void> {

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,5 +1,12 @@
 import uPlot from "uplot";
 
+import {
+  SPECTRUM_DB_MAX,
+  SPECTRUM_DB_MIN,
+  SPECTRUM_DB_REFERENCE_AMP_G,
+  SPECTRUM_MIN_RENDER_AMP_G,
+  SPECTRUM_TWEEN_DURATION_MS,
+} from "../../config";
 import { escapeHtml } from "../../format";
 import { SpectrumChart } from "../../spectrum";
 import { chartSeriesPalette, orderBandFills } from "../../theme";
@@ -7,11 +14,6 @@ import { areHeavyFramesCompatible, interpolateHeavyFrame, type SpectrumHeavyFram
 import type { UiDomElements } from "../ui_dom_registry";
 import type { AppState, ChartBand } from "../ui_app_state";
 
-const SPECTRUM_DB_MIN = 0;
-const SPECTRUM_DB_MAX = 100;
-const SPECTRUM_DB_REFERENCE_AMP_G = 1e-4;
-const SPECTRUM_MIN_RENDER_AMP_G = 1e-6;
-const SPECTRUM_TWEEN_DURATION_MS = 180;
 const SPECTRUM_LOG10_REF = Math.log10(SPECTRUM_DB_REFERENCE_AMP_G);
 const FREQ_MATCH_EPSILON = 1e-6;
 

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -4,6 +4,7 @@ import type {
   HistoryInsightWarningPayload,
   HistoryInsightsPayload,
 } from "../../api/types";
+import { HISTORY_HEATMAP_POSITIONS } from "../../config";
 import type { RunDetail } from "../ui_app_state";
 import { heatColor, normalizeUnit } from "../features/heat_utils";
 import { renderTableEmptyRow } from "./dom_helpers";
@@ -20,17 +21,6 @@ const EMPTY_RUN_DETAIL: RunDetail = {
   pdfLoading: false,
   pdfError: "",
 };
-
-const HEATMAP_POSITIONS = [
-  { key: "front-left wheel", top: 23, left: 20 },
-  { key: "front-right wheel", top: 23, left: 80 },
-  { key: "rear-left wheel", top: 76, left: 20 },
-  { key: "rear-right wheel", top: 76, left: 80 },
-  { key: "engine bay", top: 30, left: 50 },
-  { key: "driveshaft tunnel", top: 51, left: 50 },
-  { key: "driver seat", top: 43, left: 40 },
-  { key: "trunk", top: 86, left: 50 },
-];
 
 export interface HistoryTableViewParams {
   runs: HistoryEntry[];
@@ -101,9 +91,9 @@ function renderPreviewHeatmap(
   const values = Object.values(metricByLocation).filter((value) => typeof value === "number");
   const min = values.length ? Math.min(...values) : null;
   const max = values.length ? Math.max(...values) : null;
-  const knownPositionKeys = new Set(HEATMAP_POSITIONS.map((point) => point.key));
+  const knownPositionKeys = new Set<string>(HISTORY_HEATMAP_POSITIONS.map((point) => point.key));
   const unmappedLocationKeys = Object.keys(metricByLocation).filter((key) => !knownPositionKeys.has(key));
-  const dots = HEATMAP_POSITIONS
+  const dots = HISTORY_HEATMAP_POSITIONS
     .map((point) => {
       const value = metricByLocation[point.key];
       const hasValue = typeof value === "number" && Number.isFinite(value);

--- a/apps/ui/src/config.ts
+++ b/apps/ui/src/config.ts
@@ -1,0 +1,23 @@
+export const UPDATE_POLL_INTERVAL_IDLE_MS = 10_000;
+export const UPDATE_POLL_INTERVAL_RUNNING_MS = 2_000;
+export const ESP_FLASH_POLL_IDLE_MS = 4_000;
+export const ESP_FLASH_POLL_ACTIVE_MS = 1_000;
+export const GPS_POLL_FAST_MS = 2_000;
+export const GPS_POLL_SLOW_MS = 10_000;
+
+export const SPECTRUM_DB_MIN = 0;
+export const SPECTRUM_DB_MAX = 100;
+export const SPECTRUM_DB_REFERENCE_AMP_G = 1e-4;
+export const SPECTRUM_MIN_RENDER_AMP_G = 1e-6;
+export const SPECTRUM_TWEEN_DURATION_MS = 180;
+
+export const HISTORY_HEATMAP_POSITIONS = [
+  { key: "front-left wheel", top: 23, left: 20 },
+  { key: "front-right wheel", top: 23, left: 80 },
+  { key: "rear-left wheel", top: 76, left: 20 },
+  { key: "rear-right wheel", top: 76, left: 80 },
+  { key: "engine bay", top: 30, left: 50 },
+  { key: "driveshaft tunnel", top: 51, left: 50 },
+  { key: "driver seat", top: 43, left: 40 },
+  { key: "trunk", top: 86, left: 50 },
+] as const;

--- a/apps/ui/src/spectrum.ts
+++ b/apps/ui/src/spectrum.ts
@@ -1,5 +1,7 @@
 import uPlot from "uplot";
 
+import { SPECTRUM_DB_MAX, SPECTRUM_DB_MIN } from "./config";
+
 export interface SpectrumSeriesMeta {
   label: string;
   color: string;
@@ -12,7 +14,7 @@ export interface SpectrumText {
 }
 
 export class SpectrumChart {
-  private static readonly FIXED_Y_RANGE: [number, number] = [0, 100];
+  private static readonly FIXED_Y_RANGE: [number, number] = [SPECTRUM_DB_MIN, SPECTRUM_DB_MAX];
   private plot: uPlot | null = null;
   private readonly hostEl: HTMLElement;
   private readonly measureEl: HTMLElement;

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -49,6 +49,7 @@ This file is the repo map, not a workflow or policy guide. Use `.github/copilot-
 - `apps/ui/src/app/runtime/`: UI composition root and runtime controllers.
 - `apps/ui/src/app/features/`: UI feature workflows for settings, realtime, history, updates, cars, and ESP flash, plus the shared polling controller used by long-running status features.
 - `apps/ui/src/app/views/`: DOM renderers and event-target decoders, including the car wizard view helpers.
+- `apps/ui/src/config.ts`: centralized UI tuning constants (polling intervals, spectrum bounds, history heatmap positions).
 
 ## Backend layer dependency DAG
 


### PR DESCRIPTION
## Summary

Closes #1276.

Issue #1276 described a broad mix of configuration problems: hardcoded frontend values, duplicated backend defaults, missing centralized config, and absent migration/versioning support. After reconciling the ticket against current `main`, the live problem was narrower. The frontend still had a meaningful amount of UI tuning state scattered across feature and view modules, but the backend already had a real single source of truth for runtime defaults in `apps/server/vibesensor/app/config_defaults.py`, plus typed validation/clamping in the loader/schema path. The most honest fix for the current codebase was therefore not a configuration-system rewrite. Instead, this branch centralizes the remaining live UI tuning constants and makes the backend default-discovery path explicit again through the preflight CLI and docs.

## Problem being solved

The frontend still carried several clusters of magic numbers in places where they were easy to drift apart over time. Polling intervals lived independently in `update_feature.ts`, `esp_flash_feature.ts`, and `settings_gps_status_module.ts`. Spectrum-related dB/reference/tween bounds were split between `ui_spectrum_controller.ts` and `spectrum.ts`. History heatmap positions were embedded directly in `history_table_view.ts`. None of those values were wrong, but they were configuration-like values hiding inside implementation files, which made future changes harder to audit and encouraged duplication.

On the backend side, the issue body suggested defaults were duplicated and needed a new central config system. The audit showed that concern was mostly stale on current `main`: defaults already flow from `DEFAULT_CONFIG`, override YAML is already merged centrally, and schema validation already exists. The real backend gap was discoverability and documentation drift. `apps/server/README.md` told users to run `vibesensor-config-preflight --dump-defaults`, but the current CLI no longer supported that flag. That meant the documented path for inspecting defaults had silently rotted even though the underlying default model was still healthy.

## Chosen implementation approach

I kept the fix intentionally narrow and source-of-truth oriented. On the UI side, I introduced a single root module, `apps/ui/src/config.ts`, to hold the remaining shared tuning constants that are truly configuration-like from the frontend’s perspective: update/ESP/GPS polling intervals, spectrum dB/reference/tween values, and the history heatmap location map. Then I rewired the affected feature/view/runtime modules to import those constants instead of defining local copies.

On the backend side, I restored the missing default-introspection surface instead of inventing a new config mechanism. `vibesensor-config-preflight` now supports `--dump-defaults`, which prints the documented default configuration tree and exits. I also clarified the loader docstring and README text so the precedence is explicit: `DEFAULT_CONFIG -> YAML override file -> typed validation/clamping`. During review, I tightened the CLI contract further so `--dump-defaults` cannot be combined with a config path; the parser now rejects that ambiguous combination instead of silently ignoring one argument.

## Main code changes by area

Frontend configuration centralization:

- Added `apps/ui/src/config.ts` as the centralized home for the remaining UI tuning constants.
- Updated `apps/ui/src/app/features/update_feature.ts` to use shared update polling intervals.
- Updated `apps/ui/src/app/features/esp_flash_feature.ts` to use shared ESP flash polling intervals.
- Updated `apps/ui/src/app/features/settings_gps_status_module.ts` to use shared GPS polling intervals.
- Updated `apps/ui/src/app/runtime/ui_spectrum_controller.ts` to use shared spectrum bounds/reference/tween constants.
- Updated `apps/ui/src/spectrum.ts` so the chart’s fixed dB range comes from the shared config module instead of an inline tuple.
- Updated `apps/ui/src/app/views/history_table_view.ts` so the heatmap positions come from the shared config module rather than a local constant block.

Backend default discoverability and docs:

- Updated `apps/server/vibesensor/cli/preflight.py` to add `--dump-defaults` output using the existing documented default config source.
- Added an explicit parser error when `--dump-defaults` and a config path are passed together.
- Clarified the `load_config()` docstring in `apps/server/vibesensor/app/config_loader.py` to document the actual precedence rules.
- Updated `apps/server/README.md` to match the restored CLI behavior and to point readers at the backend default source of truth.

Documentation / repo map:

- Added the new frontend config seam to `apps/ui/README.md`.
- Added the same seam to `docs/ai/repo-map.md` so future work can find it quickly.

Tests:

- Added `apps/server/tests/app/test_preflight_cli.py` to cover `--dump-defaults`, the normal resolved-config path, the missing-config parser error, and the new mutual-exclusion rule.

## Validation performed

I validated the branch at both the backend and frontend layers.

Backend:

- `pytest -q apps/server/tests/app/test_preflight_cli.py apps/server/tests/app/test_config.py`
- `make typecheck-backend`
- `make lint`

The lint run is especially relevant here because it exercises the preflight CLI against the repo’s real config files (`config.dev.yaml`, `config.docker.yaml`, and `config.pi.yaml`), so it confirmed that the CLI changes did not break the existing inspection path.

Frontend:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/polling_controller.spec.ts tests/esp_flash_feature.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts tests/smoke.settings.spec.ts tests/smoke.history.spec.ts --workers=1`

Those checks cover the modules whose polling/spectrum/history configuration moved, plus the broader smoke paths that rely on those features. During the first frontend typecheck run, centralizing the history heatmap array narrowed the literal key type more than `Object.keys(metricByLocation)` expected. I fixed that boundary explicitly by widening the `Set` to `Set<string>` rather than weakening the shared constant definition.

## Risks, tradeoffs, and edge cases considered

I explicitly did not add a config migration/versioning layer here. The current backend design already centralizes defaults and validates overrides, and the repo guidance discourages compatibility scaffolding unless a real second format/version exists. Adding a migration system in this branch would have widened the change well beyond the live defect.

The new `apps/ui/src/config.ts` is also intentionally limited to existing UI tuning values that were already duplicated or embedded across multiple files. I did not try to turn every numeric literal in the UI into configuration, because that would blur the line between algorithmic/code-local constants and actual shared tuning knobs.

For the CLI, the main edge case was user ambiguity around `--dump-defaults` plus a config path. The review pass caught that early, and the parser now fails fast instead of silently doing something surprising.

## Follow-ups / out of scope

This branch does not introduce a dynamic runtime config editor, config schema versioning, or generated shared UI config derived from backend defaults. If future issues require true cross-runtime config sharing, that should be treated as a separate design task with a concrete second consumer and explicit contract decisions. For issue #1276, the complete live fix is to centralize the remaining UI tuning values and restore a truthful backend defaults/preflight story, and that is what this branch does.
