### PR TITLE
Add focused regressions for top-cause tie handling

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
@@ -69,3 +69,29 @@ def test_stale_result_is_rejected_after_buffer_eviction_and_recreation() -> None
     next_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
     assert isinstance(next_plan, MetricsSnapshot)
     assert not isinstance(next_plan, CachedMetricsHit)
+
+
+def test_sample_rate_change_forces_fresh_snapshot_before_reusing_cache() -> None:
+    config = _config()
+    store = SignalBufferStore(config)
+    computer = SignalMetricsComputer(config)
+    client_id = "sensor-3"
+
+    samples = np.random.default_rng(2).standard_normal((256, 3)).astype(np.float32)
+    store.ingest(client_id, samples, sample_rate_hz=200)
+
+    first_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(first_plan, MetricsSnapshot)
+    store.store_metrics_result(computer.compute(first_plan))
+
+    cached_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(cached_plan, CachedMetricsHit)
+
+    changed_rate_plan = store.snapshot_for_compute(client_id, sample_rate_hz=400)
+    assert isinstance(changed_rate_plan, MetricsSnapshot)
+    assert changed_rate_plan.sample_rate_hz == 400
+
+    store.store_metrics_result(computer.compute(changed_rate_plan))
+
+    refreshed_cached_plan = store.snapshot_for_compute(client_id, sample_rate_hz=400)
+    assert isinstance(refreshed_cached_plan, CachedMetricsHit)

--- a/apps/server/tests/use_cases/diagnostics/test_ranking_helpers.py
+++ b/apps/server/tests/use_cases/diagnostics/test_ranking_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from test_support.findings import make_finding_payload
+
 from vibesensor.shared.boundaries.finding import finding_from_payload
 from vibesensor.use_cases.diagnostics.top_cause_selection import group_findings_by_source
 
@@ -33,3 +35,65 @@ def test_group_findings_by_source_preserves_ranked_signatures() -> None:
     grouped = group_findings_by_source(findings)
 
     assert [rep.source_normalized for _score, rep in grouped] == ["wheel/tire", "engine"]
+
+
+def test_group_findings_by_source_keeps_first_tied_member_for_same_location_group() -> None:
+    findings = tuple(
+        finding_from_payload(payload)
+        for payload in [
+            make_finding_payload(
+                finding_id="F_FRONT_FIRST",
+                suspected_source="wheel/tire",
+                confidence=0.62,
+                strongest_location="front-left wheel",
+                frequency_hz_or_order="2x wheel order",
+            ),
+            make_finding_payload(
+                finding_id="F_FRONT_SECOND",
+                suspected_source="wheel/tire",
+                confidence=0.62,
+                strongest_location="front-left wheel",
+                frequency_hz_or_order="1x wheel order",
+            ),
+        ]
+    )
+
+    grouped = group_findings_by_source(findings)
+
+    assert len(grouped) == 1
+    _score, representative = grouped[0]
+    assert representative.finding_id == "F_FRONT_FIRST"
+    assert representative.signature_labels == ("2x wheel order", "1x wheel order")
+
+
+def test_group_findings_by_source_keeps_tied_wheel_locations_separate_in_input_order() -> None:
+    findings = tuple(
+        finding_from_payload(payload)
+        for payload in [
+            make_finding_payload(
+                finding_id="F_FRONT_LEFT",
+                suspected_source="wheel/tire",
+                confidence=0.62,
+                strongest_location="front-left wheel",
+            ),
+            make_finding_payload(
+                finding_id="F_FRONT_RIGHT",
+                suspected_source="wheel/tire",
+                confidence=0.62,
+                strongest_location="front-right wheel",
+            ),
+            make_finding_payload(
+                finding_id="F_ENGINE",
+                suspected_source="engine",
+                confidence=0.50,
+            ),
+        ]
+    )
+
+    grouped = group_findings_by_source(findings)
+
+    assert [rep.finding_id for _score, rep in grouped] == [
+        "F_FRONT_LEFT",
+        "F_FRONT_RIGHT",
+        "F_ENGINE",
+    ]

--- a/apps/server/tests/use_cases/diagnostics/test_summary_pure_functions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_summary_pure_functions.py
@@ -165,3 +165,27 @@ class TestSelectTopCauses:
         domain_findings = select_top_causes(findings)
         assert isinstance(domain_findings, tuple)
         assert all(isinstance(d, Finding) for d in domain_findings)
+
+    def test_equal_score_groups_keep_first_seen_source_order(self) -> None:
+        findings = self._to_domain(
+            make_finding_payload(
+                finding_id="F_WHEEL",
+                suspected_source="wheel/tire",
+                confidence=0.80,
+                strongest_location="front-left wheel",
+            ),
+            make_finding_payload(
+                finding_id="F_ENGINE",
+                suspected_source="engine",
+                confidence=0.80,
+            ),
+            make_finding_payload(
+                finding_id="F_DRIVELINE",
+                suspected_source="driveline",
+                confidence=0.50,
+            ),
+        )
+
+        domain_findings = select_top_causes(findings, max_causes=2)
+
+        assert [finding.finding_id for finding in domain_findings] == ["F_WHEEL", "F_ENGINE"]


### PR DESCRIPTION
## Summary

Closes #1277.

Issue #1277 described a broad set of testing gaps across diagnostics tie-breaking, UDP packet reordering, sample-rate changes, fixture masking, and real-world failure scenarios. After reconciling the issue body against current `main`, most of that scope turned out to be stale or already covered. The live gaps were much narrower: top-cause selection/grouping did not explicitly test deterministic behavior when scores tie, and the processing layer did not have a focused regression proving that a same-client sample-rate change forces a fresh compute snapshot instead of reusing a stale cached result. This branch addresses those real gaps with tightly scoped test-only changes.

## Problem being solved

The biggest real hole was in the diagnostics ranking seam. `group_findings_by_source()` and `select_top_causes()` already have straightforward coverage for filtering, grouping, and signature collection, but they did not pin what happens when multiple candidates tie on the score that actually drives top-cause selection (`phase_adjusted_score`). That left a class of behavior important to user trust under-tested: if two findings have equal score, do we keep a stable representative, preserve stable source ordering, and continue surfacing wheel findings from different locations as separate groups in a deterministic order?

The second live gap was adjacent but smaller: the processing layer already has multi-rate coverage, sample-rate clamping coverage, and cache-generation guard coverage, but it did not explicitly prove the “same client, same samples, new sample rate” path. In that situation, the system should not reuse a cached hit computed for the old rate. It should return a fresh snapshot for recompute, then only reuse the cache again after the new-rate result has been stored.

The broader issue claims did not survive audit as live gaps. UDP sequence reordering is already covered at the registry level (`test_out_of_order_not_flagged_as_duplicate`) and out-of-order timestamps are already exercised in integration (`test_fault_with_out_of_order_timestamps`). Persistence failure scenarios like repeated `OSError("disk full")` are already covered in history DB write-failure tests. Because of that, the honest fix here is not to add a large number of new scenario tests; it is to add the few regressions that current code still lacks.

## Chosen implementation approach

I kept the branch test-only and intentionally small. No production behavior changed. Instead, I added regressions exactly where the missing contracts belong:

- ranking/grouping behavior stays in the diagnostics unit-test seams already dedicated to those helpers
- sample-rate cache behavior stays in the processing regression seam already used for rate/identity guards

That approach keeps the issue reviewable and avoids encoding a much larger testing philosophy change into one backlog item. It also matches the repository’s guidance to prefer focused test modules over omnibus regressions and to use the shared `test_support` finding factories rather than inventing local payload builders.

## Main code changes by area

### Diagnostics ranking regressions

In `apps/server/tests/use_cases/diagnostics/test_ranking_helpers.py`, I extended the current direct `group_findings_by_source()` coverage with two deterministic tie cases:

1. **Same source, same location, equal score**: verifies the first tied member remains the representative and that signatures are collected in stable order.
2. **Wheel/tire findings at different locations, equal score**: verifies they remain separate groups and preserve input order when their scores tie.

These tests pin the current behavior that the implementation already implies through stable sort semantics and insertion-order grouping, but previously did not state explicitly.

In `apps/server/tests/use_cases/diagnostics/test_summary_pure_functions.py`, I added a `select_top_causes()` regression that verifies equal-score groups preserve first-seen source order. This directly covers the selection seam the issue called out, not just the lower-level grouping helper.

### Processing cache regression

In `apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py`, I added a regression that exercises this specific sequence:

1. ingest data for one client at 200 Hz
2. compute/store metrics at 200 Hz
3. confirm a repeated 200 Hz request returns `CachedMetricsHit`
4. request 400 Hz for the same client without new ingest and verify a fresh `MetricsSnapshot` is returned instead of the cached hit
5. store the 400 Hz result and confirm 400 Hz requests then become cache hits

This proves that cache reuse is keyed correctly on the compute sample rate, not just ingest generation.

## Evidence and scope decisions

The issue body suggested several additional gaps, but the audit showed they are already represented elsewhere:

- `apps/server/tests/infra/runtime/test_registry.py::test_out_of_order_not_flagged_as_duplicate` already verifies late sequence numbers are accepted rather than misclassified as duplicates.
- `apps/server/tests/integration/test_messy_real_world.py::test_fault_with_out_of_order_timestamps` already exercises out-of-order sample timing in a higher-level pipeline scenario.
- `apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py` already covers disk-full / repeated write-failure behavior in persistence.

Because that coverage already exists, I did not duplicate it just to mirror the issue text. The branch only adds coverage where the current suite was truly thin.

## Validation performed

I ran the new regressions together with the most relevant neighboring suites:

- `pytest -q apps/server/tests/use_cases/diagnostics/test_ranking_helpers.py apps/server/tests/use_cases/diagnostics/test_summary_pure_functions.py apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py apps/server/tests/infra/runtime/test_registry.py apps/server/tests/adapters/udp/test_udp_data_rx.py`

That confirms the new tests and rechecks the nearby registry/UDP seams used during the audit.

I also ran the standard backend static gates:

- `make typecheck-backend`
- `make lint`

Those passed cleanly, including the repo’s backend hygiene/static-guard checks.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here was whether to expand the branch into a much broader “testing gaps” sweep because the issue body listed many possible scenarios. I intentionally did not do that. A broad sweep would have mixed live gaps with already-covered behavior, made the PR much larger, and reduced confidence that each new test was justified by current code.

The new tie-behavior tests intentionally assert the current deterministic fallback rather than inventing a new tie-break rule in production code. That is appropriate here because the issue is about missing coverage, not a confirmed ranking bug. If a future product decision wants a different tie-break policy, that can be implemented deliberately and these tests can be updated to match the new explicit contract.

Similarly, the sample-rate regression does not assert anything about buffer resizing strategy or frequency-content correctness. It stays focused on the cache invalidation contract that matters for reusing prior compute results safely.

## Follow-ups / out of scope

This branch does not add new failure-scenario infrastructure, property-based testing, or a family of invalid-fixture variants for every router dependency. If future issues want a larger reliability or fixture-hardening effort, that should be scoped as a separate initiative. For #1277, the complete live fix is to close the remaining deterministic ranking and sample-rate cache coverage gaps, and that is what this branch does.
