### PR TITLE
Improve Docker dev workflow startup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ apps/server/config.dev.yaml` plus `npm --prefix apps/ui run dev`, then open
 If you want the browser to open automatically on local desktop workflows, use
 `npm --prefix apps/ui run dev:open` instead of `npm --prefix apps/ui run dev`.
 
+If you prefer the source-mounted Docker workflow instead of the native path,
+run `make dev`.
+
 ## Hooks and local safeguards
 
 `make setup` enables the versioned repo hooks automatically. If you skipped that
@@ -83,6 +86,7 @@ Additional local-only convenience commands:
 
 | Goal | Command |
 |---|---|
+| Docker dev stack | `make dev` |
 | Fast backend tests | `make test` |
 | UI lint | `make ui-lint` |
 | Changed-file heuristic | `make test-changed` |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
 CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests
@@ -15,6 +15,9 @@ setup: ## Install backend dev dependencies and UI node_modules
 	python3 -m pip install -e "./apps/server[dev]"
 	cd apps/ui && npm ci
 	git config --local core.hooksPath .githooks
+
+dev: ## Start the source-mounted Docker dev stack with backend reload + Vite HMR
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 
 format: ## Run Ruff formatter over backend and tooling files
 	ruff format $(LINT_TARGETS)

--- a/README.md
+++ b/README.md
@@ -127,12 +127,16 @@ build, use the Docker dev mode below.
 ```bash
 git clone https://github.com/Skamba/VibeSensor.git
 cd VibeSensor
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+make dev
 ```
 
 Open http://127.0.0.1:5173 for the Vite dev server with HMR. The backend keeps
 running on http://127.0.0.1:8000 with `vibesensor-server --reload`, so Python
 changes hot-reload without rebuilding the image.
+
+`make dev` wraps `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build`.
+The UI container now reuses the `node_modules` volume unless `apps/ui/package-lock.json`
+changes, and it fails fast if the generated frontend contracts are stale.
 
 ### Native Python + Vite (recommended for backend or UI iteration)
 

--- a/apps/server/tests/hygiene/test_dev_workflow.py
+++ b/apps/server/tests/hygiene/test_dev_workflow.py
@@ -1,0 +1,217 @@
+"""Guard the Docker dev workflow entrypoints and UI dependency caching."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from tests._paths import REPO_ROOT
+
+_MAKEFILE = REPO_ROOT / "Makefile"
+_DOCKER_DEV_COMPOSE = REPO_ROOT / "docker-compose.dev.yml"
+_UI_PACKAGE_JSON = REPO_ROOT / "apps" / "ui" / "package.json"
+_UI_DEV_SCRIPT = REPO_ROOT / "apps" / "ui" / "dev-docker.sh"
+
+
+def _package_scripts() -> dict[str, str]:
+    package_json = json.loads(_UI_PACKAGE_JSON.read_text(encoding="utf-8"))
+    return {str(name): str(command) for name, command in package_json["scripts"].items()}
+
+
+def _docker_dev_config() -> dict[str, object]:
+    loaded = yaml.safe_load(_DOCKER_DEV_COMPOSE.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _write_fake_npm(bin_dir: Path) -> None:
+    fake_npm = bin_dir / "npm"
+    fake_npm.write_text(
+        "\n".join(
+            [
+                f"#!{sys.executable}",
+                "from pathlib import Path",
+                "import os",
+                "import sys",
+                "",
+                "log_path = Path(os.environ['FAKE_NPM_LOG'])",
+                "with log_path.open('a', encoding='utf-8') as handle:",
+                "    handle.write(' '.join(sys.argv[1:]) + '\\n')",
+                "if sys.argv[1:3] == ['run', 'check:contracts'] and "
+                "os.environ.get('FAKE_CONTRACTS_FAIL') == '1':",
+                "    sys.exit(17)",
+                "sys.exit(0)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_npm.chmod(0o755)
+
+
+def _prepare_ui_workspace(
+    tmp_path: Path,
+    *,
+    create_node_modules: bool,
+    stored_lock_hash: str | None,
+) -> tuple[Path, Path]:
+    ui_dir = tmp_path / "ui"
+    ui_dir.mkdir()
+    package_lock = ui_dir / "package-lock.json"
+    package_lock.write_text('{"lockfileVersion": 3}\n', encoding="utf-8")
+    if create_node_modules:
+        (ui_dir / "node_modules").mkdir()
+    if stored_lock_hash is not None:
+        (ui_dir / ".npm-ci-lock.sha256").write_text(f"{stored_lock_hash}\n", encoding="utf-8")
+    return ui_dir, package_lock
+
+
+def _run_dev_docker_script(
+    ui_dir: Path, tmp_path: Path, *, fail_contracts: bool = False
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_npm(bin_dir)
+    log_path = tmp_path / "npm.log"
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "FAKE_NPM_LOG": str(log_path),
+    }
+    if fail_contracts:
+        env["FAKE_CONTRACTS_FAIL"] = "1"
+    result = subprocess.run(
+        ["sh", str(_UI_DEV_SCRIPT), "--host", "0.0.0.0", "--port", "5173"],
+        cwd=ui_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    commands = log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
+    return result, commands
+
+
+def test_make_dev_target_wraps_docker_dev_compose() -> None:
+    makefile_text = _MAKEFILE.read_text(encoding="utf-8")
+
+    assert (
+        "dev: ## Start the source-mounted Docker dev stack with backend reload + Vite HMR"
+        in makefile_text
+    )
+    assert (
+        "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build" in makefile_text
+    )
+
+
+def test_docker_dev_ui_service_uses_guarded_dev_script_and_healthcheck() -> None:
+    scripts = _package_scripts()
+    compose = _docker_dev_config()
+    services = compose["services"]
+    assert isinstance(services, dict)
+    ui_service = services["vibesensor-ui-dev"]
+    assert isinstance(ui_service, dict)
+
+    assert scripts["dev:docker"] == "sh ./dev-docker.sh"
+    assert ui_service["command"] == [
+        "npm",
+        "run",
+        "dev:docker",
+        "--",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "5173",
+    ]
+
+    healthcheck = ui_service["healthcheck"]
+    assert isinstance(healthcheck, dict)
+    test_command = healthcheck["test"]
+    assert test_command[:3] == ["CMD", "node", "-e"]
+    assert "127.0.0.1:5173/" in test_command[3]
+    assert healthcheck["start_period"] == "75s"
+
+
+def test_dev_docker_runs_npm_ci_and_marks_lock_hash_when_node_modules_missing(
+    tmp_path: Path,
+) -> None:
+    ui_dir, package_lock = _prepare_ui_workspace(
+        tmp_path,
+        create_node_modules=False,
+        stored_lock_hash=None,
+    )
+
+    result, commands = _run_dev_docker_script(ui_dir, tmp_path)
+
+    assert result.returncode == 0
+    assert commands == [
+        "ci",
+        "run check:contracts",
+        "run dev -- --host 0.0.0.0 --port 5173",
+    ]
+    assert (ui_dir / ".npm-ci-lock.sha256").read_text(encoding="utf-8").strip() == hashlib.sha256(
+        package_lock.read_bytes()
+    ).hexdigest()
+
+
+def test_dev_docker_reinstalls_when_lock_hash_is_stale(tmp_path: Path) -> None:
+    ui_dir, package_lock = _prepare_ui_workspace(
+        tmp_path,
+        create_node_modules=True,
+        stored_lock_hash="stale-hash",
+    )
+
+    result, commands = _run_dev_docker_script(ui_dir, tmp_path)
+
+    assert result.returncode == 0
+    assert commands == [
+        "ci",
+        "run check:contracts",
+        "run dev -- --host 0.0.0.0 --port 5173",
+    ]
+    assert (ui_dir / ".npm-ci-lock.sha256").read_text(encoding="utf-8").strip() == hashlib.sha256(
+        package_lock.read_bytes()
+    ).hexdigest()
+
+
+def test_dev_docker_skips_npm_ci_when_lock_hash_is_current(tmp_path: Path) -> None:
+    ui_dir, package_lock = _prepare_ui_workspace(
+        tmp_path,
+        create_node_modules=True,
+        stored_lock_hash=hashlib.sha256(b'{"lockfileVersion": 3}\n').hexdigest(),
+    )
+    assert (
+        hashlib.sha256(package_lock.read_bytes()).hexdigest()
+        == hashlib.sha256(b'{"lockfileVersion": 3}\n').hexdigest()
+    )
+
+    result, commands = _run_dev_docker_script(ui_dir, tmp_path)
+
+    assert result.returncode == 0
+    assert commands == [
+        "run check:contracts",
+        "run dev -- --host 0.0.0.0 --port 5173",
+    ]
+
+
+def test_dev_docker_fails_fast_when_contracts_are_stale(tmp_path: Path) -> None:
+    ui_dir, package_lock = _prepare_ui_workspace(
+        tmp_path,
+        create_node_modules=True,
+        stored_lock_hash=hashlib.sha256(b'{"lockfileVersion": 3}\n').hexdigest(),
+    )
+    assert (ui_dir / ".npm-ci-lock.sha256").read_text(encoding="utf-8").strip() == hashlib.sha256(
+        package_lock.read_bytes()
+    ).hexdigest()
+
+    result, commands = _run_dev_docker_script(ui_dir, tmp_path, fail_contracts=True)
+
+    assert result.returncode == 17
+    assert commands == ["run check:contracts"]
+    assert "make sync-contracts" in result.stderr

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -20,6 +20,7 @@ npm ci
 npm run lint         # Biome lint over the hand-written UI/config/test files
 npm run dev          # Dev server on http://localhost:5173
 npm run dev:open     # Same dev server, but opens the browser on local desktops
+npm run dev:docker   # Docker-oriented wrapper: contract check + guarded npm ci + Vite
 npm run build        # Production build to dist/
 npm run typecheck    # Type check without emitting
 ```
@@ -27,6 +28,11 @@ npm run typecheck    # Type check without emitting
 Use `npm ci` for normal repo bootstrap and dependency refresh from the checked-in
 lockfile. Only use `npm install` when you are intentionally adding or updating
 UI dependencies so the resulting `package-lock.json` change is deliberate.
+
+The source-mounted Docker dev stack calls `npm run dev:docker` inside the UI
+container. It re-runs `npm ci` only when `node_modules` is missing or the
+checked-in `package-lock.json` changes, and it fails fast if the generated UI
+contract files are stale.
 
 The Vite dev server proxies `/api`, `/ws`, and `/static` to
 `http://127.0.0.1:8000` by default so you can use HMR without manually swapping

--- a/apps/ui/dev-docker.sh
+++ b/apps/ui/dev-docker.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+if command -v sha256sum >/dev/null 2>&1; then
+	lock_hash="$(sha256sum package-lock.json | cut -d ' ' -f1)"
+elif command -v shasum >/dev/null 2>&1; then
+	lock_hash="$(shasum -a 256 package-lock.json | cut -d ' ' -f1)"
+else
+	echo "[dev:docker] Could not find sha256sum or shasum to hash package-lock.json." >&2
+	exit 1
+fi
+
+current_lock_hash=""
+
+if [ -f .npm-ci-lock.sha256 ]; then
+	current_lock_hash="$(tr -d '\n' < .npm-ci-lock.sha256)"
+fi
+
+if [ ! -d node_modules ] || [ "$lock_hash" != "$current_lock_hash" ]; then
+	echo "[dev:docker] Running npm ci because node_modules is missing or package-lock.json changed."
+	npm ci
+	printf '%s\n' "$lock_hash" > .npm-ci-lock.sha256
+fi
+
+if npm run check:contracts; then
+	:
+else
+	status=$?
+	echo "[dev:docker] Frontend contracts are stale. Run \`make sync-contracts\` or \`npm --prefix apps/ui run sync:contracts\`, then restart the dev stack." >&2
+	exit "$status"
+fi
+
+exec npm run dev -- "$@"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -13,6 +13,7 @@
     "prebuild": "npm run sync:contracts",
     "dev": "vite",
     "dev:open": "vite --open",
+    "dev:docker": "sh ./dev-docker.sh",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,9 +21,24 @@ services:
       - .:/workspace
       - vibesensor-ui-node_modules:/workspace/apps/ui/node_modules
     command:
-      - sh
-      - -lc
-      - npm ci && npm run dev -- --host 0.0.0.0 --port 5173
+      - npm
+      - run
+      - dev:docker
+      - --
+      - --host
+      - 0.0.0.0
+      - --port
+      - "5173"
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:5173/').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 75s
 
 volumes:
   vibesensor-ui-node_modules:


### PR DESCRIPTION
## Summary

This PR reduces the current developer-workflow friction around the Docker dev path without broadening into the larger stale items from issue #1295. After auditing the issue body against the current repo, the live problems were narrower than the original write-up. The repo already had a single dependency bootstrap command in `make setup`, frontend CI already enforced contract freshness through `npm run check:contracts`, `docs/testing.md` already documented focused pytest-by-directory runs, and the older E2E duration-maintenance complaint had already been resolved in earlier work. The still-live gaps were the lack of a `make dev` entrypoint for the documented Docker dev stack, the unconditional `npm ci` inside `docker-compose.dev.yml`, the absence of local contract-drift feedback before starting the Docker-backed Vite server, and the missing UI healthcheck in the Docker dev compose overlay.

The implementation keeps the fix set intentionally small and reviewable. Instead of introducing a new backend watch-mode toolchain or a second dependency bootstrap path, it improves the existing Docker dev flow so the documented stack is easier to start, faster to restart, and more explicit when the frontend contract artifacts are stale.

## Implementation approach

The main design choice was to treat the issue as a workflow-audit problem before changing code. Rather than implementing every remediation idea from the issue text, I reconciled each claim against the live repo. That showed that several items were already covered elsewhere or would require a significantly larger rollout than this issue justified. With that audit in hand, I narrowed the implementation to the Docker dev path that contributors are already instructed to use when they want source-mounted backend reload plus Vite HMR.

From there, the changes followed a simple principle: reuse the current workflow, but remove the expensive and opaque parts. The Docker UI container should continue to install dependencies when they are actually needed, but it should not pay that cost on every restart. The same startup path should also check frontend contract freshness before launching the dev server so the failure shows up immediately instead of later in CI or another command. Finally, the stack should expose a `make dev` entrypoint and a real UI healthcheck so the workflow is easier to discover and reason about.

## Main code changes

### 1. Added a canonical `make dev` entrypoint

`Makefile` now exposes `make dev`, which wraps the existing `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build` command. It standardizes the existing Docker flow behind a short, discoverable command that matches the issue’s request for a single development start command.

This target is intentionally scoped to the existing Docker dev workflow rather than trying to orchestrate a separate native multi-process setup. It makes the Docker hot-reload path the obvious one-command entrypoint.

### 2. Replaced unconditional Docker UI `npm ci` with a guarded startup script

The key runtime fix is a new `apps/ui/dev-docker.sh` helper, wired through `package.json` as `npm run dev:docker`. This script reuses the existing `.npm-ci-lock.sha256` convention and now drives the Docker UI service startup.

The script computes a SHA-256 hash of `package-lock.json`, compares it with `.npm-ci-lock.sha256`, and only runs `npm ci` when either `node_modules` is missing or the checked-in lockfile changed. After a successful install, it updates `.npm-ci-lock.sha256` to the current hash. This preserves correct behavior on the first run and on dependency changes while removing the repeated install penalty on ordinary restarts.

I also made the hash command portable between environments that provide `sha256sum` and those that provide `shasum`, which keeps the helper usable outside the exact container image if needed.

### 3. Fail fast on stale frontend contracts before launching Vite

The same guarded startup path now runs `npm run check:contracts` before `npm run dev`. If the generated UI contract artifacts are stale, the script exits immediately with a clear message telling the developer how to refresh them before restarting the dev stack.

This is intentionally a check, not an auto-regeneration step. Auto-writing generated artifacts during container startup would make the working tree change as a side effect of booting the dev environment. Failing fast keeps the workflow explicit and makes the underlying contract drift visible right away.

### 4. Added a UI healthcheck to the Docker dev compose overlay

`docker-compose.dev.yml` now routes the UI service through `npm run dev:docker` and adds a Node-based healthcheck that probes `http://127.0.0.1:5173/`. The healthcheck uses a generous `start_period` so first-run installs do not get marked unhealthy while the initial dependency bootstrap is still in progress.

This keeps the compose overlay honest about UI readiness without changing the backend service shape or the documented host/port behavior.

### 5. Updated contributor-facing documentation

The workflow documentation now matches the live behavior:

- `README.md` switches the Docker dev example to `make dev` and explains the guarded UI startup behavior.
- `CONTRIBUTING.md` points Docker-based contributors to `make dev` and adds it to the convenience command table.
- `apps/ui/README.md` documents `npm run dev:docker` and clarifies that the Docker UI startup reuses cached dependencies and checks contract freshness before launching Vite.

## Tests and validation

I added focused regression coverage in `apps/server/tests/hygiene/test_dev_workflow.py`. The new tests cover the important workflow guarantees directly:

- `make dev` remains wired to the Docker dev compose stack.
- `docker-compose.dev.yml` uses the guarded UI startup script and declares the UI healthcheck.
- the guarded startup script runs `npm ci` and records the lock hash when `node_modules` is missing.
- it re-runs `npm ci` when the stored lock hash is stale.
- it skips `npm ci` when the lock hash is current.
- it fails fast on stale contracts before launching the dev server.

Local validation completed with the following commands:

- `pytest -q apps/server/tests/hygiene/test_dev_workflow.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ui_vite_server_contract.py apps/server/tests/hygiene/test_docker_ci_hygiene.py`
- `cd apps/ui && npm run check:contracts && npm run typecheck && npm run build`
- `make lint`
- `make test-changed`

All of those passed locally.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is intentional scope control. I did not add a new watchfiles-based backend lint/typecheck loop, per-feature `make test-*` targets, or another dependency-bootstrap alias such as `make deps`. Those either were already materially covered by existing commands/docs or would require a broader toolchain decision than this issue’s live defect surface warranted.

This PR also does not attempt to auto-fix stale contract artifacts during Docker startup. That was a conscious choice to avoid hidden file mutations and to keep the developer-facing failure mode explicit.

The new healthcheck relies on Node’s built-in runtime rather than extra packages, and the guarded UI startup still runs `npm ci` whenever the lockfile hash changes. In short: this PR keeps the current Docker dev workflow, but makes it discoverable, cheaper to restart, and more transparent when the frontend workspace is out of date.
