### PR TITLE
Tighten dependency reproducibility guards

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68,<83", "wheel"]
+requires = ["setuptools>=68,<83", "wheel>=0.45,<1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,7 +15,7 @@ dependencies = [
   "packaging>=24,<27",
   "PyYAML>=6,<7",
   "reportlab>=4,<5",
-  "websockets>=12,<17",
+  "websockets>=16,<17",
 ]
 
 [project.optional-dependencies]

--- a/firmware/esp/platformio.ini
+++ b/firmware/esp/platformio.ini
@@ -5,6 +5,9 @@ default_envs = m5stack_atom
 platform = espressif32@6.13.0
 board = m5stack-atom
 framework = arduino
+; Keep the Arduino framework package pinned explicitly instead of inheriting the platform's range.
+platform_packages =
+  framework-arduinoespressif32@3.20017.0
 monitor_speed = 115200
 lib_ldf_mode = deep+
 lib_deps =

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -187,6 +187,34 @@ def _build_system_requirement_spec(requirement_name: str) -> str | None:
     return None
 
 
+def _platformio_package_pin(package_name: str) -> str | None:
+    platformio_path = ROOT / "firmware" / "esp" / "platformio.ini"
+    if not platformio_path.exists():
+        return None
+    in_platform_packages = False
+    for raw_line in platformio_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_platform_packages = False
+            continue
+        if line.startswith("platform_packages"):
+            in_platform_packages = True
+            _, _, value = line.partition("=")
+            candidate = value.strip()
+            if candidate.startswith(f"{package_name}@"):
+                return candidate.split("@", 1)[1].strip()
+            continue
+        if in_platform_packages:
+            if "=" in raw_line and not raw_line.startswith((" ", "\t")):
+                in_platform_packages = False
+                continue
+            if line.startswith(f"{package_name}@"):
+                return line.split("@", 1)[1].strip()
+    return None
+
+
 def _lower_bound_major(requirement_spec: str) -> int | None:
     match = re.search(r">=?\s*([0-9]+)", requirement_spec)
     return int(match.group(1)) if match else None
@@ -735,6 +763,48 @@ def check_dependency_reproducibility_hygiene() -> list[str]:
     elif "<" not in setuptools_spec:
         errors.append(
             f"apps/server/pyproject.toml build-system setuptools requirement must include an upper bound; found {setuptools_spec!r}."
+        )
+
+    wheel_spec = _build_system_requirement_spec("wheel")
+    if wheel_spec is None:
+        errors.append(
+            "apps/server/pyproject.toml build-system requires must declare wheel."
+        )
+    elif ">=" not in wheel_spec or "<" not in wheel_spec:
+        errors.append(
+            "apps/server/pyproject.toml build-system wheel requirement must include "
+            f"explicit lower and upper bounds; found {wheel_spec!r}."
+        )
+
+    websockets_spec = _project_dependency_spec("websockets")
+    if websockets_spec is None:
+        errors.append(
+            "apps/server/pyproject.toml is missing the websockets runtime dependency."
+        )
+    else:
+        lower_major = _lower_bound_major(websockets_spec)
+        upper_major = _upper_bound_major(websockets_spec)
+        if lower_major is None or upper_major is None:
+            errors.append(
+                "websockets dependency must declare explicit lower and upper bounds; "
+                f"found {websockets_spec!r}."
+            )
+        elif upper_major != lower_major + 1:
+            errors.append(
+                "websockets dependency must stay within a single major version window; "
+                f"found {websockets_spec!r}."
+            )
+
+    framework_pin = _platformio_package_pin("framework-arduinoespressif32")
+    if framework_pin is None:
+        errors.append(
+            "firmware/esp/platformio.ini must pin framework-arduinoespressif32 via "
+            "platform_packages."
+        )
+    elif framework_pin.startswith(("~", "^", "<", ">", "=")):
+        errors.append(
+            "firmware/esp/platformio.ini must pin framework-arduinoespressif32 to an "
+            f"exact version; found {framework_pin!r}."
         )
 
     dependabot_path = ROOT / ".github" / "dependabot.yml"


### PR DESCRIPTION
Closes #1290

## Summary

This PR fixes the live dependency-management gaps that are still real on current `main`, without reopening the parts of issue #1290 that are already intentional repo policy or have already been solved.

The issue body describes a broad dependency-management cleanup spanning frontend peer conflicts, Python lockfiles, scattered toolchain pins, broad backend ranges, PlatformIO framework pinning, and dev/test/build tooling bounds. I started by auditing each claim directly against the current manifests, lockfiles, CI workflows, hygiene checks, and local dependency tree instead of implementing that whole list literally.

That audit materially narrowed the scope.

Several claims turned out to be stale on current `main`. The TypeScript/openapi conflict is no longer live: `apps/ui/package-lock.json` resolves `openapi-typescript@6.7.6`, it no longer carries the older TypeScript peer restriction, and `npm ls openapi-typescript typescript` resolves cleanly with `typescript@6.0.2`. The missing-Python-lockfile complaint is also not a bug in the current repo model: `apps/server/README.md` explicitly documents bounded dependency specs plus editable installs and CI `pip check` as the chosen strategy instead of maintaining a second checked-in lockfile workflow. The scattered-version-pin complaint is likewise already mitigated by current guardrails: `.python-version` and `.nvmrc` are the toolchain source of truth, CI/setup actions read those files directly, and `tools/dev/check_hygiene.py` already keeps the production Dockerfile aligned with them. The broader mypy/dev-bound claims are also stale because the current specs are already bounded (`mypy>=1.19,<2`, `pytest>=8,<10`, etc.).

After removing those stale or already-intentional surfaces, the live subset was much smaller and clearer:

- `apps/server/pyproject.toml` still allowed `websockets>=12,<17`, which spans five major versions and is much broader than the repo’s current dependency-window norms.
- The build-system requirement still declared bare `wheel` with no lower or upper bound.
- `firmware/esp/platformio.ini` pinned the ESP32 platform, but not the `framework-arduinoespressif32` package version separately, so the framework package could still drift within the pinned platform’s allowed package range.

This PR fixes those three remaining gaps and extends the existing hygiene layer so they stay fixed.

## Implementation approach

The main design choice here was to treat this as a reproducibility and policy-guard issue, not as a packaging-overhaul issue.

I intentionally did **not** add a Python lockfile, switch tooling, or invent a new central version file. Those would be broader architectural changes and would conflict with the repo’s already documented editable-install workflow. Instead, I aligned the remaining loose edges with the repo’s existing approach: bounded specs in `pyproject.toml`, explicit pinning where reproducibility matters, and hygiene checks that fail fast if someone accidentally broadens those windows later.

## Main code changes

### 1. Tighten the runtime `websockets` window

`apps/server/pyproject.toml` now narrows:

- from `websockets>=12,<17`
- to `websockets>=16,<17`

That change deliberately follows the current tested resolution instead of speculating about older major versions. Local validation in this environment is already using `websockets==16.0`, and the repo’s direct usage of the `websockets` package is limited to the `ws_smoke` helper rather than the core FastAPI server path. Narrowing to the current major reduces silent future behavioral drift without broadening the issue into a larger WebSocket compatibility matrix.

### 2. Bound the build-system `wheel` requirement

`apps/server/pyproject.toml` also now changes the build-system requirement:

- from bare `wheel`
- to `wheel>=0.45,<1`

This brings `wheel` into the same bounded-spec model that the repo already uses for the rest of its Python dependency management. The practical effect is simple: the release/build path is no longer exposed to an unbounded future `wheel` change while still allowing normal 0.x updates within a controlled window.

### 3. Pin the ESP32 Arduino framework package explicitly

`firmware/esp/platformio.ini` now adds:

```ini
platform_packages =
  framework-arduinoespressif32@3.20017.0
```

The ESP32 platform itself was already pinned to `espressif32@6.13.0`, but PlatformIO still resolves the Arduino framework package through the platform’s package metadata. I verified locally that the platform currently maps that framework package to the 3.20017 line, and this PR now pins the exact framework package version instead of inheriting the platform’s package range implicitly.

That keeps firmware builds deterministic when PlatformIO package metadata evolves and makes the framework version an explicit repo decision instead of a transitive default.

### 4. Extend dependency reproducibility hygiene checks

`tools/dev/check_hygiene.py` now enforces the three policy decisions above so the repo cannot silently drift back:

- `wheel` in build-system requirements must include explicit lower and upper bounds.
- `websockets` must stay within a single major-version window.
- `firmware/esp/platformio.ini` must pin `framework-arduinoespressif32` through `platform_packages`, and that pin must be exact rather than a range such as `~`, `^`, `<`, or `>`.

I implemented the PlatformIO check by adding a small parser for the `platform_packages` block so the hygiene rule works for both inline and multi-line config styles.

## Validation

Local validation for this PR covered both the new metadata/policy constraints and their real execution paths:

- `python -m pip install -e './apps/server[dev]'`
- `pytest -q apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py`
- `cd firmware/esp && pio run -e m5stack_atom -t envdump`
- `make lint`
- `make test-changed`

All of those passed locally. The changed-file suite was substantial because the touched files feed into global hygiene, and it still completed cleanly: `5823 passed, 5 skipped, 1 xpassed`.

I also ran a code-review pass over the final diff; it did not identify any blocking issues.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this PR chooses the **current tested** `websockets` major rather than preserving a broad multi-major compatibility window. That is intentional: without a lockfile, a five-major range creates too much future variance for too little benefit.

I intentionally left several broader ideas out of scope:

- no Python lockfile was added
- no version-centralization refactor beyond the existing `.python-version` / `.nvmrc` model
- no frontend dependency changes, because the peer-conflict claim is already stale
- no dev/test dependency tightening beyond what the repo already enforces today

That keeps this PR tight and reviewable while still closing the real reproducibility gaps that remained in the manifests and firmware config.

The result is a smaller but more durable fix than the original issue body suggests: the repo now bounds the remaining loose Python/package windows that were still live, pins the firmware framework package explicitly, and enforces all three choices through the existing hygiene system.
