### PR TITLE
Finish dedup window extraction

### DIFF
--- a/apps/server/tests/infra/runtime/test_dedup_window.py
+++ b/apps/server/tests/infra/runtime/test_dedup_window.py
@@ -26,6 +26,25 @@ def test_dedup_window_prunes_entries_older_than_window_cutoff() -> None:
     assert window.contains(13) is True
 
 
+def test_dedup_window_track_detects_duplicate_sequence() -> None:
+    window = DedupWindow()
+
+    assert window.track(7) is False
+    assert window.track(7) is True
+
+
+def test_dedup_window_track_prunes_entries_using_window_size() -> None:
+    window = DedupWindow()
+
+    for seq in (10, 11, 12, 13):
+        assert window.track(seq, window_size=3) is False
+
+    assert window.contains(10) is False
+    assert window.contains(11) is True
+    assert window.contains(12) is True
+    assert window.contains(13) is True
+
+
 def test_dedup_window_clear_resets_running_max_state() -> None:
     window = DedupWindow()
     window.record(100)

--- a/apps/server/vibesensor/infra/runtime/dedup_window.py
+++ b/apps/server/vibesensor/infra/runtime/dedup_window.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 
 __all__ = ["DedupWindow"]
 
+_DEFAULT_WINDOW_SIZE = 128
+
 
 @dataclass(slots=True)
 class DedupWindow:
@@ -37,3 +39,12 @@ class DedupWindow:
         if len(self._seen_seqs) > window_size:
             cutoff = self._seen_seqs_max - window_size + 1
             self._seen_seqs = {seen for seen in self._seen_seqs if seen >= cutoff}
+
+    def track(self, seq: int, *, window_size: int = _DEFAULT_WINDOW_SIZE) -> bool:
+        """Return ``True`` for duplicates; otherwise record *seq* and prune."""
+
+        if self.contains(seq):
+            return True
+        self.record(seq)
+        self.prune(window_size)
+        return False

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -80,24 +80,6 @@ class ClientRecord:
     duplicates_received: int = 0
     dedup_window: DedupWindow = field(default_factory=DedupWindow)
 
-    # -- deduplication window helpers -----------------------------------------
-
-    def clear_dedup(self) -> None:
-        """Reset the per-client dedup window (e.g. on restart or hard reset)."""
-        self.dedup_window.clear()
-
-    def has_seq(self, seq: int) -> bool:
-        """Return True if *seq* is already in the dedup window."""
-        return self.dedup_window.contains(seq)
-
-    def record_seq(self, seq: int) -> None:
-        """Add *seq* to the dedup window and update the running max."""
-        self.dedup_window.record(seq)
-
-    def prune_seqs(self, window_size: int) -> None:
-        """Discard old entries so the window stays bounded to *window_size*."""
-        self.dedup_window.prune(window_size)
-
 
 @dataclass(frozen=True, slots=True)
 class ClientRecordSnapshot:
@@ -229,7 +211,7 @@ class ClientRegistry:
             if record.firmware_version and hello.firmware_version != record.firmware_version:
                 record.reset_count += 1
                 record.last_reset_time = now_ts
-                record.clear_dedup()
+                record.dedup_window.clear()
             record.firmware_version = hello.firmware_version
             record.queue_overflow_drops = hello.queue_overflow_drops
             self._metadata.apply_advertised_name(record, hello.name)

--- a/apps/server/vibesensor/infra/runtime/registry_updates.py
+++ b/apps/server/vibesensor/infra/runtime/registry_updates.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 
 __all__ = ["DataUpdateResult", "apply_data_message_update"]
 
-_DEDUP_WINDOW = 128
 _RESTART_SEQ_GAP = 1000
 _JITTER_EMA_ALPHA = 0.2
 _SEQ_MASK = 0xFFFFFFFF
@@ -61,17 +60,15 @@ def apply_data_message_update(
     if _is_short_session_restart(record, seq=seq, t0_us=t0_us):
         # A restarted short-lived sender can reuse low sequence numbers with a
         # strictly newer t0_us before the large-gap reset heuristic fires.
-        record.clear_dedup()
+        record.dedup_window.clear()
         record.last_seq = None
         record.last_t0_us = None
         record.timing_jitter_us_ema = 0.0
         record.timing_drift_us_total = 0.0
-    elif record.has_seq(seq):
+
+    if record.dedup_window.track(seq):
         record.duplicates_received += 1
         return DataUpdateResult(is_duplicate=True)
-
-    record.record_seq(seq)
-    record.prune_seqs(_DEDUP_WINDOW)
 
     record.frames_total += 1
     reset_detected = False
@@ -96,8 +93,8 @@ def apply_data_message_update(
             record.last_t0_us = None
             record.timing_jitter_us_ema = 0.0
             record.timing_drift_us_total = 0.0
-            record.clear_dedup()
-            record.record_seq(seq)
+            record.dedup_window.clear()
+            record.dedup_window.track(seq)
             reset_detected = True
         else:
             expected = (record.last_seq + 1) & _SEQ_MASK


### PR DESCRIPTION
## Summary

This PR resolves issue #1386 by finishing the remaining dedup-window extraction around runtime client bookkeeping. The original issue body described moving `ClientRecord` dedup window tracking into a dedicated helper, but the current codebase had already completed part of that refactor before this change: `DedupWindow` already existed as its own runtime helper. The stale part of the issue was the assumption that the helper did not yet exist.

What still remained open was the ownership of dedup *policy*. `ClientRecord` still exposed wrapper methods like `clear_dedup()`, `has_seq()`, `record_seq()`, and `prune_seqs()`, which meant the record API still presented dedup tracking as one of its own responsibilities. On top of that, `registry_updates.py` still coordinated the actual duplicate-check / record / prune lifecycle inline, including its own `_DEDUP_WINDOW` policy constant.

This PR closes that gap by making `DedupWindow` own the helper-level “track this sequence” operation directly, removing the now-obsolete dedup wrapper methods from `ClientRecord`, and routing the runtime registry update flow through the helper instead of reassembling that policy outside it.

## Implementation approach

The main goal here was to avoid a redundant refactor. Because `DedupWindow` already existed and already had focused unit coverage, the right fix was not to invent another abstraction or migrate raw sequence state out of `ClientRecord` again. Instead, I tightened the remaining boundary so the existing helper owns the lifecycle that the registry actually cares about.

I also wanted to keep the runtime semantics unchanged. Duplicate counting, short-session restart handling, hard reset detection, and frame accounting are all behavioral edges already covered by registry tests. The refactor needed to preserve those semantics while reducing the amount of dedup policy leaked through `ClientRecord` and `registry_updates.py`.

## Main code changes

### `apps/server/vibesensor/infra/runtime/dedup_window.py`

`DedupWindow` now owns a new `track()` method. That method performs the concrete operation that runtime callers need:

- check whether a sequence number is already present in the window
- return `True` for duplicates
- otherwise record the new sequence
- prune the window to its bounded size
- return `False` for first-seen sequences

This is the missing piece that makes the helper responsible for dedup tracking rather than just passive storage primitives. The existing low-level methods (`clear()`, `contains()`, `record()`, and `prune()`) remain intact, but callers that need the real “dedup lifecycle” no longer have to coordinate those steps themselves.

### `apps/server/vibesensor/infra/runtime/registry.py`

`ClientRecord` no longer exposes the dedup wrapper methods:

- `clear_dedup()`
- `has_seq()`
- `record_seq()`
- `prune_seqs()`

Those methods were thin delegation layers over `dedup_window`, but they still made dedup policy look like a direct `ClientRecord` responsibility. Removing them reduces the surface area of the record object and makes the ownership clearer: the record stores a `DedupWindow`, and the helper itself owns dedup tracking behavior.

`ClientRegistry.update_from_hello()` now clears the helper directly through `record.dedup_window.clear()` when a firmware-version change indicates a reset boundary.

### `apps/server/vibesensor/infra/runtime/registry_updates.py`

The runtime DATA update path is where the live seam really existed, and this PR simplifies it directly.

Before this change, the update flow performed dedup tracking as a three-step inline sequence:

1. ask `ClientRecord` whether the sequence had already been seen
2. if not, record the sequence
3. prune the window using a separate `_DEDUP_WINDOW` constant in `registry_updates.py`

That meant the helper existed, but the call site still owned the actual tracking policy.

After this change, `apply_data_message_update()` simply delegates that lifecycle to `record.dedup_window.track(seq)` and reacts to the returned duplicate flag. The short-session restart path and the hard-reset path still clear the window exactly where they did before, but they now work directly with the helper object instead of via wrapper methods. The dedicated `_DEDUP_WINDOW` constant is no longer needed in `registry_updates.py`, because the helper owns the default pruning behavior.

The important part is that this is a structural cleanup, not a behavior change. Duplicate retransmits still increment `duplicates_received` and return early without inflating frame counters. Restart handling still clears the seen-sequence window before tracking the new sequence. Hard resets still clear the dedup state and re-record the new baseline sequence.

## Tests

The existing registry tests already cover the behavior that mattered most here, especially:

- duplicate detection
- duplicate retransmits not inflating `frames_total`
- out-of-order frames that are not duplicates still being accepted
- sensor reset clearing the seen-sequence window
- short-session restarts beyond the dedup window not being misclassified as duplicates
- ultra-short restarts reusing low sequence numbers safely

Because those behavioral tests already existed, I kept them as the main regression net and added focused unit coverage where the helper boundary actually changed.

`apps/server/tests/infra/runtime/test_dedup_window.py` now includes dedicated tests for the new `track()` method:

- one verifies that the second observation of the same sequence returns `True` for duplicate detection
- one verifies that `track()` prunes old entries using the bounded window size

That gives the new helper-level API direct unit coverage without needing a full registry fixture, which matches the original intent of the issue.

## Contract, schema, config, and documentation impact

There are no HTTP contract, schema, configuration, or documentation changes in this PR. This is a focused runtime refactor inside the backend registry bookkeeping layer.

## Validation performed

I ran the relevant local checks for the touched runtime area plus the standard backend quality gates:

- `pytest -q apps/server/tests/infra/runtime/test_dedup_window.py apps/server/tests/infra/runtime/test_registry.py` → `30 passed`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make test-changed` → `5 passed`

I also attempted the required Docker smoke validation with:

- `docker compose build --pull && docker compose up -d`

That step is still blocked in this environment because Docker cannot connect to a daemon socket (`docker.errors.DockerException` / missing Unix socket). This is the same environment limitation seen on the previous issues in this run, not a regression introduced by this diff.

## Risks, tradeoffs, and edge cases considered

The main risk here was introducing a subtle semantic drift in duplicate handling while “cleaning up” the helper boundary. To reduce that risk, I kept the low-level helper methods in place, limited the production refactor to the runtime dedup flow, and validated against the existing registry regression set that already exercises duplicates, resets, and restart edges.

A second tradeoff was whether to move more reset/timing state into a broader helper at the same time. I intentionally did not. Those concerns are adjacent, but they are not dedup-window tracking itself, and bundling them into this issue would have broadened the scope well past the actual live seam.

## Out of scope

This PR does not refactor broader `ClientRecord` metadata, snapshot generation, or timing drift logic. It only completes the remaining move of dedup tracking policy into the dedicated helper that already existed.
