### PR TITLE
docs: deepen domain architecture guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ links onward to the scoped instruction files and repo map below.
 |------|-------------|
 | `docs/domain-model.md` | Domain object graph, modeling rules, and adapter inventory. |
 | `docs/analysis_pipeline.md` | Post-stop diagnostics pipeline: steps, modules, and data flow. |
+| `docs/order_tracking.md` | Order-reference math, tolerance bands, and order-finding flow. |
 | `docs/report_pipeline.md` | Report generation flow from analysis to PDF. |
 | `docs/design_language.md` | Visual design decisions for report layout and UI. |
 | `docs/metrics.md` | Vibration metric definitions and unit rules. |
@@ -34,8 +35,9 @@ links onward to the scoped instruction files and repo map below.
 |------|-------------|
 | `docs/operational-runbooks.md` | Troubleshooting and operational procedures. |
 | `docs/history_db_schema.md` | SQLite history database schema. |
+| `docs/run_lifecycle.md` | Recording lifecycle, persistence retries, and post-analysis queue semantics. |
 | `docs/run_schema_v2.md` | Run data persistence schema v2. |
-| `docs/intake_buffering.md` | Sample intake and buffering strategy. |
+| `docs/intake_buffering.md` | Sample intake, buffering, and live signal-processing flow. |
 | `docs/time_alignment.md` | Multi-sensor time alignment approach. |
 | `docs/multithreading_performance.md` | Threading model and performance considerations. |
 

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -36,13 +36,13 @@ This file is the repo map, not a workflow or policy guide. Use `.github/copilot-
 - `adapters/pdf/`: report mapping and PDF rendering, with grouped panel renderers under `adapters/pdf/panels/`. See `docs/report_pipeline.md` for the report flow.
 - `adapters/udp/`, `adapters/gps/`, `adapters/simulator/`, `adapters/hotspot/`: transport and device-facing runtime adapters.
 - `infra/runtime/`: runtime lifecycle, health, registry, and WebSocket coordination.
-- `infra/processing/`: signal-processing execution and payload building.
+- `infra/processing/`: signal-processing execution and payload building. See `docs/intake_buffering.md` for the live ingest, snapshot/FFT, and buffering flow.
 - `infra/config/`: runtime settings storage and read-side access.
 - `infra/workers/`: worker-pool infrastructure.
-- `use_cases/diagnostics/`: post-stop diagnostics pipeline. Core sample/statistics types stay in `_types.py`, while plot/table/output DTOs live in `_view_types.py`. See `docs/analysis_pipeline.md` for the module map and data flow.
+- `use_cases/diagnostics/`: post-stop diagnostics pipeline. Core sample/statistics types stay in `_types.py`, while plot/table/output DTOs live in `_view_types.py`. See `docs/analysis_pipeline.md` for the module map/data flow and `docs/order_tracking.md` for the shared order-reference and matching flow.
 - `use_cases/history/`: history queries, report loading/preparation/caching, and export orchestration. See `docs/report_pipeline.md` for report-specific flow.
 - `infra/runtime/health_snapshot.py`: application-level runtime health snapshot assembly for the `/api/health` route.
-- `use_cases/run/`: recording pipeline orchestration. `logger.py` is the `RunRecorder` entrypoint, `run_context.py` owns run/history context orchestration helpers, and the `post_analysis*.py` modules split queueing, loading, execution, and summary shaping.
+- `use_cases/run/`: recording pipeline orchestration. `logger.py` is the `RunRecorder` entrypoint, `run_context.py` owns run/history context orchestration helpers, and the `post_analysis*.py` modules split queueing, loading, execution, and summary shaping. See `docs/run_lifecycle.md` for the recording -> persistence -> post-analysis handoff.
 - `use_cases/updates/`: wheel-based updater workflow and public facade. Focused subpackages now group `updates/firmware/`, `updates/wifi/`, and `updates/releases/`, while the root package keeps installer/state/orchestration helpers.
 - `shared/`: cross-cutting ports, model/payload types, JSON helpers, boundary codecs, split constant modules under `shared/constants/`, and small package-level helpers such as `shared/_data_files.py`, `shared/sensor_units.py`, and `shared/run_context_warning.py`. Key stable owners include `shared/types/persisted_analysis.py`, `shared/types/analysis_views.py`, `shared/types/history_analysis_contracts.py`, `shared/types/run_schema.py`, `shared/types/car_config.py`, `shared/types/speed_source_config.py`, and the codec/projection modules under `shared/boundaries/` such as `settings_snapshot_codec.py`.
 - `domain/`: domain model package for classification, ranking, lifecycle, and query logic. See `docs/domain-model.md` for the domain object graph.

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -39,6 +39,17 @@ Mathematical primitives (e.g. `compute_vibration_strength_db`,
 `noise_floor_amp_p20_g`) live in the `vibesensor` top-level package
 and are shared by both layers.
 
+## Related deep dives
+
+- `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
+  math, and the order-matching pipeline fit together.
+- `docs/intake_buffering.md` covers the live ingest path, snapshot -> compute ->
+  store flow, FFT pipeline, and buffering/backpressure rules that feed the
+  runtime metrics layer.
+- `docs/run_lifecycle.md` documents the recording/persistence/post-analysis
+  handoff around `RunRecorder`, `RunPersistenceWriter`, and
+  `PostAnalysisWorker`.
+
 ## Trigger Flow
 
 ```

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -25,6 +25,9 @@ that `Car` context for tire geometry and driveline/reference-order
 interpretation. It is important interpretive context, but it is not a peer
 aggregate or top-level headline domain concept.
 
+See `docs/order_tracking.md` for the shared order-band math and
+matching/scoring flow built on top of `OrderReferenceSpec`.
+
 The diagnostics / reconstruction / interpretation layer uses these supporting
 typed internal concepts:
 
@@ -50,6 +53,9 @@ meaning sits above that boundary in typed concepts with owned meaning.
 
 `Report` and `HistoryRecord` are boundary-facing derived representations, not
 core diagnostic truth.
+
+See `docs/run_lifecycle.md` for the recording/persistence/post-analysis
+orchestration built around `Run`.
 
 ## Scope and context boundaries
 

--- a/docs/intake_buffering.md
+++ b/docs/intake_buffering.md
@@ -1,4 +1,4 @@
-# Intake Buffering & Live Compute Separation
+# Intake Buffering & Live Signal Processing
 
 ## Architecture
 
@@ -47,6 +47,73 @@ locking:
 Because the lock is held only during the brief snapshot and store phases,
 `ingest()` (which also needs the lock) is blocked only briefly even while
 background compute work is running.
+
+## Signal-processing flow after ingest
+
+`SignalProcessor.compute_metrics()` keeps the live path in a strict
+snapshot -> compute -> store shape:
+
+1. `buffer_store.snapshot_for_compute()` captures immutable arrays from the
+   per-client ring buffer under a short lock and skips work when there is no
+   fresh data or not enough samples for FFT.
+2. `SignalMetricsComputer.compute()` runs the heavy CPU work without holding the
+   buffer lock.
+3. `buffer_store.store_metrics_result()` commits the new metrics/spectrum back
+   onto the client buffer and invalidates cached payload views.
+
+The snapshot contains two overlapping views from the same immutable capture:
+
+- `time_window` keeps the wider waveform slice used for RMS/P2P metrics.
+- `fft_block` keeps the most recent `fft_n` samples used for spectral analysis.
+
+The FFT block is a suffix of the time window. VibeSensor does not run a dense
+overlap-add FFT bank; each compute tick snapshots the current rolling tail once,
+then analyzes that one block.
+
+### FFT pipeline
+
+`infra/processing/compute.py` owns the cached FFT setup:
+
+- `SignalMetricsComputer` precomputes a Hann window with
+  `np.hanning(config.fft_n)`.
+- `fft_scale = 2.0 / max(1.0, sum(window))` keeps amplitudes normalized after
+  windowing.
+- `fft_params(sample_rate_hz)` caches the frequency slice and valid FFT indices
+  per sample rate so repeated ticks do not rebuild them.
+
+`infra/processing/fft.py` owns the pure DSP steps:
+
+1. `medfilt3()` applies a 3-point median filter per axis before FFT work. This
+   removes isolated transport/I2C spikes without blurring normal vibration
+   content.
+2. `SignalMetricsComputer.compute()` detrends the captured windows by removing
+   the per-axis mean before RMS/P2P and FFT computation.
+3. `compute_fft_spectrum()` applies the Hann window, runs `np.fft.rfft()`,
+   scales the magnitudes, slices the configured frequency range, and produces
+   both per-axis spectra and a combined amplitude curve.
+4. `top_peaks()` smooths the spectrum with a 5-bin sliding average, estimates a
+   P20 noise floor, thresholds peaks above that floor, and returns the strongest
+   bins with SNR metadata.
+5. `compute_vibration_strength_db()` converts the dominant peak band into the
+   shared dB metric used by both live telemetry and post-stop analysis:
+
+   ```text
+   strength_db = 20 * log10((peak_rms + eps) / (floor + eps))
+   eps = max(1e-9, floor * 0.05)
+   ```
+
+### Key invariants
+
+- Each client buffer has its own lock, so ingestion and FFT work scale across
+  clients without a global bottleneck.
+- Generation counters decide freshness. If the ingest generation has not moved,
+  the compute side can reuse the cached metrics/spectrum instead of rebuilding
+  them.
+- The combined vibration-strength formula lives in `vibration_strength.py`; the
+  live path does not carry a second dB implementation.
+- Payload serialization stays downstream of computation. The processing layer
+  stores structured metrics and spectrum arrays first, and only later surfaces
+  them to HTTP/WebSocket payload builders.
 
 ## Overflow / backpressure policy
 

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -1,0 +1,140 @@
+# Order Tracking
+
+Scope: shared order-reference math and the post-stop order-analysis flow.
+
+VibeSensor uses the same vehicle-order reference model in two places:
+
+- live telemetry, where the server precomputes order bands for spectrum views
+- post-stop diagnostics, where stored samples are matched against those orders
+
+The shared physics lives in `apps/server/vibesensor/domain/order_reference.py`
+and `apps/server/vibesensor/shared/order_bands.py`. The post-stop finding flow
+lives in `apps/server/vibesensor/use_cases/diagnostics/orders/`.
+
+## Core concepts
+
+| Concept | Owner | Purpose |
+|---------|-------|---------|
+| `OrderReferenceSpec` | `domain/order_reference.py` | Tire geometry, final-drive ratio, gear ratio, and uncertainty settings for order analysis. |
+| `vehicle_orders_hz()` | `shared/order_bands.py` | Resolve wheel / driveshaft / engine reference frequencies for one speed sample. |
+| `build_order_bands()` | `shared/order_bands.py` | Precompute live order-band payloads so the frontend does not duplicate tolerance math. |
+| `OrderHypothesis` | `use_cases/diagnostics/orders/physics.py` | One named order candidate such as `wheel_1x` or `engine_2x`. |
+| `OrderAnalysisSession` | `use_cases/diagnostics/orders/pipeline.py` | Run all eligible hypotheses across stored samples and return ranked findings. |
+
+## From speed to reference frequencies
+
+`OrderReferenceSpec` turns vehicle speed plus car-reference data into rotational
+frequencies:
+
+```text
+wheel_hz      = speed_mps / tire_circumference_m
+driveshaft_hz = wheel_hz * final_drive_ratio
+engine_hz     = driveshaft_hz * current_gear_ratio
+```
+
+The spec exposes capability checks before any of that math is used:
+
+- `supports_wheel_reference`
+- `supports_driveshaft_reference`
+- `supports_engine_reference`
+
+If the required tire or driveline data is missing, VibeSensor omits the order
+reference instead of inventing one.
+
+## Uncertainty and tolerance bands
+
+Order matching is not based on a single exact frequency bin. Each reference
+order gets an uncertainty-aware tolerance band.
+
+`OrderReferenceSpec` combines uncertainty in stages:
+
+- wheel uncertainty = speed + tire diameter
+- driveshaft uncertainty = wheel uncertainty + final-drive uncertainty
+- engine uncertainty = driveshaft uncertainty + gear uncertainty
+
+The shared helper `combined_relative_uncertainty()` uses
+`sqrt(sum(part^2))`, so wider uncertainty produces wider matching bands.
+
+`tolerance_for_order()` then turns the nominal order frequency plus uncertainty
+into a half-bandwidth:
+
+```text
+base_half_rel = base_bandwidth_pct / 200
+abs_floor     = min_abs_band_hz / order_hz
+combined      = sqrt(base_half_rel^2 + uncertainty_pct^2)
+tolerance     = min(max_half_rel, max(combined, abs_floor))
+```
+
+That tolerance means a match is accepted inside:
+
+```text
+[center_hz * (1 - tolerance), center_hz * (1 + tolerance)]
+```
+
+`build_order_bands()` uses those tolerances to emit the live band payloads:
+
+- `wheel_1x`
+- `wheel_2x`
+- `driveshaft_1x` or merged `driveshaft_engine_1x`
+- `engine_1x` when it does not overlap driveshaft
+- `engine_2x`
+
+The driveshaft and engine 1x bands collapse into `driveshaft_engine_1x` when
+their centers are already inside the combined uncertainty envelope.
+
+## Post-stop hypothesis testing
+
+Diagnostics does not search an open-ended order space. It evaluates a fixed
+catalog of hypotheses from `orders/physics.py`:
+
+- wheel 1x / 2x
+- driveshaft 1x / 2x
+- engine 1x / 2x
+
+Each `OrderHypothesis` carries:
+
+- a stable `key`
+- the suspected `VibrationSource`
+- the base order family (`wheel`, `driveshaft`, or `engine`)
+- harmonic multiplier (`1` or `2`)
+- `path_compliance`, which widens tolerance for softer transmission paths such
+  as wheel/tire vibration traveling through suspension and bushings
+
+`OrderAnalysisSession.analyze()` coordinates the evidence flow:
+
+1. Skip hypotheses that do not have enough reference data (`_should_test()`).
+2. Use `match_samples_for_hypothesis()` to compare predicted order bands against
+   the stored sample peaks.
+3. Use `_compute_effective_match_rate()` to rescue or focus the evidence around
+   the best speed band or dominant location.
+4. Score the surviving evidence with `score_order_finding()`.
+5. Assemble a domain `Finding` with `assemble_order_finding()`.
+6. Split multi-location wheel findings when two corners are both strong.
+7. Apply `suppress_engine_aliases()` before returning the final ranked list.
+
+If the effective match rate stays below the current threshold, the hypothesis
+does not produce a finding.
+
+## Live vs post-stop reuse
+
+The same reference math serves both runtime and diagnostics:
+
+- live telemetry calls `vehicle_orders_hz()` and `build_order_bands()` so the
+  UI can annotate the current spectrum without duplicating the formulas
+- post-stop diagnostics uses the same order references, then asks whether peaks
+  keep recurring in the predicted bands across the saved run
+
+That shared ownership is why `shared/order_bands.py` exists outside
+`use_cases/diagnostics/`.
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/server/vibesensor/domain/order_reference.py` | Vehicle-physics reference model and frequency derivation helpers. |
+| `apps/server/vibesensor/shared/order_bands.py` | Shared uncertainty, tolerance-band, and live band-payload helpers. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/physics.py` | Fixed hypothesis catalog and per-sample predicted-Hz helpers. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/matching.py` | Match predicted order bands against stored sample peaks. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py` | Convert matched evidence into confidence and ranking score. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py` | Project scored evidence into domain `Finding` objects. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/pipeline.py` | Coordinate the full order-analysis pass. |

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -1,0 +1,148 @@
+# Run Lifecycle
+
+Scope: recording orchestration, sample persistence, and the post-analysis
+handoff after a run stops.
+
+The recording lifecycle is intentionally split across focused helpers instead of
+one big state-machine class:
+
+- `RunLifecycleState` owns only the in-memory active-run gate and timing fields.
+- `RunPersistenceWriter` owns history-run creation, sample append retries, and
+  finalization.
+- `PostAnalysisWorker` owns the background queue and retry policy after a run
+  stops.
+- `RunRecorder` coordinates those helpers without re-owning their internals.
+
+## Owning components
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| `RunLifecycleState` | `use_cases/run/lifecycle_state.py` | Active run identity, start timing, frame-progress tracking, and auto-stop gating. |
+| `SampleFlushOrchestrator` | `use_cases/run/sample_flush.py` | Build `SensorFrame` rows, refresh recent metrics, and decide when to flush or auto-stop. |
+| `RunPersistenceWriter` | `use_cases/run/persistence_writer.py` | Create the persisted run, append sample rows with retries, and finalize the run metadata. |
+| `RunRecorder` | `use_cases/run/logger.py` | Start/stop entrypoint and coordinator for lifecycle, persistence, and post-analysis. |
+| `PostAnalysisWorker` | `use_cases/run/post_analysis.py` | Non-evicting queue and single daemon thread for completed runs. |
+| `execute_post_analysis()` | `use_cases/run/post_analysis_executor.py` | Load metadata/samples, build the persisted analysis, and store success or failure. |
+
+## Lifecycle phases
+
+These are architectural phases, not one exported enum. Only the first active
+phase is stored directly on `RunLifecycleState`.
+
+```text
+idle
+  -> recording active
+  -> final flush + finalize
+  -> queued for post-analysis
+  -> analyzing
+  -> complete / analysis error stored
+```
+
+### 1. Idle
+
+No active run is recording:
+
+- `RunLifecycleState.current_run is None`
+- no active run ID is exposed
+- `PostAnalysisWorker` may still be busy with an older run
+
+### 2. Recording active
+
+`RunRecorder.start_recording()` flushes per-client processor buffers, snapshots
+the live run context, and calls `RunLifecycleState.start_new_run()`.
+
+During recording:
+
+- `current_run.is_recording` is true
+- `SampleFlushOrchestrator` periodically builds `SensorFrame` rows from the
+  registry, processor metrics, and resolved speed context
+- `refresh_data_progress()` / `mark_rows_written()` keep the no-data timeout
+  clock moving
+- auto-stop is based on elapsed monotonic time since the last data progress, not
+  on wall-clock timestamps
+
+### 3. Final flush and finalize
+
+`RunRecorder.stop_recording()` performs the stop handoff in this order:
+
+1. capture one last pending flush if new data exists
+2. ask `RunPersistenceWriter.ready_for_analysis()` whether the run has both a
+   created history row and at least one written sample
+3. call `RunPersistenceWriter.finalize_run()`
+4. call `RunLifecycleState.stop()` and clear the active run context
+5. reset the persistence helper for the next live run
+6. schedule post-analysis only when `ready_for_analysis()` returned the run ID
+
+If `finalize_run()` fails, `RunRecorder` still schedules post-analysis when the
+run was otherwise ready. The persistence layer handles that fallback path by
+storing the later analysis result or analysis error explicitly.
+
+## Persistence and retry rules
+
+`RunPersistenceWriter.ensure_history_run()` creates the persisted run record
+before sample rows are appended.
+
+- history-run creation allows up to `5` failures before entering a retry
+  cooldown
+- the cooldown grows from the `2.0s` base up to `10.0s`
+- while the history run is still missing, incoming sample rows are dropped and
+  counted as dropped samples instead of being queued forever
+
+`append_rows()` has a separate retry budget:
+
+- up to `3` append attempts total
+- retry delays come from `_APPEND_RETRY_DELAYS_S = (0.1, 0.3)`
+- if all attempts fail, the rows are counted as dropped and the last write error
+  is updated
+
+`finalize_run()` only touches the persisted run when the history row was
+actually created. If no history row exists, finalize returns success immediately
+because there is nothing persistent to close.
+
+## Post-analysis queue semantics
+
+`PostAnalysisWorker` owns the background phase after recording stops.
+
+- `schedule(run_id)` ignores duplicates for runs that are already queued or
+  active
+- the queue is FIFO and processed by one daemon thread
+- `_run_post_analysis()` retries transient failures with
+  `_RETRY_DELAYS_S = (0.5, 1.0, 2.0)`
+- `execute_post_analysis()` loads the stored run, calls the injected analysis
+  runner, and stores either analysis output or an analysis error record
+
+The worker also exposes `PostAnalysisHealthSnapshot`, which is what the health
+surface uses for queue depth, active run ID, and the most recent completion
+status.
+
+## Shutdown behavior
+
+Shutdown does not start new work:
+
+- `schedule()` ignores new runs once shutdown has started
+- `shutdown()` sets the shutdown event, clears queued-but-not-started runs, and
+  then waits briefly for the worker to exit
+- an in-flight analysis attempt is allowed to finish its current call path; the
+  worker checks the shutdown flag before starting the next queued item or retry
+
+## Key invariants
+
+- At most one live recording run is active at a time.
+- Post-analysis never starts until recording has stopped and persistence says
+  the run is ready for analysis.
+- The live recording path and the post-analysis path are decoupled; once a run
+  is queued, diagnostics work happens off the recording loop.
+- Duplicate post-analysis schedules are no-ops.
+- Retry budgets are explicit and bounded for history creation, sample appends,
+  and post-analysis retries.
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/server/vibesensor/use_cases/run/lifecycle_state.py` | In-memory active-run gate and timeout fields. |
+| `apps/server/vibesensor/use_cases/run/sample_flush.py` | Flush decisions, live metric refresh, and sample-row building. |
+| `apps/server/vibesensor/use_cases/run/persistence_writer.py` | History-run creation, append retries, counters, and finalize flow. |
+| `apps/server/vibesensor/use_cases/run/logger.py` | Public recording start/stop entrypoint. |
+| `apps/server/vibesensor/use_cases/run/post_analysis.py` | Queue, worker-thread, retry, and health behavior. |
+| `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` | Load -> analyze -> store execution path. |


### PR DESCRIPTION
Closes #1282

## Summary

This PR closes the remaining live documentation gap behind #1282 by adding focused deep dives for order tracking and run lifecycle semantics, expanding the existing live signal-processing doc, and wiring those materials into the existing docs index and repo map. The issue body described broad missing or stale documentation across order tracking, the diagnostics pipeline, FFT algorithms, and run lifecycle. An audit of current `main` showed that the diagnostics pipeline and domain-model docs were already significantly stronger than the issue text suggested, so the right fix was not to rewrite those documents wholesale. Instead, this PR adds the pieces that were still genuinely hard to discover or understand without reading the source: how order references become bands and findings, how the live FFT path works after ingest, and how recording/persistence/post-analysis hand off between the runtime helpers.

## Problem being solved

Before this change, the repository already had several useful domain documents:

- `docs/domain-model.md` describing aggregates, supporting typed concepts, and ownership boundaries
- `docs/analysis_pipeline.md` documenting the full post-stop diagnostics flow, including the current 13-step pipeline through boundary serialization
- `docs/intake_buffering.md` documenting queueing, ring buffers, and the high-level snapshot/compute separation
- `docs/ai/repo-map.md` documenting package ownership at a high level

That meant part of the issue report was stale on current `main`. In particular, the claim that `analysis_pipeline.md` ended at step 11 or lacked report assembly coverage was no longer true. However, the audit also showed that three real gaps remained.

First, there was still no single focused document explaining order tracking from `OrderReferenceSpec` through tolerance bands, hypothesis testing, scoring, and finding assembly. The code had the pieces, but they were spread across `domain/order_reference.py`, `shared/order_bands.py`, and multiple `use_cases/diagnostics/orders/` modules.

Second, the live processing doc explained buffering and compute separation but still required source reading for the actual FFT/windowing/peak-detection path and the shared dB strength calculation.

Third, there was still no dedicated run-lifecycle document tying together `RunLifecycleState`, `RunRecorder`, `RunPersistenceWriter`, `SampleFlushOrchestrator`, and `PostAnalysisWorker`. Developers could infer the flow from the code, but there was no concise explanation of the stop/finalize/schedule path, retry budgets, or queue/shutdown semantics.

## Chosen approach

I treated this as an audit-first docs task and deliberately avoided rewriting documents that were already current. The repo guidance favors keeping docs focused and removing stale assumptions rather than layering parallel explanations on top of strong existing docs. Based on that, the change set does three things:

1. adds two focused deep-dive docs where there was no natural existing owner,
2. expands the existing live processing doc instead of creating a redundant second live-DSP document,
3. updates the existing index and cross-link surfaces so readers can find the right deep dive from the current docs map.

This keeps the source of truth aligned with existing ownership boundaries instead of introducing a large umbrella “everything about diagnostics” doc that would overlap with the current pipeline and domain-model references.

## Main changes by area

### New order-tracking deep dive

The new `docs/order_tracking.md` explains the shared order-reference model end to end:

- the role of `OrderReferenceSpec`
- wheel / driveshaft / engine frequency derivation from vehicle speed and driveline data
- uncertainty propagation and tolerance-band construction
- live band emission through `build_order_bands()`
- the fixed hypothesis catalog used in post-stop diagnostics
- how matching, effective match-rate calculation, scoring, and finding assembly fit together

The goal is not to restate every implementation detail, but to give a maintainer enough conceptual context to understand how the order-reference physics and the diagnostics pipeline connect.

### Expanded live signal-processing documentation

Instead of creating a second standalone live-processing doc, this PR expands `docs/intake_buffering.md` into `Intake Buffering & Live Signal Processing`. The new section documents:

- the strict snapshot -> compute -> store pattern after ingest
- how `time_window` and `fft_block` relate
- the Hann window and cached FFT parameter setup in `SignalMetricsComputer`
- the pure DSP stages in `infra/processing/fft.py`
- median spike filtering, detrending, FFT scaling, spectrum slicing, peak picking, and the shared vibration-strength dB formula
- the key invariants around per-client locking, generation-based freshness, and downstream payload shaping

This keeps the live runtime doc co-located with the buffering architecture that feeds it, rather than splitting one tightly related topic across multiple markdown files.

### New run-lifecycle deep dive

The new `docs/run_lifecycle.md` explains the recording and post-stop orchestration that had previously been implicit across several helpers. It covers:

- the ownership split between `RunLifecycleState`, `RunRecorder`, `RunPersistenceWriter`, `SampleFlushOrchestrator`, and `PostAnalysisWorker`
- the architectural phases from idle to recording to finalization to queued analysis
- how `stop_recording()` performs the final flush/finalize/schedule handoff
- history-run creation and append retry behavior
- post-analysis queue semantics and retry behavior
- shutdown behavior and the most important invariants

One subtle point here is that the document is careful not to invent a richer public enum than the code currently exposes. The lifecycle is described as architectural phases rather than pretending there is one giant exported state machine.

### Cross-links and discoverability

This PR also updates the current docs that should route readers to those deep dives:

- `docs/analysis_pipeline.md` now points to the related deep-dive docs instead of implying it should explain every adjacent runtime concept itself
- `docs/domain-model.md` now points readers to the new order-tracking and run-lifecycle docs where those concepts leave the pure model-reference layer
- `docs/README.md` now indexes the two new docs and updates the intake-buffering description
- `docs/ai/repo-map.md` now links the relevant package areas to the matching documentation entry points

## Code, schema, and runtime impact

This is a docs-only PR. No runtime code, schema generators, persisted payloads, routes, or algorithms changed. The work is intentionally explanatory and navigational rather than behavioral.

## Validation

Because the diff is entirely documentation, the relevant repo validation was `make docs-lint`, which completed successfully. I also verified the working tree was clean after commit and ran `git diff --check` earlier in the change flow to avoid whitespace or malformed markdown issues.

## Risks, tradeoffs, and edge cases

The main tradeoff is choosing two new focused docs instead of forcing all of this material into existing files. I think that is the safer maintenance choice here. Order tracking and run lifecycle both span multiple modules and ownership boundaries, so keeping them as focused references is clearer than overloading `docs/domain-model.md` or `docs/analysis_pipeline.md`.

By contrast, I intentionally did **not** create a third standalone live-DSP doc. The live signal-processing explanation sits naturally next to the existing intake and buffering narrative, so expanding `docs/intake_buffering.md` avoids unnecessary fragmentation.

I also intentionally did **not** rewrite `docs/analysis_pipeline.md` as if it were stale. The audit showed that the document already reflects the current 13-step pipeline, so the right change was to preserve it and add deep-link context around it.

## Follow-ups and out-of-scope items

This PR does not attempt to produce academic DSP documentation or document every helper function in the diagnostics package. It focuses on the conceptual seams that were still forcing source-code reverse engineering. If the project later needs more tutorial-style onboarding material, that can build on these docs instead of replacing them.
