### PR TITLE
docs: improve API reference discoverability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Primary references:
 - Documentation index: [docs/README.md](docs/README.md)
 - Repo structure: [docs/ai/repo-map.md](docs/ai/repo-map.md)
 - Server setup and deployment: [apps/server/README.md](apps/server/README.md)
+- API surface and contracts: [apps/server/README.md#http-and-websocket-surface](apps/server/README.md#http-and-websocket-surface), [apps/ui/README.md#websocket-contract-boundary](apps/ui/README.md#websocket-contract-boundary), and [docs/operational-runbooks.md](docs/operational-runbooks.md)
 - Testing layout and commands: [docs/testing.md](docs/testing.md)
 - Operational runbooks: [docs/operational-runbooks.md](docs/operational-runbooks.md)
 - Full command reference: [.github/copilot-instructions.md](.github/copilot-instructions.md) § "Commands"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Each component has its own README with setup instructions and details.
 ## Docs Index
 
 See [docs/README.md](docs/README.md) for the complete documentation index.
+For HTTP/WebSocket developer references, start with
+[apps/server/README.md#http-and-websocket-surface](apps/server/README.md#http-and-websocket-surface)
+and
+[apps/ui/README.md#websocket-contract-boundary](apps/ui/README.md#websocket-contract-boundary),
+then use the docs index for the broader map.
 
 ## Prerequisites
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -127,29 +127,53 @@ path.
 
 The API surface is implemented in `apps/server/vibesensor/adapters/http/` and assembled by `adapters/http/__init__.py`.
 
+Start here for the human-facing API overview, then use the generated schema artifacts for endpoint-level contracts:
+
+- `python -m vibesensor.cli.http_api_schema_export` writes the committed OpenAPI artifact at `apps/ui/src/contracts/http_api_schema.json`. That schema is the endpoint-by-endpoint reference for request/response shapes, route descriptions, and documented HTTP error responses.
+- `python -m vibesensor.cli.ws_schema_export` writes the committed live-payload schema at `apps/ui/src/contracts/ws_payload_schema.json`. Pair that schema with `apps/ui/README.md` § "WebSocket contract boundary" for the human-readable field guide.
+- `docs/operational-runbooks.md` covers `/api/health` interpretation and stale-live-update debugging steps.
+
 Current route groups:
 
-- `health.py`
-- `clients.py`
-- `settings.py`
-- `recording.py`
-- `history.py`
-- `websocket.py`
-- `updates.py`
-- `car_library.py`
-- `debug.py`
+- `health.py` — `/api/health` runtime, startup, and degradation snapshots.
+- `clients.py` — sensor inventory, location assignment, and identify/blink actions.
+- `settings.py` — speed source, language, speed units, cars, and related settings state.
+- `recording.py` — recording lifecycle control and status.
+- `history.py` — saved runs, insights, reports, and exports.
+- `websocket.py` — `/ws` live update stream and selected-client updates.
+- `updates.py` — software updater and ESP flash workflows.
+- `car_library.py` — bundled car library brands/types/variants.
+- `debug.py` — raw-sample and FFT inspection endpoints for development/debugging.
 
 ### HTTP API schema export and versioning stance
 
 - Export the committed HTTP OpenAPI schema with `python -m vibesensor.cli.http_api_schema_export`.
+- Export the committed WebSocket schema with `python -m vibesensor.cli.ws_schema_export`.
 - The checked-in schema artifact lives at
-  `apps/ui/src/contracts/http_api_schema.json` and is kept in sync by CI
-  drift checks.
+  `apps/ui/src/contracts/http_api_schema.json`, while the committed WebSocket
+  payload schema lives at `apps/ui/src/contracts/ws_payload_schema.json`; both
+  are kept in sync by CI drift checks.
 - The current HTTP API intentionally remains a single unversioned `/api/*`
   surface because the backend and bundled UI ship atomically.
 - If independent or third-party clients become a real compatibility concern,
   introduce explicit path versioning starting at `/api/v1/` rather than adding
   ad hoc compatibility shims to the current routes.
+
+### Common error semantics
+
+The exported OpenAPI schema documents per-route error responses. The main status
+families currently used across the HTTP adapters are:
+
+- `400` — invalid identifiers, malformed request values, or invalid config-style inputs.
+- `404` — unknown sensors, runs, or car-library entities.
+- `409` — state conflicts such as already-running workflows or location collisions.
+- `422` — history/analysis requests that are structurally valid but not currently available for the run state.
+- `503` — live sensor actions that cannot be served because the device is not currently reachable.
+- `500` — unexpected internal failures that escape the route-specific error mapping.
+
+WebSocket error frames are separate from `LiveWsPayload` and currently use
+`{"error": "payload_build_failed"}` when the server cannot assemble a live
+update tick.
 
 ## Reports
 

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -96,6 +96,21 @@ HTML rendering helpers and event-target decoding for reusable panels.
 
 AJV-backed runtime validation now sits at the WebSocket boundary. Live payloads must satisfy that JSON Schema directly before the app-state adapter accepts them. The remaining UI-side handling is limited to current, explicit adapter behavior: schema-version warning logging, shared-`freq` fallback when the canonical shared axis is used, and dropping spectrum series that still cannot produce aligned bins for rendering.
 
+Top-level `LiveWsPayload` fields:
+
+- `schema_version` — current live-payload contract version.
+- `server_time` — server UTC timestamp for the tick.
+- `speed_mps` — resolved vehicle speed, or `null` when unavailable.
+- `clients` — current lightweight client snapshots (connectivity, identity, latest metrics metadata).
+- `selected_client_id` — the client whose heavier per-sensor detail the UI is currently focused on, or `null`.
+- `rotational_speeds` — derived wheel/driveshaft/engine speed estimates and current order-band context, or `null`.
+- `spectra` — heavier FFT payload data; omitted on light ticks and present on heavy ticks.
+
+Server-side WebSocket error frames are separate from `LiveWsPayload`. The
+current error payload is `{"error": "payload_build_failed"}`, which indicates
+the backend could not assemble the live update tick and sent an explicit error
+frame instead of the normal payload.
+
 ## Visual Tests
 
 Playwright snapshot tests capture the UI across 4 viewports:

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,14 @@ links onward to the scoped instruction files and repo map below.
 | `docs/time_alignment.md` | Multi-sensor time alignment approach. |
 | `docs/multithreading_performance.md` | Threading model and performance considerations. |
 
+## API & contract quick path
+
+Start with `apps/server/README.md` § "HTTP and WebSocket surface" for the
+human-facing route-group overview, schema export commands, and common
+HTTP/WebSocket error semantics. Pair it with `apps/ui/README.md` §
+"WebSocket contract boundary" for the live payload field guide and
+`docs/operational-runbooks.md` for `/api/health` interpretation and stale-live-update debugging.
+
 ## Testing
 
 | File | Description |


### PR DESCRIPTION
Closes #1278

## Summary

This PR closes the remaining live gap behind #1278 by improving discoverability of the existing HTTP/WebSocket contract references and by adding a concise human-readable guide for the live WebSocket payload and current error semantics. The issue body described total absence of HTTP endpoint references, WebSocket payload docs, and error-code cataloging, but an audit of current `main` showed the repo already shipped committed generated artifacts for both the OpenAPI surface and the WebSocket payload schema. What was actually missing was a clear path from the top-level docs to those artifacts and a short narrative explaining what the live WebSocket payload and explicit error frame mean without forcing readers to infer everything from JSON Schema alone.

## Problem being solved

Before this change, the project already had several meaningful API-contract assets:

- `apps/ui/src/contracts/http_api_schema.json`
- `apps/ui/src/contracts/ws_payload_schema.json`
- `apps/server/README.md` with a basic `HTTP and WebSocket surface` section
- `apps/ui/README.md` with the WebSocket validation boundary
- `docs/protocol.md` and `docs/operational-runbooks.md`

However, those pieces did not give a new contributor or operator a clean “start here” path from the root documentation. The root `README.md` and `CONTRIBUTING.md` did not point directly at the API surface. The server README listed route-group files but did not explain what each group covered or how the generated schema artifacts should be used as the canonical endpoint-level reference. The UI README documented validation mechanics but not the human meaning of the top-level `LiveWsPayload` fields or the current explicit WebSocket error frame. That left the issue report directionally correct even though the “nothing exists” framing was stale for the current codebase.

## Chosen approach

I treated this as an audit-first documentation task rather than immediately creating new standalone markdown references. The repo guidance favors keeping docs focused and avoiding redundant files when existing documents can own the truth. Since the exact endpoint-level contract already lives in generated artifacts, creating a separate hand-maintained HTTP endpoint catalog would duplicate information and drift quickly. Instead, this PR improves navigation to the existing sources of truth and adds only the missing human-readable context that schemas alone do not communicate well.

## Main changes by area

### Root docs and contribution flow

`README.md` now links directly to the server HTTP/WebSocket surface section and the UI WebSocket contract section from the docs-index area. `CONTRIBUTING.md` now includes a dedicated primary-reference bullet for API surface and contracts alongside the existing repo-map, testing, and runbook pointers. This makes the API/docs path discoverable from the first two documents most contributors read.

### Docs index

`docs/README.md` now includes an `API & contract quick path` section that tells readers where to start for the route-group overview, schema export commands, WebSocket field semantics, and operational debugging. This keeps the docs index as the navigation hub without inventing a second competing reference structure.

### Backend/server README

`apps/server/README.md` got the largest documentation update. The `HTTP and WebSocket surface` section now:

- explains that it is the human-facing starting point,
- points directly to the OpenAPI export command and committed schema artifact,
- points directly to the WebSocket schema export command and committed schema artifact,
- calls out `docs/operational-runbooks.md` as the place for `/api/health` interpretation and stale-live-update debugging,
- expands the route-group list so each adapter file has a one-line purpose description instead of just a filename,
- adds a concise `Common error semantics` section summarizing the current HTTP status-code families used across the adapters (`400`, `404`, `409`, `422`, `503`, and unexpected `500`),
- documents the current WebSocket error frame `{"error": "payload_build_failed"}`.

This gives readers a readable overview without replacing the generated schema as the exact route-by-route contract.

### Frontend/UI README

`apps/ui/README.md` already described the WebSocket validation boundary, AJV usage, and the adapter step after validation. This PR extends that section with the missing human-readable guide to the top-level `LiveWsPayload` fields:

- `schema_version`
- `server_time`
- `speed_mps`
- `clients`
- `selected_client_id`
- `rotational_speeds`
- `spectra`

It also now explains that server-side WebSocket error frames are separate from `LiveWsPayload` and documents the current `payload_build_failed` error payload. This closes the gap where someone could find the schema but still not know which fields are the main operational concepts or how the explicit error frame differs from normal live ticks.

## Schema, contract, config, and code impact

There are no runtime code changes in this PR. No HTTP routes, WebSocket payload shapes, schema generators, config defaults, or committed contract artifacts changed. The OpenAPI and WebSocket schema files remain the canonical endpoint-level and payload-level contract references. This PR only improves how the existing documentation points to them and explains them.

## Validation and checks

Because the change is documentation-only, the relevant repository validation was `make docs-lint`, which completed successfully. I also ran `git diff --check` before committing to confirm there were no whitespace or formatting issues in the edited markdown. I intentionally did not regenerate schemas or run broader code/test suites because no production code or generated contract sources were modified.

## Risks, tradeoffs, and edge cases

The main tradeoff here is choosing not to add new standalone `docs/http_api.md` or `docs/websocket_api.md` files. I think that is the safer maintenance choice for the current repository shape. The exact HTTP surface already has a committed OpenAPI export, and the exact WebSocket structure already has a committed JSON Schema. Re-documenting those in separate markdown files would create a second contract source and increase drift risk. The downside is that the server README and UI README now carry slightly more explanatory detail, but that detail is tightly scoped to navigation and human interpretation rather than duplicating every endpoint or schema field.

The error-semantics section is also intentionally framed as a summary of common status families, not an exhaustive promise that every route uses every code. The route-specific truth remains in the exported OpenAPI schema, which is exactly where the repo already keeps that precision.

## Follow-ups and out-of-scope items

The audit that led to this change matters: the original issue body implied total absence of API documentation, but current `main` already had meaningful machine-readable references. This PR closes the remaining live gap rather than recreating obsolete missing pieces. If the project later needs externally published developer docs or independently versioned third-party client support, that would justify a fuller public API reference flow and explicit versioned endpoint docs. For the current monorepo shape, improving discoverability and adding the WebSocket/error narrative is the smaller, more honest fix.

## Files touched

- `README.md`
- `CONTRIBUTING.md`
- `docs/README.md`
- `apps/server/README.md`
- `apps/ui/README.md`
