### PR TITLE
Extract UDP receiver lifecycle from `LifecycleManager`

### DIFF
--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -306,7 +306,7 @@ async def test_start_creates_tasks(monkeypatch) -> None:
         gps_monitor=gps_monitor,
         update_manager=update_manager,
     )
-    lifecycle._start_udp_receiver = _fake_udp
+    lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     await lifecycle.start()
     assert len(lifecycle.tasks) == 5
@@ -345,7 +345,7 @@ async def test_start_follows_declared_startup_phase_order(monkeypatch) -> None:
         gps_monitor=gps_monitor,
         update_manager=update_manager,
     )
-    lifecycle._start_udp_receiver = _fake_udp
+    lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     original_set_phase = runtime_module.RuntimeHealthState.set_phase
 
@@ -401,7 +401,7 @@ async def test_start_records_background_task_failure(monkeypatch) -> None:
         gps_monitor=gps_monitor,
         update_manager=update_manager,
     )
-    lifecycle._start_udp_receiver = _fake_udp
+    lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     lifecycle._task_supervisor._max_attempts = 0
 
@@ -454,7 +454,7 @@ async def test_start_restarts_supervised_task_after_failure(monkeypatch) -> None
         gps_monitor=gps_monitor,
         update_manager=update_manager,
     )
-    lifecycle._start_udp_receiver = _fake_udp
+    lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     lifecycle._task_supervisor._base_delay_s = 0.0
     lifecycle._task_supervisor._max_delay_s = 0.0
@@ -499,12 +499,13 @@ async def test_start_monitors_udp_consumer_failure(monkeypatch) -> None:
         gps_monitor=gps_monitor,
         update_manager=update_manager,
     )
-    lifecycle._start_udp_receiver = _fake_udp
+    lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     await lifecycle.start()
     await asyncio.wait_for(consumer_started.wait(), timeout=1.0)
-    if lifecycle._data_consumer_task is not None:
-        await asyncio.gather(lifecycle._data_consumer_task, return_exceptions=True)
+    consumer_task = lifecycle._udp_transport_lifecycle.consumer_task
+    if consumer_task is not None:
+        await asyncio.gather(consumer_task, return_exceptions=True)
 
     assert rt.health_state.background_task_failures["udp-data-consumer"] == "udp boom"
 
@@ -557,7 +558,7 @@ async def test_stop_cancels_tasks_and_closes_resources(monkeypatch) -> None:
         history_db=history_db,
         worker_pool=worker_pool,
     )
-    lifecycle._start_udp_receiver = _fake_udp
+    lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     await lifecycle.start()
     assert len(lifecycle.tasks) > 0

--- a/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
+++ b/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vibesensor.infra.runtime.udp_transport_lifecycle import UdpTransportLifecycle
+
+
+@pytest.mark.asyncio
+async def test_startup_tracks_transport_and_monitors_consumer_task() -> None:
+    async def _consumer() -> None:
+        await asyncio.Future()
+
+    consumer = asyncio.create_task(_consumer(), name="udp-data-consumer")
+    transport = MagicMock()
+    monitor_task = MagicMock()
+    start_udp_receiver = AsyncMock(return_value=(transport, consumer))
+    lifecycle = UdpTransportLifecycle(
+        start_udp_receiver=start_udp_receiver,
+        monitor_task=monitor_task,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+
+    await lifecycle.startup(
+        host="0.0.0.0",
+        port=9000,
+        registry=MagicMock(),
+        processor=MagicMock(),
+        queue_maxsize=64,
+    )
+
+    assert lifecycle.transport is transport
+    assert lifecycle.consumer_task is consumer
+    monitor_task.assert_called_once_with(consumer)
+
+    await lifecycle.shutdown()
+    with contextlib.suppress(asyncio.CancelledError):
+        await consumer
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_transport_and_cancels_consumer_task() -> None:
+    cancelled = asyncio.Event()
+    started = asyncio.Event()
+
+    async def _consumer() -> None:
+        started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    consumer = asyncio.create_task(_consumer(), name="udp-data-consumer")
+    transport = MagicMock()
+    lifecycle = UdpTransportLifecycle(
+        start_udp_receiver=AsyncMock(return_value=(transport, consumer)),
+        monitor_task=MagicMock(),
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+
+    await lifecycle.startup(
+        host="0.0.0.0",
+        port=9000,
+        registry=MagicMock(),
+        processor=MagicMock(),
+        queue_maxsize=64,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await lifecycle.shutdown()
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+
+    transport.close.assert_called_once_with()
+    assert lifecycle.transport is None
+    assert lifecycle.consumer_task is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_logs_transport_close_error(caplog: pytest.LogCaptureFixture) -> None:
+    transport = MagicMock()
+    transport.close.side_effect = OSError("close boom")
+    lifecycle = UdpTransportLifecycle(
+        start_udp_receiver=AsyncMock(),
+        monitor_task=MagicMock(),
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+    lifecycle._data_transport = transport
+
+    with caplog.at_level(logging.WARNING):
+        await lifecycle.shutdown()
+
+    assert "Error closing data transport" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_without_started_transport_is_noop() -> None:
+    lifecycle = UdpTransportLifecycle(
+        start_udp_receiver=AsyncMock(),
+        monitor_task=MagicMock(),
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+
+    await lifecycle.shutdown()
+
+    assert lifecycle.transport is None
+    assert lifecycle.consumer_task is None

--- a/apps/server/vibesensor/infra/runtime/__init__.py
+++ b/apps/server/vibesensor/infra/runtime/__init__.py
@@ -7,6 +7,7 @@ Submodules
 - ``registry_updates``: DATA-message dedup/reset bookkeeping
 - ``processing_loop``: ProcessingLoop (async tick loop + failure tracking)
 - ``task_supervisor``: TaskSupervisor (managed restart policy + backoff)
+- ``udp_transport_lifecycle``: UdpTransportLifecycle (UDP startup + cleanup seam)
 - ``ws_broadcast``: WsBroadcastService (payload assembly + cache)
 - ``lifecycle``: LifecycleManager (start/stop + task management)
 - ``rotational_speeds``: Stateless rotational speed payload helpers

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -19,13 +19,9 @@ from typing import Protocol
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.task_supervisor import TaskSupervisor, task_failure_message
+from vibesensor.infra.runtime.udp_transport_lifecycle import StartUdpReceiver, UdpTransportLifecycle
 from vibesensor.shared.constants.ui import UI_PUSH_HZ
 from vibesensor.shared.types.payload_types import LiveWsPayload
-
-StartUdpReceiver = Callable[
-    ...,
-    Coroutine[object, object, tuple[asyncio.DatagramTransport, asyncio.Task[None]]],
-]
 
 
 class LifecycleControlPlane(Protocol):
@@ -133,12 +129,10 @@ class LifecycleManager:
     """Manages server startup (UDP receiver, background tasks) and graceful shutdown."""
 
     __slots__ = (
-        "_data_consumer_task",
-        "_data_transport",
         "_health_state",
         "_runtime",
-        "_start_udp_receiver",
         "_task_supervisor",
+        "_udp_transport_lifecycle",
         "tasks",
     )
 
@@ -150,14 +144,16 @@ class LifecycleManager:
     ) -> None:
         self._runtime = runtime
         self._health_state = runtime.health_state
-        self._start_udp_receiver = start_udp_receiver
         self._task_supervisor = TaskSupervisor(
             health_state=self._health_state,
             logger=LOGGER,
         )
+        self._udp_transport_lifecycle = UdpTransportLifecycle(
+            start_udp_receiver=start_udp_receiver,
+            monitor_task=self._monitor_task,
+            logger=LOGGER,
+        )
         self.tasks: list[asyncio.Task[object]] = []
-        self._data_transport: asyncio.DatagramTransport | None = None
-        self._data_consumer_task: asyncio.Task[object] | None = None
 
     def _monitor_task(self, task: asyncio.Task[object]) -> None:
         task_name = task.get_name()
@@ -254,15 +250,13 @@ class LifecycleManager:
         try:
             phase = "udp_receiver"
             self._health_state.set_phase(phase)
-            self._data_transport, self._data_consumer_task = await self._start_udp_receiver(
+            await self._udp_transport_lifecycle.startup(
                 host=self._runtime.udp_data_host,
                 port=self._runtime.udp_data_port,
                 registry=self._runtime.registry,
                 processor=self._runtime.processor,
                 queue_maxsize=self._runtime.udp_data_queue_maxsize,
             )
-            if self._data_consumer_task is not None:
-                self._monitor_task(self._data_consumer_task)
 
             phase = "control_plane"
             self._health_state.set_phase(phase)
@@ -332,16 +326,7 @@ class LifecycleManager:
             self._runtime.control_plane.close()
         except OSError:
             LOGGER.warning("Error closing control plane", exc_info=True)
-        try:
-            if self._data_transport is not None:
-                self._data_transport.close()
-                self._data_transport = None
-        except OSError:
-            LOGGER.warning("Error closing data transport", exc_info=True)
-        if self._data_consumer_task is not None:
-            self._data_consumer_task.cancel()
-            await asyncio.gather(self._data_consumer_task, return_exceptions=True)
-            self._data_consumer_task = None
+        await self._udp_transport_lifecycle.shutdown()
 
         lingering_background_tasks = await self._cancel_background_tasks(timeout_s=15.0)
 

--- a/apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py
@@ -1,0 +1,83 @@
+"""UDP transport startup and cleanup lifecycle for the runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+
+__all__ = ["StartUdpReceiver", "UdpTransportLifecycle"]
+
+StartUdpReceiver = Callable[
+    ...,
+    Coroutine[
+        object,
+        object,
+        tuple[asyncio.DatagramTransport | None, asyncio.Task[object] | None],
+    ],
+]
+MonitorTask = Callable[[asyncio.Task[object]], None]
+
+
+class UdpTransportLifecycle:
+    """Own the UDP receiver transport and consumer-task lifecycle."""
+
+    __slots__ = (
+        "_data_consumer_task",
+        "_data_transport",
+        "_logger",
+        "_monitor_task",
+        "_start_udp_receiver",
+    )
+
+    def __init__(
+        self,
+        *,
+        start_udp_receiver: StartUdpReceiver,
+        monitor_task: MonitorTask,
+        logger: logging.Logger,
+    ) -> None:
+        self._start_udp_receiver = start_udp_receiver
+        self._monitor_task = monitor_task
+        self._logger = logger
+        self._data_transport: asyncio.DatagramTransport | None = None
+        self._data_consumer_task: asyncio.Task[object] | None = None
+
+    @property
+    def consumer_task(self) -> asyncio.Task[object] | None:
+        return self._data_consumer_task
+
+    @property
+    def transport(self) -> asyncio.DatagramTransport | None:
+        return self._data_transport
+
+    async def startup(
+        self,
+        *,
+        host: str,
+        port: int,
+        registry: object,
+        processor: object,
+        queue_maxsize: int,
+    ) -> None:
+        self._data_transport, self._data_consumer_task = await self._start_udp_receiver(
+            host=host,
+            port=port,
+            registry=registry,
+            processor=processor,
+            queue_maxsize=queue_maxsize,
+        )
+        if self._data_consumer_task is not None:
+            self._monitor_task(self._data_consumer_task)
+
+    async def shutdown(self) -> None:
+        try:
+            if self._data_transport is not None:
+                self._data_transport.close()
+                self._data_transport = None
+        except OSError:
+            self._logger.warning("Error closing data transport", exc_info=True)
+        if self._data_consumer_task is not None:
+            self._data_consumer_task.cancel()
+            await asyncio.gather(self._data_consumer_task, return_exceptions=True)
+            self._data_consumer_task = None


### PR DESCRIPTION
## Summary
Closes #1349.

`apps/server/vibesensor/infra/runtime/lifecycle.py` was still doing two different kinds of work around the UDP receiver. It handled the high-level lifecycle sequencing for application startup and shutdown, but it also directly stored the UDP transport handle, stored the UDP consumer task, called the UDP startup function, monitored the consumer task, and performed UDP-specific cleanup during shutdown. That made the lifecycle manager broader than it needs to be and forced transport-specific concerns to live alongside general orchestration logic.

This change extracts those UDP receiver lifecycle mechanics into a focused `UdpTransportLifecycle` helper in `apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py`. `LifecycleManager` still owns startup phase transitions, failure reporting, shutdown sequencing, and the rest of the runtime orchestration. The new helper owns the raw UDP transport/task state plus the startup and cleanup operations that go with it. That keeps the lifecycle class smaller, gives UDP startup and shutdown a dedicated seam, and adds focused tests outside the broader lifecycle phase suite.

## Implementation approach
The goal for this issue was to keep the change as small and behavior-preserving as possible. I did not change the external `LifecycleManager` constructor shape, UDP configuration values, protocol handling, or the ordering of startup and shutdown phases. Instead, I extracted only the concern called out by the issue: the UDP receiver lifecycle bookkeeping that had been embedded directly in `LifecycleManager`.

The new helper owns three things that were previously handled inline in `lifecycle.py`:

- invoking the configured UDP startup function and capturing its startup result
- tracking the raw transport and consumer task for later shutdown
- closing the transport and cancelling/gathering the consumer task during shutdown

I kept the existing task failure monitoring behavior by letting `LifecycleManager` pass its `_monitor_task()` callback into the helper. That means the UDP consumer task is still recorded in runtime health state exactly the same way as before; the responsibility split is simply cleaner now. `LifecycleManager` remains the place that defines what the startup phases are and in what order they run, while `UdpTransportLifecycle` only owns the UDP-specific resource lifecycle.

## Main code changes by area
In `apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py`, I added the new helper module. It defines the `StartUdpReceiver` callback type and the `UdpTransportLifecycle` class. The helper stores the UDP transport and consumer task internally instead of leaving those raw fields on `LifecycleManager`. Its `startup()` method delegates to the existing UDP startup callback, records the returned transport and consumer task, and attaches the existing monitoring callback when a consumer task is present. Its `shutdown()` method preserves the current cleanup behavior by closing the transport, logging the same warning on `OSError`, cancelling the consumer task, and awaiting it with `return_exceptions=True`.

In `apps/server/vibesensor/infra/runtime/lifecycle.py`, I removed the direct UDP fields from `LifecycleManager` (`_data_transport`, `_data_consumer_task`, and the stored `_start_udp_receiver` callback) and replaced them with a single `_udp_transport_lifecycle` dependency. The `udp_receiver` startup phase still happens in the same place and still transitions the health state to the same phase name, but it now delegates the resource-specific work to `self._udp_transport_lifecycle.startup(...)`. Shutdown preserves the same ordering as before: the control plane is closed first, then UDP transport cleanup happens, then background task cancellation and the rest of shutdown follow. That ordering matters because it keeps ingress shutdown behavior unchanged while moving the raw UDP cleanup details out of the lifecycle manager itself.

I also updated `apps/server/vibesensor/infra/runtime/__init__.py` so the package-level runtime map includes the new UDP lifecycle helper. This is a small documentation touch, but it keeps the runtime package overview aligned with the new seam.

## Test changes and validation
One of the acceptance criteria for this issue was providing focused UDP transport lifecycle coverage outside the broader lifecycle suite. To meet that, I added `apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py`. These new focused tests cover the extracted helper directly:

- startup stores the transport and consumer task and wires in task monitoring
- shutdown closes the transport and cancels the consumer task
- shutdown logs the existing warning when transport close raises `OSError`
- shutdown remains a safe no-op when startup never happened

Those tests exercise the new helper without needing to spin up the whole lifecycle manager or depend on unrelated runtime phases.

I also made minimal updates to `apps/server/tests/infra/runtime/test_runtime.py`. The existing lifecycle tests still validate the same orchestration behavior, but they now patch the new helper seam instead of reaching into raw UDP fields or the old stored startup callback on `LifecycleManager`. The one lifecycle test that awaited the UDP consumer task now goes through the helper’s exposed `consumer_task` property rather than a raw field on the lifecycle manager. The point of those changes was to keep existing test intent intact while aligning the fixture seam with the new ownership boundary.

For local validation, I ran:

- `python3 -m pytest -q apps/server/tests/infra/runtime`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

All of those passed successfully.

Per the repository workflow, I also attempted the Docker smoke step with `docker compose build --pull && docker compose up -d`. That is still blocked in this environment because the local Docker client cannot connect to a daemon socket, so I could not complete the compose-based smoke verification here.

## Risks, tradeoffs, and edge cases
The biggest risk in this issue was unintentionally changing lifecycle ordering while extracting the UDP seam. I avoided that by keeping the `udp_receiver` phase transition in `LifecycleManager.start()` and keeping UDP cleanup in the same relative location in `LifecycleManager.stop()`. The helper only owns the resource lifecycle details; it does not decide when those operations happen.

Another risk was subtly changing runtime health behavior for the UDP consumer task. To avoid that, the helper does not invent a new failure path or new health logic. Instead, it reuses the lifecycle manager’s existing `_monitor_task()` callback. As a result, background task failure recording for `udp-data-consumer` stays on the same path the runtime already used before the extraction.

I intentionally did not broaden this issue into changing the lifecycle manager’s public constructor, refactoring general task startup helpers, or touching the actual UDP protocol receiver implementation. Those are adjacent concerns, but they are not required to satisfy this issue and expanding into them would add churn without improving the core extraction.

## Out of scope and follow-up
This change does not alter UDP protocol handling, configuration, or processor behavior. It also does not change the startup phase list or shutdown ordering beyond delegating the UDP-specific mechanics to a focused helper. The main value here is establishing a clean seam so future runtime changes can work on UDP receiver behavior without growing `LifecycleManager` further.
