### PR TITLE
Move payload JSON conversion helpers out of history_analysis_contracts.py

### DIFF
--- a/apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import vibesensor.shared.boundaries.analysis_payload as analysis_payload
+import vibesensor.shared.json_utils as json_utils
 import vibesensor.shared.types.history_analysis_contracts as history_analysis_contracts
 
 
@@ -12,3 +13,12 @@ def test_analysis_payload_module_stays_schema_only() -> None:
 
 def test_analysis_summary_contract_is_owned_by_history_analysis_contracts() -> None:
     assert hasattr(history_analysis_contracts, "AnalysisSummary")
+
+
+def test_payload_json_helpers_live_outside_history_analysis_contracts() -> None:
+    assert not hasattr(history_analysis_contracts, "payload_value_from_json")
+    assert not hasattr(history_analysis_contracts, "payload_object_from_json")
+    assert not hasattr(history_analysis_contracts, "payload_objects_from_json")
+    assert hasattr(json_utils, "payload_value_from_json")
+    assert hasattr(json_utils, "payload_object_from_json")
+    assert hasattr(json_utils, "payload_objects_from_json")

--- a/apps/server/tests/shared/utils/test_json_utils.py
+++ b/apps/server/tests/shared/utils/test_json_utils.py
@@ -8,6 +8,9 @@ import numpy as np
 import pytest
 
 from vibesensor.shared.json_utils import (
+    payload_object_from_json,
+    payload_objects_from_json,
+    payload_value_from_json,
     safe_json_dumps,
     safe_json_loads,
     sanitize_for_json,
@@ -230,3 +233,23 @@ class TestSafeJsonLoads:
     def test_scalar_json(self) -> None:
         result = safe_json_loads("42", context="test")
         assert result == 42
+
+
+def test_payload_value_from_json_projects_nested_json() -> None:
+    value = {
+        "_i18n_key": "SUMMARY_LABEL",
+        "params": {"severity": "warn"},
+        "bands": [1, {"name": "cruise"}],
+    }
+
+    assert payload_value_from_json(value) == value
+
+
+def test_payload_object_helpers_project_json_object_sequences() -> None:
+    values = [
+        {"code": "speed_gap", "state": "warn"},
+        {"title": {"_i18n_key": "SUMMARY_LABEL"}},
+    ]
+
+    assert payload_object_from_json(values[1]) == values[1]
+    assert payload_objects_from_json(values) == values

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -34,11 +34,8 @@ from vibesensor.shared.boundaries.vibration_origin import (
     vibration_origin_from_payload,
 )
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.json_utils import i18n_ref
-from vibesensor.shared.types.history_analysis_contracts import (
-    FindingPayload,
-    payload_value_from_json,
-)
+from vibesensor.shared.json_utils import i18n_ref, payload_value_from_json
+from vibesensor.shared.types.history_analysis_contracts import FindingPayload
 
 _MAX_SIGNATURES_PER_FINDING: int = 3
 

--- a/apps/server/vibesensor/shared/boundaries/run_suitability.py
+++ b/apps/server/vibesensor/shared/boundaries/run_suitability.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from vibesensor.domain.run_suitability import RunSuitability, SuitabilityCheck
 from vibesensor.shared.boundaries.analysis_payload import RunSuitabilityCheck
-from vibesensor.shared.types.history_analysis_contracts import payload_value_from_json
+from vibesensor.shared.json_utils import payload_value_from_json
 from vibesensor.shared.types.json_types import JsonValue
 
 

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -30,16 +30,18 @@ from vibesensor.shared.boundaries.vibration_origin import (
 )
 from vibesensor.shared.constants.analysis import MEMS_NOISE_FLOOR_G
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.json_utils import i18n_ref
+from vibesensor.shared.json_utils import (
+    i18n_ref,
+    payload_object_from_json,
+    payload_objects_from_json,
+    payload_value_from_json,
+)
 from vibesensor.shared.statistics_utils import _outlier_summary, _percent_missing
 from vibesensor.shared.time_utils import format_duration_mm_ss
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary,
     PayloadObject,
     PayloadValue,
-    payload_object_from_json,
-    payload_objects_from_json,
-    payload_value_from_json,
 )
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 from vibesensor.vibration_strength import compute_db

--- a/apps/server/vibesensor/shared/boundaries/summary_warning.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_warning.py
@@ -6,11 +6,11 @@ from functools import partial
 
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.analysis_payload import SummaryWarningPayload
+from vibesensor.shared.json_utils import payload_value_from_json
 from vibesensor.shared.run_context_warning import (
     RunContextWarning,
     normalize_run_context_warnings,
 )
-from vibesensor.shared.types.history_analysis_contracts import payload_value_from_json
 from vibesensor.shared.types.json_types import JsonObject
 
 

--- a/apps/server/vibesensor/shared/json_utils.py
+++ b/apps/server/vibesensor/shared/json_utils.py
@@ -1,4 +1,4 @@
-"""Shared JSON sanitisation, merging, and coercion utilities.
+"""Shared JSON sanitisation, payload projection, merging, and coercion utilities.
 
 Provides numpy-aware non-finite-float sanitisation and recursive
 dict-merge used across config loading, WebSocket hub, and history.
@@ -9,16 +9,26 @@ from __future__ import annotations
 import json
 import logging
 import math
+from collections.abc import Sequence
 from typing import cast
 
 from vibesensor.domain import coerce_float
-from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
+from vibesensor.shared.types.json_types import (
+    JsonObject,
+    JsonSchemaObject,
+    JsonSchemaValue,
+    JsonValue,
+    is_json_object,
+)
 
 __all__ = [
     "as_float_or_none",
     "as_int_or_none",
     "deep_merge",
     "i18n_ref",
+    "payload_object_from_json",
+    "payload_objects_from_json",
+    "payload_value_from_json",
     "safe_json_dumps",
     "safe_json_loads",
     "sanitize_for_json",
@@ -47,6 +57,28 @@ def as_int_or_none(value: object) -> int | None:
     if out is None:
         return None
     return round(out)
+
+
+def payload_value_from_json(value: JsonValue | None) -> JsonSchemaValue:
+    """Project recursive JSON into the bounded schema-safe payload JSON shape."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, list):
+        return cast(JsonSchemaValue, [payload_value_from_json(item) for item in value])
+    return cast(JsonSchemaValue, payload_object_from_json(value))
+
+
+def payload_object_from_json(value: JsonObject) -> JsonSchemaObject:
+    """Project a JSON object into the bounded schema-safe payload object shape."""
+    return cast(
+        JsonSchemaObject,
+        {key: payload_value_from_json(item) for key, item in value.items()},
+    )
+
+
+def payload_objects_from_json(values: Sequence[JsonObject]) -> list[JsonSchemaObject]:
+    """Project a sequence of JSON objects into the bounded schema-safe payload list shape."""
+    return [payload_object_from_json(value) for value in values]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -11,8 +11,7 @@ remain local to ``shared.types.api_models.history``.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, Literal, Required, TypeAlias, cast
+from typing import Any, Literal, Required, TypeAlias
 
 from pydantic import ConfigDict
 from typing_extensions import TypedDict
@@ -27,10 +26,8 @@ from vibesensor.shared.types.analysis_views import (
     SpeedBreakdownRow,
 )
 from vibesensor.shared.types.json_types import (
-    JsonObject,
     JsonSchemaObject,
     JsonSchemaValue,
-    JsonValue,
 )
 
 __all__ = [
@@ -48,9 +45,6 @@ __all__ = [
     "OutlierSummaryResponse",
     "PayloadObject",
     "PayloadValue",
-    "payload_object_from_json",
-    "payload_objects_from_json",
-    "payload_value_from_json",
     "PhaseInfoResponse",
     "PhaseIntensityStatsResponse",
     "PhaseSegmentSummaryResponse",
@@ -65,25 +59,6 @@ __all__ = [
 
 PayloadObject: TypeAlias = JsonSchemaObject
 PayloadValue: TypeAlias = JsonSchemaValue
-
-
-def payload_value_from_json(value: JsonValue | None) -> PayloadValue:
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return value
-    if isinstance(value, list):
-        # History/report payload producers only emit the bounded JSON depth
-        # modeled by ``PayloadValue``, but mypy cannot prove that through the
-        # recursive conversion helper.
-        return cast(PayloadValue, [payload_value_from_json(item) for item in value])
-    return cast(PayloadValue, payload_object_from_json(value))
-
-
-def payload_object_from_json(value: JsonObject) -> PayloadObject:
-    return cast(PayloadObject, {key: payload_value_from_json(item) for key, item in value.items()})
-
-
-def payload_objects_from_json(values: Sequence[JsonObject]) -> list[PayloadObject]:
-    return [payload_object_from_json(value) for value in values]
 
 
 _FORBID_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -7,7 +7,7 @@ from vibesensor.shared.boundaries.analysis_summary import analysis_result_to_sum
 from vibesensor.shared.boundaries.persisted_analysis_codec import (
     persisted_analysis_from_summary,
 )
-from vibesensor.shared.types.history_analysis_contracts import payload_object_from_json
+from vibesensor.shared.json_utils import payload_object_from_json
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.run_schema import RunMetadata


### PR DESCRIPTION
## Summary

Closes #1353.

This PR moves the generic payload JSON conversion helpers out of `apps/server/vibesensor/shared/types/history_analysis_contracts.py` and into the neutral shared JSON utility module, `apps/server/vibesensor/shared/json_utils.py`. The issue called out a small but real ownership leak: boundary serializers were importing general-purpose helper behavior from a module whose primary responsibility is contract ownership. That made the contracts file responsible for both defining the analysis/history payload shapes and providing reusable recursive conversion logic, even though the conversion helpers are not themselves part of the public contract surface.

The implementation keeps the actual JSON conversion behavior unchanged. The same helper names are preserved, the same recursive projection rules still apply, and the same callers continue to receive schema-safe bounded JSON values. The change is intentionally limited to ownership and import boundaries, not semantics.

## Implementation approach

I chose the smallest complete fix that separates concerns without creating another unnecessary utility namespace. Instead of introducing a brand-new helper file, this PR reuses `shared/json_utils.py`, which already owns neutral JSON sanitation, loading, dumping, coercion, and merge helpers. That makes it the natural place for payload projection helpers that convert arbitrary recursive JSON into the bounded `JsonSchemaValue`/`JsonSchemaObject` shapes used by persisted analysis and history payloads.

With that direction in place, the change breaks down into three parts:

First, move `payload_value_from_json()`, `payload_object_from_json()`, and `payload_objects_from_json()` into `shared/json_utils.py`, keeping the implementations behaviorally identical. They still accept the same inputs and still return the same bounded schema-safe payload JSON shapes. The only meaningful change is ownership.

Second, remove those helper exports and implementations from `history_analysis_contracts.py`, leaving that module focused on contract aliases, TypedDict ownership, and TypedDict configuration only. The module continues to own `PayloadValue` and `PayloadObject` as aliases, but it no longer mixes those contract definitions with generic helper behavior.

Third, repoint every current caller to the new neutral import path so there is no lingering dependency on helper behavior from the contracts module.

## Main code changes

The center of the change is `apps/server/vibesensor/shared/json_utils.py`. That module now exports the three payload conversion helpers alongside the existing JSON utilities. The functions use `JsonValue`, `JsonSchemaValue`, `JsonObject`, and `JsonSchemaObject` directly, which keeps the helpers neutral and avoids reintroducing a dependency on the contracts module. The recursive list/object handling is unchanged from the previous implementation, including the explicit `cast()` calls that help mypy understand the bounded schema shape.

`apps/server/vibesensor/shared/types/history_analysis_contracts.py` was then reduced back to contract ownership. I removed the helper functions and removed them from `__all__`, while preserving the `PayloadObject` and `PayloadValue` aliases that describe the contract-facing JSON shape. This is the architectural goal of the issue: contract ownership remains here, but reusable helper logic no longer does.

The import updates are straightforward but important because they show the blast radius of the old ownership leak. The following callers now import the helpers from `shared.json_utils` instead of `history_analysis_contracts.py`:

- `apps/server/vibesensor/shared/boundaries/finding.py`
- `apps/server/vibesensor/shared/boundaries/run_suitability.py`
- `apps/server/vibesensor/shared/boundaries/summary_warning.py`
- `apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py`
- `apps/server/vibesensor/use_cases/run/post_analysis_summary.py`

These are exactly the kinds of serializer/projection modules the issue description referenced. They still build the same payloads, but they now depend on a neutral JSON helper module rather than a contract-definition module.

I also added focused regression coverage in two places. In `apps/server/tests/shared/utils/test_json_utils.py`, I added direct tests for the moved helper functions so the new home has first-class test ownership. Those tests cover nested JSON projection and list-of-object projection, which is enough to prove the recursive behavior is still intact without duplicating every existing payload consumer test.

In `apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py`, I added an ownership-boundary assertion that `history_analysis_contracts` no longer exports the three helpers, while `vibesensor.shared.json_utils` does. That guards the architectural outcome directly, which is useful because future cleanup in this area will otherwise be tempted to re-export convenience helpers back out of the contracts module.

## Contract, schema, and documentation impact

There is intentionally no wire-format change in this PR. The public analysis/history payload contracts remain identical, the helper names remain identical, and the OpenAPI-exported schema does not need regeneration. This is confirmed indirectly by `make lint`, which includes `python3 -m vibesensor.cli.http_api_schema_export --check`, and by the focused serializer tests that still assert the same payload shapes.

I did not update user-facing documentation because the change is internal and architectural rather than behavioral. The tracker and run instructions were updated locally for execution continuity, but no committed docs required changes for this issue.

## Validation

I validated the change with a focused pytest slice that exercises the moved helpers directly and the main serializer consumers that use them:

- `python3 -m pytest -q apps/server/tests/shared/utils/test_json_utils.py apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py apps/server/tests/shared/boundaries/test_run_suitability.py apps/server/tests/shared/boundaries/test_summary_warning.py apps/server/tests/shared/boundaries/test_analysis_summary_projection.py apps/server/tests/use_cases/run/test_post_analysis_summary.py`

That suite passed with `47 passed`.

I then ran broader static validation:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

Both passed. `make lint` also rechecked backend static guards, docs lint, and HTTP/WebSocket schema freshness, so this gives good confidence that the helper move did not accidentally disturb other contract surfaces.

Per repository workflow, I also attempted the local Docker smoke command:

- `docker compose build --pull && docker compose up -d`

That still fails in this environment because there is no reachable Docker daemon socket. This is the same environment limitation encountered on earlier issues in the run, so it is recorded as an execution-environment blocker rather than a code regression introduced by this PR.

## Risks, tradeoffs, and follow-ups

The main tradeoff here is keeping the helper names the same while changing only their home. I chose that on purpose because the issue is about ownership, not API churn. Renaming the helpers or changing their semantics would have turned a narrow architecture cleanup into a broader migration with more risk and less value.

There is also a subtle type design choice here: the moved helpers now return `JsonSchemaValue`/`JsonSchemaObject` directly from `json_utils.py` rather than relying on contract aliases from `history_analysis_contracts.py`. That keeps the new home neutral and avoids creating an accidental reverse dependency from JSON utilities back into contract ownership.

The next likely cleanups in this area are already visible in the backlog: additional boundary modules in `shared.boundaries.finding` still mix multiple concerns, and those follow-up issues can now build on a slightly cleaner separation between contract ownership and neutral JSON helper behavior.
