### PR TITLE
Separate history overlays from persisted reports

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -322,12 +322,11 @@ class FakeState:
         self.run_service = ProjectedHistoryRunService(
             HistoryRunService(
                 self.history_db,
-                self.settings_store,
-            )
+            ),
+            current_car_reader=self.settings_store,
         )
         self.report_service = HistoryReportService(
             self.history_db,
-            self.settings_store,
             pdf_renderer=pdf_renderer,
         )
         self.export_service = ProjectedHistoryExportService(

--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -236,13 +236,12 @@ class FakeState:
             self.run_service = ProjectedHistoryRunService(
                 HistoryRunService(
                     self.history_db,
-                    self.settings_store,
-                )
+                ),
+                current_car_reader=self.settings_store,
             )
         if self.report_service is None:
             self.report_service = HistoryReportService(
                 self.history_db,
-                self.settings_store,
                 pdf_renderer=lambda _prepared: b"%PDF-stub",
             )
         if self.export_service is None:

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -191,14 +191,6 @@ async def test_report_service_load_report_request_keeps_persisted_summary_immuta
                 "analysis": persisted_analysis,
             }
         ),
-        settings_store=_SettingsStoreStub(
-            active_car=CarSnapshot(
-                car_id="car-b",
-                name="Daily Car",
-                car_type="wagon",
-                aspects={"tire_width_mm": 225.0},
-            )
-        ),
     )
 
     request = await loader.load_report_request("run-1", "en")
@@ -216,12 +208,76 @@ async def test_report_service_load_report_request_keeps_persisted_summary_immuta
     assert [warning["code"] for warning in stored_analysis.analysis["warnings"]] == [
         WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
     ]
+    assert request.cache_key[-1] == "none"
     assert prepared.report_facts is not None
     assert [warning["code"] for warning in prepared.report_facts.warnings] == [
         WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
-        WARNING_CODE_CAR_SETTINGS_CHANGED,
     ]
     assert prepared.domain_test_run is not None
+
+
+@pytest.mark.asyncio
+async def test_projected_run_service_adds_current_context_overlay_explicitly() -> None:
+    metadata = {
+        "active_car_snapshot": {
+            "id": "car-a",
+            "name": "Track Car",
+            "type": "coupe",
+            "aspects": {"tire_width_mm": 245.0},
+        },
+        "car_name": "Track Car",
+        "tire_width_mm": 245.0,
+        "incomplete_for_order_analysis": True,
+    }
+    persisted_analysis = cast(
+        AnalysisSummary,
+        run_analysis(
+            [
+                report_sample(
+                    0,
+                    speed_kmh=55.0,
+                    dominant_freq_hz=15.0,
+                    peak_amp_g=0.12,
+                ),
+                report_sample(
+                    1,
+                    speed_kmh=65.0,
+                    dominant_freq_hz=15.0,
+                    peak_amp_g=0.14,
+                ),
+            ],
+            metadata=metadata,
+            lang="en",
+        ),
+    )
+    service = ProjectedHistoryRunService(
+        HistoryRunService(
+            _HistoryDbStub(
+                run={
+                    "run_id": "run-1",
+                    "status": "complete",
+                    "metadata": {"language": "en"},
+                    "analysis": persisted_analysis,
+                }
+            ),
+        ),
+        current_car_reader=_SettingsStoreStub(
+            active_car=CarSnapshot(
+                car_id="car-b",
+                name="Daily Car",
+                car_type="wagon",
+                aspects={"tire_width_mm": 225.0},
+            )
+        ),
+    )
+
+    payload = await service.get_insights("run-1", requested_lang="en")
+
+    assert payload is not None
+    assert [warning["code"] for warning in payload["warnings"]] == [
+        WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+        WARNING_CODE_CAR_SETTINGS_CHANGED,
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/run/test_run_context.py
+++ b/apps/server/tests/use_cases/run/test_run_context.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot, RunContextSnapshot
@@ -16,7 +14,6 @@ from vibesensor.use_cases.run.run_context import (
     add_current_context_warnings,
     apply_run_context_snapshot,
     build_run_context_snapshot,
-    current_car_snapshot_token,
     order_reference_context_complete,
 )
 
@@ -176,25 +173,6 @@ class TestBoundaryHelpers:
             )
             is True
         )
-
-    def test_current_car_snapshot_token_remains_stable_serialization(self) -> None:
-        car = CarSnapshot(
-            car_id="car-1",
-            name="Primary",
-            car_type="sedan",
-            variant="track",
-            aspects={"rim_in": 19.0, "tire_width_mm": 255.0},
-        )
-
-        token = current_car_snapshot_token(car)
-
-        assert json.loads(token) == {
-            "id": "car-1",
-            "name": "Primary",
-            "type": "sedan",
-            "variant": "track",
-            "aspects": {"rim_in": 19.0, "tire_width_mm": 255.0},
-        }
 
 
 def test_add_current_context_warnings_returns_app_level_models() -> None:

--- a/apps/server/vibesensor/adapters/history.py
+++ b/apps/server/vibesensor/adapters/history.py
@@ -18,8 +18,10 @@ from vibesensor.adapters.http.models import (
     HistoryRunResponse,
 )
 from vibesensor.shared.boundaries.analysis_summary_projection import project_analysis_summary
+from vibesensor.shared.boundaries.summary_warning import localize_warning_list
+from vibesensor.shared.ports import ActiveCarReader
 from vibesensor.shared.types.history_records import StoredHistoryRun
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
 from vibesensor.use_cases.history.exports import (
     EXPORT_SPOOL_THRESHOLD,
     HistoryExportContext,
@@ -30,6 +32,7 @@ from vibesensor.use_cases.history.exports import (
 )
 from vibesensor.use_cases.history.helpers import strip_internal_fields
 from vibesensor.use_cases.history.runs import HistoryRunService
+from vibesensor.use_cases.run.run_context import add_current_context_warnings
 
 if TYPE_CHECKING:
     from vibesensor.domain import TestRun
@@ -102,10 +105,15 @@ def build_projected_run_details_json(
 class ProjectedHistoryRunService:
     """Adapter that projects persisted history analysis before HTTP delivery."""
 
-    __slots__ = ("_service",)
+    __slots__ = ("_current_car_reader", "_service")
 
-    def __init__(self, service: HistoryRunService) -> None:
+    def __init__(
+        self,
+        service: HistoryRunService,
+        current_car_reader: ActiveCarReader | None = None,
+    ) -> None:
         self._service = service
+        self._current_car_reader = current_car_reader
 
     async def list_runs(self) -> list[HistoryListEntryResponse]:
         return [
@@ -126,7 +134,21 @@ class ProjectedHistoryRunService:
         result = await self._service.get_insights(run_id, requested_lang=requested_lang)
         if result is None:
             return None
-        validated = _HISTORY_INSIGHTS_ADAPTER.validate_python(project_history_insights(result))
+        projected = project_history_insights(result)
+        if self._current_car_reader is not None:
+            overlay_warnings = add_current_context_warnings(
+                projected.get("warnings"),
+                metadata=projected.get("metadata"),
+                current_active_car_snapshot=self._current_car_reader.active_car_snapshot(),
+            )
+            projected["warnings"] = cast(
+                JsonValue,
+                localize_warning_list(
+                    overlay_warnings,
+                    lang=str(requested_lang or projected.get("lang") or "en"),
+                ),
+            )
+        validated = _HISTORY_INSIGHTS_ADAPTER.validate_python(projected)
         return cast(
             HistoryInsightsResponse,
             _HISTORY_INSIGHTS_ADAPTER.dump_python(validated, mode="json"),

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -140,17 +140,18 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     # persistence services
     history_run_service = HistoryRunService(
         history_db,
-        settings_reader,
     )
     report_service = HistoryReportService(
         history_db,
-        settings_reader,
         pdf_renderer=_build_pdf_bytes,
     )
     history_export_service = HistoryExportService(
         history_db,
     )
-    run_service = ProjectedHistoryRunService(history_run_service)
+    run_service = ProjectedHistoryRunService(
+        history_run_service,
+        current_car_reader=settings_reader,
+    )
     export_service = ProjectedHistoryExportService(history_export_service)
 
     # ingress

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -20,6 +20,7 @@ from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload
 from vibesensor.shared.types.speed_source_config import ResolvedSpeedSource, SpeedSourcePayload
 
 __all__ = [
+    "ActiveCarReader",
     "ClockSyncBroadcaster",
     "ClientTracker",
     "ClientNamePersistence",
@@ -85,6 +86,12 @@ class RunPersistence(Protocol):
     def store_analysis_error(self, run_id: str, error: str) -> bool: ...
 
     def analyzing_run_health(self) -> AnalyzingRunHealth: ...
+
+
+class ActiveCarReader(Protocol):
+    """Minimal current-car access needed by explicit history overlay composition."""
+
+    def active_car_snapshot(self) -> CarSnapshot | None: ...
 
 
 class SettingsReader(Protocol):

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
-from vibesensor.domain import CarSnapshot, RunStatus
+from vibesensor.domain import RunStatus
 from vibesensor.shared.exceptions import AnalysisNotReadyError
-from vibesensor.shared.ports import RunPersistence, SettingsReader
+from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -17,10 +17,8 @@ from vibesensor.use_cases.history.helpers import (
     safe_filename,
 )
 from vibesensor.use_cases.history.report_cache import ReportPdfCacheKey
-from vibesensor.use_cases.run.run_context import (
-    add_current_context_warnings,
-    current_car_snapshot_token,
-)
+
+_PERSISTED_REPORT_MODE_TOKEN = "none"
 
 
 @dataclass(frozen=True)
@@ -37,15 +35,10 @@ class HistoryReportRequest:
 class HistoryReportRequestLoader:
     """Load persisted report data and shape it for PDF generation."""
 
-    __slots__ = ("_history_db", "_settings_store")
+    __slots__ = ("_history_db",)
 
-    def __init__(
-        self,
-        history_db: RunPersistence,
-        settings_store: SettingsReader | None = None,
-    ) -> None:
+    def __init__(self, history_db: RunPersistence) -> None:
         self._history_db = history_db
-        self._settings_store = settings_store
 
     async def load_report_request(
         self,
@@ -66,19 +59,11 @@ class HistoryReportRequestLoader:
             raise AnalysisNotReadyError("No analysis available for this run")
 
         requested_lang = self._analysis_language(run, requested_lang)
-        current_active_car_snapshot = (
-            self._settings_store.active_car_snapshot() if self._settings_store is not None else None
-        )
-        warnings = add_current_context_warnings(
-            analysis.get("warnings"),
-            metadata=analysis.get("metadata"),
-            current_active_car_snapshot=current_active_car_snapshot,
-        )
+        warnings = analysis.get("warnings")
         cache_key = self._report_pdf_cache_key(
             run,
             run_id,
             self._report_pdf_cache_lang(run, requested_lang),
-            current_active_car_snapshot=current_active_car_snapshot,
         )
         return HistoryReportRequest(
             cache_key=cache_key,
@@ -97,8 +82,6 @@ class HistoryReportRequestLoader:
         run: StoredHistoryRun,
         run_id: str,
         requested_lang: str,
-        *,
-        current_active_car_snapshot: CarSnapshot | None,
     ) -> ReportPdfCacheKey:
         return (
             run_id,
@@ -106,7 +89,7 @@ class HistoryReportRequestLoader:
             run.analysis_completed_at,
             run.sample_count,
             self._metadata_cache_token(run.metadata),
-            current_car_snapshot_token(current_active_car_snapshot),
+            _PERSISTED_REPORT_MODE_TOKEN,
         )
 
     @staticmethod

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from vibesensor.shared.ports import RunPersistence, SettingsReader
+from vibesensor.shared.ports import RunPersistence
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
 from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
 from vibesensor.use_cases.history.report_preparation import (
@@ -42,11 +42,10 @@ class HistoryReportService:
     def __init__(
         self,
         history_db: RunPersistence,
-        settings_store: SettingsReader | None = None,
         *,
         pdf_renderer: PdfRendererFn,
     ) -> None:
-        self._loader = HistoryReportRequestLoader(history_db, settings_store)
+        self._loader = HistoryReportRequestLoader(history_db)
         self._pdf_cache = HistoryReportPdfCache()
         self._pdf_renderer = pdf_renderer
 

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -8,7 +8,7 @@ from typing import Never, cast
 from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.summary_warning import localize_warning_list
 from vibesensor.shared.exceptions import AnalysisNotReadyError, RunNotFoundError
-from vibesensor.shared.ports import RunPersistence, SettingsReader
+from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 from vibesensor.use_cases.history.helpers import (
@@ -17,21 +17,15 @@ from vibesensor.use_cases.history.helpers import (
     resolve_run_language,
     strip_internal_fields,
 )
-from vibesensor.use_cases.run.run_context import add_current_context_warnings
 
 
 class HistoryRunService:
     """Run queries and delete operations used by history endpoints."""
 
-    __slots__ = ("_history_db", "_settings_store")
+    __slots__ = ("_history_db",)
 
-    def __init__(
-        self,
-        history_db: RunPersistence,
-        settings_store: SettingsReader | None = None,
-    ) -> None:
+    def __init__(self, history_db: RunPersistence) -> None:
         self._history_db = history_db
-        self._settings_store = settings_store
 
     async def list_runs(self) -> list[HistoryRunListEntry]:
         return await asyncio.to_thread(self._history_db.list_runs)
@@ -51,16 +45,11 @@ class HistoryRunService:
 
         raw_analysis = require_analysis_ready(run)
         analysis = strip_internal_fields(raw_analysis.to_json_object())
-        current_active_car_snapshot = (
-            self._settings_store.active_car_snapshot() if self._settings_store is not None else None
-        )
-        warnings = add_current_context_warnings(
-            analysis.get("warnings"),
-            metadata=analysis.get("metadata"),
-            current_active_car_snapshot=current_active_car_snapshot,
-        )
         response_lang = resolve_run_language(run, requested_lang)
-        analysis["warnings"] = cast(JsonValue, localize_warning_list(warnings, lang=response_lang))
+        analysis["warnings"] = cast(
+            JsonValue,
+            localize_warning_list(analysis.get("warnings"), lang=response_lang),
+        )
         analysis["run_id"] = run.run_id or run_id
         analysis["status"] = RunStatus.COMPLETE.value
 

--- a/apps/server/vibesensor/use_cases/run/run_context.py
+++ b/apps/server/vibesensor/use_cases/run/run_context.py
@@ -1,8 +1,7 @@
-"""Run-context orchestration helpers for recording and history workflows."""
+"""Run-context orchestration helpers for recording and explicit history overlays."""
 
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from typing import cast
 
@@ -88,16 +87,6 @@ def add_current_context_warnings(
     }:
         normalized.append(dynamic_warning)
     return normalized
-
-
-def current_car_snapshot_token(current_active_car_snapshot: CarSnapshot | None) -> str:
-    """Return a stable cache token for current active-car context."""
-    return json.dumps(
-        current_active_car_snapshot.to_dict() if current_active_car_snapshot else {},
-        sort_keys=True,
-        ensure_ascii=False,
-        default=str,
-    )
 
 
 def _build_car_settings_changed_warning(

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -186,9 +186,13 @@ After `RunAnalysis.summarize()` returns, `PostAnalysisWorker`:
 3. Stores the summary via `history_db.store_analysis()` as a
    versioned persistence envelope.
 
-History readers unwrap the envelope back to the summary shape.
-Report endpoints rebuild `ReportTemplateData` from that summary on demand
-via `use_cases/history/report_preparation.py:prepare_report_input()`, which
+History readers unwrap the envelope back to the summary shape. The core
+history/report projection is derived from persisted run data plus the persisted
+analysis summary only; any comparison against current mutable car settings is an
+explicit advisory overlay at the history delivery boundary, not a hidden input
+to the persisted projection or the default report cache path. Report endpoints
+rebuild `ReportTemplateData` from the persisted summary on demand via
+`use_cases/history/report_preparation.py:prepare_report_input()`, which
 reconstructs the domain aggregate and precomputes semantic report facts, and
 `adapters/pdf/mapping.py:map_summary()`, which stays focused on adapter-local
 mapping and rendering data assembly.

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -122,6 +122,10 @@ needs:
    `PreparedReportInput` preparation in
    `vibesensor.use_cases.history.report_preparation`, then populate the final
    renderer field in `map_summary()` in `vibesensor.adapters.pdf.mapping`.
+   Keep the default report-request/cache path driven only by persisted run data
+   and persisted analysis. If a feature needs to compare a historical run
+   against current mutable settings, model that as an explicit advisory overlay
+   instead of threading live settings into the base report request.
 4. Render the new field through `pdf_engine.py`, usually by wiring it into the relevant page or section module under `vibesensor.adapters.pdf`.
 5. Never add history/report semantic interpretation logic to the renderer
    package — always pre-compute it in `report_preparation.py`.


### PR DESCRIPTION
Closes #1334

## Summary

This PR separates persisted historical projection from live current-context overlays in the history/report stack. The core change is that history insights and default PDF/report preparation no longer treat the current active car as an implicit input to the persisted historical projection. Instead, the persisted-history path now stays a function of persisted run data plus persisted analysis only, while the current-car comparison warning is composed explicitly at the history delivery edge.

Before this change, the split was blurred in two places. `HistoryRunService.get_insights()` loaded persisted analysis and then immediately read `settings_store.active_car_snapshot()` to append `car_settings_changed` to the returned warnings list. `HistoryReportRequestLoader.load_report_request()` did the same and also folded the current car snapshot into the PDF cache key, which meant that the default report request and default report cache identity changed whenever the current active car changed, even if the recorded run and its persisted analysis were unchanged. That was useful product behavior in one sense because users could still see a comparison warning, but it made the default historical read model less honest and the default report cache less deterministic than it should be.

This change keeps the comparison warning behavior where it still provides value, but models it explicitly instead of threading it through the core persisted-history path.

## Implementation approach

The implementation follows the narrowest fix that matches the live code instead of the full breadth of the issue body. I did not change persisted run metadata, persisted analysis payloads, or the physical storage layout. Instead, I split the behavior along the existing seam between the framework-agnostic use-case layer and the delivery adapter layer.

`HistoryRunService` is now persisted-only. It still loads the run, unwraps persisted analysis, strips internal fields, resolves the response language, localizes persisted warnings, and returns the canonical persisted insights payload. What it no longer does is reach into live settings to mutate that payload based on the current active car.

The current-car comparison moved to `ProjectedHistoryRunService`, which is already the delivery adapter that re-projects persisted history analysis for HTTP responses. That adapter now accepts a narrow `ActiveCarReader` and, when one is provided, explicitly composes the current-context warning overlay on top of the persisted insights response. This makes the overlay an explicit edge behavior rather than a hidden property of the core historical service.

For report generation, `HistoryReportRequestLoader` is now persisted-only as well. It builds the report request from persisted run data, persisted analysis, persisted metadata, and language resolution only. The default report cache key no longer includes the current active-car snapshot. Instead, it uses a stable persisted mode token (`none`) for the cache dimension that previously varied with live car state. `HistoryReportService` therefore no longer depends on live settings for the default PDF path.

## Main code changes by area

In `apps/server/vibesensor/use_cases/history/runs.py`, `HistoryRunService` dropped its `SettingsReader` dependency and now only localizes the warnings already stored with persisted analysis. The service is back to being a true persisted-history boundary.

In `apps/server/vibesensor/adapters/history.py`, `ProjectedHistoryRunService` now accepts a narrow `ActiveCarReader` protocol from `shared/ports.py`. When that reader exists, the adapter calls `add_current_context_warnings()` explicitly after the persisted projection is built, then localizes the combined warnings using the requested response language. That keeps the history insights route behavior useful while making the overlay step deliberate and visible in the dependency graph.

In `apps/server/vibesensor/use_cases/history/report_loader.py` and `apps/server/vibesensor/use_cases/history/reports.py`, the default report request path no longer reads current live settings at all. `HistoryReportRequestLoader` now passes only persisted warnings through to report preparation, and its cache key is stable for unchanged persisted run data and metadata. `HistoryReportService` therefore no longer accepts the live settings collaborator in its constructor.

In `apps/server/vibesensor/app/container.py`, wiring now reflects the new truth: the history delivery adapter gets the explicit `ActiveCarReader` for the advisory overlay, while report generation remains on the persisted-only path.

I also removed the now-obsolete `current_car_snapshot_token()` helper from `use_cases/run/run_context.py` and updated the shared ports surface to add `ActiveCarReader` so the history overlay dependency is narrow and honest.

## Tests and docs

The tests now lock in the boundary explicitly rather than pinning the old hidden coupling.

`apps/server/tests/use_cases/history/test_history_http_services.py` now proves that the report loader keeps only persisted warnings in the default report request, and separately proves that `ProjectedHistoryRunService` adds the current-context warning only when an explicit current-car reader is provided. Existing route-state coverage still verifies that the history insights endpoint returns the localized comparison warning when the current car differs from the recorded car.

Helper fixtures in `apps/server/tests/conftest.py` and `apps/server/tests/adapters/http/_history_endpoint_helpers.py` were updated so default history route wiring matches production: persisted-only core service plus explicit delivery overlay reader.

`apps/server/tests/use_cases/run/test_run_context.py` was simplified to remove the dead snapshot-token assertion now that the production helper is gone.

Docs were updated in `docs/analysis_pipeline.md` and `docs/report_pipeline.md` so the repo’s written guidance matches the code: persisted history/report projection is built from persisted run data plus persisted analysis only, and current mutable settings comparisons are modeled as explicit advisory overlays instead of hidden inputs to the default report cache path.

## Validation

I validated the change in two stages.

First, I ran a focused history/report/run-context slice covering the intended blast radius:

- `pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_history_async_offloading.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/use_cases/run/test_run_context.py`
- Result: `46 passed`

Then I ran the standard backend gates:

- `make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make test-changed`

Those all passed. The final `make test-changed` run exercised the touched backend slice and reported `5857 passed, 5 skipped, 1 xpassed`.

## Risks, tradeoffs, and out-of-scope items

The main intentional behavior change is in the default PDF path. The old implementation let the current active car change the default report request warnings and default report cache identity. This PR intentionally stops doing that, because the issue specifically targets the hidden dependence of historical projection on current mutable settings. The current-car comparison warning still exists for history insights, but it is now explicit at the delivery edge instead of being a hidden property of the persisted-history use case.

I did not introduce a new HTTP response field or a new explicit “overlay mode” request parameter in this PR. That would be a reasonable future extension if the product wants to expose persisted warnings and current-context advisory warnings as separate payload families in the API or reintroduce optional report overlays in an explicit mode. For now, the smallest honest fix is to keep the current insights warning behavior explicit and keep the default report/cache path deterministic.
