### PR TITLE
Fix release wheel validation imports

### DIFF
--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -133,6 +137,50 @@ def test_validate_release_wheel_metadata_rejects_version_mismatch(tmp_path: Path
     )
 
     assert any("does not match expected '2025.6.15'" in error for error in errors)
+
+
+def test_release_validation_cli_import_path_does_not_require_pydantic(tmp_path: Path) -> None:
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_release_wheel(wheel_path, version="2025.6.15")
+    script = textwrap.dedent(
+        f"""
+        import importlib.abc
+        import runpy
+        import sys
+
+        class _BlockPydantic(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "pydantic" or fullname.startswith("pydantic."):
+                    raise ModuleNotFoundError("No module named 'pydantic'")
+                return None
+
+        sys.meta_path.insert(0, _BlockPydantic())
+        sys.argv = [
+            "vibesensor.use_cases.updates.releases.release_validation",
+            "validate-wheel-metadata",
+            "--wheel-path",
+            {str(wheel_path)!r},
+            "--expected-version",
+            "2025.6.15",
+        ]
+        runpy.run_module(
+            "vibesensor.use_cases.updates.releases.release_validation",
+            run_name="__main__",
+        )
+        """,
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SERVER_ROOT)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Validated release wheel metadata" in result.stdout
 
 
 def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) -> None:

--- a/apps/server/vibesensor/use_cases/updates/artifact_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/artifact_validation.py
@@ -9,12 +9,14 @@ from dataclasses import dataclass
 from email.message import Message
 from email.parser import Parser
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
 
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+if TYPE_CHECKING:
+    from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 __all__ = [
     "WheelArtifactValidator",

--- a/apps/server/vibesensor/use_cases/updates/releases/releases.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/releases.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from vibesensor.use_cases.updates.artifact_validation import sha256_file
-from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+
+if TYPE_CHECKING:
+    from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
+    from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- stop importing updater status/runtime modules at import time for release artifact validation helpers
- keep `ReleaseInfo` and `UpdateStatusTracker` as type-only imports in the release helpers
- add a regression test that runs the release validation CLI while blocking `pydantic` imports

## Root cause
`main-release` runs `python -m vibesensor.use_cases.updates.releases.release_validation validate-wheel-metadata` in a fresh Python environment that only installs `build`. The package import path eagerly pulled in updater/runtime modules that require `pydantic`, so the workflow failed before it could read the wheel metadata.

## Validation
- `python3 -m ruff check apps/server/vibesensor/use_cases/updates/artifact_validation.py apps/server/vibesensor/use_cases/updates/releases/releases.py apps/server/tests/use_cases/updates/releases/test_release_validation.py`
- `python3 -m pytest -q apps/server/tests/use_cases/updates/releases/test_release_validation.py apps/server/tests/hygiene/test_main_release_workflow.py -n0`
- reproduced the release step in a fresh temp venv with only `build` installed and verified `validate-wheel-metadata` succeeds
