### PR TITLE
Split rendering-only finding fields from the core finding contract

### DIFF
--- a/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from vibesensor.domain import Finding, OrderMatchObservation, VibrationSource
-from vibesensor.shared.boundaries.finding import finding_payload_from_domain
+from vibesensor.domain.vibration_origin import VibrationOrigin
+from vibesensor.shared.boundaries.finding import (
+    _finding_core_payload_from_domain,
+    _finding_presentation_payload_from_domain,
+    finding_payload_from_domain,
+)
 
 
 def test_projection_emits_canonical_amplitude_metric_shape() -> None:
@@ -77,3 +82,43 @@ def test_projection_serializes_matched_points_with_boundary_shape() -> None:
             "phase": "cruise",
         }
     ]
+
+
+def test_projection_separates_core_and_presentation_metadata_before_composing() -> None:
+    finding = Finding(
+        finding_id="F_ORDER",
+        suspected_source=VibrationSource.WHEEL_TIRE,
+        confidence=0.82,
+        strongest_location="rear-right",
+        strongest_speed_band="80-100 km/h",
+        dominance_ratio=3.1,
+        vibration_strength_db=22.3,
+        origin=VibrationOrigin.from_analysis_inputs(
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            dominance_ratio=3.1,
+            speed_band="80-100 km/h",
+            dominant_phase="cruise",
+            reason="Strong wheel-order correlation",
+        ),
+    ).with_confidence_assessment(
+        strength_band_key="moderate",
+        steady_speed=True,
+        has_reference_gaps=False,
+        sensor_count=2,
+    )
+
+    core_payload = _finding_core_payload_from_domain(finding)
+    presentation_payload = _finding_presentation_payload_from_domain(finding)
+    payload = finding_payload_from_domain(finding)
+
+    assert "evidence_summary" not in core_payload
+    assert "frequency_hz_or_order" not in core_payload
+    assert "amplitude_metric" not in core_payload
+    assert "confidence_tone" not in core_payload
+
+    assert "finding_id" not in presentation_payload
+    assert "strongest_location" not in presentation_payload
+    assert presentation_payload["evidence_summary"] == "Strong wheel-order correlation"
+    assert presentation_payload["confidence_tone"] == finding.confidence_assessment.tone
+
+    assert payload == {**core_payload, **presentation_payload}

--- a/apps/server/tests/shared/boundaries/test_finding_roundtrip.py
+++ b/apps/server/tests/shared/boundaries/test_finding_roundtrip.py
@@ -160,3 +160,26 @@ class TestFindingRoundtrip:
         restored = _roundtrip(original)
         assert restored.origin is not None
         assert restored.origin.reason == "Strong 1x wheel order detected"
+
+    def test_decode_ignores_pure_presentation_hints(self) -> None:
+        baseline_payload = finding_payload_from_domain(
+            Finding(
+                finding_id="F007",
+                suspected_source=VibrationSource.WHEEL_TIRE,
+                confidence=0.7,
+                order="1x wheel",
+                vibration_strength_db=22.3,
+            )
+        )
+        noisy_payload = dict(baseline_payload)
+        noisy_payload["amplitude_metric"] = {
+            "name": "render-only",
+            "value": 999.0,
+            "units": "g",
+            "definition": {"_i18n_key": "IGNORED"},
+        }
+        noisy_payload["confidence_label_key"] = "CONFIDENCE_LOW"
+        noisy_payload["confidence_tone"] = "neutral"
+        noisy_payload["confidence_pct"] = "999%"
+
+        assert finding_from_payload(noisy_payload) == finding_from_payload(baseline_payload)

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -5,12 +5,18 @@ analysis finalization).
 ``finding_payload_from_domain`` — domain → payload (persistence serialization).
 
 Also includes boundary functions for finding sub-objects (evidence,
-location hotspot, test steps) and the structured-step-content helper.
+location hotspot, test steps) and the structured-step-content helper. The
+encoder keeps an internal split between domain-owned finding fields and
+presentation-only finding metadata before composing the public
+``FindingPayload`` contract.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import cast
+
+from typing_extensions import TypedDict
 
 from vibesensor.domain import Finding, FindingEvidence, Signature, VibrationSource, coerce_float
 from vibesensor.domain.order_match import OrderMatchObservation
@@ -96,6 +102,50 @@ def _amplitude_metric_payload(finding: Finding) -> AmplitudeMetric:
     }
 
 
+class _FindingCorePayload(TypedDict, total=False):
+    """Internal domain-owned finding payload fields.
+
+    This is the core mechanical/diagnostic meaning that the boundary encoder
+    persists and the decoder reconstructs back into ``Finding``.
+    """
+
+    finding_id: str
+    finding_key: str | None
+    suspected_source: str
+    confidence: float | None
+    finding_kind: str | None
+    severity: str | None
+    matched_points: list[MatchedPoint]
+    location_hotspot: LocationHotspotPayload | None
+    strongest_location: str | None
+    strongest_speed_band: str | None
+    dominant_phase: str | None
+    dominance_ratio: float | None
+    weak_spatial_separation: bool
+    diffuse_excitation: bool
+    phase_evidence: PhaseEvidence | None
+    evidence_metrics: FindingEvidenceMetrics | None
+    ranking_score: float | None
+    peak_classification: str | None
+    signatures_observed: list[str]
+    order: str | None
+
+
+class _FindingPresentationPayload(TypedDict, total=False):
+    """Internal rendering-oriented finding metadata.
+
+    These fields keep outward API/report payload behavior stable, but the
+    domain decoder does not own most of them directly.
+    """
+
+    evidence_summary: str
+    frequency_hz_or_order: float | str
+    amplitude_metric: AmplitudeMetric
+    confidence_label_key: str | None
+    confidence_tone: str | None
+    confidence_pct: str | None
+
+
 # ---------------------------------------------------------------------------
 # Finding decoder and projector
 # ---------------------------------------------------------------------------
@@ -111,8 +161,9 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     * **analysis finalization** — converting analysis-pipeline dicts into
       domain objects at the end of ``finalize_findings()``.
 
-    Extracts the subset of fields that the domain object cares about,
-    ignoring serialization-only keys present in the full payload.
+    Extracts the domain-owned fields plus the persisted public-field fallbacks
+    still needed to reconstruct origin/order semantics, while ignoring pure
+    presentation hints such as ``amplitude_metric`` and ``confidence_*``.
 
     """
 
@@ -236,15 +287,9 @@ def finding_from_payload(payload: Mapping[str, object]) -> Finding:
     )
 
 
-def finding_payload_from_domain(
-    finding: Finding,
-) -> FindingPayload:
-    """Project a domain Finding to the current persisted/public payload dict.
-
-    Produces the documented ``FindingPayload`` contract from domain objects
-    alone, without pass-through shortcuts to original payload dicts.
-    """
-    payload: FindingPayload = {
+def _finding_core_payload_from_domain(finding: Finding) -> _FindingCorePayload:
+    """Project only the domain-owned finding fields."""
+    payload: _FindingCorePayload = {
         "finding_id": finding.finding_id,
         "finding_key": finding.finding_key,
         "suspected_source": str(finding.suspected_source),
@@ -257,11 +302,6 @@ def finding_payload_from_domain(
         "ranking_score": finding.ranking_score,
         "peak_classification": finding.peaks.classification,
         "signatures_observed": list(finding.signature_labels),
-        "evidence_summary": "",
-        "frequency_hz_or_order": (
-            finding.frequency_hz if finding.frequency_hz is not None else finding.order or ""
-        ),
-        "amplitude_metric": _amplitude_metric_payload(finding),
     }
     if finding.severity:
         payload["severity"] = finding.severity
@@ -276,7 +316,6 @@ def finding_payload_from_domain(
             matched_point_from_observation(point) for point in finding.matched_points
         ]
 
-    # Evidence metrics
     if finding.evidence is not None:
         ev = finding.evidence
         metrics: FindingEvidenceMetrics = {
@@ -312,14 +351,12 @@ def finding_payload_from_domain(
     elif finding.vibration_strength_db is not None:
         payload["evidence_metrics"] = {"vibration_strength_db": finding.vibration_strength_db}
 
-    # Phase evidence
     if finding.cruise_fraction > 0.0 or finding.phases_detected:
         phase_evidence: PhaseEvidence = {"cruise_fraction": finding.cruise_fraction}
         if finding.phases_detected:
             phase_evidence["phases_detected"] = list(finding.phases_detected)
         payload["phase_evidence"] = phase_evidence
 
-    # Location hotspot
     if finding.location is not None:
         loc = finding.location
         hotspot: LocationHotspotPayload = {
@@ -335,17 +372,41 @@ def finding_payload_from_domain(
             hotspot["location_count"] = loc.location_count
         payload["location_hotspot"] = hotspot
 
-    # Confidence assessment
+    if finding.origin is not None and finding.origin.dominant_phase is not None:
+        payload["dominant_phase"] = finding.origin.dominant_phase
+
+    return payload
+
+
+def _finding_presentation_payload_from_domain(
+    finding: Finding,
+) -> _FindingPresentationPayload:
+    """Project rendering- and report-oriented finding metadata."""
+    payload: _FindingPresentationPayload = {
+        "evidence_summary": "",
+        "frequency_hz_or_order": (
+            finding.frequency_hz if finding.frequency_hz is not None else finding.order or ""
+        ),
+        "amplitude_metric": _amplitude_metric_payload(finding),
+    }
     if finding.confidence_assessment is not None:
         ca = finding.confidence_assessment
         payload["confidence_label_key"] = ca.label_key
         payload["confidence_tone"] = ca.tone
         payload["confidence_pct"] = ca.pct_text
-
-    # Origin / evidence summary
     if finding.origin is not None:
         payload["evidence_summary"] = finding.origin.reason
-        if finding.origin.dominant_phase is not None:
-            payload["dominant_phase"] = finding.origin.dominant_phase
-
     return payload
+
+
+def finding_payload_from_domain(
+    finding: Finding,
+) -> FindingPayload:
+    """Project a domain Finding to the current persisted/public payload dict.
+
+    Produces the documented ``FindingPayload`` contract from domain objects
+    alone, without pass-through shortcuts to original payload dicts.
+    """
+    core_payload = _finding_core_payload_from_domain(finding)
+    presentation_payload = _finding_presentation_payload_from_domain(finding)
+    return cast(FindingPayload, {**core_payload, **presentation_payload})


### PR DESCRIPTION
## Summary
Closes #1352.

This PR separates rendering-oriented finding metadata from the domain-owned finding payload assembly without changing the outward `FindingPayload` contract. Before this change, `apps/server/vibesensor/shared/boundaries/finding.py::finding_payload_from_domain()` built one large dictionary that mixed mechanical/diagnostic meaning with display-only hints such as `amplitude_metric`, `evidence_summary`, `frequency_hz_or_order`, and the `confidence_*` fields. That made the encoder hard to reason about because a single function simultaneously owned the data needed to reconstruct a domain `Finding` and the data only needed to support reports, UI text, and other presentation surfaces. The issue asked for a clearer internal split so rendering hints can evolve without broadening what the “core finding payload” means inside the boundary layer.

I deliberately kept the public `FindingPayload` shape stable. The payload still contains the same keys, the same outward API/report behavior is preserved, and the OpenAPI schema did not need regeneration. That matters because a large part of the repository already depends on the current `FindingPayload` layout: history persistence, summary projection, PDF/report paths, API schema export tests, roundtrip integration coverage, and multiple helper factories all assume the current flat shape. Changing the public contract here would have widened the scope from “internal split” into a larger report/API contract migration. Instead, I treated this as an encoder-ownership cleanup: keep the public contract exactly as consumers expect, but make the internal assembly explicitly separate core finding data from presentation metadata before the final payload is composed.

The main code change is in `apps/server/vibesensor/shared/boundaries/finding.py`. I introduced two private helper TypedDicts there: `_FindingCorePayload` and `_FindingPresentationPayload`. `_FindingCorePayload` contains the domain-owned fields that represent the actual diagnostic result and the information needed to reconstruct a `Finding`: identifiers, suspected source, confidence scalar, ranking and evidence fields, location-hotspot data, phase evidence, matched points, signatures, and other semantic state. `_FindingPresentationPayload` contains the rendering-oriented metadata that the outward payload still carries today: `evidence_summary`, `frequency_hz_or_order`, `amplitude_metric`, and the `confidence_label_key` / `confidence_tone` / `confidence_pct` display hints.

With those private payload shapes in place, the encoder is now split into `_finding_core_payload_from_domain()` and `_finding_presentation_payload_from_domain()`. The core helper builds only the domain-owned portion of the payload, including evidence metrics, phase evidence, hotspot information, and the dominant phase override that can come from `finding.origin`. The presentation helper is responsible for the amplitude summary block, the public display label for frequency or order, the outward evidence summary string, and the confidence presentation metadata when a `ConfidenceAssessment` is available. `finding_payload_from_domain()` then composes the public `FindingPayload` by merging those two internal dictionaries. The final outward payload stays the same, but the ownership boundary inside the serializer is much more explicit.

I also updated the `finding_from_payload()` documentation to match the real decoder behavior. The previous docstring said the decoder ignored serialization-only keys in the full payload. That was directionally true, but it hid an important nuance: some fields that look presentation-oriented still participate in persisted reconstruction because the current public payload shape uses them as fallbacks. In particular, `frequency_hz_or_order` still feeds order/frequency reconstruction when there is no separate numeric `frequency_hz`, and `evidence_summary` still feeds `VibrationOrigin.reason` via `vibration_origin_from_payload()`. The updated docstring now states the accurate rule: pure presentation hints such as `amplitude_metric` and `confidence_*` are ignored by the decoder, while certain persisted public-field fallbacks still seed domain reconstruction. That is the actual contract the code is honoring today, and making it explicit reduces the chance of future “cleanup” work breaking historical roundtrips by assuming those keys are dead.

The test updates are focused on the new internal split and on preserving outward behavior. In `apps/server/tests/shared/boundaries/test_finding_payload_projection.py`, I added coverage that exercises `_finding_core_payload_from_domain()` and `_finding_presentation_payload_from_domain()` directly and verifies that the final public payload is the composition of those two pieces. That test also proves the split is meaningful: core payloads do not carry `evidence_summary`, `frequency_hz_or_order`, `amplitude_metric`, or confidence display fields, while the presentation payload does not carry core semantic fields such as `finding_id` or `strongest_location`. In `apps/server/tests/shared/boundaries/test_finding_roundtrip.py`, I added a decode-focused regression test that mutates `amplitude_metric` and the `confidence_*` hints and confirms the reconstructed domain `Finding` is unchanged. That directly pins the intended “ignored on decode” behavior for the pure presentation hints.

I intentionally did not change `apps/server/vibesensor/shared/types/history_analysis_contracts.py` in this PR. That module still owns the public `FindingPayload` shape, and I wanted to avoid introducing outward schema or field-order churn while solving an internal encoder-ownership problem. If we later decide to split the public type surface itself into nested or separate contracts, that should happen in a follow-up issue with explicit schema discussion and schema-artifact updates. Likewise, I did not try to remove `evidence_summary` or `frequency_hz_or_order` from the persisted reconstruction path, because the current public payload still relies on those fields. That larger compatibility shift would need a more deliberate migration plan than this issue called for.

For validation, I ran a focused suite that covers the exact blast radius of this change: `apps/server/tests/shared/boundaries/test_finding_payload_projection.py`, `apps/server/tests/shared/boundaries/test_finding_roundtrip.py`, `apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py`, `apps/server/tests/shared/boundaries/test_enrich_findings_equivalence.py`, `apps/server/tests/hygiene/test_domain_boundary_parity.py`, `apps/server/tests/hygiene/test_api_model_boundary_parity.py`, `apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py`, `apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py`, `apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py`, `apps/server/tests/adapters/http/test_http_api_schema_export.py`, and `apps/server/tests/integration/test_decode_project_roundtrip.py`. That suite passed with `405 passed`. I then ran `make typecheck-backend` and `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`; both passed after `ruff --fix` normalized the new import block in `finding.py`. The lint run also rechecked `python3 -m vibesensor.cli.http_api_schema_export --check`, which stayed green, confirming that the public schema remained unchanged.

The only validation step still blocked is the repository’s Docker smoke expectation. I attempted `docker compose build --pull && docker compose up -d`, but this environment still does not expose a Docker daemon socket, so Docker failed before the stack could start. I’m calling that out explicitly because it is an environment limitation, not a regression introduced by the code change.
