### PR TITLE
fix: add structured run lifecycle logs

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -175,6 +175,13 @@ before/after values for the changed setting or car profile. That gives a stable
 operator trail for configuration changes without adding a second persistence
 path.
 
+Run transitions now also emit structured `run_lifecycle` records with a
+`run_action` (`started` or `stopped`), the `run_id`, timestamps, and, for stop
+events, the stop reason plus written/dropped sample counters. That gives
+operators a queryable trail for manual stops, restart rollovers, inactivity
+auto-stops, and shutdown cleanup without stitching together multiple log
+messages.
+
 ## HTTP and WebSocket surface
 
 The API surface is implemented in `apps/server/vibesensor/adapters/http/` and assembled by `adapters/http/__init__.py`.

--- a/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
+++ b/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,85 @@ def test_start_append_stop_produces_complete_run_in_db(
     assert stored["score"] == 42
     assert stored["details"] == "looks good"
     assert "analysis_metadata" in stored
+
+
+def test_start_and_stop_recording_emit_structured_run_lifecycle_events(
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = make_logger(history_db=fake_history_db)
+    monkeypatch.setattr(logger, "schedule_post_analysis", lambda _run_id: None)
+
+    with caplog.at_level(logging.INFO, logger="vibesensor.use_cases.run.logger"):
+        started = logger.start_recording()
+        assert started.run_id is not None
+        snapshot = logger._session_snapshot()
+        assert snapshot is not None
+        logger._sample_flush.append_records(
+            snapshot.run_id,
+            snapshot.start_time_utc,
+            snapshot.start_mono_s,
+        )
+        logger.stop_recording()
+
+    lifecycle_records = [rec for rec in caplog.records if rec.message == "run_lifecycle"]
+    assert [rec.run_action for rec in lifecycle_records] == ["started", "stopped"]
+
+    start_record, stop_record = lifecycle_records
+    assert start_record.event == "run_lifecycle"
+    assert start_record.run_id == snapshot.run_id
+    assert start_record.start_time_utc == snapshot.start_time_utc
+    assert not hasattr(start_record, "stop_reason")
+
+    assert stop_record.event == "run_lifecycle"
+    assert stop_record.run_id == snapshot.run_id
+    assert stop_record.start_time_utc == snapshot.start_time_utc
+    assert stop_record.stop_reason == "manual"
+    assert stop_record.samples_written > 0
+    assert stop_record.samples_dropped == 0
+    assert isinstance(stop_record.end_time_utc, str)
+
+
+def test_restart_recording_emits_stop_then_start_lifecycle_events(
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = make_logger(history_db=fake_history_db)
+    monkeypatch.setattr(logger, "schedule_post_analysis", lambda _run_id: None)
+    first_status = logger.start_recording()
+    assert first_status.run_id is not None
+    first_snapshot = logger._session_snapshot()
+    assert first_snapshot is not None
+    logger._sample_flush.append_records(
+        first_snapshot.run_id,
+        first_snapshot.start_time_utc,
+        first_snapshot.start_mono_s,
+    )
+
+    with caplog.at_level(logging.INFO, logger="vibesensor.use_cases.run.logger"):
+        second_status = logger.start_recording()
+
+    assert second_status.run_id is not None
+    assert second_status.run_id != first_snapshot.run_id
+    second_snapshot = logger._session_snapshot()
+    assert second_snapshot is not None
+    lifecycle_records = [rec for rec in caplog.records if rec.message == "run_lifecycle"]
+    assert [rec.run_action for rec in lifecycle_records] == ["stopped", "started"]
+
+    stop_record, start_record = lifecycle_records
+    assert stop_record.event == "run_lifecycle"
+    assert stop_record.run_id == first_snapshot.run_id
+    assert stop_record.stop_reason == "restart"
+    assert stop_record.samples_written > 0
+    assert stop_record.samples_dropped == 0
+
+    assert start_record.event == "run_lifecycle"
+    assert start_record.run_id == second_status.run_id
+    assert start_record.start_time_utc == second_snapshot.start_time_utc
 
 
 class _SpyLock:

--- a/apps/server/tests/use_cases/run/test_recorder_runtime.py
+++ b/apps/server/tests/use_cases/run/test_recorder_runtime.py
@@ -83,11 +83,15 @@ async def test_runtime_auto_stop_uses_to_thread(
     monkeypatch.setattr(logger._sample_flush, "build_sample_records", lambda **_: [])
     monkeypatch.setattr(logger._sample_flush, "append_records", lambda *args, **kwargs: True)
 
-    stop_calls: list[str] = []
+    stop_calls: list[tuple[str, str]] = []
 
-    def fake_stop_recording(*, _only_if_run_id: str | None = None):
+    def fake_stop_recording(
+        *,
+        _only_if_run_id: str | None = None,
+        reason: str = "manual",
+    ):
         assert _only_if_run_id is not None
-        stop_calls.append(_only_if_run_id)
+        stop_calls.append((_only_if_run_id, reason))
         logger._lifecycle.stop()
         return logger.status()
 
@@ -105,7 +109,7 @@ async def test_runtime_auto_stop_uses_to_thread(
     with pytest.raises(_StopLoop):
         await _recorder_runtime.run_loop(logger, logger=logging.getLogger(__name__))
 
-    assert stop_calls == [snapshot.run_id]
+    assert stop_calls == [(snapshot.run_id, "no_data_timeout")]
     assert fake_stop_recording in to_thread_calls
 
 

--- a/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
@@ -116,6 +116,7 @@ async def run_loop(recorder: RunRecorder, *, logger: logging.Logger) -> None:
                     asyncio.to_thread(
                         recorder.stop_recording,
                         _only_if_run_id=run_id,
+                        reason="no_data_timeout",
                     ),
                     timeout=_DB_THREAD_TIMEOUT_S,
                 )

--- a/apps/server/vibesensor/use_cases/run/_recorder_types.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_types.py
@@ -72,7 +72,7 @@ def _shutdown_report(recorder: RunRecorder, timeout_s: float) -> RecorderShutdow
         active_run_id_before_stop = recorder._run_id
     recorder._lifecycle.shutdown_requested = True
     try:
-        final_status = recorder.stop_recording()
+        final_status = recorder.stop_recording(reason="shutdown")
         analysis_completed = recorder.wait_for_post_analysis(timeout_s)
         health = recorder.health_snapshot()
         if not analysis_completed:

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -16,6 +16,7 @@ from vibesensor.shared.ports import (
     SignalSource,
     SpeedProvider,
 )
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.use_cases.run.lifecycle_state import RunLifecycleState
 from vibesensor.use_cases.run.persistence_writer import (
@@ -215,8 +216,38 @@ class RunRecorder:
             logger=LOGGER,
         )
 
+    def _log_run_lifecycle_event(
+        self,
+        *,
+        action: str,
+        run_id: str,
+        start_time_utc: str,
+        end_time_utc: str | None = None,
+        stop_reason: str | None = None,
+        samples_written: int | None = None,
+        samples_dropped: int | None = None,
+    ) -> None:
+        extra: dict[str, object] = {
+            "event": "run_lifecycle",
+            "run_action": action,
+            "run_id": run_id,
+            "start_time_utc": start_time_utc,
+        }
+        if end_time_utc is not None:
+            extra["end_time_utc"] = end_time_utc
+        if stop_reason is not None:
+            extra["stop_reason"] = stop_reason
+        if samples_written is not None:
+            extra["samples_written"] = samples_written
+        if samples_dropped is not None:
+            extra["samples_dropped"] = samples_dropped
+        LOGGER.info("run_lifecycle", extra=log_extra(**extra))
+
     def start_recording(self) -> RunRecorderStatusSnapshot:
         completed_run_id: str | None = None
+        lifecycle_events: list[
+            tuple[str, str, str, str | None, str | None, int | None, int | None]
+        ] = []
         with self._lock:
             if self._lifecycle.shutdown_requested:
                 LOGGER.info(
@@ -236,10 +267,12 @@ class RunRecorder:
                 run_id = self._run_id
                 completed_run_id = self._persistence.ready_for_analysis(run_id)
                 start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
+                end_time_utc = utc_now_iso()
+                persistence_snapshot = self._persistence.status_snapshot()
                 if run_id and not self._persistence.finalize_run(
                     run_id,
                     start_time_utc,
-                    utc_now_iso(),
+                    end_time_utc,
                 ):
                     # finalize_run may fail (e.g. DB unavailable), but
                     # store_analysis handles the RECORDING→COMPLETE bypass
@@ -248,8 +281,48 @@ class RunRecorder:
                         "finalize_run failed for %s; scheduling analysis anyway",
                         run_id,
                     )
-            self._start_new_run_locked()
+                lifecycle_events.append(
+                    (
+                        "stopped",
+                        run_id,
+                        start_time_utc,
+                        end_time_utc,
+                        "restart",
+                        persistence_snapshot.written_sample_count,
+                        persistence_snapshot.dropped_sample_count,
+                    )
+                )
+            started_run = self._start_new_run_locked()
+            lifecycle_events.append(
+                (
+                    "started",
+                    started_run.run_id,
+                    started_run.start_time_utc,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            )
             result = self.status()
+        for (
+            event_action,
+            event_run_id,
+            event_start_time_utc,
+            event_end_time_utc,
+            event_stop_reason,
+            event_samples_written,
+            event_samples_dropped,
+        ) in lifecycle_events:
+            self._log_run_lifecycle_event(
+                action=event_action,
+                run_id=event_run_id,
+                start_time_utc=event_start_time_utc,
+                end_time_utc=event_end_time_utc,
+                stop_reason=event_stop_reason,
+                samples_written=event_samples_written,
+                samples_dropped=event_samples_dropped,
+            )
         if completed_run_id and self._history_db is not None:
             self.schedule_post_analysis(completed_run_id)
         return result
@@ -258,7 +331,11 @@ class RunRecorder:
         self,
         *,
         _only_if_run_id: str | None = None,
+        reason: str = "manual",
     ) -> RunRecorderStatusSnapshot:
+        lifecycle_event: (
+            tuple[str, str, str, str | None, str | None, int | None, int | None] | None
+        ) = None
         with self._lock:
             if _only_if_run_id is not None and self._run_id != _only_if_run_id:
                 return self.status()
@@ -275,10 +352,12 @@ class RunRecorder:
             run_id = self._run_id
             run_id_to_analyze = self._persistence.ready_for_analysis(run_id)
             start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
+            end_time_utc = utc_now_iso()
+            persistence_snapshot = self._persistence.status_snapshot()
             if run_id and not self._persistence.finalize_run(
                 run_id,
                 start_time_utc,
-                utc_now_iso(),
+                end_time_utc,
             ):
                 # finalize_run may fail (e.g. DB unavailable), but
                 # store_analysis handles the RECORDING→COMPLETE bypass
@@ -287,10 +366,39 @@ class RunRecorder:
                     "finalize_run failed for %s; scheduling analysis anyway",
                     run_id,
                 )
+            if run_id is not None:
+                lifecycle_event = (
+                    "stopped",
+                    run_id,
+                    start_time_utc,
+                    end_time_utc,
+                    reason,
+                    persistence_snapshot.written_sample_count,
+                    persistence_snapshot.dropped_sample_count,
+                )
             self._lifecycle.stop()
             self._active_run_context = None
             self._persistence.reset()
             result = self.status()
+        if lifecycle_event is not None:
+            (
+                event_action,
+                event_run_id,
+                event_start_time_utc,
+                event_end_time_utc,
+                event_stop_reason,
+                event_samples_written,
+                event_samples_dropped,
+            ) = lifecycle_event
+            self._log_run_lifecycle_event(
+                action=event_action,
+                run_id=event_run_id,
+                start_time_utc=event_start_time_utc,
+                end_time_utc=event_end_time_utc,
+                stop_reason=event_stop_reason,
+                samples_written=event_samples_written,
+                samples_dropped=event_samples_dropped,
+            )
         if run_id_to_analyze and self._history_db is not None:
             self.schedule_post_analysis(run_id_to_analyze)
         return result


### PR DESCRIPTION
Closes #1286

## Summary

This PR closes the remaining live part of #1286 by adding structured run lifecycle events to the recorder path. The issue body described a much broader observability gap: missing structured logging, no remote diagnostics, no config audit trail, weak health reporting, and opaque update progress. An audit of current `main` showed that most of those claims are stale. The repo already has structured JSON logging support, request-ID propagation, configuration audit logs, remote diagnostics endpoints, health degradation state/reason reporting, and update-status APIs. The real gap was narrower: `RunRecorder` state transitions still were not emitted as structured log events, so operators could not query run start/stop/restart activity from logs the same way they can query HTTP and settings events.

## Problem being solved

Before this change, recorder lifecycle behavior was observable indirectly but not explicitly:

- `RunRecorder.start_recording()` created a run and updated in-memory state
- `RunRecorder.stop_recording()` finalized the run and reset recorder state
- auto-stop logic in the recorder runtime could stop a run after a no-data timeout
- shutdown handling could also stop the active run during service teardown

However, those transitions did not produce structured lifecycle events. The recorder only logged exceptional cases such as finalize failures or ignored start requests during shutdown. That meant the log stream could tell an operator that a request happened or a setting changed, but not that a run actually started, stopped, restarted, auto-stopped for inactivity, or was stopped during shutdown.

For a system that already uses structured events such as `http_request`, `http_request_failed`, and `settings_change`, that gap stood out. Operators and support tooling had to infer run lifecycle behavior from API traffic, database state, or the absence of later samples rather than from an explicit event trail.

## Audit result and why the scope was narrowed

I treated #1286 as an audit-first issue rather than assuming the entire issue body was still current. That audit showed the following existing observability surfaces are already present on `main`:

- `apps/server/vibesensor/shared/structured_logging.py` already provides structured JSON log formatting and request-ID-aware `log_extra(...)`
- `apps/server/vibesensor/adapters/http/middleware.py` already binds and echoes `X-Request-ID` and emits structured request logs
- `apps/server/vibesensor/infra/config/settings_store.py` and `car_settings.py` already emit `settings_change` audit records with before/after data
- `apps/server/vibesensor/infra/runtime/health_snapshot.py` already produces `ok` / `warn` / `degraded` health states with degradation reasons for `/api/health`
- the backend README and operational runbooks already document remote operator diagnostics and health checks
- update/flash status endpoints already expose phase-oriented progress and logs

Because of that, the smallest honest fix was not a broad logging rewrite or a new observability subsystem. It was to fill the one still-live gap: structured recorder lifecycle events.

## Main code changes by area

### Structured recorder lifecycle events

The core implementation is in `apps/server/vibesensor/use_cases/run/logger.py`.

This PR adds a small helper that emits a structured `run_lifecycle` event using the existing `log_extra(...)` path instead of inventing a parallel logging mechanism. The event includes stable machine-parseable fields:

- `event="run_lifecycle"`
- `run_action` (`started` or `stopped`)
- `run_id`
- `start_time_utc`
- `end_time_utc` for stop events
- `stop_reason` for stop events
- `samples_written` and `samples_dropped` for stop events

`start_recording()` now emits a `started` event for the new run every time a recording session begins. If `start_recording()` rolls an already-active run into a new one, it also emits a `stopped` event for the previous run with `stop_reason="restart"` before logging the new `started` event. That means restart rollover is now fully visible in logs rather than only in state transitions.

`stop_recording()` now emits a `stopped` lifecycle event whenever it actually ends a run, including the current sample counters before persistence state is reset.

### Explicit stop reasons for non-manual paths

To make the stop events more useful, I threaded explicit stop reasons through the other real stop paths instead of hard-coding everything as a generic stop:

- `_recorder_runtime.py` now passes `reason="no_data_timeout"` when auto-stop fires after inactivity
- `_recorder_types.py` now passes `reason="shutdown"` during recorder shutdown reporting
- direct stop calls continue to default to `reason="manual"`

That keeps the public behavior unchanged while making the structured event stream far more useful for operators and postmortem analysis.

### Focused regression coverage

The test coverage stays narrow and behavior-focused.

In `apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py`, I added assertions that:

- a normal start/stop flow emits exactly two `run_lifecycle` events in the expected order
- the start event includes the run identifier and start timestamp
- the stop event includes the expected `manual` stop reason and sample counters
- a restart flow emits `stopped` followed by `started`, with the previous run using `stop_reason="restart"`

In `apps/server/tests/use_cases/run/test_recorder_runtime.py`, I extended the existing auto-stop runtime test so it verifies that the runtime now forwards `reason="no_data_timeout"` into `stop_recording()`.

### Documentation update

Because this change affects a real operator-facing observability surface, I also updated `apps/server/README.md` in the existing `Observability` section. It now documents the new `run_lifecycle` event stream and explains that operators can use it to trace manual stops, restart rollovers, inactivity auto-stops, and shutdown cleanup.

## Validation

This change is fully validated locally.

Focused validation:

- `python3 -m pytest -q apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/use_cases/run/test_recorder_runtime.py`
- `python3 -m pytest -q apps/server/tests/use_cases/run/`

Repository gates:

- `make typecheck-backend`
- `make lint`
- `make test-changed`

I also ran a native runtime smoke because this is a backend behavior change and Docker is unavailable in this environment. Using a session-local config on `127.0.0.1:8001`, I exercised:

- `GET /api/health`
- `POST /api/recording/start`
- `POST /api/recording/stop`

and verified that the structured app log captured both `run_lifecycle` events, including the expected `started` and `stopped` actions and the manual stop reason.

## Risks, tradeoffs, and edge cases

The main tradeoff here is choosing a small extension to the existing structured logging surface instead of introducing a more elaborate observability abstraction. I think that is the right choice for this repo: it keeps the change easy to review, preserves the existing logging model, and directly addresses the still-live operator gap.

I also intentionally did not broaden the fix into health-threshold configuration, remote log shipping, or new metrics surfaces because the current issue text overstates those gaps on present-day `main`. This PR fixes the real missing observability seam without reopening areas that are already implemented.

## Out of scope

This PR does not add a central monitoring system, log shipping, Prometheus metrics, or new health API fields. It also does not redefine the broader observability model. If future work needs richer lifecycle telemetry, `run_lifecycle` is now the right anchor to extend rather than creating a second parallel event path.
