### PR TITLE
Extract lifecycle background task coordinator

### DIFF
--- a/apps/server/tests/infra/runtime/test_background_task_coordinator.py
+++ b/apps/server/tests/infra/runtime/test_background_task_coordinator.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+import pytest
+
+from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.infra.runtime.task_supervisor import TaskSupervisor
+
+
+async def _stubborn_task() -> None:
+    first_wait = asyncio.Event()
+    second_wait = asyncio.Event()
+    try:
+        await first_wait.wait()
+    except asyncio.CancelledError:
+        await second_wait.wait()
+
+
+@pytest.mark.asyncio
+async def test_start_monitors_failure_via_task_supervisor() -> None:
+    health_state = RuntimeHealthState()
+    supervisor = TaskSupervisor(
+        health_state=health_state,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+    coordinator = BackgroundTaskCoordinator(
+        monitor_task=supervisor.monitor_task,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+
+    async def _fail() -> None:
+        raise RuntimeError("boom")
+
+    task = coordinator.start(_fail(), name="update-startup-recover")
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert health_state.background_task_failures["update-startup-recover"] == "boom"
+    assert coordinator.tasks == [task]
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_retains_pending_tasks_after_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import vibesensor.infra.runtime.background_task_coordinator as coordinator_module
+
+    coordinator = BackgroundTaskCoordinator(
+        monitor_task=lambda task: None,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+    stubborn = asyncio.create_task(_stubborn_task(), name="stubborn-background")
+    coordinator.tasks = [stubborn]
+    await asyncio.sleep(0)
+
+    async def _wait_pending(tasks, timeout):
+        del timeout
+        await asyncio.sleep(0)
+        return set(), set(tasks)
+
+    monkeypatch.setattr(coordinator_module.asyncio, "wait", _wait_pending)
+
+    with caplog.at_level(logging.WARNING):
+        lingering = await coordinator.cancel_all(timeout_s=1.0)
+
+    assert lingering == [stubborn]
+    assert coordinator.tasks == [stubborn]
+    assert "stubborn-background" in caplog.text
+    assert "remain pending" in caplog.text
+
+    stubborn.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await stubborn
+
+
+@pytest.mark.asyncio
+async def test_retain_pending_drops_completed_tasks() -> None:
+    coordinator = BackgroundTaskCoordinator(
+        monitor_task=lambda task: None,
+        logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
+    )
+    done_task = asyncio.create_task(asyncio.sleep(0), name="completed-background")
+    coordinator.tasks = [done_task]
+
+    await done_task
+
+    assert coordinator.retain_pending() == []
+    assert coordinator.tasks == []

--- a/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
@@ -65,7 +65,7 @@ async def test_stop_retains_background_tasks_that_outlive_cancel_timeout(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    import vibesensor.infra.runtime.lifecycle as lifecycle_module
+    import vibesensor.infra.runtime.background_task_coordinator as coordinator_module
 
     lifecycle = _make_lifecycle()
     stubborn = asyncio.create_task(_stubborn_task(), name="stubborn-background")
@@ -77,7 +77,7 @@ async def test_stop_retains_background_tasks_that_outlive_cancel_timeout(
         await asyncio.sleep(0)
         return set(), set(tasks)
 
-    monkeypatch.setattr(lifecycle_module.asyncio, "wait", _wait_pending)
+    monkeypatch.setattr(coordinator_module.asyncio, "wait", _wait_pending)
 
     with caplog.at_level(logging.WARNING):
         await lifecycle.stop()

--- a/apps/server/vibesensor/infra/runtime/__init__.py
+++ b/apps/server/vibesensor/infra/runtime/__init__.py
@@ -4,12 +4,13 @@ Submodules
 ----------
 - ``builders``: focused service builders
 - ``client_metadata``: persisted/user-assigned client metadata helpers
+- ``background_task_coordinator``: lifecycle-owned task tracking + cancellation
 - ``registry_updates``: DATA-message dedup/reset bookkeeping
 - ``processing_loop``: ProcessingLoop (async tick loop + failure tracking)
 - ``task_supervisor``: TaskSupervisor (managed restart policy + backoff)
 - ``udp_transport_lifecycle``: UdpTransportLifecycle (UDP startup + cleanup seam)
 - ``ws_broadcast``: WsBroadcastService (payload assembly + cache)
-- ``lifecycle``: LifecycleManager (start/stop + task management)
+- ``lifecycle``: LifecycleManager (phase sequencing + graceful shutdown)
 - ``rotational_speeds``: Stateless rotational speed payload helpers
 """
 

--- a/apps/server/vibesensor/infra/runtime/background_task_coordinator.py
+++ b/apps/server/vibesensor/infra/runtime/background_task_coordinator.py
@@ -1,0 +1,67 @@
+"""Background task tracking and coordinated cancellation for runtime services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+
+MonitorTask = Callable[[asyncio.Task[object]], None]
+
+
+class BackgroundTaskCoordinator:
+    """Track lifecycle-owned background tasks and cancel them coherently."""
+
+    __slots__ = ("_logger", "_monitor_task", "_tasks")
+
+    def __init__(
+        self,
+        *,
+        monitor_task: MonitorTask,
+        logger: logging.Logger,
+    ) -> None:
+        self._monitor_task = monitor_task
+        self._logger = logger
+        self._tasks: list[asyncio.Task[object]] = []
+
+    @property
+    def tasks(self) -> list[asyncio.Task[object]]:
+        return self._tasks
+
+    @tasks.setter
+    def tasks(self, tasks: list[asyncio.Task[object]]) -> None:
+        self._tasks = tasks
+
+    def add(self, task: asyncio.Task[object]) -> asyncio.Task[object]:
+        self._tasks.append(task)
+        return task
+
+    def start(
+        self,
+        coroutine: Coroutine[object, object, object],
+        *,
+        name: str,
+    ) -> asyncio.Task[object]:
+        task = asyncio.create_task(coroutine, name=name)
+        self._monitor_task(task)
+        self._tasks.append(task)
+        return task
+
+    def retain_pending(self) -> list[asyncio.Task[object]]:
+        self._tasks = [task for task in self._tasks if not task.done()]
+        return list(self._tasks)
+
+    async def cancel_all(self, *, timeout_s: float) -> list[asyncio.Task[object]]:
+        for task in self._tasks:
+            task.cancel()
+        if not self._tasks:
+            return []
+        _done, pending = await asyncio.wait(self._tasks, timeout=timeout_s)
+        if pending:
+            self._logger.warning(
+                "%d background task(s) did not finish within the cancellation "
+                "deadline and remain pending: %s",
+                len(pending),
+                [task.get_name() for task in pending],
+            )
+        return self.retain_pending()

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.task_supervisor import TaskSupervisor, task_failure_message
 from vibesensor.infra.runtime.udp_transport_lifecycle import StartUdpReceiver, UdpTransportLifecycle
@@ -129,11 +130,11 @@ class LifecycleManager:
     """Manages server startup (UDP receiver, background tasks) and graceful shutdown."""
 
     __slots__ = (
+        "_background_tasks",
         "_health_state",
         "_runtime",
         "_task_supervisor",
         "_udp_transport_lifecycle",
-        "tasks",
     )
 
     def __init__(
@@ -148,56 +149,24 @@ class LifecycleManager:
             health_state=self._health_state,
             logger=LOGGER,
         )
-        self._udp_transport_lifecycle = UdpTransportLifecycle(
-            start_udp_receiver=start_udp_receiver,
-            monitor_task=self._monitor_task,
+        self._background_tasks = BackgroundTaskCoordinator(
+            monitor_task=self._task_supervisor.monitor_task,
             logger=LOGGER,
         )
-        self.tasks: list[asyncio.Task[object]] = []
+        self._udp_transport_lifecycle = UdpTransportLifecycle(
+            start_udp_receiver=start_udp_receiver,
+            monitor_task=self._task_supervisor.monitor_task,
+            logger=LOGGER,
+        )
+        self.tasks = []
 
-    def _monitor_task(self, task: asyncio.Task[object]) -> None:
-        task_name = task.get_name()
+    @property
+    def tasks(self) -> list[asyncio.Task[object]]:
+        return self._background_tasks.tasks
 
-        def _record_failure(done_task: asyncio.Task[object]) -> None:
-            if done_task.cancelled():
-                return
-            try:
-                exc = done_task.exception()
-            except asyncio.CancelledError:
-                return
-            if exc is None:
-                return
-            message = task_failure_message(exc)
-            self._health_state.record_task_failure(task_name, message)
-            LOGGER.error("Managed task %s failed: %s", task_name, message, exc_info=exc)
-
-        task.add_done_callback(_record_failure)
-
-    def _start_task(
-        self,
-        coroutine: Coroutine[object, object, object],
-        *,
-        name: str,
-    ) -> asyncio.Task[object]:
-        task = asyncio.create_task(coroutine, name=name)
-        self._monitor_task(task)
-        return task
-
-    async def _cancel_background_tasks(self, *, timeout_s: float) -> list[asyncio.Task[object]]:
-        for task in self.tasks:
-            task.cancel()
-        if not self.tasks:
-            return []
-        _done, _pending = await asyncio.wait(self.tasks, timeout=timeout_s)
-        if _pending:
-            LOGGER.warning(
-                "%d background task(s) did not finish within the cancellation "
-                "deadline and remain pending: %s",
-                len(_pending),
-                [task.get_name() for task in _pending],
-            )
-        self.tasks = [task for task in self.tasks if not task.done()]
-        return list(self.tasks)
+    @tasks.setter
+    def tasks(self, tasks: list[asyncio.Task[object]]) -> None:
+        self._background_tasks.tasks = tasks
 
     @staticmethod
     async def _cancel_managed_tasks(
@@ -266,7 +235,7 @@ class LifecycleManager:
 
             phase = "processing-loop"
             self._health_state.set_phase(phase)
-            self.tasks.append(
+            self._background_tasks.add(
                 self._task_supervisor.start(
                     lambda: self._runtime.processing_loop.run(),
                     name=phase,
@@ -275,7 +244,7 @@ class LifecycleManager:
 
             phase = "ws-broadcast"
             self._health_state.set_phase(phase)
-            self.tasks.append(
+            self._background_tasks.add(
                 self._task_supervisor.start(
                     lambda: self._runtime.ws_hub.run(
                         UI_PUSH_HZ,
@@ -288,7 +257,7 @@ class LifecycleManager:
 
             phase = "metrics-log"
             self._health_state.set_phase(phase)
-            self.tasks.append(
+            self._background_tasks.add(
                 self._task_supervisor.start(
                     lambda: self._runtime.run_recorder.run(),
                     name=phase,
@@ -297,7 +266,7 @@ class LifecycleManager:
 
             phase = "gps-speed"
             self._health_state.set_phase(phase)
-            self.tasks.append(
+            self._background_tasks.add(
                 self._task_supervisor.start(
                     lambda: self._runtime.gps_monitor.run(
                         host=self._runtime.gpsd_host,
@@ -309,11 +278,9 @@ class LifecycleManager:
 
             phase = "update-startup-recover"
             self._health_state.set_phase(phase)
-            self.tasks.append(
-                self._start_task(
-                    self._runtime.update_manager.startup_recover(),
-                    name=phase,
-                ),
+            self._background_tasks.start(
+                self._runtime.update_manager.startup_recover(),
+                name=phase,
             )
             self._health_state.mark_ready()
         except Exception as exc:
@@ -328,7 +295,7 @@ class LifecycleManager:
             LOGGER.warning("Error closing control plane", exc_info=True)
         await self._udp_transport_lifecycle.shutdown()
 
-        lingering_background_tasks = await self._cancel_background_tasks(timeout_s=15.0)
+        await self._background_tasks.cancel_all(timeout_s=15.0)
 
         # Cancel any in-progress update or flash jobs so cleanup
         # (e.g. hotspot restore) can run before shutdown completes.
@@ -367,7 +334,7 @@ class LifecycleManager:
             self._runtime.history_db.close()
         except Exception:
             LOGGER.warning("Error closing history DB", exc_info=True)
-        self.tasks = [task for task in self.tasks if not task.done()]
+        lingering_background_tasks = self._background_tasks.retain_pending()
         lingering_task_names = [
             *(task.get_name() for task in lingering_background_tasks if not task.done()),
             *(task.get_name() for task in lingering_managed_tasks if not task.done()),

--- a/apps/server/vibesensor/infra/runtime/task_supervisor.py
+++ b/apps/server/vibesensor/infra/runtime/task_supervisor.py
@@ -55,7 +55,7 @@ class TaskSupervisor:
         self._max_delay_s = max_delay_s
         self._reset_after_s = reset_after_s
 
-    def _monitor_task(self, task: asyncio.Task[object]) -> None:
+    def monitor_task(self, task: asyncio.Task[object]) -> None:
         task_name = task.get_name()
 
         def _record_failure(done_task: asyncio.Task[object]) -> None:
@@ -137,5 +137,5 @@ class TaskSupervisor:
                 self._health_state.clear_task_failure(name)
 
         task = asyncio.create_task(_run_supervised(), name=name)
-        self._monitor_task(task)
+        self.monitor_task(task)
         return task


### PR DESCRIPTION
## Summary

This PR addresses issue #1389 by finishing the extraction of lifecycle-managed task supervision out of `LifecycleManager` without redoing the restart/backoff work that already lives in `TaskSupervisor`. When I scoped the issue against current `main`, the original issue text was partially stale: the exponential restart policy, restart-attempt limits, and backoff timing had already been moved into `TaskSupervisor`, but `LifecycleManager` still owned a second task-management seam around that work. In practice, that remaining seam included three responsibilities that were still implemented directly in `lifecycle.py`: creating one-shot background tasks, keeping the lifecycle-owned background task list in sync, and cancelling that task set with timeout-aware lingering-task logging during shutdown. The goal of this PR is to extract that remaining coordination logic into a focused helper so `LifecycleManager` is left with phase sequencing and shutdown orchestration rather than low-level task bookkeeping.

## Problem

Before this change, `LifecycleManager` still contained `_monitor_task()`, `_start_task()`, and `_cancel_background_tasks()` even though the runtime already had a dedicated `TaskSupervisor` for managed restart behavior. That left two closely related task-management implementations in the same runtime area: one in `TaskSupervisor` for restartable services such as the processing loop, WebSocket broadcast loop, metrics recorder, and GPS monitor, and another in `LifecycleManager` for non-restarting background task creation and cancellation. The duplication was not only structural. The same failure-recording callback pattern existed in both places, which made the lifecycle code carry supervision concerns that the newer helper-based design was already trying to remove. It also meant that future lifecycle changes would still have to reason about task monitoring details in multiple places instead of routing through one focused seam.

## Approach

The implementation keeps the previously extracted restart/backoff policy in place and narrows the live scope of the issue to the remaining background-task coordination seam. Instead of broadening `TaskSupervisor` into a mixed “everything about tasks” utility, this PR adds a dedicated `BackgroundTaskCoordinator` alongside the existing runtime helpers. The coordinator owns exactly the responsibilities that were still local to `LifecycleManager`: tracking lifecycle-owned background tasks, starting one-shot tasks that should be monitored but not restarted, cancelling the tracked set during shutdown, and pruning the lingering task list after cancellation attempts. That leaves `TaskSupervisor` responsible for restart policy and failure normalization, while the new coordinator owns task-list lifecycle and coordinated shutdown.

## Main code changes

The new `apps/server/vibesensor/infra/runtime/background_task_coordinator.py` module is the core of the change. It introduces `BackgroundTaskCoordinator`, a small helper that stores the lifecycle-owned background task list, starts named background coroutines, records them in the tracked set, and performs timeout-aware bulk cancellation. It also exposes a `retain_pending()` helper so shutdown code can re-evaluate which tasks are still unfinished after the rest of shutdown completes. The warning text for lingering tasks remains behaviorally consistent with the previous inline implementation.

`TaskSupervisor` now exposes `monitor_task()` as a public method instead of keeping that callback registration private. That is a small but important seam change: both the new coordinator and `UdpTransportLifecycle` can now reuse the same failure-recording path that normalizes task exceptions into bounded health-state messages and logs them consistently. The supervised `start()` path continues to call the same monitoring logic, so there is no behavior fork between restarted tasks and one-shot monitored tasks.

`LifecycleManager` was then simplified to delegate rather than implement task bookkeeping. The constructor now creates a `BackgroundTaskCoordinator` and passes `TaskSupervisor.monitor_task` into both the coordinator and `UdpTransportLifecycle`. The direct lifecycle-owned implementations of `_monitor_task()`, `_start_task()`, and `_cancel_background_tasks()` are removed. During startup, supervised tasks are still created via `TaskSupervisor.start(...)`, but they are now tracked through the coordinator rather than appended to a lifecycle-owned list directly. The one-shot `update-startup-recover` task is created through `BackgroundTaskCoordinator.start(...)`, which preserves monitoring without introducing restart behavior. During shutdown, background task cancellation now flows through `BackgroundTaskCoordinator.cancel_all(...)`, after which `LifecycleManager` only needs to combine lingering background tasks with lingering managed update/flash jobs for final logging.

There is one intentionally small compatibility seam left in `LifecycleManager`: the `tasks` attribute remains available as a thin property over the coordinator’s task list. This keeps existing lifecycle tests readable and preserves the current internal contract used around runtime startup/shutdown assertions without putting the supervision logic back into `LifecycleManager` itself.

I also updated the runtime package docstring in `infra/runtime/__init__.py` so the helper list matches the current structure of this package.

## Tests and validation

The refactor comes with focused coverage in a new `apps/server/tests/infra/runtime/test_background_task_coordinator.py` module. Those tests cover monitoring of one-shot task failure through the shared `TaskSupervisor.monitor_task()` seam, timeout-aware cancellation that retains lingering tasks, and pruning of completed tasks from the tracked set. I also updated `test_lifecycle_shutdown_consistency.py` so the lingering-background-task test monkeypatches the new helper module’s `asyncio.wait` call site instead of the old inline lifecycle implementation.

Local validation included:

- `pytest -q apps/server/tests/infra/runtime/test_background_task_coordinator.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py apps/server/tests/infra/runtime/test_task_supervisor.py apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py`
- `pytest -q apps/server/tests/infra/runtime`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make test-changed`

All of the above passed locally. I also ran the required Docker smoke attempt with `docker compose build --pull && docker compose up -d`, but this environment still does not have a reachable Docker daemon socket, so that step failed for the same infrastructure reason seen earlier in the run rather than because of a code regression.

## Risks, tradeoffs, and out of scope

The main tradeoff here is that `LifecycleManager` still orchestrates shutdown ordering and still owns the separate cancellation path for update/ESP flash managed jobs. I intentionally did not broaden this PR to refactor those shutdown-specific concerns, because the live issue seam was the lifecycle-owned background task supervision path, not the full shutdown pipeline. Similarly, I did not fold background task tracking into `TaskSupervisor`; keeping restart policy separate from task-list coordination makes the runtime helpers easier to reason about and keeps one-shot tasks from accidentally inheriting restart semantics.

No API contracts, schemas, or user-facing behavior changed in this PR. The change is internal runtime structure only, with the goal of making the lifecycle code thinner, more maintainable, and less likely to accumulate another round of duplicated task-management logic.
