### PR TITLE
Tighten history contract JSON typing

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -208,6 +208,45 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     }
 
 
+def test_export_schema_avoids_unknown_contract_shapes_for_history_payloads(
+    schema_dict: dict[str, Any],
+) -> None:
+    history_run = schema_dict["components"]["schemas"]["HistoryRunResponse"]
+    analysis_summary = schema_dict["components"]["schemas"]["AnalysisSummaryResponse"]
+    amplitude_metric = schema_dict["components"]["schemas"]["AmplitudeMetric"]
+    finding_payload = schema_dict["components"]["schemas"]["FindingPayload"]
+    run_suitability = schema_dict["components"]["schemas"]["RunSuitabilityCheck"]
+    summary_warning = schema_dict["components"]["schemas"]["SummaryWarningResponse"]
+    suspected_origin = schema_dict["components"]["schemas"]["SuspectedVibrationOriginPayload"]
+
+    def _contains_untyped_object(schema: object) -> bool:
+        if isinstance(schema, dict):
+            if schema.get("type") == "object" and schema.get("additionalProperties") is True:
+                return True
+            return any(_contains_untyped_object(value) for value in schema.values())
+        if isinstance(schema, list):
+            return any(_contains_untyped_object(value) for value in schema)
+        return False
+
+    assert finding_payload["properties"]["evidence_summary"]["type"] == "string"
+    assert finding_payload["properties"]["frequency_hz_or_order"]["anyOf"] == [
+        {"type": "number"},
+        {"type": "string"},
+    ]
+
+    for schema in (
+        history_run["properties"]["metadata"],
+        analysis_summary["properties"]["metadata"],
+        analysis_summary["properties"]["speed_breakdown_skipped_reason"],
+        amplitude_metric["properties"]["definition"],
+        run_suitability["properties"]["explanation"],
+        summary_warning["properties"]["title"],
+        summary_warning["properties"]["detail"],
+        suspected_origin["properties"]["explanation"],
+    ):
+        assert _contains_untyped_object(schema) is False
+
+
 def test_export_schema_contains_debug_endpoint_response_shapes(
     schema_dict: dict[str, Any],
 ) -> None:

--- a/apps/server/tests/test_support/findings.py
+++ b/apps/server/tests/test_support/findings.py
@@ -46,7 +46,7 @@ def make_finding_payload(
     base: FindingPayload = {
         "finding_id": finding_id,
         "suspected_source": suspected_source,
-        "evidence_summary": {"_i18n_key": "TEST"},
+        "evidence_summary": "Test evidence summary",
         "frequency_hz_or_order": "1x wheel",
         "amplitude_metric": {
             "name": "vibration_strength_db",

--- a/apps/server/vibesensor/adapters/http/models/base.py
+++ b/apps/server/vibesensor/adapters/http/models/base.py
@@ -6,8 +6,10 @@ from typing import TypeAlias
 
 from pydantic import BaseModel, ConfigDict
 
-ApiPayloadObject: TypeAlias = dict[str, object]
-ApiPayloadValue: TypeAlias = None | bool | int | float | str | list[object] | ApiPayloadObject
+from vibesensor.shared.types.json_types import JsonSchemaObject, JsonSchemaValue
+
+ApiPayloadObject: TypeAlias = JsonSchemaObject
+ApiPayloadValue: TypeAlias = JsonSchemaValue
 
 
 class _FrozenBase(BaseModel):

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -10,7 +10,7 @@ names, while endpoint-specific HTTP wrappers remain local to
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Literal, Required, TypeAlias
+from typing import Any, Literal, Required, TypeAlias, cast
 
 from pydantic import ConfigDict
 from typing_extensions import TypedDict
@@ -24,7 +24,12 @@ from vibesensor.shared.types.analysis_views import (
     PlotDataResult,
     SpeedBreakdownRow,
 )
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import (
+    JsonObject,
+    JsonSchemaObject,
+    JsonSchemaValue,
+    JsonValue,
+)
 
 __all__ = [
     "AmplitudeMetric",
@@ -55,20 +60,23 @@ __all__ = [
     "TestPlanStepResponse",
 ]
 
-PayloadObject: TypeAlias = dict[str, object]
-PayloadValue: TypeAlias = None | bool | int | float | str | list[object] | PayloadObject
+PayloadObject: TypeAlias = JsonSchemaObject
+PayloadValue: TypeAlias = JsonSchemaValue
 
 
 def payload_value_from_json(value: JsonValue | None) -> PayloadValue:
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     if isinstance(value, list):
-        return [payload_value_from_json(item) for item in value]
-    return payload_object_from_json(value)
+        # History/report payload producers only emit the bounded JSON depth
+        # modeled by ``PayloadValue``, but mypy cannot prove that through the
+        # recursive conversion helper.
+        return cast(PayloadValue, [payload_value_from_json(item) for item in value])
+    return cast(PayloadValue, payload_object_from_json(value))
 
 
 def payload_object_from_json(value: JsonObject) -> PayloadObject:
-    return {key: payload_value_from_json(item) for key, item in value.items()}
+    return cast(PayloadObject, {key: payload_value_from_json(item) for key, item in value.items()})
 
 
 def payload_objects_from_json(values: Sequence[JsonObject]) -> list[PayloadObject]:
@@ -279,8 +287,8 @@ class FindingPayload(TypedDict, total=False):
     finding_id: Required[str]
     finding_key: str | None
     suspected_source: Required[str]
-    evidence_summary: Required[PayloadValue]
-    frequency_hz_or_order: Required[PayloadValue]
+    evidence_summary: Required[str]
+    frequency_hz_or_order: Required[float | str]
     amplitude_metric: Required[AmplitudeMetric]
     confidence: Required[float | None]
     finding_kind: str | None

--- a/apps/server/vibesensor/shared/types/json_types.py
+++ b/apps/server/vibesensor/shared/types/json_types.py
@@ -8,10 +8,28 @@ JsonScalar: TypeAlias = None | bool | int | float | str
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 JsonObject: TypeAlias = dict[str, JsonValue]
 JsonArray: TypeAlias = list[JsonValue]
+JsonSchemaScalar: TypeAlias = JsonScalar
+
+# OpenAPI -> TypeScript generation cannot represent recursive component aliases
+# safely here, so keep the schema-facing JSON shape bounded to the nesting depth
+# used by the persisted analysis/history payloads.
+JsonSchemaLeafObject: TypeAlias = dict[str, JsonSchemaScalar]
+JsonSchemaNestedValue: TypeAlias = (
+    JsonSchemaScalar | JsonSchemaLeafObject | list[JsonSchemaScalar | JsonSchemaLeafObject]
+)
+JsonSchemaValue: TypeAlias = (
+    JsonSchemaNestedValue | dict[str, JsonSchemaNestedValue] | list[JsonSchemaNestedValue]
+)
+JsonSchemaObject: TypeAlias = dict[str, JsonSchemaValue]
 
 __all__ = [
     "JsonArray",
     "JsonObject",
+    "JsonSchemaLeafObject",
+    "JsonSchemaNestedValue",
+    "JsonSchemaObject",
+    "JsonSchemaScalar",
+    "JsonSchemaValue",
     "JsonScalar",
     "JsonValue",
     "is_json_array",

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -83,12 +83,246 @@
                 "type": "string"
               },
               {
-                "items": {},
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "array"
               },
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               {
                 "type": "null"
@@ -421,7 +655,267 @@
             "title": "Accel Scale G Per Lsb"
           },
           "analysis_metadata": {
-            "additionalProperties": true,
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "title": "Analysis Metadata",
             "type": "object"
           },
@@ -518,7 +1012,267 @@
             "type": "string"
           },
           "metadata": {
-            "additionalProperties": true,
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "title": "Metadata",
             "type": "object"
           },
@@ -624,7 +1378,267 @@
           },
           "samples": {
             "items": {
-              "additionalProperties": true,
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "type": "object"
             },
             "title": "Samples",
@@ -676,7 +1690,267 @@
           "speed_breakdown_skipped_reason": {
             "anyOf": [
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
               },
               {
@@ -2559,32 +3833,8 @@
             ]
           },
           "evidence_summary": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Evidence Summary"
+            "title": "Evidence Summary",
+            "type": "string"
           },
           "finding_id": {
             "title": "Finding Id",
@@ -2615,27 +3865,10 @@
           "frequency_hz_or_order": {
             "anyOf": [
               {
-                "type": "boolean"
-              },
-              {
-                "type": "integer"
-              },
-              {
                 "type": "number"
               },
               {
                 "type": "string"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
               }
             ],
             "title": "Frequency Hz Or Order"
@@ -3263,7 +4496,267 @@
             "title": "Accel Scale G Per Lsb"
           },
           "analysis_metadata": {
-            "additionalProperties": true,
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "title": "Analysis Metadata",
             "type": "object"
           },
@@ -3360,7 +4853,267 @@
             "type": "string"
           },
           "metadata": {
-            "additionalProperties": true,
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "title": "Metadata",
             "type": "object"
           },
@@ -3466,7 +5219,267 @@
           },
           "samples": {
             "items": {
-              "additionalProperties": true,
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "type": "object"
             },
             "title": "Samples",
@@ -3518,7 +5531,267 @@
           "speed_breakdown_skipped_reason": {
             "anyOf": [
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
               },
               {
@@ -3710,7 +5983,267 @@
             "title": "Error Message"
           },
           "metadata": {
-            "additionalProperties": true,
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "title": "Metadata",
             "type": "object"
           },
@@ -5102,12 +7635,246 @@
                 "type": "string"
               },
               {
-                "items": {},
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "array"
               },
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               {
                 "type": "null"
@@ -5848,12 +8615,246 @@
                 "type": "string"
               },
               {
-                "items": {},
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "array"
               },
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               {
                 "type": "null"
@@ -5884,12 +8885,246 @@
                 "type": "string"
               },
               {
-                "items": {},
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "array"
               },
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               {
                 "type": "null"
@@ -5955,12 +9190,246 @@
                 "type": "string"
               },
               {
-                "items": {},
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "array"
               },
               {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "type": "object"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               {
                 "type": "null"

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -350,9 +350,21 @@ export interface components {
      */
     AmplitudeMetric: {
       /** Definition */
-      definition?: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      definition?: boolean | number | string | ({
+        [key: string]: boolean | number | string | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | null)[]) | ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null)[]) | null;
       /** Name */
       name?: string | null;
       /** Units */
@@ -441,7 +453,21 @@ export interface components {
       accel_scale_g_per_lsb: number | null;
       /** Analysis Metadata */
       analysis_metadata?: {
-        [key: string]: unknown;
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
       };
       /** Case Id */
       case_id?: string | null;
@@ -468,7 +494,21 @@ export interface components {
       lang: string;
       /** Metadata */
       metadata: {
-        [key: string]: unknown;
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
       };
       most_likely_origin: components["schemas"]["SuspectedVibrationOriginPayload"];
       /** Peak Picker Method */
@@ -496,9 +536,23 @@ export interface components {
       /** Run Suitability */
       run_suitability: components["schemas"]["RunSuitabilityCheck"][];
       /** Samples */
-      samples?: {
-          [key: string]: unknown;
-        }[];
+      samples?: ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | ({
+            [key: string]: boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | ((boolean | number | string | ({
+                [key: string]: boolean | number | string | null;
+              }) | null)[]) | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | ((boolean | number | string | ({
+                [key: string]: boolean | number | string | null;
+              }) | null)[]) | null)[]) | null;
+        })[];
       /** Sensor Count Used */
       sensor_count_used: number;
       /** Sensor Intensity By Location */
@@ -512,9 +566,23 @@ export interface components {
       /** Speed Breakdown */
       speed_breakdown: components["schemas"]["SpeedBreakdownRow"][];
       /** Speed Breakdown Skipped Reason */
-      speed_breakdown_skipped_reason: {
-        [key: string]: unknown;
-      } | null;
+      speed_breakdown_skipped_reason: ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
+      }) | null;
       speed_stats: components["schemas"]["SpeedStatsResponse"];
       /** Speed Stats By Phase */
       speed_stats_by_phase: {
@@ -1105,9 +1173,7 @@ export interface components {
       dominant_phase?: string | null;
       evidence_metrics?: components["schemas"]["FindingEvidenceMetrics"] | null;
       /** Evidence Summary */
-      evidence_summary: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      evidence_summary: string;
       /** Finding Id */
       finding_id: string;
       /** Finding Key */
@@ -1115,9 +1181,7 @@ export interface components {
       /** Finding Kind */
       finding_kind?: string | null;
       /** Frequency Hz Or Order */
-      frequency_hz_or_order: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      frequency_hz_or_order: number | string;
       location_hotspot?: components["schemas"]["LocationHotspotPayload"] | null;
       /** Matched Points */
       matched_points?: components["schemas"]["MatchedPoint"][];
@@ -1359,7 +1423,21 @@ export interface components {
       accel_scale_g_per_lsb: number | null;
       /** Analysis Metadata */
       analysis_metadata?: {
-        [key: string]: unknown;
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
       };
       /** Case Id */
       case_id?: string | null;
@@ -1386,7 +1464,21 @@ export interface components {
       lang: string;
       /** Metadata */
       metadata: {
-        [key: string]: unknown;
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
       };
       most_likely_origin: components["schemas"]["SuspectedVibrationOriginPayload"];
       /** Peak Picker Method */
@@ -1414,9 +1506,23 @@ export interface components {
       /** Run Suitability */
       run_suitability: components["schemas"]["RunSuitabilityCheck"][];
       /** Samples */
-      samples?: {
-          [key: string]: unknown;
-        }[];
+      samples?: ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | ({
+            [key: string]: boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | ((boolean | number | string | ({
+                [key: string]: boolean | number | string | null;
+              }) | null)[]) | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | ((boolean | number | string | ({
+                [key: string]: boolean | number | string | null;
+              }) | null)[]) | null)[]) | null;
+        })[];
       /** Sensor Count Used */
       sensor_count_used: number;
       /** Sensor Intensity By Location */
@@ -1430,9 +1536,23 @@ export interface components {
       /** Speed Breakdown */
       speed_breakdown: components["schemas"]["SpeedBreakdownRow"][];
       /** Speed Breakdown Skipped Reason */
-      speed_breakdown_skipped_reason: {
-        [key: string]: unknown;
-      } | null;
+      speed_breakdown_skipped_reason: ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
+      }) | null;
       speed_stats: components["schemas"]["SpeedStatsResponse"];
       /** Speed Stats By Phase */
       speed_stats_by_phase: {
@@ -1491,7 +1611,21 @@ export interface components {
       error_message?: string | null;
       /** Metadata */
       metadata?: {
-        [key: string]: unknown;
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | ({
+          [key: string]: boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | ((boolean | number | string | ({
+              [key: string]: boolean | number | string | null;
+            }) | null)[]) | null)[]) | null;
       };
       /** Run Id */
       run_id: string;
@@ -1922,9 +2056,21 @@ export interface components {
       /** Check Key */
       check_key: string;
       /** Explanation */
-      explanation?: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      explanation?: boolean | number | string | ({
+        [key: string]: boolean | number | string | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | null)[]) | ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null)[]) | null;
       /** State */
       state: string;
     };
@@ -2180,18 +2326,42 @@ export interface components {
       /** Code */
       code: string;
       /** Detail */
-      detail?: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      detail?: boolean | number | string | ({
+        [key: string]: boolean | number | string | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | null)[]) | ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null)[]) | null;
       /**
        * Severity
        * @enum {string}
        */
       severity: "warn" | "error";
       /** Title */
-      title: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      title: boolean | number | string | ({
+        [key: string]: boolean | number | string | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | null)[]) | ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null)[]) | null;
     };
     /**
      * SuspectedVibrationOriginPayload
@@ -2205,9 +2375,21 @@ export interface components {
       /** Dominant Phase */
       dominant_phase?: string | null;
       /** Explanation */
-      explanation?: boolean | number | string | unknown[] | {
-        [key: string]: unknown;
-      } | null;
+      explanation?: boolean | number | string | ({
+        [key: string]: boolean | number | string | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | null)[]) | ({
+        [key: string]: boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null;
+      }) | ((boolean | number | string | ({
+          [key: string]: boolean | number | string | null;
+        }) | ((boolean | number | string | ({
+            [key: string]: boolean | number | string | null;
+          }) | null)[]) | null)[]) | null;
       /** Location */
       location?: string | null;
       /** Speed Band */


### PR DESCRIPTION
Closes #1329.

## Summary

This PR tightens the history/report contract types that currently degrade the generated UI HTTP contracts into broad `object` / `unknown` shapes, while keeping the runtime payloads and public API behavior unchanged.

The issue body described a fairly wide typing cleanup across history preparation, adapters, and generated contracts. After reconciling that against current `main`, the live problem turned out to be narrower and more concrete: the shared history-analysis payload layer was still exposing several schema-critical fields through anonymous `dict[str, object]`-style aliases. Those broad aliases were then flowing through the HTTP/OpenAPI export path and into `openapi-typescript`, which meant the generated UI contracts were losing useful structure exactly where the frontend most needs it. The highest-signal regressions were in `AmplitudeMetric.definition`, `FindingPayload.evidence_summary`, `FindingPayload.frequency_hz_or_order`, `RunSuitabilityCheck.explanation`, `SummaryWarningResponse.title` / `detail`, `SuspectedVibrationOriginPayload.explanation`, and the metadata-style maps exposed on history/analysis summary responses.

## Problem being solved

Before this change, those fields were typed through generic payload aliases in two key places:

- `apps/server/vibesensor/shared/types/history_analysis_contracts.py`
- `apps/server/vibesensor/adapters/http/models/base.py`

That broad typing let runtime code work, but it weakened the schema story. In the exported OpenAPI document, several history/report payload properties effectively collapsed into anonymous object maps or loose mixed unions. Once the frontend regenerated `apps/ui/src/generated/http_api_contracts.ts`, the resulting types were vague enough that important parts of the history contract became awkward to consume safely.

During implementation I also verified that a just use recursive JSON everywhere” approach was the wrong fix here. A first attempt swapped the payload aliases to an unrestricted recursive JSON shape. That exposed two issues immediately: FastAPI/Pydantic schema export became unhappy in the `HistoryRunResponse` path, and the generated UI contracts still were not tight in the places this issue actually cares about. That experiment was discarded in favor of a schema-facing alias family that matches the bounded JSON nesting used by these persisted history/report payloads.naive 

## Chosen approach

The final approach keeps the runtime payloads exactly as they are today, but introduces a schema-friendly JSON alias family specifically for the contract/export path. The goal is to make the OpenAPI surface explicit enough for generation tools without rewriting the underlying persistence or business logic.

The implementation is intentionally small and concentrated in the contract-owning files:

1. `apps/server/vibesensor/shared/types/json_types.py`
   adds `JsonSchemaScalar`, `JsonSchemaLeafObject`, `JsonSchemaNestedValue`, `JsonSchemaValue`, and `JsonSchemaObject`. These are bounded schema-facing aliases used only so the history/report contract path exports real JSON structure instead of anonymous catch-all objects.

2. `apps/server/vibesensor/shared/types/history_analysis_contracts.py`
   switches `PayloadObject` / `PayloadValue` over to those schema-facing aliases. It also tightens two fields that already have narrower real producers today:
   - `FindingPayload.evidence_summary` is now explicitly `str`
   - `FindingPayload.frequency_hz_or_order` is now explicitly `float | str`

3. `apps/server/vibesensor/adapters/http/models/base.py`
   now reuses the same schema-facing payload aliases for the shared HTTP model base instead of its older anonymous `dict[str, object]` family.

## Main code changes by area

In the shared contract layer, this PR makes the exported schema reflect the contract shapes that already exist in practice. `FindingPayload.evidence_summary` is serialized from a plain string producer today, so the contract now says that directly. `FindingPayload.frequency_hz_or_order` comes from either a numeric frequency or a display label, so the contract now models exactly `number | string` instead of a vague JSON payload bucket.

For the remaining fields that genuinely do carry language-neutral JSON fragments, the contract still allows JSON-like values, but no longer through untyped catch-all objects. That means `AmplitudeMetric.definition`, `RunSuitabilityCheck.explanation`, `SummaryWarningResponse.title/detail`, `SuspectedVibrationOriginPayload.explanation`, `HistoryRunResponse.metadata`, `AnalysisSummaryResponse.metadata`, and `speed_breakdown_skipped_reason` now export as explicit bounded JSON structures instead of degrading to anonymous open objects.

On the test side, `apps/server/tests/test_support/findings.py` now matches the real runtime producer by using a string `evidence_summary` in the shared finding factory. That keeps downstream tests aligned with the live payload semantics rather than the older broader alias.

I also added a regression to `apps/server/tests/adapters/http/test_http_api_schema_export.py` that checks the exported schema rather than an internal helper. The new test verifies two things:

- the intentionally narrowed fields keep their stronger shapes (`string` and `number | string`)
- the affected history/report payload surfaces stop emitting anonymous untyped object nodes in the OpenAPI export

That gives us a direct guard against future regressions where a refactor might accidentally reintroduce `additionalProperties: true`-style shapes into the exported contract.

## Generated contract updates

Because this issue is explicitly about the generated UI contract experience, I regenerated both:

- `apps/ui/src/contracts/http_api_schema.json`
- `apps/ui/src/generated/http_api_contracts.ts`

The generated TypeScript now reflects the tighter backend model. The previously vague history/report fields now either have precise scalar unions (`string`, `number | string`) or reference the explicit schema-facing JSON contract instead of collapsing to anonymous `unknown`-like shapes.

## Validation

I validated this change in layers.

Focused validation:

- `pytest -q apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_api_model_boundary_parity.py`
- Result: `74 passed`

Frontend validation:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Repository gates:

- `make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make test-changed`

`make test-changed` covered the affected adapters/shared/test-support slice, including the UI contract freshness checks and the relevant pytest suites, and finished green with `1449 passed` in the pytest portion.

## Risks and tradeoffs considered

The main tradeoff here is that the schema-facing JSON alias is intentionally bounded rather than modeled as an unrestricted recursive JSON universe. That is deliberate. The unrestricted recursive version made the export/generation path worse, not better. The bounded alias matches the nesting depth actually used by these persisted history/report payloads today, which keeps the schema truthful for the live contract while remaining compatible with the repo’s OpenAPI and TypeScript generation pipeline.

I also avoided changing runtime payload layouts or adding new wrapper objects. That keeps the fix narrow and behavior-safe: consumers still receive the same payload content, but the exported schema now describes it far more accurately.

## Out of scope

This PR does not attempt a repo-wide elimination of every broad JSON alias or every `object` annotation. It only fixes the live high-signal degradation points in the history/report/HTTP contract path that were actually affecting generated UI contracts on current `main`.
