### PR TITLE
Stop build_peak_rows_from_plots() from taking raw AnalysisSummary

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+import vibesensor.adapters.pdf.peak_table as peak_table
 from vibesensor.adapters.pdf.pattern_parts import parts_for_pattern, why_parts_listed
 from vibesensor.adapters.pdf.peak_table import (
     build_peak_row,
-    build_peak_rows_from_plots,
     peak_row_system_label,
 )
 from vibesensor.adapters.pdf.presentation import (
@@ -78,7 +78,8 @@ def test_peak_classification_text_uses_translations() -> None:
 
 
 def test_extracted_pdf_builders_are_importable() -> None:
-    assert callable(build_peak_rows_from_plots)
+    assert not hasattr(peak_table, "build_peak_rows_from_plots")
+    assert "build_peak_rows_from_plots" not in peak_table.__all__
     assert callable(build_peak_row)
     assert callable(peak_row_system_label)
     assert callable(build_next_steps)

--- a/apps/server/vibesensor/adapters/pdf/peak_table.py
+++ b/apps/server/vibesensor/adapters/pdf/peak_table.py
@@ -9,12 +9,10 @@ from vibesensor.adapters.pdf.report_data import PeakRow
 from vibesensor.adapters.pdf.report_types import PeakTableRow
 from vibesensor.domain import VibrationSource
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 
 __all__ = [
     "build_peak_rows",
     "build_peak_row",
-    "build_peak_rows_from_plots",
     "peak_row_system_label",
 ]
 
@@ -30,22 +28,6 @@ def build_peak_rows(
     above_noise = [row for row in raw_peaks if (_as_float(row.get("strength_db")) or 0.0) > 0]
     ranked = above_noise or raw_peaks
     return [build_peak_row(row, lang=lang, tr=tr) for row in ranked[:8]]
-
-
-def build_peak_rows_from_plots(
-    summary: AnalysisSummary,
-    *,
-    lang: str,
-    tr: Callable[..., str],
-) -> list[PeakRow]:
-    """Build peak-table rows from the plots section."""
-    plots = summary.get("plots")
-    if not isinstance(plots, Mapping):
-        return []
-    raw_peaks = plots.get("peaks_table")
-    if not isinstance(raw_peaks, list):
-        return []
-    return build_peak_rows(raw_peaks, lang=lang, tr=tr)
 
 
 def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> PeakRow:


### PR DESCRIPTION
## Summary

Closes #1357.

This PR removes the last raw-summary peak-table helper from the PDF adapter layer. Before this change, `apps/server/vibesensor/adapters/pdf/peak_table.py` still exposed `build_peak_rows_from_plots(summary: AnalysisSummary, ...)` even though the report pipeline had already converged on the prepared-row seam. The canonical production path already extracts `peak_table_rows` during report preparation and passes those prepared rows into `build_peak_rows(...)`, so the summary-based helper had become stale surface area rather than a real dependency.

The fix is intentionally small. I deleted the unused `build_peak_rows_from_plots()` helper, removed the corresponding `AnalysisSummary` import from `peak_table.py`, and updated the remaining PDF label/importability test to assert that the raw-summary helper is gone while the prepared peak-row builders remain available. No peak-row formatting, ranking, or rendering behavior changed.

## Problem being solved

Issue #1357 is the peak-table analogue of #1356. In the prior issue, the report metadata helper that still accepted a raw `AnalysisSummary` was removed so the report mapping seam no longer exposed a summary-based shortcut. The same kind of stale pathway still existed in the peak-table code:

- `peak_table.py` exported `build_peak_rows_from_plots(summary, ...)`
- the function reached into `summary["plots"]["peaks_table"]`
- then it delegated to `build_peak_rows(...)`

That seemed harmless, but it kept the wrong architectural message alive. The reporting pipeline already has a clear ownership split:

- history-side preparation extracts renderer payload data
- the prepared renderer payload carries `peak_table_rows`
- the PDF adapter consumes those prepared rows

Keeping a raw-summary helper in the adapter layer muddied that split. Even if production no longer used it, an exported helper inside the adapter module still looks like supported API. That makes future cleanup harder, encourages test code to pin the old seam, and leaves direct `AnalysisSummary` coupling in a layer that should be working with prepared presentation inputs instead.

## Chosen implementation approach

I took the smallest complete fix that removes the stale seam without turning a dead-code cleanup into a refactor.

The key observation was that no production caller still needed migration. `apps/server/vibesensor/adapters/pdf/mapping.py` already builds peak rows from `prepared.renderer_payload.peak_table_rows`, and `apps/server/vibesensor/use_cases/history/report_preparation.py` already extracts those rows into `PreparedReportRendererPayload`. In other words, the prepared seam was not merely available; it was already the only production path.

Because of that, the right change was deletion rather than adaptation. I did not replace `build_peak_rows_from_plots()` with another helper that accepts a prepared object. That would have created a second helper surface where the existing `build_peak_rows(rows, ...)` function already does exactly what the prepared seam needs.

So the implementation goal became simpler: remove the raw-summary helper entirely, keep `build_peak_rows()` as the single supported entrypoint for prepared peak-table rows, and add a small test assertion that the stale export does not come back.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/peak_table.py`, I removed two things:

- the `AnalysisSummary` import
- the `build_peak_rows_from_plots()` helper and its `__all__` export

What remains in that module is now cleaner and more focused:

- `build_peak_rows(rows, ...)` for prepared peak-table rows
- `build_peak_row(row, ...)` for one prepared row
- `peak_row_system_label(row, ...)` for presentation labeling

That leaves the module aligned with its actual responsibility: presentation-layer construction from already prepared `PeakTableRow` values.

In `apps/server/tests/adapters/pdf/test_report_new_modules_labels.py`, I updated the one test that still depended on the old helper surface. Previously, the test imported `build_peak_rows_from_plots` and asserted it was callable. After this change, the test imports the module itself and verifies two things instead:

- `peak_table` no longer has a `build_peak_rows_from_plots` attribute
- `peak_table.__all__` no longer advertises that name

The test still checks that the real prepared-row helpers (`build_peak_row` and `peak_row_system_label`) remain importable, along with the other extracted PDF helper modules.

There were no contract, schema, config, or documentation changes required here. This PR is an internal seam cleanup in the PDF/report adapter surface.

## Why this preserves behavior

The issue explicitly says not to change peak-row formatting or ranking behavior, and this PR does not.

The deleted helper never implemented its own ranking or formatting logic. It only:

- read `plots.peaks_table` from a raw summary
- delegated to `build_peak_rows(...)`

The logic that actually matters for behavior still lives in `build_peak_rows()` and `build_peak_row()`:

- filtering rows above noise when possible
- falling back to raw rows when needed
- capping output to the top eight rows
- formatting order/frequency/db fields and system labels

Those functions were not changed. Production was already using them through the prepared-row seam before this PR, so report output remains stable.

## Validation and tests

I validated this change in the focused area first:

- `python3 -m pytest -q apps/server/tests/adapters/pdf/test_report_new_modules_labels.py`

That passed with `33 passed`.

I then ran the broader backend safety checks:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

Both passed. The lint workflow also reran the backend static guards, docs lint, and schema freshness checks, which is useful here because the issue is partly about preserving the layer boundary that keeps raw `AnalysisSummary` handling out of the PDF adapter surface.

Per repository workflow, I also attempted the Docker smoke validation:

- `docker compose build --pull && docker compose up -d`

That failed in this environment because there is no reachable Docker daemon socket. This is the same external limitation encountered on the prior issues in the run and is not caused by the peak-table cleanup itself.

## Risks, tradeoffs, and follow-ups

The regression risk here is very low because the deleted helper was effectively dead code. Still, there were two subtle points worth preserving.

First, I chose not to add a replacement helper that accepts a prepared renderer payload. That would have kept an unnecessary second abstraction layer around peak-row building even though `build_peak_rows()` already matches the prepared seam precisely. Keeping only one helper makes future changes easier to reason about.

Second, I converted the old importability test into a surface guard rather than simply deleting it. That matters because the issue is about API shape as much as code execution. By asserting that the removed helper is absent from both the module and `__all__`, the test now protects the cleanup instead of pinning the obsolete surface.

I did not widen the scope into additional PDF/report helper consolidation. The next backlog issues are still working through adjacent cleanup seams, and this PR stays narrowly focused on removing the raw-summary peak-table adapter path now that the prepared-row path is already established.
