### PR TITLE
Harden release validation gates and install compatibility

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -78,6 +78,15 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build --wheel apps/server/
 
+      - name: Validate built server wheel metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheel_path="$(echo apps/server/dist/*.whl)"
+          PYTHONPATH=apps/server python -m vibesensor.use_cases.updates.releases.release_validation validate-wheel-metadata \
+            --wheel-path "${wheel_path}" \
+            --expected-version "${{ steps.version.outputs.version }}"
+
       - name: Smoke-validate built server wheel
         shell: bash
         run: |
@@ -221,7 +230,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH=apps/server python -m vibesensor.use_cases.updates.release_validation validate-firmware-manifest \
+          PYTHONPATH=apps/server python -m vibesensor.use_cases.updates.releases.release_validation validate-firmware-manifest \
             --dist-dir "${{ steps.firmware_dir.outputs.path }}/dist"
 
       - name: Create firmware bundle

--- a/apps/server/tests/hygiene/test_main_release_workflow.py
+++ b/apps/server/tests/hygiene/test_main_release_workflow.py
@@ -1,0 +1,38 @@
+"""Guard the main release workflow's wheel-validation path."""
+
+from __future__ import annotations
+
+import yaml
+
+from tests._paths import REPO_ROOT
+
+
+def test_main_release_workflow_fetches_full_history_and_validates_wheel_metadata() -> None:
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "main-release.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    release_job = workflow["jobs"]["release"]
+    steps = release_job["steps"]
+
+    checkout_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("uses") == "actions/checkout@v6"
+    )
+    assert checkout_step["with"]["fetch-depth"] == 0
+
+    metadata_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Validate built server wheel metadata"
+    )
+    run_script = metadata_step["run"]
+    assert "vibesensor.use_cases.updates.releases.release_validation" in run_script
+    assert "validate-wheel-metadata" in run_script
+    assert "--expected-version" in run_script
+
+    firmware_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Validate firmware manifest"
+    )
+    assert "vibesensor.use_cases.updates.releases.release_validation" in firmware_step["run"]

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -15,6 +15,7 @@ from vibesensor.use_cases.updates.releases.release_validation import (
     run_server_smoke,
     validate_firmware_dist,
     validate_packaged_static_assets,
+    validate_release_wheel_metadata,
 )
 
 
@@ -77,6 +78,61 @@ def test_validate_firmware_dist_reports_missing_firmware_bin(tmp_path: Path) -> 
 
     errors = validate_firmware_dist(dist_dir)
     assert any("must contain at least one segment" in error for error in errors)
+
+
+def _build_fake_release_wheel(
+    path: Path,
+    *,
+    version: str,
+    name: str = "vibesensor",
+    requires_python: str = "",
+    requires_dist: tuple[str, ...] = (),
+) -> None:
+    import zipfile
+
+    dist_info = f"vibesensor-{version}.dist-info"
+    metadata_lines = [
+        "Metadata-Version: 2.1",
+        f"Name: {name}",
+        f"Version: {version}",
+    ]
+    if requires_python:
+        metadata_lines.append(f"Requires-Python: {requires_python}")
+    metadata_lines.extend(f"Requires-Dist: {entry}" for entry in requires_dist)
+    with zipfile.ZipFile(path, "w") as wheel_zip:
+        wheel_zip.writestr("vibesensor/__init__.py", f"__version__ = '{version}'\n")
+        wheel_zip.writestr(f"{dist_info}/METADATA", "\n".join(metadata_lines) + "\n")
+        wheel_zip.writestr(f"{dist_info}/WHEEL", "Wheel-Version: 1.0\nTag: py3-none-any\n")
+
+
+def test_validate_release_wheel_metadata_accepts_matching_wheel(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_release_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_python=">=3.11",
+        requires_dist=("packaging>=24,<27",),
+    )
+
+    assert (
+        validate_release_wheel_metadata(
+            wheel_path,
+            expected_version="2025.6.15",
+        )
+        == []
+    )
+
+
+def test_validate_release_wheel_metadata_rejects_version_mismatch(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_release_wheel(wheel_path, version="2025.6.14")
+
+    errors = validate_release_wheel_metadata(
+        wheel_path,
+        expected_version="2025.6.15",
+    )
+
+    assert any("does not match expected '2025.6.15'" in error for error in errors)
 
 
 def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) -> None:

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator
+from vibesensor.use_cases.updates.artifact_validation import (
+    WheelArtifactValidator,
+    read_wheel_metadata,
+    wheel_dependency_issues,
+)
 from vibesensor.use_cases.updates.firmware.firmware_refresh import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
@@ -52,13 +56,28 @@ class RecordingCommands:
         return self.default_response
 
 
-def _build_fake_wheel(path: Path, *, version: str) -> None:
+def _build_fake_wheel(
+    path: Path,
+    *,
+    version: str,
+    name: str = "vibesensor",
+    requires_python: str = "",
+    requires_dist: tuple[str, ...] = (),
+) -> None:
     dist_info = f"vibesensor-{version}.dist-info"
+    metadata_lines = [
+        "Metadata-Version: 2.1",
+        f"Name: {name}",
+        f"Version: {version}",
+    ]
+    if requires_python:
+        metadata_lines.append(f"Requires-Python: {requires_python}")
+    metadata_lines.extend(f"Requires-Dist: {entry}" for entry in requires_dist)
     with zipfile.ZipFile(path, "w") as wheel_zip:
         wheel_zip.writestr("vibesensor/__init__.py", f"__version__ = '{version}'\n")
         wheel_zip.writestr(
             f"{dist_info}/METADATA",
-            f"Metadata-Version: 2.1\nName: vibesensor\nVersion: {version}\n",
+            "\n".join(metadata_lines) + "\n",
         )
         wheel_zip.writestr(f"{dist_info}/WHEEL", "Wheel-Version: 1.0\nTag: py3-none-any\n")
 
@@ -274,6 +293,91 @@ def test_wheel_validator_rejects_corrupt_wheel_without_installer(tmp_path: Path)
 
     assert not ok
     assert any(issue.message == "Downloaded wheel is corrupt" for issue in tracker.status.issues)
+
+
+def test_wheel_validator_rejects_invalid_metadata_requirement(tmp_path: Path) -> None:
+    tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "update_status.json"))
+    validator = WheelArtifactValidator(tracker)
+    wheel_path = tmp_path / "broken-metadata.whl"
+    _build_fake_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_dist=("not a valid requirement ;;;",),
+    )
+
+    ok = validator.validate_wheel(
+        wheel_path,
+        phase="installing",
+        context="Downloaded wheel",
+        fatal=False,
+    )
+
+    assert not ok
+    assert any(
+        issue.message == "Downloaded wheel metadata is invalid" for issue in tracker.status.issues
+    )
+
+
+def test_wheel_dependency_issues_report_python_and_dependency_mismatches(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_python=">=3.12",
+        requires_dist=(
+            "packaging>=99",
+            "missingdep>=1",
+            "colorama>=0.4; sys_platform == 'win32'",
+        ),
+    )
+
+    issues = wheel_dependency_issues(
+        read_wheel_metadata(wheel_path),
+        python_full_version="3.11.9",
+        marker_environment={
+            "python_full_version": "3.11.9",
+            "python_version": "3.11",
+            "sys_platform": "linux",
+        },
+        installed_versions={"packaging": "24.2"},
+    )
+
+    assert "Python 3.11.9 does not satisfy wheel Requires-Python >=3.12" in issues
+    assert "Dependency packaging==24.2 does not satisfy >=99" in issues
+    assert "Missing dependency: missingdep>=1" in issues
+    assert all("colorama" not in issue for issue in issues)
+
+
+@pytest.mark.asyncio
+async def test_install_release_rejects_incompatible_environment_before_pip_install(
+    tmp_path: Path,
+) -> None:
+    installer, commands, tracker = _make_installer(tmp_path)
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_dist=("missingdep>=1",),
+    )
+    commands.set_response(
+        "missingdep",
+        0,
+        (
+            '{"python_full_version":"3.11.9","marker_environment":{"python_full_version":"3.11.9",'
+            '"python_version":"3.11","sys_platform":"linux"},"installed_versions":{"missingdep":""}}\n'
+        ),
+        "",
+    )
+
+    assert await installer.install_release(wheel_path, "2025.6.15") is False
+    assert tracker.status.state.value == "failed"
+    assert any(
+        issue.message == "Downloaded wheel is incompatible with the current environment"
+        for issue in tracker.status.issues
+    )
+    assert not any(
+        "pip install --force-reinstall --no-deps" in " ".join(call[0]) for call in commands.calls
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/updates/artifact_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/artifact_validation.py
@@ -4,11 +4,161 @@ from __future__ import annotations
 
 import hashlib
 import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from email.message import Message
+from email.parser import Parser
 from pathlib import Path
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
 
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
-__all__ = ["WheelArtifactValidator", "sha256_file"]
+__all__ = [
+    "WheelArtifactValidator",
+    "WheelMetadata",
+    "read_wheel_metadata",
+    "sha256_file",
+    "wheel_dependency_issues",
+    "wheel_metadata_validation_errors",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WheelMetadata:
+    """Parsed wheel metadata relevant to release/update validation."""
+
+    name: str
+    version: str
+    requires_python: str = ""
+    requires_dist: tuple[str, ...] = ()
+
+
+def _metadata_message_from_archive(wheel_zip: zipfile.ZipFile) -> Message:
+    metadata_name = next(
+        (name for name in wheel_zip.namelist() if name.endswith(".dist-info/METADATA")),
+        "",
+    )
+    if not metadata_name:
+        raise ValueError("wheel archive is missing dist-info metadata")
+    try:
+        metadata_text = wheel_zip.read(metadata_name).decode("utf-8")
+    except (KeyError, UnicodeDecodeError) as exc:
+        raise ValueError(f"could not read wheel metadata: {exc}") from exc
+    return Parser().parsestr(metadata_text)
+
+
+def _parse_metadata_message(message: Message) -> WheelMetadata:
+    return WheelMetadata(
+        name=(message.get("Name") or "").strip(),
+        version=(message.get("Version") or "").strip(),
+        requires_python=(message.get("Requires-Python") or "").strip(),
+        requires_dist=tuple(
+            entry.strip()
+            for entry in message.get_all("Requires-Dist", [])
+            if isinstance(entry, str) and entry.strip()
+        ),
+    )
+
+
+def read_wheel_metadata(wheel_path: Path) -> WheelMetadata:
+    """Read and parse ``.dist-info/METADATA`` from a wheel archive."""
+    with zipfile.ZipFile(wheel_path) as wheel_zip:
+        return _parse_metadata_message(_metadata_message_from_archive(wheel_zip))
+
+
+def wheel_metadata_validation_errors(
+    wheel_path: Path,
+    *,
+    expected_name: str | None = None,
+    expected_version: str | None = None,
+) -> list[str]:
+    try:
+        metadata = read_wheel_metadata(wheel_path)
+    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+        return [f"{wheel_path}: {exc}"]
+
+    errors: list[str] = []
+    if not metadata.name:
+        errors.append("wheel metadata is missing Name")
+    elif expected_name and metadata.name != expected_name:
+        errors.append(
+            f"wheel metadata Name {metadata.name!r} does not match expected {expected_name!r}",
+        )
+    if not metadata.version:
+        errors.append("wheel metadata is missing Version")
+    elif expected_version and metadata.version != expected_version:
+        errors.append(
+            "wheel metadata Version "
+            f"{metadata.version!r} does not match expected {expected_version!r}",
+        )
+    if metadata.requires_python:
+        try:
+            SpecifierSet(metadata.requires_python)
+        except InvalidSpecifier as exc:
+            errors.append(
+                f"wheel metadata Requires-Python {metadata.requires_python!r} is invalid: {exc}",
+            )
+    for raw_requirement in metadata.requires_dist:
+        try:
+            Requirement(raw_requirement)
+        except InvalidRequirement as exc:
+            errors.append(
+                f"wheel metadata Requires-Dist {raw_requirement!r} is invalid: {exc}",
+            )
+    return errors
+
+
+def wheel_dependency_issues(
+    metadata: WheelMetadata,
+    *,
+    python_full_version: str,
+    marker_environment: Mapping[str, str],
+    installed_versions: Mapping[str, str],
+) -> list[str]:
+    """Evaluate wheel dependency metadata against a concrete target environment."""
+    issues: list[str] = []
+    environment = {key: str(value) for key, value in marker_environment.items()}
+    if metadata.requires_python:
+        try:
+            specifier = SpecifierSet(metadata.requires_python)
+        except InvalidSpecifier as exc:
+            return [
+                f"wheel metadata Requires-Python {metadata.requires_python!r} is invalid: {exc}",
+            ]
+        if python_full_version and not specifier.contains(python_full_version, prereleases=True):
+            issues.append(
+                "Python "
+                f"{python_full_version} does not satisfy wheel Requires-Python "
+                f"{metadata.requires_python}",
+            )
+    for raw_requirement in metadata.requires_dist:
+        try:
+            requirement = Requirement(raw_requirement)
+        except InvalidRequirement as exc:
+            issues.append(
+                f"wheel metadata Requires-Dist {raw_requirement!r} is invalid: {exc}",
+            )
+            continue
+        if requirement.marker is not None and not requirement.marker.evaluate(environment):
+            continue
+        requirement_name = canonicalize_name(requirement.name)
+        installed_version = installed_versions.get(requirement_name, "")
+        if not installed_version:
+            suffix = str(requirement.specifier) if requirement.specifier else ""
+            issues.append(f"Missing dependency: {requirement.name}{suffix}")
+            continue
+        if requirement.specifier and not requirement.specifier.contains(
+            installed_version,
+            prereleases=True,
+        ):
+            issues.append(
+                f"Dependency {requirement.name}=={installed_version} does not satisfy "
+                f"{requirement.specifier}",
+            )
+    return issues
 
 
 class WheelArtifactValidator:
@@ -89,6 +239,18 @@ class WheelArtifactValidator:
                 phase=phase,
                 message=f"{context} could not be opened",
                 detail=f"{wheel_path}: {exc}",
+                fatal=fatal,
+            )
+            return False
+        metadata_errors = wheel_metadata_validation_errors(
+            wheel_path,
+            expected_name="vibesensor",
+        )
+        if metadata_errors:
+            self._report_failure(
+                phase=phase,
+                message=f"{context} metadata is invalid",
+                detail="; ".join(metadata_errors),
                 fatal=fatal,
             )
             return False

--- a/apps/server/vibesensor/use_cases/updates/installer.py
+++ b/apps/server/vibesensor/use_cases/updates/installer.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator, sha256_file
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+from vibesensor.use_cases.updates.artifact_validation import (
+    WheelArtifactValidator,
+    read_wheel_metadata,
+    sha256_file,
+    wheel_dependency_issues,
+)
 from vibesensor.use_cases.updates.rollback_snapshot import (
     RollbackSnapshotMetadata,
     RollbackSnapshotStore,
@@ -22,6 +31,34 @@ class UpdateInstallerConfig:
     rollback_dir: Path
     reinstall_timeout_s: float
     firmware_refresh_timeout_s: float
+
+
+_TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
+    [
+        "import importlib.metadata as metadata",
+        "import json",
+        "import sys",
+        "from packaging.markers import default_environment",
+        "from packaging.utils import canonicalize_name",
+        "payload = json.loads(sys.argv[1])",
+        "distribution_names = [",
+        "    canonicalize_name(str(name))",
+        "    for name in payload.get('distribution_names', [])",
+        "]",
+        "installed_versions = {}",
+        "for distribution_name in distribution_names:",
+        "    try:",
+        "        installed_versions[distribution_name] = metadata.version(distribution_name)",
+        "    except metadata.PackageNotFoundError:",
+        "        installed_versions[distribution_name] = ''",
+        "marker_environment = default_environment()",
+        "print(json.dumps({",
+        "    'python_full_version': marker_environment.get('python_full_version', ''),",
+        "    'marker_environment': marker_environment,",
+        "    'installed_versions': installed_versions,",
+        "}))",
+    ],
+)
 
 
 class UpdateInstaller:
@@ -126,6 +163,8 @@ class UpdateInstaller:
         ):
             return False
         venv_python = reinstall_python_executable(self._config.repo)
+        if not await self._validate_dependency_compatibility(wheel_path, venv_python=venv_python):
+            return False
         rc, _, stderr = await self._commands.run(
             [
                 venv_python,
@@ -154,6 +193,86 @@ class UpdateInstaller:
 
         self._tracker.log(f"Installed vibesensor {expected_version}")
         self._tracker.log(f"Verified installed version: {installed_version}")
+        return True
+
+    async def _validate_dependency_compatibility(
+        self,
+        wheel_path: Path,
+        *,
+        venv_python: str,
+    ) -> bool:
+        metadata = read_wheel_metadata(wheel_path)
+        requirement_names = sorted(
+            {
+                canonicalize_name(Requirement(raw_requirement).name)
+                for raw_requirement in metadata.requires_dist
+            },
+        )
+        if not metadata.requires_python and not requirement_names:
+            return True
+
+        rc, stdout, stderr = await self._commands.run(
+            [
+                venv_python,
+                "-c",
+                _TARGET_ENV_SNAPSHOT_SCRIPT,
+                json.dumps({"distribution_names": requirement_names}),
+            ],
+            phase="installing",
+            timeout=30,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.fail(
+                "installing",
+                f"Could not validate wheel dependency compatibility (exit {rc})",
+                stderr or stdout,
+            )
+            return False
+        try:
+            snapshot = json.loads(stdout or "{}")
+        except json.JSONDecodeError:
+            self._tracker.fail(
+                "installing",
+                "Could not parse wheel dependency compatibility results",
+                stdout or stderr,
+            )
+            return False
+
+        marker_environment_raw = snapshot.get("marker_environment", {})
+        installed_versions_raw = snapshot.get("installed_versions", {})
+        if not isinstance(marker_environment_raw, dict) or not isinstance(
+            installed_versions_raw,
+            dict,
+        ):
+            self._tracker.fail(
+                "installing",
+                "Could not parse wheel dependency compatibility results",
+                stdout or stderr,
+            )
+            return False
+        issues = wheel_dependency_issues(
+            metadata,
+            python_full_version=str(snapshot.get("python_full_version") or ""),
+            marker_environment={
+                str(key): str(value)
+                for key, value in marker_environment_raw.items()
+                if isinstance(key, str)
+            },
+            installed_versions={
+                str(key): str(value)
+                for key, value in installed_versions_raw.items()
+                if isinstance(key, str)
+            },
+        )
+        if issues:
+            self._tracker.fail(
+                "installing",
+                "Downloaded wheel is incompatible with the current environment",
+                "; ".join(issues),
+            )
+            return False
+        self._tracker.log("Validated wheel dependency compatibility against target environment")
         return True
 
     async def rollback(self) -> bool:

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -15,6 +15,8 @@ import urllib.request
 from collections.abc import Sequence
 from pathlib import Path
 
+from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_validation_errors
+
 
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
@@ -153,6 +155,18 @@ def validate_firmware_dist(dist_dir: Path) -> list[str]:
             errors.append(f"{prefix} does not include firmware.bin")
 
     return errors
+
+
+def validate_release_wheel_metadata(
+    wheel_path: Path,
+    *,
+    expected_version: str,
+) -> list[str]:
+    return wheel_metadata_validation_errors(
+        wheel_path,
+        expected_name="vibesensor",
+        expected_version=expected_version,
+    )
 
 
 def _read_http(url: str) -> tuple[int, str, str]:
@@ -307,6 +321,19 @@ def _cmd_smoke_server(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_validate_wheel_metadata(args: argparse.Namespace) -> int:
+    errors = validate_release_wheel_metadata(
+        args.wheel_path,
+        expected_version=args.expected_version,
+    )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print(f"Validated release wheel metadata: {args.wheel_path}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate VibeSensor release artifacts")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -332,6 +359,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     firmware_parser.add_argument("--dist-dir", type=Path, required=True)
     firmware_parser.set_defaults(handler=_cmd_validate_firmware_manifest)
+
+    wheel_parser = subparsers.add_parser(
+        "validate-wheel-metadata",
+        help="Validate built server wheel metadata for release publishing",
+    )
+    wheel_parser.add_argument("--wheel-path", type=Path, required=True)
+    wheel_parser.add_argument("--expected-version", required=True)
+    wheel_parser.set_defaults(handler=_cmd_validate_wheel_metadata)
     return parser
 
 


### PR DESCRIPTION
Closes #1289

## Summary

This PR hardens the remaining live release/update validation gaps behind issue #1289 without reopening the parts of the issue body that are already solved on current `main`.

During the audit I confirmed that several claims in the issue are now stale: the main release workflow already checks out with full history (`fetch-depth: 0`), same-day server releases already get deterministic numeric suffixes by scanning existing `server-v<date>*` tags and incrementing the highest match, and rollback snapshots are already validated structurally and pinned by SHA256 before the updater trusts them. I intentionally left those areas alone.

The still-live problem was narrower and more concrete. The updater’s wheel validation path only verified archive integrity and the presence of `.dist-info/METADATA`, so malformed or semantically broken wheel metadata could still pass local validation. On top of that, the OTA install path went straight from that structural validation into `pip install --force-reinstall --no-deps`, which meant the Pi never checked whether the downloaded wheel’s declared `Requires-Python` or `Requires-Dist` constraints were compatible with the target environment before replacing the currently installed package. Release CI also smoke-booted the built wheel but never explicitly validated the wheel metadata payload itself.

This PR closes those gaps with one shared validation path used in both release-time and install-time flows.

## Implementation approach

The main design choice here was to avoid creating a second release-validation stack just for CI or a separate dependency checker just for the updater. Instead, I extended the existing updater/release validation seam so the workflow, the wheel validator, and the installer all use the same understanding of wheel metadata.

That keeps the validation logic in one place, reduces the chance of CI and runtime drifting apart, and makes the updater fail early with actionable errors before it mutates the live installation.

## Main code changes

### 1. Shared wheel metadata parsing and semantic validation

`apps/server/vibesensor/use_cases/updates/artifact_validation.py` now does more than check that a wheel is a readable zip archive. It now parses the wheel’s `METADATA` file into a small `WheelMetadata` model, exposes `read_wheel_metadata()`, and validates the semantic fields that matter for release/install safety:

- `Name` must be present and match the expected distribution name when that is known.
- `Version` must be present and can be checked against an expected release version.
- `Requires-Python` must parse as a valid specifier set.
- Every `Requires-Dist` entry must parse as a valid requirement string.

`WheelArtifactValidator.validate_wheel()` now uses that semantic validation in addition to the existing archive-integrity and checksum checks, so snapshot wheels, downloaded wheels, and rollback candidates all benefit from the same stronger validation.

I also added `wheel_dependency_issues()` to evaluate a parsed wheel’s dependency requirements against a concrete target environment. That helper applies markers, checks Python-version compatibility, canonicalizes dependency names, and reports missing or version-mismatched installed distributions in a user-facing way.

### 2. Pre-install dependency compatibility gate in the updater

`apps/server/vibesensor/use_cases/updates/installer.py` now performs an explicit compatibility preflight before it calls `pip install --force-reinstall --no-deps`.

The updater already has a reliable way to run commands inside the reinstall venv, so I reused that seam. The installer now asks the target interpreter for a small environment snapshot: the effective Python version, the packaging marker environment, and the installed versions for the distributions declared by the wheel. It then evaluates the wheel’s `Requires-Python` and `Requires-Dist` metadata locally using the shared helper above.

If the wheel is incompatible, the update fails before `pip install` runs and the tracker records a precise reason such as a Python version mismatch, a missing dependency, or an installed dependency version that does not satisfy the wheel’s requirement specifier. That preserves the repo’s existing `--no-deps` install model while removing the blind spot that previously let an obviously incompatible wheel replace a working install.

### 3. Release workflow wheel-metadata validation

`apps/server/vibesensor/use_cases/updates/releases/release_validation.py` now exposes `validate_release_wheel_metadata()` and a matching `validate-wheel-metadata` CLI subcommand.

The main release workflow uses that new command immediately after building the server wheel and before running the existing release smoke test. That means the workflow now fails fast if the built wheel’s metadata is malformed, names the wrong distribution, or carries a version that does not match the version stamped into the release job.

While wiring that step, I also corrected the firmware-manifest validation step to invoke the actual `vibesensor.use_cases.updates.releases.release_validation` module path. That fix is tightly coupled to the same workflow seam and is covered by the new workflow hygiene test below.

## Test and validation coverage

I added focused regression coverage in three places.

`apps/server/tests/use_cases/updates/test_update_installer_verification.py` now covers invalid `Requires-Dist` metadata, dependency/Python mismatch evaluation, and the updater refusing to proceed to `pip install` when the target environment is incompatible.

`apps/server/tests/use_cases/updates/releases/test_release_validation.py` now covers the positive path for release-wheel metadata validation and a version-mismatch failure.

`apps/server/tests/hygiene/test_main_release_workflow.py` now guards the release workflow itself so future edits do not accidentally remove full-history checkout, the wheel-metadata validation step, or the correct release-validation module path.

Local validation run for this PR:

- `pytest -q apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/releases/test_release_validation.py apps/server/tests/hygiene/test_main_release_workflow.py`
- `make lint`
- `make test-changed`
- `PYTHONPATH=apps/server python -m vibesensor.use_cases.updates.releases.release_validation validate-wheel-metadata ...` against a synthetic wheel built during the validation run

All of the above passed locally. I also ran a code-review pass over the final diff; it did not surface any blocking issues.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that the updater now performs one extra pre-install check using the target interpreter before the actual install step. That adds a small amount of latency, but the payoff is high: failures now happen before we mutate the live package state, and the failure mode is explicit instead of a post-install import/runtime surprise.

I did not broaden this PR into a general dependency-locking or packaging-policy overhaul. Issue #1290 is a better home for the broader dependency-management questions. I also intentionally did not revisit the already-solved parts of #1289 around fetch depth, same-day version suffixing, or rollback checksum handling.

The result is a tight, reviewable fix for the live gap: release artifacts now get semantic wheel-metadata validation in CI, and OTA installs now verify compatibility with the target environment before replacing the installed server package.
