### PR TITLE
Move test-plan payload projection out of `shared.boundaries.finding`

### DIFF
--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -18,8 +18,8 @@ from vibesensor.shared.boundaries.analysis_summary_projection import project_ana
 from vibesensor.shared.boundaries.diagnostic_case import (
     test_run_from_summary as _test_run_from_summary,
 )
-from vibesensor.shared.boundaries.finding import step_payloads_from_plan
 from vibesensor.shared.boundaries.report_interpretation import resolve_report_origin
+from vibesensor.shared.boundaries.test_plan_projection import step_payloads_from_plan
 from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_finding
 
 

--- a/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
@@ -129,3 +129,5 @@ def test_boundary_module_no_longer_owns_encoder_private_helpers() -> None:
     assert not hasattr(boundary_finding, "_finding_core_payload_from_domain")
     assert not hasattr(boundary_finding, "_finding_presentation_payload_from_domain")
     assert not hasattr(boundary_finding, "matched_point_from_observation")
+    assert not hasattr(boundary_finding, "step_payload_from_action")
+    assert not hasattr(boundary_finding, "step_payloads_from_plan")

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -15,7 +15,6 @@ from vibesensor.domain import (
 from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
 from vibesensor.domain.speed_profile_summary import SpeedProfileSummary
 from vibesensor.domain.vibration_origin import VibrationOrigin
-from vibesensor.shared.boundaries.finding import step_payloads_from_plan
 from vibesensor.shared.boundaries.summary_serialization import (
     AccelStatisticsLike,
     AnalysisSummaryBuildContext,
@@ -27,6 +26,7 @@ from vibesensor.shared.boundaries.summary_serialization import (
     serialize_plot_data,
 )
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
+from vibesensor.shared.boundaries.test_plan_projection import step_payloads_from_plan
 from vibesensor.shared.run_context_warning import build_summary_warnings
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py
@@ -6,12 +6,12 @@ from typing import cast
 
 from vibesensor.domain.test_run import TestRun
 from vibesensor.shared.boundaries.diagnostic_case import test_run_from_summary
-from vibesensor.shared.boundaries.finding import (
+from vibesensor.shared.boundaries.finding import finding_payload_from_domain
+from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
+from vibesensor.shared.boundaries.test_plan_projection import (
     _has_structured_step_content,
-    finding_payload_from_domain,
     step_payloads_from_plan,
 )
-from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
 from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_finding
 from vibesensor.shared.types.json_types import JsonObject
 

--- a/apps/server/vibesensor/shared/boundaries/finding.py
+++ b/apps/server/vibesensor/shared/boundaries/finding.py
@@ -1,47 +1,11 @@
-"""Boundary entrypoints for Finding payloads and test-plan projection."""
+"""Boundary entrypoints for Finding payload codecs."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
-from vibesensor.domain.test_plan import RecommendedAction, TestPlan
-from vibesensor.shared.boundaries.analysis_payload import TestPlanStepPayload
 from vibesensor.shared.boundaries.finding_decoder import finding_from_payload
 from vibesensor.shared.boundaries.finding_encoder import finding_payload_from_domain
 
 __all__ = [
     "finding_from_payload",
     "finding_payload_from_domain",
-    "step_payload_from_action",
-    "step_payloads_from_plan",
 ]
-
-
-def _has_structured_step_content(steps: object) -> bool:
-    if not isinstance(steps, list):
-        return False
-    for step in steps:
-        if not isinstance(step, Mapping):
-            continue
-        for key in ("what", "why", "confirm", "falsify"):
-            value = step.get(key)
-            if isinstance(value, (Mapping, list)):
-                return True
-    return False
-
-
-def step_payload_from_action(action: RecommendedAction) -> TestPlanStepPayload:
-    """Project one semantic action into the persisted TestStep shape."""
-    return {
-        "action_id": action.action_id,
-        "what": action.instruction,
-        "why": action.rationale,
-        "confirm": action.confirmation_signal,
-        "falsify": action.falsification_signal,
-        "eta": action.estimated_duration,
-    }
-
-
-def step_payloads_from_plan(test_plan: TestPlan) -> list[TestPlanStepPayload]:
-    """Project a semantic TestPlan into the persisted TestStep payload list."""
-    return [step_payload_from_action(action) for action in test_plan.prioritized_actions]

--- a/apps/server/vibesensor/shared/boundaries/test_plan_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/test_plan_projection.py
@@ -1,0 +1,43 @@
+"""Project domain test-plan objects into persisted boundary payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from vibesensor.domain.test_plan import RecommendedAction, TestPlan
+from vibesensor.shared.boundaries.analysis_payload import TestPlanStepPayload
+
+__all__ = [
+    "step_payload_from_action",
+    "step_payloads_from_plan",
+]
+
+
+def _has_structured_step_content(steps: object) -> bool:
+    if not isinstance(steps, list):
+        return False
+    for step in steps:
+        if not isinstance(step, Mapping):
+            continue
+        for key in ("what", "why", "confirm", "falsify"):
+            value = step.get(key)
+            if isinstance(value, (Mapping, list)):
+                return True
+    return False
+
+
+def step_payload_from_action(action: RecommendedAction) -> TestPlanStepPayload:
+    """Project one semantic action into the persisted test-step shape."""
+    return {
+        "action_id": action.action_id,
+        "what": action.instruction,
+        "why": action.rationale,
+        "confirm": action.confirmation_signal,
+        "falsify": action.falsification_signal,
+        "eta": action.estimated_duration,
+    }
+
+
+def step_payloads_from_plan(test_plan: TestPlan) -> list[TestPlanStepPayload]:
+    """Project a semantic TestPlan into the persisted TestStep payload list."""
+    return [step_payload_from_action(action) for action in test_plan.prioritized_actions]


### PR DESCRIPTION
Closes #1360

## Summary
This PR moves test-plan payload projection out of `apps/server/vibesensor/shared/boundaries/finding.py` and into a dedicated boundary module, `apps/server/vibesensor/shared/boundaries/test_plan_projection.py`. The change is intentionally narrow: it relocates `step_payload_from_action()`, `step_payloads_from_plan()`, and the structured-step-content guard used by summary re-projection, then repoints the handful of serializer and test imports that actually depend on that seam. It does **not** change the test-plan payload shape, and it does **not** broaden into the other remaining boundary-refactor issues.

## Problem being solved
After `#1359`, `finding.py` had already been reduced to a public facade for finding encode/decode responsibilities. The only unrelated logic left there was the test-plan projection path: projecting domain `RecommendedAction` and `TestPlan` objects into persisted summary payload rows, plus the helper that detects whether structured test-plan content is already present.

That leftover placement mattered for two reasons. First, it kept `finding.py` broader than its name and current purpose suggested. Second, it made boundary navigation harder: when someone needed to change finding codecs, test-plan payload behavior showed up in the same module even though it is a different domain concern. The issue explicitly asked to move that responsibility into a focused test-plan boundary module and leave payload behavior unchanged.

## Implementation approach
I followed the smallest complete path that matches the issue scope and the repository's current boundary conventions:

- create a dedicated shared boundary module for test-plan payload projection,
- move the two public projection helpers and the existing structured-content guard there with minimal code motion,
- remove all `RecommendedAction` / `TestPlan` references from `finding.py`,
- update the summary serialization and summary projection call sites to import from the new module,
- update the tests that exercise this seam,
- add a guardrail so `finding.py` does not quietly grow the moved helpers back.

I deliberately did **not** change any payload keys, normalization rules, or ordering behavior. The point of this PR is ownership cleanup, not contract redesign.

That means the acceptance criteria map directly onto the diff: `finding.py` no longer mentions `RecommendedAction` or `TestPlan`, the summary serializers now import test-plan projection from the dedicated module, and the behavior-facing tests still assert the same canonical payload rows as before. The structural change is visible in imports and module ownership, while the runtime behavior is pinned by the existing regression tests.

## Main code changes by area
`apps/server/vibesensor/shared/boundaries/test_plan_projection.py` is the new canonical home for the test-plan payload projection responsibility. It now owns:

- `_has_structured_step_content()`
- `step_payload_from_action()`
- `step_payloads_from_plan()`

Those functions moved essentially as-is. The new module keeps the same mapping from semantic domain fields to payload keys: `instruction -> what`, `rationale -> why`, `confirmation_signal -> confirm`, `falsification_signal -> falsify`, and `estimated_duration -> eta`. It also keeps the same list/Mapping guard logic used when deciding whether an incoming summary already contains structured step content.

`apps/server/vibesensor/shared/boundaries/finding.py` is now fully aligned with the intent of `#1359`. It only exposes the finding payload codec entrypoints, `finding_from_payload` and `finding_payload_from_domain`, via `__all__`. The test-plan projection helpers and the related domain imports are gone, and the module docstring was tightened so it now describes finding payload codecs only.

`apps/server/vibesensor/shared/boundaries/analysis_summary.py` now imports `step_payloads_from_plan` from `test_plan_projection.py` when serializing a fresh `AnalysisSummary` from a domain `TestRun`.

`apps/server/vibesensor/shared/boundaries/analysis_summary_projection.py` now imports `_has_structured_step_content()` and `step_payloads_from_plan()` from `test_plan_projection.py` while continuing to import `finding_payload_from_domain()` from `finding.py`. That split is the important architectural line in this PR: finding payload projection stays on the finding boundary, while test-plan projection moves to the test-plan boundary.

`apps/server/tests/adapters/pdf/test_summary_view.py` was updated to import `step_payloads_from_plan()` from the new module. Those tests already exercised the exact behavior this issue cares about, so they remain the best direct regression coverage for semantic action projection and canonical test-plan history projection.

`apps/server/tests/shared/boundaries/test_finding_payload_projection.py` now asserts that `finding.py` no longer exposes `step_payload_from_action()` or `step_payloads_from_plan()`. That matters because this issue is fundamentally about ownership. The guardrail ensures the module does not quietly regain unrelated test-plan helpers later.

## Contract, schema, config, and docs impact
There are no user-facing contract changes in this PR. The persisted test-plan payload shape is unchanged. No generated frontend contracts changed, no schema export needed regeneration, and no config or documentation updates were required. This is a backend boundary-ownership cleanup with behavior preservation.

## Validation and tests
I ran the validations most relevant to the moved seam:

- `pytest -q apps/server/tests/shared/boundaries apps/server/tests/adapters/pdf/test_summary_view.py`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

These checks cover the moved helper behavior, the summary re-projection path, the PDF-facing summary-view tests that directly use the projected test-plan payloads, backend typing, and the repository's static boundary guards.

I also attempted the required Docker smoke validation with `docker compose build --pull && docker compose up -d`, but that step remains blocked in this environment because no Docker daemon socket is available. This is the same environment limitation seen on the previous issues in this run, not a change introduced by this PR.

## Risks, tradeoffs, and out of scope
The main tradeoff is that `_has_structured_step_content()` remains a private helper imported across modules rather than being turned into a more public utility surface. I think that is the right choice here because it keeps the PR small and leaves the helper encapsulated inside the new test-plan boundary instead of creating extra public API surface without a real second consumer.

Another deliberate choice was **not** to touch the other remaining boundary refactors. This PR does not revisit finding encode/decode ownership from `#1359`, and it does not reach into the still-open `#1361` or `#1362` work. That keeps the change reviewable and aligned with the issue's explicit acceptance criteria.

Out of scope here: changing the `TestPlanStepPayload` shape, changing payload normalization semantics, redesigning how `diagnostic_case.py` reconstructs test-plan objects, or combining this cleanup with broader summary-serialization refactors.
