### PR TITLE
Clean up runtime naming and WS logs

### DIFF
--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -321,6 +321,10 @@ async def test_payload_error_affected_count_logged(caplog) -> None:
 
     # Summary log mentions 2 affected connections
     assert any("2 connection(s)" in r.message for r in caplog.records)
+    assert any(
+        "WebSocket payload build failed for 1 client id(s) ('bad')" in r.message
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/hygiene/test_domain_model_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_model_guardrails.py
@@ -1,7 +1,7 @@
 """Domain model guardrails — snapshot enum members, graph relationships,
 analysis machinery boundaries, and typed-concept conformance.
 
-Covers TODO items T02, T03, T05, T06, T07 from the domain migration plan.
+Covers migration-plan items T02, T03, T05, T06, and T07.
 """
 
 from __future__ import annotations

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -456,7 +456,7 @@ class WebSocketHub:
                 if selected_client_id in failed_client_ids
             )
             LOGGER.error(
-                "Payload build failed for %d client id(s) (%s); "
+                "WebSocket payload build failed for %d client id(s) (%s); "
                 "%d connection(s) received error payloads.",
                 len(failed_client_ids),
                 ", ".join(repr(cid) for cid in failed_client_ids),

--- a/apps/server/vibesensor/infra/runtime/client_metadata.py
+++ b/apps/server/vibesensor/infra/runtime/client_metadata.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Iterable
 from threading import RLock
 from typing import TYPE_CHECKING
 
-from vibesensor.domain import normalize_sensor_id as _normalize_client_id
+from vibesensor.domain import normalize_sensor_id
 
 if TYPE_CHECKING:
     from .registry import ClientRecord
@@ -93,12 +93,12 @@ class ClientMetadataManager:
         return f"client-{client_id[-4:]}"
 
     def default_name_for(self, client_id: str) -> str:
-        normalized = _normalize_client_id(client_id)
+        normalized = normalize_sensor_id(client_id)
         with self._lock:
             return self._user_names.get(normalized, self._default_name(normalized))
 
     def has_user_name(self, client_id: str) -> bool:
-        normalized = _normalize_client_id(client_id)
+        normalized = normalize_sensor_id(client_id)
         with self._lock:
             return normalized in self._user_names
 
@@ -135,7 +135,7 @@ class ClientMetadataManager:
         return record
 
     def discard_name(self, client_id: str) -> bool:
-        normalized = _normalize_client_id(client_id)
+        normalized = normalize_sensor_id(client_id)
         with self._lock:
             existed = normalized in self._user_names
             self._user_names.pop(normalized, None)

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -11,7 +11,7 @@ import time
 from dataclasses import dataclass, field
 from threading import RLock
 
-from vibesensor.domain import normalize_sensor_id as _normalize_client_id
+from vibesensor.domain import normalize_sensor_id
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 from vibesensor.infra.runtime.registry_updates import (
@@ -189,7 +189,7 @@ class ClientRegistry:
 
     @staticmethod
     def _normalize_wire_client_id(client_id: bytes) -> str:
-        return _normalize_client_id(client_id.hex())
+        return normalize_sensor_id(client_id.hex())
 
     def _is_live_unlocked(self, record: ClientRecord, mono_now: float) -> bool:
         return bool(
@@ -203,7 +203,7 @@ class ClientRegistry:
         )
 
     def _get_or_create(self, client_id: str) -> ClientRecord:
-        normalized = _normalize_client_id(client_id)
+        normalized = normalize_sensor_id(client_id)
         record = self._clients.get(normalized)
         if record is None:
             default_name = self._metadata.default_name_for(normalized)
@@ -289,7 +289,7 @@ class ClientRegistry:
         if not client_id:
             return
         try:
-            normalized = _normalize_client_id(client_id)
+            normalized = normalize_sensor_id(client_id)
         except ValueError:
             return
         with self._lock:
@@ -332,7 +332,7 @@ class ClientRegistry:
                     (
                         cid
                         for cid, rec in self._clients.items()
-                        if cid != _normalize_client_id(client_id) and rec.location_code == clean
+                        if cid != normalize_sensor_id(client_id) and rec.location_code == clean
                     ),
                     None,
                 )
@@ -345,7 +345,7 @@ class ClientRegistry:
 
     def remove_client(self, client_id: str) -> bool:
         try:
-            normalized = _normalize_client_id(client_id)
+            normalized = normalize_sensor_id(client_id)
         except ValueError:
             return False
         with self._lock:
@@ -357,7 +357,7 @@ class ClientRegistry:
     def get(self, client_id: str) -> ClientRecordSnapshot | None:
         """Return an immutable point-in-time snapshot for *client_id*."""
         try:
-            normalized = _normalize_client_id(client_id)
+            normalized = normalize_sensor_id(client_id)
         except ValueError:
             return None
         with self._lock:


### PR DESCRIPTION
Closes #1299

## Summary

This PR resolves #1299 by auditing the issue against current `main`, separating the historical claims from the still-live hygiene gaps, and then fixing only the live gaps that remain.

The original issue frames the codebase as carrying a broad hygiene sweep across stale TODO/FIXME/HACK comments, dead code, naming inconsistency, WebSocket validation gaps, pass-through test helpers, outdated type suppressions, `__init__.py` inconsistency, magic numbers, and logging-format drift. On current `main`, that diagnosis is much broader than the code actually supports. Most of the “sweep” work has already happened over earlier cleanups and architecture tickets. What remained here was smaller and more specific: one residual historical TODO phrase in a test docstring, one inconsistent local naming choice around `normalize_sensor_id` in the runtime layer, and one WebSocket hub summary error log that had drifted away from the subsystem-prefixed format used elsewhere in the same module.

## Problem being solved

The real problem on current `main` is not that the repository still needs a repo-wide hygiene rewrite. The real problem is that a few small inconsistencies survived after earlier cleanup work, which made the older issue wording sound more current than it really is.

After auditing the issue against the live code, I found:

- no meaningful backlog of TODO/FIXME/HACK comments in tracked server code,
- no evidence for the claimed inbound WebSocket validation hole,
- no convincing dead-code or pass-through-test-helper sweep left in the touched areas,
- and no reason to introduce new lint tooling or broad style-only churn under this issue.

What did still need work was narrower:

1. the remaining historical TODO wording in the domain-model guardrail test should no longer read like a pending task,
2. the runtime layer should use the canonical `normalize_sensor_id` name directly instead of aliasing it to `_normalize_client_id` in the two modules that still did that, and
3. WebSocket hub error logs should use one consistent subsystem-prefixed summary format.

## Audit results that shaped the implementation

A large part of this issue was resolved by investigation rather than code changes, and that matters for understanding why the final diff is intentionally small.

### TODO / FIXME / HACK comments

A repo search no longer shows the large backlog implied by the issue body. In the server code path touched here, the only meaningful residual hit was the docstring in `apps/server/tests/hygiene/test_domain_model_guardrails.py`, which still said it “covers TODO items” from the older migration plan. That wording had become historical noise, so I changed it to “migration-plan items” instead of leaving it sounding like active pending work.

### WebSocket validation

The claimed WebSocket validation gap audited out as stale. `apps/server/vibesensor/adapters/http/websocket.py` already rejects malformed JSON, rejects non-dict payloads, validates the payload with `TypeAdapter(WsClientSelectionPayload)`, revalidates `client_id` through `normalize_sensor_id`, and logs unrecognized-key shapes instead of passing malformed data deeper into runtime handling. Because the boundary already validates before mutating state, this PR does not add a second validation path or change the existing `extra="ignore"` behavior.

### Type suppressions, dead code, and broad style sweeps

The broad dead-code and type-suppression claims also did not justify wide edits on current `main`. The remaining suppressions are narrow and tied to concrete typing gaps or external libraries, and the hot-path modules touched here are already fairly lean. That meant the honest fix was to leave those broader claims out of scope for this PR.

## Main code changes

### 1. Canonical runtime naming for sensor/client normalization

`apps/server/vibesensor/infra/runtime/client_metadata.py` and `apps/server/vibesensor/infra/runtime/registry.py` now import and use `normalize_sensor_id` directly instead of aliasing it to `_normalize_client_id`.

This is a small change, but it removes one of the remaining local naming inconsistencies in the runtime layer. The helper is already defined in the domain layer with the sensor-oriented name, and the rest of the codebase uses that canonical name directly. Keeping the runtime layer aligned with that shared vocabulary reduces cognitive overhead when moving between registry, HTTP/WebSocket, and domain-level sensor handling.

### 2. Consistent WebSocket summary error message

`apps/server/vibesensor/adapters/websocket/hub.py` now logs the aggregate payload-build failure summary as:

`WebSocket payload build failed for ...`

instead of the shorter `Payload build failed for ...`.

That brings the summary log line into alignment with the rest of the module, which already prefixes related failures with `WebSocket ...`. This is intentionally a small cleanup, but it matters in operator logs because the subsystem context should be consistent when scanning mixed backend output.

### 3. Regression coverage for the log-format cleanup

`apps/server/tests/adapters/websocket/test_ws_hub.py` now asserts the full subsystem-prefixed summary error message in the multi-connection failure case, not just the affected-connection count.

That turns the log-format cleanup into an explicit tested contract instead of a one-off string change that can drift again later.

### 4. Remove the stale residual TODO phrasing

`apps/server/tests/hygiene/test_domain_model_guardrails.py` now refers to “migration-plan items” rather than “TODO items.”

This keeps the test description historically accurate without implying unfinished work that is already complete.

## Behavior, contract, and risk impact

There are no API, schema, or persistence changes in this PR. HTTP contracts, WebSocket payload shapes, settings formats, and runtime behavior remain the same. The only user-visible effect is slightly clearer log output in one WebSocket error path.

The main tradeoff here is deliberate restraint: I did not turn a mostly stale hygiene issue into a repository-wide style campaign. That keeps the diff easy to review and avoids accidental churn in stable code. It also makes the issue history more honest by distinguishing “already fixed earlier” from “still worth changing now.”

## Validation

I validated this change in layers:

- Focused pytest:
  - `pytest -q apps/server/tests/adapters/websocket/test_ws_hub.py apps/server/tests/hygiene/test_domain_model_guardrails.py apps/server/tests/infra/runtime`
- Standard repo gates:
  - `make lint`
  - `make typecheck-backend`
  - `make docs-lint`
  - `make test-changed`

The focused suite finished green (`157 passed`). The repo gates also finished green, including the changed-file selection under `make test-changed` (`1728 passed`).

## Follow-ups and out-of-scope items

The larger hygiene themes from the original issue are now better understood than they were at issue creation time:

- WebSocket inbound validation is already explicit.
- The server code no longer carries the large TODO/FIXME/HACK backlog described in the issue.
- The remaining broad dead-code/type-suppression/module-organization claims do not justify a mechanical repo-wide sweep in this PR.

If future cleanup is still desired in those areas, it should land as narrower issues with concrete current examples rather than as a generic hygiene umbrella. This PR intentionally handles only the live residual inconsistencies that the audit could prove on current `main`.
