### PR TITLE
Stop build_report_from_summary() from taking raw AnalysisSummary

### DIFF
--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -282,7 +282,8 @@ class TestReport:
             r.title = "new"
 
     def test_from_summary(self) -> None:
-        from vibesensor.adapters.pdf.mapping import build_report_from_summary
+        from vibesensor.adapters.pdf.mapping import prepare_report_input
+        from vibesensor.adapters.pdf.report_data import build_report_from_renderer_payload
 
         summary: dict[str, object] = {
             "run_id": "run-123",
@@ -297,7 +298,11 @@ class TestReport:
             ],
             "metadata": {"car_name": "BMW 3", "car_type": "sedan"},
         }
-        r = build_report_from_summary(summary)
+        prepared = prepare_report_input(summary)
+        r = build_report_from_renderer_payload(
+            prepared.renderer_payload,
+            language=str(summary["lang"]),
+        )
         assert r.run_id == "run-123"
         assert r.lang == "de"
         assert r.sample_count == 500
@@ -308,17 +313,27 @@ class TestReport:
         assert r.duration_s == 125.0
 
     def test_from_summary_minimal(self) -> None:
-        from vibesensor.adapters.pdf.mapping import build_report_from_summary
+        from vibesensor.adapters.pdf.mapping import prepare_report_input
+        from vibesensor.adapters.pdf.report_data import build_report_from_renderer_payload
 
-        r = build_report_from_summary({"run_id": "r1"})
+        prepared = prepare_report_input({"run_id": "r1"})
+        r = build_report_from_renderer_payload(
+            prepared.renderer_payload,
+            language=prepared.language,
+        )
         assert r.run_id == "r1"
         assert r.sample_count == 0
         assert r.car_name is None
 
     def test_from_summary_short_duration(self) -> None:
-        from vibesensor.adapters.pdf.mapping import build_report_from_summary
+        from vibesensor.adapters.pdf.mapping import prepare_report_input
+        from vibesensor.adapters.pdf.report_data import build_report_from_renderer_payload
 
-        r = build_report_from_summary({"run_id": "r1", "duration_s": 45.0})
+        prepared = prepare_report_input({"run_id": "r1", "duration_s": 45.0})
+        r = build_report_from_renderer_payload(
+            prepared.renderer_payload,
+            language=prepared.language,
+        )
         assert r.duration_s == 45.0
 
 
@@ -512,13 +527,19 @@ class TestReportValidation:
         assert r.duration_s == 0.0
 
     def test_from_summary_empty_run_id_gets_fallback(self) -> None:
-        from vibesensor.adapters.pdf.mapping import build_report_from_summary
+        from vibesensor.adapters.pdf.mapping import prepare_report_input
+        from vibesensor.adapters.pdf.report_data import build_report_from_renderer_payload
 
-        r = build_report_from_summary({"run_id": ""})
+        prepared = prepare_report_input({"run_id": ""})
+        r = build_report_from_renderer_payload(
+            prepared.renderer_payload,
+            language=prepared.language,
+        )
         assert r.run_id == "unknown"
 
     def test_from_summary_creates_metadata(self) -> None:
-        from vibesensor.adapters.pdf.mapping import build_report_from_summary
+        from vibesensor.adapters.pdf.mapping import prepare_report_input
+        from vibesensor.adapters.pdf.report_data import build_report_from_renderer_payload
 
         summary: dict[str, object] = {
             "run_id": "run-1",
@@ -530,7 +551,11 @@ class TestReportValidation:
                 },
             ],
         }
-        r = build_report_from_summary(summary)
+        prepared = prepare_report_input(summary)
+        r = build_report_from_renderer_payload(
+            prepared.renderer_payload,
+            language=prepared.language,
+        )
         assert r.run_id == "run-1"
         assert r.lang == "en"
 

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -232,3 +232,9 @@ def test_next_steps_consume_prepared_actions() -> None:
     assert "recommended_actions" in params
     assert "summary" not in params
     assert "aggregate" not in params
+
+
+def test_mapping_module_no_longer_reexports_raw_summary_report_builder() -> None:
+    import vibesensor.adapters.pdf.mapping as mapping
+
+    assert not hasattr(mapping, "build_report_from_summary")

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -34,7 +34,7 @@ from vibesensor.adapters.pdf.report_data import (
     PatternEvidence,
     Report,
     ReportTemplateData,
-    build_report_from_summary,
+    build_report_from_renderer_payload,
 )
 from vibesensor.adapters.pdf.report_sections import (
     build_data_trust,
@@ -62,7 +62,6 @@ __all__ = [
     "PreparedReportInput",
     "Report",
     "ReportMappingContext",
-    "build_report_from_summary",
     "build_system_cards",
     "humanize_signatures",
     "map_summary",
@@ -175,15 +174,9 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
     """
     validated = validate_prepared_report_input(prepared)
     lang = str(normalize_lang(validated.language))
-    report = Report(
-        run_id=validated.renderer_payload.run_id,
-        lang=lang,
-        car_name=validated.renderer_payload.car_name,
-        car_type=validated.renderer_payload.car_type,
-        report_date=validated.renderer_payload.report_date,
-        duration_s=validated.renderer_payload.duration_s,
-        sample_count=validated.renderer_payload.sample_count,
-        sensor_count=validated.renderer_payload.sensor_count,
+    report = build_report_from_renderer_payload(
+        validated.renderer_payload,
+        language=lang,
     )
 
     def tr(key: str, **kw: JsonValue) -> str:

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -9,6 +9,7 @@ Canvas-based renderer.
 from __future__ import annotations
 
 __all__ = [
+    "build_report_from_renderer_payload",
     "DataTrustItem",
     "FindingPresentation",
     "NextStep",
@@ -18,13 +19,12 @@ __all__ = [
     "Report",
     "ReportTemplateData",
     "SystemFindingCard",
-    "build_report_from_summary",
 ]
 
 from dataclasses import dataclass, field
 
-from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary, coerce_float
-from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
+from vibesensor.use_cases.history.report_preparation import PreparedReportRendererPayload
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -185,41 +185,19 @@ class ReportTemplateData:
     location_hotspot_rows: list[LocationHotspotRow] = field(default_factory=list)
 
 
-def build_report_from_summary(summary: AnalysisSummary) -> Report:
-    """Create a ``Report`` metadata object from an analysis summary."""
-    meta = summary.get("metadata") or {}
-    if not isinstance(meta, dict):
-        meta = {}
-
-    car_name = str(meta.get("car_name") or "").strip() or None
-    car_type = str(meta.get("car_type") or "").strip() or None
-
-    rows = summary.get("rows")
-    sample_count = int(rows) if isinstance(rows, (int, float, str)) else 0
-
-    sensor_count_raw = summary.get("sensor_count_used")
-    sensor_count = int(sensor_count_raw) if isinstance(sensor_count_raw, (int, float, str)) else 0
-
-    duration_s_raw = summary.get("duration_s")
-    duration_s: float | None = None
-    if duration_s_raw is not None:
-        try:
-            duration_s = coerce_float(duration_s_raw)
-        except (TypeError, ValueError):
-            pass
-
-    report_date = summary.get("report_date")
-    report_date_str = str(report_date) if isinstance(report_date, str) else None
-
-    run_id = str(summary.get("run_id", ""))
-
+def build_report_from_renderer_payload(
+    renderer_payload: PreparedReportRendererPayload,
+    *,
+    language: str,
+) -> Report:
+    """Create a ``Report`` metadata object from the prepared renderer payload."""
     return Report(
-        run_id=run_id or "unknown",
-        lang=str(summary.get("lang", "en")),
-        car_name=car_name,
-        car_type=car_type,
-        report_date=report_date_str,
-        duration_s=duration_s,
-        sample_count=sample_count,
-        sensor_count=sensor_count,
+        run_id=renderer_payload.run_id or "unknown",
+        lang=language,
+        car_name=renderer_payload.car_name,
+        car_type=renderer_payload.car_type,
+        report_date=renderer_payload.report_date,
+        duration_s=renderer_payload.duration_s,
+        sample_count=renderer_payload.sample_count,
+        sensor_count=renderer_payload.sensor_count,
     )


### PR DESCRIPTION
## Summary

Closes #1356.

This PR removes the last raw-summary report metadata entrypoint from the PDF/report adapter surface. Before this change, `apps/server/vibesensor/adapters/pdf/report_data.py` still defined `build_report_from_summary(summary: AnalysisSummary) -> Report`, and `apps/server/vibesensor/adapters/pdf/mapping.py` re-exported that helper. The wider report pipeline had already moved toward the prepared-report seam introduced in the previous issues, but this leftover helper meant callers and tests could still bypass that seam and construct report metadata directly from a raw `AnalysisSummary` dict.

The change finishes that cleanup without changing the `Report` dataclass itself or altering report metadata behavior. `Report` metadata is now built from `PreparedReportRendererPayload` via an explicit helper, and the remaining tests that had been pinning the old summary-based helper now exercise the prepared-report path instead.

## Problem being solved

Issue #1356 exists because the reporting seam had become inconsistent. The intended flow is now:

- `prepare_report_input(...)` prepares renderer payload and report facts
- `map_summary(...)` consumes the prepared handoff
- the PDF adapter maps that prepared handoff into `ReportTemplateData`

But one legacy escape hatch remained. `build_report_from_summary()` accepted a raw `AnalysisSummary`, extracted a few top-level values and metadata fields, and returned a `Report` dataclass. That was small, but it mattered for three reasons.

First, it kept a second supported-looking seam alive. Once a helper is exported from `mapping.py`, tests and future code can treat it as part of the public adapter surface even if the architectural direction has already changed.

Second, it kept raw summary parsing logic in `report_data.py`, which is supposed to be the renderer-facing dataclass layer rather than a boundary-decoding layer. The previous issues in this backlog deliberately moved report preparation toward typed, validated, history-owned handoffs. Keeping this one helper around weakened that line.

Third, it made future report cleanup harder. As long as a raw-summary helper exists, any subsequent refactor has to remember to preserve or deprecate both the prepared seam and the legacy helper. The issue’s goal is to narrow the reporting API so there is one clear path for report metadata construction.

## Chosen implementation approach

I took the smallest complete change that removes the raw-summary entrypoint without over-refactoring the reporting stack.

Instead of folding `Report` construction into some unrelated mapper helper, I introduced a new explicit helper in `report_data.py`: `build_report_from_renderer_payload(renderer_payload, *, language) -> Report`. That keeps the metadata-construction responsibility next to the `Report` dataclass while moving its inputs to the prepared seam.

The key choice here was to accept `PreparedReportRendererPayload` plus an explicit language string instead of accepting all of `PreparedReportInput`. That keeps the helper narrow and presentation-focused. It only needs the renderer-ready metadata fields, and the caller can decide whether to pass the normalized mapping language or the original explicit language string depending on context. That is important because this issue explicitly says not to change report metadata formatting behavior. The production mapping path continues to pass the normalized language it already uses, while the migrated metadata-focused tests can still preserve the older expectations where needed.

I also removed the helper re-export from `mapping.py` rather than leaving behind a compatibility alias. The repository guidance for this run is to avoid backward-compatibility shims unless they are explicitly required, and this issue specifically asks to stop exposing a raw `AnalysisSummary` entrypoint. So the cleanest outcome is for `mapping.py` to stop exporting that helper entirely.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/report_data.py`, I removed the `AnalysisSummary` import and deleted `build_report_from_summary()`. In its place, I added `build_report_from_renderer_payload()`, which constructs the same `Report` dataclass from `PreparedReportRendererPayload`. This also let me remove the local raw-dict extraction and coercion logic from that module.

In `apps/server/vibesensor/adapters/pdf/mapping.py`, I replaced the inline `Report(...)` construction inside `map_summary()` with a call to `build_report_from_renderer_payload(validated.renderer_payload, language=lang)`. I also removed the old helper from the module imports and from `__all__`, so the mapping module no longer exposes a summary-based report builder.

In `apps/server/tests/domain/test_domain_objects.py`, I rewrote the remaining metadata-focused tests that had been importing `build_report_from_summary` from `vibesensor.adapters.pdf.mapping`. Those tests now use `prepare_report_input(...)` to obtain the prepared renderer payload and then build `Report` metadata through `build_report_from_renderer_payload(...)`. The assertions stay focused on the same metadata outcomes: run id fallback, duration handling, sample counts, and extracted vehicle metadata.

In `apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py`, I added a focused guardrail asserting that `vibesensor.adapters.pdf.mapping` no longer has a `build_report_from_summary` attribute. That makes the architectural cleanup durable and catches any accidental reintroduction of the old seam in future work.

There were no schema, contract-sync, config, or user-facing documentation changes required for this issue. The change is an internal report-boundary cleanup.

## Validation and tests

I validated the change in three layers.

First, I ran the focused pytest slice that covers the migrated tests, the report mapping seam, and the prepared-input contract that now owns the data feeding this helper:

- `python3 -m pytest -q apps/server/tests/domain/test_domain_objects.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/use_cases/history/test_report_preparation_contract.py`

That passed with `90 passed`.

Second, I ran the broader backend static checks:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

Both passed. The lint workflow also reran backend static guard checks, docs lint, and schema freshness checks, which gives good confidence that removing the raw-summary helper did not reintroduce a layering violation or stale contract surface.

Third, per repository workflow, I attempted the Docker smoke validation:

- `docker compose build --pull && docker compose up -d`

That failed in the current environment because there is no reachable Docker daemon socket. This is the same external environment limitation encountered on the earlier issues in this run and is not caused by the report-helper change itself.

## Risks, tradeoffs, and edge cases considered

The main risk here was accidentally changing metadata behavior while moving the seam. I avoided that by keeping the `Report` dataclass unchanged and making the new helper a structural input swap rather than a semantic rewrite.

The most subtle case is language handling. The old helper used the raw summary `lang` value directly, while the main production mapping path already normalizes language before building template data. By making the new helper accept `language` explicitly, the caller controls which behavior is appropriate. That preserves production behavior and lets the migrated tests maintain the expectations they were previously asserting without forcing a broader behavior change into this cleanup issue.

I intentionally did not remove the `Report` dataclass, change `map_summary()` semantics beyond the helper swap, or refactor unrelated report-building helpers. Those are separate concerns. The goal here was to remove the raw-summary metadata seam cleanly and make the prepared-report path the only supported route.
