### PR TITLE
Extract WiFi recovery and hotspot orchestration from UpdateManager

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -369,7 +369,7 @@ class TestUpdateManagerAsync:
         manager.status.phase = UpdatePhase.installing
 
         with patch(
-            "vibesensor.use_cases.updates.manager.parse_wifi_diagnostics",
+            "vibesensor.use_cases.updates.wifi.wifi_orchestrator.parse_wifi_diagnostics",
             side_effect=TypeError("diagnostics bug"),
         ):
             with pytest.raises(TypeError, match="diagnostics bug"):

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_orchestrator.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_orchestrator.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from _update_manager_test_helpers import FakeRunner
+
+from vibesensor.use_cases.updates.models import UpdateIssue
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
+from vibesensor.use_cases.updates.wifi import UpdateWifiOrchestrator, build_default_wifi_config
+
+
+def _build_orchestrator(
+    tmp_path: Path,
+    *,
+    restore_retries: int = 3,
+    restore_delay_s: float = 0.01,
+) -> tuple[UpdateWifiOrchestrator, FakeRunner, UpdateStatusTracker]:
+    runner = FakeRunner()
+    tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "state.json"))
+    config = replace(
+        build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
+        hotspot_restore_retries=restore_retries,
+        hotspot_restore_delay_s=restore_delay_s,
+    )
+    commands = UpdateCommandExecutor(runner=runner, tracker=tracker)
+    orchestrator = UpdateWifiOrchestrator(
+        commands=commands,
+        tracker=tracker,
+        config=config,
+    )
+    return orchestrator, runner, tracker
+
+
+@pytest.mark.asyncio
+async def test_recover_interrupted_update_cleans_uplink_and_restores_hotspot(
+    tmp_path: Path,
+) -> None:
+    orchestrator, runner, tracker = _build_orchestrator(tmp_path)
+
+    await orchestrator.recover_interrupted_update()
+
+    commands = [" ".join(call[0]) for call in runner.calls]
+    assert any("connection down VibeSensor-Uplink" in command for command in commands)
+    assert any("connection delete VibeSensor-Uplink" in command for command in commands)
+    assert any("connection up VibeSensor-AP" in command for command in commands)
+    assert any(
+        "startup_recover: hotspot restored successfully" in line for line in tracker.status.log_tail
+    )
+
+
+@pytest.mark.asyncio
+async def test_recover_interrupted_update_records_restore_failure(tmp_path: Path) -> None:
+    orchestrator, runner, tracker = _build_orchestrator(
+        tmp_path,
+        restore_retries=1,
+        restore_delay_s=0,
+    )
+    runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
+
+    await orchestrator.recover_interrupted_update()
+
+    assert any(
+        issue.message == "Failed to restore hotspot after interrupted update"
+        for issue in tracker.status.issues
+    )
+    assert any(
+        "startup_recover: hotspot restore failed" in line for line in tracker.status.log_tail
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_restore_hotspot_records_issue_on_failure(tmp_path: Path) -> None:
+    orchestrator, runner, tracker = _build_orchestrator(
+        tmp_path,
+        restore_retries=1,
+        restore_delay_s=0,
+    )
+    runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
+
+    await orchestrator.cleanup_restore_hotspot()
+
+    assert any(
+        issue.phase == "cleanup" and issue.message == "Failed to restore hotspot during cleanup"
+        for issue in tracker.status.issues
+    )
+    assert any("Cleanup hotspot restore failed" in line for line in tracker.status.log_tail)
+
+
+@pytest.mark.asyncio
+async def test_collect_cleanup_diagnostics_returns_parsed_issues(tmp_path: Path) -> None:
+    orchestrator, _runner, _tracker = _build_orchestrator(tmp_path)
+    expected_issues = [
+        UpdateIssue(
+            phase="diagnostics",
+            message="Hotspot summary reports failure",
+            detail="status=failed",
+        ),
+    ]
+
+    with patch(
+        "vibesensor.use_cases.updates.wifi.wifi_orchestrator.parse_wifi_diagnostics",
+        return_value=expected_issues,
+    ):
+        assert await orchestrator.collect_cleanup_diagnostics() == expected_issues

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -35,9 +35,8 @@ from vibesensor.use_cases.updates.validation import (
     validate_prerequisites,
 )
 from vibesensor.use_cases.updates.wifi import (
-    UpdateWifiController,
+    UpdateWifiOrchestrator,
     build_default_wifi_config,
-    parse_wifi_diagnostics,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -135,35 +134,8 @@ class UpdateManager:
             return
         LOGGER.warning("Detected interrupted update job; marking as failed and cleaning up")
         self._tracker.mark_interrupted("Update interrupted by server restart")
-        wifi = self._build_wifi_controller()
-
-        self._tracker.log("startup_recover: cleaning up uplink connection")
-        try:
-            await wifi.cleanup_uplink()
-        except Exception as exc:
-            self._tracker.add_issue(
-                "startup",
-                "Failed to clean up uplink connection",
-                str(exc),
-            )
-
-        self._tracker.log("startup_recover: restoring hotspot")
-        try:
-            restored = await wifi.restore_hotspot()
-            if restored:
-                self._tracker.log("startup_recover: hotspot restored successfully")
-            else:
-                self._tracker.add_issue(
-                    "startup",
-                    "Failed to restore hotspot after interrupted update",
-                )
-                self._tracker.log("startup_recover: hotspot restore failed")
-        except Exception as exc:
-            self._tracker.add_issue(
-                "startup",
-                "Hotspot restore error during recovery",
-                str(exc),
-            )
+        wifi = self._build_wifi_orchestrator()
+        await wifi.recover_interrupted_update()
         self._tracker.persist()
 
     async def _run_update(
@@ -214,7 +186,7 @@ class UpdateManager:
         )
         commands = self._build_command_executor()
         tracker = self._tracker
-        wifi = self._build_wifi_controller(commands=commands)
+        wifi = self._build_wifi_orchestrator(commands=commands)
         installer = UpdateInstaller(
             commands=commands,
             tracker=tracker,
@@ -329,7 +301,7 @@ class UpdateManager:
     async def _complete_update_success(
         self,
         tracker: UpdateStatusTracker,
-        wifi: UpdateWifiController,
+        wifi: UpdateWifiOrchestrator,
         message: str,
     ) -> None:
         tracker.transition(UpdatePhase.restoring_hotspot)
@@ -343,6 +315,7 @@ class UpdateManager:
 
     async def _cleanup_after_update(self) -> None:
         tracker = self._tracker
+        wifi = self._build_wifi_orchestrator()
         try:
             restore_phases = {
                 UpdatePhase.stopping_hotspot,
@@ -358,22 +331,11 @@ class UpdateManager:
             ):
                 tracker.transition(UpdatePhase.restoring_hotspot)
                 tracker.log("Restoring hotspot...")
-                try:
-                    restored = await asyncio.shield(self._build_wifi_controller().restore_hotspot())
-                    if not restored:
-                        tracker.add_issue("cleanup", "Failed to restore hotspot during cleanup")
-                        tracker.log("Cleanup hotspot restore failed")
-                except Exception as exc:
-                    tracker.add_issue(
-                        "cleanup",
-                        "Hotspot restore error during cleanup",
-                        str(exc),
-                    )
-                    LOGGER.warning("Cleanup hotspot restore failed", exc_info=True)
+                await wifi.cleanup_restore_hotspot()
             tracker.clear_secrets()
             tracker.set_runtime(await asyncio.to_thread(collect_runtime_details, self._repo))
             self._status = tracker.status
-            diag_issues = await asyncio.to_thread(parse_wifi_diagnostics)
+            diag_issues = await wifi.collect_cleanup_diagnostics()
             tracker.extend_issues(diag_issues)
             tracker.finish_cleanup()
             self._status = tracker.status
@@ -387,12 +349,12 @@ class UpdateManager:
     def _build_command_executor(self) -> UpdateCommandExecutor:
         return UpdateCommandExecutor(runner=self._runner, tracker=self._tracker)
 
-    def _build_wifi_controller(
+    def _build_wifi_orchestrator(
         self,
         *,
         commands: UpdateCommandExecutor | None = None,
-    ) -> UpdateWifiController:
-        return UpdateWifiController(
+    ) -> UpdateWifiOrchestrator:
+        return UpdateWifiOrchestrator(
             commands=commands or self._build_command_executor(),
             tracker=self._tracker,
             config=build_default_wifi_config(

--- a/apps/server/vibesensor/use_cases/updates/wifi/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/__init__.py
@@ -6,10 +6,12 @@ from vibesensor.use_cases.updates.wifi.wifi_config import (
     build_default_wifi_config,
 )
 from vibesensor.use_cases.updates.wifi.wifi_diagnostics import parse_wifi_diagnostics
+from vibesensor.use_cases.updates.wifi.wifi_orchestrator import UpdateWifiOrchestrator
 
 __all__ = [
     "UpdateWifiConfig",
     "UpdateWifiController",
+    "UpdateWifiOrchestrator",
     "build_default_wifi_config",
     "parse_wifi_diagnostics",
 ]

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from vibesensor.use_cases.updates.models import UpdateIssue
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.wifi.wifi import UpdateWifiController
+from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
+from vibesensor.use_cases.updates.wifi.wifi_diagnostics import parse_wifi_diagnostics
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UpdateWifiOrchestrator:
+    """Focused Wi-Fi transition helper for updater startup and cleanup paths."""
+
+    __slots__ = ("_controller", "_tracker")
+
+    def __init__(
+        self,
+        *,
+        commands: UpdateCommandExecutor,
+        tracker: UpdateStatusTracker,
+        config: UpdateWifiConfig,
+    ) -> None:
+        self._tracker = tracker
+        self._controller = UpdateWifiController(
+            commands=commands,
+            tracker=tracker,
+            config=config,
+        )
+
+    async def stop_hotspot(self) -> bool:
+        return await self._controller.stop_hotspot()
+
+    async def connect_uplink(self, ssid: str, password: str) -> bool:
+        return await self._controller.connect_uplink(ssid, password)
+
+    async def restore_hotspot(self) -> bool:
+        return await self._controller.restore_hotspot()
+
+    async def recover_interrupted_update(self) -> None:
+        self._tracker.log("startup_recover: cleaning up uplink connection")
+        try:
+            await self._controller.cleanup_uplink()
+        except Exception as exc:
+            self._tracker.add_issue(
+                "startup",
+                "Failed to clean up uplink connection",
+                str(exc),
+            )
+
+        self._tracker.log("startup_recover: restoring hotspot")
+        try:
+            restored = await self.restore_hotspot()
+            if restored:
+                self._tracker.log("startup_recover: hotspot restored successfully")
+            else:
+                self._tracker.add_issue(
+                    "startup",
+                    "Failed to restore hotspot after interrupted update",
+                )
+                self._tracker.log("startup_recover: hotspot restore failed")
+        except Exception as exc:
+            self._tracker.add_issue(
+                "startup",
+                "Hotspot restore error during recovery",
+                str(exc),
+            )
+
+    async def cleanup_restore_hotspot(self) -> None:
+        try:
+            restored = await asyncio.shield(self.restore_hotspot())
+            if not restored:
+                self._tracker.add_issue("cleanup", "Failed to restore hotspot during cleanup")
+                self._tracker.log("Cleanup hotspot restore failed")
+        except Exception as exc:
+            self._tracker.add_issue(
+                "cleanup",
+                "Hotspot restore error during cleanup",
+                str(exc),
+            )
+            LOGGER.warning("Cleanup hotspot restore failed", exc_info=True)
+
+    async def collect_cleanup_diagnostics(self) -> list[UpdateIssue]:
+        return await asyncio.to_thread(parse_wifi_diagnostics)


### PR DESCRIPTION
## Summary

This PR addresses `#1343` by extracting Wi-Fi recovery and hotspot orchestration out of `UpdateManager` and moving that behavior behind a focused helper. Before this change, `UpdateManager` was responsible for both the high-level update workflow and the low-level Wi-Fi transition details needed to keep the hotspot and uplink connection in a sane state. In practice that meant the same class owned startup interruption recovery, hotspot stop/connect/restore sequencing, cleanup-time hotspot restoration, and post-update Wi-Fi diagnostics collection. That mixture made the updater harder to reason about because release/install workflow changes and network transition changes had to be edited in the same place.

The goal here was to make the seam sharper without broadening the issue into a larger updater redesign. The implementation therefore keeps `UpdateManager` as the public facade and phase sequencer, but delegates the Wi-Fi transition work to a new helper in the existing Wi-Fi subpackage. The HTTP/API surface stays unchanged, the update phase model stays unchanged, and the current tracker logging and issue-reporting behavior are intentionally preserved.

## Implementation approach

The refactor introduces a new `UpdateWifiOrchestrator` in `apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py`. This class wraps the existing `UpdateWifiController` rather than replacing it. That choice keeps the change narrow: the low-level hotspot recovery, uplink provisioning, and readiness checks continue to live in their existing focused collaborators, while the new orchestrator becomes the place where updater-specific Wi-Fi transition policy lives.

Concretely, the new helper exposes the small set of operations `UpdateManager` actually needs:

- `stop_hotspot()`
- `connect_uplink(...)`
- `restore_hotspot()`
- `recover_interrupted_update()`
- `cleanup_restore_hotspot()`
- `collect_cleanup_diagnostics()`

This gives `UpdateManager` a single Wi-Fi-facing seam without turning the issue into a full async lifecycle rewrite. Phase transitions, cancellation checks, release download/install logic, and service restart scheduling all remain in `UpdateManager`, which is still the right owner for overall update sequencing.

## Main code changes by area

In `manager.py`, the direct imports of `UpdateWifiController` and `parse_wifi_diagnostics` are removed. The manager now imports `UpdateWifiOrchestrator`, builds it through `_build_wifi_orchestrator(...)`, and uses that helper everywhere it previously touched Wi-Fi behavior directly.

The most important behavior moves are in three places.

First, `startup_recover()` now delegates the interrupted-update recovery path to `recover_interrupted_update()`. That extracted method owns the “clean up uplink connection, attempt hotspot restore, and record startup issues” behavior that previously lived inline in the manager.

Second, `_run_update_inner()` still controls update phases, but hotspot/uplink steps now go through the orchestrator rather than the controller directly. This keeps the phase sequencing in the manager while moving the Wi-Fi action seam to the helper.

Third, `_cleanup_after_update()` no longer restores the hotspot or parses diagnostics itself. Instead it delegates cleanup-time hotspot restoration to `cleanup_restore_hotspot()` and obtains diagnostics from `collect_cleanup_diagnostics()`. That specifically addresses the issue’s requirement to move cleanup-time diagnostics collection behind the Wi-Fi orchestration seam.

The Wi-Fi package `__init__.py` now exports `UpdateWifiOrchestrator` so the helper is discoverable from the same package boundary as the other updater Wi-Fi collaborators.

## Tests and validation changes

I added a focused test module at `apps/server/tests/use_cases/updates/wifi/test_wifi_orchestrator.py`. These tests cover the new seam directly instead of relying only on the full update manager flow. The new coverage includes:

- interrupted-update recovery cleaning up the uplink and restoring the hotspot
- interrupted-update recovery recording the expected startup issue when hotspot restore fails
- cleanup-time hotspot restoration recording the expected cleanup issue when restore fails
- cleanup diagnostics retrieval staying behind the new orchestrator helper

I also updated the existing updater async test that intentionally patched the old `manager.parse_wifi_diagnostics` import seam. The behavior under test did not change, but the patch target now points at the new orchestrator-owned diagnostics seam instead of the removed manager import.

## Contracts, config, and documentation

This change does not alter the HTTP API, persisted update status schema, phase names, or update request/config contracts. It also does not change the nmcli command structure, hotspot retry policy, or diagnostics parser behavior. I did a documentation/reference scan for updater architecture mentions, hotspot recovery prose, and manager-specific Wi-Fi wording in repo docs and READMEs. Nothing required updating for this refactor because the existing user-facing and operational docs describe behavior rather than the internal class seam that changed here.

## Validation performed

I validated the change in layers.

First, I ran the focused updater-area test suite before the refactor to confirm the local baseline and again after the change to verify the full updater area still passed.

Second, I ran backend type checking.

Third, I ran the repository lint/static-guard suite. Because the interactive shell environment here does not put the repo virtualenv tools on `PATH`, I ran the lint target with `PATH=/workspace/VibeSensor/.venv/bin:$PATH` so the repo’s pinned `ruff` and related tooling were used. That surfaced one formatter adjustment in the new test file, which was applied before rerunning lint and the updater tests.

Commands run:

- `cd apps/server && python3 -m pytest -q tests/use_cases/updates`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

Final local results:

- updater tests: `173 passed`
- backend typecheck: clean
- lint/static guards/docs/schema checks: clean

I also attempted the repo-required Docker smoke path with `docker compose build --pull && docker compose up -d`, but that is blocked in this environment because no Docker daemon socket is available. I am calling that out explicitly rather than silently skipping it.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is that the new orchestrator intentionally wraps the existing `UpdateWifiController` instead of flattening or replacing the current Wi-Fi stack. That keeps this PR small and reviewable, but it also means this is a seam-cleanup change rather than a deeper architectural rewrite. I think that is the right call for `#1343` because it satisfies the issue without overlapping the adjacent updater issues about task lifecycle and other manager responsibilities.

I was careful to preserve tracker logs, issue messages, cleanup semantics, and phase sequencing. In particular, cleanup-time restore still uses shielding around hotspot restoration, and the manager still owns the decision about when the update flow should transition phases. That preserves existing runtime behavior while making Wi-Fi orchestration easier to test in isolation.

## Out of scope / follow-up

This PR does not change update job task ownership, cancellation state handling, release/install workflow, or route behavior. Those concerns remain in `UpdateManager` and are better handled by follow-up issues such as the existing task-lifecycle cleanup work. This PR is specifically about moving Wi-Fi recovery/orchestration responsibilities behind a focused seam.

Closes #1343.
