### PR TITLE
Make app imports side-effect free

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -131,9 +131,12 @@ debug workflows:
   the hotspot/systemd launch path.
 - `VIBESENSOR_SERVE_STATIC=0`: disable mounting bundled UI static files for
   API-only runs, backend tests, or release validation helpers.
-- `VIBESENSOR_DISABLE_AUTO_APP=1`: prevent import-time FastAPI app creation;
-  mainly useful for tests, CLI entrypoints, and release validation subprocesses.
 - `VIBESENSOR_WS_DEBUG=1`: enable dev-only WebSocket payload-size debug logs.
+
+Importing `vibesensor.app` or `vibesensor.app.bootstrap` is now side-effect
+free. Config loading, runtime construction, SQLite opening, and static-asset
+validation happen only when callers explicitly invoke `create_app(...)` or the
+CLI startup path.
 
 Updater and release tooling also expose focused overrides:
 

--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import os
-
-os.environ.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 

--- a/apps/server/tests/adapters/websocket/test_ws_models.py
+++ b/apps/server/tests/adapters/websocket/test_ws_models.py
@@ -3,10 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
-
-os.environ.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
-
 from typing import Any
 
 import numpy as np

--- a/apps/server/tests/app/test_app_lifecycle.py
+++ b/apps/server/tests/app/test_app_lifecycle.py
@@ -23,7 +23,6 @@ async def test_lifespan_shutdown_closes_history_db(tmp_path: Path, monkeypatch) 
         encoding="utf-8",
     )
     monkeypatch.setenv("VIBESENSOR_SERVE_STATIC", "0")
-    monkeypatch.setenv("VIBESENSOR_DISABLE_AUTO_APP", "1")
     from vibesensor import app as app_module
     from vibesensor.app import bootstrap as bootstrap_mod
 

--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -20,7 +20,6 @@ def _runtime_app(port: int):
 
 def _run_main(monkeypatch, *, port: int, fail_port: int | None = None) -> list[int]:
     """Shared harness: patch app_module, call ``main()``, return recorded port calls."""
-    monkeypatch.setenv("VIBESENSOR_DISABLE_AUTO_APP", "1")
     from vibesensor.app import bootstrap as app_module
 
     monkeypatch.setattr(
@@ -53,7 +52,6 @@ def test_main_port_behaviour(monkeypatch, port, fail_port, expected_calls) -> No
 
 
 def test_create_app_from_env_uses_exported_config_path(monkeypatch) -> None:
-    monkeypatch.setenv("VIBESENSOR_DISABLE_AUTO_APP", "1")
     from vibesensor.app import bootstrap as app_module
 
     config_path = Path("apps/server/config.dev.yaml")
@@ -70,7 +68,6 @@ def test_create_app_from_env_uses_exported_config_path(monkeypatch) -> None:
 
 
 def test_main_reload_uses_factory_target(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBESENSOR_DISABLE_AUTO_APP", "1")
     from vibesensor.app import bootstrap as app_module
 
     config_path = tmp_path / "config.dev.yaml"

--- a/apps/server/tests/app/test_import_purity.py
+++ b/apps/server/tests/app/test_import_purity.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SERVER_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_import_probe(import_code: str) -> subprocess.CompletedProcess[str]:
+    script = "\n".join(
+        [
+            "import logging.handlers",
+            "import sqlite3",
+            "from pathlib import Path",
+            "",
+            "def _boom_connect(*args, **kwargs):",
+            '    raise AssertionError("sqlite-connect-called")',
+            "",
+            "class _BoomHandler:",
+            "    def __init__(self, *args, **kwargs):",
+            '        raise AssertionError("file-logging-called")',
+            "",
+            "_orig_exists = Path.exists",
+            "",
+            "def _guard_exists(self):",
+            '    if self.name == "index.html":',
+            '        raise AssertionError("static-validation-called")',
+            "    return _orig_exists(self)",
+            "",
+            "sqlite3.connect = _boom_connect",
+            "logging.handlers.RotatingFileHandler = _BoomHandler",
+            "Path.exists = _guard_exists",
+            "",
+            textwrap.dedent(import_code).strip(),
+            "",
+            'print("ok")',
+        ]
+    )
+    env = os.environ.copy()
+    env.pop("VIBESENSOR_DISABLE_AUTO_APP", None)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=SERVER_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_importing_app_package_stays_lightweight() -> None:
+    result = _run_import_probe(
+        """
+import importlib
+import sys
+
+module = importlib.import_module("vibesensor.app")
+assert module.__name__ == "vibesensor.app"
+assert "vibesensor.app.bootstrap" not in sys.modules
+        """
+    )
+    assert result.stdout.strip() == "ok"
+
+
+def test_importing_bootstrap_does_not_construct_runtime() -> None:
+    result = _run_import_probe(
+        """
+import importlib
+
+bootstrap = importlib.import_module("vibesensor.app.bootstrap")
+assert callable(bootstrap.create_app)
+assert callable(bootstrap.create_app_from_env)
+assert callable(bootstrap.main)
+assert not hasattr(bootstrap, "app")
+        """
+    )
+    assert result.stdout.strip() == "ok"
+
+
+def test_importing_create_app_from_package_is_side_effect_free() -> None:
+    result = _run_import_probe(
+        """
+from vibesensor.app import create_app, create_app_from_env, main
+
+assert callable(create_app)
+assert callable(create_app_from_env)
+assert callable(main)
+        """
+    )
+    assert result.stdout.strip() == "ok"

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -8,15 +8,11 @@ in isolation.
 from __future__ import annotations
 
 import asyncio
-import os
 from dataclasses import dataclass
 from typing import Any, get_type_hints
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-os.environ.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
-
 
 # ---------------------------------------------------------------------------
 # Stubs – lightweight stand-ins for RuntimeState dependencies

--- a/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
@@ -142,7 +142,6 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
         encoding="utf-8",
     )
     monkeypatch.setenv("VIBESENSOR_SERVE_STATIC", "0")
-    monkeypatch.setenv("VIBESENSOR_DISABLE_AUTO_APP", "1")
 
     from vibesensor import app as app_module
     from vibesensor.app import bootstrap as bootstrap_mod

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -205,7 +205,7 @@ def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) 
     assert list(popen_args[0][:2]) == [release_validation.sys.executable, "-c"]
     assert "from vibesensor.app import create_app" in popen_args[0][2]
     assert popen_args[0][3].endswith("release-smoke.yaml")
-    assert popen_kwargs["env"]["VIBESENSOR_DISABLE_AUTO_APP"] == "1"
+    assert "VIBESENSOR_DISABLE_AUTO_APP" not in popen_kwargs["env"]
     assert popen_kwargs["env"]["VIBESENSOR_SERVE_STATIC"] == "0"
     assert popen_kwargs["env"]["VIBESENSOR_UPDATE_STATE_PATH"].endswith("update_status.json")
     assert recorded["terminated"] is True

--- a/apps/server/vibesensor/app/__init__.py
+++ b/apps/server/vibesensor/app/__init__.py
@@ -1,6 +1,6 @@
-"""Application bootstrap and wiring."""
+"""Lightweight application package facade for explicit startup entrypoints."""
 
-__all__ = ["create_app", "main"]
+__all__ = ["create_app", "create_app_from_env", "main"]
 
 
 def __getattr__(name: str) -> object:

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -145,13 +145,6 @@ def create_app_from_env() -> FastAPI:
     return create_app(config_path=config_path)
 
 
-app: FastAPI | None = (
-    create_app()
-    if __name__ != "__main__" and os.getenv("VIBESENSOR_DISABLE_AUTO_APP", "0") != "1"
-    else None
-)
-
-
 def _run_server(
     app_target: FastAPI | str,
     *,
@@ -219,7 +212,6 @@ def _run_server_with_port_fallback(
 
 def main() -> None:
     """Entry point for the ``vibesensor-server`` CLI command."""
-    os.environ.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
     parser = argparse.ArgumentParser(description="Run VibeSensor server")
     parser.add_argument("--config", type=Path, default=None, help="Path to config YAML")
     parser.add_argument(

--- a/apps/server/vibesensor/cli/server.py
+++ b/apps/server/vibesensor/cli/server.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import os
-
 
 def main() -> None:
     """Entry point for the ``vibesensor-server`` CLI command."""
-    os.environ.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
     from vibesensor.app.bootstrap import main as app_main
 
     app_main()

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -210,15 +210,7 @@ _SMOKE_SERVER_BOOTSTRAP = "\n".join(
 def packaged_static_index_path() -> Path:
     import importlib
 
-    previous_disable_auto_app = os.environ.get("VIBESENSOR_DISABLE_AUTO_APP")
-    os.environ["VIBESENSOR_DISABLE_AUTO_APP"] = "1"
-    try:
-        app_module = importlib.import_module("vibesensor.app")
-    finally:
-        if previous_disable_auto_app is None:
-            os.environ.pop("VIBESENSOR_DISABLE_AUTO_APP", None)
-        else:
-            os.environ["VIBESENSOR_DISABLE_AUTO_APP"] = previous_disable_auto_app
+    app_module = importlib.import_module("vibesensor.app")
     module_file = app_module.__file__
     if module_file is None:
         raise RuntimeError("vibesensor.app module is missing __file__")
@@ -249,7 +241,6 @@ def run_server_smoke(
         config_path = build_release_smoke_config(source_config, tmp_dir, host=host, port=port)
         env = os.environ.copy()
         env.setdefault("PYTHONUNBUFFERED", "1")
-        env.setdefault("VIBESENSOR_DISABLE_AUTO_APP", "1")
         env.setdefault("VIBESENSOR_UPDATE_STATE_PATH", str(tmp_dir / "data" / "update_status.json"))
         if extra_env:
             env.update(extra_env)

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -237,7 +237,6 @@ ls /opt/VibeSensor/apps/server/.venv/lib/python*/site-packages/__editable__.vibe
 
   if ! run_qemu_chroot /bin/bash -lc '
 set -e
-export VIBESENSOR_DISABLE_AUTO_APP=1
 pkill -f "vibesensor-server" >/dev/null 2>&1 || true
 cp /etc/vibesensor/config.yaml /tmp/vibesensor-smoke-config.yaml
 /opt/VibeSensor/apps/server/.venv/bin/python - <<'PY'


### PR DESCRIPTION
## Summary

Closes #1328.

This PR makes `vibesensor.app` import-pure by removing the last import-time app-construction path from `apps/server/vibesensor/app/bootstrap.py` and retiring `VIBESENSOR_DISABLE_AUTO_APP` as a normal control path across the repo. Before this change, importing `vibesensor.app.bootstrap` still executed a module-level `app = create_app()` binding, which meant that a seemingly harmless import could load config, attach rotating file handlers, open or migrate the history SQLite database, build the runtime graph, and validate bundled static assets. The package-level `vibesensor.app.__getattr__` facade made that behavior broader than it looked, because `from vibesensor.app import create_app` still imported `bootstrap` and therefore triggered the side effects unless callers remembered to set the environment flag first.

The goal of the fix was not to redesign application startup or change what an explicit `create_app(...)` call does. The goal was to make imports cheap and predictable again, while preserving the existing explicit factory paths and the current reload/factory-target behavior used by the CLI and `uvicorn`.

## Implementation approach

The main design choice in this PR is to remove the import-time runtime creation outright instead of preserving it behind more environment checks or adding another layer of lazy bootstrap machinery. The issue already existed because the codebase had normalized a workaround (`VIBESENSOR_DISABLE_AUTO_APP`) into multiple call sites. Continuing down that path would have kept import behavior fragile and would have preserved an easy footgun for future maintenance. The cleaner fix was to make `bootstrap.py` definition-only at import time and let the explicit startup entrypoints remain the only code paths that are allowed to construct the app.

That approach still preserves the stable internal API surface. `create_app(...)`, `create_app_from_env()`, and `main()` remain available, and reload mode still targets `vibesensor.app.bootstrap:create_app_from_env`. The change is specifically about *when* runtime setup happens, not about changing runtime setup itself.

## Main code changes

In `apps/server/vibesensor/app/bootstrap.py`, I removed the module-level `app = create_app()` binding entirely. After this change, importing the module no longer instantiates the FastAPI app or any of its runtime dependencies. The explicit factory functions remain unchanged in behavior, and `main()` still parses CLI args, loads config when needed, and starts the server through the same fallback/reload logic as before.

In `apps/server/vibesensor/app/__init__.py`, I clarified the package role as a lightweight facade for explicit startup entrypoints and aligned `__all__` with the public callable surface by exporting `create_app`, `create_app_from_env`, and `main`. This keeps the `from vibesensor.app import create_app` contract intact while making the import semantics honest.

In `apps/server/vibesensor/cli/server.py`, I removed the `VIBESENSOR_DISABLE_AUTO_APP` pre-import mutation. The CLI no longer needs to pre-arm the process environment just to import the server entrypoint safely, because the underlying module import is now side-effect free.

In `apps/server/vibesensor/use_cases/updates/releases/release_validation.py`, I removed the same workaround from both the packaged-static path lookup and the server smoke environment setup. Release validation can now import `vibesensor.app` directly to locate packaged assets and can launch the smoke server without injecting an import-order compatibility flag into the child environment.

I also removed the workaround from the test modules and the Pi image smoke-validation script that had only been carrying it to protect themselves from bootstrap side effects. That cleanup touched the app, runtime, websocket, shutdown-analysis, and release-validation tests, plus `infra/pi-image/pi-gen/lib/image_validation.sh`.

On the documentation side, `apps/server/README.md` now documents the new contract explicitly: importing `vibesensor.app` or `vibesensor.app.bootstrap` is side-effect free, and config loading / runtime construction / SQLite opening / static validation happen only through explicit app creation or CLI startup.

## Regression coverage

The most important new tests are in `apps/server/tests/app/test_import_purity.py`. These are subprocess-based on purpose, because in-process tests are not a reliable way to prove import purity once a module has already been imported in the current interpreter. The new helper launches a fresh Python process, patches `sqlite3.connect`, `logging.handlers.RotatingFileHandler`, and `Path.exists` to fail loudly, and then performs three probes:

1. importing `vibesensor.app` should stay lightweight and should not even load `vibesensor.app.bootstrap`;
2. importing `vibesensor.app.bootstrap` should expose the explicit entrypoints without constructing the runtime;
3. `from vibesensor.app import create_app, create_app_from_env, main` should remain a supported import surface and should also stay side-effect free.

That gives the repo a concrete regression harness for the exact failure mode behind the issue, instead of relying on convention or comments.

The existing app and release-validation tests were also updated to reflect the new normal path. They no longer seed `VIBESENSOR_DISABLE_AUTO_APP` before imports, and the release-validation assertion now verifies that the smoke environment does **not** inject that flag.

## Validation

Focused validation for the issue blast radius passed:

- `pytest -q apps/server/tests/app/test_import_purity.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_app_lifecycle.py apps/server/tests/use_cases/updates/releases/test_release_validation.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py`
- Result: `49 passed`

Broader repo validation also passed:

- `make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make test-changed`

`make test-changed` ran the full backend test suite for the changed backend files and completed green with `5850 passed, 5 skipped, 1 xpassed`.

I did not run the Docker Compose runtime stack locally because this environment does not expose a usable Docker daemon socket. For this issue, the compensating validation was the focused import-purity subprocess tests plus the standard repo gates above. CI will still exercise the broader containerized paths after the PR opens.

## Risks, tradeoffs, and scope boundaries

The main intentional tradeoff here is that the repo no longer provides a module-level `vibesensor.app.bootstrap:app` object. That is the right tradeoff for this codebase: the in-repo startup paths already use explicit factories, and preserving `bootstrap:app` would have required keeping import-time construction alive or layering on more compatibility indirection. Under the repo’s no-backward-compatibility policy, removing that implicit side-effect path is preferable to preserving it “just in case.”

I deliberately did **not** change what `create_app(...)` does when explicitly invoked. If there are separate problems inside explicit app construction, those should be handled in follow-up issues rather than bundled into an import-purity fix. I also did not broaden the work into startup sequencing, runtime graph refactoring, or release-smoke behavior beyond removing the now-unnecessary workaround path.

## Follow-up notes

If future work touches `vibesensor.app`, CLI startup, release validation, or ASGI entrypoints, the new invariant to preserve is simple: imports must remain definition-only, and runtime construction must remain explicit. The new subprocess regression file is intended to keep that contract enforceable rather than aspirational.
