### PR TITLE
Formalize and validate the PreparedReportInput handoff contract

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from test_support.findings import make_finding_payload
+
+from vibesensor.adapters.pdf import mapping as pdf_mapping
+from vibesensor.use_cases.history.report_preparation import (
+    PreparedReportInput,
+    ValidatedPreparedReportInput,
+    prepare_report_input,
+    validate_prepared_report_input,
+)
+
+
+def _prepared_report_input() -> PreparedReportInput:
+    finding = make_finding_payload(finding_id="F001")
+    prepared = prepare_report_input(
+        {
+            "run_id": "prepared-contract",
+            "file_name": "prepared-contract.csv",
+            "rows": 32,
+            "duration_s": 12.5,
+            "sensor_count_used": 2,
+            "lang": "en",
+            "metadata": {},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "warnings": [],
+            "sensor_locations": [],
+            "sensor_locations_connected_throughout": [],
+            "sensor_intensity_by_location": [],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "plots": {},
+            "test_plan": [],
+            "findings": [finding],
+            "top_causes": [finding],
+        }
+    )
+    assert prepared.domain_test_run is not None
+    assert prepared.report_facts is not None
+    return prepared
+
+
+def test_validate_prepared_report_input_rejects_missing_domain_test_run() -> None:
+    prepared = replace(_prepared_report_input(), domain_test_run=None)
+
+    with pytest.raises(ValueError, match="domain_test_run"):
+        validate_prepared_report_input(prepared)
+
+
+def test_validate_prepared_report_input_rejects_missing_report_facts() -> None:
+    prepared = replace(_prepared_report_input(), report_facts=None)
+
+    with pytest.raises(ValueError, match="report_facts"):
+        validate_prepared_report_input(prepared)
+
+
+def test_validate_prepared_report_input_returns_mapping_ready_handoff() -> None:
+    validated = validate_prepared_report_input(_prepared_report_input())
+
+    assert isinstance(validated, ValidatedPreparedReportInput)
+    assert validated.domain_test_run is not None
+    assert validated.report_facts is not None
+
+
+def test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = replace(_prepared_report_input(), report_facts=None)
+
+    def _explode(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("map_summary should validate the prepared handoff before mapping")
+
+    monkeypatch.setattr(pdf_mapping, "_build_report_template_data", _explode)
+
+    with pytest.raises(ValueError, match="report_facts"):
+        pdf_mapping.map_summary(prepared)

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -52,7 +52,9 @@ from vibesensor.shared.types.json_types import JsonValue
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportFacts,
     PreparedReportInput,
+    ValidatedPreparedReportInput,
     prepare_report_input,
+    validate_prepared_report_input,
 )
 
 __all__ = [
@@ -167,38 +169,33 @@ def build_version_marker() -> str:
 def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
     """Map a prepared report input into the final report template data model.
 
-    ``PreparedReportInput`` guarantees that report projection and domain
-    reconstruction have already happened on the history side, so the PDF
-    adapter can stay focused on mapping and rendering decisions.
+    Mapping begins by validating the prepared handoff once so the rest of the
+    PDF adapter consumes a mapping-ready shape with domain reconstruction and
+    report facts already guaranteed.
     """
-    lang = str(normalize_lang(prepared.language))
+    validated = validate_prepared_report_input(prepared)
+    lang = str(normalize_lang(validated.language))
     report = Report(
-        run_id=prepared.renderer_payload.run_id,
+        run_id=validated.renderer_payload.run_id,
         lang=lang,
-        car_name=prepared.renderer_payload.car_name,
-        car_type=prepared.renderer_payload.car_type,
-        report_date=prepared.renderer_payload.report_date,
-        duration_s=prepared.renderer_payload.duration_s,
-        sample_count=prepared.renderer_payload.sample_count,
-        sensor_count=prepared.renderer_payload.sensor_count,
+        car_name=validated.renderer_payload.car_name,
+        car_type=validated.renderer_payload.car_type,
+        report_date=validated.renderer_payload.report_date,
+        duration_s=validated.renderer_payload.duration_s,
+        sample_count=validated.renderer_payload.sample_count,
+        sensor_count=validated.renderer_payload.sensor_count,
     )
-    domain_test_run = prepared.domain_test_run
-    report_facts = prepared.report_facts
-    if domain_test_run is None:
-        raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
-    if report_facts is None:
-        raise ValueError("PreparedReportInput must include report_facts for report mapping")
 
     def tr(key: str, **kw: JsonValue) -> str:
         return str(_tr(lang, key, **kw))
 
     return _build_report_template_data(
-        prepared,
+        validated,
         report=report,
         lang=lang,
         tr=tr,
-        test_run=domain_test_run,
-        report_facts=report_facts,
+        test_run=validated.domain_test_run,
+        report_facts=validated.report_facts,
     )
 
 
@@ -216,7 +213,7 @@ def _finding_to_presentation(f: Finding) -> FindingPresentation:
 
 
 def _build_report_template_data(
-    prepared: PreparedReportInput,
+    prepared: ValidatedPreparedReportInput,
     *,
     report: Report,
     lang: str,

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -22,7 +22,10 @@ from vibesensor.shared.time_utils import utc_now_iso
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
-    from vibesensor.use_cases.history.report_preparation import PreparedReportInput
+    from vibesensor.use_cases.history.report_preparation import (
+        PreparedReportInput,
+        ValidatedPreparedReportInput,
+    )
 
 __all__ = [
     "ReportMappingContext",
@@ -105,21 +108,20 @@ class ReportMappingContext:
 
 
 def prepare_report_mapping_context(
-    prepared: PreparedReportInput,
+    prepared: PreparedReportInput | ValidatedPreparedReportInput,
 ) -> ReportMappingContext:
     """Extract structural prepared-report context for report mapping.
 
-    Consumes the prepared domain ``TestRun`` aggregate plus minimal
-    renderer-edge metadata so downstream business decisions stay domain-first
-    without depending on a raw summary payload.
+    Consumes the validated prepared report seam plus minimal renderer-edge
+    metadata so downstream business decisions stay domain-first without
+    depending on a raw summary payload.
     """
-    report_facts = prepared.report_facts
-    test_run = prepared.domain_test_run
-    if report_facts is None:
-        raise ValueError("PreparedReportInput must include report_facts for report mapping")
-    if test_run is None:
-        raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
-    renderer_payload = prepared.renderer_payload
+    from vibesensor.use_cases.history.report_preparation import validate_prepared_report_input
+
+    validated = validate_prepared_report_input(prepared)
+    report_facts = validated.report_facts
+    test_run = validated.domain_test_run
+    renderer_payload = validated.renderer_payload
     report_date = renderer_payload.report_date or utc_now_iso()
     date_str = str(report_date)[:19].replace("T", " ") + " UTC"
 

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -177,10 +177,13 @@ class PreparedReportInput:
       downstream PDF mapping helpers as the authoritative report aggregate.
     - ``report_facts`` contains the semantic report facts that the PDF adapter
       needs so it does not have to call back into history-layer interpretation.
-    - ``renderer_payload`` contains only the minimal final-edge payload that the
-      PDF mapper still needs after domain/report preparation is complete.
-    - ``language`` is canonicalized once so the renderer consumes one
-      consistent locale choice.
+     - ``renderer_payload`` contains only the minimal final-edge payload that the
+       PDF mapper still needs after domain/report preparation is complete.
+     - ``language`` is canonicalized once so the renderer consumes one
+       consistent locale choice.
+     - ``domain_test_run`` and ``report_facts`` may still be ``None`` for
+       non-projectable inputs; call ``validate_prepared_report_input()`` before
+       entering the PDF mapping seam.
     """
 
     renderer_payload: PreparedReportRendererPayload
@@ -189,6 +192,42 @@ class PreparedReportInput:
     domain_test_run: TestRun | None
     cache_key: ReportPdfCacheKey | None = None
     report_facts: PreparedReportFacts | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedPreparedReportInput:
+    """Prepared report handoff validated for PDF mapping.
+
+    This mapping-ready shape guarantees the domain aggregate and prepared report
+    facts are both present before adapter-side mapping begins.
+    """
+
+    renderer_payload: PreparedReportRendererPayload
+    language: str
+    filename: str
+    domain_test_run: TestRun
+    report_facts: PreparedReportFacts
+    cache_key: ReportPdfCacheKey | None = None
+
+
+def validate_prepared_report_input(
+    prepared: PreparedReportInput | ValidatedPreparedReportInput,
+) -> ValidatedPreparedReportInput:
+    """Validate that the prepared report seam is ready for PDF mapping."""
+    if isinstance(prepared, ValidatedPreparedReportInput):
+        return prepared
+    if prepared.domain_test_run is None:
+        raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
+    if prepared.report_facts is None:
+        raise ValueError("PreparedReportInput must include report_facts for report mapping")
+    return ValidatedPreparedReportInput(
+        renderer_payload=prepared.renderer_payload,
+        language=prepared.language,
+        filename=prepared.filename,
+        domain_test_run=prepared.domain_test_run,
+        report_facts=prepared.report_facts,
+        cache_key=prepared.cache_key,
+    )
 
 
 def _reconstruct_report_test_run(payload: Mapping[str, object]) -> TestRun | None:


### PR DESCRIPTION
## Summary

Closes #1354.

This PR formalizes the handoff between history-side report preparation and the PDF mapping layer by introducing an explicit validation step for `PreparedReportInput`. Before this change, the seam was only enforced indirectly: `PreparedReportInput` carried nullable `domain_test_run` and `report_facts` fields, and the PDF adapter defended itself with late `ValueError` checks inside `map_summary()` and `prepare_report_mapping_context()`. That arrangement technically worked on the happy path, but it left the key boundary between preparation and mapping enforced mostly by convention and duplicated runtime checks.

The change makes that contract explicit. History-side preparation now owns a single validator that turns a raw `PreparedReportInput` into a mapping-ready `ValidatedPreparedReportInput`. The PDF adapter consumes that validated seam instead of re-checking nullable fields in multiple places. Invalid prepared inputs still fail with the same clear error messages, but they now fail through one deliberate handoff validator rather than through loosely duplicated checks scattered across the adapter layer.

## Problem being solved

Issue #1354 called out an architectural gap in the report pipeline. `PreparedReportInput` and `PreparedReportFacts` already describe the intended seam between history preparation and PDF mapping, but the guarantee was incomplete because two of the most important fields remained optional all the way into the adapter. As a result:

- `map_summary()` had to raise if `domain_test_run` was missing.
- `map_summary()` also had to raise if `report_facts` was missing.
- `prepare_report_mapping_context()` repeated the same invariant checks again.

That duplication had two downsides. First, it made the contract harder to reason about because the validation logic lived where the data was consumed rather than where the seam was defined. Second, it made future report migration work riskier because more adapter code still had to deal with partially prepared inputs instead of one well-defined validated handoff shape.

## Chosen implementation approach

I took the smallest change that makes the seam explicit without redesigning the reporting pipeline.

Instead of broadening the issue into new rendering abstractions or changing user-facing report content, I kept the existing `PreparedReportInput` dataclass as the history-side “possibly incomplete” preparation result and added a second dataclass, `ValidatedPreparedReportInput`, for the mapping-ready form. A new `validate_prepared_report_input()` helper in `use_cases/history/report_preparation.py` now owns the seam validation. It accepts either a raw `PreparedReportInput` or an already validated input, raises the existing `ValueError` messages when `domain_test_run` or `report_facts` are missing, and otherwise returns the mapping-ready handoff object.

This approach keeps the public preparation entrypoints stable (`prepare_report_input()` and `prepare_persisted_report_input()` still return `PreparedReportInput`) while making the mapping seam explicit for the code that needs it. It also avoids inventing parallel preparation flows or spreading more report-specific validation into adapter modules.

## Main code changes by area

The primary change is in `apps/server/vibesensor/use_cases/history/report_preparation.py`.

I updated the `PreparedReportInput` docstring to state the important nuance directly: `domain_test_run` and `report_facts` may still be `None` for non-projectable inputs, and callers must validate before entering the PDF mapping seam. I then added `ValidatedPreparedReportInput`, which mirrors the prepared handoff shape but makes `domain_test_run` and `report_facts` required. Finally, I added `validate_prepared_report_input()`, which centralizes the seam validation and constructs the mapping-ready handoff.

In `apps/server/vibesensor/adapters/pdf/mapping.py`, `map_summary()` now validates first and then works entirely from the validated handoff. That removes the local duplicated `None` checks and makes the function’s contract closer to its docstring: by the time mapping begins, the prepared data has already been confirmed ready for mapping.

I also updated `_build_report_template_data()` to accept the validated handoff type. That is a useful internal signal that the late-stage mapping pipeline should only ever see the already validated seam.

In `apps/server/vibesensor/adapters/pdf/report_context.py`, `prepare_report_mapping_context()` now delegates to the same history-owned validator instead of maintaining its own copy of the invariant checks. This is important because the issue was not just about `map_summary()`; it was about the seam itself. The adapter context builder still accepts the same caller-visible shape at runtime, but it now resolves the invariants through the shared validator instead of repeating them inline.

## Tests and validation

The main new regression coverage lives in `apps/server/tests/use_cases/history/test_report_preparation_contract.py`, which is a new focused test module rather than another addition to a broad integration file.

That module covers four specific behaviors:

- missing `domain_test_run` fails validation
- missing `report_facts` fails validation
- a valid prepared input produces a `ValidatedPreparedReportInput`
- `map_summary()` validates before beginning deeper PDF mapping work

That last case matters because it proves the failure happens at the seam before the adapter’s template-building work starts.

I also re-ran the focused PDF/report tests that exercise the existing happy path and mapping-context consumers:

- `python3 -m pytest -q apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py`

That suite passed with `30 passed`.

Broader validation also passed:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

`make lint` additionally re-ran backend static guards and schema freshness checks, which helps confirm that the seam cleanup did not leak into unrelated reporting or contract surfaces.

Per repository workflow, I also attempted the Docker smoke command:

- `docker compose build --pull && docker compose up -d`

That still fails in this environment because there is no reachable Docker daemon socket. This is the same environment limitation seen on earlier issues in the run and is not caused by this report-contract change.

## Risks, tradeoffs, and out-of-scope considerations

The main tradeoff here is that `PreparedReportInput` remains the return type of the existing preparation helpers instead of being fully replaced by the validated type. I chose that intentionally to keep the change small and behavior-safe. The existing preparation functions still describe the broader handoff object, while validation is only required when the code crosses into the mapping seam that depends on `domain_test_run` and `report_facts`.

I also intentionally kept the validation errors as `ValueError` with the existing messages. The issue asked for an explicit validated contract, not a new exception hierarchy, and preserving the existing failure strings keeps the change focused and reduces surprise for any current callers or tests.

What I did not do here is redesign report template data, change renderer output, or restructure the broader report preparation flow. Those are separate concerns and would have broadened the issue beyond its stated scope. This PR is specifically about making the seam explicit, validated, and reusable for the next round of report-boundary cleanup work.
