### PR TITLE
Split finding payload core and rendering contracts

### DIFF
--- a/apps/server/tests/shared/types/test_finding_payload_parts.py
+++ b/apps/server/tests/shared/types/test_finding_payload_parts.py
@@ -6,18 +6,27 @@ from vibesensor.shared.types.finding_payload_parts import (
     FindingCorePayload,
     FindingPresentationPayload,
 )
-from vibesensor.shared.types.history_analysis_contracts import FindingPayload
+from vibesensor.shared.types.finding_payload_parts import (
+    FindingPayload as SplitFindingPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    FindingPayload as SharedFindingPayload,
+)
 
 
-def test_finding_payload_part_types_keep_core_and_presentation_split() -> None:
-    finding_payload_fields = set(get_type_hints(FindingPayload))
+def test_finding_payload_uses_split_core_and_presentation_types() -> None:
+    finding_payload_fields = set(get_type_hints(SharedFindingPayload))
     core_fields = set(get_type_hints(FindingCorePayload))
     presentation_fields = set(get_type_hints(FindingPresentationPayload))
 
+    assert SharedFindingPayload is SplitFindingPayload
     assert {"finding_id", "suspected_source", "evidence_metrics"} <= core_fields
     assert {"evidence_summary", "frequency_hz_or_order", "amplitude_metric"} <= presentation_fields
     assert core_fields.isdisjoint(
         {"evidence_summary", "frequency_hz_or_order", "amplitude_metric"},
     )
     assert presentation_fields.isdisjoint({"finding_id", "suspected_source", "evidence_metrics"})
-    assert core_fields | presentation_fields <= finding_payload_fields
+    assert core_fields | presentation_fields == finding_payload_fields
+    assert SharedFindingPayload.__required_keys__ == (
+        FindingCorePayload.__required_keys__ | FindingPresentationPayload.__required_keys__
+    )

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -63,8 +63,8 @@ def test_findings_module_no_longer_reexports_helper_names() -> None:
         assert not hasattr(findings_module, helper_name)
 
 
-def test_finding_typed_dict_exposes_core_contract() -> None:
-    """FindingPayload TypedDict must expose all expected core fields."""
+def test_finding_typed_dict_exposes_shared_finding_contract() -> None:
+    """FindingPayload TypedDict must expose the shared outward finding fields."""
     hints = get_type_hints(FindingPayload)
     assert {
         "finding_id",

--- a/apps/server/vibesensor/shared/boundaries/finding_encoder.py
+++ b/apps/server/vibesensor/shared/boundaries/finding_encoder.py
@@ -160,7 +160,7 @@ def _finding_presentation_payload_from_domain(
 def finding_payload_from_domain(
     finding: Finding,
 ) -> FindingPayload:
-    """Project a domain Finding to the current persisted/public payload dict."""
+    """Compose the persisted/public finding payload from core and presentation parts."""
     core_payload = _finding_core_payload_from_domain(finding)
     presentation_payload = _finding_presentation_payload_from_domain(finding)
     return cast(FindingPayload, {**core_payload, **presentation_payload})

--- a/apps/server/vibesensor/shared/types/finding_payload_parts.py
+++ b/apps/server/vibesensor/shared/types/finding_payload_parts.py
@@ -1,6 +1,8 @@
-"""Internal finding payload-part contracts used by the finding encoder."""
+"""Split finding payload contracts used to compose the shared finding wrapper."""
 
 from __future__ import annotations
+
+from typing import Required
 
 from typing_extensions import TypedDict
 
@@ -10,18 +12,32 @@ from vibesensor.shared.types.analysis_views import (
     MatchedPoint,
     PhaseEvidence,
 )
-from vibesensor.shared.types.history_analysis_contracts import AmplitudeMetric
+from vibesensor.shared.types.json_types import JsonSchemaValue
 
-__all__ = ["FindingCorePayload", "FindingPresentationPayload"]
+__all__ = [
+    "AmplitudeMetric",
+    "FindingCorePayload",
+    "FindingPayload",
+    "FindingPresentationPayload",
+]
+
+
+class AmplitudeMetric(TypedDict, total=False):
+    """HTTP contract for finding amplitude/strength metadata."""
+
+    name: str | None
+    value: float | None
+    units: str | None
+    definition: JsonSchemaValue
 
 
 class FindingCorePayload(TypedDict, total=False):
     """Internal domain-owned finding payload fields."""
 
-    finding_id: str
+    finding_id: Required[str]
     finding_key: str | None
-    suspected_source: str
-    confidence: float | None
+    suspected_source: Required[str]
+    confidence: Required[float | None]
     finding_kind: str | None
     severity: str | None
     matched_points: list[MatchedPoint]
@@ -30,8 +46,8 @@ class FindingCorePayload(TypedDict, total=False):
     strongest_speed_band: str | None
     dominant_phase: str | None
     dominance_ratio: float | None
-    weak_spatial_separation: bool
-    diffuse_excitation: bool
+    weak_spatial_separation: bool | None
+    diffuse_excitation: bool | None
     phase_evidence: PhaseEvidence | None
     evidence_metrics: FindingEvidenceMetrics | None
     ranking_score: float | None
@@ -43,9 +59,20 @@ class FindingCorePayload(TypedDict, total=False):
 class FindingPresentationPayload(TypedDict, total=False):
     """Internal rendering-oriented finding metadata."""
 
-    evidence_summary: str
-    frequency_hz_or_order: float | str
-    amplitude_metric: AmplitudeMetric
+    evidence_summary: Required[str]
+    frequency_hz_or_order: Required[float | str]
+    amplitude_metric: Required[AmplitudeMetric]
     confidence_label_key: str | None
     confidence_tone: str | None
     confidence_pct: str | None
+
+
+class FindingPayload(FindingCorePayload, FindingPresentationPayload, total=False):
+    """Canonical shared contract for one serialized finding payload.
+
+    Boundary serializers and HTTP models should import this TypedDict directly
+    so future field changes have one source of truth. It intentionally includes
+    a few presentation-oriented projections (``evidence_summary``,
+    ``frequency_hz_or_order``, ``amplitude_metric``, and the confidence label
+    fields) alongside the domain-owned finding data.
+    """

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -2,11 +2,14 @@
 
 These TypedDicts are the single semantic owners for analysis/history wrapper
 and composite contracts that are shared between persisted boundary payloads and
-the HTTP/OpenAPI response schema. ``FindingPayload``, ``AnalysisSummary``,
-``AnalysisSummaryCoreResponse``, and ``AnalysisSummaryResponse`` are
-canonically owned here. Boundary modules should import these shared wrapper
-contracts directly from this module, while endpoint-specific HTTP wrappers
-remain local to ``shared.types.api_models.history``.
+the HTTP/OpenAPI response schema. ``AnalysisSummary``,
+``AnalysisSummaryCoreResponse``, and ``AnalysisSummaryResponse`` are defined
+here, while ``FindingPayload`` remains the canonical shared outward finding
+wrapper re-exported from ``finding_payload_parts`` so its internal core versus
+presentation split can evolve without broadening this module's direct field
+ownership. Boundary modules should import these shared wrapper contracts
+directly from this module, while endpoint-specific HTTP wrappers remain local
+to ``shared.types.api_models.history``.
 """
 
 from __future__ import annotations
@@ -17,14 +20,11 @@ from pydantic import ConfigDict
 from typing_extensions import TypedDict
 
 from vibesensor.shared.types.analysis_views import (
-    FindingEvidenceMetrics,
-    LocationHotspotPayload,
-    MatchedPoint,
-    PhaseEvidence,
     PhaseSpeedBreakdownRow,
     PlotDataResult,
     SpeedBreakdownRow,
 )
+from vibesensor.shared.types.finding_payload_parts import AmplitudeMetric, FindingPayload
 from vibesensor.shared.types.json_types import (
     JsonSchemaObject,
     JsonSchemaValue,
@@ -63,15 +63,6 @@ PayloadValue: TypeAlias = JsonSchemaValue
 
 _FORBID_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")
 _IGNORE_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="ignore")
-
-
-class AmplitudeMetric(TypedDict, total=False):
-    """HTTP contract for finding amplitude/strength metadata."""
-
-    name: str | None
-    value: float | None
-    units: str | None
-    definition: PayloadValue
 
 
 class RunSuitabilityCheck(TypedDict, total=False):
@@ -251,44 +242,6 @@ class LocationIntensitySummaryResponse(TypedDict, total=False):
     queue_overflow_drops_delta: Required[float | None]
     strength_bucket_distribution: Required[StrengthBucketDistributionResponse]
     phase_intensity: dict[str, PhaseIntensityStatsResponse] | None
-
-
-class FindingPayload(TypedDict, total=False):
-    """Canonical shared contract for one serialized finding payload.
-
-    Boundary serializers and HTTP models should import this TypedDict directly
-    so future field changes have one source of truth. It intentionally includes
-    a few presentation-oriented projections (``evidence_summary``,
-    ``frequency_hz_or_order``, ``amplitude_metric``, and the confidence label
-    fields) alongside the domain-owned finding data.
-    """
-
-    finding_id: Required[str]
-    finding_key: str | None
-    suspected_source: Required[str]
-    evidence_summary: Required[str]
-    frequency_hz_or_order: Required[float | str]
-    amplitude_metric: Required[AmplitudeMetric]
-    confidence: Required[float | None]
-    finding_kind: str | None
-    severity: str | None
-    confidence_label_key: str | None
-    confidence_tone: str | None
-    confidence_pct: str | None
-    matched_points: list[MatchedPoint]
-    location_hotspot: LocationHotspotPayload | None
-    strongest_location: str | None
-    strongest_speed_band: str | None
-    dominant_phase: str | None
-    dominance_ratio: float | None
-    weak_spatial_separation: bool | None
-    diffuse_excitation: bool | None
-    phase_evidence: PhaseEvidence | None
-    evidence_metrics: FindingEvidenceMetrics | None
-    ranking_score: float | None
-    peak_classification: str | None
-    signatures_observed: list[str]
-    order: str | None
 
 
 class SuspectedVibrationOriginPayload(TypedDict, total=False):

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -3992,10 +3992,10 @@
         "required": [
           "finding_id",
           "suspected_source",
+          "confidence",
           "evidence_summary",
           "frequency_hz_or_order",
-          "amplitude_metric",
-          "confidence"
+          "amplitude_metric"
         ],
         "title": "FindingPayload",
         "type": "object"


### PR DESCRIPTION
## Summary

This PR finishes the internal contract split requested by #1394 without redesigning the outward history/API shape. Before this change, the encoder already had a clear internal split between `_finding_core_payload_from_domain()` and `_finding_presentation_payload_from_domain()`, but `apps/server/vibesensor/shared/types/history_analysis_contracts.py` still directly defined the full outward `FindingPayload` field list, including rendering-oriented metadata such as `evidence_summary`, `frequency_hz_or_order`, `amplitude_metric`, and the confidence-label fields. That meant the shared history contract module still owned presentation-field definitions directly even though the implementation had already started separating those concerns.

The goal here was to make that split authoritative internally while preserving the existing outward payload shape unless a parity-tested schema change was truly necessary. The resulting behavior stays the same: callers still import `FindingPayload` from `history_analysis_contracts`, the encoder still emits the same combined finding payload, decoder/roundtrip behavior is unchanged, and the HTTP schema still exposes the same `FindingPayload` field set. The main architectural improvement is that the internal split between domain-owned fields and rendering-only metadata now has a single home instead of being duplicated across modules.

## Implementation approach

The narrowest complete fix was to reuse the existing `finding_payload_parts.py` seam rather than inventing a second helper or move a large amount of unrelated history-contract code. That module was added recently as an internal split between `FindingCorePayload` and `FindingPresentationPayload`, but the shared outward `FindingPayload` contract and `AmplitudeMetric` were still defined elsewhere. This PR makes the split module the authoritative source for those finding-specific payload pieces, then keeps the public import path stable by re-exporting the outward types from `history_analysis_contracts.py`.

That approach keeps the issue focused. It does not change ranking logic, confidence scoring, report wording, or the decoder semantics. It also does not redesign the HTTP model layer, which would have widened the blast radius beyond the scope described in the issue. Instead, it tightens the existing seam so future rendering-field changes can happen in the finding payload split module without broadening the direct field ownership of `history_analysis_contracts.py`.

## Main code changes

In `apps/server/vibesensor/shared/types/finding_payload_parts.py`, I expanded the module from “internal parts used by the encoder” into the authoritative split definition for finding payload pieces. It now owns `AmplitudeMetric`, `FindingCorePayload`, `FindingPresentationPayload`, and a composed outward `FindingPayload` built from the two split TypedDicts. I also aligned the part definitions with the outward contract’s required-key semantics by using `Required[...]` on the same fields that were previously required in the monolithic `FindingPayload` definition. That matters because the issue is about internal ownership boundaries, not about silently changing the persisted/API contract.

In `apps/server/vibesensor/shared/types/history_analysis_contracts.py`, I removed the direct `AmplitudeMetric` and `FindingPayload` definitions and replaced them with imports from `finding_payload_parts.py`. The module still re-exports both names, so existing consumers keep the same import path and the same outward shared contract surface. I updated the module docstring to reflect the new ownership boundary: summary wrappers are still defined there directly, while the outward `FindingPayload` is now surfaced from the dedicated split module so the internal core-versus-presentation seam can evolve independently.

In `apps/server/vibesensor/shared/boundaries/finding_encoder.py`, I kept the implementation behavior the same but tightened the public docstring on `finding_payload_from_domain()` so it explicitly describes composition from the split core and presentation parts. The implementation was already doing the right thing by composing `{**core_payload, **presentation_payload}`; the refactor makes the type ownership line match that runtime behavior.

## Tests and contract protection

I updated `apps/server/tests/shared/types/test_finding_payload_parts.py` so it now protects the new ownership boundary more directly. Instead of only checking that the core and presentation fields are both subsets of `FindingPayload`, the test now verifies that the shared `FindingPayload` imported from `history_analysis_contracts` is the exact same TypedDict exported from `finding_payload_parts`, that its field set is exactly the union of the core and presentation field sets, and that its required keys are the union of the required keys from both split parts. That makes it much harder to regress back to a duplicated or partially re-monolithized contract definition.

I also renamed the stale wording in `apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py` so it no longer describes `FindingPayload` as if it were purely a “core contract” while simultaneously asserting on presentation fields. The assertions remain aligned with the existing outward shared payload, but the test description now matches the actual role of the type.

Finally, I regenerated the committed HTTP schema artifact. The composed TypedDict keeps the same outward `FindingPayload` field set, but the exported OpenAPI JSON emits the required-field array in a different order because the required metadata now comes from the composed split types instead of one direct field list. This is a serialization-order change in the generated schema artifact, not a semantic contract redesign, but it still needed to be checked in so the committed artifact stayed in sync with the generated schema.

## Validation

I validated the change in three layers.

First, I ran the focused finding-contract tests that cover the split module, the encoder projection, roundtrip decoding, the findings subpackage contract assertions, and the schema/parity guards:

- `pytest -q apps/server/tests/shared/types/test_finding_payload_parts.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/hygiene/test_domain_boundary_parity.py`
- Result: `99 passed`

Second, I ran the standard backend gates for typing and linting:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

Third, I ran the repository’s changed-area validation:

- `make test-changed`

That run included UI contract checks, UI lint/typecheck, and the changed backend/shared pytest selection. All of those checks passed.

I also ran the usual Docker smoke command for consistency with earlier issues in this run:

- `docker compose build --pull && docker compose up -d`

That remains blocked in this environment because there is no Docker daemon socket available. This is the same environment limitation seen on the earlier issues and not a regression from this PR.

## Risks, tradeoffs, and scope decisions

The main tradeoff here is that the generated OpenAPI JSON now lists the same `FindingPayload` required fields in a different order. The outward field set did not change, and the runtime encode/decode behavior did not change, but the generated artifact needed to be refreshed because the composition source changed. I kept that change explicit in the diff rather than trying to preserve the old ordering with extra indirection or duplicate field declarations, because the whole point of the issue is to reduce duplicated field ownership.

I intentionally did not fold this into a broader HTTP-model cleanup or a breaking API redesign. The issue explicitly called for an internal split with stable outward shape unless a contract change was intentional and parity-tested. This PR stays within that boundary.
