### PR TITLE
Harden boundary-condition handling

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -119,6 +119,22 @@ def test_buffer_store_does_not_regress_last_t0_us_for_older_frame() -> None:
         assert buf.samples_since_t0 == 6
 
 
+def test_buffer_store_warns_and_truncates_oversized_ingest(caplog) -> None:
+    store = SignalBufferStore(_config(sample_rate_hz=4, waveform_seconds=1))
+    client_id = "client-oversized"
+    samples = np.arange(18, dtype=np.float32).reshape(6, 3)
+
+    with caplog.at_level("WARNING", logger="vibesensor.infra.processing.buffer_store"):
+        store.ingest(client_id, samples, sample_rate_hz=4)
+
+    assert "exceeds buffer capacity 4" in caplog.text
+    assert "discarding 2 oldest samples" in caplog.text
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        latest = store.copy_latest(buf, 4).T
+    np.testing.assert_array_equal(latest, samples[-4:])
+
+
 def test_fft_params_uses_lru_eviction(monkeypatch) -> None:
     monkeypatch.setattr("vibesensor.infra.processing.compute._FFT_CACHE_MAXSIZE", 2)
     computer = SignalMetricsComputer(_config(fft_n=8, sample_rate_hz=200, spectrum_max_hz=90.0))

--- a/apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py
+++ b/apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py
@@ -337,3 +337,39 @@ class TestPhaseSummaryPhaseTypeSegments:
     def test_empty_segments(self) -> None:
         summary = phase_summary([])
         assert summary.phase_type_summaries == ()
+
+    def test_zero_duration_segment_stays_safe(self) -> None:
+        summary = phase_summary(
+            [
+                PhaseSegment(
+                    phase=DrivingPhase.CRUISE,
+                    start_idx=0,
+                    end_idx=0,
+                    start_t_s=5.0,
+                    end_t_s=5.0,
+                    sample_count=1,
+                )
+            ]
+        )
+
+        cruise = summary.phase_type_summaries[0]
+        assert cruise.duration_s == 0.0
+        assert cruise.fraction == pytest.approx(1.0)
+
+    def test_descending_segment_time_clamps_duration_to_zero(self) -> None:
+        summary = phase_summary(
+            [
+                PhaseSegment(
+                    phase=DrivingPhase.DECELERATION,
+                    start_idx=0,
+                    end_idx=9,
+                    start_t_s=8.0,
+                    end_t_s=6.0,
+                    sample_count=10,
+                )
+            ]
+        )
+
+        decel = summary.phase_type_summaries[0]
+        assert decel.duration_s == 0.0
+        assert decel.fraction == pytest.approx(1.0)

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -102,7 +102,15 @@ class SignalBufferStore:
 
             n = int(chunk.shape[0])
             capacity = buf.capacity
-            if n >= capacity:
+            if n > capacity:
+                dropped = n - capacity
+                LOGGER.warning(
+                    "Sample chunk for %s exceeds buffer capacity %d; discarding %d oldest samples "
+                    "from the incoming batch",
+                    client_id,
+                    capacity,
+                    dropped,
+                )
                 chunk = chunk[-capacity:]
                 n = capacity
 

--- a/apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py
@@ -105,6 +105,12 @@ def _estimate_speed_derivative(
     return None
 
 
+def _segment_duration_s(segment: PhaseSegment) -> float:
+    if not (math.isfinite(segment.start_t_s) and math.isfinite(segment.end_t_s)):
+        return 0.0
+    return max(0.0, segment.end_t_s - segment.start_t_s)
+
+
 def classify_sample_phase(
     speed_kmh: float | None,
     speed_deriv_kmh_s: float | None,
@@ -240,8 +246,9 @@ def segment_run_phases(
         seg_end = i - 1
         seg_speeds = [s for s in speeds[seg_start : seg_end + 1] if s is not None]
         seg_times = [t for t in times[seg_start : seg_end + 1] if t is not None]
-        # When no time values are available in this segment, estimate from
-        # neighboring segments or fall back to the sample index.
+        # When no time values are available in this segment, preserve
+        # continuity only if the previous segment had a finite end timestamp;
+        # otherwise leave the time bounds unknown.
         if seg_times:
             start_t = min(seg_times)
             end_t = max(seg_times)
@@ -279,9 +286,7 @@ def phase_summary(segments: list[PhaseSegment]) -> DrivingPhaseSummary:
         key = seg.phase.value
         phase_counts[key] = phase_counts.get(key, 0) + seg.sample_count
         total += seg.sample_count
-        # Accumulate duration
-        has_times = math.isfinite(seg.end_t_s) and math.isfinite(seg.start_t_s)
-        dur = (seg.end_t_s - seg.start_t_s) if has_times else 0.0
+        dur = _segment_duration_s(seg)
         phase_durations[key] = phase_durations.get(key, 0.0) + dur
         # Track speed range
         if seg.speed_min_kmh is not None:


### PR DESCRIPTION
Closes #1296

## Summary

This PR fixes the narrow set of boundary-condition defects from issue `#1296` that are still real on current `main`, without broadening into protocol or architecture churn that the live code no longer needs.

The issue body grouped together several concerns: firmware counter overflow, zero-length phases, unclamped interpolation, clock drift, and silent data loss. After auditing the current firmware, UDP protocol, runtime registry, phase segmentation, time-alignment code, and their matching tests, most of that issue text turned out to be stale. The firmware DATA sequence counter is already 32-bit rather than 16-bit, the backend already uses modular arithmetic when tracking DATA gaps, the current speed-profile logic does not use an extrapolating `numpy.interp` path, and clock drift is already handled through the existing `CMD_SYNC_CLOCK` flow with time-alignment coverage. The live defects were narrower and more concrete:

1. `SignalBufferStore.ingest()` silently truncated oversized incoming sample batches down to the per-client circular-buffer capacity without any operator-visible warning, which made one real data-loss path easy to miss during debugging.
2. `phase_summary()` relied on implicit behavior when phase segments had degenerate or malformed time bounds. It did not currently explode on zero-length segments, but it also did not explicitly clamp negative or otherwise invalid durations before accumulating per-phase summaries.

This change addresses those two verified problems directly.

## Implementation approach

The goal here was to keep the fix set surgical and evidence-based. Instead of trying to “solve” every claim in the original issue body, I reconciled the issue against the current repository state and limited the code changes to the defects that were still reproducible.

For the buffer path, I stayed inside the existing `SignalBufferStore` implementation rather than adding a parallel metrics channel or changing the circular-buffer semantics. The buffer still keeps the newest samples, which is the right default for a live rolling window. The missing behavior was visibility, not storage strategy. The fix therefore adds a targeted warning at the moment an oversized batch exceeds buffer capacity and the oldest samples from that batch must be discarded. This preserves the existing runtime behavior while making that truncation explicit in logs.

For phase summarization, I avoided changing phase classification or segment construction rules more broadly. Instead, the change introduces an explicit helper that computes a non-negative segment duration: non-finite bounds contribute zero seconds, and descending timestamps are clamped to zero rather than leaking a negative duration into the aggregate summary.

## Main code changes by area

### `apps/server/vibesensor/infra/processing/buffer_store.py`

`SignalBufferStore.ingest()` now distinguishes between a batch that exactly fills the buffer and a batch that actually exceeds it. When the incoming chunk is larger than the client buffer capacity, the store logs a warning that includes the client id, the buffer capacity, and how many oldest samples from the incoming batch were discarded before continuing with the existing “keep the newest samples” behavior.

This is intentionally a visibility fix, not a semantics change. The circular buffer still ends up containing the most recent capacity-sized window.

### `apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py`

This file now contains a small helper for segment duration calculation, and `phase_summary()` uses that helper instead of directly subtracting timestamps inline. The helper treats non-finite start/end values as zero duration and clamps negative durations to zero.

I also tightened the nearby explanatory comment around segment time-bound fallback so the code better reflects the intended handling for missing timestamps.

### `apps/server/tests/infra/processing/test_processing_components.py`

Added a focused regression that ingests a sample batch larger than the configured buffer capacity, asserts that the warning is emitted, and verifies that the stored data still contains the newest samples.

### `apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py`

Added focused regressions for two degenerate cases:

- a zero-duration segment where `start_t_s == end_t_s`
- a malformed segment where `end_t_s < start_t_s`

Both cases now assert that the summarized phase duration is `0.0` while the sample-count-based fraction behavior remains stable. These tests make the new explicit duration-clamping rule part of the contract instead of leaving it as an incidental consequence of the current implementation.

## Schema, config, and documentation impact

There are no schema changes, contract changes, config changes, or user-facing documentation changes in this PR. That is intentional: the audit showed this issue was about tightening two backend edge cases in place, not introducing a protocol migration or broader workflow change.

## Validation performed

Focused validation:

- `pytest -q apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py apps/server/tests/infra/processing/test_time_alignment.py`

Broader repository validation:

- `make lint`
- `make typecheck-backend`
- `make test-changed`

`make test-changed` exercised the affected backend areas more broadly and completed green with the changed-file suite. Docker-backed runtime validation was not run in this environment because the Docker daemon/socket is unavailable here.

## Risks, tradeoffs, and edge cases considered

The biggest review risk here was scope creep. Because the issue body was written as a broad “boundary conditions” sweep, it would have been easy to mix in speculative changes to sequence-wrap handling, speed interpolation, or timestamp synchronization. I deliberately did not do that.

Another design tradeoff was whether to add new metrics for buffer truncation instead of just logging it. I chose not to expand the telemetry surface in this PR because the confirmed defect was silent truncation, not a total absence of queue/drop observability across the system. Existing queue-drop reporting already covers other data-loss paths. A warning on the buffer-truncation path solves the real debugging gap with much lower risk.

For phase durations, the main edge case is malformed input data rather than ordinary runs. Clamping invalid durations to zero is the safest behavior because it prevents negative totals while preserving the sample counts and phase presence needed by downstream diagnostics.

## Out of scope / follow-ups

The following issue-body claims were intentionally left untouched because the audit showed they are stale or already handled on current `main`:

- 16-bit sequence overflow in firmware DATA counters
- missing modular arithmetic for dropped-frame tracking
- unclamped extrapolating speed interpolation
- missing clock-drift correction

If future evidence shows a separate problem in those areas, it should be handled as a fresh, targeted issue rather than folded into this narrowly validated fix.
