### PR TITLE
Move broadcast tick and backoff control out of WebSocketHub.run

### DIFF
--- a/apps/server/tests/adapters/websocket/test_tick_controller.py
+++ b/apps/server/tests/adapters/websocket/test_tick_controller.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from vibesensor.adapters.websocket.tick_controller import BroadcastTickController
+
+
+@pytest.mark.asyncio
+async def test_controller_calls_on_tick_and_broadcast() -> None:
+    controller = BroadcastTickController(
+        hz=1000,
+        logger=logging.getLogger("vibesensor.adapters.websocket.hub"),
+    )
+    tick_count = 0
+    broadcast_count = 0
+
+    def on_tick() -> None:
+        nonlocal tick_count
+        tick_count += 1
+
+    async def broadcast_tick() -> None:
+        nonlocal broadcast_count
+        broadcast_count += 1
+        if broadcast_count >= 3:
+            raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller.run(broadcast_tick=broadcast_tick, on_tick=on_tick)
+
+    assert tick_count == 3
+    assert broadcast_count == 3
+
+
+@pytest.mark.asyncio
+async def test_controller_on_tick_exception_logs_warning_and_continues(caplog) -> None:
+    logger = logging.getLogger("vibesensor.adapters.websocket.hub")
+    controller = BroadcastTickController(hz=1000, logger=logger)
+    tick_count = 0
+    broadcast_count = 0
+
+    def on_tick() -> None:
+        nonlocal tick_count
+        tick_count += 1
+        if tick_count == 1:
+            raise RuntimeError("tick fail")
+
+    async def broadcast_tick() -> None:
+        nonlocal broadcast_count
+        broadcast_count += 1
+        if broadcast_count >= 2:
+            raise asyncio.CancelledError
+
+    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"):
+        with pytest.raises(asyncio.CancelledError):
+            await controller.run(broadcast_tick=broadcast_tick, on_tick=on_tick)
+
+    assert broadcast_count == 2
+    assert any("on_tick callback raised" in record.message for record in caplog.records)
+    assert not any("broadcast tick failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_controller_backs_off_after_consecutive_failures(caplog) -> None:
+    logger = logging.getLogger("vibesensor.adapters.websocket.hub")
+    controller = BroadcastTickController(
+        hz=10,
+        logger=logger,
+        max_consecutive_failures=2,
+        backoff_multiplier=5,
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError
+
+    async def failing_broadcast() -> None:
+        raise RuntimeError("boom")
+
+    with (
+        patch(
+            "vibesensor.adapters.websocket.tick_controller.asyncio.sleep",
+            side_effect=fake_sleep,
+        ),
+        caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await controller.run(broadcast_tick=failing_broadcast)
+
+    assert sleep_calls[0] == pytest.approx(0.1, rel=0.2)
+    assert sleep_calls[1] == pytest.approx(0.5, rel=0.01)
+    assert any("1 consecutive" in record.message for record in caplog.records)
+    assert any("2 consecutive times; backing off." in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_controller_clamps_hz_to_minimum_one(caplog) -> None:
+    logger = logging.getLogger("vibesensor.adapters.websocket.hub")
+    controller = BroadcastTickController(hz=0, logger=logger)
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+        raise asyncio.CancelledError
+
+    async def broadcast_tick() -> None:
+        return None
+
+    with (
+        patch(
+            "vibesensor.adapters.websocket.tick_controller.asyncio.sleep",
+            side_effect=fake_sleep,
+        ),
+        caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await controller.run(broadcast_tick=broadcast_tick)
+
+    assert sleep_calls == [pytest.approx(1.0, rel=0.05)]
+    assert any("clamping to 1 Hz" in record.message for record in caplog.records)

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from fastapi import WebSocket
 
 from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
+from vibesensor.adapters.websocket.tick_controller import BroadcastTickController
 from vibesensor.shared.types.payload_types import LiveWsPayload
 
 LOGGER = logging.getLogger(__name__)
@@ -35,12 +36,6 @@ _SEND_TIMEOUT_S: float = 0.5
 
 _SEND_ERROR_LOG_INTERVAL_S: float = 10.0
 """Minimum interval between logged send-error warnings to avoid log spam."""
-
-_MAX_CONSECUTIVE_FAILURES: int = 10
-"""Back off after this many consecutive broadcast tick failures."""
-
-_BACKOFF_MULTIPLIER: int = 5
-"""Sleep multiplier applied to the tick interval during error back-off."""
 
 
 @dataclass(slots=True)
@@ -287,45 +282,8 @@ class WebSocketHub:
         Consecutive broadcast failures trigger back-off to avoid thundering-herd
         log spam.
         """
-        if hz <= 0:
-            LOGGER.warning(
-                "WebSocketHub.run called with hz=%r; clamping to 1 Hz.",
-                hz,
-            )
-        interval = 1.0 / max(1, hz)
-        consecutive_failures = 0
-        loop = asyncio.get_running_loop()
-        while True:
-            tick_start = loop.time()
-            try:
-                if on_tick is not None:
-                    try:
-                        on_tick()
-                    except Exception:
-                        LOGGER.warning(
-                            "WebSocket on_tick callback raised; proceeding to broadcast.",
-                            exc_info=True,
-                        )
-                await self.broadcast(payload_builder)
-                consecutive_failures = 0
-            except Exception:
-                consecutive_failures += 1
-                if consecutive_failures >= _MAX_CONSECUTIVE_FAILURES:
-                    LOGGER.error(
-                        "WebSocket broadcast tick failed %d consecutive times; backing off.",
-                        consecutive_failures,
-                        exc_info=True,
-                    )
-                    await asyncio.sleep(interval * _BACKOFF_MULTIPLIER)
-                    # Reset the tick clock after the backoff sleep so the
-                    # post-tick sleep uses the correct remaining time.
-                    tick_start = loop.time()
-                    consecutive_failures = 0
-                else:
-                    LOGGER.warning(
-                        "WebSocket broadcast tick failed (%d consecutive); will retry.",
-                        consecutive_failures,
-                        exc_info=True,
-                    )
-            elapsed = loop.time() - tick_start
-            await asyncio.sleep(max(0, interval - elapsed))
+        controller = BroadcastTickController(hz=hz, logger=LOGGER)
+        await controller.run(
+            broadcast_tick=lambda: self.broadcast(payload_builder),
+            on_tick=on_tick,
+        )

--- a/apps/server/vibesensor/adapters/websocket/tick_controller.py
+++ b/apps/server/vibesensor/adapters/websocket/tick_controller.py
@@ -1,0 +1,77 @@
+"""Broadcast tick scheduling and backoff control for WebSocket run loops."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+__all__ = ["BroadcastTickController"]
+
+_MAX_CONSECUTIVE_FAILURES: int = 10
+_BACKOFF_MULTIPLIER: int = 5
+
+
+class BroadcastTickController:
+    """Drive a broadcast loop with fixed-rate timing and failure backoff."""
+
+    def __init__(
+        self,
+        *,
+        hz: int,
+        logger: logging.Logger,
+        max_consecutive_failures: int = _MAX_CONSECUTIVE_FAILURES,
+        backoff_multiplier: int = _BACKOFF_MULTIPLIER,
+    ) -> None:
+        if hz <= 0:
+            logger.warning(
+                "WebSocketHub.run called with hz=%r; clamping to 1 Hz.",
+                hz,
+            )
+        self._logger = logger
+        self._interval = 1.0 / max(1, hz)
+        self._max_consecutive_failures = max_consecutive_failures
+        self._backoff_multiplier = backoff_multiplier
+
+    async def run(
+        self,
+        *,
+        broadcast_tick: Callable[[], Awaitable[None]],
+        on_tick: Callable[[], None] | None = None,
+    ) -> None:
+        """Drive the loop until cancelled, preserving existing retry behavior."""
+
+        consecutive_failures = 0
+        loop = asyncio.get_running_loop()
+        while True:
+            tick_start = loop.time()
+            try:
+                if on_tick is not None:
+                    try:
+                        on_tick()
+                    except Exception:
+                        self._logger.warning(
+                            "WebSocket on_tick callback raised; proceeding to broadcast.",
+                            exc_info=True,
+                        )
+                await broadcast_tick()
+                consecutive_failures = 0
+            except Exception:
+                consecutive_failures += 1
+                if consecutive_failures >= self._max_consecutive_failures:
+                    self._logger.error(
+                        "WebSocket broadcast tick failed %d consecutive times; backing off.",
+                        consecutive_failures,
+                        exc_info=True,
+                    )
+                    await asyncio.sleep(self._interval * self._backoff_multiplier)
+                    tick_start = loop.time()
+                    consecutive_failures = 0
+                else:
+                    self._logger.warning(
+                        "WebSocket broadcast tick failed (%d consecutive); will retry.",
+                        consecutive_failures,
+                        exc_info=True,
+                    )
+            elapsed = loop.time() - tick_start
+            await asyncio.sleep(max(0, self._interval - elapsed))


### PR DESCRIPTION
## Summary

This PR addresses `#1347` by extracting the broadcast tick scheduler and failure-backoff policy out of `WebSocketHub.run()` while keeping the hub’s delivery behavior unchanged. Before this change, `apps/server/vibesensor/adapters/websocket/hub.py` bundled two different responsibilities into the same method: `run()` handled the infrastructure loop policy around each broadcast tick, and it also served as the public websocket entrypoint that wired `broadcast(payload_builder)` together with the optional `on_tick()` hook.

Concretely, the old `run()` implementation still owned all of the control-policy mechanics the issue called out: Hz clamping, interval calculation, tick timing, `consecutive_failures` tracking, warning-versus-error logging thresholds, the longer backoff sleep after repeated failures, reset of the failure counter after the backoff cycle, and the final sleep used to maintain the requested broadcast frequency. Those are legitimate responsibilities, but they are loop-policy concerns rather than websocket connection-management concerns.

The goal here was to move that policy behind a focused helper without changing send-time cleanup, payload generation, payload timeouts, connection registry behavior, or the user-visible logging contract. `WebSocketHub.run()` is now a thin wrapper around the extracted controller, while `broadcast()` and the connection lifecycle remain in the hub.

## Implementation approach

The smallest complete fix was to extract the entire loop-policy implementation into a dedicated helper rather than only teasing out a few calculations. That satisfies the issue’s acceptance criteria more directly because `WebSocketHub.run()` no longer contains the backoff/tick loop implementation itself.

The new helper is `BroadcastTickController` in `apps/server/vibesensor/adapters/websocket/tick_controller.py`. It owns:

- Hz clamping to a minimum of 1 Hz
- interval calculation from the requested frequency
- per-tick timing using the event loop clock
- `consecutive_failures` tracking
- threshold-based escalation from warning-level retries to error-level backoff
- the backoff sleep duration (`interval * backoff_multiplier`)
- the normal per-tick sleep used to preserve target frequency

I kept the extracted controller narrowly scoped. It does not know anything about websocket payloads, connection registries, selected client IDs, or send failures inside `broadcast()`. Instead, it accepts two callbacks:

- `broadcast_tick`, an async callable for the work of one broadcast iteration
- `on_tick`, an optional synchronous callback invoked just before each broadcast attempt

That lets the helper own only scheduling and retry policy, while `WebSocketHub` stays responsible for websocket-specific behavior.

## Main code changes by area

The main addition is `tick_controller.py`. `BroadcastTickController.run()` now holds the loop that previously lived inside the hub. It preserves the existing behavior intentionally:

- `on_tick()` still runs before each broadcast attempt
- an `on_tick()` exception is still downgraded to a warning and does not block the broadcast
- successful broadcast ticks still reset the consecutive-failure counter
- repeated broadcast exceptions still log warnings below the threshold and an error once the threshold is reached
- the threshold path still performs a longer backoff sleep and resets the failure counter afterward
- the final interval sleep still runs after each tick so broadcast frequency remains rate-limited

In `apps/server/vibesensor/adapters/websocket/hub.py`, `WebSocketHub.run()` is now just a thin wrapper that constructs `BroadcastTickController(hz=hz, logger=LOGGER)` and delegates to it with:

- `broadcast_tick=lambda: self.broadcast(payload_builder)`
- `on_tick=on_tick`

That leaves the hub with the websocket-specific public surface but removes the scheduler/backoff implementation from the class itself.

I also moved the loop-policy constants out of `hub.py` and into the new controller module so send-oriented constants in the hub stay separated from retry-policy constants.

## Tests

To satisfy the issue’s testing requirement, I added `apps/server/tests/adapters/websocket/test_tick_controller.py`. These new focused tests exercise the extracted controller directly rather than going through the full websocket hub and connection stack.

The controller tests cover:

- basic loop execution where `on_tick()` and `broadcast_tick()` are both invoked
- `on_tick()` exceptions being logged as warnings while the broadcast still runs
- threshold-based backoff after consecutive broadcast failures, including the expected normal sleep followed by the longer backoff sleep
- Hz clamping to 1 Hz when the caller passes `hz <= 0`

Those tests give direct coverage to the loop policy that previously had to be inferred through the hub.

I kept the existing websocket and integration tests in place as public-surface coverage. In particular, the run-loop tests in `test_coverage_gap_audit_round2.py` and `test_report_delivery_and_stream_resilience_regressions.py` still validate the real `WebSocketHub.run()` path, including the behavior that `on_tick()` failures do not break the loop and that repeated ticks still happen through the hub entrypoint.

## Contracts, logging, and scope boundaries

This PR does not change websocket payload generation, send timeout behavior, connection registration APIs, or the payload-orchestration extraction that landed in the previous issue. It is deliberately limited to the loop scheduler/backoff concern inside `run()`.

I also preserved the existing log messages and logger identity. The controller logs through the hub logger passed in from `WebSocketHub`, so operational output and caplog-based tests continue to observe the same logger name and the same warning/error messages. That matters because the issue explicitly asks to preserve current logging and retry timing unless intentionally changed.

This PR also does not attempt to generalize the controller into a cross-runtime scheduler abstraction. The helper is specific to the websocket broadcast loop because that is the narrow change this issue asks for.

## Validation performed

I validated the change in layers.

First, I ran the websocket adapter tests together with the websocket-related integration regressions:

- `python3 -m pytest -q apps/server/tests/adapters/websocket apps/server/tests/integration/test_coverage_gap_audit_round2.py apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py`

That finished green with `120 passed`.

Second, I ran the backend type check:

- `make typecheck-backend`

This passed cleanly.

Third, I ran the repo lint/static-guard/docs/schema validation:

- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

That also passed cleanly.

As with the preceding backend issues in this run, I attempted the repo-required Docker smoke step, but this environment still has no reachable Docker daemon socket, so `docker compose build --pull` fails before the stack can start. That remains an environment limitation rather than a code regression.

## Risks and tradeoffs considered

The main risk here was subtly changing retry timing or failure-count semantics while moving the code. I avoided that by copying the existing loop behavior almost verbatim into the controller and then making `WebSocketHub.run()` delegate to it rather than rewriting the policy from scratch.

A second tradeoff was whether to move the `on_tick()` callback handling out of the hub as well. I kept it within the controller’s execution loop because it is part of the per-tick policy, but I left the callback supplied by the hub so `WebSocketHub.run()` still exposes the same public API and remains the surface that wires broadcast behavior together.

Closes #1347.
