### PR TITLE
Unify sensor metadata ownership

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -31,7 +31,8 @@ state. Current `main` is intentionally split more narrowly:
   configuration loaded at startup, such as network bindings, retention windows,
   processing budgets, and update paths.
 - `SettingsStore` owns persisted user-facing runtime settings, such as car
-  profiles, speed-source preferences, language, units, and sensor placement.
+  profiles, speed-source preferences, language, units, and canonical sensor
+  metadata (display name plus `location_code`).
   `SettingsDerivationService` projects those persisted car settings into the
   current analysis/run context, while `SettingsRuntimeApplier` pushes the
   current speed-source selection into live runtime collaborators.
@@ -114,7 +115,9 @@ Those YAML files cover deployment/process settings. User-facing runtime
 preferences are stored separately through `SettingsStore` snapshots in
 `history.db`; runtime consumers read the derived current-context view rather
 than mutating persisted settings directly, and completed runs persist immutable
-per-run snapshots for later analysis/reporting.
+per-run snapshots for later analysis/reporting. Persisted sensor display
+metadata also lives in that settings snapshot, while `ClientRegistry` remains
+the owner of live transport/connection state only.
 
 For live sensor presence, `processing.client_live_ttl_seconds` controls how long
 `/api/clients` and `/ws` keep reporting `connected: true` after the last

--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -154,19 +154,19 @@ async def test_identify_client_normalizes_client_id_before_registry_and_control_
 
 
 @pytest.mark.asyncio
-async def test_set_client_location_maps_registry_conflict_to_409() -> None:
+async def test_set_client_location_maps_canonical_location_conflict_to_409() -> None:
     from vibesensor.adapters.http.clients import create_client_routes
 
-    class ConflictRegistry:
+    class KnownRegistry:
         def get(self, _client_id: str) -> object:
             return object()
 
-        def set_location(self, _client_id: str, _location: str) -> None:
-            raise ValueError("Location 'front_left_wheel' already assigned to other sensor")
-
-    registry = ConflictRegistry()
+    registry = KnownRegistry()
     control_plane = MagicMock()
     settings_store = MagicMock()
+    settings_store.set_sensor.side_effect = ValueError(
+        "Location 'front_left_wheel' already assigned to other sensor",
+    )
     router = create_client_routes(registry, control_plane, settings_store, MagicMock())
     endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
 
@@ -175,6 +175,45 @@ async def test_set_client_location_maps_registry_conflict_to_409() -> None:
         await endpoint("aa:bb:cc:dd:ee:ff", request)
     assert exc_info.value.status_code == 409
     assert "already assigned" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_set_client_location_persists_canonical_name_and_location() -> None:
+    from vibesensor.adapters.http.clients import create_client_routes
+
+    class KnownRegistry:
+        def __init__(self) -> None:
+            self.cleared: list[str] = []
+
+        def get(self, _client_id: str):
+            return type("Rec", (), {"name": "legacy-name"})()
+
+        def clear_name(self, client_id: str):
+            self.cleared.append(client_id)
+            return type("Rec", (), {"name": f"client-{client_id[-4:]}"})()
+
+    registry = KnownRegistry()
+    control_plane = MagicMock()
+    settings_store = MagicMock()
+    settings_store.set_sensor.return_value = {
+        "aabbccddeeff": {
+            "name": "Front Left Wheel",
+            "location_code": "front_left_wheel",
+        }
+    }
+    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
+    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+
+    request = type("Req", (), {"location_code": "front_left_wheel"})()
+    resp = response_payload(await endpoint("aa:bb:cc:dd:ee:ff", request))
+
+    settings_store.set_sensor.assert_called_once_with(
+        "aa:bb:cc:dd:ee:ff",
+        {"name": "Front Left Wheel", "location_code": "front_left_wheel"},
+    )
+    assert registry.cleared == []
+    assert resp["name"] == "Front Left Wheel"
+    assert resp["location_code"] == "front_left_wheel"
 
 
 @pytest.mark.asyncio
@@ -204,6 +243,7 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
 
     control_plane = MagicMock()
     settings_store = MagicMock()
+    settings_store.get_sensors.return_value = {}
     processor = MagicMock()
     processor.all_latest_metrics.return_value = {}
     router = create_client_routes(registry, control_plane, settings_store, processor)
@@ -222,6 +262,73 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
             "sample_rate_hz": 800,
             "frame_samples": 0,
             "last_seen_age_ms": 8000,
+            "frames_total": 0,
+            "dropped_frames": 0,
+            "latest_metrics": {},
+            "reset_count": 0,
+            "last_reset_time": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from vibesensor.adapters.http.clients import create_client_routes
+    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.udp.protocol import HelloMessage
+    from vibesensor.infra.config.settings_store import SettingsStore
+    from vibesensor.infra.runtime.registry import ClientRegistry
+
+    db = HistoryDB(tmp_path / "history.db")
+    initial_settings = SettingsStore(db=db)
+    initial_settings.set_sensor(
+        "00:11:22:33:44:55",
+        {"name": "Rear Left Wheel", "location_code": "rear_left_wheel"},
+    )
+
+    settings_store = SettingsStore(db=db)
+    registry = ClientRegistry(db=db)
+    registry.update_from_hello(
+        HelloMessage(
+            client_id=bytes.fromhex("001122334455"),
+            control_port=9010,
+            sample_rate_hz=800,
+            name="advertised-name",
+            firmware_version="fw",
+        ),
+        ("10.4.0.2", 9010),
+        now=1.0,
+        now_mono=1.0,
+    )
+    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: 1.0)
+    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: 1.0)
+
+    control_plane = MagicMock()
+    processor = MagicMock()
+    processor.all_latest_metrics.return_value = {}
+    router = create_client_routes(registry, control_plane, settings_store, processor)
+    endpoint = route_endpoint(router, "/api/clients")
+
+    resp = response_payload(await endpoint())
+
+    assert settings_store.get_sensors()["001122334455"] == {
+        "name": "Rear Left Wheel",
+        "location_code": "rear_left_wheel",
+    }
+    assert resp["clients"] == [
+        {
+            "id": "001122334455",
+            "mac_address": "00:11:22:33:44:55",
+            "name": "Rear Left Wheel",
+            "connected": True,
+            "location_code": "rear_left_wheel",
+            "firmware_version": "fw",
+            "sample_rate_hz": 800,
+            "frame_samples": 0,
+            "last_seen_age_ms": 0,
             "frames_total": 0,
             "dropped_frames": 0,
             "latest_metrics": {},

--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -297,6 +297,26 @@ class TestSensorEndpoint:
             {"name": "Wheel sensor", "location_code": "front_left"},
         )
 
+    @pytest.mark.asyncio
+    async def test_update_sensor_maps_duplicate_location_to_409(self, _settings_router) -> None:
+        router, state = _settings_router
+        endpoint = _find_endpoint(router, "/api/settings/sensors/{mac}", "POST")
+        assert endpoint is not None
+
+        from vibesensor.adapters.http.models import SensorRequest
+
+        state.settings_store.set_sensor.side_effect = ValueError(
+            "Location 'front_left' already assigned to Rear Left",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await endpoint(
+                mac="AA:BB:CC:DD:EE:FF",
+                req=SensorRequest(name="Wheel sensor", location_code="front_left"),
+            )
+
+        assert exc_info.value.status_code == 409
+
 
 class TestSetAnalysisSettingsEndpoint:
     @pytest.mark.asyncio

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -252,6 +252,14 @@ def test_store_set_and_get_sensor() -> None:
     assert sensors["aabbccddeeff"]["location_code"] == "front_left_wheel"
 
 
+def test_store_set_sensor_rejects_duplicate_location() -> None:
+    store = SettingsStore()
+    store.set_sensor("aa:bb:cc:dd:ee:ff", {"location_code": "front_left_wheel"})
+
+    with pytest.raises(ValueError, match="already assigned"):
+        store.set_sensor("11:22:33:44:55:66", {"location_code": "front_left_wheel"})
+
+
 def test_store_remove_sensor() -> None:
     store = SettingsStore()
     store.set_sensor("aa:bb:cc:dd:ee:ff", {"name": "Test"})

--- a/apps/server/tests/infra/processing/test_sample_builder.py
+++ b/apps/server/tests/infra/processing/test_sample_builder.py
@@ -298,3 +298,47 @@ class TestBuildSampleRecords:
                 "strength_bucket": "l2",
             },
         ]
+
+    def test_uses_canonical_sensor_metadata_when_runtime_fields_are_stale(self) -> None:
+        record = MagicMock()
+        record.client_id = "001122334455"
+        record.name = "advertised-name"
+        record.location_code = ""
+        record.sample_rate_hz = 400
+        record.frames_dropped = 0
+        record.queue_overflow_drops = 0
+
+        reg = MagicMock()
+        reg.active_client_ids.return_value = ["001122334455"]
+        reg.get.return_value = record
+
+        proc = MagicMock()
+        proc.clients_with_recent_data.return_value = ["001122334455"]
+        proc.latest_metrics.return_value = {"combined": {}}
+        proc.latest_sample_xyz.return_value = None
+        proc.latest_sample_rate_hz.return_value = 400
+
+        class _Reader:
+            def get_sensors(self) -> dict[str, dict[str, str]]:
+                return {
+                    "001122334455": {
+                        "name": "Rear Left Wheel",
+                        "location_code": "rear_left_wheel",
+                    }
+                }
+
+        records = build_sample_records(
+            run_id="r1",
+            t_s=1.25,
+            timestamp_utc="2026-01-01T00:00:00Z",
+            registry=reg,
+            processor=proc,
+            speed_context=SpeedContext(None, None, "none", None),
+            analysis_settings_snapshot=AnalysisSettingsSnapshot(),
+            default_sample_rate_hz=800,
+            sensor_metadata_reader=_Reader(),
+        )
+
+        assert len(records) == 1
+        assert records[0].client_name == "Rear Left Wheel"
+        assert records[0].location == "rear_left_wheel"

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -25,7 +25,9 @@ from vibesensor.adapters.http.models import (
 from vibesensor.adapters.udp.protocol import client_id_mac
 from vibesensor.infra.runtime.client_snapshot import snapshot_for_api
 from vibesensor.shared.locations import all_locations, label_for_code
-from vibesensor.shared.ports import SensorSettingsWriter
+from vibesensor.shared.ports import SensorMetadataStore
+from vibesensor.shared.sensor_metadata import resolve_sensor_presentation
+from vibesensor.shared.types.sensor_config import SensorConfigPayload, SensorConfigUpdatePayload
 
 if TYPE_CHECKING:
     from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
@@ -53,7 +55,7 @@ _REMOVE_CLIENT_RESPONSES: OpenAPIResponses = {
 def create_client_routes(
     registry: ClientRegistry,
     control_plane: UDPControlPlane,
-    sensor_settings_writer: SensorSettingsWriter,
+    sensor_settings_store: SensorMetadataStore,
     processor: SignalProcessor,
 ) -> APIRouter:
     """Create and return the client-management API routes."""
@@ -64,7 +66,13 @@ def create_client_routes(
         """List known sensor clients with live connection state and latest computed metrics."""
         active_ids = registry.active_client_ids()
         metrics = processor.all_latest_metrics(active_ids)
-        return ClientsResponse(clients=snapshot_for_api(registry, metrics_by_client=metrics))
+        return ClientsResponse(
+            clients=snapshot_for_api(
+                registry,
+                metrics_by_client=metrics,
+                sensor_metadata_reader=sensor_settings_store,
+            ),
+        )
 
     @router.get("/api/client-locations", response_model=ClientLocationsResponse)
     async def get_client_locations() -> ClientLocationsResponse:
@@ -107,25 +115,34 @@ def create_client_routes(
             raise HTTPException(status_code=404, detail="Sensor not found")
 
         code = req.location_code.strip()
+        payload: SensorConfigUpdatePayload
 
         if code:
             label = label_for_code(code)
             if label is None:
                 raise HTTPException(status_code=400, detail="Unknown location_code")
 
-            with domain_errors_to_http(catch_value_error=409):
-                registry.set_location(normalized_client_id, code)
-
-            registry.set_name(normalized_client_id, label)
+            payload = {"location_code": code, "name": label}
         else:
-            # Empty location_code → clear the assignment
-            registry.set_location(normalized_client_id, code)
+            payload = {"location_code": "", "name": normalized_client_id}
             registry.clear_name(normalized_client_id)
 
         updated = registry.get(normalized_client_id)
-        name = updated.name if updated and updated.name is not None else ""
         mac = client_id_mac(normalized_client_id)
-        await asyncio.to_thread(sensor_settings_writer.set_sensor, mac, {"location_code": code})
+        with domain_errors_to_http(catch_value_error=409):
+            stored = await asyncio.to_thread(sensor_settings_store.set_sensor, mac, payload)
+        fallback_sensor: SensorConfigPayload = {
+            "name": payload["name"],
+            "location_code": payload["location_code"],
+        }
+        stored_sensor = stored.get(normalized_client_id, fallback_sensor)
+        fallback_name = updated.name if updated and updated.name is not None else ""
+        name, _ = resolve_sensor_presentation(
+            sensor_id=normalized_client_id,
+            sensors_by_mac={normalized_client_id: stored_sensor},
+            fallback_name=fallback_name,
+            fallback_location_code=code,
+        )
         return SetClientLocationResponse(
             id=normalized_client_id,
             mac_address=mac,

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -69,6 +69,7 @@ _UPDATE_SPEED_SOURCE_RESPONSES: OpenAPIResponses = {
 
 _UPDATE_SENSOR_RESPONSES: OpenAPIResponses = {
     400: {"description": "Invalid sensor MAC address or sensor settings payload."},
+    409: {"description": "Requested sensor location is already assigned to another sensor."},
 }
 
 _DELETE_SENSOR_RESPONSES: OpenAPIResponses = {
@@ -319,7 +320,7 @@ def create_settings_routes(
         """Create or update persisted sensor metadata for a specific MAC address."""
         normalized_mac = normalize_mac_or_400(mac)
         payload = _sensor_update_payload(req)
-        with domain_errors_to_http(catch_value_error=400):
+        with domain_errors_to_http(catch_value_error=409):
             await asyncio.to_thread(
                 settings_store.set_sensor,
                 normalized_mac,

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -200,6 +200,7 @@ def build_runtime(config: AppConfig) -> AppRuntime:
         gps_enabled=config.gps.gps_enabled,
         settings_reader=settings_reader,
         speed_source_reader=settings_store,
+        sensor_metadata_reader=settings_store,
     )
 
     # run recorder
@@ -218,6 +219,7 @@ def build_runtime(config: AppConfig) -> AppRuntime:
         processor=processor,
         history_db=history_db,
         settings_store=settings_reader,
+        sensor_metadata_reader=settings_store,
         language_provider=lambda: settings_store.language,
     )
 

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -327,7 +327,22 @@ class SettingsStore:
                 name = _clamp_str(data["name"], 64)
                 updated.name = name or sensor_id
             if "location_code" in data:
-                updated.location_code = _clamp_str(data["location_code"], 64)
+                location_code = _clamp_str(data["location_code"], 64)
+                if location_code:
+                    conflict = next(
+                        (
+                            other
+                            for other_id, other in self._sensors.items()
+                            if other_id != sensor_id and other.location_code == location_code
+                        ),
+                        None,
+                    )
+                    if conflict is not None:
+                        conflict_name = conflict.name or conflict.sensor_id
+                        raise ValueError(
+                            f"Location '{location_code}' already assigned to {conflict_name}",
+                        )
+                updated.location_code = location_code
             self._sensors[sensor_id] = updated
             return True
 

--- a/apps/server/vibesensor/infra/runtime/client_snapshot.py
+++ b/apps/server/vibesensor/infra/runtime/client_snapshot.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import normalize_sensor_id
+from vibesensor.shared.ports import SensorMetadataReader
+from vibesensor.shared.sensor_metadata import resolve_sensor_presentation
 from vibesensor.shared.types.payload_types import ClientApiRow, ClientMetrics
 
 if TYPE_CHECKING:
@@ -80,13 +82,33 @@ def snapshot_for_api(
     now_mono: float | None = None,
     metrics_by_client: dict[str, ClientMetrics] | None = None,
     include_metrics: bool = True,
+    sensor_metadata_reader: SensorMetadataReader | None = None,
 ) -> list[ClientApiRow]:
     """Convenience presenter from registry snapshots to API rows."""
+    snapshots = registry.client_snapshots(
+        now=now,
+        now_mono=now_mono,
+        metrics_by_client=metrics_by_client,
+    )
+    if sensor_metadata_reader is not None:
+        sensors_by_mac = sensor_metadata_reader.get_sensors()
+        snapshots = [
+            replace(
+                snapshot,
+                name=resolved_name,
+                location_code=resolved_location,
+            )
+            for snapshot in snapshots
+            for resolved_name, resolved_location in [
+                resolve_sensor_presentation(
+                    sensor_id=snapshot.client_id,
+                    sensors_by_mac=sensors_by_mac,
+                    fallback_name=snapshot.name,
+                    fallback_location_code=snapshot.location_code,
+                ),
+            ]
+        ]
     return build_client_api_rows(
-        registry.client_snapshots(
-            now=now,
-            now_mono=now_mono,
-            metrics_by_client=metrics_by_client,
-        ),
+        snapshots,
         include_metrics=include_metrics,
     )

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -18,7 +18,12 @@ from vibesensor.infra.runtime.rotational_speeds import (
     build_rotational_speeds_payload,
     rotational_basis_speed_source,
 )
-from vibesensor.shared.ports import SettingsReader, SpeedProvider, SpeedSourceSettingsReader
+from vibesensor.shared.ports import (
+    SensorMetadataReader,
+    SettingsReader,
+    SpeedProvider,
+    SpeedSourceSettingsReader,
+)
 
 if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
@@ -36,6 +41,7 @@ class WsBroadcastService:
         "_gps_monitor",
         "_processor",
         "_registry",
+        "_sensor_metadata_reader",
         "_settings_reader",
         "_speed_source_reader",
         "_ui_heavy_push_hz",
@@ -58,6 +64,7 @@ class WsBroadcastService:
         gps_enabled: bool,
         settings_reader: SettingsReader,
         speed_source_reader: SpeedSourceSettingsReader,
+        sensor_metadata_reader: SensorMetadataReader | None = None,
     ) -> None:
         self.tick = 0
         self.include_heavy = True
@@ -70,6 +77,7 @@ class WsBroadcastService:
         self._registry = registry
         self._processor = processor
         self._gps_monitor = gps_monitor
+        self._sensor_metadata_reader = sensor_metadata_reader
         self._settings_reader = settings_reader
         self._speed_source_reader = speed_source_reader
 
@@ -83,7 +91,11 @@ class WsBroadcastService:
         self.include_heavy = (self.tick % heavy_every) == 0
 
     def _build_shared_payload(self) -> LiveWsPayload:
-        clients = snapshot_for_api(self._registry, include_metrics=False)
+        clients = snapshot_for_api(
+            self._registry,
+            include_metrics=False,
+            sensor_metadata_reader=self._sensor_metadata_reader,
+        )
         client_ids = [c["id"] for c in clients]
         fresh_ids = self._processor.clients_with_recent_data(
             client_ids,

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -29,6 +29,8 @@ __all__ = [
     "RegistryHelloMessage",
     "ResolvedSpeedSnapshot",
     "RunPersistence",
+    "SensorMetadataReader",
+    "SensorMetadataStore",
     "SensorSettingsWriter",
     "SettingsReader",
     "SettingsSnapshotPersistence",
@@ -114,6 +116,20 @@ class SensorSettingsWriter(Protocol):
     """Minimal persisted sensor-settings surface needed by client-location routes."""
 
     def set_sensor(self, mac: str, data: SensorConfigUpdatePayload) -> SensorsByMacPayload: ...
+
+
+class SensorMetadataReader(Protocol):
+    """Read-only access to canonical persisted sensor display metadata."""
+
+    def get_sensors(self) -> SensorsByMacPayload: ...
+
+
+class SensorMetadataStore(SensorMetadataReader, Protocol):
+    """Canonical sensor-metadata surface shared by settings and client routes."""
+
+    def set_sensor(self, mac: str, data: SensorConfigUpdatePayload) -> SensorsByMacPayload: ...
+
+    def remove_sensor(self, mac: str) -> bool: ...
 
 
 class SettingsSnapshotPersistence(Protocol):

--- a/apps/server/vibesensor/shared/sensor_metadata.py
+++ b/apps/server/vibesensor/shared/sensor_metadata.py
@@ -1,0 +1,40 @@
+"""Helpers for resolving canonical sensor metadata over runtime state."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from vibesensor.domain import normalize_sensor_id
+from vibesensor.shared.types.sensor_config import SensorConfigPayload
+
+__all__ = ["resolve_sensor_presentation"]
+
+
+def resolve_sensor_presentation(
+    *,
+    sensor_id: str,
+    sensors_by_mac: Mapping[str, SensorConfigPayload],
+    fallback_name: str,
+    fallback_location_code: str,
+) -> tuple[str, str]:
+    """Return canonical display metadata for *sensor_id* with runtime fallbacks.
+
+    Persisted sensor settings are authoritative when they contain a custom name
+    or location. A stored name equal to the normalized sensor identifier is
+    treated as the default placeholder, so live runtime naming can still supply
+    the visible label in that case.
+    """
+
+    try:
+        normalized_sensor_id = normalize_sensor_id(sensor_id)
+    except ValueError:
+        return fallback_name, fallback_location_code
+    sensor = sensors_by_mac.get(normalized_sensor_id)
+    if sensor is None:
+        return fallback_name, fallback_location_code
+
+    raw_name = str(sensor.get("name") or "").strip()
+    resolved_name = fallback_name if not raw_name or raw_name == normalized_sensor_id else raw_name
+    raw_location = str(sensor.get("location_code") or "").strip()
+    resolved_location = raw_location or fallback_location_code
+    return resolved_name, resolved_location

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from vibesensor.shared.ports import (
     ClientTracker,
     RunPersistence,
+    SensorMetadataReader,
     SettingsReader,
     SignalSource,
     SpeedProvider,
@@ -66,6 +67,7 @@ class RunRecorder:
         processor: SignalSource,
         history_db: RunPersistence | None = None,
         settings_store: SettingsReader | None = None,
+        sensor_metadata_reader: SensorMetadataReader | None = None,
         language_provider: Callable[[], str] | None = None,
     ):
         self.metrics_log_hz = max(1, config.metrics_log_hz)
@@ -119,6 +121,7 @@ class RunRecorder:
             processor=self.processor,
             analysis_settings_snapshot=self._recording_analysis_settings_snapshot,
             default_sample_rate_hz=self.default_sample_rate_hz,
+            sensor_metadata_reader=sensor_metadata_reader,
             lifecycle=self._lifecycle,
             persistence=self._persistence,
             active_frames_total=lambda: _recorder_runtime.active_frames_total(self.registry),

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -15,7 +15,8 @@ from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.domain.strength_metrics import StrengthMetrics
 from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.constants.units import MPS_TO_KMH
-from vibesensor.shared.ports import ClientTracker
+from vibesensor.shared.ports import ClientTracker, SensorMetadataReader
+from vibesensor.shared.sensor_metadata import resolve_sensor_presentation
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.payload_types import ClientMetrics
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -129,6 +130,7 @@ def build_sample_records(
     speed_context: SpeedContext,
     analysis_settings_snapshot: AnalysisSettingsSnapshot,
     default_sample_rate_hz: int,
+    sensor_metadata_reader: SensorMetadataReader | None = None,
 ) -> list[SensorFrame]:
     """Build one batch of typed sample records from all active clients."""
     (
@@ -144,6 +146,7 @@ def build_sample_records(
     gear_ratio = (
         order_reference_spec.current_gear_ratio if order_reference_spec is not None else None
     )
+    sensors_by_mac = sensor_metadata_reader.get_sensors() if sensor_metadata_reader else {}
 
     records: list[SensorFrame] = []
     active_client_ids = sorted(
@@ -185,13 +188,19 @@ def build_sample_records(
             or default_sample_rate_hz
             or None
         )
+        resolved_name, resolved_location = resolve_sensor_presentation(
+            sensor_id=record.client_id,
+            sensors_by_mac=sensors_by_mac,
+            fallback_name=str(record.name or ""),
+            fallback_location_code=str(getattr(record, "location_code", "") or ""),
+        )
         frame = SensorFrame(
             run_id=run_id,
             timestamp_utc=timestamp_utc,
             t_s=t_s,
             client_id=client_id,
-            client_name=record.name,
-            location=str(getattr(record, "location_code", "") or ""),
+            client_name=resolved_name,
+            location=resolved_location,
             sample_rate_hz=int(sample_rate_hz) if sample_rate_hz else None,
             speed_kmh=speed_kmh,
             gps_speed_kmh=gps_speed_kmh,

--- a/apps/server/vibesensor/use_cases/run/sample_flush.py
+++ b/apps/server/vibesensor/use_cases/run/sample_flush.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import replace
 
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
-from vibesensor.shared.ports import ClientTracker, SignalSource, SpeedProvider
+from vibesensor.shared.ports import ClientTracker, SensorMetadataReader, SignalSource, SpeedProvider
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.run.lifecycle_state import ActiveRunSnapshot, RunLifecycleState
@@ -38,6 +38,7 @@ class SampleFlushOrchestrator:
         processor: SignalSource,
         analysis_settings_snapshot: AnalysisSettingsProvider,
         default_sample_rate_hz: int,
+        sensor_metadata_reader: SensorMetadataReader | None = None,
         lifecycle: RunLifecycleState,
         persistence: RunPersistenceWriter,
         active_frames_total: CurrentTotalProvider,
@@ -50,6 +51,7 @@ class SampleFlushOrchestrator:
         self._processor = processor
         self._analysis_settings_snapshot = analysis_settings_snapshot
         self._default_sample_rate_hz = default_sample_rate_hz
+        self._sensor_metadata_reader = sensor_metadata_reader
         self._lifecycle = lifecycle
         self._persistence = persistence
         self._active_frames_total = active_frames_total
@@ -104,6 +106,7 @@ class SampleFlushOrchestrator:
             ),
             analysis_settings_snapshot=analysis_settings_snapshot,
             default_sample_rate_hz=self._default_sample_rate_hz,
+            sensor_metadata_reader=self._sensor_metadata_reader,
         )
 
     def build_live_sample_records(

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -11386,6 +11386,9 @@
           "400": {
             "description": "Invalid sensor MAC address or sensor settings payload."
           },
+          "409": {
+            "description": "Requested sensor location is already assigned to another sensor."
+          },
           "422": {
             "content": {
               "application/json": {

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -3495,6 +3495,10 @@ export interface operations {
       400: {
         content: never;
       };
+      /** @description Requested sensor location is already assigned to another sensor. */
+      409: {
+        content: never;
+      };
       /** @description Validation Error */
       422: {
         content: {

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -106,12 +106,17 @@ Single-row table for persistent application settings.
 
 ### `client_names`
 
-Maps sensor client IDs to human-readable names.
+Legacy compatibility table for sensor client display names.
+
+Canonical user-managed sensor metadata now lives in the `settings_snapshot`
+payload (`sensorsByMac`). The runtime registry may still read `client_names`
+for older/offline compatibility paths, but it is no longer the authoritative
+home for persisted sensor name/location semantics.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `client_id` | TEXT PK | Sensor MAC (hex) |
-| `name` | TEXT | Display name |
+| `name` | TEXT | Legacy display name |
 | `updated_at` | TEXT | Last update timestamp |
 
 ## Schema upgrades / migrations


### PR DESCRIPTION
Closes #1335

## Summary

This PR resolves issue #1335 by making persisted sensor settings the canonical owner of user-managed sensor display metadata and then composing that canonical metadata into the runtime/read-model paths that previously read directly from `ClientRegistry`. The issue text described a broad split-brain architecture between `SettingsStore`, `ClientRegistry`, and the `client_names` persistence path. After auditing the current code on `main`, the live defect was narrower but still real: `/api/settings/sensors` persisted sensor `name` and `location_code` in `SettingsStore`, while `/api/clients/{client_id}/location` still derived sensor labels through registry/client-name state, and `/api/clients`, `/ws`, plus recorded sample rows still projected sensor display metadata from runtime records rather than from canonical persisted settings. That meant the same sensor could show different display metadata depending on which endpoint or workflow touched it.

The chosen implementation keeps the existing SQLite-backed settings snapshot model and avoids a storage-engine rewrite. Instead of inventing a new persistence layer, it treats `SettingsStore.sensorsByMac` as the authoritative persisted sensor-metadata source and moves the runtime-facing read paths to compose that metadata explicitly. This preserves the existing HTTP surface while making the dependency graph honest: persisted user-managed metadata comes from settings, live runtime/transport state stays in the registry, and presenters/recording compose the two when they need a complete view.

## Implementation approach

The first part of the fix formalizes the canonical read path. `shared/ports.py` now exposes a narrow `SensorMetadataReader` plus a combined `SensorMetadataStore` protocol for the client-route path. I added `shared/sensor_metadata.py` with `resolve_sensor_presentation()`, a small helper that overlays canonical persisted sensor metadata over runtime fallbacks. It intentionally treats a stored name equal to the normalized sensor ID as the default placeholder rather than a true user override, so runtime naming can still provide the visible label when settings do not contain a custom name.

That helper is now used in the two runtime/read-model surfaces that mattered for the bug. In `infra/runtime/client_snapshot.py`, `snapshot_for_api()` accepts an optional sensor-metadata reader and rewrites the projected `name` and `location_code` from canonical settings before the HTTP/WebSocket payload rows are built. In `use_cases/run/sample_builder.py`, `build_sample_records()` now accepts the same narrow reader and uses canonical settings metadata when writing `client_name` and `location` into persisted `SensorFrame` rows. This is the key behavior change for restart safety: recorded sample metadata no longer depends on whatever stale or incomplete runtime display fields happen to be sitting on the registry record.

The second part of the fix moves the write-side invariant to the canonical layer. `SettingsStore.set_sensor()` now enforces uniqueness for non-empty `location_code` values across persisted sensors. That means the “one sensor per location” rule no longer exists only in a live registry mutation path; it now lives where persisted sensor metadata actually lives. The settings endpoint response documentation was updated accordingly so the sensor update route now advertises the new `409` conflict case in the generated contract.

The client location route was then rewired around that canonical store. In `adapters/http/clients.py`, `/api/clients/{client_id}/location` now writes both the derived display name and `location_code` through persisted sensor settings instead of persisting only the location there and pushing the display label through registry/client-name state. The route maps canonical location conflicts to HTTP 409, derives the response payload from the stored canonical metadata, and clears the legacy registry name when location removal happens so the old registry-backed naming path stops being the active write path for this workflow. The route still preserves the existing UX convention where assigning a location derives a human-readable label from that location, but now that rule lives in one canonical place instead of being split between registry and settings behavior.

## Main code changes by area

In the runtime presentation layer, `WsBroadcastService` now accepts the optional sensor-metadata reader and threads it into `snapshot_for_api()`, so `/ws` sees the same canonical sensor metadata as `/api/clients`. In the recording path, `SampleFlushOrchestrator`, `RunRecorder`, and the container wiring were updated to thread that same optional reader into `build_sample_records()` without broadening unrelated settings ports. In other words, the implementation follows the issue’s stated direction: narrow explicit composition instead of another hidden synchronization convention.

On the documentation/contract side, I updated `apps/server/README.md` to state that canonical persisted sensor display metadata lives in `SettingsStore`, while `ClientRegistry` owns live transport/connection state. `docs/history_db_schema.md` now describes `client_names` as a legacy compatibility table rather than the authoritative home for persisted sensor name/location semantics. The committed OpenAPI schema and generated UI HTTP contracts were regenerated so the explicit sensor-update conflict response stays in sync with the code.

## Validation

I validated the change in layers.

Focused regressions:
- `pytest -q apps/server/tests/infra/config/test_settings_store.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/infra/processing/test_sample_builder.py`
- Result: `95 passed`

Broader touched-area regression slice:
- `pytest -q apps/server/tests/infra/runtime/test_registry.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/use_cases/run/ apps/server/tests/infra/runtime/test_runtime.py`
- Result: `150 passed`

Standard repo gates:
- `make lint`
- `make typecheck-backend`
- `make docs-lint`
- `make test-changed`
- `make test-changed` completed green with the changed-file pytest selection reporting `3776 passed, 1 xpassed`, and it also covered the UI contract/typecheck path after regenerating the checked-in HTTP schema and UI-generated TypeScript contract file.

## Risks, tradeoffs, and edge cases

The main tradeoff here is that this PR intentionally does not delete the legacy `client_names` table or fully remove registry compatibility code in one shot. The issue explicitly asked to avoid a flag-day rewrite, so the narrower and safer fix is to make canonical persisted settings authoritative for user-facing metadata while moving the active read/write production paths onto that boundary. That addresses the live bug and the architectural split without mixing in a larger persistence migration. The docs now call out that `client_names` is legacy compatibility data rather than the source of truth.

I also kept the existing client-location UX behavior where assigning a location auto-derives a display label from the chosen location. The change here is not to remove that behavior, but to make the rule canonical and consistent: the derived name is now written through persisted sensor settings alongside the location, and all relevant runtime/read-model paths observe the same stored metadata.

## Out of scope

This PR does not redesign the entire sensor domain model, add multi-user/auth concepts, or introduce a new dedicated storage engine. It also does not attempt a full removal of every compatibility seam tied to `client_names`; that would be a broader migration. The goal here was the smallest complete fix that makes sensor metadata ownership honest in the current production paths, and this PR accomplishes that while keeping the HTTP surface and existing workflows intact.
