### PR TITLE
Formalize PreparedReportInput handoff contract tests (#1397)

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -63,6 +63,21 @@ def test_validate_prepared_report_input_rejects_missing_report_facts() -> None:
         validate_prepared_report_input(prepared)
 
 
+def test_validate_prepared_report_input_rejects_missing_mapping_context() -> None:
+    prepared = replace(_prepared_report_input(), mapping_context=None)
+
+    with pytest.raises(ValueError, match="mapping_context"):
+        validate_prepared_report_input(prepared)
+
+
+def test_validate_prepared_report_input_is_idempotent() -> None:
+    prepared = _prepared_report_input()
+    validated = validate_prepared_report_input(prepared)
+    revalidated = validate_prepared_report_input(validated)
+
+    assert revalidated is validated
+
+
 def test_validate_prepared_report_input_returns_mapping_ready_handoff() -> None:
     prepared = _prepared_report_input()
     validated = validate_prepared_report_input(prepared)
@@ -81,6 +96,13 @@ def test_prepare_report_mapping_context_returns_precomputed_context() -> None:
     assert prepare_report_mapping_context(prepared) is prepared.mapping_context
 
 
+def test_prepare_report_mapping_context_rejects_invalid_input() -> None:
+    prepared = replace(_prepared_report_input(), domain_test_run=None)
+
+    with pytest.raises(ValueError, match="domain_test_run"):
+        prepare_report_mapping_context(prepared)
+
+
 def test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,6 +114,20 @@ def test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input(
     monkeypatch.setattr(pdf_mapping, "_build_report_template_data", _explode)
 
     with pytest.raises(ValueError, match="report_facts"):
+        pdf_mapping.map_summary(prepared)
+
+
+def test_map_summary_fails_before_pdf_mapping_for_missing_mapping_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = replace(_prepared_report_input(), mapping_context=None)
+
+    def _explode(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("map_summary should validate the prepared handoff before mapping")
+
+    monkeypatch.setattr(pdf_mapping, "_build_report_template_data", _explode)
+
+    with pytest.raises(ValueError, match="mapping_context"):
         pdf_mapping.map_summary(prepared)
 
 


### PR DESCRIPTION
## Problem

The `PreparedReportInput` handoff contract between history-side report preparation and PDF mapping adapter already had a working validation gate (`validate_prepared_report_input()`), but its test coverage left several important paths unexercised. Specifically:

1. **Missing `mapping_context=None` rejection test**: The validator checks three fields — `domain_test_run`, `report_facts`, and `mapping_context` — but only two of the three rejection branches had dedicated tests. The `mapping_context` branch was uncovered, meaning a regression that broke that particular check could go unnoticed.

2. **No idempotency test**: `validate_prepared_report_input()` has a fast-path that returns the input as-is when it's already a `ValidatedPreparedReportInput`. This idempotent behavior is important because both `map_summary()` and `prepare_report_mapping_context()` call the validator, meaning the same prepared input may pass through validation more than once. No test exercised this path.

3. **No rejection test for `prepare_report_mapping_context()`**: The `report_context.py` bridge function `prepare_report_mapping_context()` also calls `validate_prepared_report_input()` internally, but no test verified that it raises on invalid input independently of the `map_summary()` path. This matters because `prepare_report_mapping_context()` is a separately callable entry point.

4. **No `map_summary()` guard test for missing `mapping_context`**: The existing `map_summary` guard test only verified rejection when `report_facts` was `None`. No test confirmed that `map_summary()` also rejects a missing `mapping_context` before reaching `_build_report_template_data()`.

## Chosen Implementation Approach

Rather than restructuring the existing validation logic — which is already well-designed as a single-gate validator that produces a typed `ValidatedPreparedReportInput` — this change focuses entirely on closing the test coverage gaps. The existing `validate_prepared_report_input()` function is the correct architectural seam: it runs before any PDF mapping work begins, it produces a stronger typed output, and both `map_summary()` and `prepare_report_mapping_context()` delegate to it.

The four new tests follow the exact patterns established by the existing tests in `test_report_preparation_contract.py`, using the same `_prepared_report_input()` factory and `dataclasses.replace()` to null out individual fields.

## Main Code Changes

All changes are in a single file: `apps/server/tests/use_cases/history/test_report_preparation_contract.py`.

### New test: `test_validate_prepared_report_input_rejects_missing_mapping_context`
Uses `replace(_prepared_report_input(), mapping_context=None)` and asserts that `validate_prepared_report_input()` raises `ValueError` matching `"mapping_context"`. This completes 100% branch coverage of the three-field validation gate. The test mirrors the existing `test_validate_prepared_report_input_rejects_missing_domain_test_run` and `test_validate_prepared_report_input_rejects_missing_report_facts` patterns.

### New test: `test_validate_prepared_report_input_is_idempotent`
Validates a `PreparedReportInput`, then passes the resulting `ValidatedPreparedReportInput` through validation again, and asserts the result is the same object (`is` identity check). This ensures the `isinstance` fast-path works correctly and that double-validation doesn't reconstruct the object.

### New test: `test_prepare_report_mapping_context_rejects_invalid_input`
Calls `prepare_report_mapping_context()` (from `adapters/pdf/report_context.py`) with a `PreparedReportInput` where `domain_test_run=None`, and asserts it raises `ValueError`. This ensures the bridge function properly delegates validation before extracting the mapping context, covering the independently-callable entry point.

### New test: `test_map_summary_fails_before_pdf_mapping_for_missing_mapping_context`
Uses a monkeypatch to replace `_build_report_template_data` with a function that raises `AssertionError` (proving it was never reached), then calls `map_summary()` with `mapping_context=None`, and asserts `ValueError` matching `"mapping_context"`. This mirrors the existing `test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input` but covers the `mapping_context` branch specifically.

## Schema, Contract, Config, and Documentation Changes

No schema, contract, config, or documentation changes are needed. The validation logic itself is unchanged — only the test coverage is expanded. The `PreparedReportInput` and `ValidatedPreparedReportInput` dataclasses, the `validate_prepared_report_input()` function, and all downstream consumers remain identical.

## Validation and Tests Performed

- All 10 tests in `test_report_preparation_contract.py` pass (6 existing + 4 new).
- Ruff lint passes with no issues on the changed file.
- The new tests exercise all three rejection branches, the idempotent pass-through, the bridge function rejection path, and the `map_summary` guard for both `report_facts` and `mapping_context` missing cases.

## Risks, Tradeoffs, and Edge Cases

**Low risk**: This is a pure test addition with no production code changes. The tests follow established patterns in the same file and use the same factory functions.

**Tradeoff**: The tests use `monkeypatch` to prove that `map_summary()` validates before reaching `_build_report_template_data`. This creates a coupling to the internal function name, but this pattern was already established by the existing `test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input` test and is acceptable for a contract guard.

**Edge case coverage**: The idempotency test specifically covers the `isinstance(prepared, ValidatedPreparedReportInput)` early-return path, which is important for callers that may chain validation calls. The `prepare_report_mapping_context` rejection test covers an independently-callable entry point that could regress separately from `map_summary`.

## Follow-ups

- A future test could exercise the non-projectable path where `prepare_report_input()` produces a `PreparedReportInput` with all three optional fields as `None` (when the summary has neither `findings` nor `top_causes`), confirming that `map_summary()` correctly rejects it.
- The `prepare_persisted_report_input()` entry point (for persisted-analysis reports) currently has no dedicated contract test at this seam level and could benefit from one in a follow-up.