### PR TITLE
Make `AnalysisSummary` have one canonical owner

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -24,7 +24,7 @@ from vibesensor.adapters.http.dependencies import (
 )
 from vibesensor.domain import RunStatus
 from vibesensor.infra.runtime import RuntimeHealthState
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.run_schema import RunMetadata

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -12,7 +12,7 @@ import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.persistence.history_db import HistoryDB, SQLiteHistoryEngine
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -8,7 +8,7 @@ import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
@@ -8,8 +8,8 @@ import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.persistence.history_db import HistoryDB
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import sanitize_value
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 

--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -113,9 +113,6 @@ from vibesensor.shared.boundaries.analysis_payload import (
     AmpVsPhaseRow as BoundaryAmpVsPhaseRow,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
-    AnalysisSummary as BoundaryAnalysisSummary,
-)
-from vibesensor.shared.boundaries.analysis_payload import (
     DataQualityAccelSanityPayload as BoundaryDataQualityAccelSanityPayload,
 )
 from vibesensor.shared.boundaries.analysis_payload import (
@@ -204,6 +201,9 @@ from vibesensor.shared.boundaries.analysis_payload import (
 )
 from vibesensor.shared.boundaries.vibration_origin import (
     SuspectedVibrationOrigin as BoundarySuspectedVibrationOrigin,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummary as BoundaryAnalysisSummary,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     FindingPayload as BoundaryFindingPayload,

--- a/apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import vibesensor.shared.boundaries.analysis_payload as analysis_payload
+import vibesensor.shared.types.history_analysis_contracts as history_analysis_contracts
 
 
 def test_analysis_payload_module_stays_schema_only() -> None:
     assert not hasattr(analysis_payload, "matched_point_from_observation")
     assert not hasattr(analysis_payload, "OrderMatchObservation")
+    assert not hasattr(analysis_payload, "AnalysisSummary")
+
+
+def test_analysis_summary_contract_is_owned_by_history_analysis_contracts() -> None:
+    assert hasattr(history_analysis_contracts, "AnalysisSummary")

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
@@ -13,7 +13,7 @@ from test_support.persisted_analysis import make_persisted_analysis
 from tests.conftest import FakeState
 from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.domain.run_status import RunStatus
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame

--- a/apps/server/tests/use_cases/diagnostics/test_run_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_run_analysis.py
@@ -12,7 +12,7 @@ from vibesensor.adapters.analysis_summary import (
     summarize_run_data,
 )
 from vibesensor.domain import SpeedProfile
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.use_cases.diagnostics._context_decode import build_diagnostics_context
 from vibesensor.use_cases.diagnostics.run_data_preparation import (
     PreparedRunData,

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -18,12 +18,12 @@ from vibesensor.adapters.history import (
     build_projected_run_details_json,
 )
 from vibesensor.domain import CarSnapshot, RunStatus
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.run_context_warning import (
     WARNING_CODE_CAR_SETTINGS_CHANGED,
     WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
 )
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame

--- a/apps/server/vibesensor/adapters/analysis_summary.py
+++ b/apps/server/vibesensor/adapters/analysis_summary.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.analysis_summary import analysis_result_to_summary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.diagnostics import (
     AnalysisSampleInput,

--- a/apps/server/vibesensor/adapters/pdf/peak_table.py
+++ b/apps/server/vibesensor/adapters/pdf/peak_table.py
@@ -8,8 +8,8 @@ from vibesensor.adapters.pdf.presentation import order_label_human, peak_classif
 from vibesensor.adapters.pdf.report_data import PeakRow
 from vibesensor.adapters.pdf.report_types import PeakTableRow
 from vibesensor.domain import VibrationSource
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 
 __all__ = [
     "build_peak_rows",

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -24,7 +24,7 @@ __all__ = [
 from dataclasses import dataclass, field
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary, coerce_float
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 
 # ---------------------------------------------------------------------------
 # Data model

--- a/apps/server/vibesensor/shared/boundaries/analysis_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payload.py
@@ -4,8 +4,9 @@ These aliases define the wire/persistence shapes for analysis data that
 crosses the domain-adapter boundary. Stable exact history/view shapes shared
 with the HTTP layer live in ``shared.types.analysis_views``. Shared
 analysis/history wrapper and composite owners live in
-``shared.types.history_analysis_contracts`` and are only re-exported here when
-the boundary layer needs a distinct payload-oriented alias.
+``shared.types.history_analysis_contracts`` and should be imported directly
+from there when the same contract spans boundary, persistence, and HTTP flows.
+This module only carries payload-oriented aliases for supporting leaf shapes.
 """
 
 from __future__ import annotations
@@ -29,9 +30,6 @@ from vibesensor.shared.types.analysis_views import (
 from vibesensor.shared.types.history_analysis_contracts import (
     AmplitudeMetric,
     RunSuitabilityCheck,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    AnalysisSummaryResponse as AnalysisSummary,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     DataQualityAccelSanityResponse as DataQualityAccelSanityPayload,
@@ -82,7 +80,6 @@ from vibesensor.shared.types.history_analysis_contracts import (
 __all__ = [
     "AmpVsPhaseRow",
     "AmplitudeMetric",
-    "AnalysisSummary",
     "DataQualityAccelSanityPayload",
     "DataQualityOutliersPayload",
     "DataQualityPayload",

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -15,7 +15,6 @@ from vibesensor.domain import (
 from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
 from vibesensor.domain.speed_profile_summary import SpeedProfileSummary
 from vibesensor.domain.vibration_origin import VibrationOrigin
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.finding import step_payloads_from_plan
 from vibesensor.shared.boundaries.summary_serialization import (
     AccelStatisticsLike,
@@ -30,6 +29,7 @@ from vibesensor.shared.boundaries.summary_serialization import (
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.run_context_warning import build_summary_warnings
 from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.json_types import JsonObject
 
 

--- a/apps/server/vibesensor/shared/boundaries/persisted_analysis_codec.py
+++ b/apps/server/vibesensor/shared/boundaries/persisted_analysis_codec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import cast
 
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_findings.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_findings.py
@@ -7,10 +7,9 @@ from statistics import median as _median
 from vibesensor.domain import (
     Finding as DomainFinding,
 )
-from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
 from vibesensor.shared.boundaries.finding import finding_payload_from_domain
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.types.history_analysis_contracts import FindingPayload
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary, FindingPayload
 from vibesensor.shared.types.json_types import is_json_object
 
 

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -13,7 +13,6 @@ from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
 from vibesensor.domain.speed_profile_summary import SpeedProfileSummary
 from vibesensor.domain.vibration_origin import VibrationOrigin
 from vibesensor.shared.boundaries.analysis_payload import (
-    AnalysisSummary,
     DataQualityPayload,
     LocationIntensitySummaryPayload,
     OutlierSummaryPayload,
@@ -35,6 +34,7 @@ from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.statistics_utils import _outlier_summary, _percent_missing
 from vibesensor.shared.time_utils import format_duration_mm_ss
 from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummary,
     PayloadObject,
     PayloadValue,
     payload_object_from_json,

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -2,10 +2,11 @@
 
 These TypedDicts are the single semantic owners for analysis/history wrapper
 and composite contracts that are shared between persisted boundary payloads and
-the HTTP/OpenAPI response schema. ``FindingPayload`` is canonically owned here.
-Boundary modules only alias contracts that need boundary-specific payload
-names, while endpoint-specific HTTP wrappers remain local to
-``shared.types.api_models.history``.
+the HTTP/OpenAPI response schema. ``FindingPayload``, ``AnalysisSummary``,
+``AnalysisSummaryCoreResponse``, and ``AnalysisSummaryResponse`` are
+canonically owned here. Boundary modules should import these shared wrapper
+contracts directly from this module, while endpoint-specific HTTP wrappers
+remain local to ``shared.types.api_models.history``.
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ from vibesensor.shared.types.json_types import (
 
 __all__ = [
     "AmplitudeMetric",
+    "AnalysisSummary",
     "AnalysisSummaryCoreResponse",
     "AnalysisSummaryResponse",
     "DataQualityAccelSanityResponse",
@@ -378,6 +380,9 @@ class AnalysisSummaryResponse(AnalysisSummaryCoreResponse):
     """Typed HTTP contract for the persisted analysis summary on one history run."""
 
     warnings: Required[list[SummaryWarningResponse]]
+
+
+AnalysisSummary: TypeAlias = AnalysisSummaryResponse
 
 
 def _configure_pydantic_schema(typed_dict: Any, config: ConfigDict) -> None:

--- a/apps/server/vibesensor/use_cases/diagnostics/__init__.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/__init__.py
@@ -7,9 +7,12 @@ lives here.  Report-mapping logic lives in ``vibesensor.adapters.pdf.mapping``.
 High-level analysis entry points are re-exported here so callers can use
 ``from vibesensor.use_cases.diagnostics import …`` without depending on file layout.
 
-``FindingPayload`` is the TypedDict shape used for serialised analysis
-findings and is canonically owned by
-``vibesensor.shared.types.history_analysis_contracts``. The domain ``Finding``
+``FindingPayload`` and the shared serialized summary contracts
+(``AnalysisSummary``, ``AnalysisSummaryCoreResponse``, and
+``AnalysisSummaryResponse``) are canonically owned by
+``vibesensor.shared.types.history_analysis_contracts``. The boundary serializer
+that produces ``AnalysisSummary`` lives in
+``vibesensor.shared.boundaries.analysis_summary``, and the domain ``Finding``
 lives in ``vibesensor.domain``.
 """
 

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -16,7 +16,6 @@ from vibesensor.domain import (
 )
 from vibesensor.report_i18n import normalize_lang
 from vibesensor.shared.boundaries.analysis_payload import (
-    AnalysisSummary,
     PeakTableRow,
     RunSuitabilityCheck,
     SummaryWarningPayload,
@@ -24,6 +23,7 @@ from vibesensor.shared.boundaries.analysis_payload import (
 from vibesensor.shared.boundaries.diagnostic_case import test_run_from_summary
 from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.helpers import safe_filename
 from vibesensor.use_cases.history.report_cache import ReportPdfCacheKey

--- a/tools/dev/fuzz_analysis_engine.py
+++ b/tools/dev/fuzz_analysis_engine.py
@@ -723,7 +723,7 @@ def _run_worker_main(config: FuzzConfig) -> dict[str, object]:
 
     from vibesensor.adapters.analysis_summary import summarize_run_data
     from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
-    from vibesensor.shared.boundaries.analysis_payload import AnalysisSummary
+    from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
     from vibesensor.strength_bands import bucket_for_strength
     from vibesensor.use_cases.diagnostics import vehicle_orders_hz
     from vibesensor.vibration_strength import vibration_strength_db_scalar


### PR DESCRIPTION
## Summary
Closes #1351.

This change gives `AnalysisSummary` one canonical home without changing the serialized payload shape. Before this patch, the shared summary wrapper types lived in `apps/server/vibesensor/shared/types/history_analysis_contracts.py`, but most boundary-side producers and consumers reached the contract through `apps/server/vibesensor/shared/boundaries/analysis_payload.py`, which re-exported `AnalysisSummaryResponse` as `AnalysisSummary`. That arrangement worked mechanically, but it left two import paths for the same cross-layer contract: the HTTP layer used the shared contracts module directly, while boundary serialization, persistence, reporting, and test helpers mostly relied on the boundary alias. The issue asked us to collapse that ambiguity so the contract has one explicit owner and downstream code imports it from that owner instead of a peer alias.

The smallest complete fix was to keep `history_analysis_contracts.py` as the single source of truth rather than moving the type to a new location. That module already owns the shared wrapper and composite contracts that need to stay aligned across persisted summaries and the HTTP/OpenAPI surface, and it was already the place where `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse` were defined. Moving the TypedDicts elsewhere would have expanded the change set without buying much. Instead, I made the owner more explicit by exporting a canonical `AnalysisSummary` alias from `history_analysis_contracts.py`, updating the module documentation to say that `AnalysisSummary`, `AnalysisSummaryCoreResponse`, and `AnalysisSummaryResponse` are canonically owned there, and then removing the peer re-export from `shared/boundaries/analysis_payload.py`.

The boundary payload module now keeps doing what it is best at: providing payload-oriented aliases for leaf or supporting shapes such as `DataQualityPayload`, `SummaryWarningPayload`, `RunSuitabilityCheck`, and the various phase and intensity payload helpers. It no longer re-exports the top-level `AnalysisSummary` wrapper. I also updated the `analysis_payload` module docstring to make that boundary explicit so future cleanups do not reintroduce the same ambiguity. The idea is that if a contract spans boundary serialization, persisted history state, and the HTTP API, callers should import it from the shared contracts owner directly; if a boundary module just needs a clearer payload-oriented alias for a leaf shape, that alias still belongs in `analysis_payload.py`.

Once the owner was clear, I repointed the affected producer and consumer sites. On the producer side, `shared/boundaries/analysis_summary.py`, `shared/boundaries/summary_serialization/_summary.py`, and `shared/boundaries/summary_serialization/_findings.py` now import `AnalysisSummary` from `history_analysis_contracts.py` instead of the boundary alias. The persistence and adapter edges were updated the same way in `shared/boundaries/persisted_analysis_codec.py`, `vibesensor/adapters/analysis_summary.py`, `vibesensor/adapters/pdf/report_data.py`, `vibesensor/adapters/pdf/peak_table.py`, and `use_cases/history/report_preparation.py`. I also updated `tools/dev/fuzz_analysis_engine.py` so the fuzz harness validates against the same canonical import path that production code now uses. The HTTP model layer did not need a semantic change because it was already importing the response contracts from the shared owner; that was an important signal that the right fix was to collapse the extra alias rather than relocate the definitions.

The test updates were intentionally focused. Most existing parity and persistence coverage already exercises the contract shape rather than caring where the type name comes from, so the majority of the test changes are import-path updates in the diagnostics, history-service, and history DB test modules. I added one new regression guard in `apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py` because this issue is specifically about ownership, not behavior. That test now asserts two things: `analysis_payload` does not export `AnalysisSummary`, and the shared contracts module does. That gives us a lightweight, explicit signal if someone later reintroduces the alias or moves the contract back into an ambiguous location.

I also kept a close eye on schema and compatibility risk. This patch does not change any required or optional fields on `AnalysisSummary`, does not change the serializer output, and does not change the HTTP schema component name `AnalysisSummaryResponse`. The typed dicts are still the same objects, and the strict Pydantic configuration that enforces `additionalProperties: false` on the summary contract remains attached to the underlying response classes in the same owner module. Because the shape stayed identical, the HTTP schema export stayed current and did not require regenerating committed contract artifacts. That distinction matters here: the issue is about ownership and import hygiene, not about reshaping the persisted or API contract.

For validation, I ran a focused pytest suite that covers the exact seams affected by the ownership cleanup: `apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py`, `apps/server/tests/hygiene/test_api_model_boundary_parity.py`, `apps/server/tests/use_cases/diagnostics/test_run_analysis.py`, `apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py`, `apps/server/tests/use_cases/history/test_history_http_services.py`, `apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py`, `apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py`, `apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py`, `apps/server/tests/adapters/http/test_http_api_schema_export.py`, `apps/server/tests/adapters/pdf/test_report_summary_basics.py`, and `apps/server/tests/adapters/pdf/test_report_analysis_phase_flow.py`. That suite passed cleanly with `159 passed`. I then ran `make typecheck-backend`, which passed, and `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`, which also passed after `ruff --fix` normalized import ordering in four touched files.

The only validation step that is still environment-blocked is the repository’s Docker smoke expectation. I attempted `docker compose build --pull && docker compose up -d`, but this environment still does not expose a Docker daemon socket, so the command failed before any stack startup could occur. I am calling that out explicitly because it is an external environment limitation, not a code-level regression introduced by this change.

I treated a few related cleanups as intentionally out of scope. This PR does not split `AnalysisSummary` into smaller contracts, does not move payload JSON conversion helpers out of `history_analysis_contracts.py`, does not change report preparation behavior, and does not address the later issues that stop report helpers from taking raw `AnalysisSummary` objects. Those follow-up issues become easier once the summary contract has one clear owner, but they should stay separate so this PR remains a narrow, reviewable ownership cleanup.

One deliberate tradeoff here is that I did not leave a compatibility alias behind in `analysis_payload.py`. The repository guidance for these cleanup issues is to standardize on the current contract path rather than preserve duplicate import surfaces indefinitely, and all in-repo callers were updated in the same change set. That keeps the ownership signal crisp: if a maintainer is working with the top-level persisted summary wrapper, there is now one import path to reach for, not two equally plausible ones with different layer names.
