### PR TITLE
Extract payload build and cache orchestration from WebSocketHub.broadcast

### DIFF
--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
+
+
+@pytest.mark.asyncio
+async def test_prepare_builds_payload_once_per_unique_selection() -> None:
+    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
+    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+
+    await orchestrator.prepare(["same", "same", None])
+
+    assert payload_builder.call_count == 2
+    assert json.loads(orchestrator.payload_cache["same"]) == {"selected": "same"}
+    assert json.loads(orchestrator.payload_cache[None]) == {"selected": None}
+
+
+@pytest.mark.asyncio
+async def test_get_or_build_payload_text_reuses_pending_task() -> None:
+    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
+    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        await asyncio.sleep(0)
+        return func(*args, **kwargs)
+
+    with patch(
+        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        side_effect=fake_to_thread,
+    ):
+        first, second = await asyncio.gather(
+            orchestrator.get_or_build_payload_text("same"),
+            orchestrator.get_or_build_payload_text("same"),
+        )
+
+    assert first == second
+    assert payload_builder.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_falls_back_to_error_payload_on_serialization_failure() -> None:
+    payload_builder = MagicMock(return_value={"bad": object()})
+    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+
+    with patch(
+        "vibesensor.adapters.websocket.payload_orchestrator.sanitize_for_json",
+        return_value=({"still_bad": object()}, False),
+    ):
+        await orchestrator.prepare(["broken"])
+
+    assert orchestrator.failed_client_ids == {"broken"}
+    assert json.loads(orchestrator.payload_cache["broken"]) == {
+        "error": "payload_build_failed",
+    }

--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -198,7 +198,10 @@ async def test_broadcast_uses_latest_selection_when_selection_changes_during_ser
             await hub.update_selected_client(ws, "client_b")
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        fake_to_thread,
+    )
 
     await hub.broadcast(payload_builder)
 
@@ -229,7 +232,10 @@ async def test_broadcast_reuses_lazy_payload_for_connections_converging_on_same_
             await hub.update_selected_client(ws2, "client_b")
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        fake_to_thread,
+    )
 
     await hub.broadcast(payload_builder)
 
@@ -259,7 +265,10 @@ async def test_payload_error_affected_count_uses_updated_selection(
             await hub.update_selected_client(ws, "client_b")
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        fake_to_thread,
+    )
 
     def selective_builder(client_id):
         if client_id == "client_b":
@@ -362,7 +371,7 @@ async def test_broadcast_serializes_plain_payload_without_recursive_sanitizing()
     await hub.add(ws, None)
 
     with patch(
-        "vibesensor.adapters.websocket.hub.sanitize_for_json",
+        "vibesensor.adapters.websocket.payload_orchestrator.sanitize_for_json",
         side_effect=AssertionError(
             "sanitize_for_json should not run on the common plain-Python path"
         ),
@@ -385,7 +394,10 @@ async def test_broadcast_offloads_serialization_to_thread(monkeypatch: pytest.Mo
         seen_selected_ids.append(args[0])
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("vibesensor.adapters.websocket.hub.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        fake_to_thread,
+    )
 
     await hub.broadcast(lambda selected: {"selected": selected})
 
@@ -402,7 +414,7 @@ async def test_broadcast_falls_back_to_sanitizer_for_numpy_payload() -> None:
     payload = {"freq": np.array([1.0, float("nan"), 3.0], dtype=np.float32)}
 
     with patch(
-        "vibesensor.adapters.websocket.hub.sanitize_for_json",
+        "vibesensor.adapters.websocket.payload_orchestrator.sanitize_for_json",
         wraps=sanitize_for_json,
     ) as sanitize:
         await hub.broadcast(lambda _: payload)

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import logging
 import os
 from collections.abc import Callable
@@ -17,8 +16,8 @@ from dataclasses import dataclass
 
 from fastapi import WebSocket
 
-from vibesensor.shared.json_utils import sanitize_for_json
-from vibesensor.shared.types.payload_types import LiveWsPayload, WsErrorPayload
+from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
+from vibesensor.shared.types.payload_types import LiveWsPayload
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,10 +35,6 @@ _SEND_TIMEOUT_S: float = 0.5
 
 _SEND_ERROR_LOG_INTERVAL_S: float = 10.0
 """Minimum interval between logged send-error warnings to avoid log spam."""
-
-_ERROR_PAYLOAD_BODY: WsErrorPayload = {"error": "payload_build_failed"}
-_ERROR_PAYLOAD: str = json.dumps(_ERROR_PAYLOAD_BODY, separators=(",", ":"))
-"""Pre-serialised error payload sent to clients when their payload build fails."""
 
 _MAX_CONSECUTIVE_FAILURES: int = 10
 """Back off after this many consecutive broadcast tick failures."""
@@ -163,148 +158,6 @@ class WebSocketHub:
             if current is not None and current.connection_id == conn.connection_id:
                 self._connections.pop(id(conn.websocket), None)
 
-    def _build_raw_payload(
-        self,
-        selected_client_id: str | None,
-        payload_builder: Callable[[str | None], LiveWsPayload],
-        failed_client_ids: set[str | None],
-    ) -> LiveWsPayload | None:
-        """Build the raw payload for *selected_client_id* on the event-loop thread.
-
-        Builder failures keep the transport behavior consistent with the
-        previous implementation: the caller records the failure and falls back
-        to the shared error payload for affected connections.
-        """
-        try:
-            return payload_builder(selected_client_id)
-        except (TypeError, ValueError, OverflowError, KeyError, AttributeError, RuntimeError):
-            LOGGER.error(
-                "WebSocket payload build failed for client %r; "
-                "sending error payload to affected connections.",
-                selected_client_id,
-                exc_info=True,
-            )
-            failed_client_ids.add(selected_client_id)
-            return None
-
-    @staticmethod
-    def _payload_has_per_client_freq(payload: object) -> bool:
-        """Return True when *payload* contains per-client frequency data."""
-        try:
-            spectra = payload.get("spectra") if isinstance(payload, dict) else None
-            if isinstance(spectra, dict):
-                for _cid, cs in (spectra.get("clients") or {}).items():
-                    if isinstance(cs, dict) and cs.get("freq"):
-                        return True
-        except (AttributeError, TypeError, ValueError, KeyError):
-            LOGGER.debug("Debug freq-inspection failed", exc_info=True)
-        return False
-
-    def _serialize_payload(
-        self,
-        selected_client_id: str | None,
-        raw_payload: LiveWsPayload,
-        *,
-        capture_debug: bool,
-    ) -> tuple[str | None, str, bool, bool | None]:
-        """Serialize *raw_payload* off the event loop and report debug metadata."""
-        payload_for_debug: object = raw_payload
-        _dumps = json.dumps  # local-bind for hot-path
-        try:
-            try:
-                text = _dumps(
-                    raw_payload,
-                    separators=(",", ":"),
-                    allow_nan=False,
-                )
-                had_non_finite = False
-            except (TypeError, ValueError, OverflowError):
-                payload_for_debug, had_non_finite = sanitize_for_json(raw_payload)
-                if had_non_finite:
-                    LOGGER.warning(
-                        "WebSocket payload for client %r contained NaN/Inf values; "
-                        "replaced with null.",
-                        selected_client_id,
-                    )
-                text = _dumps(
-                    payload_for_debug,
-                    separators=(",", ":"),
-                    allow_nan=False,
-                )
-            has_freq = (
-                self._payload_has_per_client_freq(payload_for_debug) if capture_debug else None
-            )
-            return selected_client_id, text, False, has_freq
-        except (TypeError, ValueError, OverflowError, KeyError, AttributeError, RuntimeError):
-            LOGGER.error(
-                "WebSocket payload build failed for client %r; "
-                "sending error payload to affected connections.",
-                selected_client_id,
-                exc_info=True,
-            )
-            return selected_client_id, _ERROR_PAYLOAD, True, None
-
-    async def _build_payload_text(
-        self,
-        selected_client_id: str | None,
-        payload_builder: Callable[[str | None], LiveWsPayload],
-        payload_cache: dict[str | None, str],
-        failed_client_ids: set[str | None],
-        debug_info: dict[str | None, bool] | None,
-    ) -> str:
-        """Build and serialize payload text for *selected_client_id* once for the tick."""
-        raw_payload = self._build_raw_payload(
-            selected_client_id,
-            payload_builder,
-            failed_client_ids,
-        )
-        if raw_payload is None:
-            payload_cache[selected_client_id] = _ERROR_PAYLOAD
-            return _ERROR_PAYLOAD
-        _selected_client_id, text, failed, has_freq = await asyncio.to_thread(
-            self._serialize_payload,
-            selected_client_id,
-            raw_payload,
-            capture_debug=debug_info is not None,
-        )
-        payload_cache[selected_client_id] = text
-        if failed:
-            failed_client_ids.add(selected_client_id)
-        if debug_info is not None and has_freq is not None:
-            debug_info[selected_client_id] = has_freq
-        return text
-
-    async def _get_or_build_payload_text(
-        self,
-        selected_client_id: str | None,
-        payload_builder: Callable[[str | None], LiveWsPayload],
-        payload_cache: dict[str | None, str],
-        pending_payload_tasks: dict[str | None, asyncio.Task[str]],
-        failed_client_ids: set[str | None],
-        debug_info: dict[str | None, bool] | None,
-    ) -> str:
-        """Return cached payload text or build it once for the current tick."""
-        cached = payload_cache.get(selected_client_id)
-        if cached is not None:
-            return cached
-        task = pending_payload_tasks.get(selected_client_id)
-        if task is None:
-            task = asyncio.create_task(
-                self._build_payload_text(
-                    selected_client_id,
-                    payload_builder,
-                    payload_cache,
-                    failed_client_ids,
-                    debug_info,
-                )
-            )
-            pending_payload_tasks[selected_client_id] = task
-        try:
-            return await task
-        finally:
-            if pending_payload_tasks.get(selected_client_id) is task and task.done():
-                pending_payload_tasks.pop(selected_client_id, None)
-
     async def _send_conn(
         self,
         conn: _WSConnectionSnapshot,
@@ -338,38 +191,20 @@ class WebSocketHub:
     async def _send_current_conn(
         self,
         conn: _WSConnectionSnapshot,
-        payload_builder: Callable[[str | None], LiveWsPayload],
-        payload_cache: dict[str | None, str],
-        pending_payload_tasks: dict[str | None, asyncio.Task[str]],
-        failed_client_ids: set[str | None],
+        payloads: PayloadBuildOrchestrator,
         sent_selected_client_ids: dict[int, str | None],
-        debug_info: dict[str | None, bool] | None,
     ) -> _WSConnectionSnapshot | None:
         """Send a payload built for the connection's current selection."""
         is_current, selected_client_id = await self._current_selected_client_id(conn)
         if not is_current:
             return None
-        payload_text = await self._get_or_build_payload_text(
-            selected_client_id,
-            payload_builder,
-            payload_cache,
-            pending_payload_tasks,
-            failed_client_ids,
-            debug_info,
-        )
+        payload_text = await payloads.get_or_build_payload_text(selected_client_id)
         still_current, latest_selected_client_id = await self._current_selected_client_id(conn)
         if not still_current:
             return None
         if latest_selected_client_id != selected_client_id:
             selected_client_id = latest_selected_client_id
-            payload_text = await self._get_or_build_payload_text(
-                selected_client_id,
-                payload_builder,
-                payload_cache,
-                pending_payload_tasks,
-                failed_client_ids,
-                debug_info,
-            )
+            payload_text = await payloads.get_or_build_payload_text(selected_client_id)
         sent_selected_client_ids[conn.connection_id] = selected_client_id
         return await self._send_conn(
             conn,
@@ -390,55 +225,19 @@ class WebSocketHub:
         conns = await self._snapshot()
         if not conns:
             return
-        payload_cache: dict[str | None, str] = {}
-        pending_payload_tasks: dict[str | None, asyncio.Task[str]] = {}
-        failed_client_ids: set[str | None] = set()
+        payloads = PayloadBuildOrchestrator(
+            payload_builder,
+            capture_debug=_ws_debug_enabled(),
+        )
+        await payloads.prepare(conn.selected_client_id for conn in conns)
         sent_selected_client_ids: dict[int, str | None] = {}
-        # Collect debug inspection data during build (avoids redundant json.loads later).
-        debug_info: dict[str | None, bool] | None = {} if _ws_debug_enabled() else None
-        unique_selected_ids = list(dict.fromkeys(conn.selected_client_id for conn in conns))
-        raw_payloads: dict[str | None, LiveWsPayload] = {}
-
-        for selected_client_id in unique_selected_ids:
-            raw_payload = self._build_raw_payload(
-                selected_client_id,
-                payload_builder,
-                failed_client_ids,
-            )
-            if raw_payload is None:
-                payload_cache[selected_client_id] = _ERROR_PAYLOAD
-                continue
-            raw_payloads[selected_client_id] = raw_payload
-
-        if raw_payloads:
-            serialized_payloads = await asyncio.gather(
-                *(
-                    asyncio.to_thread(
-                        self._serialize_payload,
-                        selected_client_id,
-                        raw_payload,
-                        capture_debug=debug_info is not None,
-                    )
-                    for selected_client_id, raw_payload in raw_payloads.items()
-                ),
-            )
-            for selected_client_id, text, failed, has_freq in serialized_payloads:
-                payload_cache[selected_client_id] = text
-                if failed:
-                    failed_client_ids.add(selected_client_id)
-                if debug_info is not None and has_freq is not None:
-                    debug_info[selected_client_id] = has_freq
 
         dead_ws = await asyncio.gather(
             *(
                 self._send_current_conn(
                     conn,
-                    payload_builder,
-                    payload_cache,
-                    pending_payload_tasks,
-                    failed_client_ids,
+                    payloads,
                     sent_selected_client_ids,
-                    debug_info,
                 )
                 for conn in conns
             ),
@@ -448,31 +247,31 @@ class WebSocketHub:
                 with contextlib.suppress(Exception):
                     await conn.websocket.close()
                 await self._remove_snapshot(conn)
-        if failed_client_ids:
+        if payloads.failed_client_ids:
             # Count how many connections were affected by build failures.
             affected = sum(
                 1
                 for selected_client_id in sent_selected_client_ids.values()
-                if selected_client_id in failed_client_ids
+                if selected_client_id in payloads.failed_client_ids
             )
             LOGGER.error(
                 "WebSocket payload build failed for %d client id(s) (%s); "
                 "%d connection(s) received error payloads.",
-                len(failed_client_ids),
-                ", ".join(repr(cid) for cid in failed_client_ids),
+                len(payloads.failed_client_ids),
+                ", ".join(repr(cid) for cid in payloads.failed_client_ids),
                 affected,
             )
 
         # Dev-only instrumentation: log payload sizes when VIBESENSOR_WS_DEBUG=1.
-        if debug_info is not None and payload_cache:
+        if payloads.debug_info is not None and payloads.payload_cache:
             live_count = len(conns) - sum(1 for ws in dead_ws if ws is not None)
-            for sel_id, text in payload_cache.items():
+            for sel_id, text in payloads.payload_cache.items():
                 LOGGER.debug(
                     "WS_DEBUG selected=%r size_bytes=%d connections=%d per_client_freq=%s",
                     sel_id,
                     len(text),
                     live_count,
-                    debug_info.get(sel_id, False),
+                    payloads.debug_info.get(sel_id, False),
                 )
 
     async def run(

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -1,0 +1,188 @@
+"""Per-tick payload build and cache orchestration for WebSocket broadcasts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable, Iterable, Mapping
+
+from vibesensor.shared.json_utils import sanitize_for_json
+from vibesensor.shared.types.payload_types import LiveWsPayload, WsErrorPayload
+
+LOGGER = logging.getLogger("vibesensor.adapters.websocket.hub")
+
+__all__ = ["PayloadBuildOrchestrator"]
+
+_ERROR_PAYLOAD_BODY: WsErrorPayload = {"error": "payload_build_failed"}
+_ERROR_PAYLOAD: str = json.dumps(_ERROR_PAYLOAD_BODY, separators=(",", ":"))
+
+
+class PayloadBuildOrchestrator:
+    """Own payload build, serialization, cache reuse, and fallback state for one tick."""
+
+    def __init__(
+        self,
+        payload_builder: Callable[[str | None], LiveWsPayload],
+        *,
+        capture_debug: bool,
+    ) -> None:
+        self._payload_builder = payload_builder
+        self._payload_cache: dict[str | None, str] = {}
+        self._pending_payload_tasks: dict[str | None, asyncio.Task[str]] = {}
+        self._failed_client_ids: set[str | None] = set()
+        self._debug_info: dict[str | None, bool] | None = {} if capture_debug else None
+
+    @property
+    def payload_cache(self) -> Mapping[str | None, str]:
+        return self._payload_cache
+
+    @property
+    def failed_client_ids(self) -> set[str | None]:
+        return self._failed_client_ids
+
+    @property
+    def debug_info(self) -> dict[str | None, bool] | None:
+        return self._debug_info
+
+    def _build_raw_payload(self, selected_client_id: str | None) -> LiveWsPayload | None:
+        """Build the raw payload for *selected_client_id* on the event-loop thread."""
+
+        try:
+            return self._payload_builder(selected_client_id)
+        except (TypeError, ValueError, OverflowError, KeyError, AttributeError, RuntimeError):
+            LOGGER.error(
+                "WebSocket payload build failed for client %r; "
+                "sending error payload to affected connections.",
+                selected_client_id,
+                exc_info=True,
+            )
+            self._failed_client_ids.add(selected_client_id)
+            return None
+
+    @staticmethod
+    def _payload_has_per_client_freq(payload: object) -> bool:
+        """Return True when *payload* contains per-client frequency data."""
+
+        try:
+            spectra = payload.get("spectra") if isinstance(payload, dict) else None
+            if isinstance(spectra, dict):
+                for _cid, cs in (spectra.get("clients") or {}).items():
+                    if isinstance(cs, dict) and cs.get("freq"):
+                        return True
+        except (AttributeError, TypeError, ValueError, KeyError):
+            LOGGER.debug("Debug freq-inspection failed", exc_info=True)
+        return False
+
+    def _serialize_payload(
+        self,
+        selected_client_id: str | None,
+        raw_payload: LiveWsPayload,
+    ) -> tuple[str, bool, bool | None]:
+        """Serialize *raw_payload* off the event loop and report debug metadata."""
+
+        payload_for_debug: object = raw_payload
+        _dumps = json.dumps
+        try:
+            try:
+                text = _dumps(
+                    raw_payload,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+                had_non_finite = False
+            except (TypeError, ValueError, OverflowError):
+                payload_for_debug, had_non_finite = sanitize_for_json(raw_payload)
+                if had_non_finite:
+                    LOGGER.warning(
+                        "WebSocket payload for client %r contained NaN/Inf values; "
+                        "replaced with null.",
+                        selected_client_id,
+                    )
+                text = _dumps(
+                    payload_for_debug,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+            has_freq = (
+                self._payload_has_per_client_freq(payload_for_debug)
+                if self._debug_info is not None
+                else None
+            )
+            return text, False, has_freq
+        except (TypeError, ValueError, OverflowError, KeyError, AttributeError, RuntimeError):
+            LOGGER.error(
+                "WebSocket payload build failed for client %r; "
+                "sending error payload to affected connections.",
+                selected_client_id,
+                exc_info=True,
+            )
+            return _ERROR_PAYLOAD, True, None
+
+    async def prepare(self, selected_client_ids: Iterable[str | None]) -> None:
+        """Prime cached payloads for the current snapshot's unique client selections."""
+
+        unique_selected_ids = list(dict.fromkeys(selected_client_ids))
+        raw_payloads: dict[str | None, LiveWsPayload] = {}
+
+        for selected_client_id in unique_selected_ids:
+            raw_payload = self._build_raw_payload(selected_client_id)
+            if raw_payload is None:
+                self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
+                continue
+            raw_payloads[selected_client_id] = raw_payload
+
+        if not raw_payloads:
+            return
+
+        serialized_payloads = await asyncio.gather(
+            *(
+                asyncio.to_thread(self._serialize_payload, selected_client_id, raw_payload)
+                for selected_client_id, raw_payload in raw_payloads.items()
+            ),
+        )
+        for selected_client_id, (text, failed, has_freq) in zip(
+            raw_payloads,
+            serialized_payloads,
+            strict=True,
+        ):
+            self._payload_cache[selected_client_id] = text
+            if failed:
+                self._failed_client_ids.add(selected_client_id)
+            if self._debug_info is not None and has_freq is not None:
+                self._debug_info[selected_client_id] = has_freq
+
+    async def _build_payload_text(self, selected_client_id: str | None) -> str:
+        """Build and serialize payload text for *selected_client_id* once for the tick."""
+
+        raw_payload = self._build_raw_payload(selected_client_id)
+        if raw_payload is None:
+            self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
+            return _ERROR_PAYLOAD
+        text, failed, has_freq = await asyncio.to_thread(
+            self._serialize_payload,
+            selected_client_id,
+            raw_payload,
+        )
+        self._payload_cache[selected_client_id] = text
+        if failed:
+            self._failed_client_ids.add(selected_client_id)
+        if self._debug_info is not None and has_freq is not None:
+            self._debug_info[selected_client_id] = has_freq
+        return text
+
+    async def get_or_build_payload_text(self, selected_client_id: str | None) -> str:
+        """Return cached payload text or build it once for the current tick."""
+
+        cached = self._payload_cache.get(selected_client_id)
+        if cached is not None:
+            return cached
+        task = self._pending_payload_tasks.get(selected_client_id)
+        if task is None:
+            task = asyncio.create_task(self._build_payload_text(selected_client_id))
+            self._pending_payload_tasks[selected_client_id] = task
+        try:
+            return await task
+        finally:
+            if self._pending_payload_tasks.get(selected_client_id) is task and task.done():
+                self._pending_payload_tasks.pop(selected_client_id, None)


### PR DESCRIPTION
## Summary

This PR addresses `#1346` by extracting the per-tick payload build and cache orchestration out of `WebSocketHub.broadcast()` while keeping connection registration, send handling, and removal behavior in the hub. Before this change, `apps/server/vibesensor/adapters/websocket/hub.py` mixed several different responsibilities in the same broadcast path: it snapshotted the current connections, built raw payloads per selected client, serialized them off the event loop, tracked per-tick payload cache state, managed lazy pending build tasks for selection changes, tracked failed client IDs, captured debug metadata, sent payloads to live connections, removed dead ones, and finally logged payload-build summaries.

That structure worked, but the issue is correct that the method was dominated by payload-orchestration concerns rather than websocket transport concerns. It also made the payload cache and serialization fallback behavior harder to test in isolation because the logic lived inside a hub class whose main purpose is connection fan-out. The goal here was to extract the per-tick payload orchestration behind a focused helper without changing payload shapes, send timeout behavior, selection handling, or error/debug logging.

## Implementation approach

The smallest complete fix was to introduce a dedicated helper for one broadcast tick and make `WebSocketHub.broadcast()` use it. I kept the transport-oriented lifecycle in the hub and moved only the payload-specific state and behavior into the helper.

The new helper is `PayloadBuildOrchestrator` in `apps/server/vibesensor/adapters/websocket/payload_orchestrator.py`. It owns the per-tick payload state:

- the serialized `payload_cache`
- `pending_payload_tasks` for lazy, deduplicated payload builds
- the `failed_client_ids` set used for error fallback and summary logging
- optional `debug_info` for per-client payload metadata

It also owns the payload-specific operations that used to be buried in the hub:

- raw payload build with builder-failure fallback
- JSON serialization offloaded through `asyncio.to_thread()`
- NaN/Inf sanitization fallback
- eager cache priming for the unique selected-client IDs in the current snapshot
- lazy cache population when a connection’s selected client changes during the tick

## Main code changes by area

The new `payload_orchestrator.py` module introduces `PayloadBuildOrchestrator`. It is deliberately a per-tick object rather than a long-lived service because the cache and pending-task state should exist only for one broadcast cycle. The constructor accepts the payload builder and whether debug capture is enabled. From there, `prepare()` handles the eager build-and-serialize pass for unique selected-client IDs, and `get_or_build_payload_text()` provides the lazy, deduplicated build path used when a connection’s selected client changes during serialization or when multiple connections converge on the same new selection.

The helper keeps the payload behavior aligned with the old implementation. Builder failures still log an error and fall back to the shared error payload. Serialization still prefers a direct `json.dumps(..., allow_nan=False)` fast path, then falls back to `sanitize_for_json()` if needed, and still logs the same NaN/Inf warning when sanitization replaces non-finite values. If serialization still fails after sanitization, the helper returns the shared error payload and marks that client as failed for the tick.

In `apps/server/vibesensor/adapters/websocket/hub.py`, `broadcast()` is materially smaller. It now:

- snapshots current connections
- creates a `PayloadBuildOrchestrator` for the tick
- primes the initial payload cache for the current snapshot selections
- iterates connections via `_send_current_conn()`
- removes dead sockets
- logs payload-build summaries and debug payload size information

The hub no longer allocates the payload cache dictionaries directly or owns the eager serialization pass inline.

I also updated `_send_current_conn()` so it no longer accepts raw payload dictionaries and helper state as separate arguments. Instead, it receives the orchestrator object and asks it for payload text for the current or updated selected client. That keeps the hub method focused on connection-currentness checks, selection refresh, and send behavior.

## Tests

To satisfy the issue’s testing requirement, I added `apps/server/tests/adapters/websocket/test_payload_orchestrator.py`. These focused tests exercise the payload orchestration without needing fake websocket connection state. They cover the behaviors the issue explicitly calls out:

- unique-selection cache priming only builds once per selected client ID
- lazy payload retrieval reuses a pending task rather than duplicating work
- serialization failure falls back to the error payload and marks the client as failed

I kept the existing hub integration tests and updated them to patch the new orchestration seam where appropriate. That includes the selection-race tests, error-affected-count test, and the serialization/sanitization tests that previously patched `asyncio.to_thread()` or `sanitize_for_json()` inside `hub.py`. After the extraction those hooks now live in `payload_orchestrator.py`, so the tests were updated accordingly while preserving their original behavioral assertions.

The end result is a better split of test responsibility: the new focused module covers payload orchestration directly, while `test_ws_hub.py` continues to validate broadcast lifecycle, send cleanup, selection changes, timeout removal, and warning/error logs.

## Contracts, logging, and scope boundaries

This PR does not change websocket payload shapes, send timeout semantics, selected-client behavior, or connection CRUD APIs. It also does not touch `WebSocketHub.run()`, which is a separate concern covered by issue `#1347`.

I preserved the existing logging surface deliberately. The helper logs through the same logger name used by the hub so the current warning/error expectations remain stable. That matters for both operational continuity and the existing caplog-based tests that assert on logger output.

I also kept the broadcast summary log in `WebSocketHub.broadcast()` because it depends on the post-send connection state and the selected-client IDs actually used during the send path. That summary belongs with the transport step even after the payload orchestration is extracted.

## Validation performed

I validated the change in layers.

First, I ran the websocket adapter test area:

- `python3 -m pytest -q apps/server/tests/adapters/websocket`

That finished green with `68 passed`.

Second, I ran the websocket-related integration regressions that cover the hub’s runtime loop and related resilience paths:

- `python3 -m pytest -q apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py apps/server/tests/integration/test_coverage_gap_audit_round2.py`

That finished green with `48 passed`.

Third, I ran the backend type check:

- `make typecheck-backend`

This passed cleanly.

Fourth, I ran the repo lint/static-guard/docs/schema validation:

- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

That also passed cleanly.

As with the preceding backend issues in this run, I attempted the repo-required Docker smoke step, but this environment still has no reachable Docker daemon socket, so `docker compose build --pull` fails before the local stack can start. That remains an environment limitation rather than a code failure.

## Risks and tradeoffs considered

The main risk here was breaking subtle selection-change behavior while extracting the payload cache out of `broadcast()`. I limited that risk by keeping the current send flow and only swapping the payload source from raw dictionaries to the helper. The selection refresh and lazy rebuild behavior in `_send_current_conn()` stay intact.

A second tradeoff was whether to make the helper long-lived on the hub. I chose a per-tick object instead because the issue is specifically about per-tick payload orchestration, and long-lived state would unnecessarily widen scope.

Closes #1346.
