### PR TITLE
Add analysis-persistence-http contract bridge

### DIFF
--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -1,0 +1,147 @@
+"""Contract bridge tests: Analysis → Persistence → HTTP boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+from test_support.analysis import run_analysis
+from test_support.report_helpers import report_sample
+
+from vibesensor.adapters.history import ProjectedHistoryRunService
+from vibesensor.domain import RunStatus
+from vibesensor.shared.boundaries.persisted_analysis_codec import (
+    persisted_analysis_from_summary,
+    persisted_analysis_to_summary,
+)
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
+from vibesensor.shared.types.history_records import StoredHistoryRun
+from vibesensor.shared.types.persisted_analysis import (
+    PERSISTED_ANALYSIS_SCHEMA_VERSION,
+    PersistedAnalysis,
+)
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.use_cases.history.runs import HistoryRunService
+
+pytestmark = pytest.mark.smoke
+
+
+@dataclass
+class _RunPersistenceStub:
+    run: StoredHistoryRun
+
+    def get_run(self, run_id: str) -> StoredHistoryRun | None:
+        if run_id != self.run.run_id:
+            return None
+        return self.run
+
+
+def _representative_summary() -> AnalysisSummary:
+    return cast(
+        AnalysisSummary,
+        run_analysis(
+            [
+                report_sample(
+                    0,
+                    speed_kmh=55.0,
+                    dominant_freq_hz=15.0,
+                    peak_amp_g=0.12,
+                ),
+                report_sample(
+                    1,
+                    speed_kmh=65.0,
+                    dominant_freq_hz=15.0,
+                    peak_amp_g=0.14,
+                ),
+            ],
+            language="en",
+        ),
+    )
+
+
+def _stored_run_from_summary(
+    summary: AnalysisSummary,
+) -> tuple[StoredHistoryRun, AnalysisSummary]:
+    persisted = persisted_analysis_from_summary(summary)
+    storage_payload = persisted.to_storage_json_object()
+    assert storage_payload["_schema_version"] == PERSISTED_ANALYSIS_SCHEMA_VERSION
+
+    reloaded = PersistedAnalysis.from_storage_json_object(storage_payload)
+    restored_summary = persisted_analysis_to_summary(reloaded)
+
+    metadata = RunMetadata.from_dict(
+        {
+            "run_id": str(summary.get("run_id") or "run-1"),
+            "start_time_utc": (
+                str(summary.get("start_time_utc"))
+                if summary.get("start_time_utc") is not None
+                else "2026-01-01T00:00:00Z"
+            ),
+            "end_time_utc": summary.get("end_time_utc"),
+            "sensor_model": str(summary.get("sensor_model") or "ADXL345"),
+            "raw_sample_rate_hz": int(summary.get("raw_sample_rate_hz") or 800),
+            "feature_interval_s": float(summary.get("feature_interval_s") or 1.0),
+            **dict(summary.get("metadata") or {}),
+        }
+    )
+    run = StoredHistoryRun(
+        run_id=metadata.run_id or "run-1",
+        status=RunStatus.COMPLETE,
+        start_time_utc=metadata.start_time_utc,
+        end_time_utc=metadata.end_time_utc,
+        metadata=metadata,
+        created_at=metadata.start_time_utc,
+        sample_count=int(summary.get("rows") or 0),
+        analysis=reloaded,
+        analysis_completed_at=metadata.end_time_utc,
+    )
+    return run, restored_summary
+
+
+@pytest.mark.asyncio
+async def test_representative_analysis_contract_survives_persistence_and_http_layers() -> None:
+    summary = _representative_summary()
+    stored_run, restored_summary = _stored_run_from_summary(summary)
+
+    service = ProjectedHistoryRunService(HistoryRunService(_RunPersistenceStub(stored_run)))
+
+    run_response = await service.get_run(stored_run.run_id)
+    insights_response = await service.get_insights(stored_run.run_id, requested_lang="en")
+
+    assert run_response.analysis is not None
+    assert insights_response is not None
+
+    restored_analysis = restored_summary
+    run_analysis_payload = run_response.analysis
+    insights_payload = insights_response
+
+    restored_top = restored_analysis["top_causes"][0]
+    run_top = run_analysis_payload["top_causes"][0]
+    insights_top = insights_payload["top_causes"][0]
+
+    assert set(restored_top) == set(run_top) == set(insights_top)
+    for field in (
+        "finding_id",
+        "suspected_source",
+        "confidence",
+        "evidence_summary",
+        "amplitude_metric",
+        "ranking_score",
+    ):
+        assert run_top[field] == restored_top[field]
+        assert insights_top[field] == restored_top[field]
+
+    for field in ("run_id", "file_name", "rows", "record_length", "lang"):
+        assert run_analysis_payload[field] == restored_analysis[field]
+        assert insights_payload[field] == restored_analysis[field]
+
+    assert (
+        run_analysis_payload["findings"][0]["finding_id"]
+        == restored_analysis["findings"][0]["finding_id"]
+    )
+    assert (
+        insights_payload["findings"][0]["finding_id"]
+        == restored_analysis["findings"][0]["finding_id"]
+    )
+    assert run_top == insights_top

--- a/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import vibesensor.shared.boundaries.finding as boundary_finding
-from vibesensor.domain import Finding, OrderMatchObservation, VibrationSource
+from vibesensor.domain import Finding, FindingEvidence, OrderMatchObservation, VibrationSource
 from vibesensor.domain.vibration_origin import VibrationOrigin
 from vibesensor.shared.boundaries.finding_encoder import (
     _finding_core_payload_from_domain,
@@ -49,6 +49,29 @@ def test_projection_omits_removed_dead_contract_fields() -> None:
         "grouped_count",
         "diagnostic_caveat",
     }.isdisjoint(payload)
+
+
+def test_projection_keeps_strength_metric_when_evidence_exists_without_nested_strength() -> None:
+    payload = finding_payload_from_domain(
+        Finding(
+            finding_id="F001",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            vibration_strength_db=22.3,
+            evidence=FindingEvidence(
+                match_rate=0.8,
+                presence_ratio=0.9,
+                burstiness=0.1,
+                spatial_concentration=0.7,
+                frequency_correlation=0.6,
+                speed_uniformity=0.5,
+                spatial_uniformity=0.4,
+                snr_db=15.0,
+            ),
+        )
+    )
+
+    assert payload["amplitude_metric"]["value"] == 22.3
+    assert payload["evidence_metrics"]["vibration_strength_db"] == 22.3
 
 
 def test_projection_serializes_matched_points_with_boundary_shape() -> None:

--- a/apps/server/vibesensor/shared/boundaries/finding_encoder.py
+++ b/apps/server/vibesensor/shared/boundaries/finding_encoder.py
@@ -101,6 +101,8 @@ def _finding_core_payload_from_domain(finding: Finding) -> FindingCorePayload:
             metrics["snr_db"] = ev.snr_db
         if ev.vibration_strength_db is not None:
             metrics["vibration_strength_db"] = ev.vibration_strength_db
+        elif finding.vibration_strength_db is not None:
+            metrics["vibration_strength_db"] = finding.vibration_strength_db
         if ev.phases_with_evidence is not None:
             metrics["phases_with_evidence"] = ev.phases_with_evidence
         if ev.phase_confidences:


### PR DESCRIPTION
## Summary

This PR adds the focused cross-layer contract guardrail requested by #1395 and fixes the concrete contract drift that the new test exposed. The repository already had several narrow guardrails around the analysis/history contract surface, but they were split across separate files: some checked that contract types lived in the right modules, some checked alias parity between shared contracts and HTTP models, and others exercised adjacent history-service behavior. What was still missing was one representative end-to-end test that starts with a real analysis summary, moves it through the persisted-analysis seam, then proves the HTTP-facing history wrappers still expose the same contract shape and representative values.

That is what this change adds. The new integration-style test drives a small real analysis summary through `persisted_analysis_from_summary()`, a storage JSON round-trip, `HistoryRunService`, and `ProjectedHistoryRunService`, then verifies the same representative top-cause and summary fields survive into both `HistoryRunResponse` and `HistoryInsightsResponse`. While implementing that guardrail, the test immediately exposed a real bug instead of just adding a green assertion: when a finding carried `vibration_strength_db` on the domain object but its nested evidence object did not also repeat that strength value, the persisted payload lost the value in `evidence_metrics`, and the history projection path later re-emitted `amplitude_metric.value` as `None`.

The PR therefore includes both halves of the complete fix: the new end-to-end contract bridge test and the encoder correction that preserves the strength metric through persistence and HTTP projection.

## Implementation approach

The issue explicitly asked for one focused representative path rather than replacing all existing narrow parity tests with a giant umbrella test. I kept to that by adding a single dedicated integration test module instead of extending one of the existing omnibus history service files. The new test reuses existing helpers and real code paths rather than inventing synthetic parallel payload builders.

I chose a small real-analysis path instead of a hand-written fake `AnalysisSummary` dict because that gives the test better signal. It starts from actual analysis output produced by `run_analysis()` and `report_sample()`, which means the boundary payload entering persistence is already shaped the same way production analysis produces it. From there, the test exercises the persisted-analysis boundary codec, the storage schema marker round-trip, the persisted history loading seam, and the HTTP-facing projection/validation path. That makes the test broad enough to catch the kind of drift described in the issue while still staying fast and focused.

## Main code changes

The main addition is `apps/server/tests/integration/test_contract_analysis_persistence_http.py`. This file lives next to the existing cross-layer bridge tests (`test_contract_persistence_analysis.py` and `test_contract_analysis_report.py`) and follows the same overall intent: validate a specific subsystem handoff end to end in fast CI-safe tests.

The new test builds a representative summary with `run_analysis()` and `report_sample()`, serializes it through `persisted_analysis_from_summary()`, writes and reloads the storage JSON form through `PersistedAnalysis.to_storage_json_object()` and `PersistedAnalysis.from_storage_json_object()`, wraps the reloaded object in a `StoredHistoryRun`, and then passes that run through `HistoryRunService` plus `ProjectedHistoryRunService`. The assertions intentionally focus on one representative top-cause contract path and a small set of summary wrapper fields rather than restating every narrow parity test in the repository. In particular, it checks that the top-cause payload shape remains stable across the restored summary, the history-run response, and the insights response, and that representative fields like `finding_id`, `suspected_source`, `confidence`, `evidence_summary`, `amplitude_metric`, and `ranking_score` survive intact.

While adding that test, the new guardrail caught a real inconsistency in `apps/server/vibesensor/shared/boundaries/finding_encoder.py`. When a `Finding` had an attached evidence object, the encoder populated `evidence_metrics` from the evidence fields. However, if the domain-level `Finding` also carried `vibration_strength_db` directly while the nested evidence object did not contain its own `vibration_strength_db`, the encoder never copied that value into persisted `evidence_metrics`. The decoder and reconstruction path depend on persisted `evidence_metrics` to recover `Finding.vibration_strength_db`, so the value disappeared during the persisted-history → HTTP projection path even though the original boundary summary had a populated `amplitude_metric.value`.

The fix is deliberately small: when an evidence block exists but does not provide `ev.vibration_strength_db`, the encoder now backfills `metrics["vibration_strength_db"]` from `finding.vibration_strength_db` if it is present. That preserves the cross-layer contract value without changing the outward schema or redesigning the payload shape.

I also added a focused unit regression in `apps/server/tests/shared/boundaries/test_finding_payload_projection.py` to lock this down at the encoder seam. That test covers the exact bug shape: a finding with evidence metrics but no nested evidence strength still needs to persist the canonical `vibration_strength_db` so the amplitude metric survives future reconstruction.

## Validation and tests

I validated the change in layers.

First, I ran the focused suites around the new bridge and the directly related history/boundary guardrails:

- `pytest -q apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/integration/test_contract_persistence_analysis.py apps/server/tests/shared/boundaries/test_analysis_payload_schema_surface.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/use_cases/history/test_history_http_services.py`
- Result: `61 passed`

Second, I ran the standard backend validation stack used throughout this backlog run:

- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make test-changed`

Those all passed. The changed-file runner re-exercised the new integration bridge plus the relevant shared-boundary coverage and stayed green.

I also ran the usual Docker smoke command for consistency with the earlier issues in this run:

- `docker compose build --pull && docker compose up -d`

That remains blocked in this environment because there is no Docker daemon socket available. This is the same environment limitation already seen on the previous issues in this run and is not a regression introduced by this PR.

## Risks, tradeoffs, and scope decisions

The main tradeoff here was whether to make the new test purely observational or let it drive a coupled bug fix if it found one. I chose the latter because the issue is specifically about contract consistency across layers. A test that immediately demonstrated real value loss but was then weakened to avoid the failure would not have delivered the user-visible goal of a trustworthy cross-layer guardrail.

I also kept the test intentionally narrow. It does not try to prove every field on every nested contract across every history endpoint. Existing parity and schema-surface tests still provide that narrower coverage. This PR adds the missing bridge test that joins the boundary, persistence, and HTTP layers together through one representative path and makes regressions easier to understand when one of those seams drifts.

No outward schema redesign was introduced here. The fix preserves the existing contract shape and only restores a value that the system was already expected to keep consistent across the boundary and history projection path.
