### PR TITLE
Extract managed task supervision from `LifecycleManager`

### DIFF
--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -375,8 +375,6 @@ async def test_start_follows_declared_startup_phase_order(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_start_records_background_task_failure(monkeypatch) -> None:
-    import vibesensor.infra.runtime.lifecycle as lifecycle_module
-
     async def _fake_udp(*args, **kwargs):
         return None, None
 
@@ -405,7 +403,7 @@ async def test_start_records_background_task_failure(monkeypatch) -> None:
     )
     lifecycle._start_udp_receiver = _fake_udp
 
-    monkeypatch.setattr(lifecycle_module, "_TASK_RESTART_MAX_ATTEMPTS", 0)
+    lifecycle._task_supervisor._max_attempts = 0
 
     await lifecycle.start()
     failed_task = next(task for task in lifecycle.tasks if task.get_name() == "ws-broadcast")
@@ -418,7 +416,7 @@ async def test_start_records_background_task_failure(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_start_restarts_supervised_task_after_failure(monkeypatch) -> None:
-    import vibesensor.infra.runtime.lifecycle as lifecycle_module
+    import vibesensor.infra.runtime.task_supervisor as task_supervisor_module
 
     async def _fake_udp(*args, **kwargs):
         return None, None
@@ -458,9 +456,9 @@ async def test_start_restarts_supervised_task_after_failure(monkeypatch) -> None
     )
     lifecycle._start_udp_receiver = _fake_udp
 
-    monkeypatch.setattr(lifecycle_module, "_TASK_RESTART_BASE_DELAY_S", 0.0)
-    monkeypatch.setattr(lifecycle_module, "_TASK_RESTART_MAX_DELAY_S", 0.0)
-    monkeypatch.setattr(lifecycle_module.asyncio, "sleep", _fast_sleep)
+    lifecycle._task_supervisor._base_delay_s = 0.0
+    lifecycle._task_supervisor._max_delay_s = 0.0
+    monkeypatch.setattr(task_supervisor_module.asyncio, "sleep", _fast_sleep)
 
     await lifecycle.start()
     await asyncio.wait_for(restart_started.wait(), timeout=1.0)

--- a/apps/server/tests/infra/runtime/test_task_supervisor.py
+++ b/apps/server/tests/infra/runtime/test_task_supervisor.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.infra.runtime.task_supervisor import TaskSupervisor
+
+
+@pytest.mark.asyncio
+async def test_supervisor_restarts_failed_task_and_clears_health(monkeypatch) -> None:
+    import vibesensor.infra.runtime.task_supervisor as task_supervisor_module
+
+    health_state = RuntimeHealthState()
+    supervisor = TaskSupervisor(
+        health_state=health_state,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+        base_delay_s=0.0,
+        max_delay_s=0.0,
+    )
+    restart_started = asyncio.Event()
+    call_count = 0
+    original_sleep = asyncio.sleep
+
+    async def _fast_sleep(delay: float) -> None:
+        del delay
+        await original_sleep(0)
+
+    async def task_factory() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("boom")
+        restart_started.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(task_supervisor_module.asyncio, "sleep", _fast_sleep)
+
+    task = supervisor.start(task_factory, name="ws-broadcast")
+    await asyncio.wait_for(restart_started.wait(), timeout=1.0)
+
+    assert call_count == 2
+    assert health_state.background_task_failures == {}
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_supervisor_restarts_unexpected_exit(monkeypatch) -> None:
+    import vibesensor.infra.runtime.task_supervisor as task_supervisor_module
+
+    health_state = RuntimeHealthState()
+    supervisor = TaskSupervisor(
+        health_state=health_state,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+        base_delay_s=0.0,
+        max_delay_s=0.0,
+    )
+    restart_started = asyncio.Event()
+    call_count = 0
+    original_sleep = asyncio.sleep
+
+    async def _fast_sleep(delay: float) -> None:
+        del delay
+        await original_sleep(0)
+
+    async def task_factory() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return
+        restart_started.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(task_supervisor_module.asyncio, "sleep", _fast_sleep)
+
+    task = supervisor.start(task_factory, name="metrics-log")
+    await asyncio.wait_for(restart_started.wait(), timeout=1.0)
+
+    assert call_count == 2
+    assert health_state.background_task_failures == {}
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_supervisor_records_terminal_failure_after_max_attempts() -> None:
+    health_state = RuntimeHealthState()
+    supervisor = TaskSupervisor(
+        health_state=health_state,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+        max_attempts=0,
+    )
+
+    async def task_factory() -> None:
+        raise RuntimeError("boom")
+
+    task = supervisor.start(task_factory, name="processing-loop")
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert health_state.background_task_failures["processing-loop"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_supervisor_caps_restart_delay() -> None:
+    health_state = RuntimeHealthState()
+    supervisor = TaskSupervisor(
+        health_state=health_state,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+        max_attempts=10,
+        base_delay_s=1.0,
+        max_delay_s=2.0,
+    )
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        if len(sleep_calls) >= 3:
+            raise asyncio.CancelledError
+
+    async def task_factory() -> None:
+        raise RuntimeError("boom")
+
+    with (
+        patch("vibesensor.infra.runtime.task_supervisor.asyncio.sleep", side_effect=_fake_sleep),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        task = supervisor.start(task_factory, name="gps-speed")
+        await task
+
+    assert sleep_calls == [1.0, 2.0, 2.0]

--- a/apps/server/vibesensor/infra/runtime/__init__.py
+++ b/apps/server/vibesensor/infra/runtime/__init__.py
@@ -6,6 +6,7 @@ Submodules
 - ``client_metadata``: persisted/user-assigned client metadata helpers
 - ``registry_updates``: DATA-message dedup/reset bookkeeping
 - ``processing_loop``: ProcessingLoop (async tick loop + failure tracking)
+- ``task_supervisor``: TaskSupervisor (managed restart policy + backoff)
 - ``ws_broadcast``: WsBroadcastService (payload assembly + cache)
 - ``lifecycle``: LifecycleManager (start/stop + task management)
 - ``rotational_speeds``: Stateless rotational speed payload helpers

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
-import time
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.infra.runtime.task_supervisor import TaskSupervisor, task_failure_message
 from vibesensor.shared.constants.ui import UI_PUSH_HZ
 from vibesensor.shared.types.payload_types import LiveWsPayload
 
@@ -26,12 +26,6 @@ StartUdpReceiver = Callable[
     ...,
     Coroutine[object, object, tuple[asyncio.DatagramTransport, asyncio.Task[None]]],
 ]
-TaskFactory = Callable[[], Coroutine[object, object, object]]
-
-_TASK_RESTART_MAX_ATTEMPTS = 3
-_TASK_RESTART_BASE_DELAY_S = 1.0
-_TASK_RESTART_MAX_DELAY_S = 10.0
-_TASK_RESTART_RESET_AFTER_S = 60.0
 
 
 class LifecycleControlPlane(Protocol):
@@ -144,6 +138,7 @@ class LifecycleManager:
         "_health_state",
         "_runtime",
         "_start_udp_receiver",
+        "_task_supervisor",
         "tasks",
     )
 
@@ -156,14 +151,13 @@ class LifecycleManager:
         self._runtime = runtime
         self._health_state = runtime.health_state
         self._start_udp_receiver = start_udp_receiver
+        self._task_supervisor = TaskSupervisor(
+            health_state=self._health_state,
+            logger=LOGGER,
+        )
         self.tasks: list[asyncio.Task[object]] = []
         self._data_transport: asyncio.DatagramTransport | None = None
         self._data_consumer_task: asyncio.Task[object] | None = None
-
-    @staticmethod
-    def _task_failure_message(exc: BaseException) -> str:
-        message = str(exc).strip() or exc.__class__.__name__
-        return message[:240]
 
     def _monitor_task(self, task: asyncio.Task[object]) -> None:
         task_name = task.get_name()
@@ -177,16 +171,11 @@ class LifecycleManager:
                 return
             if exc is None:
                 return
-            message = self._task_failure_message(exc)
+            message = task_failure_message(exc)
             self._health_state.record_task_failure(task_name, message)
             LOGGER.error("Managed task %s failed: %s", task_name, message, exc_info=exc)
 
         task.add_done_callback(_record_failure)
-
-    @staticmethod
-    def _restart_delay_s(restart_count: int) -> float:
-        exponent = max(0, restart_count - 1)
-        return float(min(_TASK_RESTART_MAX_DELAY_S, _TASK_RESTART_BASE_DELAY_S * (2**exponent)))
 
     def _start_task(
         self,
@@ -195,67 +184,6 @@ class LifecycleManager:
         name: str,
     ) -> asyncio.Task[object]:
         task = asyncio.create_task(coroutine, name=name)
-        self._monitor_task(task)
-        return task
-
-    def _start_supervised_task(
-        self,
-        task_factory: TaskFactory,
-        *,
-        name: str,
-    ) -> asyncio.Task[object]:
-        async def _run_supervised() -> None:
-            restart_count = 0
-            while True:
-                started_at = time.monotonic()
-                try:
-                    await task_factory()
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:
-                    runtime_s = time.monotonic() - started_at
-                    if runtime_s >= _TASK_RESTART_RESET_AFTER_S:
-                        restart_count = 0
-                    if restart_count >= _TASK_RESTART_MAX_ATTEMPTS:
-                        raise
-                    restart_count += 1
-                    delay_s = self._restart_delay_s(restart_count)
-                    self._health_state.record_task_failure(name, self._task_failure_message(exc))
-                    LOGGER.error(
-                        "Managed task %s failed; restarting in %.1fs (%d/%d).",
-                        name,
-                        delay_s,
-                        restart_count,
-                        _TASK_RESTART_MAX_ATTEMPTS,
-                        exc_info=exc,
-                    )
-                    await asyncio.sleep(delay_s)
-                    self._health_state.clear_task_failure(name)
-                    continue
-
-                runtime_s = time.monotonic() - started_at
-                if runtime_s >= _TASK_RESTART_RESET_AFTER_S:
-                    restart_count = 0
-                unexpected_exit = RuntimeError(f"managed task {name} exited unexpectedly")
-                if restart_count >= _TASK_RESTART_MAX_ATTEMPTS:
-                    raise unexpected_exit
-                restart_count += 1
-                delay_s = self._restart_delay_s(restart_count)
-                self._health_state.record_task_failure(
-                    name,
-                    self._task_failure_message(unexpected_exit),
-                )
-                LOGGER.error(
-                    "Managed task %s exited unexpectedly; restarting in %.1fs (%d/%d).",
-                    name,
-                    delay_s,
-                    restart_count,
-                    _TASK_RESTART_MAX_ATTEMPTS,
-                )
-                await asyncio.sleep(delay_s)
-                self._health_state.clear_task_failure(name)
-
-        task = asyncio.create_task(_run_supervised(), name=name)
         self._monitor_task(task)
         return task
 
@@ -345,7 +273,7 @@ class LifecycleManager:
             phase = "processing-loop"
             self._health_state.set_phase(phase)
             self.tasks.append(
-                self._start_supervised_task(
+                self._task_supervisor.start(
                     lambda: self._runtime.processing_loop.run(),
                     name=phase,
                 ),
@@ -354,7 +282,7 @@ class LifecycleManager:
             phase = "ws-broadcast"
             self._health_state.set_phase(phase)
             self.tasks.append(
-                self._start_supervised_task(
+                self._task_supervisor.start(
                     lambda: self._runtime.ws_hub.run(
                         UI_PUSH_HZ,
                         self._runtime.ws_broadcast.build_payload,
@@ -367,7 +295,7 @@ class LifecycleManager:
             phase = "metrics-log"
             self._health_state.set_phase(phase)
             self.tasks.append(
-                self._start_supervised_task(
+                self._task_supervisor.start(
                     lambda: self._runtime.run_recorder.run(),
                     name=phase,
                 ),
@@ -376,7 +304,7 @@ class LifecycleManager:
             phase = "gps-speed"
             self._health_state.set_phase(phase)
             self.tasks.append(
-                self._start_supervised_task(
+                self._task_supervisor.start(
                     lambda: self._runtime.gps_monitor.run(
                         host=self._runtime.gpsd_host,
                         port=self._runtime.gpsd_port,
@@ -395,7 +323,7 @@ class LifecycleManager:
             )
             self._health_state.mark_ready()
         except Exception as exc:
-            self._health_state.mark_failed(phase, self._task_failure_message(exc))
+            self._health_state.mark_failed(phase, task_failure_message(exc))
             raise
 
     async def stop(self) -> None:

--- a/apps/server/vibesensor/infra/runtime/task_supervisor.py
+++ b/apps/server/vibesensor/infra/runtime/task_supervisor.py
@@ -1,0 +1,141 @@
+"""Managed task supervision with restart/backoff policy for runtime services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable, Coroutine
+
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+
+__all__ = ["TaskSupervisor", "task_failure_message"]
+
+TaskFactory = Callable[[], Coroutine[object, object, object]]
+
+_TASK_RESTART_MAX_ATTEMPTS = 3
+_TASK_RESTART_BASE_DELAY_S = 1.0
+_TASK_RESTART_MAX_DELAY_S = 10.0
+_TASK_RESTART_RESET_AFTER_S = 60.0
+
+
+def task_failure_message(exc: BaseException) -> str:
+    """Normalize a task failure into a bounded health-state message."""
+
+    message = str(exc).strip() or exc.__class__.__name__
+    return message[:240]
+
+
+class TaskSupervisor:
+    """Create managed tasks that restart with exponential backoff on failure."""
+
+    __slots__ = (
+        "_base_delay_s",
+        "_health_state",
+        "_logger",
+        "_max_attempts",
+        "_max_delay_s",
+        "_reset_after_s",
+    )
+
+    def __init__(
+        self,
+        *,
+        health_state: RuntimeHealthState,
+        logger: logging.Logger,
+        max_attempts: int = _TASK_RESTART_MAX_ATTEMPTS,
+        base_delay_s: float = _TASK_RESTART_BASE_DELAY_S,
+        max_delay_s: float = _TASK_RESTART_MAX_DELAY_S,
+        reset_after_s: float = _TASK_RESTART_RESET_AFTER_S,
+    ) -> None:
+        self._health_state = health_state
+        self._logger = logger
+        self._max_attempts = max_attempts
+        self._base_delay_s = base_delay_s
+        self._max_delay_s = max_delay_s
+        self._reset_after_s = reset_after_s
+
+    def _monitor_task(self, task: asyncio.Task[object]) -> None:
+        task_name = task.get_name()
+
+        def _record_failure(done_task: asyncio.Task[object]) -> None:
+            if done_task.cancelled():
+                return
+            try:
+                exc = done_task.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is None:
+                return
+            message = task_failure_message(exc)
+            self._health_state.record_task_failure(task_name, message)
+            self._logger.error("Managed task %s failed: %s", task_name, message, exc_info=exc)
+
+        task.add_done_callback(_record_failure)
+
+    def _restart_delay_s(self, restart_count: int) -> float:
+        exponent = max(0, restart_count - 1)
+        return float(min(self._max_delay_s, self._base_delay_s * (2**exponent)))
+
+    def start(
+        self,
+        task_factory: TaskFactory,
+        *,
+        name: str,
+    ) -> asyncio.Task[object]:
+        """Create a supervised task that restarts on failure or unexpected exit."""
+
+        async def _run_supervised() -> None:
+            restart_count = 0
+            while True:
+                started_at = time.monotonic()
+                try:
+                    await task_factory()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    runtime_s = time.monotonic() - started_at
+                    if runtime_s >= self._reset_after_s:
+                        restart_count = 0
+                    if restart_count >= self._max_attempts:
+                        raise
+                    restart_count += 1
+                    delay_s = self._restart_delay_s(restart_count)
+                    self._health_state.record_task_failure(name, task_failure_message(exc))
+                    self._logger.error(
+                        "Managed task %s failed; restarting in %.1fs (%d/%d).",
+                        name,
+                        delay_s,
+                        restart_count,
+                        self._max_attempts,
+                        exc_info=exc,
+                    )
+                    await asyncio.sleep(delay_s)
+                    self._health_state.clear_task_failure(name)
+                    continue
+
+                runtime_s = time.monotonic() - started_at
+                if runtime_s >= self._reset_after_s:
+                    restart_count = 0
+                unexpected_exit = RuntimeError(f"managed task {name} exited unexpectedly")
+                if restart_count >= self._max_attempts:
+                    raise unexpected_exit
+                restart_count += 1
+                delay_s = self._restart_delay_s(restart_count)
+                self._health_state.record_task_failure(
+                    name,
+                    task_failure_message(unexpected_exit),
+                )
+                self._logger.error(
+                    "Managed task %s exited unexpectedly; restarting in %.1fs (%d/%d).",
+                    name,
+                    delay_s,
+                    restart_count,
+                    self._max_attempts,
+                )
+                await asyncio.sleep(delay_s)
+                self._health_state.clear_task_failure(name)
+
+        task = asyncio.create_task(_run_supervised(), name=name)
+        self._monitor_task(task)
+        return task


### PR DESCRIPTION
## Summary
Closes #1348.

`apps/server/vibesensor/infra/runtime/lifecycle.py` was still doing two different jobs at once. It owned lifecycle sequencing for startup and shutdown, but it also embedded the reusable mechanics for monitoring long-running managed tasks, normalizing their failure messages, retrying them with exponential backoff, and escalating terminal failures into runtime health state. That coupling made the lifecycle file longer and harder to reason about, and it also made the restart policy difficult to test in isolation because the only realistic test seam lived inside the full `LifecycleManager` suite.

This change separates those concerns by introducing a focused `TaskSupervisor` helper in `apps/server/vibesensor/infra/runtime/task_supervisor.py` and routing supervised task startup through it. `LifecycleManager` still owns phase ordering, health phase transitions, transport setup, and shutdown sequencing. The new helper owns the restart/backoff policy and the health-state failure recording for supervised managed tasks. The result is smaller lifecycle orchestration code, a clearer runtime boundary, and dedicated tests that cover restart behavior without needing to stand up the entire lifecycle manager.

## Implementation approach
The goal here was to make the smallest complete change that satisfied the issue without broadening the runtime design. I kept `LifecycleManager.start()` responsible for sequencing the existing phases in exactly the same order, and I did not move UDP setup, stop behavior, or other unrelated lifecycle helpers. Instead, I extracted only the logic that was specifically about supervising managed tasks over time.

The new `TaskSupervisor` helper centralizes four pieces of behavior that previously lived inline in `lifecycle.py`:

- task failure message normalization
- restart attempt counting and reset-after-runtime handling
- exponential backoff calculation with a cap
- creation and monitoring of supervised `asyncio.Task` instances

I preserved the existing runtime health semantics rather than redesigning them. Transient failures are still recorded before a retry and cleared once the supervisor finishes the backoff and restarts the task. Terminal failures still surface as background task failures with the bounded message text that the rest of the runtime already expects. Cancellation behavior is also unchanged: explicit task cancellation still exits immediately rather than being treated as a retryable failure.

## Main code changes by area
In `apps/server/vibesensor/infra/runtime/task_supervisor.py`, I added the new helper module. It exposes `TaskSupervisor` plus a shared `task_failure_message()` helper. `TaskSupervisor.start()` now wraps a coroutine factory in the managed supervision loop that had previously been nested inside `LifecycleManager._start_supervised_task()`. The helper owns the restart constants, exponential backoff calculation, retry logging, health-state recording for transient failures, and done-callback monitoring for terminal failures. Keeping those behaviors together gives the supervision code a single reason to change and makes it possible to test directly.

In `apps/server/vibesensor/infra/runtime/lifecycle.py`, I removed the inlined restart constants, `_restart_delay_s()`, `_start_supervised_task()`, and the local task failure message formatter. `LifecycleManager` now constructs a `TaskSupervisor` in `__init__()` and delegates the managed runtime phases to `self._task_supervisor.start(...)`. That keeps the `start()` method focused on the actual lifecycle phases—UDP receiver, control plane, processing loop, websocket broadcast, metrics log, GPS speed, and update startup recovery—without re-embedding the retry policy. The non-supervised `_start_task()` path remains local to `LifecycleManager`, which keeps the extraction scoped to the issue instead of collapsing all task management into a broader abstraction.

I also updated `apps/server/vibesensor/infra/runtime/__init__.py` to mention the new runtime supervision module in the package-level orientation docstring. This is a very small documentation touch, but it keeps the runtime package map aligned with the code after the refactor.

## Test changes and validation
A key acceptance criterion for this issue was adding focused tests for restart and backoff behavior outside the full lifecycle suite. To cover that, I added `apps/server/tests/infra/runtime/test_task_supervisor.py` with targeted tests for the extracted helper. Those tests cover the core supervision behaviors directly:

- restarting after an exception and clearing the transient health-state failure once the restart is underway
- restarting after an unexpected clean task exit
- recording the terminal failure once retry attempts are exhausted
- capping exponential backoff at the configured maximum delay

Those tests give us much tighter coverage of the retry policy than the previous lifecycle-only approach because they exercise the supervisor in isolation instead of depending on broader runtime setup.

I also made minimal updates to `apps/server/tests/infra/runtime/test_runtime.py`. The existing lifecycle tests that pinned restart configuration were left in place conceptually, but they now tweak the `LifecycleManager`’s embedded `TaskSupervisor` instance or patch the supervisor module’s `asyncio.sleep()` seam instead of reaching into restart constants inside `lifecycle.py`. That keeps the lifecycle suite validating the same high-level behavior while acknowledging the new ownership boundary.

For local validation, I ran:

- `python3 -m pytest -q apps/server/tests/infra/runtime`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

All of those completed successfully.

Per the repo instructions, I also attempted the Docker smoke step with `docker compose build --pull && docker compose up -d`. That remains blocked in this environment because the Docker client cannot connect to a local daemon socket, so I could not complete the compose-based smoke verification here.

## Risks, tradeoffs, and edge cases
The main risk in a change like this is accidentally changing lifecycle ordering while extracting helper logic. I avoided that by keeping the phase transitions and startup ordering in `LifecycleManager.start()` untouched and only swapping the supervision call sites from the local helper to `TaskSupervisor.start()`.

Another risk is subtly changing runtime health behavior. To avoid that, I preserved the existing retry flow: failures are recorded before the backoff sleep, cleared before retrying, cancellations are not retried, and terminal failures still land in background task failure tracking. The focused supervisor tests and existing lifecycle tests now cover both the isolated retry mechanics and the orchestration-level behavior.

I intentionally did not broaden this issue into refactoring `_start_task()`, UDP lifecycle setup, or shutdown sequencing. Those are adjacent concerns, but they were explicitly out of scope for the issue and keeping them local avoids unnecessary churn before the next lifecycle-focused backlog items.

## Out of scope and follow-up
This change does not alter phase order, shutdown behavior, or runtime health model semantics. It also does not attempt to extract the separate UDP receiver lifecycle concerns, which are already represented by the next backlog item. The value here is making the supervision seam explicit now so later lifecycle work can build on a smaller, more focused orchestration class.
