### PR TITLE
Clarify summary wrapper ownership

### DIFF
--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -11,9 +11,6 @@ from vibesensor.adapters.http.models.history import (
     AmpVsPhaseRow as ApiAmpVsPhaseRow,
 )
 from vibesensor.adapters.http.models.history import (
-    AnalysisSummaryResponse as ApiAnalysisSummaryResponse,
-)
-from vibesensor.adapters.http.models.history import (
     DataQualityAccelSanityResponse as ApiDataQualityAccelSanityResponse,
 )
 from vibesensor.adapters.http.models.history import (
@@ -206,6 +203,9 @@ from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary as BoundaryAnalysisSummary,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummaryResponse as ApiAnalysisSummaryResponse,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
     FindingPayload as BoundaryFindingPayload,
 )
 
@@ -315,3 +315,12 @@ def test_shared_analysis_history_shapes_have_single_owner_alias(
         f"{name} should be re-exported from one shared owner instead of "
         "duplicated across boundary and api_models.history modules"
     )
+
+
+def test_http_history_models_do_not_reexport_shared_summary_wrappers() -> None:
+    import vibesensor.adapters.http.models as http_models
+    import vibesensor.adapters.http.models.history as history_models
+
+    assert not hasattr(history_models, "AnalysisSummaryCoreResponse")
+    assert not hasattr(history_models, "AnalysisSummaryResponse")
+    assert not hasattr(http_models, "AnalysisSummaryResponse")

--- a/apps/server/vibesensor/adapters/http/models/__init__.py
+++ b/apps/server/vibesensor/adapters/http/models/__init__.py
@@ -31,7 +31,6 @@ from .health import (
 from .history import (
     AmplitudeMetric,
     AmpVsPhaseRow,
-    AnalysisSummaryResponse,
     DeleteHistoryRunResponse,
     FindingEvidenceMetrics,
     FindingPayload,
@@ -130,7 +129,6 @@ __all__ = [
     "HistoryListEntryResponse",
     "HistoryListResponse",
     "HistoryRunResponse",
-    "AnalysisSummaryResponse",
     "HistoryInsightsAnalyzingResponse",
     "HistoryInsightWarningResponse",
     "AmpVsPhaseRow",

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -1,10 +1,10 @@
 """History and finding-oriented HTTP API models.
 
 Stable exact analysis/history view shapes live in
-``vibesensor.shared.types.analysis_views``. Shared wrapper/composite contracts
-that must stay aligned with persisted boundary payloads live in
-``vibesensor.shared.types.history_analysis_contracts`` so this module only
-keeps HTTP-specific wrappers and localized response models.
+``vibesensor.shared.types.analysis_views``. Canonical shared summary wrappers
+live in ``vibesensor.shared.types.history_analysis_contracts`` and are imported
+privately here so this module only exports adapter-local wrappers and
+localized response models.
 """
 
 from __future__ import annotations
@@ -31,8 +31,6 @@ from vibesensor.shared.types.analysis_views import (
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     AmplitudeMetric,
-    AnalysisSummaryCoreResponse,
-    AnalysisSummaryResponse,
     DataQualityAccelSanityResponse,
     DataQualityOutliersResponse,
     DataQualityRequiredMissingPctResponse,
@@ -52,14 +50,18 @@ from vibesensor.shared.types.history_analysis_contracts import (
     SuspectedVibrationOriginPayload,
     TestPlanStepResponse,
 )
+from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummaryCoreResponse as _SharedAnalysisSummaryCoreResponse,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummaryResponse as _SharedAnalysisSummaryResponse,
+)
 
 from .base import ApiPayloadObject, _StrictBase
 
 __all__ = [
     "AmplitudeMetric",
     "AmpVsPhaseRow",
-    "AnalysisSummaryCoreResponse",
-    "AnalysisSummaryResponse",
     "DataQualityAccelSanityResponse",
     "DataQualityOutliersResponse",
     "DataQualityRequiredMissingPctResponse",
@@ -120,7 +122,7 @@ class HistoryRunResponse(_StrictBase):
     sample_count: int
     error_message: str | None = None
     metadata: ApiPayloadObject = Field(default_factory=dict)
-    analysis: AnalysisSummaryResponse | None = None
+    analysis: _SharedAnalysisSummaryResponse | None = None
 
 
 class HistoryInsightWarningResponse(BaseModel):
@@ -140,7 +142,7 @@ class HistoryInsightsAnalyzingResponse(BaseModel):
     status: Literal["analyzing"]
 
 
-class HistoryInsightsResponse(AnalysisSummaryCoreResponse, total=False):
+class HistoryInsightsResponse(_SharedAnalysisSummaryCoreResponse, total=False):
     """Response body for the localized history insights endpoint payload."""
 
     status: Annotated[Literal["complete"], Field(default="complete")]

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -305,7 +305,7 @@ class SuspectedVibrationOriginPayload(TypedDict, total=False):
 
 
 class AnalysisSummaryCoreResponse(TypedDict, total=False):
-    """Shared core fields reused by persisted and localized history summaries."""
+    """Canonical shared owner for persisted/localized summary core fields."""
 
     file_name: Required[str]
     run_id: Required[str]
@@ -352,7 +352,7 @@ class AnalysisSummaryCoreResponse(TypedDict, total=False):
 
 
 class AnalysisSummaryResponse(AnalysisSummaryCoreResponse):
-    """Typed HTTP contract for the persisted analysis summary on one history run."""
+    """Canonical shared owner for the persisted analysis summary wrapper."""
 
     warnings: Required[list[SummaryWarningResponse]]
 

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -641,7 +641,7 @@
       },
       "AnalysisSummaryResponse": {
         "additionalProperties": false,
-        "description": "Typed HTTP contract for the persisted analysis summary on one history run.",
+        "description": "Canonical shared owner for the persisted analysis summary wrapper.",
         "properties": {
           "accel_scale_g_per_lsb": {
             "anyOf": [

--- a/apps/ui/src/generated/http_api_contracts.ts
+++ b/apps/ui/src/generated/http_api_contracts.ts
@@ -446,7 +446,7 @@ export interface components {
     };
     /**
      * AnalysisSummaryResponse
-     * @description Typed HTTP contract for the persisted analysis summary on one history run.
+     * @description Canonical shared owner for the persisted analysis summary wrapper.
      */
     AnalysisSummaryResponse: {
       /** Accel Scale G Per Lsb */


### PR DESCRIPTION
## Summary

This PR addresses issue #1393 by making the ownership boundary between the shared summary wrapper contracts and the HTTP-local history wrappers explicit in code, exports, and tests. The actual payload shape is unchanged. The problem on current `main` was signaling and module ownership: `vibesensor.shared.types.history_analysis_contracts` already documented itself as the canonical owner of the shared analysis/history wrapper contracts, but `vibesensor.adapters.http.models.history` and `vibesensor.adapters.http.models.__init__` still re-exported `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse` in a way that made the HTTP layer look like a peer owner. This PR removes that ambiguity by keeping the shared summary wrappers canonical in `history_analysis_contracts`, importing them privately where the HTTP layer needs them for local composition, and adding a hygiene guard so the adapter layer does not drift back into acting like a second owner.

## Problem

Before this change, there were two conflicting signals in the codebase. On one hand, `history_analysis_contracts.py` explicitly said that `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse` were the canonical shared wrapper contracts reused across boundary and HTTP flows. On the other hand, `adapters/http/models/history.py` imported those same types under their public names, listed them in `__all__`, and `adapters/http/models/__init__.py` re-exported `AnalysisSummaryResponse` again from the top-level HTTP models package. That structure did not create a runtime bug, but it blurred ownership in exactly the area the issue describes. A maintainer inspecting the HTTP model layer could reasonably conclude that the shared summary wrappers were also owned there, or at least that the adapter layer was a peer contract surface rather than a consumer of the canonical shared types.

That ambiguity also leaked into the hygiene tests. The API/boundary parity test imported `AnalysisSummaryResponse` from the HTTP models module, which unintentionally reinforced the idea that the adapter layer was the place to reach for the shared wrapper. The codebase therefore had the right ownership statement in prose but mixed signals in exports and tests.

## Approach

The implementation keeps the schema stable and focuses only on ownership signaling. I did not rename any payload fields, change any endpoint responses, or redesign the summary wrappers. Instead, I made the HTTP layer clearly consume the shared wrappers rather than publicly re-export them. The shared summary wrappers remain defined in `history_analysis_contracts.py`, and the HTTP history models continue to use them for composition and annotations where appropriate, but those imports are now private implementation details instead of part of the HTTP models’ public symbol surface.

## Main code changes

`apps/server/vibesensor/adapters/http/models/history.py` now imports `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse` under private aliases (`_SharedAnalysisSummaryCoreResponse` and `_SharedAnalysisSummaryResponse`). That is the key ownership signal in the code: the HTTP history module still depends on the shared wrappers, but it no longer exposes them as if they were adapter-owned HTTP models. `HistoryRunResponse.analysis` still references the shared `AnalysisSummaryResponse` shape via the private alias, and `HistoryInsightsResponse` still layers its localized wrapper fields on top of the shared core response, but the public API of the module now consists only of actual adapter-local wrappers and the directly reused shared shapes that are intended to be publicly aliased there.

`apps/server/vibesensor/adapters/http/models/history.py` also drops `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse` from `__all__`, and `apps/server/vibesensor/adapters/http/models/__init__.py` no longer re-exports `AnalysisSummaryResponse` from the top-level HTTP models package. There were no in-repo consumers of those HTTP-layer re-exports, so this is a clean ownership correction rather than a compatibility change the codebase depends on.

On the shared side, `apps/server/vibesensor/shared/types/history_analysis_contracts.py` now makes the canonical-owner wording more direct in the docstrings for `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse`. The previous wording described what they were; the new wording makes it explicit that these wrappers are the canonical shared owners.

Finally, `apps/server/tests/hygiene/test_api_model_boundary_parity.py` now imports `AnalysisSummaryResponse` directly from the shared owner instead of the HTTP history module, and it adds a focused hygiene assertion that `adapters.http.models.history` and `adapters.http.models` do not re-expose the shared summary wrappers. That guard is the regression test this issue was really missing: it will fail if the adapter layer starts acting like a second owner again.

## Tests and validation

Because the docstring changes on the shared summary wrappers flow into the generated OpenAPI descriptions, this PR also refreshes the committed `apps/ui/src/contracts/http_api_schema.json` artifact and the derived `apps/ui/src/generated/http_api_contracts.ts` file. The payload schema itself is unchanged; only the ownership wording in the schema descriptions changed.

Validation included:

- `pytest -q apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py`
- `pytest -q apps/server/tests/adapters/http apps/server/tests/hygiene`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make test-changed`

`test-changed` also exercised the changed UI contract artifacts through `ui-typecheck`, which reran the contract sync check, frontend lint, frontend typecheck, and the changed-area pytest selection. All of the above passed locally. I also ran the required Docker smoke attempt with `docker compose build --pull && docker compose up -d`, but this environment still lacks a reachable Docker daemon socket, so that step failed for the same infrastructure reason seen throughout this backlog run rather than due to this change.

## Risks, tradeoffs, and out of scope

The main tradeoff is that this PR intentionally solves the ownership signal without redesigning the wrappers themselves. `HistoryInsightsResponse` still composes from the shared core wrapper, and `HistoryRunResponse` still references the shared persisted summary wrapper; the change is that those dependencies are now clearly private to the adapter layer instead of looking like adapter-owned contracts. This keeps the refactor small and avoids bundling schema redesign work into an ownership clarification issue.

I also did not attempt to stop every shared-shape re-export from the HTTP history module. The issue is specifically about the summary wrapper ownership line, so I limited the export correction and the new hygiene assertion to `AnalysisSummaryCoreResponse` and `AnalysisSummaryResponse`. Other shared shape aliases remain untouched in this PR.

No response payload fields, endpoint behavior, or persisted summary semantics changed here. The goal is architectural clarity: one canonical shared owner for the summary wrappers, one adapter-local history wrapper layer, and tests that make that line explicit instead of inferred.
