### PR TITLE
Fix #1287: add UI lint workflow and clarify native onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
           cd apps/ui
           npm run check:contracts
 
+      - name: UI lint
+        run: |
+          cd apps/ui
+          npm run lint
+
       - name: UI typecheck
         run: |
           cd apps/ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ Additional local-only convenience commands:
 | Goal | Command |
 |---|---|
 | Fast backend tests | `make test` |
+| UI lint | `make ui-lint` |
 | Changed-file heuristic | `make test-changed` |
 | Non-Docker CI subset | `make test-ci-lite` |
 | Full local CI runner | `make test-all` |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup format lint typecheck-backend typecheck ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
 CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job backend-tests
@@ -74,5 +74,8 @@ loc: ## Run the repo lines-of-code budget check
 docs-lint: ## Run docs lint without the broader lint suite
 	python3 tools/dev/docs_lint.py
 
-ui-typecheck: ## Run UI contract freshness checks and TypeScript type checking
-	cd apps/ui && npm run check:contracts && npm run typecheck
+ui-lint: ## Run UI lint checks
+	cd apps/ui && npm run lint
+
+ui-typecheck: ## Run UI contract freshness, lint, and TypeScript type checking
+	cd apps/ui && npm run check:contracts && npm run lint && npm run typecheck

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ No internet connection required. No cloud. Everything runs locally on the Pi.
 - Hardware simulator for full-stack testing without physical sensors
 - Extensive pytest suite with CI integration
 - Playwright visual regression tests across 4 viewports
-- Ruff linting and TypeScript type checking enforced in CI
+- Ruff backend linting plus UI linting and TypeScript type checking enforced in CI
 - Custom binary UDP protocol with sequence-based loss detection
 
 ## Units
@@ -137,10 +137,17 @@ changes hot-reload without rebuilding the image.
 ### Native Python + Vite (recommended for backend or UI iteration)
 
 ```bash
+. .venv/bin/activate  # after creating a local Python 3.11 venv, if you use one
+python3 -m pip install --upgrade pip
 python3 -m pip install -e "./apps/server[dev]"
 npm --prefix apps/ui ci
 vibesensor-server --reload --config apps/server/config.dev.yaml
 ```
+
+The backend uses an editable install from `apps/server/pyproject.toml` so
+commands like `vibesensor-server` and `vibesensor-sim` stay tied to your working
+tree. A local Python 3.11 virtualenv is the recommended native-dev path before
+you run the install above.
 
 In another terminal:
 

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -17,11 +17,16 @@ server over HTTP (REST) and WebSocket (live data).
 ```bash
 cd apps/ui
 npm ci
+npm run lint         # Biome lint over the hand-written UI/config/test files
 npm run dev          # Dev server on http://localhost:5173
 npm run dev:open     # Same dev server, but opens the browser on local desktops
 npm run build        # Production build to dist/
 npm run typecheck    # Type check without emitting
 ```
+
+Use `npm ci` for normal repo bootstrap and dependency refresh from the checked-in
+lockfile. Only use `npm install` when you are intentionally adding or updating
+UI dependencies so the resulting `package-lock.json` change is deliberate.
 
 The Vite dev server proxies `/api`, `/ws`, and `/static` to
 `http://127.0.0.1:8000` by default so you can use HMR without manually swapping
@@ -44,6 +49,16 @@ It regenerates:
 - `src/constants.ts`
 
 `npm run check:contracts` fails if any of those generated files are stale.
+
+## Code Quality
+
+- `npm run lint` checks the hand-written TypeScript, config, and support scripts
+  with Biome.
+- `npm run format` rewrites the supported files when you want to apply the repo
+  UI formatting locally.
+
+Generated contract artifacts stay out of the lint/format path on purpose so the
+source-of-truth export commands remain the only writers for those files.
 
 ## Source Modules
 

--- a/apps/ui/biome.json
+++ b/apps/ui/biome.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!src/generated",
+      "!src/contracts",
+      "!src/constants.ts",
+      "!package-lock.json",
+      "!!dist",
+      "!!test-results",
+      "!!tests/snapshots"
+    ]
+  },
+  "linter": {
+    "enabled": true,
+    "includes": [
+      "src/**/*.ts",
+      "tests/**/*.ts",
+      "playwright.config.ts",
+      "playwright.smoke.config.ts",
+      "vite.config.ts",
+      "take-screenshot.mjs",
+      "update-snapshots.mjs"
+    ],
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "includes": [
+      "src/**/*.ts",
+      "src/**/*.css",
+      "src/i18n/catalogs/*.json",
+      "tests/**/*.ts",
+      "index.html",
+      "playwright.config.ts",
+      "playwright.smoke.config.ts",
+      "vite.config.ts",
+      "take-screenshot.mjs",
+      "update-snapshots.mjs",
+      "tsconfig.json",
+      "package.json",
+      "biome.json"
+    ],
+    "indentStyle": "space"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -12,10 +12,174 @@
         "uplot": "^1.6.31"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.8",
         "@playwright/test": "^1.58.2",
         "openapi-typescript": "^6.7.6",
         "typescript": "^6.0.2",
         "vite": "^8.0.2"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.8.tgz",
+      "integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.8",
+        "@biomejs/cli-darwin-x64": "2.4.8",
+        "@biomejs/cli-linux-arm64": "2.4.8",
+        "@biomejs/cli-linux-arm64-musl": "2.4.8",
+        "@biomejs/cli-linux-x64": "2.4.8",
+        "@biomejs/cli-linux-x64-musl": "2.4.8",
+        "@biomejs/cli-win32-arm64": "2.4.8",
+        "@biomejs/cli-win32-x64": "2.4.8"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.8.tgz",
+      "integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
+      "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
+      "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
+      "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
+      "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
+      "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
+      "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
+      "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "sync:contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs",
     "check:contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs --check",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint . --write",
+    "format": "biome format . --write",
     "pretypecheck": "npm run sync:contracts",
     "prebuild": "npm run sync:contracts",
     "dev": "vite",
@@ -24,6 +27,7 @@
     "uplot": "^1.6.31"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.8",
     "@playwright/test": "^1.58.2",
     "openapi-typescript": "^6.7.6",
     "typescript": "^6.0.2",

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,4 +1,4 @@
-import type { EspFlashStatusPayload } from "../../api/types";
+import type { EspFlashHistoryPayload, EspFlashStatusPayload } from "../../api/types";
 import {
   ESP_FLASH_POLL_ACTIVE_MS,
   ESP_FLASH_POLL_IDLE_MS,
@@ -80,7 +80,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
 
   async function refreshHistory(): Promise<void> {
     if (!els.espFlashHistoryPanel) return;
-    let payload;
+    let payload: EspFlashHistoryPayload;
     try {
       payload = await getEspFlashHistory();
     } catch {

--- a/apps/ui/src/app/features/history_download_delete_module.ts
+++ b/apps/ui/src/app/features/history_download_delete_module.ts
@@ -6,7 +6,7 @@ const DOWNLOAD_REVOKE_DELAY_MS = 1000;
 export function filenameFromDisposition(headerValue: string | null, fallback: string): string {
   if (!headerValue) return fallback;
   const utf8Match = headerValue.match(/filename\*=UTF-8''([^;]+)/i);
-  if (utf8Match && utf8Match[1]) {
+  if (utf8Match?.[1]) {
     try {
       return decodeURIComponent(utf8Match[1]);
     } catch {
@@ -14,7 +14,7 @@ export function filenameFromDisposition(headerValue: string | null, fallback: st
     }
   }
   const simpleMatch = headerValue.match(/filename="?([^";]+)"?/i);
-  if (simpleMatch && simpleMatch[1]) return simpleMatch[1];
+  if (simpleMatch?.[1]) return simpleMatch[1];
   return fallback;
 }
 

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,4 +1,4 @@
-import { adaptServerPayload } from "../../server_payload";
+import { adaptServerPayload, type AdaptedPayload } from "../../server_payload";
 import { runDemoMode } from "../demo_mode";
 import { WsClient } from "../../ws";
 import type { AppFeatureBundle } from "../app_feature_bundle";
@@ -80,7 +80,7 @@ export class UiLiveTransportController {
 
   private applyPayload(payload: unknown): void {
     const features = this.requireFeatures();
-    let adapted;
+    let adapted: AdaptedPayload;
     try {
       adapted = adaptServerPayload(payload);
     } catch (error) {

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -43,8 +43,7 @@ export interface UiShellStatusModule {
 export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShellStatusModule {
   const { shell, transport, realtime, settings, els } = ctx;
 
-  function speedValueInSelectedUnit(speedMps: number | null): number | null {
-    if (!(typeof speedMps === "number") || !Number.isFinite(speedMps)) return null;
+  function speedValueInSelectedUnit(speedMps: number): number {
     return shell.speedUnit === "mps" ? speedMps : speedMps * 3.6;
   }
 
@@ -64,7 +63,7 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
         || realtime.rotationalSpeeds?.basis_speed_source === "fallback_manual";
       const isOverride = isManualSource || isFallbackOverride;
       els.speed.textContent = ctx.t(isOverride ? "speed.override" : "speed.gps", {
-        value: fmt(value!, 1),
+        value: fmt(value, 1),
         unit: unitLabel,
       });
       return;

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,4 +1,4 @@
-import uPlot from "uplot";
+import type uPlot from "uplot";
 
 import {
   SPECTRUM_DB_MAX,
@@ -206,7 +206,9 @@ export class UiSpectrumController {
         [this.bandPlugin()],
       );
     }
-    this.state.spectrum.spectrumPlot!.renderLegend(this.els.legend!, entries);
+    if (this.els.legend) {
+      this.state.spectrum.spectrumPlot?.renderLegend(this.els.legend, entries);
+    }
     this.state.spectrum.chartBands = this.calculateBands();
     if (this.els.bandLegend) {
       this.els.bandLegend.innerHTML = "";
@@ -222,7 +224,7 @@ export class UiSpectrumController {
       this.stopSpectrumTween();
       this.spectrumLastFrame = null;
       this.state.spectrum.hasSpectrumData = false;
-      this.state.spectrum.spectrumPlot!.setData([[], ...entries.map(() => [] as number[])]);
+      this.state.spectrum.spectrumPlot?.setData([[], ...entries.map(() => [] as number[])]);
       this.updateSpectrumOverlay();
       return;
     }
@@ -334,8 +336,9 @@ export class UiSpectrumController {
       this.state.spectrum.spectrumPlot.destroy();
       this.state.spectrum.spectrumPlot = null;
     }
+    if (!this.els.specChart) return;
     this.state.spectrum.spectrumPlot = new SpectrumChart(
-      this.els.specChart!,
+      this.els.specChart,
       this.els.spectrumOverlay,
       360,
       this.els.specChartWrap,

--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -12,6 +12,7 @@ export const supported = ["en", "nl"] as const;
 
 const _PLACEHOLDER_RE = /\{([a-zA-Z0-9_]+)\}/g;
 const _numberFormatCache = new Map<string, Intl.NumberFormat>();
+const _HAS_OWN = Object.prototype.hasOwnProperty;
 
 function _getDefaultNumberFormat(lang: string): Intl.NumberFormat {
   let fmt = _numberFormatCache.get(lang);
@@ -55,7 +56,7 @@ export function get(lang: string, key: string, vars?: Record<string, unknown>): 
   const template = dict[normalized]?.[key] || fallback;
   if (!vars || typeof vars !== "object") return template;
   return String(template).replace(_PLACEHOLDER_RE, (_m, placeholder) => {
-    if (Object.prototype.hasOwnProperty.call(vars, placeholder)) {
+    if (_HAS_OWN.call(vars, placeholder)) {
       return formatVar(normalized, vars[placeholder]);
     }
     return `{${placeholder}}`;

--- a/apps/ui/src/spectrum.ts
+++ b/apps/ui/src/spectrum.ts
@@ -18,16 +18,14 @@ export class SpectrumChart {
   private plot: uPlot | null = null;
   private readonly hostEl: HTMLElement;
   private readonly measureEl: HTMLElement;
-  private readonly overlayEl: HTMLElement | null;
   private readonly height: number;
   private readonly rootStyle: CSSStyleDeclaration;
   private resizeObserver: ResizeObserver | null = null;
   private resizeRaf: number | null = null;
 
-  constructor(hostEl: HTMLElement, overlayEl?: HTMLElement | null, height = 360, measureEl?: HTMLElement | null) {
+  constructor(hostEl: HTMLElement, _overlayEl?: HTMLElement | null, height = 360, measureEl?: HTMLElement | null) {
     this.hostEl = hostEl;
     this.measureEl = measureEl || hostEl;
-    this.overlayEl = overlayEl || null;
     this.height = height;
     this.rootStyle = getComputedStyle(document.documentElement);
     this.startResizeObserver();

--- a/apps/ui/take-screenshot.mjs
+++ b/apps/ui/take-screenshot.mjs
@@ -5,8 +5,8 @@
  * Exits with code 1 on failure (timeout, no graph data, etc.)
  */
 import { chromium } from "@playwright/test";
-import { spawn } from "child_process";
-import { writeFileSync } from "fs";
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
 
 const OUTPUT_PATH = process.argv[2] || "/tmp/vibesensor-screenshot.png";
 const SERVER_PORT = 4175;

--- a/apps/ui/tests/cycle2_fixes.spec.ts
+++ b/apps/ui/tests/cycle2_fixes.spec.ts
@@ -26,6 +26,12 @@ function makeStrengthMetrics(vibrationStrengthDb: number) {
   };
 }
 
+function requireSpectra(adapted: ReturnType<typeof adaptServerPayload>) {
+  expect(adapted.spectra).not.toBeNull();
+  if (!adapted.spectra) throw new Error("Expected adapted spectra");
+  return adapted.spectra;
+}
+
 // ---------------------------------------------------------------------------
 // 1. adaptServerPayload – spectra null yields null, not stale data
 // ---------------------------------------------------------------------------
@@ -53,9 +59,9 @@ test.describe("adaptServerPayload spectra handling", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
-    expect(adapted.spectra!.clients).toHaveProperty("sensor1");
-    expect(adapted.spectra!.clients.sensor1.freq).toEqual([1, 2, 3]);
+    const spectra = requireSpectra(adapted);
+    expect(spectra.clients).toHaveProperty("sensor1");
+    expect(spectra.clients.sensor1.freq).toEqual([1, 2, 3]);
   });
 
   test("skips client with missing strength_metrics", () => {
@@ -72,9 +78,9 @@ test.describe("adaptServerPayload spectra handling", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
-    expect(adapted.spectra!.clients).not.toHaveProperty("bad");
-    expect(adapted.spectra!.clients).toHaveProperty("good");
+    const spectra = requireSpectra(adapted);
+    expect(spectra.clients).not.toHaveProperty("bad");
+    expect(spectra.clients).toHaveProperty("good");
   });
 });
 

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -1,4 +1,4 @@
-import { type Page, type Route } from "@playwright/test";
+import type { Page, Route } from "@playwright/test";
 import { EXPECTED_SCHEMA_VERSION } from "../src/contracts/ws_payload_types";
 
 export type FakeWebSocketOptions = {
@@ -55,7 +55,7 @@ export type CommonRouteOptions = {
   espFlashHandler?: (route: Route) => Promise<void>;
 };
 
-export type SettingsRouteValue = unknown | ((route: Route, path: string, method: string) => Promise<unknown | void>);
+export type SettingsRouteValue = unknown | ((route: Route, path: string, method: string) => Promise<unknown | undefined>);
 
 function jsonOk(body: unknown) {
   return { status: 200, contentType: "application/json", body: JSON.stringify(body) };

--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -34,6 +34,12 @@ const basePayload = {
   speed_mps: 10,
 };
 
+function requireSpectra(adapted: ReturnType<typeof adaptServerPayload>) {
+  expect(adapted.spectra).not.toBeNull();
+  if (!adapted.spectra) throw new Error("Expected adapted spectra");
+  return adapted.spectra;
+}
+
 // ---------------------------------------------------------------------------
 // Schema version handling
 // ---------------------------------------------------------------------------
@@ -109,12 +115,12 @@ test.describe("shared freq optimization", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
-    expect(adapted.spectra!.clients.sensor1.freq).toEqual([10, 20, 30]);
-    expect(adapted.spectra!.clients.sensor2.freq).toEqual([10, 20, 30]);
-    expect(adapted.spectra!.clients.sensor1.strength_metrics.peak_amp_g).toBe(0);
-    expect(adapted.spectra!.clients.sensor1.strength_metrics.noise_floor_amp_g).toBe(0);
-    expect(adapted.spectra!.clients.sensor1.strength_metrics.top_peaks).toEqual([]);
+    const spectra = requireSpectra(adapted);
+    expect(spectra.clients.sensor1.freq).toEqual([10, 20, 30]);
+    expect(spectra.clients.sensor2.freq).toEqual([10, 20, 30]);
+    expect(spectra.clients.sensor1.strength_metrics.peak_amp_g).toBe(0);
+    expect(spectra.clients.sensor1.strength_metrics.noise_floor_amp_g).toBe(0);
+    expect(spectra.clients.sensor1.strength_metrics.top_peaks).toEqual([]);
   });
 
   test("prefers per-client freq over shared when both present", () => {
@@ -131,9 +137,9 @@ test.describe("shared freq optimization", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
+    const spectra = requireSpectra(adapted);
     // Per-client freq takes precedence
-    expect(adapted.spectra!.clients.sensor1.freq).toEqual([15, 25, 35]);
+    expect(spectra.clients.sensor1.freq).toEqual([15, 25, 35]);
   });
 
   test("still works with old-style per-client freq (no shared)", () => {
@@ -150,8 +156,8 @@ test.describe("shared freq optimization", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
-    expect(adapted.spectra!.clients.sensor1.freq).toEqual([10, 20, 30]);
+    const spectra = requireSpectra(adapted);
+    expect(spectra.clients.sensor1.freq).toEqual([10, 20, 30]);
   });
 
   test("skips client when neither shared nor per-client freq available", () => {
@@ -168,8 +174,8 @@ test.describe("shared freq optimization", () => {
       },
     });
     // No freq at all → client should be skipped
-    expect(adapted.spectra).not.toBeNull();
-    expect(Object.keys(adapted.spectra!.clients)).toHaveLength(0);
+    const spectra = requireSpectra(adapted);
+    expect(Object.keys(spectra.clients)).toHaveLength(0);
   });
 
   test("rejects malformed per-client freq elements instead of skipping the client", () => {
@@ -202,8 +208,8 @@ test.describe("shared freq optimization", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
-    expect(Object.keys(adapted.spectra!.clients)).toHaveLength(0);
+    const spectra = requireSpectra(adapted);
+    expect(Object.keys(spectra.clients)).toHaveLength(0);
   });
 
   test("handles mixed: some clients with per-client freq, some without", () => {
@@ -224,11 +230,11 @@ test.describe("shared freq optimization", () => {
         },
       },
     });
-    expect(adapted.spectra).not.toBeNull();
+    const spectra = requireSpectra(adapted);
     // sensor1 uses shared freq
-    expect(adapted.spectra!.clients.sensor1.freq).toEqual([10, 20, 30]);
+    expect(spectra.clients.sensor1.freq).toEqual([10, 20, 30]);
     // sensor2 uses its own per-client freq
-    expect(adapted.spectra!.clients.sensor2.freq).toEqual([15, 25, 35]);
+    expect(spectra.clients.sensor2.freq).toEqual([15, 25, 35]);
   });
 
   test("rejects malformed strength metric peaks instead of dropping them", () => {

--- a/apps/ui/update-snapshots.mjs
+++ b/apps/ui/update-snapshots.mjs
@@ -3,9 +3,9 @@
  * Run with: node update-snapshots.mjs
  */
 import { chromium } from "playwright-core";
-import { spawn } from "child_process";
-import { writeFileSync, mkdirSync } from "fs";
-import { dirname } from "path";
+import { spawn } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 
 const CHROME_EXEC = "/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome";
 const SERVER_PORT = 4176;

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -194,6 +194,7 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                 ["npm", "run", "check:contracts"],
                 cwd=ROOT / "apps" / "ui",
             ),
+            Step("UI lint", ["npm", "run", "lint"], cwd=ROOT / "apps" / "ui"),
             Step("UI typecheck", ["npm", "run", "typecheck"], cwd=ROOT / "apps" / "ui"),
         ],
         "ui-smoke": [


### PR DESCRIPTION
## Summary

Closes #1287.

This PR adds a first-class UI lint workflow and tightens the onboarding docs that were still ambiguous when contributing outside Docker. The issue body described several developer-experience problems, but most were already addressed on current `main`. After auditing the live docs and workflows, the remaining gaps were narrower: the `apps/ui` package still lacked repo-standard lint tooling, and the top-level native setup path still did not clearly explain the editable backend install and recommended virtualenv flow.

## Problem being solved

The frontend had build and typecheck commands, but no dedicated lint command, no single repo target for running UI quality checks, and no CI/local parity step that asserted the UI tree stayed lint-clean. That made the dashboard code easier to drift over time and left contributors without an obvious pre-PR quality loop. At the same time, the root README jumped straight into `pip install -e "./apps/server[dev]"` without clearly explaining that this is an editable install tied to the working tree and that a local Python virtualenv is the preferred native path.

During the audit I also confirmed that several issue claims were already stale on `main`: contract sync, test-tier guidance, Vite proxy docs, `npm ci` usage, and troubleshooting around prerequisites were already documented. I intentionally did not reopen those areas because the live gap was smaller than the original issue description suggested.

## Implementation approach

I kept the fix narrow and reviewable. The core goal was to introduce UI lint tooling and make it part of the normal contributor loop, without turning this issue into a repo-wide formatting rewrite. I chose Biome because the repo already uses TypeScript 6, and the current stable ESLint/TypeScript-ESLint combination still declares a peer range below TypeScript 6. Rather than forcing an incompatible dependency tree or downgrading TypeScript, Biome provided a TS6-compatible lint/format toolchain that works on the existing UI tree today.

I also separated “available formatting tooling” from “CI-enforced formatting drift.” The first attempt at enforcing formatter checks immediately expanded the diff into a wide UI reformat. That was technically viable, but it made the change set much noisier than the issue needed. I therefore kept `npm run format` available locally while limiting CI enforcement to contract freshness, lint, and typecheck. That closes the missing-tooling gap without smuggling a broad style normalization into the same PR.

## Main code changes

In `apps/ui/package.json` I added Biome-backed `lint`, `lint:fix`, and `format` scripts, and I added `@biomejs/biome` to `devDependencies` with the corresponding `package-lock.json` update. I also added a new `apps/ui/biome.json` configuration that scopes linting to handwritten UI source, test, and support files while excluding generated contract outputs and build artifacts.

At the repo level, I added `make ui-lint` and updated `make ui-typecheck` so the local developer entry points now mirror the intended frontend validation flow. I then updated `.github/workflows/ci.yml` and `tools/tests/run_ci_parallel.py` together so `frontend-typecheck` runs the same sequence in both places: contract sync check, UI lint, and UI typecheck. This keeps the repo’s CI-parity hygiene intact.

For documentation, I clarified the native contributor path in `README.md` by explicitly calling out the recommended Python virtualenv bootstrap and why the backend uses an editable install from `apps/server/pyproject.toml`. I also updated `apps/ui/README.md` to document the new UI quality commands and `CONTRIBUTING.md` to advertise `make ui-lint` as the quick local frontend check.

Adding linting exposed a handful of pre-existing warning/error sites in the UI code and test helpers. I fixed only the minimum needed to make the new baseline pass cleanly:

- typed previously implicit `let` variables in `esp_flash_feature.ts` and `ui_live_transport_controller.ts`
- removed unnecessary non-null assertions and added safer guards in `ui_shell_status_module.ts` and `ui_spectrum_controller.ts`
- tightened filename parsing in `history_download_delete_module.ts` with optional chaining
- updated Node builtin imports in `take-screenshot.mjs` and `update-snapshots.mjs` to use `node:` specifiers
- cleaned up a couple of TypeScript 6 and lint friction points in `i18n.ts`, `spectrum.ts`, and a few UI tests/helpers (`cycle2_fixes.spec.ts`, `smoke.helpers.ts`, and `ws_contract.spec.ts`)

Those fixes are all narrow and directly coupled to the new quality gate. I did not use this issue to refactor unrelated UI behavior.

## Validation

I validated the change set locally in the session venv and from the UI workspace:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run check:contracts`
- `make ui-lint`
- `python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --skip-bootstrap --skip-npm-ci`
- `make lint`
- `make docs-lint`
- `make test-changed`

All of those are green on the final narrowed diff. `make test-changed` also reran the affected UI typecheck path plus the backend hygiene suite successfully.

I did not run Docker Compose runtime validation because this environment still does not have a usable Docker daemon socket. That limitation is pre-existing and not specific to this issue. Given that this PR only changes UI tooling, docs, and CI/local validation wiring, the relevant local validation surface is already covered by the commands above.

## Risks and tradeoffs

The main tradeoff in this PR is choosing Biome instead of the more common ESLint and Prettier stack. That choice is deliberate, not arbitrary: it avoids a known peer-dependency conflict with the repo’s current TypeScript 6 line and lets us land working linting now instead of carrying an intentionally broken dependency tree.

The other deliberate tradeoff is not enforcing formatter drift in CI yet. I think that is the right call for this issue because it keeps the review focused on the missing tooling and onboarding gap instead of pulling in a broad cosmetic reformat. If the team later wants CI-enforced formatting, that can happen in a dedicated follow-up PR that intentionally accepts the larger churn.

## Out of scope / follow-ups

This PR does not attempt to rewrite already-correct contributor docs, add watch-mode workflow changes, or revisit broader developer-experience complaints from the original issue body that are no longer live on `main`. It also does not do a repo-wide UI formatting pass. If we want to standardize formatter output across the entire dashboard later, that would be a reasonable follow-up once the new tooling has had a chance to settle.

Overall, this closes the real live gap from `#1287`: the UI now has a first-class lint command, a repo-level entry point, CI/local parity coverage, and clearer native onboarding guidance for contributors working outside Docker.
