### PR TITLE
Harden E2E CI reliability and local parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,14 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/vibesensor/e2e-duration-cache.json
+          key: ${{ runner.os }}-e2e-durations-${{ hashFiles('tools/tests/run_e2e_parallel.py', 'apps/server/tests_e2e/**/*.py') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-e2e-durations-${{ hashFiles('tools/tests/run_e2e_parallel.py', 'apps/server/tests_e2e/**/*.py') }}-
+            ${{ runner.os }}-e2e-durations-
+
       - name: Prebuild cached E2E image
         uses: docker/build-push-action@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: help doctor setup format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
-CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job backend-tests
+CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests
 
 help: ## Show the available make targets and what each one does
 	@awk 'BEGIN {FS = ":.*## "; printf "Available targets:\n"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/apps/server/tests/hygiene/test_ci_lite_job_parity.py
+++ b/apps/server/tests/hygiene/test_ci_lite_job_parity.py
@@ -1,0 +1,24 @@
+"""Guard: Makefile CI_LITE_JOBS matches the non-Docker CI subset."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from tests._paths import REPO_ROOT
+
+_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "check_hygiene.py"
+
+
+def _load_check_hygiene_module():
+    spec = importlib.util.spec_from_file_location("check_hygiene_ci_lite_local", _CHECK_HYGIENE)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_HYGIENE}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ci_lite_jobs_match_non_docker_ci_subset() -> None:
+    module = _load_check_hygiene_module()
+    assert module.check_ci_lite_job_sync() == []

--- a/apps/server/tests/hygiene/test_run_e2e_parallel.py
+++ b/apps/server/tests/hygiene/test_run_e2e_parallel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import xml.etree.ElementTree as ET
 
 from tests._paths import REPO_ROOT
 
@@ -86,6 +87,74 @@ def test_prepare_image_exits_cleanly_when_skip_requested_but_image_is_missing(
 
     assert module._prepare_image("missing-image", env={module._SKIP_BUILD_ENV: "1"}) == 2
     assert any("missing-image" in line for line in emitted)
+
+
+def test_assign_shards_uses_cached_durations() -> None:
+    module = _load_run_e2e_parallel_module()
+    slow_test = "apps/server/tests_e2e/test_slow.py::test_slow"
+    fast_a = "apps/server/tests_e2e/test_fast.py::test_fast_a"
+    fast_b = "apps/server/tests_e2e/test_fast.py::test_fast_b"
+
+    shards = module._assign_shards_by_duration(
+        [fast_a, slow_test, fast_b],
+        2,
+        {
+            slow_test: module.SLOW_TEST_THRESHOLD + 1.0,
+            fast_a: 1.0,
+            fast_b: 1.5,
+        },
+    )
+
+    assert shards[0] == [slow_test]
+    assert shards[1] == [fast_b, fast_a]
+
+
+def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path) -> None:
+    module = _load_run_e2e_parallel_module()
+    junit_path = tmp_path / "shard.xml"
+    root = ET.Element("testsuite")
+    ET.SubElement(
+        root,
+        "testcase",
+        classname="tests_e2e.test_sample",
+        name="test_alpha[param]",
+        time="4.25",
+    )
+    ET.SubElement(
+        root,
+        "testcase",
+        classname="tests_e2e.test_other",
+        name="test_beta",
+        time="1.75",
+    )
+    ET.ElementTree(root).write(junit_path, encoding="utf-8", xml_declaration=True)
+
+    observed = module._observed_durations_from_junit(
+        junit_path,
+        [
+            "apps/server/tests_e2e/test_sample.py::test_alpha[param]",
+            "apps/server/tests_e2e/test_other.py::test_beta",
+        ],
+    )
+
+    assert observed == {
+        "apps/server/tests_e2e/test_sample.py::test_alpha[param]": 4.25,
+        "apps/server/tests_e2e/test_other.py::test_beta": 1.75,
+    }
+
+
+def test_cleanup_active_containers_removes_tracked_names(monkeypatch) -> None:
+    module = _load_run_e2e_parallel_module()
+    removed: list[str] = []
+    module._ACTIVE_CONTAINERS.clear()
+    module._track_active_container("vibesensor-e2e-shard-a")
+    module._track_active_container("vibesensor-e2e-shard-b")
+    monkeypatch.setattr(module, "_force_remove_container", lambda name: removed.append(name) or 0)
+
+    module._cleanup_active_containers()
+
+    assert removed == ["vibesensor-e2e-shard-a", "vibesensor-e2e-shard-b"]
+    assert module._ACTIVE_CONTAINERS == set()
 
 
 def test_parse_args_defaults_to_six_shards(monkeypatch) -> None:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,7 @@
 - Use `make test-ci-lite` for the non-Docker blocking-CI subset.
 - Use `make test-all` (`python3 tools/tests/run_ci_parallel.py`) for the broader local runner, including Docker-backed jobs when Docker is available.
 - The full Docker-backed verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`).
+- `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
 - Python test configuration lives in `apps/server/pyproject.toml`.
 - Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py` and run via `make lint` (or directly with `cd apps/server && python3 ../../tools/dev/verify_backend_static_guards.py`).
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -95,6 +95,7 @@ _MIRRORED_BACKEND_INSTALL_JOBS = (
     "e2e",
 )
 _FIRMWARE_INSTALL_JOB = "firmware-native-tests"
+_CI_LITE_EXCLUDED_JOBS = ("e2e",)
 _LOCAL_BACKEND_SETUP_ACTION = "./.github/actions/setup-backend"
 _DOCKER_NODE_RE = re.compile(r"^FROM node:(\S+) AS ui-build$", re.MULTILINE)
 _DOCKER_PYTHON_RE = re.compile(r"^FROM python:(\S+)$", re.MULTILINE)
@@ -125,6 +126,22 @@ def _load_ci_parallel_module():
 
 def _read_required_text(path: Path) -> str:
     return path.read_text(encoding="utf-8").strip()
+
+
+def _makefile_job_list(var_name: str) -> list[str]:
+    text = (ROOT / "Makefile").read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(var_name)}\s*[:+?]?=\s*(.+)$", text, re.MULTILINE)
+    if match is None:
+        return []
+    tokens = shlex.split(match.group(1))
+    jobs: list[str] = []
+    index = 0
+    while index < len(tokens):
+        if tokens[index] != "--job" or index + 1 >= len(tokens):
+            return []
+        jobs.append(tokens[index + 1])
+        index += 2
+    return jobs
 
 
 def _load_server_pyproject() -> dict[str, object]:
@@ -495,6 +512,23 @@ def check_ci_command_sync() -> list[str]:
     return errors
 
 
+def check_ci_lite_job_sync() -> list[str]:
+    """Verify Makefile CI_LITE_JOBS tracks the non-Docker CI job subset."""
+    ci_jobs = list(_ci_run_steps_by_job())
+    expected = [
+        job_name for job_name in ci_jobs if job_name not in _CI_LITE_EXCLUDED_JOBS
+    ]
+    actual = _makefile_job_list("CI_LITE_JOBS")
+    if not actual:
+        return ["Makefile CI_LITE_JOBS is missing or unparsable."]
+    if actual == expected:
+        return []
+    return [
+        "Makefile CI_LITE_JOBS drifted from the non-Docker CI subset: "
+        f"expected={expected!r} actual={actual!r}"
+    ]
+
+
 def check_docker_ci_dependency_hygiene() -> list[str]:
     errors: list[str] = []
 
@@ -612,6 +646,42 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
     if not playwright_cache_ok:
         errors.append(
             "ui-smoke must cache ~/.cache/ms-playwright with a package-lock-based actions/cache key."
+        )
+
+    e2e_job = jobs.get("e2e") if isinstance(jobs, Mapping) else None
+    steps = e2e_job.get("steps") if isinstance(e2e_job, Mapping) else None
+    e2e_duration_cache_ok = False
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, Mapping):
+                continue
+            uses = step.get("uses")
+            if not isinstance(uses, str) or not uses.startswith("actions/cache@"):
+                continue
+            with_data = step.get("with")
+            if not isinstance(with_data, Mapping):
+                continue
+            path = with_data.get("path")
+            key = with_data.get("key")
+            restore_keys = with_data.get("restore-keys")
+            if (
+                isinstance(path, str)
+                and path.strip() == "~/.cache/vibesensor/e2e-duration-cache.json"
+                and isinstance(key, str)
+                and "e2e-durations" in key
+                and "run_e2e_parallel.py" in key
+                and "tests_e2e" in key
+                and "github.run_id" in key
+                and isinstance(restore_keys, str)
+                and "tests_e2e" in restore_keys
+                and "${{ runner.os }}-e2e-durations-" in restore_keys
+            ):
+                e2e_duration_cache_ok = True
+                break
+    if not e2e_duration_cache_ok:
+        errors.append(
+            "e2e must cache ~/.cache/vibesensor/e2e-duration-cache.json with a "
+            "restoreable actions/cache key tied to run_e2e_parallel.py, tests_e2e, and github.run_id."
         )
 
     numpy_spec = _project_dependency_spec("numpy")
@@ -747,6 +817,15 @@ def main() -> int:
         failures += 1
     else:
         print("CI commands in sync between ci.yml and run_ci_parallel.py.")
+
+    ci_lite_sync_errors = check_ci_lite_job_sync()
+    if ci_lite_sync_errors:
+        print("CI lite job drift detected:")
+        for item in ci_lite_sync_errors:
+            print(f"  - {item}")
+        failures += 1
+    else:
+        print("Makefile CI_LITE_JOBS matches the non-Docker CI subset.")
 
     docker_ci_hygiene_errors = check_docker_ci_dependency_hygiene()
     if docker_ci_hygiene_errors:

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+import xml.etree.ElementTree as ET
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -53,7 +56,15 @@ ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "e2e_parallel"
 PRINT_LOCK = threading.Lock()
 _SKIP_BUILD_ENV = "VIBESENSOR_E2E_SKIP_BUILD"
+_DURATION_CACHE_ENV = "VIBESENSOR_E2E_DURATION_CACHE"
 _DEFAULT_MIN_SHARDS = 6
+_DEFAULT_DURATION = 3.0
+_SCOPE_LABEL = "com.vibesensor.role=e2e-shard"
+_RUN_LABEL_KEY = "com.vibesensor.run-id"
+_ACTIVE_CONTAINERS: set[str] = set()
+_ACTIVE_CONTAINERS_LOCK = threading.Lock()
+_CLEANUP_HOOKS_REGISTERED = False
+_PREVIOUS_SIGNAL_HANDLERS: dict[int, object] = {}
 
 
 @dataclass(frozen=True)
@@ -68,6 +79,7 @@ class ShardConfig:
     sim_control_port: int
     sim_client_control_base: int
     log_path: Path
+    junit_path: Path
 
 
 @dataclass(frozen=True)
@@ -79,30 +91,122 @@ class ShardResult:
     selected_tests: int
 
 
-# Duration hints (seconds) for known slow fast-E2E tests.
 # Tests exceeding SLOW_TEST_THRESHOLD get their own dedicated shard.
+# Observed timings are loaded from and saved back to a local cache so the
+# runner can rebalance without hand-maintained per-test constants.
 SLOW_TEST_THRESHOLD = 5.0
-_DURATION_HINTS: dict[str, float] = {
-    "test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys[clients_and_cars]": 17.1,
-    "test_e2e_docker_edge_cases.py::test_logging_start_while_recording_rollover": 11.5,
-    "test_e2e_docker_rear_left_wheel_fault.py::test_e2e_docker_rear_left_wheel_fault": 9.5,
-    "test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys[language_pdf]": 8.9,
-    "test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys[speed_export_delete]": 8.8,
-    "test_e2e_docker_edge_cases.py::test_delete_active_run_returns_409_e2e": 5.8,
-}
-_DEFAULT_DURATION = 3.0
 
 
-def _estimate_duration(test_id: str) -> float:
-    """Return estimated duration for a test ID by matching against duration hints."""
-    for hint_key, duration in _DURATION_HINTS.items():
-        if hint_key in test_id:
-            return duration
-    return _DEFAULT_DURATION
+def _duration_cache_path(env: Mapping[str, str] | None = None) -> Path:
+    source = os.environ if env is None else env
+    raw_path = source.get(_DURATION_CACHE_ENV, "").strip()
+    if raw_path:
+        return Path(raw_path).expanduser()
+    return Path.home() / ".cache" / "vibesensor" / "e2e-duration-cache.json"
+
+
+def _load_duration_cache(path: Path) -> dict[str, float]:
+    try:
+        raw_payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        _emit(f"[e2e-parallel] ignoring unreadable duration cache: {path}")
+        return {}
+    if not isinstance(raw_payload, dict):
+        _emit(f"[e2e-parallel] ignoring invalid duration cache payload: {path}")
+        return {}
+
+    durations: dict[str, float] = {}
+    for test_id, raw_duration in raw_payload.items():
+        if not isinstance(test_id, str):
+            continue
+        try:
+            duration = float(raw_duration)
+        except (TypeError, ValueError):
+            continue
+        if duration > 0:
+            durations[test_id] = duration
+    return durations
+
+
+def _write_duration_cache(path: Path, durations: Mapping[str, float]) -> None:
+    payload = {
+        test_id: round(duration, 3)
+        for test_id, duration in sorted(durations.items())
+        if duration > 0
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8"
+        )
+    except OSError:
+        _emit(f"[e2e-parallel] failed to update duration cache: {path}")
+
+
+def _merge_duration_observations(
+    cached: Mapping[str, float], observed: Mapping[str, float]
+) -> dict[str, float]:
+    merged = dict(cached)
+    for test_id, duration in observed.items():
+        if duration <= 0:
+            continue
+        previous = merged.get(test_id)
+        merged[test_id] = (
+            duration if previous is None else round((previous + duration) / 2.0, 3)
+        )
+    return merged
+
+
+def _junit_case_key(test_id: str) -> tuple[str, str]:
+    path_part, *segments = test_id.split("::")
+    normalized_path = path_part.removeprefix("apps/server/").removesuffix(".py")
+    module_name = normalized_path.replace("/", ".")
+    name = segments[-1] if segments else test_id
+    classname_segments = [module_name, *segments[:-1]]
+    return ".".join(segment for segment in classname_segments if segment), name
+
+
+def _observed_durations_from_junit(
+    junit_path: Path, selected_tests: list[str]
+) -> dict[str, float]:
+    if not junit_path.exists():
+        return {}
+    try:
+        root = ET.parse(junit_path).getroot()
+    except (ET.ParseError, OSError):
+        _emit(f"[e2e-parallel] ignoring unreadable junit timings: {junit_path}")
+        return {}
+
+    lookup = {_junit_case_key(test_id): test_id for test_id in selected_tests}
+    observed: dict[str, float] = {}
+    for case in root.iter("testcase"):
+        classname = case.attrib.get("classname")
+        name = case.attrib.get("name")
+        raw_time = case.attrib.get("time")
+        if not isinstance(classname, str) or not isinstance(name, str):
+            continue
+        if not isinstance(raw_time, str):
+            continue
+        test_id = lookup.get((classname, name))
+        if test_id is None:
+            continue
+        try:
+            duration = float(raw_time)
+        except ValueError:
+            continue
+        if duration >= 0:
+            observed[test_id] = duration
+    return observed
+
+
+def _estimate_duration(test_id: str, durations: Mapping[str, float]) -> float:
+    return durations.get(test_id, _DEFAULT_DURATION)
 
 
 def _assign_shards_by_duration(
-    collected: list[str], min_shards: int
+    collected: list[str], min_shards: int, durations: Mapping[str, float]
 ) -> list[list[str]]:
     """Assign tests to shards using duration-aware greedy bin-packing.
 
@@ -113,7 +217,7 @@ def _assign_shards_by_duration(
     slow_tests: list[tuple[str, float]] = []
     fast_tests: list[tuple[str, float]] = []
     for test_id in collected:
-        est = _estimate_duration(test_id)
+        est = _estimate_duration(test_id, durations)
         if est > SLOW_TEST_THRESHOLD:
             slow_tests.append((test_id, est))
         else:
@@ -173,6 +277,58 @@ def _tail(path: Path, lines: int = 60) -> str:
         return "<missing log>"
     content = path.read_text(encoding="utf-8").splitlines()
     return "\n".join(content[-lines:])
+
+
+def _force_remove_container(container_name: str) -> int:
+    result = subprocess.run(
+        ["docker", "rm", "-f", container_name],
+        cwd=str(ROOT),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode
+
+
+def _track_active_container(container_name: str) -> None:
+    with _ACTIVE_CONTAINERS_LOCK:
+        _ACTIVE_CONTAINERS.add(container_name)
+
+
+def _untrack_active_container(container_name: str) -> None:
+    with _ACTIVE_CONTAINERS_LOCK:
+        _ACTIVE_CONTAINERS.discard(container_name)
+
+
+def _cleanup_active_containers() -> None:
+    with _ACTIVE_CONTAINERS_LOCK:
+        container_names = sorted(_ACTIVE_CONTAINERS)
+    for container_name in container_names:
+        _force_remove_container(container_name)
+        _untrack_active_container(container_name)
+
+
+def _cleanup_on_signal(signum: int, frame) -> None:
+    _emit(f"[e2e-parallel] received signal {signum}; cleaning up active docker shards")
+    _cleanup_active_containers()
+    previous = _PREVIOUS_SIGNAL_HANDLERS.get(signum, signal.SIG_DFL)
+    if previous is signal.default_int_handler:
+        raise KeyboardInterrupt
+    if callable(previous):
+        previous(signum, frame)
+        raise SystemExit(128 + signum)
+    raise SystemExit(128 + signum)
+
+
+def _register_cleanup_hooks() -> None:
+    global _CLEANUP_HOOKS_REGISTERED
+    if _CLEANUP_HOOKS_REGISTERED:
+        return
+    atexit.register(_cleanup_active_containers)
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        _PREVIOUS_SIGNAL_HANDLERS[signum] = signal.getsignal(signum)
+        signal.signal(signum, _cleanup_on_signal)
+    _CLEANUP_HOOKS_REGISTERED = True
 
 
 def _build_image(image: str) -> int:
@@ -288,6 +444,10 @@ def _run_shard_e2e(
             "--detach",
             "--name",
             config.container_name,
+            "--label",
+            _SCOPE_LABEL,
+            "--label",
+            f"{_RUN_LABEL_KEY}={os.getpid()}",
             "-p",
             f"{config.http_port}:8000",
             "-p",
@@ -302,6 +462,7 @@ def _run_shard_e2e(
         if rc != 0:
             return rc
         container_started = True
+        _track_active_container(config.container_name)
         _wait_health(base_url)
         env = os.environ.copy()
         env.update(
@@ -325,6 +486,8 @@ def _run_shard_e2e(
             "-q",
             "-n",
             "0",
+            "--junitxml",
+            str(config.junit_path),
             "-m",
             marker,
             *config.tests,
@@ -349,12 +512,8 @@ def _run_shard_e2e(
         raise
     finally:
         if container_started:
-            subprocess.run(
-                ["docker", "rm", "-f", config.container_name],
-                cwd=str(ROOT),
-                check=False,
-                capture_output=True,
-            )
+            _force_remove_container(config.container_name)
+            _untrack_active_container(config.container_name)
 
 
 def _shard_worker(
@@ -463,8 +622,15 @@ def main() -> int:
         marker = "e2e and not long_sim" if args.fast_e2e else "e2e"
 
     collected = collect_test_ids(["-m", marker, "apps/server/tests_e2e"])
+    duration_cache_path = _duration_cache_path()
+    duration_cache = _load_duration_cache(duration_cache_path)
+    if duration_cache:
+        _emit(
+            f"[e2e-parallel] loaded {len(duration_cache)} cached test durations from "
+            f"{duration_cache_path}"
+        )
 
-    shard_test_ids = _assign_shards_by_duration(collected, args.shards)
+    shard_test_ids = _assign_shards_by_duration(collected, args.shards, duration_cache)
     num_shards = len(shard_test_ids)
 
     _emit(
@@ -476,6 +642,7 @@ def main() -> int:
     if build_rc != 0:
         return build_rc
 
+    _register_cleanup_hooks()
     pid = str(os.getpid())
     shards: list[ShardConfig] = []
     for shard_index in range(1, num_shards + 1):
@@ -493,6 +660,7 @@ def main() -> int:
                 sim_control_port=args.sim_control_port_base + (shard_index - 1),
                 sim_client_control_base=9100 + ((shard_index - 1) * 100),
                 log_path=LOG_DIR / f"shard-{shard_index}.log",
+                junit_path=LOG_DIR / f"shard-{shard_index}.xml",
             )
         )
 
@@ -517,6 +685,21 @@ def main() -> int:
 
     for thread in threads:
         thread.join()
+
+    observed_durations: dict[str, float] = {}
+    for shard in shards:
+        observed_durations.update(
+            _observed_durations_from_junit(shard.junit_path, shard.tests)
+        )
+    if observed_durations:
+        merged_durations = _merge_duration_observations(
+            duration_cache, observed_durations
+        )
+        _write_duration_cache(duration_cache_path, merged_durations)
+        _emit(
+            f"[e2e-parallel] updated duration cache with {len(observed_durations)} observed "
+            f"test timings at {duration_cache_path}"
+        )
 
     elapsed = time.monotonic() - started
     _emit("\n=== e2e parallel summary ===")


### PR DESCRIPTION
Closes #1288

## Summary

This PR fixes the still-live CI reliability problems from issue #1288 without reopening the stale parts of the issue body that current `main` has already solved. I started by auditing the current workflow, Makefile, E2E runner, hygiene checks, and pytest configuration rather than implementing the issue text literally. That audit showed that three defects were still real on current `main`: `tools/tests/run_e2e_parallel.py` still depended on hand-maintained fast-E2E duration hints for shard balancing, Docker-backed shard cleanup still relied only on per-shard `finally` blocks and had no process-level cleanup when the runner is interrupted, and `Makefile` `CI_LITE_JOBS` still omitted `firmware-native-tests` even though the repo docs describe `make test-ci-lite` as the non-Docker blocking CI subset.

The audit also showed that several claims in the issue body were stale and should not drive new code churn. The Playwright cache complaint is no longer accurate because the existing `ui-smoke` cache key already hashes `apps/ui/package-lock.json`, which includes Playwright version changes. The marker/discovery complaint is also stale because the backend pytest config already declares the markers the repo actively uses (`e2e`, `long_sim`, `smoke`), the standard backend suite runs against explicit `apps/server/tests` paths, and the Docker E2E runner explicitly selects `apps/server/tests_e2e` with marker expressions. I also intentionally did not broaden this PR into Docker build-cache parity work because the current CI/local cache-backend difference is not the root cause of a current correctness problem in the runner.

## Implementation approach

For shard balancing, the main goal was to remove manual maintenance from the current hardcoded duration map without introducing a large new service or a checked-in generated artifact. The runner now learns from observed timings instead of embedding a static list of “known slow tests” in code. `tools/tests/run_e2e_parallel.py` loads cached per-test durations from `~/.cache/vibesensor/e2e-duration-cache.json`, uses those durations when packing tests into shards, emits per-shard JUnit XML from the pytest subprocesses, parses the observed testcase times back into exact node IDs, and merges the new observations back into the same cache after the run. That keeps the sharding logic self-contained in the runner, removes the need to edit Python constants every time test timings drift, and lets both local and CI executions steadily improve their shard balance from real measurements.

In CI, that cache only helps if it survives across runs, so the `e2e` job now restores and saves `~/.cache/vibesensor/e2e-duration-cache.json` with `actions/cache`. The key is tied to `tools/tests/run_e2e_parallel.py`, the `apps/server/tests_e2e/**` tree, and `github.run_id`, which means each run writes a fresh cache entry while still restoring the latest compatible timing history. I also added a broader restore fallback so the job can still reuse older timing data after the fast-E2E test tree changes, instead of dropping all historical timings and going fully cold on the next run.

For Docker lifecycle reliability, the runner already had per-shard `finally` cleanup, but that only covers normal shard teardown paths. It does not help enough when the outer process is interrupted before all worker threads finish their own cleanup. To close that gap, the runner now labels shard containers, tracks active container names in process memory, and registers `atexit`, `SIGINT`, and `SIGTERM` cleanup hooks. If the runner is cancelled or interrupted, it now makes a best-effort pass to remove any containers it started and still considers active, which is the case that most directly causes retry port conflicts and dirty Docker state.

For local CI parity, `Makefile` `CI_LITE_JOBS` now includes `firmware-native-tests`. That brings `make test-ci-lite` back into alignment with its documented purpose as the non-Docker blocking subset of CI. I added hygiene enforcement around that so this does not silently drift again the next time a CI job list changes.

## Main code changes by area

In `tools/tests/run_e2e_parallel.py`, I removed the hardcoded duration-hint table and replaced it with duration-cache load/save helpers, JUnit testcase-to-node-ID normalization, observation merging, and process-level active-container tracking/cleanup hooks. The shard config now carries a JUnit XML path so each shard can record per-test timings for future balancing. The runner still keeps the existing dedicated-shard behavior for tests whose observed durations exceed the slow-test threshold, but it now derives that from cached observations rather than from code constants.

In `.github/workflows/ci.yml`, I added the `actions/cache` step for the E2E duration cache ahead of the prebuild and test execution steps.

In `Makefile`, I added `firmware-native-tests` to `CI_LITE_JOBS`.

In `tools/dev/check_hygiene.py`, I added a parser for the Makefile CI-lite job list, a new `check_ci_lite_job_sync()` guard, and a Docker/CI hygiene assertion that the `e2e` workflow caches the new duration-cache file with the expected restore/save shape.

In tests, `apps/server/tests/hygiene/test_run_e2e_parallel.py` now covers cached-duration shard assignment, parsing JUnit timings back to selected test IDs, and best-effort cleanup of tracked containers. I also added `apps/server/tests/hygiene/test_ci_lite_job_parity.py` to pin the Makefile subset guard.

In docs, `docs/testing.md` now briefly notes that `run_e2e_parallel.py` records observed durations in the user cache so later runs can rebalance without manual hint maintenance.

## Validation

I validated the narrowed fix set with focused and broader local checks.

Focused runner/CI hygiene coverage:

- `python -m pytest -q apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_ci_lite_job_parity.py apps/server/tests/hygiene/test_docker_ci_hygiene.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py`

Broader repo gates:

- `make lint`
- `make test-changed`

Those all passed from the session-local virtualenv.

I did not run the Docker-backed E2E suite itself in this environment because the Docker daemon/socket is unavailable here, but this PR is specifically scoped to runner/workflow/hygiene behavior. The local validation therefore focused on the repo’s existing guardrails for CI/workflow parity and on the new deterministic unit-style coverage around the runner logic.

## Risks, tradeoffs, and out of scope

The duration cache still starts from a cold default estimate for tests that have never been observed before, so the very first run after a brand-new test lands may not be perfectly balanced. That is an intentional tradeoff in exchange for removing the brittle hand-maintained duration map. The new cache step plus broader restore fallback should keep that cold-start window small in CI.

I intentionally left the stale Playwright-cache complaint, broad marker-tagging request, and Docker cache-backend parity request out of this PR because the audit showed they were either already covered or not the root cause of a current reliability bug on `main`. That keeps this change set tied to the real live defects instead of expanding it into a larger workflow refactor.
