### PR TITLE
Precompute ReportMappingContext during report preparation

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_context.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_context.py
@@ -130,7 +130,6 @@ class TestHasSignificantLocationIntensity:
 
 class TestObservedSignature:
     def test_builds_from_primary(self) -> None:
-        context = _make_context()
         primary = PrimaryCandidateContext(
             primary_candidate=_make_finding(),
             primary_source="wheel/tire",
@@ -150,7 +149,7 @@ class TestObservedSignature:
             certainty_reason="Consistent order-tracking match",
             tier="C",
         )
-        sig = context.observed_signature(primary)
+        sig = report_context.observed_signature(primary)
         assert sig.primary_system == "Wheel / Tire"
         assert sig.strongest_location == "front_left"
         assert sig.speed_band == "80-100 km/h"

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -6,6 +6,7 @@ import pytest
 from test_support.findings import make_finding_payload
 
 from vibesensor.adapters.pdf import mapping as pdf_mapping
+from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportInput,
     ValidatedPreparedReportInput,
@@ -61,11 +62,21 @@ def test_validate_prepared_report_input_rejects_missing_report_facts() -> None:
 
 
 def test_validate_prepared_report_input_returns_mapping_ready_handoff() -> None:
-    validated = validate_prepared_report_input(_prepared_report_input())
+    prepared = _prepared_report_input()
+    validated = validate_prepared_report_input(prepared)
 
     assert isinstance(validated, ValidatedPreparedReportInput)
     assert validated.domain_test_run is not None
     assert validated.report_facts is not None
+    assert prepared.mapping_context is not None
+    assert validated.mapping_context is prepared.mapping_context
+
+
+def test_prepare_report_mapping_context_returns_precomputed_context() -> None:
+    prepared = _prepared_report_input()
+
+    assert prepared.mapping_context is not None
+    assert prepare_report_mapping_context(prepared) is prepared.mapping_context
 
 
 def test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input(

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -1,10 +1,9 @@
 """report_mapping – thin mapper from prepared report inputs to template data.
 
-Context assembly (domain aggregate reconstruction, primary-candidate
-preparation) lives in :mod:`report_context`, with focused helper logic in
-``_candidate_resolver.py`` and ``_card_builder.py``. This module receives
-an explicit prepared report input and maps it to :class:`ReportTemplateData`
-for the PDF renderer.
+Context preparation now happens on the history side, while this module keeps
+focused PDF mapping logic plus the final renderer-facing orchestration. It
+receives an explicit prepared report input and maps it to
+:class:`ReportTemplateData` for the PDF renderer.
 """
 
 from __future__ import annotations
@@ -27,6 +26,7 @@ from vibesensor.adapters.pdf.peak_table import build_peak_rows
 from vibesensor.adapters.pdf.presentation import order_label_human
 from vibesensor.adapters.pdf.report_context import (
     ReportMappingContext,
+    observed_signature,
     prepare_report_mapping_context,
 )
 from vibesensor.adapters.pdf.report_data import (
@@ -234,7 +234,7 @@ def _build_report_template_data(
         tr=tr,
         lang=lang,
     )
-    observed = context.observed_signature(primary)
+    observed = observed_signature(primary)
     system_cards = build_system_cards(
         context,
         primary,

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -1,144 +1,44 @@
-"""Report context assembly for the PDF mapper.
-
-Owns :class:`ReportMappingContext` plus
-:func:`prepare_report_mapping_context`, which bridge prepared report facts
-into normalized context consumed by ``mapping.py``.
-"""
+"""PDF-side bridge helpers for the precomputed report mapping context."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.report_data import PatternEvidence
-from vibesensor.domain import (
-    Finding,
-    LocationIntensitySummary,
-    TestRun,
-    VibrationOrigin,
+from vibesensor.use_cases.history.report_preparation import (
+    PreparedReportInput,
+    ReportMappingContext,
+    ValidatedPreparedReportInput,
+    validate_prepared_report_input,
 )
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.time_utils import utc_now_iso
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
-    from vibesensor.use_cases.history.report_preparation import (
-        PreparedReportInput,
-        ValidatedPreparedReportInput,
-    )
 
 __all__ = [
     "ReportMappingContext",
+    "observed_signature",
     "prepare_report_mapping_context",
 ]
 
 
-@dataclass(frozen=True)
-class ReportMappingContext:
-    """Normalized structural context pulled from an analysis summary.
-
-    Owns display-ready metadata access, primary hotspot / candidate
-    selection helpers, and report-mapping decisions that were previously
-    spread across helper functions and ``dict.get(...)`` calls.
-
-    Domain ``Finding`` objects are available alongside payload dicts so
-    that business decisions (classification, ranking, actionability) use
-    the domain model while rendering-level evidence detail comes from
-    the payloads.
-    """
-
-    car_name: str | None
-    car_type: str | None
-    date_str: str
-    origin: VibrationOrigin | None
-    origin_location: str
-    sensor_locations_active: list[str]
-    # Typed run metadata (replaces dict[str, object] + type: ignore).
-    duration_text: str | None
-    start_time_utc: str | None
-    end_time_utc: str | None
-    sample_rate_hz: str | None
-    tire_spec_text: str | None
-    sample_count: int
-    sensor_model: str | None
-    firmware_version: str | None
-    # Domain aggregate — the primary data source for business decisions.
-    domain_aggregate: TestRun
-
-    # -- candidate selection ------------------------------------------------
-
-    def top_report_candidate(self) -> Finding | None:
-        """Return the primary report candidate (first effective top cause or finding)."""
-        effective = self.domain_aggregate.effective_top_causes()
-        if effective:
-            return effective[0]
-        non_ref = self.domain_aggregate.non_reference_findings
-        if non_ref:
-            return non_ref[0]
-        all_findings = self.domain_aggregate.findings
-        return all_findings[0] if all_findings else None
-
-    # -- intensity queries --------------------------------------------------
-
-    def has_significant_location_intensity(
-        self,
-        sensor_intensity: list[LocationIntensitySummary],
-    ) -> bool:
-        """Whether any sensor location shows significant above-noise intensity."""
-        for row in sensor_intensity:
-            p95 = _as_float(row.p95_intensity_db)
-            if p95 is not None and p95 > 0:
-                return True
-        return False
-
-    # -- observed signature -------------------------------------------------
-
-    def observed_signature(self, primary: PrimaryCandidateContext) -> PatternEvidence:
-        """Build the observed-signature block for the report template."""
-        return PatternEvidence(
-            primary_system=primary.primary_system,
-            strongest_location=primary.primary_location,
-            speed_band=primary.primary_speed,
-            strength_label=primary.strength_text,
-            strength_peak_db=primary.strength_db,
-            certainty_label=primary.certainty_label_text,
-            certainty_pct=primary.certainty_pct,
-            certainty_reason=primary.certainty_reason,
-        )
+def observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
+    """Build the observed-signature block for the report template."""
+    return PatternEvidence(
+        primary_system=primary.primary_system,
+        strongest_location=primary.primary_location,
+        speed_band=primary.primary_speed,
+        strength_label=primary.strength_text,
+        strength_peak_db=primary.strength_db,
+        certainty_label=primary.certainty_label_text,
+        certainty_pct=primary.certainty_pct,
+        certainty_reason=primary.certainty_reason,
+    )
 
 
 def prepare_report_mapping_context(
     prepared: PreparedReportInput | ValidatedPreparedReportInput,
 ) -> ReportMappingContext:
-    """Extract structural prepared-report context for report mapping.
-
-    Consumes the validated prepared report seam plus minimal renderer-edge
-    metadata so downstream business decisions stay domain-first without
-    depending on a raw summary payload.
-    """
-    from vibesensor.use_cases.history.report_preparation import validate_prepared_report_input
-
+    """Return the precomputed report mapping context from the validated handoff."""
     validated = validate_prepared_report_input(prepared)
-    report_facts = validated.report_facts
-    test_run = validated.domain_test_run
-    renderer_payload = validated.renderer_payload
-    report_date = renderer_payload.report_date or utc_now_iso()
-    date_str = str(report_date)[:19].replace("T", " ") + " UTC"
-
-    return ReportMappingContext(
-        car_name=renderer_payload.car_name,
-        car_type=renderer_payload.car_type,
-        date_str=date_str,
-        origin=report_facts.origin,
-        origin_location=report_facts.origin_location,
-        sensor_locations_active=list(report_facts.sensor_locations_active),
-        duration_text=report_facts.duration_text,
-        start_time_utc=report_facts.start_time_utc,
-        end_time_utc=report_facts.end_time_utc,
-        sample_rate_hz=report_facts.sample_rate_hz,
-        tire_spec_text=report_facts.tire_spec_text,
-        sample_count=report_facts.sample_count,
-        sensor_model=report_facts.sensor_model,
-        firmware_version=report_facts.firmware_version,
-        domain_aggregate=test_run,
-    )
+    return validated.mapping_context

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -23,6 +23,8 @@ from vibesensor.shared.boundaries.analysis_payload import (
 from vibesensor.shared.boundaries.diagnostic_case import test_run_from_summary
 from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.helpers import safe_filename
@@ -38,7 +40,7 @@ from vibesensor.use_cases.history.report_interpretation import (
 )
 
 if TYPE_CHECKING:
-    from vibesensor.domain import TestRun
+    from vibesensor.domain import Finding, TestRun
 
 
 def _has_projectable_payload(payload: Mapping[str, object]) -> bool:
@@ -168,6 +170,49 @@ class PreparedReportFacts:
     warnings: tuple[SummaryWarningPayload, ...]
 
 
+@dataclass(frozen=True)
+class ReportMappingContext:
+    """Normalized structural context prepared on the history side for PDF mapping."""
+
+    car_name: str | None
+    car_type: str | None
+    date_str: str
+    origin: VibrationOrigin | None
+    origin_location: str
+    sensor_locations_active: list[str]
+    duration_text: str | None
+    start_time_utc: str | None
+    end_time_utc: str | None
+    sample_rate_hz: str | None
+    tire_spec_text: str | None
+    sample_count: int
+    sensor_model: str | None
+    firmware_version: str | None
+    domain_aggregate: TestRun
+
+    def top_report_candidate(self) -> Finding | None:
+        """Return the primary report candidate (first effective top cause or finding)."""
+        effective = self.domain_aggregate.effective_top_causes()
+        if effective:
+            return effective[0]
+        non_ref = self.domain_aggregate.non_reference_findings
+        if non_ref:
+            return non_ref[0]
+        all_findings = self.domain_aggregate.findings
+        return all_findings[0] if all_findings else None
+
+    def has_significant_location_intensity(
+        self,
+        sensor_intensity: list[LocationIntensitySummary],
+    ) -> bool:
+        """Whether any sensor location shows significant above-noise intensity."""
+        for row in sensor_intensity:
+            p95 = _as_float(row.p95_intensity_db)
+            if p95 is not None and p95 > 0:
+                return True
+        return False
+
+
 @dataclass(frozen=True, slots=True)
 class PreparedReportInput:
     """Resolved report input ready for PDF mapping and rendering.
@@ -177,13 +222,13 @@ class PreparedReportInput:
       downstream PDF mapping helpers as the authoritative report aggregate.
     - ``report_facts`` contains the semantic report facts that the PDF adapter
       needs so it does not have to call back into history-layer interpretation.
-     - ``renderer_payload`` contains only the minimal final-edge payload that the
-       PDF mapper still needs after domain/report preparation is complete.
-     - ``language`` is canonicalized once so the renderer consumes one
-       consistent locale choice.
-     - ``domain_test_run`` and ``report_facts`` may still be ``None`` for
-       non-projectable inputs; call ``validate_prepared_report_input()`` before
-       entering the PDF mapping seam.
+    - ``renderer_payload`` contains only the minimal final-edge payload that the
+      PDF mapper still needs after domain/report preparation is complete.
+    - ``language`` is canonicalized once so the renderer consumes one
+      consistent locale choice.
+    - ``domain_test_run`` and ``report_facts`` may still be ``None`` for
+      non-projectable inputs; ``mapping_context`` is likewise absent until the
+      report handoff is projectable and validated for PDF mapping.
     """
 
     renderer_payload: PreparedReportRendererPayload
@@ -192,6 +237,7 @@ class PreparedReportInput:
     domain_test_run: TestRun | None
     cache_key: ReportPdfCacheKey | None = None
     report_facts: PreparedReportFacts | None = None
+    mapping_context: ReportMappingContext | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,7 +253,35 @@ class ValidatedPreparedReportInput:
     filename: str
     domain_test_run: TestRun
     report_facts: PreparedReportFacts
+    mapping_context: ReportMappingContext
     cache_key: ReportPdfCacheKey | None = None
+
+
+def _build_report_mapping_context(
+    *,
+    renderer_payload: PreparedReportRendererPayload,
+    report_facts: PreparedReportFacts,
+    test_run: TestRun,
+) -> ReportMappingContext:
+    report_date = renderer_payload.report_date or utc_now_iso()
+    date_str = str(report_date)[:19].replace("T", " ") + " UTC"
+    return ReportMappingContext(
+        car_name=renderer_payload.car_name,
+        car_type=renderer_payload.car_type,
+        date_str=date_str,
+        origin=report_facts.origin,
+        origin_location=report_facts.origin_location,
+        sensor_locations_active=list(report_facts.sensor_locations_active),
+        duration_text=report_facts.duration_text,
+        start_time_utc=report_facts.start_time_utc,
+        end_time_utc=report_facts.end_time_utc,
+        sample_rate_hz=report_facts.sample_rate_hz,
+        tire_spec_text=report_facts.tire_spec_text,
+        sample_count=report_facts.sample_count,
+        sensor_model=report_facts.sensor_model,
+        firmware_version=report_facts.firmware_version,
+        domain_aggregate=test_run,
+    )
 
 
 def validate_prepared_report_input(
@@ -220,12 +294,15 @@ def validate_prepared_report_input(
         raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
     if prepared.report_facts is None:
         raise ValueError("PreparedReportInput must include report_facts for report mapping")
+    if prepared.mapping_context is None:
+        raise ValueError("PreparedReportInput must include mapping_context for report mapping")
     return ValidatedPreparedReportInput(
         renderer_payload=prepared.renderer_payload,
         language=prepared.language,
         filename=prepared.filename,
         domain_test_run=prepared.domain_test_run,
         report_facts=prepared.report_facts,
+        mapping_context=prepared.mapping_context,
         cache_key=prepared.cache_key,
     )
 
@@ -294,18 +371,29 @@ def _build_prepared_report_input(
 ) -> PreparedReportInput:
     domain_test_run = _reconstruct_report_test_run(payload)
     prepared_language = str(normalize_lang(language or payload.get("lang")))
+    renderer_payload = _build_renderer_payload(payload)
     report_facts = (
         _prepare_report_facts(payload, test_run=domain_test_run, warnings=warnings)
         if domain_test_run is not None
         else None
     )
+    mapping_context = (
+        _build_report_mapping_context(
+            renderer_payload=renderer_payload,
+            report_facts=report_facts,
+            test_run=domain_test_run,
+        )
+        if domain_test_run is not None and report_facts is not None
+        else None
+    )
     return PreparedReportInput(
-        renderer_payload=_build_renderer_payload(payload),
+        renderer_payload=renderer_payload,
         language=prepared_language,
         filename=filename or _default_report_filename(payload),
         domain_test_run=domain_test_run,
         cache_key=cache_key,
         report_facts=report_facts,
+        mapping_context=mapping_context,
     )
 
 


### PR DESCRIPTION
## Summary

Closes #1355.

This PR moves `ReportMappingContext` preparation to the history-side report seam so the PDF adapter consumes a fully prepared context instead of rebuilding one from `PreparedReportInput`. Before this change, the report pipeline had already converged on a validated handoff object for the mapping seam, but the context that powers candidate selection and report mapping was still assembled one step later inside `adapters/pdf/report_context.py`. That meant the handoff was “prepared” in two layers: history preparation computed semantic report facts, and then the PDF adapter converted those facts plus renderer payload fields back into a `ReportMappingContext`.

The change makes the prepared-report seam the single source of truth for that context. `ReportMappingContext` is now owned and built in `use_cases/history/report_preparation.py`, stored directly on the prepared handoff, and passed through the adapter layer unchanged. The PDF adapter keeps only the adapter-specific bridge helpers it actually owns.

## Problem being solved

Issue #1355 is a direct follow-on from #1354. In the previous step, the prepared-report handoff became explicitly validated before PDF mapping began. But even with that validated seam in place, there was still a secondary assembly step:

- `report_preparation.py` prepared `PreparedReportFacts`
- `mapping.py` called `prepare_report_mapping_context(prepared)`
- `report_context.py` rebuilt `ReportMappingContext` from `renderer_payload`, `report_facts`, and `domain_test_run`

That arrangement had two drawbacks.

First, it left the seam split across two modules that had to stay synchronized. The history side already knew the exact context inputs, but the PDF adapter still owned the conversion back into a structural context object.

Second, it blurred the PDF adapter’s role. Instead of staying focused on rendering decisions, candidate selection, and template mapping, it still had to reconstruct a context object from prepared input fields. The issue explicitly called out that the report seam should converge on one canonical handoff object rather than a handoff plus another assembly step.

## Chosen implementation approach

I took the smallest change that makes the prepared-report seam the source of truth without redesigning the reporting pipeline.

The key decision was to move `ReportMappingContext` ownership into `use_cases/history/report_preparation.py` rather than teaching the use-case layer to import an adapter type. That preserves the layer direction while letting history preparation construct the exact context object that the PDF mapping layer needs. To make that possible without introducing an adapter dependency into the history layer, I also separated the one adapter-only behavior that had lived on `ReportMappingContext`: `observed_signature()`.

After the refactor, the responsibilities are clearer:

- `report_preparation.py` owns `ReportMappingContext` and precomputes it during prepared-input construction
- `PreparedReportInput` and `ValidatedPreparedReportInput` carry that precomputed context
- `report_context.py` becomes a thin adapter bridge that returns the precomputed context and keeps only adapter-specific helpers like `observed_signature()`
- `mapping.py` consumes the prepared context rather than reassembling it

## Main code changes by area

The center of the change is `apps/server/vibesensor/use_cases/history/report_preparation.py`.

I moved the `ReportMappingContext` dataclass there and kept its business-oriented helper methods (`top_report_candidate()` and `has_significant_location_intensity()`) with it. Those methods are context/business helpers, not renderer-only concerns, so they fit naturally with the history-side prepared seam once the context itself moves there.

I then added `_build_report_mapping_context()`, which constructs the context directly from the already prepared `renderer_payload`, `report_facts`, and `domain_test_run`. `_build_prepared_report_input()` now computes that context once and attaches it to the prepared handoff.

To support that, both `PreparedReportInput` and `ValidatedPreparedReportInput` now carry a `mapping_context` field. For raw prepared input it is still optional because non-projectable inputs can lack the domain aggregate and report facts entirely. For `ValidatedPreparedReportInput`, it is required. The validator now ensures the mapping context is present before the handoff enters PDF mapping.

In `apps/server/vibesensor/adapters/pdf/report_context.py`, I removed the old structural assembly logic. The module now imports the history-owned `ReportMappingContext`, exposes `prepare_report_mapping_context()` as a thin pass-through that returns `validated.mapping_context`, and keeps only the adapter-specific `observed_signature()` helper that still returns `PatternEvidence` for the renderer pipeline.

In `apps/server/vibesensor/adapters/pdf/mapping.py`, `_build_report_template_data()` still asks for a mapping context, but it now gets the precomputed one from the handoff rather than triggering a rebuild from individual prepared-input fields. It also now calls the adapter-side `observed_signature()` helper instead of relying on a method that used to live on the context type itself.

## Tests and validation

I updated the focused report-seam contract tests in `apps/server/tests/use_cases/history/test_report_preparation_contract.py` to prove the new behavior directly. In addition to the existing validation assertions from #1354, the tests now verify that:

- prepared report inputs include a precomputed mapping context
- validation preserves and exposes that exact precomputed context
- `prepare_report_mapping_context()` returns the precomputed context unchanged instead of rebuilding it

I also updated `apps/server/tests/adapters/pdf/test_report_mapping_context.py` so the observed-signature assertion targets the new adapter helper function rather than a method on the moved context type.

Then I ran the focused suite that covers the new seam and the existing report callers that depend on it:

- `python3 -m pytest -q apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py`

That passed with `41 passed`.

Broader static validation also passed:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

That lint run also rechecked backend static guards, docs lint, and schema freshness, which gives good confidence that moving the context ownership did not violate layering or disturb unrelated contracts.

Per repository workflow, I again attempted the Docker smoke command:

- `docker compose build --pull && docker compose up -d`

That still fails in this environment because there is no reachable Docker daemon socket. This is the same environment limitation encountered on prior issues in the run and is not caused by the report-context refactor in this PR.

## Risks, tradeoffs, and follow-ups

The biggest design tradeoff here was deciding how far to move responsibility. I intentionally moved the context type and its construction, but not the renderer-specific `observed_signature()` behavior. That helper still belongs in the adapter because it returns `PatternEvidence`, which is part of the PDF/report presentation layer. Keeping that split avoids creating a new history-to-adapter dependency while still making the history seam the single source of truth for structural report context.

I also kept `prepare_report_mapping_context()` as a thin adapter bridge instead of deleting it outright. That keeps the call surface stable for existing tests and callers while making the function behaviorally trivial: it now returns the precomputed context rather than rebuilding one. This matches the issue’s acceptance criteria without forcing unnecessary API churn.

I did not change candidate resolution, card building, or rendered report content. Those were explicitly out of scope, and this PR keeps them behaviorally stable while preparing the seam for the next report-boundary cleanup steps.
