### PR TITLE
Codify architecture guardrails

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -22,6 +22,41 @@ See [docs/ai/repo-map.md#backend-package-layout](../../docs/ai/repo-map.md#backe
 for the detailed backend ownership map. This README stays focused on
 backend-specific setup, configuration, routes, updates, and testing.
 
+## State and configuration scopes
+
+Several issue reports have described the backend as one pool of global mutable
+state. Current `main` is intentionally split more narrowly:
+
+- `AppConfig` in `vibesensor.app.config_schema` owns deployment/process
+  configuration loaded at startup, such as network bindings, retention windows,
+  processing budgets, and update paths.
+- `SettingsStore` owns persisted user-facing runtime settings, such as car
+  profiles, speed-source preferences, language, units, and sensor placement.
+- Run lifecycle helpers (`RunLifecycleState`, `RunRecorder`,
+  `PostAnalysisWorker`) own live per-process coordination and per-run state.
+- `HistoryDB` is shared storage for settings snapshots and run history, but the
+  live recording path and post-analysis/report path remain separate phases with
+  different owners.
+
+That separation is deliberate: deployment config, mutable user settings, and
+run-attached snapshots are related, but they are not interchangeable sources of
+truth.
+
+## Startup sequencing
+
+Backend startup is explicit rather than ambient:
+
+1. `vibesensor.app.bootstrap` resolves config and builds the runtime/container.
+2. `LifecycleManager.start()` runs lightweight startup validation, opens the UDP
+   receiver, starts the control plane, and then launches the supervised
+   processing, WebSocket, metrics, GPS, and update-recovery tasks in a declared
+   order.
+3. The runtime is only marked ready after those startup phases succeed.
+
+See `apps/server/vibesensor/infra/runtime/lifecycle.py` and
+`apps/server/tests/infra/runtime/test_runtime.py` for the executable phase
+contract.
+
 ## Important directories
 
 ```text
@@ -70,6 +105,11 @@ Configuration is YAML-based. Runtime defaults live in `vibesensor/app/config_def
 Use [docs/configuration_reference.md](../../docs/configuration_reference.md) for
 the key-by-key operator reference across the `ap`, `server`, `udp`,
 `processing`, `logging`, `gps`, and `update` sections.
+
+Those YAML files cover deployment/process settings. User-facing runtime
+preferences are stored separately through `SettingsStore` snapshots in
+`history.db`, and completed runs persist immutable per-run snapshots for later
+analysis/reporting.
 
 For live sensor presence, `processing.client_live_ttl_seconds` controls how long
 `/api/clients` and `/ws` keep reporting `connected: true` after the last

--- a/apps/server/tests/hygiene/test_history_db_mixins.py
+++ b/apps/server/tests/hygiene/test_history_db_mixins.py
@@ -1,0 +1,48 @@
+"""Guardrails for the intentional ``HistoryDB`` mixin composition."""
+
+from __future__ import annotations
+
+from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db._queries import _HistoryDBQueryMixin
+from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
+from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
+
+
+def _public_method_names(cls: type[object]) -> set[str]:
+    return {
+        name
+        for name in cls.__dict__
+        if not name.startswith("_") and callable(getattr(cls, name, None))
+    }
+
+
+def test_history_db_mixins_expose_disjoint_public_methods() -> None:
+    mixins = (
+        _HistoryDBRunLifecycleMixin,
+        _HistoryDBSampleIOMixin,
+        _HistoryDBQueryMixin,
+    )
+    owners_by_name: dict[str, list[str]] = {}
+
+    for mixin in mixins:
+        for name in _public_method_names(mixin):
+            owners_by_name.setdefault(name, []).append(mixin.__name__)
+
+    overlaps = {name: owners for name, owners in owners_by_name.items() if len(owners) > 1}
+    assert overlaps == {}, f"HistoryDB mixins must keep disjoint public APIs: {overlaps}"
+
+
+def test_history_db_wrapper_owns_shared_cursor_contract() -> None:
+    history_db_members = set(HistoryDB.__dict__)
+
+    assert {"_cursor", "_cursor_connection"} <= history_db_members
+    assert "write_transaction_cursor" in history_db_members
+
+    assert "_cursor_connection" not in _HistoryDBRunLifecycleMixin.__dict__
+    assert "write_transaction_cursor" not in _HistoryDBSampleIOMixin.__dict__
+    assert "write_transaction_cursor" not in _HistoryDBQueryMixin.__dict__
+
+    for mixin in (_HistoryDBSampleIOMixin, _HistoryDBQueryMixin):
+        assert "_cursor_connection" not in mixin.__dict__, (
+            "sample/query mixins must rely on the wrapper-owned cursor-selection logic"
+        )

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -321,6 +321,62 @@ async def test_start_creates_tasks(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_follows_declared_startup_phase_order(monkeypatch) -> None:
+    import vibesensor.infra.runtime as runtime_module
+
+    observed_phases: list[str] = []
+
+    async def _fake_udp(*args, **kwargs):
+        return None, None
+
+    control_plane = MagicMock()
+    control_plane.start = AsyncMock()
+    ws_hub = MagicMock()
+    ws_hub.run = AsyncMock(side_effect=asyncio.CancelledError)
+    run_recorder = MagicMock()
+    run_recorder.run = AsyncMock(side_effect=asyncio.CancelledError)
+    gps_monitor = MagicMock()
+    gps_monitor.run = AsyncMock(side_effect=asyncio.CancelledError)
+    update_manager = MagicMock()
+    update_manager.startup_recover = AsyncMock()
+    update_manager.job_task = None
+
+    rt, lifecycle = _make_runtime(
+        control_plane=control_plane,
+        ws_hub=ws_hub,
+        run_recorder=run_recorder,
+        gps_monitor=gps_monitor,
+        update_manager=update_manager,
+    )
+    lifecycle._start_udp_receiver = _fake_udp
+
+    original_set_phase = runtime_module.RuntimeHealthState.set_phase
+
+    def _record_phase(self, phase: str) -> None:
+        observed_phases.append(phase)
+        original_set_phase(self, phase)
+
+    monkeypatch.setattr(runtime_module.RuntimeHealthState, "set_phase", _record_phase)
+
+    await lifecycle.start()
+
+    assert observed_phases == [
+        "starting",
+        "udp_receiver",
+        "control_plane",
+        "processing-loop",
+        "ws-broadcast",
+        "metrics-log",
+        "gps-speed",
+        "update-startup-recover",
+    ]
+    assert rt.health_state.startup_state == "ready"
+    assert rt.health_state.startup_phase == "ready"
+
+    await lifecycle.stop()
+
+
+@pytest.mark.asyncio
 async def test_start_records_background_task_failure(monkeypatch) -> None:
     import vibesensor.infra.runtime.lifecycle as lifecycle_module
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -41,7 +41,14 @@ _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION = 10
 
 
 class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDBQueryMixin):
-    """Thin wrapper around a SQLite database for run history."""
+    """Thin wrapper around a SQLite database for run history.
+
+    The mixins deliberately group non-overlapping public method families:
+    lifecycle writes, sample I/O, and read/query helpers. ``HistoryDB`` owns the
+    shared connection state plus the ``_cursor()`` / transaction hooks that each
+    mixin uses, so the class remains a small composition root rather than a
+    cross-calling diamond of partially overlapping base classes.
+    """
 
     def __init__(
         self,

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -8,6 +8,9 @@ Boundary note
 -------------
 Settings management spans two layers:
 
+- ``vibesensor.app.config_schema`` / ``AppConfig`` — deployment and process
+  configuration loaded at startup (network bindings, retention windows, update
+  paths, processing budgets).
 - ``settings_store.py`` (this module) — user-facing settings (cars, speed
   source, language, unit, sensors) persisted through a narrow snapshot
   persistence port. Also owns the in-memory analysis parameter cache
@@ -16,6 +19,9 @@ Settings management spans two layers:
 - concrete adapters such as ``history_db/`` implement
   ``get_settings_snapshot()`` / ``set_settings_snapshot()`` and persist
   settings as a single JSON blob.
+
+Per-run captures and history rows then store snapshots derived from those
+runtime settings; they are not a second mutable settings source.
 
 ``SettingsStore`` owns the semantic meaning of settings, delegates
 persistence to its injected snapshot-store collaborator, and is the canonical source for

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -88,6 +88,24 @@ The model uses explicit scope boundaries:
 details are known), and every `TestRun`, `RunCapture`, and `RunSetup` in that
 case is interpreted within that same car context when present.
 
+## Invariant enforcement
+
+Domain objects own invariant enforcement at construction/factory boundaries.
+Adapters, codecs, and settings stores may sanitize payloads, but they should
+feed domain objects rather than duplicating business rules in parallel.
+
+Current examples on `main`:
+
+- `Car` normalizes blank names to `Unnamed Car` and rebuilds its
+  `OrderReferenceSpec` / aspect state from sanitized settings input.
+- `SensorPlacement` rejects empty placement codes.
+- `Finding` rejects out-of-range confidence and cruise-fraction values plus
+  non-finite ranking scores.
+- `TestRun` requires `top_causes` to be drawn from `findings`.
+
+The backend therefore does not rely on one external boundary to keep objects
+valid; invariant ownership lives with the domain concepts that use those rules.
+
 ## Aggregate hierarchy
 
 The aggregate hierarchy is decisive:


### PR DESCRIPTION
Closes #1298

## Summary

This PR resolves #1298 by narrowing the issue to the parts that are still real on current `main` and then codifying those boundaries directly in docs and tests instead of doing a speculative architecture rewrite.

The original issue text describes a backend suffering from fragile MRO-heavy composition, missing domain invariants, one large pool of global mutable runtime state, and implicit startup/config coupling. After auditing the current codebase against the cited areas, that broad diagnosis no longer matches the live system closely enough to justify a large refactor in this issue-sized change. The remaining mixin usage is small and orthogonal, core domain invariants are already enforced in domain objects and existing tests, and the live recording path is already separated from post-analysis execution. What was still missing was explicit codification of those facts. The architecture had become more disciplined than the issue text suggests, but some of that discipline was still “tribal knowledge” rather than something the codebase clearly documents and guards.

## Problem being solved

The real problem on current `main` is not that the backend is still one uncontrolled architectural tangle. The real problem is that several intentional boundaries were not obvious enough to a reader, which made the stale issue description plausible and left a few important seams protected by convention more than by executable guardrails.

There were three concrete gaps worth fixing:

1. The distinction between deployment/process configuration, persisted user settings, and per-run snapshots was implemented but not explained clearly enough in the backend docs and settings ownership notes.
2. Domain invariants existed in the core model, but the domain-model reference did not explicitly say that invariant ownership lives with domain objects rather than with adapters or UI boundaries.
3. The lifecycle startup order and the remaining `HistoryDB` mixin composition were intentionally structured, but the codebase lacked focused regressions that make those contracts explicit.

## Chosen implementation approach

I kept the fix deliberately narrow. Instead of introducing new services, changing persistence formats, or refactoring runtime ownership boundaries, this PR documents the architecture that already exists and adds tests where the current design relied on implicit understanding.

## Main changes by area

### 1. Backend docs now explain the real state/config/runtime split

`apps/server/README.md` now has a dedicated section describing the current state and configuration scopes. It distinguishes:

- startup-loaded `AppConfig` process/deployment configuration,
- persisted user-facing settings owned by `SettingsStore`,
- live run coordination owned by runtime/run-lifecycle helpers, and
- shared persistence in `HistoryDB` without pretending the recording and post-analysis paths are the same thing.

The README also now documents backend startup sequencing explicitly. It states that startup resolves config and the runtime/container first, then `LifecycleManager.start()` executes startup validation, opens the UDP receiver, starts the control plane, launches the supervised background tasks in a declared order, and only then marks the runtime ready.

This addresses the “single-user/global-state” and “implicit startup/config coupling” portions of the issue with current, concrete architecture documentation instead of broad prose.

### 2. Settings ownership notes now separate config from settings from run snapshots

The module-level boundary note in `apps/server/vibesensor/infra/config/settings_store.py` now explicitly distinguishes startup `AppConfig` from `SettingsStore` data and clarifies that per-run captures/history rows store snapshots derived from runtime settings rather than acting as a second mutable settings source.

This is intentionally small, but it matters because `SettingsStore` is exactly where the issue text makes the broader architecture sound more coupled than it really is. The updated docstring makes the current layering visible at the code seam where future maintainers are most likely to look first.

### 3. The domain-model reference now states where invariants belong

`docs/domain-model.md` now includes an “Invariant enforcement” section. It explicitly states that domain objects own invariant enforcement at their construction/factory boundaries and that adapters/codecs/settings layers should feed those objects rather than recreating business rules in parallel.

The section also points at concrete live examples already present on `main`, including `Car` normalization, `SensorPlacement` code validation, `Finding` numeric guards, and `TestRun` top-cause consistency rules. That closes the documentation gap behind the “missing invariants” part of the issue without duplicating logic or adding redundant runtime checks where the model already enforces them.

### 4. `HistoryDB` mixin composition is now documented and regression-guarded

The public `HistoryDB` wrapper docstring now explains the intent behind the remaining mixin composition: the mixins group non-overlapping public method families, while the wrapper owns the shared connection state and cursor/transaction hooks.

To make that more than a comment, this PR adds `apps/server/tests/hygiene/test_history_db_mixins.py`. The new hygiene coverage verifies that the `HistoryDB` mixins keep disjoint public APIs and that the wrapper retains ownership of the concrete cursor-selection and transaction machinery. In practice, that turns the “this MRO is safe because the mixins are orthogonal” claim into an executable contract.

### 5. Startup ordering is now locked in with a focused runtime regression

`apps/server/tests/infra/runtime/test_runtime.py` now includes a regression that records the health-state startup phases during `LifecycleManager.start()` and asserts the declared order:

`starting -> udp_receiver -> control_plane -> processing-loop -> ws-broadcast -> metrics-log -> gps-speed -> update-startup-recover`

This makes the startup contract explicit in tests instead of leaving it as something that only exists by reading the implementation.

## Schema, contract, and behavior impact

There are no HTTP, WebSocket, persistence, or user-facing behavior changes in this PR. No payload shapes changed. No migrations were required. No runtime ownership was refactored. This was intentionally a codification-and-guardrails change.

## Validation

I validated this change in layers:

- Focused pytest:
  - `pytest -q apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/hygiene/test_history_db_mixins.py`
- Broader architecture-adjacent pytest:
  - `pytest -q apps/server/tests/infra/runtime/test_lifecycle.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/app/test_config_validation.py apps/server/tests/domain/test_aggregate_invariants.py apps/server/tests/domain/test_car_domain.py apps/server/tests/domain/test_configuration_and_sensor_value_objects.py apps/server/tests/hygiene/test_history_db_mixins.py`
- Standard repo gates:
  - `make lint`
  - `make typecheck-backend`
  - `make docs-lint`
  - `make test-changed`

All of the above completed successfully on the final diff.

## Risks, tradeoffs, and follow-ups

The main tradeoff here is deliberate restraint. I did not use #1298 as a reason to perform a large architectural split of `SettingsStore` or to rewrite runtime composition that is already stable in production behavior. That would have been hard to justify against the audited current state and would have mixed genuine follow-up refactors with stale issue framing.

The upside is that this PR is small, reviewable, and directly tied to the live defects: missing codification and missing guardrails. The likely follow-up work, if still desired, belongs in narrower issues that propose concrete structural changes from the current baseline rather than assuming the older broad diagnosis still fully applies. During backlog reconciliation, a new follow-up issue (`#1331`) was opened specifically about splitting `SettingsStore` responsibilities; that is a better vehicle for any deeper refactor than overloading this PR.
