### PR TITLE
docs: expand operational guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,9 @@ cp apps/server/config.dev.yaml apps/server/config.yaml
 
 Then edit `config.yaml` as needed. The file is gitignored, so your local changes won't affect others.
 
+Use [docs/configuration_reference.md](docs/configuration_reference.md) for the
+full key-by-key runtime config reference.
+
 ## API contract sync
 
 The contract-sync flow lives in

--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ within seconds.
 > Default AP credentials are for prototype use only. Change SSID/PSK before
 > real-world deployment.
 
+For post-install config tuning, service management, and field troubleshooting,
+use [apps/server/README.md](apps/server/README.md),
+[docs/configuration_reference.md](docs/configuration_reference.md), and
+[docs/operational-runbooks.md](docs/operational-runbooks.md).
+
 ## ESP Sensor Setup
 
 ```bash

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -67,6 +67,10 @@ install path.
 
 Configuration is YAML-based. Runtime defaults live in `vibesensor/app/config_defaults.py`, and `load_config()` applies precedence `DEFAULT_CONFIG -> selected YAML override file -> typed validation/clamping`. Run `vibesensor-config-preflight --dump-defaults` to see all available keys with defaults, or run `vibesensor-config-preflight apps/server/config.dev.yaml` / `apps/server/config.docker.yaml` to inspect a resolved override file.
 
+Use [docs/configuration_reference.md](../../docs/configuration_reference.md) for
+the key-by-key operator reference across the `ap`, `server`, `udp`,
+`processing`, `logging`, `gps`, and `update` sections.
+
 For live sensor presence, `processing.client_live_ttl_seconds` controls how long
 `/api/clients` and `/ws` keep reporting `connected: true` after the last
 packet. `processing.client_ttl_seconds` is the longer retention/eviction window
@@ -109,6 +113,54 @@ Common runtime files under `apps/server/data/` include:
 - `metrics.jsonl`: optional metrics log output.
 - `clients.json`: persisted client metadata.
 - `report_i18n.json`: report translation data.
+
+## Pi deployment & service operations
+
+Use the top-level [README deployment section](../../README.md#deploying-to-raspberry-pi)
+to choose between manual install and the prebuilt image flow. After the software
+is on the device, this README owns the backend-side service and config path.
+
+- Runtime config lives at `/etc/vibesensor/config.yaml`. Manual install copies
+  `apps/server/config.pi.yaml` there on first install, and the prebuilt image
+  bakes the same overlay into the image build.
+- Validate the on-device config before restarting services:
+
+  ```bash
+  /path/to/venv/bin/vibesensor-config-preflight /etc/vibesensor/config.yaml
+  ```
+
+- The main service units are:
+  - `vibesensor.service`
+  - `vibesensor-hotspot.service`
+  - `vibesensor-hotspot-self-heal.timer`
+
+- Common service operations:
+
+  ```bash
+  sudo systemctl status vibesensor.service vibesensor-hotspot.service --no-pager
+  sudo systemctl restart vibesensor.service
+  sudo systemctl restart vibesensor-hotspot.service
+  sudo systemctl status vibesensor-hotspot-self-heal.timer --no-pager
+  sudo journalctl -u vibesensor.service -u vibesensor-hotspot.service -n 200 --no-pager
+  ```
+
+- Hotspot diagnostics are written under `/var/log/wifi/`, including
+  `hotspot.log` plus the latest `summary.txt`/dump files emitted by
+  `apps/server/scripts/hotspot_nmcli.sh`.
+- Backend runtime data lives under `/var/lib/vibesensor/` and `/var/log/vibesensor/`
+  on Pi installs.
+- First verification after install/flash:
+
+  ```bash
+  curl -sf http://10.4.0.1/api/health || curl -sf http://10.4.0.1:8000/api/health
+  curl -sf http://10.4.0.1/api/clients || curl -sf http://10.4.0.1:8000/api/clients
+  ```
+
+Use [docs/configuration_reference.md](../../docs/configuration_reference.md) for
+config tuning, [docs/operational-runbooks.md](../../docs/operational-runbooks.md)
+for incident response, and
+[infra/pi-image/pi-gen/README.md](../../infra/pi-image/pi-gen/README.md) for the
+image-build path and artifact validation.
 
 ## Observability
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ links onward to the scoped instruction files and repo map below.
 | File | Description |
 |------|-------------|
 | `docs/operational-runbooks.md` | Troubleshooting and operational procedures. |
+| `docs/configuration_reference.md` | Runtime config keys, defaults, constraints, and common override examples. |
 | `docs/history_db_schema.md` | SQLite history database schema. |
 | `docs/run_lifecycle.md` | Recording lifecycle, persistence retries, and post-analysis queue semantics. |
 | `docs/run_schema_v2.md` | Run data persistence schema v2. |

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -1,0 +1,122 @@
+# Configuration Reference
+
+Scope: operator-facing reference for the YAML runtime configuration accepted by
+`vibesensor.app.settings`.
+
+The source of truth for defaults lives in
+`apps/server/vibesensor/app/config_defaults.py`. Typed validation and clamping
+live in `apps/server/vibesensor/app/config_schema.py`. This document exists so
+operators do not need to read Python source just to discover the supported keys.
+
+## How to inspect and validate config
+
+Dump the documented defaults:
+
+```bash
+vibesensor-config-preflight --dump-defaults
+```
+
+Validate a resolved YAML file:
+
+```bash
+vibesensor-config-preflight /etc/vibesensor/config.yaml
+```
+
+Load order is:
+
+1. built-in defaults
+2. selected YAML override file
+3. typed validation/clamping from the config schema
+
+For local development examples, see `apps/server/config.dev.yaml`,
+`apps/server/config.docker.yaml`, and `apps/server/config.pi.yaml`.
+
+## `ap`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `ap.ssid` | `VibeSensor` | Hotspot SSID. Change this before real deployments. |
+| `ap.psk` | `""` | Empty string means an open AP. Set a PSK for non-prototype deployments. |
+| `ap.ip` | `10.4.0.1/24` | Hotspot subnet/address used by NetworkManager shared mode. |
+| `ap.channel` | `7` | 2.4 GHz Wi-Fi channel. The typed config accepts channels `1`-`14`. |
+| `ap.ifname` | `wlan0` | Preferred Wi-Fi interface name. The hotspot script falls back to a detected Wi-Fi device if this one is missing. |
+| `ap.con_name` | `VibeSensor-AP` | NetworkManager connection profile name for the hotspot. |
+| `ap.self_heal.enabled` | `true` | Enable the hotspot self-heal watchdog/timer. |
+| `ap.self_heal.diagnostics_lookback_minutes` | `5` | Positive integer window for hotspot diagnostics lookback. |
+| `ap.self_heal.min_restart_interval_seconds` | `120` | Minimum seconds between self-heal restarts. Non-negative integer. |
+| `ap.self_heal.state_file` | `data/hotspot-self-heal-state.json` | Writable state file used by the self-heal logic. Pi deployments override this into `/var/lib/vibesensor/`. |
+
+## `server`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `server.host` | `0.0.0.0` | Bind host for the FastAPI server. |
+| `server.port` | `80` | TCP port for HTTP/UI traffic. Must stay within `1`-`65535`. Dev configs typically override this to `8000`. |
+
+## `udp`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `udp.data_host` | `0.0.0.0` | Bind host for sensor data packets. |
+| `udp.data_port` | `9000` | UDP port for sensor data. Must stay within `1`-`65535`. |
+| `udp.control_host` | `0.0.0.0` | Bind host for control/ACK traffic. |
+| `udp.control_port` | `9001` | UDP port for control traffic. Must stay within `1`-`65535`. |
+| `udp.data_queue_maxsize` | `1024` | Max async UDP queue depth before packets are dropped and counted. Must be `>= 1`. |
+
+## `processing`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `processing.sample_rate_hz` | `800` | Expected live sample rate for metrics/FFT processing. Values below `1` clamp to `1`. |
+| `processing.waveform_seconds` | `8` | Ring-buffer window length per client. Values below `1` clamp to `1`, and very large values are clamped so `sample_rate_hz * waveform_seconds` stays within the per-client buffer limit. |
+| `processing.client_live_ttl_seconds` | `10` | How long clients remain `connected: true` after their last packet. |
+| `processing.client_ttl_seconds` | `120` | Longer metadata retention window after clients go stale. Clamped up to at least `client_live_ttl_seconds`. |
+| `processing.accel_scale_g_per_lsb` | `null` | Optional raw accelerometer scale factor. Leave unset when the sender already emits values in g. |
+
+## `logging`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `logging.history_db_path` | `data/history.db` | Persisted history/settings database path. Pi deployments override this to `/var/lib/vibesensor/history.db`. |
+| `logging.metrics_log_hz` | `4` | Live metrics logging cadence. Invalid values clamp up to at least `1`. |
+| `logging.no_data_timeout_s` | `15.0` | Auto-stop timeout when recording stops seeing new data. Invalid values clamp to `15.0`. |
+| `logging.persist_history_db` | `true` | Enable/disable writing run history to the DB. |
+| `logging.run_retention_days` | `7` | Startup maintenance retention window for terminal runs (`complete` / `error`). Invalid values clamp up to at least `1`. |
+| `logging.shutdown_analysis_timeout_s` | `30` | How long shutdown waits for post-analysis cleanup before giving up. Invalid values clamp to `30.0`. |
+| `logging.app_log_path` | `data/app.log` | Structured JSON application-log output path. Set to `null` if file logging is not wanted. |
+
+## `gps`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `gps.gps_enabled` | `true` | Enable gpsd-backed GPS reads. Disable this on dev benches or deployments without GPS hardware. |
+| `gps.gpsd_host` | `127.0.0.1` | gpsd host. |
+| `gps.gpsd_port` | `2947` | gpsd port. Must stay within `1`-`65535`. |
+
+## `update`
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `update.rollback_dir` | `/var/lib/vibesensor/rollback` | Rollback snapshot directory used by the updater. Keep this on writable persistent storage. |
+
+## Common operator overrides
+
+```yaml
+# secure the default hotspot
+ap:
+  ssid: VibeSensor-Workshop
+  psk: change-me-first
+
+# dev bench without GPS and with the backend on :8000
+server:
+  port: 8000
+gps:
+  gps_enabled: false
+
+# retain run history longer on a device with more storage
+logging:
+  run_retention_days: 30
+```
+
+Use `apps/server/config.pi.yaml` as the starting point for Pi installs and the
+other preset configs as examples for dev/docker environments.

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -66,6 +66,91 @@ vibesensor-sim --count 3 --duration 20 --server-host 127.0.0.1 --no-auto-server
 
 4. If health is good but the UI is stale, check browser console and recent frontend builds.
 
+## Diagnose service or hotspot startup failures
+
+1. Check the systemd units first:
+
+```bash
+sudo systemctl status vibesensor.service vibesensor-hotspot.service --no-pager
+sudo systemctl status vibesensor-hotspot-self-heal.timer --no-pager
+```
+
+2. Inspect the recent service logs:
+
+```bash
+sudo journalctl -u vibesensor.service -u vibesensor-hotspot.service -n 200 --no-pager
+```
+
+3. Validate the on-device config before restarting anything:
+
+```bash
+/path/to/venv/bin/vibesensor-config-preflight /etc/vibesensor/config.yaml
+```
+
+4. For hotspot bring-up or DHCP failures, inspect the files under `/var/log/wifi/`:
+   - `hotspot.log` — full timestamped hotspot script output
+   - `summary.txt` — last status/rc plus effective interface, SSID, and IP
+   - `*_nm_dev.txt`, `*_nm_conn_active.txt`, `*_rfkill.txt` — captured NetworkManager/radio diagnostics
+5. If the hotspot service failed after boot, restart only the AP path first:
+
+```bash
+sudo systemctl restart vibesensor-hotspot.service
+```
+
+6. If the backend service is unhealthy after a config change or package update, restart it separately:
+
+```bash
+sudo systemctl restart vibesensor.service
+```
+
+## Diagnose GPS timeout or missing speed
+
+1. Confirm whether GPS is even enabled in the active config (`gps.gps_enabled`).
+2. Check the daemon status:
+
+```bash
+sudo systemctl status gpsd --no-pager
+```
+
+3. If `gpsd-clients` is installed on the Pi image/manual install path, confirm
+   the device is producing fixes:
+
+```bash
+cgps -s
+```
+
+4. If `/api/health` is good but speed stays empty, verify the configured speed
+   source and whether the environment has enough sky view or signal quality for
+   a lock.
+5. For indoor benches or weak-signal environments, prefer a non-GPS speed path
+   in config instead of repeatedly treating poor satellite reception as a server
+   failure.
+
+## Diagnose storage or history DB write problems
+
+1. Start with `/api/health` and look for persistence-facing degradation reasons
+   such as `persistence_write_error`, `persistence_samples_dropped`, or
+   `last_analysis_failed`.
+2. Check disk headroom before chasing application logic:
+
+```bash
+df -h /var/lib/vibesensor /var/log/vibesensor
+```
+
+3. Review recent backend service logs:
+
+```bash
+sudo journalctl -u vibesensor.service -n 200 --no-pager
+```
+
+4. If file logging is enabled, inspect the structured app log configured by
+   `logging.app_log_path`.
+5. Before any manual DB recovery, copy `/var/lib/vibesensor/history.db` off the
+   device (or snapshot the card) so the original evidence is preserved.
+6. If the device lost power and now reports repeated write failures, treat that
+   as storage integrity or free-space triage first, then rerun the health checks
+   before attempting new recordings.
+
 ## Update and rollback checks
 
 1. Confirm current runtime and update status from the UI or update endpoints.

--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -84,6 +84,33 @@ VS_FIRST_USER_NAME=pi VS_FIRST_USER_PASS='your-password' ./infra/pi-image/pi-gen
 
 If you require key-only SSH, provision authorized keys during image customization and validate they exist; this repo defaults to password auth for recovery-oriented hotspot deployments.
 
+## Failure recovery
+
+When `build.sh` fails, isolate which stage failed before retrying everything:
+
+1. If the app artifact build failed, rerun just that stage:
+
+   ```bash
+   BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh
+   ```
+
+2. If the app artifacts are already good and the image stage failed, rerun only
+   the image build:
+
+   ```bash
+   BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh
+   ```
+
+3. If the main build finished but the validator failed, rerun
+   `validate-image.sh` directly against the existing artifact so you can debug
+   validation separately from the build itself.
+4. Use `FAST=1` or `VALIDATE=0` only to narrow down where the failure occurs;
+   rerun with normal validation before trusting the artifact.
+5. If the generated pi-gen workspace looks suspect, remove `.cache/pi-gen/` and
+   rerun from a clean checkout state.
+6. If first-boot SSH availability is the problem, rebuild with
+   `SSH_FIRST_BOOT_DEBUG=1` so the image writes diagnostics to `/boot/ssh-debug.txt`.
+
 ## What's Included
 
 The image contains:


### PR DESCRIPTION
Closes #1285

## Summary

This PR closes the remaining live operational-documentation gap behind #1285 by adding a dedicated configuration reference, expanding the backend deployment/service guidance, broadening the troubleshooting runbook with common field recovery flows, and adding failure-recovery notes to the Pi image build README. The issue body described total absence of configuration, deployment, and runbook documentation, but an audit of current `main` showed the repo already had meaningful operational material spread across the root README, `apps/server/README.md`, `docs/operational-runbooks.md`, and `infra/pi-image/pi-gen/README.md`. The real gap was not “no docs at all”; it was the lack of a searchable runtime-config reference and the lack of a tighter operator-facing bridge between install/flash instructions and real day-two service recovery steps.

## Problem being solved

Before this change, operators could already find some useful information:

- the root `README.md` already documented the two Raspberry Pi deployment modes and a basic verification path
- `apps/server/README.md` already described the layered YAML config system and the `vibesensor-config-preflight` CLI
- `docs/operational-runbooks.md` already covered health checks, dropped frames, stale live updates, and update/rollback validation
- `infra/pi-image/pi-gen/README.md` already covered the wheel-first image build path, build flags, and standalone validation

That meant part of the issue report was stale on current `main`. In particular, there already *was* a deployment guide and there already *was* a troubleshooting runbook. The missing part was that operators still had to jump between multiple files and source code to answer routine questions such as:

- which runtime keys actually exist and what do they mean?
- where does the Pi config live after install?
- which systemd units own the backend, hotspot, and self-heal timer?
- what logs or files should I inspect when the hotspot fails, GPS never locks, or the history DB starts erroring?
- how should I recover when the Pi image build or validation fails midway?

## Audit result and chosen approach

I treated this as an audit-first docs task and deliberately avoided creating three brand-new standalone manuals for configuration, deployment, and troubleshooting. The repo already had owners for most of that material. The smaller honest fix was:

1. add one focused config reference where there was no good existing owner,
2. deepen the current backend README where service-management and on-device operations naturally belong,
3. deepen the existing operational runbook instead of forking a second troubleshooting guide,
4. add failure-recovery notes to the existing Pi image README instead of inventing a separate build-troubleshooting doc.

This keeps the documentation aligned with current ownership boundaries and reduces future drift.

## Main changes by area

### New configuration reference

The new `docs/configuration_reference.md` is the main addition in this PR. It documents the runtime YAML surface section by section:

- `ap`
- `server`
- `udp`
- `processing`
- `logging`
- `gps`
- `update`

For each supported key, the doc lists the default value and the operational meaning or constraint. It also points readers back to the real source of truth in `config_defaults.py` and `config_schema.py`, and it documents the two most useful preflight commands:

- `vibesensor-config-preflight --dump-defaults`
- `vibesensor-config-preflight /etc/vibesensor/config.yaml`

This closes the biggest real gap from the issue: operators no longer need to read Python source just to discover the supported runtime keys.

### Backend deployment and service operations

`apps/server/README.md` now does more than explain the config loader. It also includes a focused `Pi deployment & service operations` section covering:

- where the live Pi config file lives (`/etc/vibesensor/config.yaml`)
- how `config.pi.yaml` relates to manual install and image build flows
- which systemd units matter on-device
- common `systemctl` and `journalctl` commands for day-two operations
- where hotspot diagnostics are written on disk
- the first verification curls to run after install or flash
- pointers to the new configuration reference and the operational runbook

This turns the backend README into the place a human operator can go after the software is already installed.

### Expanded operational runbook

`docs/operational-runbooks.md` now covers the field issues that were still under-documented:

- service or hotspot startup failures
- hotspot/DHCP diagnostics via `/var/log/wifi/` artifacts
- GPS timeout or missing speed
- storage/history DB write issues after low disk or abrupt power loss

The new sections stay command-oriented and operator-facing. They build on the existing health-check sections instead of replacing them. The result is a more complete runbook from “is the system healthy?” to “what should I inspect and restart next?”

### Pi image failure recovery

`infra/pi-image/pi-gen/README.md` now has an explicit `Failure recovery` section that explains how to isolate app-artifact failures, image-build failures, validator failures, suspicious generated pi-gen workspaces, and first-boot SSH debugging. The guidance is built around the current wheel-first flow and existing commands such as `BUILD_MODE=app`, `BUILD_MODE=image`, and `validate-image.sh` rather than inventing a second recovery workflow.

### Discoverability updates

This PR also updates the current navigation surfaces so the new operational docs can actually be found:

- `docs/README.md` now indexes `docs/configuration_reference.md`
- `CONTRIBUTING.md` now points its config section at the full key-by-key reference
- the root `README.md` now points Raspberry Pi operators at the config reference and operational runbook after install/flash

## Config, code, and runtime impact

This is a docs-only PR. No runtime configuration logic, services, schemas, or deployment scripts changed. The work is explanatory and navigational only.

One important audit finding is that the live config surface is smaller than the issue body suggested. Current runtime defaults are defined in `config_defaults.py` and are materially smaller than a “50+ field across seven classes” framing implies. The doc work reflects the actual current keys instead of blindly mirroring the original issue text.

## Validation

Because the diff is entirely documentation, the relevant repo validation was `make docs-lint`, which completed successfully. The working tree was also verified clean after commit.

## Risks, tradeoffs, and edge cases

The main tradeoff here is adding one new reference doc while keeping the rest of the changes inside existing owners. I think that is the right balance. Configuration needed its own searchable reference, but deployment, troubleshooting, and Pi image recovery already had natural homes that only needed expansion.

I also intentionally avoided claiming stronger operational guarantees than the code or scripts provide. The new runbook tells operators what to inspect and how to validate, but it does not invent unsupported recovery procedures or promise that every failure can be repaired automatically on-device.

## Follow-ups and out-of-scope items

This PR does not attempt to document every environment variable or every possible field incident. It focuses on the operator paths that were still forcing source-code or script reading. If future work adds materially new runtime config sections or service flows, `docs/configuration_reference.md`, `apps/server/README.md`, and `docs/operational-runbooks.md` are now the obvious places to extend.
