### PR TITLE
Extract finding payload-part schemas

### DIFF
--- a/apps/server/tests/shared/types/test_finding_payload_parts.py
+++ b/apps/server/tests/shared/types/test_finding_payload_parts.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import get_type_hints
+
+from vibesensor.shared.types.finding_payload_parts import (
+    FindingCorePayload,
+    FindingPresentationPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import FindingPayload
+
+
+def test_finding_payload_part_types_keep_core_and_presentation_split() -> None:
+    finding_payload_fields = set(get_type_hints(FindingPayload))
+    core_fields = set(get_type_hints(FindingCorePayload))
+    presentation_fields = set(get_type_hints(FindingPresentationPayload))
+
+    assert {"finding_id", "suspected_source", "evidence_metrics"} <= core_fields
+    assert {"evidence_summary", "frequency_hz_or_order", "amplitude_metric"} <= presentation_fields
+    assert core_fields.isdisjoint(
+        {"evidence_summary", "frequency_hz_or_order", "amplitude_metric"},
+    )
+    assert presentation_fields.isdisjoint({"finding_id", "suspected_source", "evidence_metrics"})
+    assert core_fields | presentation_fields <= finding_payload_fields

--- a/apps/server/vibesensor/shared/boundaries/finding_encoder.py
+++ b/apps/server/vibesensor/shared/boundaries/finding_encoder.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import cast
 
-from typing_extensions import TypedDict
-
 from vibesensor.domain import Finding
 from vibesensor.domain.order_match import OrderMatchObservation
 from vibesensor.shared.boundaries.analysis_payload import (
@@ -16,6 +14,10 @@ from vibesensor.shared.boundaries.analysis_payload import (
     PhaseEvidence,
 )
 from vibesensor.shared.json_utils import i18n_ref, payload_value_from_json
+from vibesensor.shared.types.finding_payload_parts import (
+    FindingCorePayload,
+    FindingPresentationPayload,
+)
 from vibesensor.shared.types.history_analysis_contracts import FindingPayload
 
 
@@ -43,45 +45,9 @@ def _amplitude_metric_payload(finding: Finding) -> AmplitudeMetric:
     }
 
 
-class _FindingCorePayload(TypedDict, total=False):
-    """Internal domain-owned finding payload fields."""
-
-    finding_id: str
-    finding_key: str | None
-    suspected_source: str
-    confidence: float | None
-    finding_kind: str | None
-    severity: str | None
-    matched_points: list[MatchedPoint]
-    location_hotspot: LocationHotspotPayload | None
-    strongest_location: str | None
-    strongest_speed_band: str | None
-    dominant_phase: str | None
-    dominance_ratio: float | None
-    weak_spatial_separation: bool
-    diffuse_excitation: bool
-    phase_evidence: PhaseEvidence | None
-    evidence_metrics: FindingEvidenceMetrics | None
-    ranking_score: float | None
-    peak_classification: str | None
-    signatures_observed: list[str]
-    order: str | None
-
-
-class _FindingPresentationPayload(TypedDict, total=False):
-    """Internal rendering-oriented finding metadata."""
-
-    evidence_summary: str
-    frequency_hz_or_order: float | str
-    amplitude_metric: AmplitudeMetric
-    confidence_label_key: str | None
-    confidence_tone: str | None
-    confidence_pct: str | None
-
-
-def _finding_core_payload_from_domain(finding: Finding) -> _FindingCorePayload:
+def _finding_core_payload_from_domain(finding: Finding) -> FindingCorePayload:
     """Project only the domain-owned finding fields."""
-    payload: _FindingCorePayload = {
+    payload: FindingCorePayload = {
         "finding_id": finding.finding_id,
         "finding_key": finding.finding_key,
         "suspected_source": str(finding.suspected_source),
@@ -172,9 +138,9 @@ def _finding_core_payload_from_domain(finding: Finding) -> _FindingCorePayload:
 
 def _finding_presentation_payload_from_domain(
     finding: Finding,
-) -> _FindingPresentationPayload:
+) -> FindingPresentationPayload:
     """Project rendering- and report-oriented finding metadata."""
-    payload: _FindingPresentationPayload = {
+    payload: FindingPresentationPayload = {
         "evidence_summary": "",
         "frequency_hz_or_order": (
             finding.frequency_hz if finding.frequency_hz is not None else finding.order or ""

--- a/apps/server/vibesensor/shared/types/finding_payload_parts.py
+++ b/apps/server/vibesensor/shared/types/finding_payload_parts.py
@@ -1,0 +1,51 @@
+"""Internal finding payload-part contracts used by the finding encoder."""
+
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+from vibesensor.shared.types.analysis_views import (
+    FindingEvidenceMetrics,
+    LocationHotspotPayload,
+    MatchedPoint,
+    PhaseEvidence,
+)
+from vibesensor.shared.types.history_analysis_contracts import AmplitudeMetric
+
+__all__ = ["FindingCorePayload", "FindingPresentationPayload"]
+
+
+class FindingCorePayload(TypedDict, total=False):
+    """Internal domain-owned finding payload fields."""
+
+    finding_id: str
+    finding_key: str | None
+    suspected_source: str
+    confidence: float | None
+    finding_kind: str | None
+    severity: str | None
+    matched_points: list[MatchedPoint]
+    location_hotspot: LocationHotspotPayload | None
+    strongest_location: str | None
+    strongest_speed_band: str | None
+    dominant_phase: str | None
+    dominance_ratio: float | None
+    weak_spatial_separation: bool
+    diffuse_excitation: bool
+    phase_evidence: PhaseEvidence | None
+    evidence_metrics: FindingEvidenceMetrics | None
+    ranking_score: float | None
+    peak_classification: str | None
+    signatures_observed: list[str]
+    order: str | None
+
+
+class FindingPresentationPayload(TypedDict, total=False):
+    """Internal rendering-oriented finding metadata."""
+
+    evidence_summary: str
+    frequency_hz_or_order: float | str
+    amplitude_metric: AmplitudeMetric
+    confidence_label_key: str | None
+    confidence_tone: str | None
+    confidence_pct: str | None


### PR DESCRIPTION
## Summary

This PR addresses issue #1392 by extracting the internal finding payload-part TypedDicts out of `apps/server/vibesensor/shared/boundaries/finding_encoder.py` and into a focused internal contract module. The outward `FindingPayload` contract already lives in `shared.types.history_analysis_contracts`, but the encoder still defined two private schema fragments inline: one for domain-owned/core finding data and one for presentation/report-oriented metadata. That left `finding_encoder.py` responsible for both serialization logic and the definitions of the internal payload-part contracts it was composing. This change separates those concerns without changing the outward payload shape or the encoder behavior.

## Problem

Before this PR, `finding_encoder.py` contained three different kinds of logic in one file. First, it had the actual encoder behavior: converting domain `Finding` objects into persisted/public payload dictionaries. Second, it had leaf serialization helpers such as `matched_point_from_observation()` and `_amplitude_metric_payload()`. Third, it also owned the definitions of the internal core/presentation payload fragments as private `TypedDict`s (`_FindingCorePayload` and `_FindingPresentationPayload`). Those fragment types are not the public contract, but they are still schema definitions with their own maintenance cost. Keeping them inline inside the encoder meant that schema ownership and serialization behavior were coupled in the same implementation file.

That coupling matters because the codebase already distinguishes outward shared contracts from internal helper shapes. `FindingPayload` lives in `shared.types.history_analysis_contracts`, and other supporting payload/view types live in `shared.types.analysis_views`. Leaving the internal finding payload-part schemas inside the encoder made the encoder a second schema home instead of only a serialization home. It also made it harder to write a focused test that locks the intended split between core and presentation fragments independently of the encoder’s runtime value projection.

## Approach

The implementation keeps the scope deliberately narrow. I did not change `FindingPayload`, any outward boundary fields, or the encoder’s composition logic. Instead, I introduced a small internal contract module under `shared/types/` named `finding_payload_parts.py`. That module owns exactly the two extracted internal schema fragments: `FindingCorePayload` and `FindingPresentationPayload`. They remain internal shared types used by the encoder, not new outward API contracts.

This placement is intentional. The issue called for a dedicated internal schema home, and `shared/types/` is already the stable location for shared payload/schema contracts and helper TypedDict definitions. Putting these two fragments there keeps them near the outward analysis/history contracts they support, while still leaving the actual encoder behavior in `shared/boundaries/finding_encoder.py`.

## Main code changes

The new `apps/server/vibesensor/shared/types/finding_payload_parts.py` module now defines the extracted internal payload-part schemas. `FindingCorePayload` carries the domain-owned fields such as `finding_id`, `suspected_source`, `matched_points`, `location_hotspot`, `phase_evidence`, `evidence_metrics`, `ranking_score`, and related diagnostic metadata. `FindingPresentationPayload` carries the presentation-oriented fields such as `evidence_summary`, `frequency_hz_or_order`, `amplitude_metric`, and the confidence-label/tone/pct metadata. The new module imports its leaf payload types directly from `shared.types.analysis_views` and `shared.types.history_analysis_contracts`, which keeps it aligned with the current contract ownership structure rather than routing those type definitions back through a boundary helper module.

`finding_encoder.py` is correspondingly simpler. The inline private `TypedDict` definitions are removed, and the file now imports `FindingCorePayload` and `FindingPresentationPayload` from the new module. The helper functions `_finding_core_payload_from_domain()` and `_finding_presentation_payload_from_domain()` continue to do the same projection work as before; only their return annotations and local payload variable types changed to use the extracted contracts. `finding_payload_from_domain()` still composes the final outward payload the same way by merging the core and presentation payload fragments and casting the result to `FindingPayload`.

Importantly, this PR does not redesign the split itself. The current separation between “core” and “presentation” remains exactly the same; the change is only about moving the schema ownership for those fragments out of the encoder implementation file.

## Tests and validation

To lock that intended split in place, I added a focused schema-level test at `apps/server/tests/shared/types/test_finding_payload_parts.py`. That test uses `get_type_hints()` to verify four things:

- the expected core-only fields remain in `FindingCorePayload`
- the expected presentation-only fields remain in `FindingPresentationPayload`
- those two sets stay disjoint where intended
- the union of the internal fragment fields remains a subset of the outward `FindingPayload` contract

This complements the existing encoder behavior tests rather than duplicating them. The existing projection test in `test_finding_payload_projection.py` still verifies that the encoder composes the core and presentation payloads into the final outward payload correctly, and the roundtrip tests continue to exercise the serialization/deserialization behavior through `FindingPayload`.

Local validation included:

- `pytest -q apps/server/tests/shared/types/test_finding_payload_parts.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `pytest -q apps/server/tests/shared`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make test-changed`

All of the above passed locally. I also ran the required Docker smoke attempt with `docker compose build --pull && docker compose up -d`, but this environment still lacks a reachable Docker daemon socket, so that step failed for the same infrastructure reason seen in earlier issues during this run rather than because of this change.

## Risks, tradeoffs, and out of scope

The main tradeoff is that this PR does not attempt a broader contract redesign. It does not move any fields between the core and presentation fragments, does not change `FindingPayload`, and does not touch other adjacent refactor issues around finding-field ownership. That restraint is intentional: issue #1392 is specifically about extracting the internal payload-part schemas, and keeping the field split itself stable makes the change easier to review and safer to merge.

I also did not move the leaf payload aliases such as `MatchedPoint`, `PhaseEvidence`, or `AmplitudeMetric`; those already have established homes in the shared type modules. This PR simply makes the internal core/presentation composition layer explicit instead of leaving it buried inside the encoder file.

No outward API schema, persisted payload shape, or domain semantics changed in this PR. The goal is structural clarity: one focused internal schema home for the encoder’s payload fragments, and a thinner encoder file that can concentrate on serialization behavior rather than co-owning the fragment type definitions.
