### PR TITLE
Split history persistence adapters

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -37,9 +37,10 @@ state. Current `main` is intentionally split more narrowly:
   current speed-source selection into live runtime collaborators.
 - Run lifecycle helpers (`RunLifecycleState`, `RunRecorder`,
   `PostAnalysisWorker`) own live per-process coordination and per-run state.
-- `HistoryDB` is shared storage for settings snapshots and run history, but the
-  live recording path and post-analysis/report path remain separate phases with
-  different owners.
+- History persistence now uses a shared SQLite lifecycle engine plus narrow
+  run, settings-snapshot, and client-name repositories. The live recording path
+  and post-analysis/report path still remain separate phases with different
+  owners even though they share one SQLite file.
 
 That separation is deliberate: deployment config, mutable user settings, and
 run-attached snapshots are related, but they are not interchangeable sources of

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -11,7 +11,7 @@ from typing import cast
 import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import HistoryDB, SQLiteHistoryEngine
 from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
@@ -329,13 +329,13 @@ def test_history_db_runs_startup_quick_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[Path] = []
-    original = HistoryDB._run_startup_quick_check
+    original = SQLiteHistoryEngine._run_startup_quick_check
 
-    def _tracking(self: HistoryDB) -> None:
+    def _tracking(self: SQLiteHistoryEngine) -> None:
         calls.append(self.db_path)
         original(self)
 
-    monkeypatch.setattr(HistoryDB, "_run_startup_quick_check", _tracking)
+    monkeypatch.setattr(SQLiteHistoryEngine, "_run_startup_quick_check", _tracking)
     db = HistoryDB(tmp_path / "history.db")
     try:
         assert calls == [tmp_path / "history.db"]

--- a/apps/server/tests/adapters/persistence/history_db/test_schema_migration.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_schema_migration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import HistoryDB, SQLiteHistoryEngine
 from vibesensor.adapters.persistence.history_db._schema import SCHEMA_VERSION
 from vibesensor.shared.types.run_schema import RunMetadata
 
@@ -577,12 +577,16 @@ def test_historydb_restores_backup_when_v10_migration_fails(
         analysis_json='{"findings": [], "top_causes": [], "warnings": []}',
     )
 
-    def _broken(self: HistoryDB) -> None:
+    def _broken(self: SQLiteHistoryEngine) -> None:
         with self._cursor() as cur:
             cur.execute("UPDATE runs SET analysis_json = NULL WHERE run_id = ?", ("legacy-run",))
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(HistoryDB, "_migrate_v10_to_v11_persisted_analysis_version", _broken)
+    monkeypatch.setattr(
+        SQLiteHistoryEngine,
+        "_migrate_v10_to_v11_persisted_analysis_version",
+        _broken,
+    )
 
     with pytest.raises(RuntimeError, match="restored backup"):
         HistoryDB(db_path)

--- a/apps/server/tests/app/test_app_lifecycle.py
+++ b/apps/server/tests/app/test_app_lifecycle.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import SQLiteHistoryEngine
 from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 
 
@@ -39,7 +39,7 @@ async def test_lifespan_shutdown_closes_history_db(tmp_path: Path, monkeypatch) 
 
     monkeypatch.setattr(bootstrap_mod, "start_udp_data_receiver", _fake_udp_receiver)
     monkeypatch.setattr(UDPControlPlane, "start", _fake_start)
-    monkeypatch.setattr(HistoryDB, "close", _fake_close)
+    monkeypatch.setattr(SQLiteHistoryEngine, "close", _fake_close)
 
     app = app_module.create_app(config_path=cfg_path)
     async with app.router.lifespan_context(app):

--- a/apps/server/tests/app/test_container.py
+++ b/apps/server/tests/app/test_container.py
@@ -12,17 +12,23 @@ def test_create_history_db_skips_stale_recovery_when_quick_check_marked_corrupte
 ) -> None:
     recovered = {"called": False}
     pruned = {"called": False}
-    fake_db = SimpleNamespace(
-        corruption_detected=True,
-        recover_stale_recording_runs=lambda: recovered.__setitem__("called", True),
-        prune_terminal_runs_older_than_days=lambda _days: pruned.__setitem__("called", True),
+    fake_history = SimpleNamespace(
+        lifecycle=SimpleNamespace(corruption_detected=True),
+        run_repository=SimpleNamespace(
+            recover_stale_recording_runs=lambda: recovered.__setitem__("called", True),
+            prune_terminal_runs_older_than_days=lambda _days: pruned.__setitem__("called", True),
+        ),
     )
 
-    def _fake_history_db(_path: Path, *, corruption_reporter=None):
+    def _fake_history_adapters(_path: Path, *, corruption_reporter=None):
         assert corruption_reporter is not None
-        return fake_db
+        return fake_history
 
-    monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
+    monkeypatch.setattr(
+        container_module,
+        "create_history_persistence_adapters",
+        _fake_history_adapters,
+    )
     config = SimpleNamespace(
         logging=SimpleNamespace(history_db_path=tmp_path / "history.db", run_retention_days=7),
     )
@@ -32,7 +38,7 @@ def test_create_history_db_skips_stale_recovery_when_quick_check_marked_corrupte
         corruption_reporter=lambda _details: None,
     )
 
-    assert result is fake_db
+    assert result is fake_history
     assert recovered["called"] is False
     assert pruned["called"] is False
 
@@ -51,17 +57,23 @@ def test_create_history_db_prunes_old_terminal_runs_on_startup(
         calls.append(("prune", days))
         return 2
 
-    fake_db = SimpleNamespace(
-        corruption_detected=False,
-        recover_stale_recording_runs=_recover,
-        prune_terminal_runs_older_than_days=_prune,
+    fake_history = SimpleNamespace(
+        lifecycle=SimpleNamespace(corruption_detected=False),
+        run_repository=SimpleNamespace(
+            recover_stale_recording_runs=_recover,
+            prune_terminal_runs_older_than_days=_prune,
+        ),
     )
 
-    def _fake_history_db(_path: Path, *, corruption_reporter=None):
+    def _fake_history_adapters(_path: Path, *, corruption_reporter=None):
         assert corruption_reporter is not None
-        return fake_db
+        return fake_history
 
-    monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
+    monkeypatch.setattr(
+        container_module,
+        "create_history_persistence_adapters",
+        _fake_history_adapters,
+    )
     config = SimpleNamespace(
         logging=SimpleNamespace(history_db_path=tmp_path / "history.db", run_retention_days=14),
     )
@@ -71,7 +83,7 @@ def test_create_history_db_prunes_old_terminal_runs_on_startup(
         corruption_reporter=lambda _details: None,
     )
 
-    assert result is fake_db
+    assert result is fake_history
     assert calls == [("recover", None), ("prune", 14)]
 
 
@@ -80,19 +92,25 @@ def test_create_history_db_continues_when_retention_prune_fails(
     monkeypatch,
     caplog,
 ) -> None:
-    fake_db = SimpleNamespace(
-        corruption_detected=False,
-        recover_stale_recording_runs=lambda: 0,
-        prune_terminal_runs_older_than_days=lambda _days: (_ for _ in ()).throw(
-            RuntimeError("prune failed")
+    fake_history = SimpleNamespace(
+        lifecycle=SimpleNamespace(corruption_detected=False),
+        run_repository=SimpleNamespace(
+            recover_stale_recording_runs=lambda: 0,
+            prune_terminal_runs_older_than_days=lambda _days: (_ for _ in ()).throw(
+                RuntimeError("prune failed")
+            ),
         ),
     )
 
-    def _fake_history_db(_path: Path, *, corruption_reporter=None):
+    def _fake_history_adapters(_path: Path, *, corruption_reporter=None):
         assert corruption_reporter is not None
-        return fake_db
+        return fake_history
 
-    monkeypatch.setattr(container_module, "HistoryDB", _fake_history_db)
+    monkeypatch.setattr(
+        container_module,
+        "create_history_persistence_adapters",
+        _fake_history_adapters,
+    )
     config = SimpleNamespace(
         logging=SimpleNamespace(history_db_path=tmp_path / "history.db", run_retention_days=7),
     )
@@ -103,5 +121,5 @@ def test_create_history_db_continues_when_retention_prune_fails(
             corruption_reporter=lambda _details: None,
         )
 
-    assert result is fake_db
+    assert result is fake_history
     assert "Failed to prune terminal runs older than 7 day(s)" in caplog.text

--- a/apps/server/tests/hygiene/test_history_db_mixins.py
+++ b/apps/server/tests/hygiene/test_history_db_mixins.py
@@ -1,8 +1,17 @@
-"""Guardrails for the intentional ``HistoryDB`` mixin composition."""
+"""Guardrails for the split history persistence composition."""
 
 from __future__ import annotations
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from pathlib import Path
+
+from vibesensor.adapters.persistence.history_db import (
+    ClientNameRepository,
+    HistoryDB,
+    RunHistoryRepository,
+    SettingsSnapshotRepository,
+    SQLiteHistoryEngine,
+    create_history_persistence_adapters,
+)
 from vibesensor.adapters.persistence.history_db._queries import _HistoryDBQueryMixin
 from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
 from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
@@ -16,7 +25,7 @@ def _public_method_names(cls: type[object]) -> set[str]:
     }
 
 
-def test_history_db_mixins_expose_disjoint_public_methods() -> None:
+def test_run_history_repository_mixins_expose_disjoint_public_methods() -> None:
     mixins = (
         _HistoryDBRunLifecycleMixin,
         _HistoryDBSampleIOMixin,
@@ -29,20 +38,29 @@ def test_history_db_mixins_expose_disjoint_public_methods() -> None:
             owners_by_name.setdefault(name, []).append(mixin.__name__)
 
     overlaps = {name: owners for name, owners in owners_by_name.items() if len(owners) > 1}
-    assert overlaps == {}, f"HistoryDB mixins must keep disjoint public APIs: {overlaps}"
+    assert overlaps == {}, f"run-history mixins must keep disjoint public APIs: {overlaps}"
 
 
-def test_history_db_wrapper_owns_shared_cursor_contract() -> None:
+def test_history_db_wrapper_is_no_longer_the_primary_mixin_stack() -> None:
     history_db_members = set(HistoryDB.__dict__)
 
-    assert {"_cursor", "_cursor_connection"} <= history_db_members
-    assert "write_transaction_cursor" in history_db_members
+    assert not issubclass(HistoryDB, _HistoryDBRunLifecycleMixin)
+    assert not issubclass(HistoryDB, _HistoryDBSampleIOMixin)
+    assert not issubclass(HistoryDB, _HistoryDBQueryMixin)
+    assert "__getattr__" in history_db_members
+    assert {"_cursor", "_cursor_connection", "write_transaction_cursor"} <= history_db_members
+
+
+def test_history_persistence_factory_returns_split_adapters(tmp_path: Path) -> None:
+    adapters = create_history_persistence_adapters(tmp_path / "history.db")
+    try:
+        assert isinstance(adapters.lifecycle, SQLiteHistoryEngine)
+        assert isinstance(adapters.run_repository, RunHistoryRepository)
+        assert isinstance(adapters.settings_snapshot_repository, SettingsSnapshotRepository)
+        assert isinstance(adapters.client_name_repository, ClientNameRepository)
+    finally:
+        adapters.lifecycle.close()
 
     assert "_cursor_connection" not in _HistoryDBRunLifecycleMixin.__dict__
     assert "write_transaction_cursor" not in _HistoryDBSampleIOMixin.__dict__
     assert "write_transaction_cursor" not in _HistoryDBQueryMixin.__dict__
-
-    for mixin in (_HistoryDBSampleIOMixin, _HistoryDBQueryMixin):
-        assert "_cursor_connection" not in mixin.__dict__, (
-            "sample/query mixins must rely on the wrapper-owned cursor-selection logic"
-        )

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -582,12 +582,12 @@ def test_runtime_state_has_public_attribute(attr: str) -> None:
 def test_runtime_state_uses_focused_ports_for_read_side_runtime_fields() -> None:
     """RuntimeState should expose existing shared ports for read-side services."""
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
-    from vibesensor.adapters.persistence.history_db import HistoryDB
     from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
     from vibesensor.adapters.websocket.hub import WebSocketHub
     from vibesensor.app import runtime_state as runtime_state_module
     from vibesensor.app.runtime_state import RuntimeState
     from vibesensor.app.settings import AppConfig
+    from vibesensor.infra.runtime.lifecycle import LifecycleHistoryDb
     from vibesensor.shared.ports import ClientTracker, SettingsReader, SignalSource
 
     hints = get_type_hints(
@@ -596,7 +596,7 @@ def test_runtime_state_uses_focused_ports_for_read_side_runtime_fields() -> None
             **vars(runtime_state_module),
             "AppConfig": AppConfig,
             "GPSSpeedMonitor": GPSSpeedMonitor,
-            "HistoryDB": HistoryDB,
+            "LifecycleHistoryDb": LifecycleHistoryDb,
             "UDPControlPlane": UDPControlPlane,
             "WebSocketHub": WebSocketHub,
         },

--- a/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import SQLiteHistoryEngine
 from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
@@ -154,7 +154,7 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
 
     events: list[str] = []
 
-    original_close = HistoryDB.close
+    original_close = SQLiteHistoryEngine.close
 
     def _tracking_close(self):
         events.append("db_close")
@@ -169,7 +169,7 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
 
     monkeypatch.setattr(bootstrap_mod, "start_udp_data_receiver", _fake_udp_receiver)
     monkeypatch.setattr(UDPControlPlane, "start", _fake_start)
-    monkeypatch.setattr(HistoryDB, "close", _tracking_close)
+    monkeypatch.setattr(SQLiteHistoryEngine, "close", _tracking_close)
     monkeypatch.setattr(RunRecorder, "wait_for_post_analysis", _tracking_wait)
 
     app = app_module.create_app(config_path=cfg_path)

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -1,53 +1,82 @@
-"""SQLite-backed persistence for the VibeSensor server.
-
-``HistoryDB`` remains the public entry point while internal lifecycle,
-sample-I/O, and query helpers live in focused sibling modules.
-"""
+"""SQLite-backed history persistence adapters built on a shared engine."""
 
 from __future__ import annotations
 
 import logging
-import os
-import shutil
 import sqlite3
-import tempfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
+from typing import Any
 
-from vibesensor.adapters.persistence.history_db._queries import _HistoryDBQueryMixin
-from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
-from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
-from vibesensor.adapters.persistence.history_db._schema import (
-    SCHEMA_SQL,
-    SCHEMA_VERSION,
+from vibesensor.adapters.persistence.history_db._client_names_repository import (
+    ClientNameRepository,
 )
-from vibesensor.shared.boundaries.settings_snapshot_codec import settings_snapshot_from_payload
-from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
-from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import is_json_object
-from vibesensor.shared.types.persisted_analysis import PERSISTED_ANALYSIS_SCHEMA_VERSION
-from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload
+from vibesensor.adapters.persistence.history_db._engine import SQLiteHistoryEngine
+from vibesensor.adapters.persistence.history_db._run_repository import RunHistoryRepository
+from vibesensor.adapters.persistence.history_db._settings_repository import (
+    SettingsSnapshotRepository,
+)
 
-# Re-export for public API.
-__all__ = ["HistoryDB"]
+__all__ = [
+    "ClientNameRepository",
+    "HistoryDB",
+    "HistoryPersistenceAdapters",
+    "RunHistoryRepository",
+    "SQLiteHistoryEngine",
+    "SettingsSnapshotRepository",
+    "create_history_persistence_adapters",
+]
 
 LOGGER = logging.getLogger(__name__)
 
-_CASE_ID_MIGRATION_SOURCE_VERSION = 8
-_SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION = 9
-_PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION = 10
+
+@dataclass(frozen=True, slots=True)
+class HistoryPersistenceAdapters:
+    """Concrete persistence collaborators built over one SQLite history engine."""
+
+    lifecycle: SQLiteHistoryEngine
+    run_repository: RunHistoryRepository
+    settings_snapshot_repository: SettingsSnapshotRepository
+    client_name_repository: ClientNameRepository
 
 
-class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDBQueryMixin):
-    """Thin wrapper around a SQLite database for run history.
+def create_history_persistence_adapters(
+    db_path: Path,
+    *,
+    corruption_reporter: Callable[[str], None] | None = None,
+) -> HistoryPersistenceAdapters:
+    """Build the shared history engine plus narrow repositories on top of it."""
+    lifecycle = SQLiteHistoryEngine(
+        db_path,
+        corruption_reporter=corruption_reporter,
+    )
+    cursor_provider = lifecycle._cursor
+    return HistoryPersistenceAdapters(
+        lifecycle=lifecycle,
+        run_repository=RunHistoryRepository(
+            cursor_provider=cursor_provider,
+            write_transaction_cursor_provider=lifecycle.write_transaction_cursor,
+        ),
+        settings_snapshot_repository=SettingsSnapshotRepository(
+            cursor_provider=cursor_provider,
+        ),
+        client_name_repository=ClientNameRepository(
+            cursor_provider=cursor_provider,
+        ),
+    )
 
-    The mixins deliberately group non-overlapping public method families:
-    lifecycle writes, sample I/O, and read/query helpers. ``HistoryDB`` owns the
-    shared connection state plus the ``_cursor()`` / transaction hooks that each
-    mixin uses, so the class remains a small composition root rather than a
-    cross-calling diamond of partially overlapping base classes.
+
+class HistoryDB:
+    """Compatibility facade over the split history persistence collaborators.
+
+    New production wiring should prefer the narrow repositories returned by
+    :func:`create_history_persistence_adapters`. This wrapper is retained so the
+    focused history-db tests and any remaining legacy call sites can continue to
+    exercise the same public surface while the app transitions to explicit
+    injection of narrower persistence capabilities.
     """
 
     def __init__(
@@ -56,336 +85,122 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
         *,
         corruption_reporter: Callable[[str], None] | None = None,
     ) -> None:
-        self.db_path = db_path
-        self._corruption_reporter = corruption_reporter
-        self._corruption_details: str | None = None
-        self._lock = RLock()
-        self._read_lock = RLock()
-        db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._use_separate_read_conn = str(db_path) != ":memory:"
-        self._conn: sqlite3.Connection | None = sqlite3.connect(db_path, check_same_thread=False)
-        self._read_conn: sqlite3.Connection | None = None
-        try:
-            self._configure_connection(self._conn, read_only=False)
-            self._ensure_schema()
-            self._run_startup_quick_check()
-            if self._use_separate_read_conn:
-                self._read_conn = sqlite3.connect(db_path, check_same_thread=False)
-                self._configure_connection(self._read_conn, read_only=True)
-        except sqlite3.Error:
-            if self._read_conn is not None:
-                self._read_conn.close()
-            self._conn.close()
-            raise
+        self._engine = SQLiteHistoryEngine(
+            db_path,
+            corruption_reporter=corruption_reporter,
+        )
+        self._run_repository = RunHistoryRepository(
+            cursor_provider=lambda *, commit=True: self._cursor(commit=commit),
+            write_transaction_cursor_provider=lambda: self.write_transaction_cursor(),
+        )
+        self._settings_snapshot_repository = SettingsSnapshotRepository(
+            cursor_provider=lambda *, commit=True: self._cursor(commit=commit),
+        )
+        self._client_name_repository = ClientNameRepository(
+            cursor_provider=lambda *, commit=True: self._cursor(commit=commit),
+        )
 
-    # -- lifecycle ------------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:
+        for delegate in (
+            self._run_repository,
+            self._settings_snapshot_repository,
+            self._client_name_repository,
+            self._engine,
+        ):
+            try:
+                return getattr(delegate, name)
+            except AttributeError:
+                continue
+        raise AttributeError(f"{self.__class__.__name__!s} object has no attribute {name!r}")
 
-    @staticmethod
-    def _configure_connection(conn: sqlite3.Connection, *, read_only: bool) -> None:
-        conn.execute("PRAGMA journal_mode=WAL")
-        if not read_only:
-            conn.execute("PRAGMA wal_autocheckpoint=500")
-        conn.execute("PRAGMA foreign_keys=ON")
-        conn.execute("PRAGMA busy_timeout=5000")
-        if read_only:
-            conn.execute("PRAGMA query_only=ON")
+    @property
+    def _conn(self) -> sqlite3.Connection | None:
+        return self._engine._conn
+
+    @_conn.setter
+    def _conn(self, value: sqlite3.Connection | None) -> None:
+        self._engine._conn = value
+
+    @property
+    def _read_conn(self) -> sqlite3.Connection | None:
+        return self._engine._read_conn
+
+    @_read_conn.setter
+    def _read_conn(self, value: sqlite3.Connection | None) -> None:
+        self._engine._read_conn = value
+
+    @property
+    def _lock(self) -> RLock:
+        return self._engine._lock
+
+    @_lock.setter
+    def _lock(self, value: RLock) -> None:
+        self._engine._lock = value
+
+    @property
+    def _read_lock(self) -> RLock:
+        return self._engine._read_lock
+
+    @_read_lock.setter
+    def _read_lock(self, value: RLock) -> None:
+        self._engine._read_lock = value
 
     def close(self) -> None:
-        with self._lock:
-            if self._conn is not None:
-                self._conn.close()
-                self._conn = None
-        with self._read_lock:
-            if self._read_conn is not None:
-                self._read_conn.close()
-                self._read_conn = None
+        self._engine.close()
 
     def _cursor_connection(
         self,
         *,
         commit: bool,
     ) -> tuple[sqlite3.Connection | None, RLock]:
-        if not commit and self._read_conn is not None:
-            return self._read_conn, self._read_lock
-        return self._conn, self._lock
+        return self._engine._cursor_connection(commit=commit)
 
     @contextmanager
     def _cursor(self, *, commit: bool = True) -> Iterator[sqlite3.Cursor]:
-        conn, lock = self._cursor_connection(commit=commit)
-        with lock:
-            if conn is None:
-                raise RuntimeError("HistoryDB is closed")
-            if commit:
-                self._assert_write_allowed()
-            cur = conn.cursor()
-            try:
-                yield cur
-                if commit:
-                    conn.commit()
-            except BaseException:
-                if conn.in_transaction:
-                    conn.rollback()
-                raise
-            finally:
-                cur.close()
+        with self._engine._cursor(commit=commit) as cur:
+            yield cur
 
     @contextmanager
     def write_transaction_cursor(self) -> Iterator[sqlite3.Cursor]:
-        """Run a multi-step write sequence as one explicit transaction."""
-        with self._lock:
-            if self._conn is None:
-                raise RuntimeError("HistoryDB is closed")
-            self._assert_write_allowed()
-            cur = self._conn.cursor()
-            try:
-                cur.execute("BEGIN IMMEDIATE")
-                yield cur
-                self._conn.commit()
-            except BaseException:
-                if self._conn.in_transaction:
-                    self._conn.rollback()
-                raise
-            finally:
-                cur.close()
-
-    @property
-    def corruption_detected(self) -> bool:
-        return self._corruption_details is not None
-
-    @property
-    def corruption_details(self) -> str | None:
-        return self._corruption_details
+        with self._engine.write_transaction_cursor() as cur:
+            yield cur
 
     def _assert_write_allowed(self) -> None:
-        if self._corruption_details is None:
-            return
-        raise sqlite3.DatabaseError(
-            "History DB quick_check reported corruption for "
-            f"{self.db_path}: {self._corruption_details}. Writes are disabled until "
-            "the database is repaired or replaced."
-        )
+        self._engine._assert_write_allowed()
 
     def _mark_corrupted(self, details: str) -> None:
-        self._corruption_details = details
-        if self._corruption_reporter is not None:
-            self._corruption_reporter(details)
-
-    # -- schema ---------------------------------------------------------------
+        self._engine._mark_corrupted(details)
 
     def _ensure_schema(self) -> None:
-        with self._cursor() as cur:
-            cur.executescript(SCHEMA_SQL)
-
-        version = self._schema_version()
-
-        if version == 0:
-            # Check for legacy schema_meta table (pre-v5 databases).
-            with self._cursor(commit=False) as cur:
-                cur.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'"
-                )
-                if cur.fetchone() is not None:
-                    raise RuntimeError(
-                        f"Database at {self.db_path} uses a legacy "
-                        "schema_meta table incompatible with the current "
-                        f"v{SCHEMA_VERSION} format. Delete it to recreate."
-                    )
-            # Fresh database — stamp with current version.
-            with self._cursor() as cur:
-                cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
-            return
-
-        if version == SCHEMA_VERSION:
-            return
-        if version > SCHEMA_VERSION:
-            raise RuntimeError(
-                f"History DB schema version {version} is newer than "
-                f"supported {SCHEMA_VERSION}. Cannot downgrade.",
-            )
-        while version < SCHEMA_VERSION:
-            migration = self._migration_step(version)
-            if migration is None:
-                msg = (
-                    f"Database schema v{version} is incompatible with "
-                    f"current v{SCHEMA_VERSION}. "
-                    f"Delete the database file at {self.db_path} to recreate it."
-                )
-                raise RuntimeError(msg)
-            next_version, handler = migration
-            backup_path = self._create_migration_backup(version)
-            try:
-                handler()
-                actual_version = self._schema_version()
-                if actual_version != next_version:
-                    raise RuntimeError(
-                        "History DB migration "
-                        f"v{version}→v{next_version} completed without updating "
-                        f"PRAGMA user_version (found v{actual_version})"
-                    )
-            except BaseException as exc:
-                self._restore_migration_backup(backup_path)
-                raise RuntimeError(
-                    "History DB migration "
-                    f"v{version}→v{next_version} failed; restored backup from {backup_path}"
-                ) from exc
-            version = next_version
+        self._engine._ensure_schema()
 
     def _schema_version(self) -> int:
-        with self._cursor(commit=False) as cur:
-            cur.execute("PRAGMA user_version")
-            row = cur.fetchone()
-        return int(row[0]) if row is not None else 0
+        return self._engine._schema_version()
 
     def _migration_step(self, version: int) -> tuple[int, Callable[[], None]] | None:
-        steps: tuple[tuple[int, int, Callable[[], None]], ...] = (
-            (
-                _CASE_ID_MIGRATION_SOURCE_VERSION,
-                _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION,
-                self._migrate_v8_to_v9_case_id,
-            ),
-            (
-                _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION,
-                _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION,
-                self._migrate_v9_to_v10_settings_table,
-            ),
-            (
-                _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION,
-                SCHEMA_VERSION,
-                self._migrate_v10_to_v11_persisted_analysis_version,
-            ),
-        )
-        for from_version, to_version, handler in steps:
-            if from_version == version:
-                return to_version, handler
-        return None
+        return self._engine._migration_step(version)
 
     def _migration_backup_path(self, version: int) -> Path:
-        return self.db_path.with_suffix(f".bak-v{version}")
+        return self._engine._migration_backup_path(version)
 
     def _create_migration_backup(self, version: int) -> Path:
-        if self._conn is None:
-            raise RuntimeError("HistoryDB is closed")
-        if str(self.db_path) == ":memory:":
-            raise RuntimeError("Cannot create migration backup for in-memory HistoryDB")
-        backup_path = self._migration_backup_path(version)
-        fd, temp_path_text = tempfile.mkstemp(
-            prefix=f"{backup_path.name}.",
-            suffix=".tmp",
-            dir=backup_path.parent,
-        )
-        os.close(fd)
-        temp_path = Path(temp_path_text)
-        backup_conn = sqlite3.connect(temp_path)
-        try:
-            try:
-                backup_conn.execute("PRAGMA journal_mode=DELETE")
-                self._conn.backup(backup_conn)
-            finally:
-                backup_conn.close()
-            temp_path.chmod(0o600)
-            temp_path.replace(backup_path)
-        except BaseException:
-            temp_path.unlink(missing_ok=True)
-            raise
-        LOGGER.warning(
-            "Created pre-migration backup for %s at %s",
-            self.db_path,
-            backup_path,
-        )
-        return backup_path
+        return self._engine._create_migration_backup(version)
 
     def _restore_migration_backup(self, backup_path: Path) -> None:
-        if self._conn is not None:
-            self._conn.close()
-            self._conn = None
-        if self._read_conn is not None:
-            self._read_conn.close()
-            self._read_conn = None
-        Path(f"{self.db_path}-wal").unlink(missing_ok=True)
-        Path(f"{self.db_path}-shm").unlink(missing_ok=True)
-        shutil.copy2(backup_path, self.db_path)
-        LOGGER.error(
-            "Restored History DB backup after migration failure: %s -> %s",
-            backup_path,
-            self.db_path,
-        )
+        self._engine._restore_migration_backup(backup_path)
 
     @staticmethod
     def _has_runs_column(cur: sqlite3.Cursor, column_name: str) -> bool:
-        cur.execute("PRAGMA table_info(runs)")
-        return any(str(row[1]) == column_name for row in cur.fetchall())
+        return SQLiteHistoryEngine._has_runs_column(cur, column_name)
 
     def _migrate_v8_to_v9_case_id(self) -> None:
-        LOGGER.info("Migrating history DB at %s from schema v8 to v9", self.db_path)
-        with self._cursor() as cur:
-            if not self._has_runs_column(cur, "case_id"):
-                cur.execute("ALTER TABLE runs ADD COLUMN case_id TEXT")
-
-            cur.execute(
-                "SELECT run_id, analysis_json FROM runs "
-                "WHERE case_id IS NULL AND analysis_json IS NOT NULL"
-            )
-            updates: list[tuple[str, str]] = []
-            for run_id, analysis_json in cur.fetchall():
-                parsed_analysis = safe_json_loads(
-                    analysis_json,
-                    context=f"run {run_id} analysis during schema migration",
-                )
-                if not is_json_object(parsed_analysis):
-                    continue
-                case_id = parsed_analysis.get("case_id")
-                if isinstance(case_id, str) and case_id.strip():
-                    updates.append((case_id, str(run_id)))
-
-            if updates:
-                cur.executemany(
-                    "UPDATE runs SET case_id = ? WHERE run_id = ? AND case_id IS NULL",
-                    updates,
-                )
-
-            cur.execute("PRAGMA user_version = 9")
+        self._engine._migrate_v8_to_v9_case_id()
 
     def _migrate_v9_to_v10_settings_table(self) -> None:
-        LOGGER.info("Migrating history DB at %s from schema v9 to v10", self.db_path)
-        with self._cursor() as cur:
-            cur.execute(
-                "CREATE TABLE IF NOT EXISTS settings_snapshot ("
-                "id INTEGER PRIMARY KEY CHECK(id = 1), "
-                "value_json TEXT NOT NULL, "
-                "updated_at TEXT NOT NULL)"
-            )
-            cur.execute(
-                "INSERT OR IGNORE INTO settings_snapshot (id, value_json, updated_at) "
-                "SELECT 1, value_json, updated_at FROM settings_kv "
-                "WHERE key = 'settings_snapshot'"
-            )
-            cur.execute("DROP TABLE IF EXISTS settings_kv")
-            cur.execute(
-                f"PRAGMA user_version = {_PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION}"
-            )
+        self._engine._migrate_v9_to_v10_settings_table()
 
     def _migrate_v10_to_v11_persisted_analysis_version(self) -> None:
-        LOGGER.info("Migrating history DB at %s from schema v10 to v11", self.db_path)
-        with self._cursor() as cur:
-            cur.execute("SELECT run_id, analysis_json FROM runs WHERE analysis_json IS NOT NULL")
-            updates: list[tuple[str, str]] = []
-            for run_id, analysis_json in cur.fetchall():
-                parsed_analysis = safe_json_loads(
-                    analysis_json,
-                    context=f"run {run_id} analysis during schema migration",
-                )
-                if not is_json_object(parsed_analysis):
-                    continue
-                if parsed_analysis.get("_schema_version") == PERSISTED_ANALYSIS_SCHEMA_VERSION:
-                    continue
-                parsed_analysis["_schema_version"] = PERSISTED_ANALYSIS_SCHEMA_VERSION
-                updates.append((safe_json_dumps(parsed_analysis), str(run_id)))
-            if updates:
-                cur.executemany(
-                    "UPDATE runs SET analysis_json = ? WHERE run_id = ?",
-                    updates,
-                )
-            cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        self._engine._migrate_v10_to_v11_persisted_analysis_version()
 
     def _run_startup_quick_check(self) -> None:
         try:
@@ -407,47 +222,3 @@ class HistoryDB(_HistoryDBRunLifecycleMixin, _HistoryDBSampleIOMixin, _HistoryDB
                 self.db_path,
                 details,
             )
-
-    # -- settings_snapshot persistence -----------------------------------------
-
-    def get_settings_snapshot(self) -> SettingsSnapshotPayload | None:
-        with self._cursor(commit=False) as cur:
-            cur.execute("SELECT value_json FROM settings_snapshot WHERE id = 1")
-            row = cur.fetchone()
-        if row is None:
-            return None
-        snapshot = safe_json_loads(row[0], context="settings_snapshot")
-        return settings_snapshot_from_payload(snapshot) if is_json_object(snapshot) else None
-
-    def set_settings_snapshot(self, snapshot: SettingsSnapshotPayload) -> None:
-        now = utc_now_iso()
-        with self._cursor() as cur:
-            cur.execute(
-                "INSERT INTO settings_snapshot (id, value_json, updated_at) VALUES (1, ?, ?) "
-                "ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, "
-                "updated_at = excluded.updated_at",
-                (safe_json_dumps(snapshot), now),
-            )
-
-    # -- client_names persistence ---------------------------------------------
-
-    def list_client_names(self) -> dict[str, str]:
-        with self._cursor(commit=False) as cur:
-            cur.execute("SELECT client_id, name FROM client_names")
-            rows = cur.fetchall()
-        return {row[0]: row[1] for row in rows}
-
-    def upsert_client_name(self, client_id: str, name: str) -> None:
-        now = utc_now_iso()
-        with self._cursor() as cur:
-            cur.execute(
-                "INSERT INTO client_names (client_id, name, updated_at) VALUES (?, ?, ?) "
-                "ON CONFLICT(client_id) DO UPDATE SET name = excluded.name, "
-                "updated_at = excluded.updated_at",
-                (client_id, name, now),
-            )
-
-    def delete_client_name(self, client_id: str) -> bool:
-        with self._cursor() as cur:
-            cur.execute("DELETE FROM client_names WHERE client_id = ?", (client_id,))
-            return bool(int(cur.rowcount) > 0)

--- a/apps/server/vibesensor/adapters/persistence/history_db/_client_names_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_client_names_repository.py
@@ -1,0 +1,48 @@
+"""SQLite-backed client-name repository built on the shared history engine."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+
+from vibesensor.shared.time_utils import utc_now_iso
+
+__all__ = ["ClientNameRepository"]
+
+
+class ClientNameRepository:
+    """Own only the `client_names` table operations."""
+
+    __slots__ = ("_cursor_provider",)
+
+    def __init__(
+        self,
+        *,
+        cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+    ) -> None:
+        self._cursor_provider = cursor_provider
+
+    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+        return self._cursor_provider(commit=commit)
+
+    def list_client_names(self) -> dict[str, str]:
+        with self._cursor(commit=False) as cur:
+            cur.execute("SELECT client_id, name FROM client_names")
+            rows = cur.fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def upsert_client_name(self, client_id: str, name: str) -> None:
+        now = utc_now_iso()
+        with self._cursor() as cur:
+            cur.execute(
+                "INSERT INTO client_names (client_id, name, updated_at) VALUES (?, ?, ?) "
+                "ON CONFLICT(client_id) DO UPDATE SET name = excluded.name, "
+                "updated_at = excluded.updated_at",
+                (client_id, name, now),
+            )
+
+    def delete_client_name(self, client_id: str) -> bool:
+        with self._cursor() as cur:
+            cur.execute("DELETE FROM client_names WHERE client_id = ?", (client_id,))
+            return bool(int(cur.rowcount) > 0)

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -1,0 +1,396 @@
+"""Shared SQLite lifecycle/engine utilities for history persistence adapters."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sqlite3
+import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from threading import RLock
+
+from vibesensor.adapters.persistence.history_db._schema import (
+    SCHEMA_SQL,
+    SCHEMA_VERSION,
+)
+from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
+from vibesensor.shared.types.json_types import is_json_object
+from vibesensor.shared.types.persisted_analysis import PERSISTED_ANALYSIS_SCHEMA_VERSION
+
+LOGGER = logging.getLogger(__name__)
+
+_CASE_ID_MIGRATION_SOURCE_VERSION = 8
+_SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION = 9
+_PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION = 10
+
+__all__ = ["SQLiteHistoryEngine"]
+
+
+class SQLiteHistoryEngine:
+    """Own SQLite lifecycle, schema, migration, corruption, and cursor state."""
+
+    __slots__ = (
+        "db_path",
+        "_conn",
+        "_corruption_details",
+        "_corruption_reporter",
+        "_lock",
+        "_read_conn",
+        "_read_lock",
+        "_use_separate_read_conn",
+    )
+
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        corruption_reporter: Callable[[str], None] | None = None,
+    ) -> None:
+        self.db_path = db_path
+        self._corruption_reporter = corruption_reporter
+        self._corruption_details: str | None = None
+        self._lock = RLock()
+        self._read_lock = RLock()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._use_separate_read_conn = str(db_path) != ":memory:"
+        self._conn: sqlite3.Connection | None = sqlite3.connect(db_path, check_same_thread=False)
+        self._read_conn: sqlite3.Connection | None = None
+        try:
+            self._configure_connection(self._conn, read_only=False)
+            self._ensure_schema()
+            self._run_startup_quick_check()
+            if self._use_separate_read_conn:
+                self._read_conn = sqlite3.connect(db_path, check_same_thread=False)
+                self._configure_connection(self._read_conn, read_only=True)
+        except sqlite3.Error:
+            if self._read_conn is not None:
+                self._read_conn.close()
+            self._conn.close()
+            raise
+
+    @staticmethod
+    def _configure_connection(conn: sqlite3.Connection, *, read_only: bool) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        if not read_only:
+            conn.execute("PRAGMA wal_autocheckpoint=500")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA busy_timeout=5000")
+        if read_only:
+            conn.execute("PRAGMA query_only=ON")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+        with self._read_lock:
+            if self._read_conn is not None:
+                self._read_conn.close()
+                self._read_conn = None
+
+    def _cursor_connection(
+        self,
+        *,
+        commit: bool,
+    ) -> tuple[sqlite3.Connection | None, RLock]:
+        if not commit and self._read_conn is not None:
+            return self._read_conn, self._read_lock
+        return self._conn, self._lock
+
+    @contextmanager
+    def _cursor(self, *, commit: bool = True) -> Iterator[sqlite3.Cursor]:
+        conn, lock = self._cursor_connection(commit=commit)
+        with lock:
+            if conn is None:
+                raise RuntimeError("HistoryDB is closed")
+            if commit:
+                self._assert_write_allowed()
+            cur = conn.cursor()
+            try:
+                yield cur
+                if commit:
+                    conn.commit()
+            except BaseException:
+                if conn.in_transaction:
+                    conn.rollback()
+                raise
+            finally:
+                cur.close()
+
+    @contextmanager
+    def write_transaction_cursor(self) -> Iterator[sqlite3.Cursor]:
+        """Run a multi-step write sequence as one explicit transaction."""
+        with self._lock:
+            if self._conn is None:
+                raise RuntimeError("HistoryDB is closed")
+            self._assert_write_allowed()
+            cur = self._conn.cursor()
+            try:
+                cur.execute("BEGIN IMMEDIATE")
+                yield cur
+                self._conn.commit()
+            except BaseException:
+                if self._conn.in_transaction:
+                    self._conn.rollback()
+                raise
+            finally:
+                cur.close()
+
+    @property
+    def corruption_detected(self) -> bool:
+        return self._corruption_details is not None
+
+    @property
+    def corruption_details(self) -> str | None:
+        return self._corruption_details
+
+    def _assert_write_allowed(self) -> None:
+        if self._corruption_details is None:
+            return
+        raise sqlite3.DatabaseError(
+            "History DB quick_check reported corruption for "
+            f"{self.db_path}: {self._corruption_details}. Writes are disabled until "
+            "the database is repaired or replaced."
+        )
+
+    def _mark_corrupted(self, details: str) -> None:
+        self._corruption_details = details
+        if self._corruption_reporter is not None:
+            self._corruption_reporter(details)
+
+    def _ensure_schema(self) -> None:
+        with self._cursor() as cur:
+            cur.executescript(SCHEMA_SQL)
+
+        version = self._schema_version()
+
+        if version == 0:
+            with self._cursor(commit=False) as cur:
+                cur.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'"
+                )
+                if cur.fetchone() is not None:
+                    raise RuntimeError(
+                        f"Database at {self.db_path} uses a legacy "
+                        "schema_meta table incompatible with the current "
+                        f"v{SCHEMA_VERSION} format. Delete it to recreate."
+                    )
+            with self._cursor() as cur:
+                cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            return
+
+        if version == SCHEMA_VERSION:
+            return
+        if version > SCHEMA_VERSION:
+            raise RuntimeError(
+                f"History DB schema version {version} is newer than "
+                f"supported {SCHEMA_VERSION}. Cannot downgrade.",
+            )
+        while version < SCHEMA_VERSION:
+            migration = self._migration_step(version)
+            if migration is None:
+                msg = (
+                    f"Database schema v{version} is incompatible with "
+                    f"current v{SCHEMA_VERSION}. "
+                    f"Delete the database file at {self.db_path} to recreate it."
+                )
+                raise RuntimeError(msg)
+            next_version, handler = migration
+            backup_path = self._create_migration_backup(version)
+            try:
+                handler()
+                actual_version = self._schema_version()
+                if actual_version != next_version:
+                    raise RuntimeError(
+                        "History DB migration "
+                        f"v{version}→v{next_version} completed without updating "
+                        f"PRAGMA user_version (found v{actual_version})"
+                    )
+            except BaseException as exc:
+                self._restore_migration_backup(backup_path)
+                raise RuntimeError(
+                    "History DB migration "
+                    f"v{version}→v{next_version} failed; restored backup from {backup_path}"
+                ) from exc
+            version = next_version
+
+    def _schema_version(self) -> int:
+        with self._cursor(commit=False) as cur:
+            cur.execute("PRAGMA user_version")
+            row = cur.fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def _migration_step(self, version: int) -> tuple[int, Callable[[], None]] | None:
+        steps: tuple[tuple[int, int, Callable[[], None]], ...] = (
+            (
+                _CASE_ID_MIGRATION_SOURCE_VERSION,
+                _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION,
+                self._migrate_v8_to_v9_case_id,
+            ),
+            (
+                _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION,
+                _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION,
+                self._migrate_v9_to_v10_settings_table,
+            ),
+            (
+                _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION,
+                SCHEMA_VERSION,
+                self._migrate_v10_to_v11_persisted_analysis_version,
+            ),
+        )
+        for from_version, to_version, handler in steps:
+            if from_version == version:
+                return to_version, handler
+        return None
+
+    def _migration_backup_path(self, version: int) -> Path:
+        return self.db_path.with_suffix(f".bak-v{version}")
+
+    def _create_migration_backup(self, version: int) -> Path:
+        if self._conn is None:
+            raise RuntimeError("HistoryDB is closed")
+        if str(self.db_path) == ":memory:":
+            raise RuntimeError("Cannot create migration backup for in-memory HistoryDB")
+        backup_path = self._migration_backup_path(version)
+        fd, temp_path_text = tempfile.mkstemp(
+            prefix=f"{backup_path.name}.",
+            suffix=".tmp",
+            dir=backup_path.parent,
+        )
+        os.close(fd)
+        temp_path = Path(temp_path_text)
+        backup_conn = sqlite3.connect(temp_path)
+        try:
+            try:
+                backup_conn.execute("PRAGMA journal_mode=DELETE")
+                self._conn.backup(backup_conn)
+            finally:
+                backup_conn.close()
+            temp_path.chmod(0o600)
+            temp_path.replace(backup_path)
+        except BaseException:
+            temp_path.unlink(missing_ok=True)
+            raise
+        LOGGER.warning(
+            "Created pre-migration backup for %s at %s",
+            self.db_path,
+            backup_path,
+        )
+        return backup_path
+
+    def _restore_migration_backup(self, backup_path: Path) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+        if self._read_conn is not None:
+            self._read_conn.close()
+            self._read_conn = None
+        Path(f"{self.db_path}-wal").unlink(missing_ok=True)
+        Path(f"{self.db_path}-shm").unlink(missing_ok=True)
+        shutil.copy2(backup_path, self.db_path)
+        LOGGER.error(
+            "Restored History DB backup after migration failure: %s -> %s",
+            backup_path,
+            self.db_path,
+        )
+
+    @staticmethod
+    def _has_runs_column(cur: sqlite3.Cursor, column_name: str) -> bool:
+        cur.execute("PRAGMA table_info(runs)")
+        return any(str(row[1]) == column_name for row in cur.fetchall())
+
+    def _migrate_v8_to_v9_case_id(self) -> None:
+        LOGGER.info("Migrating history DB at %s from schema v8 to v9", self.db_path)
+        with self._cursor() as cur:
+            if not self._has_runs_column(cur, "case_id"):
+                cur.execute("ALTER TABLE runs ADD COLUMN case_id TEXT")
+
+            cur.execute(
+                "SELECT run_id, analysis_json FROM runs "
+                "WHERE case_id IS NULL AND analysis_json IS NOT NULL"
+            )
+            updates: list[tuple[str, str]] = []
+            for run_id, analysis_json in cur.fetchall():
+                parsed_analysis = safe_json_loads(
+                    analysis_json,
+                    context=f"run {run_id} analysis during schema migration",
+                )
+                if not is_json_object(parsed_analysis):
+                    continue
+                case_id = parsed_analysis.get("case_id")
+                if isinstance(case_id, str) and case_id.strip():
+                    updates.append((case_id, str(run_id)))
+
+            if updates:
+                cur.executemany(
+                    "UPDATE runs SET case_id = ? WHERE run_id = ? AND case_id IS NULL",
+                    updates,
+                )
+
+            cur.execute("PRAGMA user_version = 9")
+
+    def _migrate_v9_to_v10_settings_table(self) -> None:
+        LOGGER.info("Migrating history DB at %s from schema v9 to v10", self.db_path)
+        with self._cursor() as cur:
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS settings_snapshot ("
+                "id INTEGER PRIMARY KEY CHECK(id = 1), "
+                "value_json TEXT NOT NULL, "
+                "updated_at TEXT NOT NULL)"
+            )
+            cur.execute(
+                "INSERT OR IGNORE INTO settings_snapshot (id, value_json, updated_at) "
+                "SELECT 1, value_json, updated_at FROM settings_kv "
+                "WHERE key = 'settings_snapshot'"
+            )
+            cur.execute("DROP TABLE IF EXISTS settings_kv")
+            cur.execute(
+                f"PRAGMA user_version = {_PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION}"
+            )
+
+    def _migrate_v10_to_v11_persisted_analysis_version(self) -> None:
+        LOGGER.info("Migrating history DB at %s from schema v10 to v11", self.db_path)
+        with self._cursor() as cur:
+            cur.execute("SELECT run_id, analysis_json FROM runs WHERE analysis_json IS NOT NULL")
+            updates: list[tuple[str, str]] = []
+            for run_id, analysis_json in cur.fetchall():
+                parsed_analysis = safe_json_loads(
+                    analysis_json,
+                    context=f"run {run_id} analysis during schema migration",
+                )
+                if not is_json_object(parsed_analysis):
+                    continue
+                if parsed_analysis.get("_schema_version") == PERSISTED_ANALYSIS_SCHEMA_VERSION:
+                    continue
+                parsed_analysis["_schema_version"] = PERSISTED_ANALYSIS_SCHEMA_VERSION
+                updates.append((safe_json_dumps(parsed_analysis), str(run_id)))
+            if updates:
+                cur.executemany(
+                    "UPDATE runs SET analysis_json = ? WHERE run_id = ?",
+                    updates,
+                )
+            cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def _run_startup_quick_check(self) -> None:
+        try:
+            with self._cursor(commit=False) as cur:
+                cur.execute("PRAGMA quick_check")
+                problems = [str(row[0]) for row in cur.fetchall() if str(row[0]) != "ok"]
+        except sqlite3.Error:
+            LOGGER.critical(
+                "History DB quick_check failed during startup for %s",
+                self.db_path,
+                exc_info=True,
+            )
+            raise
+        if problems:
+            details = "; ".join(problems)
+            self._mark_corrupted(details)
+            LOGGER.critical(
+                "History DB quick_check reported corruption for %s: %s",
+                self.db_path,
+                details,
+            )

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
@@ -1,0 +1,38 @@
+"""SQLite-backed run/history repository built on the shared history engine."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+
+from vibesensor.adapters.persistence.history_db._queries import _HistoryDBQueryMixin
+from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
+from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
+
+__all__ = ["RunHistoryRepository"]
+
+
+class RunHistoryRepository(
+    _HistoryDBRunLifecycleMixin,
+    _HistoryDBSampleIOMixin,
+    _HistoryDBQueryMixin,
+):
+    """Run/sample/query persistence bound to one shared SQLite history engine."""
+
+    __slots__ = ("_cursor_provider", "_write_transaction_cursor_provider")
+
+    def __init__(
+        self,
+        *,
+        cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+        write_transaction_cursor_provider: Callable[[], AbstractContextManager[sqlite3.Cursor]],
+    ) -> None:
+        self._cursor_provider = cursor_provider
+        self._write_transaction_cursor_provider = write_transaction_cursor_provider
+
+    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+        return self._cursor_provider(commit=commit)
+
+    def write_transaction_cursor(self) -> AbstractContextManager[sqlite3.Cursor]:
+        return self._write_transaction_cursor_provider()

--- a/apps/server/vibesensor/adapters/persistence/history_db/_settings_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_settings_repository.py
@@ -1,0 +1,50 @@
+"""SQLite-backed settings-snapshot repository built on the shared history engine."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+
+from vibesensor.shared.boundaries.settings_snapshot_codec import settings_snapshot_from_payload
+from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
+from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.json_types import is_json_object
+from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload
+
+__all__ = ["SettingsSnapshotRepository"]
+
+
+class SettingsSnapshotRepository:
+    """Own only the `settings_snapshot` table operations."""
+
+    __slots__ = ("_cursor_provider",)
+
+    def __init__(
+        self,
+        *,
+        cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+    ) -> None:
+        self._cursor_provider = cursor_provider
+
+    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+        return self._cursor_provider(commit=commit)
+
+    def get_settings_snapshot(self) -> SettingsSnapshotPayload | None:
+        with self._cursor(commit=False) as cur:
+            cur.execute("SELECT value_json FROM settings_snapshot WHERE id = 1")
+            row = cur.fetchone()
+        if row is None:
+            return None
+        snapshot = safe_json_loads(row[0], context="settings_snapshot")
+        return settings_snapshot_from_payload(snapshot) if is_json_object(snapshot) else None
+
+    def set_settings_snapshot(self, snapshot: SettingsSnapshotPayload) -> None:
+        now = utc_now_iso()
+        with self._cursor() as cur:
+            cur.execute(
+                "INSERT INTO settings_snapshot (id, value_json, updated_at) VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, "
+                "updated_at = excluded.updated_at",
+                (safe_json_dumps(snapshot), now),
+            )

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -16,7 +16,10 @@ from vibesensor.adapters.http.dependencies import (
     TelemetryDeps,
     UpdateDeps,
 )
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 from vibesensor.adapters.websocket.hub import WebSocketHub
 from vibesensor.app.runtime_state import AppRuntime, RuntimeState
@@ -69,29 +72,29 @@ def create_history_db(
     config: AppConfig,
     *,
     corruption_reporter: Callable[[str], None] | None = None,
-) -> HistoryDB:
-    """Create and initialise the HistoryDB, recovering stale runs and pruning old ones."""
-    history_db = HistoryDB(
+) -> HistoryPersistenceAdapters:
+    """Create and initialise the shared history persistence collaborators."""
+    history = create_history_persistence_adapters(
         config.logging.history_db_path,
         corruption_reporter=corruption_reporter,
     )
-    if history_db.corruption_detected:
+    if history.lifecycle.corruption_detected:
         LOGGER.error(
             "History DB corruption detected at startup; skipping stale-run recovery, "
             "retention pruning, and "
             "continuing with writes disabled until the DB is repaired.",
         )
-        return history_db
+        return history
     try:
-        recovered_runs = history_db.recover_stale_recording_runs()
+        recovered_runs = history.run_repository.recover_stale_recording_runs()
     except Exception:
         LOGGER.error("Failed during early startup DB operations; closing DB.", exc_info=True)
-        history_db.close()
+        history.lifecycle.close()
         raise
     if recovered_runs:
         LOGGER.warning("Recovered %d stale recording run(s) on startup", recovered_runs)
     try:
-        pruned_runs = history_db.prune_terminal_runs_older_than_days(
+        pruned_runs = history.run_repository.prune_terminal_runs_older_than_days(
             config.logging.run_retention_days,
         )
     except Exception:
@@ -107,7 +110,7 @@ def create_history_db(
                 pruned_runs,
                 config.logging.run_retention_days,
             )
-    return history_db
+    return history
 
 
 def build_runtime(config: AppConfig) -> AppRuntime:
@@ -116,12 +119,14 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     health_state = RuntimeHealthState()
 
     # DB + settings
-    history_db = create_history_db(
+    history = create_history_db(
         config,
         corruption_reporter=health_state.mark_db_corrupted,
     )
+    history_db = history.run_repository
+    history_lifecycle = history.lifecycle
     gps_monitor = GPSSpeedMonitor(gps_enabled=config.gps.gps_enabled)
-    settings_store = SettingsStore(db=history_db)
+    settings_store = SettingsStore(db=history.settings_snapshot_repository)
     settings_reader = SettingsDerivationService(
         active_car_aspects=settings_store.active_car_aspects,
         active_car_snapshot=settings_store.active_car_snapshot,
@@ -150,7 +155,7 @@ def build_runtime(config: AppConfig) -> AppRuntime:
 
     # ingress
     registry = ClientRegistry(
-        db=history_db,
+        db=history.client_name_repository,
         live_ttl_seconds=config.processing.client_live_ttl_seconds,
         retention_ttl_seconds=config.processing.client_ttl_seconds,
     )
@@ -240,7 +245,7 @@ def build_runtime(config: AppConfig) -> AppRuntime:
         worker_pool=worker_pool,
         settings_store=settings_reader,
         gps_monitor=gps_monitor,
-        history_db=history_db,
+        history_db=history_lifecycle,
         processing_loop_state=processing_loop_state,
         health_state=health_state,
         processing_loop=processing_loop,

--- a/apps/server/vibesensor/app/runtime_state.py
+++ b/apps/server/vibesensor/app/runtime_state.py
@@ -22,10 +22,10 @@ from vibesensor.use_cases.updates.manager import UpdateManager
 
 if TYPE_CHECKING:
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
-    from vibesensor.adapters.persistence.history_db import HistoryDB
     from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
     from vibesensor.adapters.websocket.hub import WebSocketHub
     from vibesensor.app.settings import AppConfig
+    from vibesensor.infra.runtime.lifecycle import LifecycleHistoryDb
 
 
 @dataclass(slots=True)
@@ -39,7 +39,7 @@ class RuntimeState:
     worker_pool: WorkerPool
     settings_store: SettingsReader
     gps_monitor: GPSSpeedMonitor
-    history_db: HistoryDB
+    history_db: LifecycleHistoryDb
     processing_loop_state: ProcessingLoopState
     health_state: RuntimeHealthState
     processing_loop: ProcessingLoop

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -14,11 +14,17 @@ application settings and client names in a single SQLite file located at
 
 ## Module organization
 
-`adapters/persistence/history_db/` keeps `HistoryDB` as the public facade and
-splits internal responsibilities across focused modules:
+`adapters/persistence/history_db/` now builds a shared SQLite engine plus narrow
+repositories over the same database file:
 
-- `__init__.py`: shared SQLite connection/lock/cursor ownership, schema
-  initialization/migrations, settings snapshot persistence, and client-name persistence.
+- `_engine.py`: shared SQLite connection/lock/cursor ownership, schema
+  initialization/migrations, migration backup/restore, and corruption detection.
+- `_run_repository.py`: run persistence composed from `_run_lifecycle.py`,
+  `_sample_io.py`, and `_queries.py` over the shared engine.
+- `_settings_repository.py`: `settings_snapshot` table persistence only.
+- `_client_names_repository.py`: `client_names` table persistence only.
+- `__init__.py`: adapter bundle factory plus a temporary `HistoryDB`
+  compatibility facade for tests/legacy call sites.
 - `_run_lifecycle.py`: run creation/finalization, sample appends, analysis writes, delete
   flows, stale-recording recovery, and startup retention pruning for old terminal runs.
 - `_sample_io.py`: batched sample reads and keyset-pagination helpers.
@@ -110,8 +116,9 @@ Maps sensor client IDs to human-readable names.
 
 ## Schema upgrades / migrations
 
-Schema versioning uses SQLite's `PRAGMA user_version`. On startup `HistoryDB`
-creates the current tables first, then checks the stored integer version:
+Schema versioning uses SQLite's `PRAGMA user_version`. On startup the shared
+SQLite history engine creates the current tables first, then checks the stored
+integer version:
 
 | Stored version | Action |
 |----------------|--------|
@@ -154,10 +161,10 @@ For a 30-minute run at 4 Hz × 4 sensors (~28,800 samples):
 
 ## Startup retention policy
 
-On startup, `create_history_db()` first recovers stale `recording` rows into
-`error`, then prunes `complete` and `error` runs older than
-`logging.run_retention_days` (default `7`). The prune cutoff uses the run's
-terminal timestamp (`analysis_completed_at`, then `end_time_utc`, then
-`created_at`) so active `recording` / `analyzing` runs are never deleted by the
-automatic policy. Sample rows are removed automatically through the existing
-`ON DELETE CASCADE` foreign key on `samples_v2`.
+On startup, the container builds the shared history engine and run repository,
+first recovers stale `recording` rows into `error`, then prunes `complete` and
+`error` runs older than `logging.run_retention_days` (default `7`). The prune
+cutoff uses the run's terminal timestamp (`analysis_completed_at`, then
+`end_time_utc`, then `created_at`) so active `recording` / `analyzing` runs are
+never deleted by the automatic policy. Sample rows are removed automatically
+through the existing `ON DELETE CASCADE` foreign key on `samples_v2`.


### PR DESCRIPTION
Closes #1333

## Summary

This PR splits the overloaded `HistoryDB` persistence boundary into a shared SQLite lifecycle engine plus narrower repositories for run history, settings snapshots, and client names. The goal is to keep the current database file, schema, and runtime behavior intact while making the dependency graph honest. Before this change, one public adapter owned SQLite connection lifecycle, schema creation and migrations, corruption detection, migration backup and restore, run recovery and retention maintenance, run/sample/query persistence, settings snapshot storage, and client-name persistence. That meant callers that only needed `SettingsSnapshotPersistence` or `ClientNamePersistence` were still coupled to the same object that knew about WAL setup, `PRAGMA quick_check`, write disabling after corruption, and run lifecycle recovery.

The fix deliberately avoids a storage-engine rewrite or a physical database split. Instead, it preserves the current SQLite-backed behavior and reorganizes the code around explicit capabilities. The result is a smaller blast radius for future changes, more truthful constructor signatures in the composition root, and narrower test seams for the areas that actually own each concern.

## Implementation approach

The implementation keeps the existing history database file and schema as the source of truth. Rather than moving tables or changing persisted formats, it extracts the broad `HistoryDB` behavior into focused collaborators that share one engine.

`SQLiteHistoryEngine` is the new owner of SQLite lifecycle concerns. It now holds connection setup, read/write cursor coordination, schema initialization, migration dispatch, migration backup and restore, startup quick-check corruption handling, and write-disable behavior after corruption. Those responsibilities were already present in the old `HistoryDB`; this change gives them one explicit owner.

`RunHistoryRepository` now owns the run lifecycle, sample I/O, and history query APIs by reusing the existing `_run_lifecycle.py`, `_sample_io.py`, and `_queries.py` mixins over engine-provided cursor helpers. `SettingsSnapshotRepository` now owns only the `settings_snapshot` table operations, and `ClientNameRepository` now owns only the `client_names` table operations. Those repositories are intentionally narrow and have constructor signatures that describe the precise database capability they need.

To keep the transition incremental, `HistoryDB` remains as a thin compatibility facade. It delegates to the engine and repositories instead of remaining the primary production boundary. This lets the focused history-db tests and any residual legacy call sites continue to work while production wiring moves to explicit collaborators.

## Main code changes by area

In `apps/server/vibesensor/adapters/persistence/history_db/`, the public entrypoint now exports a frozen `HistoryPersistenceAdapters` bundle and a `create_history_persistence_adapters()` factory. That factory creates one shared `SQLiteHistoryEngine` and layers the run, settings-snapshot, and client-name repositories on top of it. The old monolithic logic was removed from `__init__.py` and replaced with bundle construction plus the compatibility wrapper.

The new `_engine.py` centralizes SQLite lifecycle logic that previously lived beside unrelated persistence APIs. This keeps migration, corruption, backup, and cursor-state changes from automatically broadening every consumer of history persistence.

The new `_run_repository.py`, `_settings_repository.py`, and `_client_names_repository.py` files define the three focused repository surfaces used by the rest of the app. They are intentionally small and avoid introducing a second layer of duplicated business logic; they reuse the existing SQL/query behavior instead of rewriting it.

In `apps/server/vibesensor/app/container.py`, the composition root now creates `HistoryPersistenceAdapters` instead of constructing one broad concrete `HistoryDB` for everything. Startup maintenance continues to use the same retained SQLite file and run-maintenance behavior, but it does so through `history.run_repository` and `history.lifecycle`. `SettingsStore` now receives only the settings-snapshot repository, `ClientRegistry` receives only the client-name repository, history/report/export/run-recorder services receive the run repository, and runtime shutdown keeps only the lifecycle capability it actually needs.

`apps/server/vibesensor/app/runtime_state.py` now reflects that narrower dependency by typing the stored history handle as the lifecycle protocol instead of the full `HistoryDB` concrete class.

## Tests and docs

The test updates focus on the new seams rather than pinning the old wrapper shape. The previous history-db hygiene test guarded the wrapper-plus-mixins arrangement directly; it now verifies the split design instead by checking that the run mixins expose disjoint public APIs, that `HistoryDB` is no longer the primary mixin stack, and that the bundle factory returns the expected split collaborators.

Focused history lifecycle and schema migration tests were updated to patch `SQLiteHistoryEngine` at the construction points that now own startup quick checks and migration behavior. Container and runtime tests were updated so they assert against the new bundle return type and the narrowed lifecycle dependency. Shutdown-analysis coverage was adjusted for the same reason.

Documentation was updated in `apps/server/README.md` and `docs/history_db_schema.md` so the live architecture description matches the code: one shared SQLite engine, several narrow repositories, and a temporary compatibility facade rather than one all-purpose public adapter.

## Validation

I validated the change in two layers.

First, I ran a focused history-db/runtime/container/settings/history slice covering the refactor blast radius:

- `pytest -q apps/server/tests/adapters/persistence/history_db apps/server/tests/hygiene/test_history_db_mixins.py apps/server/tests/app/test_container.py apps/server/tests/app/test_app_lifecycle.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/use_cases/run/test_recorder_runtime.py apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py`
- Result: `205 passed`

Then I ran the standard backend gates for the touched area:

- `make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make test-changed`

Those all passed. The final `make test-changed` run exercised the touched adapters/app/runtime/docs slice and reported `1388 passed` in the selected pytest subset.

## Risks, tradeoffs, and follow-ups

The main tradeoff is that `HistoryDB` still exists temporarily as a compatibility facade instead of being removed outright. I kept that shim intentionally to make this issue incremental and reviewable, and because several focused tests still rely on wrapper-level seams such as `_cursor` and transaction helpers. The important change is that production wiring no longer depends on that broad concrete object.

I also intentionally did not change the SQLite schema, persisted payload formats, or maintenance behavior. That keeps this PR scoped to dependency boundaries rather than mixing in storage migration risk. If a later follow-up wants to remove the compatibility facade entirely, it can do so from a much better starting point now that the engine and repository seams are explicit.
