### PR TITLE
Extract location assignment validator

### DIFF
--- a/apps/server/tests/infra/test_location_assignment_validator.py
+++ b/apps/server/tests/infra/test_location_assignment_validator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.infra.location_assignment_validator import (
+    AssignedLocation,
+    LocationAssignmentValidator,
+)
+
+
+def test_normalize_strips_whitespace() -> None:
+    validator = LocationAssignmentValidator()
+
+    assert validator.normalize("  front-left  ") == "front-left"
+
+
+def test_normalize_caps_utf8_bytes_without_splitting_codepoints() -> None:
+    validator = LocationAssignmentValidator(max_utf8_bytes=64)
+
+    normalized = validator.normalize("€" * 25)
+
+    assert len(normalized.encode("utf-8")) <= 64
+    assert normalized.encode("utf-8").decode("utf-8") == normalized
+
+
+def test_validate_assignment_rejects_duplicate_location() -> None:
+    validator = LocationAssignmentValidator()
+
+    with pytest.raises(ValueError, match="Location 'front_left' already assigned to Rear Left"):
+        validator.validate_assignment(
+            owner_id="aabbccddeeff",
+            location_code="front_left",
+            assigned_locations=[
+                AssignedLocation(
+                    owner_id="112233445566",
+                    owner_name="Rear Left",
+                    location_code="front_left",
+                ),
+            ],
+        )
+
+
+def test_validate_assignment_allows_reassigning_same_owner() -> None:
+    validator = LocationAssignmentValidator()
+
+    validator.validate_assignment(
+        owner_id="aabbccddeeff",
+        location_code="front_left",
+        assigned_locations=[
+            AssignedLocation(
+                owner_id="aabbccddeeff",
+                owner_name="Front Left",
+                location_code="front_left",
+            ),
+        ],
+    )

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -49,6 +49,10 @@ from vibesensor.infra.config.car_settings import (
     _clamp_str,
 )
 from vibesensor.infra.config.settings_derivation import analysis_settings_snapshot_from_aspects
+from vibesensor.infra.location_assignment_validator import (
+    AssignedLocation,
+    LocationAssignmentValidator,
+)
 from vibesensor.shared.boundaries.settings_snapshot_codec import (
     coerce_language_code as _coerce_language,
 )
@@ -87,6 +91,7 @@ from vibesensor.shared.types.speed_source_config import (
 )
 
 LOGGER = logging.getLogger(__name__)
+_LOCATION_VALIDATOR = LocationAssignmentValidator()
 
 VALID_LANGUAGES: frozenset[str] = frozenset(get_args(LanguageCode))
 """Supported UI languages — derived from ``LanguageCode``."""
@@ -328,20 +333,18 @@ class SettingsStore:
                 updated.name = name or sensor_id
             if "location_code" in data:
                 location_code = _clamp_str(data["location_code"], 64)
-                if location_code:
-                    conflict = next(
-                        (
-                            other
-                            for other_id, other in self._sensors.items()
-                            if other_id != sensor_id and other.location_code == location_code
-                        ),
-                        None,
-                    )
-                    if conflict is not None:
-                        conflict_name = conflict.name or conflict.sensor_id
-                        raise ValueError(
-                            f"Location '{location_code}' already assigned to {conflict_name}",
+                _LOCATION_VALIDATOR.validate_assignment(
+                    owner_id=sensor_id,
+                    location_code=location_code,
+                    assigned_locations=(
+                        AssignedLocation(
+                            owner_id=other_id,
+                            owner_name=other.name or other.sensor_id,
+                            location_code=other.location_code,
                         )
+                        for other_id, other in self._sensors.items()
+                    ),
+                )
                 updated.location_code = location_code
             self._sensors[sensor_id] = updated
             return True

--- a/apps/server/vibesensor/infra/location_assignment_validator.py
+++ b/apps/server/vibesensor/infra/location_assignment_validator.py
@@ -1,0 +1,48 @@
+"""Shared location-assignment validation for runtime and settings infrastructure."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+__all__ = ["AssignedLocation", "LocationAssignmentValidator"]
+
+
+@dataclass(frozen=True, slots=True)
+class AssignedLocation:
+    owner_id: str
+    owner_name: str
+    location_code: str
+
+
+class LocationAssignmentValidator:
+    """Normalize registry locations and reject duplicate assignments."""
+
+    __slots__ = ("_max_utf8_bytes",)
+
+    def __init__(self, *, max_utf8_bytes: int = 64) -> None:
+        self._max_utf8_bytes = max_utf8_bytes
+
+    def normalize(self, location: str) -> str:
+        clean = location.strip()
+        encoded = clean.encode("utf-8", errors="ignore")
+        if len(encoded) <= self._max_utf8_bytes:
+            return clean
+        return encoded[: self._max_utf8_bytes].decode("utf-8", errors="ignore")
+
+    def validate_assignment(
+        self,
+        *,
+        owner_id: str,
+        location_code: str,
+        assigned_locations: Iterable[AssignedLocation],
+    ) -> None:
+        if not location_code:
+            return
+        for assigned in assigned_locations:
+            if assigned.owner_id == owner_id or assigned.location_code != location_code:
+                continue
+            conflict_name = assigned.owner_name or assigned.owner_id
+            raise ValueError(
+                f"Location '{location_code}' already assigned to {conflict_name}",
+            )

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -12,6 +12,10 @@ from dataclasses import dataclass, field
 from threading import RLock
 
 from vibesensor.domain import normalize_sensor_id
+from vibesensor.infra.location_assignment_validator import (
+    AssignedLocation,
+    LocationAssignmentValidator,
+)
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 from vibesensor.infra.runtime.dedup_window import DedupWindow
@@ -28,6 +32,7 @@ from vibesensor.shared.ports import (
 from vibesensor.shared.types.payload_types import ClientMetrics
 
 LOGGER = logging.getLogger(__name__)
+_LOCATION_VALIDATOR = LocationAssignmentValidator()
 
 __all__ = [
     "ClientRecord",
@@ -299,25 +304,22 @@ class ClientRegistry:
         ValueError
             If the location is already assigned to a different client.
         """
-        clean = location.strip()
-        # Cap at 64 UTF-8 bytes without splitting multi-byte characters.
-        encoded = clean.encode("utf-8", errors="ignore")
-        if len(encoded) > 64:
-            clean = encoded[:64].decode("utf-8", errors="ignore")
+        normalized_client_id = normalize_sensor_id(client_id)
+        clean = _LOCATION_VALIDATOR.normalize(location)
         with self._lock:
-            if clean:
-                conflict = next(
-                    (
-                        cid
-                        for cid, rec in self._clients.items()
-                        if cid != normalize_sensor_id(client_id) and rec.location_code == clean
-                    ),
-                    None,
-                )
-                if conflict is not None:
-                    conflict_name = self._clients[conflict].name or conflict
-                    raise ValueError(f"Location '{clean}' already assigned to {conflict_name}")
-            record = self._get_or_create(client_id)
+            _LOCATION_VALIDATOR.validate_assignment(
+                owner_id=normalized_client_id,
+                location_code=clean,
+                assigned_locations=(
+                    AssignedLocation(
+                        owner_id=cid,
+                        owner_name=rec.name or cid,
+                        location_code=rec.location_code,
+                    )
+                    for cid, rec in self._clients.items()
+                ),
+            )
+            record = self._get_or_create(normalized_client_id)
             record.location_code = clean
             return record
 


### PR DESCRIPTION
## Summary

This PR addresses issue #1391 by extracting sensor-location assignment policy into a focused validator instead of leaving that behavior embedded inside `ClientRegistry.set_location()`. When I scoped the issue against current `main`, the original issue description was directionally correct but no longer complete: `ClientRegistry.set_location()` still bundled whitespace trimming, UTF-8-safe 64-byte capping, duplicate-location detection, and final mutation, but the codebase had also grown a second copy of the duplicate-location rule in `SettingsStore.set_sensor()` for persisted sensor metadata. The practical maintenance problem was no longer just one crowded registry method. The same “is this location already assigned to a different sensor?” policy was now split across multiple infrastructure paths, which made it easy for future changes to drift between live runtime behavior and persisted settings behavior. This PR extracts that policy into a shared validator so the registry stops owning validation details directly and the settings store stops carrying a parallel uniqueness scan.

## Problem

Before this change, `ClientRegistry.set_location()` mixed several independent concerns in one method. It normalized user input by trimming whitespace, truncated the result to 64 UTF-8 bytes without splitting multi-byte characters, scanned the in-memory client map for conflicts, formatted the duplicate-assignment error message, and then finally mutated the client record. That was exactly the seam called out in the issue. However, the live architecture had evolved since the issue was written. The main user-facing HTTP/settings flow for location assignment now persists through `SettingsStore.set_sensor()` rather than mutating `ClientRegistry` directly, and `SettingsStore.set_sensor()` had picked up its own inline duplicate-location scan with the same error shape. The issue therefore represented a broader code-health problem than the title alone suggested: the location-assignment policy was duplicated across runtime and settings infrastructure, but only one copy had an explicit refactor issue attached to it.

## Approach

The implementation keeps the external behavior unchanged but moves the policy boundary into a small helper: `LocationAssignmentValidator`. I placed it under `vibesensor/infra/` rather than inside `runtime/` or `config/` because both of the current consumers live in infrastructure code and neither should need to depend on the other’s subpackage. The validator exposes two responsibilities that match the current behavior split. First, it provides `normalize()` for the runtime registry’s existing whitespace trimming and UTF-8-safe byte cap. Second, it provides `validate_assignment()` for duplicate-location detection against a supplied collection of already assigned locations. That keeps the validator focused on policy and lets each caller remain responsible for its own record mutation and snapshot/persistence flow.

## Main code changes

The new `apps/server/vibesensor/infra/location_assignment_validator.py` module introduces `AssignedLocation` and `LocationAssignmentValidator`. `AssignedLocation` is a small typed value used to describe an existing owner/location pairing plus the owner’s display name for conflict reporting. `LocationAssignmentValidator.normalize()` preserves the registry’s current normalization contract, including the UTF-8 byte-safe 64-byte cap. `validate_assignment()` accepts the target owner ID, the proposed location code, and the currently assigned locations, then raises the same `ValueError` message shape when a duplicate assignment is found.

`ClientRegistry.set_location()` is now much thinner. It normalizes the incoming client ID once, delegates location normalization to the validator, delegates duplicate-location checking to the validator while holding the registry lock, and then performs only the record mutation itself. That means the method no longer embeds policy logic directly, and the focused validator tests can exercise normalization/conflict behavior without requiring full registry setup.

`SettingsStore.set_sensor()` now reuses the same duplicate-assignment validator for persisted sensor configuration updates. I intentionally did not change its existing `_clamp_str(..., 64)` normalization path, because the issue was about extracting validation ownership, not silently changing the settings-path normalization contract. The resulting split is deliberate: the registry keeps its established UTF-8 byte-safe normalization through `LocationAssignmentValidator.normalize()`, while both runtime and settings code share the same duplicate-assignment rule and conflict-message behavior.

## Tests and validation

The refactor adds a new focused test module at `apps/server/tests/infra/test_location_assignment_validator.py`. Those tests cover whitespace trimming, UTF-8-safe byte capping, duplicate-assignment rejection, and the same-owner reassignment case. This gives the extracted policy the standalone coverage the issue asked for without pushing more assertions into the registry lock-management tests.

I also kept the existing behavior coverage in place by running the suites that exercise the touched callers and the relevant HTTP boundary:

- `pytest -q apps/server/tests/infra/test_location_assignment_validator.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py`
- `pytest -q apps/server/tests/infra`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make test-changed`

All of the above passed locally. I also ran the required Docker smoke attempt with `docker compose build --pull && docker compose up -d`, but this environment still does not have a reachable Docker daemon socket, so that step failed for the same infrastructure reason seen in earlier issues during this run rather than due to a code regression.

## Risks, tradeoffs, and out of scope

The main tradeoff is that the validator currently centralizes duplicate-assignment policy across runtime and settings infrastructure but does not attempt to unify every location-code normalization path in the codebase. In particular, `SettingsStore.set_sensor()` still uses its existing character-based `_clamp_str()` helper, while the registry keeps the older UTF-8-byte-aware normalization contract. I left that difference in place intentionally because changing settings normalization semantics would go beyond the refactor requested here and could create externally visible behavior drift without explicit issue scope.

I also did not remove `ClientRegistry.set_location()` even though the main HTTP location-assignment flow now persists through `SettingsStore`. The method still exists, is covered by tests, and is used by runtime/integration test scenarios, so this PR focuses on extracting its validation responsibilities rather than redesigning its place in the architecture.

No HTTP contracts, schemas, or user-visible API shapes changed in this PR. The goal is purely to narrow validation ownership, reduce duplication, and make location-assignment rules easier to test and evolve without reworking registry mutation logic and settings persistence logic in parallel.
