### PR TITLE
Move UpdateManager task lifecycle into a focused update job executor

### DIFF
--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -20,6 +20,7 @@ from vibesensor.use_cases.diagnostics.math_utils import _corr_abs_clamped
 from vibesensor.use_cases.updates.firmware.firmware_bundle import dir_sha256
 from vibesensor.use_cases.updates.firmware.firmware_release_fetcher import GitHubReleaseFetcher
 from vibesensor.use_cases.updates.firmware.firmware_types import FirmwareCacheConfig
+from vibesensor.use_cases.updates.job_executor import UpdateJobExecutor
 from vibesensor.use_cases.updates.manager import UpdateManager, UpdateState
 
 # ── 2. _corr_abs_clamped returns at most 1.0 ─────────────────────────────
@@ -176,14 +177,13 @@ class TestUpdateManagerCancelledError:
         tracker = MagicMock()
         tracker.status = mgr._status
         mgr._tracker = tracker
+        mgr._executor = UpdateJobExecutor(task_name="system-update")
 
         async def mock_inner(ssid, password):
             raise asyncio.CancelledError()
 
         mgr._run_update_inner = mock_inner
-        mgr._runtime_details = MagicMock()
-        mgr._runtime_details.collect = MagicMock(return_value={})
-        mgr._build_wifi_controller = MagicMock()
+        mgr._cleanup_after_update = AsyncMock(return_value=None)
 
         with pytest.raises(asyncio.CancelledError):
             await mgr._run_update("ssid", "pass")

--- a/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
+++ b/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
@@ -92,10 +92,11 @@ def seed_runtime_artifacts(repo: Path, mgr: UpdateManager, *, valid: bool = True
 
 
 async def cancel_task(mgr: UpdateManager) -> None:
-    if mgr._task:
-        mgr._task.cancel()
+    task = mgr.job_task
+    if task is not None:
+        mgr.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
-            await mgr._task
+            await task
 
 
 def assert_hotspot_restored(runner: FakeRunner) -> None:
@@ -115,8 +116,9 @@ async def run_update(
     timeout: float = 10,
 ) -> None:
     mgr.start(ssid, password)
-    assert mgr._task is not None
-    await asyncio.wait_for(mgr._task, timeout=timeout)
+    task = mgr.job_task
+    assert task is not None
+    await asyncio.wait_for(task, timeout=timeout)
 
 
 @contextmanager

--- a/apps/server/tests/use_cases/updates/test_update_job_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_job_executor.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from vibesensor.shared.exceptions import UpdateError
+from vibesensor.use_cases.updates.job_executor import UpdateJobExecutor
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_concurrent_job() -> None:
+    executor = UpdateJobExecutor()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def running_job() -> None:
+        started.set()
+        await release.wait()
+
+    executor.start(lambda: running_job())
+    task = executor.job_task
+    assert task is not None
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    with pytest.raises(UpdateError, match="already in progress"):
+        executor.start(lambda: running_job())
+
+    executor.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_cancel_sets_event_and_cancels_running_task() -> None:
+    executor = UpdateJobExecutor()
+    started = asyncio.Event()
+
+    async def running_job() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    executor.start(lambda: running_job())
+    task = executor.job_task
+    assert task is not None
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert executor.cancel_requested() is False
+    assert executor.cancel() is True
+    assert executor.cancel_requested() is True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_run_timeout_calls_timeout_handler_and_cleanup() -> None:
+    executor = UpdateJobExecutor()
+    events: list[str] = []
+
+    async def slow_workflow() -> None:
+        await asyncio.sleep(1)
+
+    async def cleanup() -> None:
+        events.append("cleanup")
+
+    await executor.run(
+        workflow_factory=lambda: slow_workflow(),
+        timeout_s=0.01,
+        on_timeout=lambda: events.append("timeout"),
+        on_cancelled=lambda: events.append("cancelled"),
+        on_unexpected=lambda exc: events.append(f"unexpected:{type(exc).__name__}"),
+        cleanup=cleanup,
+        on_cancelled_cleanup_error=lambda: events.append("cancelled-cleanup-error"),
+    )
+
+    assert events == ["timeout", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_run_reraises_cancelled_error_and_reports_cleanup_error() -> None:
+    executor = UpdateJobExecutor()
+    events: list[str] = []
+
+    async def cancelled_workflow() -> None:
+        raise asyncio.CancelledError()
+
+    async def cleanup() -> None:
+        events.append("cleanup")
+        raise RuntimeError("cleanup bug")
+
+    with pytest.raises(asyncio.CancelledError):
+        await executor.run(
+            workflow_factory=lambda: cancelled_workflow(),
+            timeout_s=1.0,
+            on_timeout=lambda: events.append("timeout"),
+            on_cancelled=lambda: events.append("cancelled"),
+            on_unexpected=lambda exc: events.append(f"unexpected:{type(exc).__name__}"),
+            cleanup=cleanup,
+            on_cancelled_cleanup_error=lambda: events.append("cancelled-cleanup-error"),
+        )
+
+    assert events == ["cancelled", "cleanup", "cancelled-cleanup-error"]

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -138,7 +138,9 @@ class TestUpdateManagerAsync:
         ):
             mock_fetcher.return_value.check_update_available.return_value = None
             manager.start("TestNet", "pass123")
-            await asyncio.wait_for(manager._task, timeout=10)
+            task = manager.job_task
+            assert task is not None
+            await asyncio.wait_for(task, timeout=10)
 
         assert manager.status.state == UpdateState.success
         assert connect_calls["count"] >= 2
@@ -322,7 +324,9 @@ class TestUpdateManagerAsync:
             patch("vibesensor.use_cases.updates.wifi.wifi_config.HOTSPOT_RESTORE_RETRIES", 1),
         ):
             manager.start("TestNet", "pass")
-            await asyncio.wait_for(manager._task, timeout=3)
+            task = manager.job_task
+            assert task is not None
+            await asyncio.wait_for(task, timeout=3)
         assert manager.status.state == UpdateState.failed
 
     async def test_cleanup_records_hotspot_restore_failure(self, tmp_path) -> None:

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -232,9 +232,9 @@ class TestNoSecretsInPersistedFile:
 
         with patch("shutil.which", _mock_which):
             mgr.start("TestNet", secret_password)
-            assert mgr._task is not None
+            assert mgr.job_task is not None
             with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-                await asyncio.wait_for(mgr._task, timeout=15)
+                await asyncio.wait_for(mgr.job_task, timeout=15)
 
         assert state_path.is_file(), "State file should have been created"
         contents = state_path.read_text(encoding="utf-8")
@@ -419,10 +419,11 @@ class TestPersistenceDuringLifecycle:
             loaded = store.load()
             assert loaded is not None
             assert loaded.state == UpdateState.running
-            if mgr._task is not None:
-                mgr._task.cancel()
+            task = mgr.job_task
+            if task is not None:
+                mgr.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await mgr._task
+                    await task
 
     @pytest.mark.asyncio
     async def test_state_persisted_after_job_ends(self, update_env) -> None:
@@ -433,8 +434,9 @@ class TestPersistenceDuringLifecycle:
 
         with patch("shutil.which", _mock_which):
             mgr.start("TestNet", "")
-            assert mgr._task is not None
-            await asyncio.wait_for(mgr._task, timeout=10)
+            task = mgr.job_task
+            assert task is not None
+            await asyncio.wait_for(task, timeout=10)
 
         loaded = store.load()
         assert loaded is not None

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -11,7 +11,8 @@ Module topology
 - **Validation**: ``validation.py`` — runtime prerequisite checks for tools,
   privileges, rollback storage, and disk space before update orchestration.
 - **Services**: ``manager.py`` — backend restart scheduling and runtime update
-  lifecycle orchestration.
+  workflow orchestration; ``job_executor.py`` — task ownership, cancellation,
+  timeout handling, and cleanup coordination for long-running update jobs.
 - **Firmware**: ``firmware/`` — ESP flash orchestration, firmware cache,
   bundle validation, refresh, release fetcher, and flash-specific contracts.
 - **Wi-Fi**: ``wifi/`` — uplink setup, readiness policy, hotspot recovery,

--- a/apps/server/vibesensor/use_cases/updates/job_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/job_executor.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Coroutine
+
+from vibesensor.shared.exceptions import UpdateError
+
+BeforeStartCallback = Callable[[], None]
+CleanupCallback = Callable[[], Awaitable[None]]
+UnexpectedCallback = Callable[[Exception], None]
+VoidCallback = Callable[[], None]
+WorkflowFactory = Callable[[], Awaitable[None]]
+TaskCoroutineFactory = Callable[[], Coroutine[object, object, None]]
+
+
+class UpdateJobExecutor:
+    """Own update task lifecycle mechanics apart from the update workflow itself."""
+
+    __slots__ = ("_cancel_event", "_task", "_task_name")
+
+    def __init__(self, *, task_name: str = "system-update") -> None:
+        self._task_name = task_name
+        self._task: asyncio.Task[None] | None = None
+        self._cancel_event = asyncio.Event()
+
+    @property
+    def job_task(self) -> asyncio.Task[None] | None:
+        return self._task
+
+    def cancel_requested(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def start(
+        self,
+        workflow_factory: TaskCoroutineFactory,
+        *,
+        before_start: BeforeStartCallback | None = None,
+    ) -> None:
+        if self._task is not None and not self._task.done():
+            raise UpdateError("Update already in progress", status="conflict")
+        self._cancel_event.clear()
+        if before_start is not None:
+            before_start()
+        self._task = asyncio.get_running_loop().create_task(
+            workflow_factory(),
+            name=self._task_name,
+        )
+
+    def cancel(self) -> bool:
+        if self._task is None or self._task.done():
+            return False
+        self._cancel_event.set()
+        self._task.cancel()
+        return True
+
+    async def run(
+        self,
+        *,
+        workflow_factory: WorkflowFactory,
+        timeout_s: float,
+        on_timeout: VoidCallback,
+        on_cancelled: VoidCallback,
+        on_unexpected: UnexpectedCallback,
+        cleanup: CleanupCallback,
+        on_cancelled_cleanup_error: VoidCallback,
+    ) -> None:
+        cancelled = False
+        try:
+            await asyncio.wait_for(workflow_factory(), timeout=timeout_s)
+        except TimeoutError:
+            on_timeout()
+        except asyncio.CancelledError:
+            cancelled = True
+            on_cancelled()
+            raise
+        except Exception as exc:
+            on_unexpected(exc)
+        finally:
+            if cancelled:
+                try:
+                    await cleanup()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    on_cancelled_cleanup_error()
+            else:
+                await cleanup()

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -9,9 +9,10 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from vibesensor.shared.exceptions import ConfigurationError, UpdateError
+from vibesensor.shared.exceptions import ConfigurationError
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
+from vibesensor.use_cases.updates.job_executor import UpdateJobExecutor
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
     UpdatePhase,
@@ -78,8 +79,7 @@ class UpdateManager:
         )
         self._tracker.set_runtime(collect_runtime_details(self._repo))
         self._status = self._tracker.status
-        self._task: asyncio.Task[None] | None = None
-        self._cancel_event = asyncio.Event()
+        self._executor = UpdateJobExecutor(task_name="system-update")
 
         # Build config objects once — shared by workflow, snapshot, and rollback.
         self._installer_config = UpdateInstallerConfig(
@@ -99,7 +99,7 @@ class UpdateManager:
 
     @property
     def job_task(self) -> asyncio.Task[None] | None:
-        return self._task
+        return self._executor.job_task
 
     def start(self, ssid: str, password: str) -> None:
         ssid = ssid.strip()
@@ -107,24 +107,19 @@ class UpdateManager:
             raise ConfigurationError("SSID must be 1-64 characters")
         if password and len(password) > 128:
             raise ConfigurationError("Password must be at most 128 characters")
-        if self._task is not None and not self._task.done():
-            raise UpdateError("Update already in progress", status="conflict")
-        self._cancel_event.clear()
-        self._tracker.start_job(ssid)
-        self._status = self._tracker.status
-        self._tracker.track_secret(password)
         request = UpdateRequest(ssid=ssid, password=password)
-        self._task = asyncio.get_running_loop().create_task(
-            self._run_update(request),
-            name="system-update",
+        self._executor.start(
+            lambda: self._run_update(request),
+            before_start=lambda: self._prepare_start(request),
         )
 
     def cancel(self) -> bool:
-        if self._task is None or self._task.done():
-            return False
-        self._cancel_event.set()
-        self._task.cancel()
-        return True
+        return self._executor.cancel()
+
+    def _prepare_start(self, request: UpdateRequest) -> None:
+        self._tracker.start_job(request.ssid)
+        self._status = self._tracker.status
+        self._tracker.track_secret(request.password)
 
     async def startup_recover(self) -> None:
         if (
@@ -143,36 +138,33 @@ class UpdateManager:
         request_or_ssid: UpdateRequest | str,
         password: str | None = None,
     ) -> None:
-        cancelled = False
-        try:
-            await asyncio.wait_for(
-                self._run_update_inner(request_or_ssid, password),
-                timeout=UPDATE_TIMEOUT_S,
-            )
-        except TimeoutError:
-            if hasattr(self, "_tracker"):
-                self._tracker.fail("timeout", f"Update timed out after {UPDATE_TIMEOUT_S}s")
-                self._tracker.log(f"Update timed out after {UPDATE_TIMEOUT_S}s")
-        except asyncio.CancelledError:
-            cancelled = True
-            if hasattr(self, "_tracker"):
-                self._tracker.fail("cancelled", "Update was cancelled")
-                self._tracker.log("Update cancelled")
-            raise
-        except Exception as exc:
-            if hasattr(self, "_tracker"):
-                self._tracker.fail("unexpected", f"Unexpected error: {exc}")
-            LOGGER.exception("update: unexpected error")
-        finally:
-            if cancelled:
-                try:
-                    await self._cleanup_after_update()
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    LOGGER.warning("Update cleanup interrupted during cancellation", exc_info=True)
-            else:
-                await self._cleanup_after_update()
+        await self._executor.run(
+            workflow_factory=lambda: self._run_update_inner(request_or_ssid, password),
+            timeout_s=UPDATE_TIMEOUT_S,
+            on_timeout=self._handle_timeout,
+            on_cancelled=self._handle_cancelled,
+            on_unexpected=self._handle_unexpected,
+            cleanup=self._cleanup_after_update,
+            on_cancelled_cleanup_error=self._handle_cancelled_cleanup_error,
+        )
+
+    def _handle_timeout(self) -> None:
+        if hasattr(self, "_tracker"):
+            self._tracker.fail("timeout", f"Update timed out after {UPDATE_TIMEOUT_S}s")
+            self._tracker.log(f"Update timed out after {UPDATE_TIMEOUT_S}s")
+
+    def _handle_cancelled(self) -> None:
+        if hasattr(self, "_tracker"):
+            self._tracker.fail("cancelled", "Update was cancelled")
+            self._tracker.log("Update cancelled")
+
+    def _handle_unexpected(self, exc: Exception) -> None:
+        if hasattr(self, "_tracker"):
+            self._tracker.fail("unexpected", f"Unexpected error: {exc}")
+        LOGGER.exception("update: unexpected error")
+
+    def _handle_cancelled_cleanup_error(self) -> None:
+        LOGGER.warning("Update cleanup interrupted during cancellation", exc_info=True)
 
     async def _run_update_inner(
         self,
@@ -193,7 +185,7 @@ class UpdateManager:
             config=self._installer_config,
         )
         firmware_refresher = self._build_firmware_refresher(commands=commands)
-        cancel_requested = self._cancel_event.is_set
+        cancel_requested = self._executor.cancel_requested
 
         if not await validate_prerequisites(
             commands=commands,


### PR DESCRIPTION
## Summary

This PR addresses `#1344` by moving `UpdateManager`’s async task lifecycle mechanics into a focused helper while leaving the actual update workflow in place. Before this change, `UpdateManager` owned both the update flow and the concurrency/control mechanics around it: it stored the running task, tracked a cancel event, created the task in `start()`, cancelled it in `cancel()`, wrapped the workflow with `asyncio.wait_for()`, and coordinated cleanup differently depending on whether the job ended by timeout, generic failure, or `CancelledError`. That meant the manager had to change for both workflow reasons and task-lifecycle reasons, which is the coupling this issue called out.

The goal here was not to redesign the updater. The public API stays the same, the HTTP routes continue to call `start()`, `cancel()`, and `status` the same way, and `_run_update_inner()` continues to own the real updater workflow. The change is about extracting the task ownership, cancellation, timeout, and cleanup-coordination mechanics into a smaller seam that is easier to reason about and test directly.

## Implementation approach

The main addition is a new `UpdateJobExecutor` in `apps/server/vibesensor/use_cases/updates/job_executor.py`. This helper owns three things that used to live directly on `UpdateManager`:

- the running asyncio task
- the cancel event used by workflow checkpoints
- the timeout / cancellation / cleanup wrapper around the workflow

I kept the design intentionally narrow. The executor does not know anything about release checking, installation, hotspot transitions, or update status payload shapes. Instead, it accepts workflow and callback functions from `UpdateManager`:

- a workflow factory for the actual update work
- timeout/cancel/unexpected-error callbacks
- the cleanup callback
- a cancellation-cleanup-error callback for the existing warning path

This keeps `UpdateManager` as the public facade and workflow owner, while moving the lifecycle mechanics behind a dedicated execution seam.

## Main code changes by area

In `manager.py`, `_task` and `_cancel_event` are removed from `UpdateManager` state. The manager now constructs an `UpdateJobExecutor` in `__init__` and exposes `job_task` by delegating to `self._executor.job_task`. That preserves the lifecycle contract used by runtime shutdown code without keeping task state directly on the manager.

`start()` now validates the request, builds the immutable `UpdateRequest`, and hands task creation to the executor. The important detail is that the executor accepts a `before_start` callback, so the tracker state initialization still happens before the task begins, but after the executor has confirmed that no update is already running. That preserves the previous “reject concurrent starts before mutating job state” behavior.

`cancel()` is now just a thin delegation to the executor. The manager no longer owns the cancel event or the task cancellation call directly.

`_run_update()` remains as a thin seam, but it no longer implements timeout and cancellation logic itself. Instead it delegates to `self._executor.run(...)`, passing `_run_update_inner()` as the workflow factory plus focused callbacks for timeout, cancellation, unexpected exceptions, cleanup, and the cancellation-cleanup warning path. This keeps the behavior localized and preserves direct testability for `_run_update()` without leaving the mechanics in the manager.

`_run_update_inner()` remains the actual update workflow owner. The only functional change there is that cancellation checkpoints now use `self._executor.cancel_requested` rather than `self._cancel_event.is_set`. All update phases, release/install logic, hotspot restore success handling, and cleanup behavior stay where they were.

I also updated `apps/server/vibesensor/use_cases/updates/__init__.py` so the package topology documentation reflects the new `job_executor.py` seam.

## Tests and test-support changes

To satisfy the issue’s requirement for focused lifecycle tests, I added `apps/server/tests/use_cases/updates/test_update_job_executor.py`. Those tests cover the executor directly instead of driving everything through the full update manager stack. The new focused coverage verifies:

- concurrent start rejection
- cancel-event setting plus task cancellation behavior
- timeout handling invoking the timeout callback and cleanup
- `CancelledError` re-raise behavior while still reporting cleanup errors through the dedicated callback

I also updated the existing updater helpers and tests to stop depending on `UpdateManager._task`. They now use the public `job_task` seam instead. That includes `_update_manager_test_helpers.py`, `test_update_manager_async.py`, and `test_update_state_persistence.py`. This is important because the issue explicitly requires `UpdateManager` to stop storing `_task` directly.

Finally, I updated the mixed integration regression in `test_runtime_nan_and_update_guard_regressions.py` so it initializes the new executor explicitly and stubs cleanup directly. That keeps the regression focused on the thing it actually cares about: `CancelledError` being re-raised after the wrapper path runs.

## Contracts, config, and documentation

This PR does not change route behavior, status payloads, phase names, or persisted state shape. The updater still exposes the same public methods and the lifecycle manager still sees the same `job_task` property. No config files or schema exports needed changes.

The only documentation touchpoint was the internal package topology docstring in `use_cases/updates/__init__.py`, which now mentions `job_executor.py` as the task-lifecycle owner. I also re-ran the repo docs lint/static checks to make sure this refactor did not leave any guidance drift behind.

## Validation performed

I validated the change in several layers.

First, I ran the updater-area tests plus the specific integration regression that exercises the manager `CancelledError` path:

- `python3 -m pytest -q apps/server/tests/use_cases/updates apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py`

That finished green with `215 passed`.

Second, I ran backend type checking:

- `make typecheck-backend`

That initially found one useful type issue in the new executor: `create_task()` wants a coroutine, not a generic awaitable. I tightened the task-factory type accordingly and reran the check successfully.

Third, I ran the full repo lint/static-guard/docs/schema validation:

- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

That passed after Ruff normalized import ordering in the touched files.

As with `#1343`, I attempted the local Docker smoke path conceptually required by the repo instructions, but this environment still has no Docker daemon socket, so `docker-compose` cannot connect and that step is blocked by environment rather than code.

## Risks, tradeoffs, and edge cases considered

The biggest behavior risk here was changing the subtle cancellation semantics around `_run_update()`. I preserved the important parts deliberately:

- timeout behavior still uses the current `UPDATE_TIMEOUT_S` constant at call time, so tests that patch the constant after manager construction still work
- cancellation still marks the tracker failed with a cancelled message and re-raises `CancelledError`
- cleanup still always runs
- cleanup errors during the cancelled path are still suppressed in favor of re-raising `CancelledError`
- the runtime lifecycle still consumes `job_task` the same way it did before

I also kept `_run_update_inner()` untouched apart from the cancel-check seam, which limits blast radius. This PR is about execution mechanics, not updater workflow redesign.

## Out of scope / follow-up

This PR does not change release/install behavior, Wi-Fi orchestration, or the ESP flash path. It also does not attempt to unify the updater and ESP flash managers behind a shared generic executor abstraction. That could be a future cleanup if the duplication becomes concrete, but it would be a broader design step than `#1344` asked for.

Closes #1344.
