### PR TITLE
Surface buffer overflow drops in health

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -309,6 +309,7 @@ class FakeState:
                     "last_compute_all_duration_s": 0.0,
                     "last_ingest_duration_s": 0.0,
                 },
+                "buffer_overflow_drops": lambda self: 0,
             },
         )()
         from vibesensor.infra.runtime import ProcessingLoopState

--- a/apps/server/tests/adapters/http/test_health_endpoint.py
+++ b/apps/server/tests/adapters/http/test_health_endpoint.py
@@ -54,6 +54,7 @@ async def test_health_endpoint_response_shape(_health_router):
     assert result["frame_size_mismatch_count"] == 0
     assert result["degradation_reasons"] == []
     assert result["data_loss"]["tracked_clients"] == 0
+    assert result["data_loss"]["buffer_overflow_drops"] == 0
     assert result["persistence"]["write_error"] is None
     assert result["persistence"]["analysis_in_progress"] is False
     assert result["persistence"]["analysis_queue_depth"] == 0
@@ -141,6 +142,21 @@ async def test_health_endpoint_degrades_for_db_corruption(_health_router):
     assert result["status"] == "degraded"
     assert result["db_corruption_detected"] is True
     assert "db_corruption_detected" in result["degradation_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_warns_for_buffer_overflow_drops(_health_router):
+    router, state = _health_router
+    endpoint = _find_endpoint(router, "/api/health")
+    assert endpoint is not None
+
+    state.processor.buffer_overflow_drops.return_value = 4
+
+    result = response_payload(await endpoint())
+
+    assert result["status"] == "warn"
+    assert result["data_loss"]["buffer_overflow_drops"] == 4
+    assert "buffer_overflow_drops" in result["degradation_reasons"]
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -94,6 +94,7 @@ def _processor_mock() -> SignalProcessor:
         "last_compute_all_duration_s": 0.0,
         "last_ingest_duration_s": 0.0,
     }
+    processor.buffer_overflow_drops.return_value = 0
     processor.all_latest_metrics.return_value = {}
     processor.debug_spectrum.return_value = {
         "error": "insufficient samples",

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -129,6 +129,7 @@ def test_buffer_store_warns_and_truncates_oversized_ingest(caplog) -> None:
 
     assert "exceeds buffer capacity 4" in caplog.text
     assert "discarding 2 oldest samples" in caplog.text
+    assert store.buffer_overflow_drops() == 2
     with store.locked_client_buffer(client_id) as buf:
         assert buf is not None
         latest = store.copy_latest(buf, 4).T

--- a/apps/server/tests/use_cases/test_system_health.py
+++ b/apps/server/tests/use_cases/test_system_health.py
@@ -13,6 +13,7 @@ from vibesensor.shared.types.payload_types import IntakeStatsPayload, WorkerPool
 def _clean_data_loss() -> dict:
     return {
         "frames_dropped": 0,
+        "buffer_overflow_drops": 0,
         "queue_overflow_drops": 0,
         "server_queue_drops": 0,
         "parse_errors": 0,
@@ -75,6 +76,7 @@ def _make_deps(
 def _make_processor(*, intake_stats: IntakeStatsPayload | None = None) -> MagicMock:
     proc = MagicMock()
     proc.intake_stats.return_value = intake_stats or _clean_intake_stats()
+    proc.buffer_overflow_drops.return_value = 0
     return proc
 
 
@@ -274,6 +276,22 @@ class TestBuildSystemHealthSnapshotWarn:
 
         assert result["status"] == "warn"
         assert "frames_dropped" in result["degradation_reasons"]
+
+    def test_buffer_overflow_drops_add_reason(self) -> None:
+        loop_state = ProcessingLoopState()
+        health_state = RuntimeHealthState()
+        health_state.mark_ready()
+        registry, run_recorder = _make_deps()
+        processor = _make_processor()
+        processor.buffer_overflow_drops.return_value = 3
+
+        result = build_system_health_snapshot(
+            loop_state, health_state, processor, registry, run_recorder
+        )
+
+        assert result["status"] == "warn"
+        assert result["data_loss"]["buffer_overflow_drops"] == 3
+        assert "buffer_overflow_drops" in result["degradation_reasons"]
 
     def test_sample_rate_mismatch_adds_reason(self) -> None:
         loop_state = ProcessingLoopState(sample_rate_mismatch_logged={"client_a"})

--- a/apps/server/vibesensor/adapters/http/models/health.py
+++ b/apps/server/vibesensor/adapters/http/models/health.py
@@ -13,6 +13,7 @@ class HealthDataLossResponse(BaseModel):
     tracked_clients: int
     affected_clients: int
     frames_dropped: int
+    buffer_overflow_drops: int
     queue_overflow_drops: int
     server_queue_drops: int
     parse_errors: int

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -79,6 +79,7 @@ class SignalBufferStore:
             return
 
         ingested_samples = 0
+        dropped_samples = 0
         with self.locked_client_buffer(client_id, create=True) as buf:
             assert buf is not None
             chunk: FloatArray = np.asarray(samples, dtype=np.float32)
@@ -103,13 +104,13 @@ class SignalBufferStore:
             n = int(chunk.shape[0])
             capacity = buf.capacity
             if n > capacity:
-                dropped = n - capacity
+                dropped_samples = n - capacity
                 LOGGER.warning(
                     "Sample chunk for %s exceeds buffer capacity %d; discarding %d oldest samples "
                     "from the incoming batch",
                     client_id,
                     capacity,
-                    dropped,
+                    dropped_samples,
                 )
                 chunk = chunk[-capacity:]
                 n = capacity
@@ -138,6 +139,7 @@ class SignalBufferStore:
             ingested_samples = n
         with self.lock:
             self.stats.total_ingested_samples += ingested_samples
+            self.stats.buffer_overflow_drops += dropped_samples
             self.stats.last_ingest_duration_s = clock() - t_start
 
     def snapshot_for_compute(
@@ -331,6 +333,10 @@ class SignalBufferStore:
                 "last_compute_all_duration_s": self.stats.last_compute_all_duration_s,
                 "last_ingest_duration_s": self.stats.last_ingest_duration_s,
             }
+
+    def buffer_overflow_drops(self) -> int:
+        with self.lock:
+            return self.stats.buffer_overflow_drops
 
     def _get_or_create_unlocked(self, client_id: str) -> ClientBuffer:
         buf = self.buffers.get(client_id)

--- a/apps/server/vibesensor/infra/processing/models.py
+++ b/apps/server/vibesensor/infra/processing/models.py
@@ -53,6 +53,7 @@ class ProcessorStats:
     """Mutable observability counters owned by the buffer store."""
 
     total_ingested_samples: int = 0
+    buffer_overflow_drops: int = 0
     total_compute_calls: int = 0
     last_compute_duration_s: float = 0.0
     last_compute_all_duration_s: float = 0.0

--- a/apps/server/vibesensor/infra/processing/processor.py
+++ b/apps/server/vibesensor/infra/processing/processor.py
@@ -211,6 +211,9 @@ class SignalProcessor:
         worker_pool_stats = self._worker_pool.stats() if self._worker_pool is not None else None
         return build_intake_stats_payload(self._store.intake_stats(), worker_pool_stats)
 
+    def buffer_overflow_drops(self) -> int:
+        return self._store.buffer_overflow_drops()
+
     def time_alignment_info(self, client_ids: list[str]) -> TimeAlignmentPayload:
         with self._store.locked_client_buffers(client_ids) as buffers:
             return build_time_alignment_payload(

--- a/apps/server/vibesensor/infra/runtime/health_snapshot.py
+++ b/apps/server/vibesensor/infra/runtime/health_snapshot.py
@@ -17,6 +17,8 @@ class IntakeStatsProvider(Protocol):
 
     def intake_stats(self) -> IntakeStatsPayload: ...
 
+    def buffer_overflow_drops(self) -> int: ...
+
 
 class DataLossSnapshotProvider(Protocol):
     """Collaborator that exposes data-loss counters."""
@@ -49,7 +51,8 @@ def build_system_health_snapshot(
         return value if value is not None else 0.0
 
     failures = loop_state.processing_failure_count
-    data_loss = registry.data_loss_snapshot()
+    data_loss = dict(registry.data_loss_snapshot())
+    data_loss["buffer_overflow_drops"] = int(processor.buffer_overflow_drops())
     persistence = run_recorder.health_snapshot()
     failure_categories = dict(loop_state.processing_failure_categories)
     sample_rate_mismatch_count = len(loop_state.sample_rate_mismatch_logged)
@@ -83,6 +86,7 @@ def build_system_health_snapshot(
         degradation_reasons.append("frame_size_mismatch")
     for key in (
         "frames_dropped",
+        "buffer_overflow_drops",
         "queue_overflow_drops",
         "server_queue_drops",
         "parse_errors",

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -2837,6 +2837,10 @@
             "title": "Affected Clients",
             "type": "integer"
           },
+          "buffer_overflow_drops": {
+            "title": "Buffer Overflow Drops",
+            "type": "integer"
+          },
           "frames_dropped": {
             "title": "Frames Dropped",
             "type": "integer"
@@ -2862,6 +2866,7 @@
           "tracked_clients",
           "affected_clients",
           "frames_dropped",
+          "buffer_overflow_drops",
           "queue_overflow_drops",
           "server_queue_drops",
           "parse_errors"

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -1165,6 +1165,8 @@ export interface components {
     HealthDataLossResponse: {
       /** Affected Clients */
       affected_clients: number;
+      /** Buffer Overflow Drops */
+      buffer_overflow_drops: number;
       /** Frames Dropped */
       frames_dropped: number;
       /** Parse Errors */


### PR DESCRIPTION
Closes #1297

## Summary

This PR fixes the narrow queue-management defect from issue `#1297` that is still real on current `main`: oversized sample batches truncated inside the processing buffer were visible in logs but not surfaced through the runtime health data-loss snapshot.

The original issue body described a broader set of problems: unbounded queues, stride mismatch between UDP chunks and FFT windows, registry memory growth, and missing backpressure. After auditing the current runtime path end to end, most of that narrative no longer matches the live code. The UDP ingest queue is already explicitly bounded, queue-full drops are already counted, stale registry and buffer state are already evicted, and the processor intentionally decouples variable UDP frame sizes from fixed FFT windows through a circular buffer. The one remaining observability gap was narrower: when `SignalBufferStore.ingest()` had to discard oldest samples from an oversized incoming batch, the operator only got a warning log line.

This change closes that observability gap without broadening into a speculative queueing or pipeline redesign.

## Problem being solved

Issue `#1297` is fundamentally about data-flow resilience under imperfect runtime conditions. On current `main`, the runtime already handled several of the issue’s originally claimed failure modes:

- `DataDatagramProtocol` uses a bounded `asyncio.Queue(maxsize=...)` for UDP ingest and records `server_queue_drops` when that queue fills.
- The registry and processing buffer store both evict stale client state rather than holding onto old references forever.
- The mismatch between variable UDP frame sizes and fixed FFT windows is an intentional design choice built around a rolling circular buffer, not an accidental misalignment bug.

That left one real loss path with weaker visibility than the rest of the system. In `SignalBufferStore.ingest()`, if a single incoming batch exceeded the circular-buffer capacity, the store intentionally kept the newest samples and discarded the oldest ones from that batch. After issue `#1296`, that path already emitted a warning log. What it still did not do was increment any runtime counter that the health endpoint could surface. As a result, operators could miss real processing-buffer loss unless they were actively inspecting logs.

The fix in this PR makes that drop path visible in the same runtime health surface that already reports firmware queue overflows, server queue drops, frame loss, and parse errors.

## Implementation approach

I kept the change set deliberately small and aligned with existing ownership boundaries.

The processing-buffer truncation happens inside `SignalBufferStore`, not inside `ClientRegistry`, so I did not push a new callback or dependency from processing back into runtime registry code. Instead, the store now maintains a dedicated `buffer_overflow_drops` counter in its existing mutable `ProcessorStats`, the `SignalProcessor` facade exposes that total through a narrow accessor, and the health snapshot builder merges the value into the health `data_loss` payload.

That approach keeps responsibility where it belongs:

- processing owns processing-buffer overflow accounting
- the health builder owns combining runtime collaborators into the HTTP-facing health snapshot
- the HTTP response model owns the public schema

This avoids a more invasive redesign while still making the loss path observable.

## Main code changes by area

### Processing stats and buffer store

`apps/server/vibesensor/infra/processing/models.py` now adds `buffer_overflow_drops` to `ProcessorStats`.

`apps/server/vibesensor/infra/processing/buffer_store.py` now accumulates the exact number of samples discarded when an incoming chunk exceeds the per-client buffer capacity. The existing log warning remains in place, but the drop count is now recorded as well. The store also exposes a small accessor so higher layers can query the total safely.

### Processor facade

`apps/server/vibesensor/infra/processing/processor.py` now exposes `buffer_overflow_drops()` as a thin delegate to the store. This keeps the existing facade pattern intact and avoids leaking store internals into runtime health code.

### Runtime health snapshot

`apps/server/vibesensor/infra/runtime/health_snapshot.py` now merges the processing-owned overflow count into the existing `data_loss` payload returned by the health builder. It also adds `buffer_overflow_drops` to the degradation-reason scan so the overall health status becomes `warn` when that counter is non-zero, just like other already-surfaced loss indicators.

### HTTP model and generated contracts

`apps/server/vibesensor/adapters/http/models/health.py` now includes `buffer_overflow_drops` in `HealthDataLossResponse`.

Because this changes the public health response schema, I regenerated:

- `apps/ui/src/contracts/http_api_schema.json`
- `apps/ui/src/generated/http_api_contracts.ts`

No frontend behavior changes were needed, but the generated HTTP contract had to stay in sync with the updated backend response model.

### Tests and shared test doubles

Focused coverage was added or updated in:

- `apps/server/tests/infra/processing/test_processing_components.py`
- `apps/server/tests/use_cases/test_system_health.py`
- `apps/server/tests/adapters/http/test_health_endpoint.py`
- `apps/server/tests/conftest.py`
- `apps/server/tests/adapters/http/_history_endpoint_helpers.py`

The new tests verify both halves of the change: oversized ingest truncation increments the new counter, and the health snapshot plus `/api/health` surface that counter with the matching degradation reason.

## Contract, schema, and documentation impact

This PR changes the HTTP health response shape by adding `data_loss.buffer_overflow_drops`.

That is an intentional API contract change, but it is small and additive. No request shapes changed, no stored schema changed, and no documentation changes were required beyond regenerating the exported HTTP contract used by the UI toolchain.

## Validation performed

Focused validation:

- `pytest -q apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/use_cases/test_system_health.py apps/server/tests/adapters/http/test_health_endpoint.py`

Schema / generated artifact validation:

- `python -m vibesensor.cli.http_api_schema_export`
- `cd apps/ui && npm run sync:contracts`

Broader validation:

- `make lint`
- `make typecheck-backend`
- `make test-changed`

`make test-changed` also re-ran UI contract checking, UI lint/typecheck, and the changed-file pytest sweep. Docker-backed runtime validation was not run in this environment because the Docker daemon/socket is unavailable here, but the touched code paths are backend/runtime and health-contract surfaces that were fully exercised by the focused and broader non-Docker gates above.

## Risks, tradeoffs, and edge cases considered

The main risk was overfitting the implementation to the issue body instead of the current codebase. A literal implementation of the issue text could have led to unnecessary queue rewrites, registry lifecycle changes, or FFT/packet “alignment” work that the current architecture no longer needs.

Another tradeoff was where to store the new counter. Threading it into `ClientRegistry` would have mixed processing-layer ownership into runtime registry code. Exposing it through processor-owned stats and merging it in the health builder kept the layering cleaner.

The counter tracks the number of dropped samples, not just the number of overflow events. That gives a more useful measure of actual loss severity when a single oversized batch exceeds buffer capacity by a large margin.

## Out of scope

The following issue-body claims were intentionally not implemented because the audit showed they are stale or already handled on current `main`:

- unbounded UDP ingest queues
- registry reference leakage from stale clients
- variable packet size versus FFT window size as an unhandled bug
- a broader producer/consumer redesign or adaptive backpressure system

If later evidence shows a separate runtime bottleneck or memory-growth problem, it should be handled as a fresh targeted issue rather than folded into this now-validated observability fix.
