### PR TITLE
refactor: remove prepare_report_mapping_context indirection from mapping.py

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
@@ -4,9 +4,9 @@ import pytest
 
 from vibesensor.adapters.pdf.mapping import (
     prepare_report_input,
-    prepare_report_mapping_context,
     resolve_primary_report_candidate,
 )
+from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.report_preparation import prepare_persisted_report_input
 

--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from vibesensor.adapters.pdf.mapping import prepare_report_input, prepare_report_mapping_context
+from vibesensor.adapters.pdf.mapping import prepare_report_input
+from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
 from vibesensor.domain import (
     Finding,
     LocationHotspot,

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -7,7 +7,8 @@ def test_report_mapping_context_has_domain_aggregate() -> None:
     """``prepare_report_mapping_context`` must consume a prepared domain aggregate."""
     from test_support.findings import make_finding_payload
 
-    from vibesensor.adapters.pdf.mapping import prepare_report_input, prepare_report_mapping_context
+    from vibesensor.adapters.pdf.mapping import prepare_report_input
+    from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
     from vibesensor.domain import TestRun
 
     summary = {
@@ -145,9 +146,9 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
 
     from vibesensor.adapters.pdf.mapping import (
         prepare_report_input,
-        prepare_report_mapping_context,
         resolve_primary_report_candidate,
     )
+    from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
     from vibesensor.domain import TestRun, VibrationSource
     from vibesensor.report_i18n import tr
 

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -23,9 +23,9 @@ from vibesensor.adapters.analysis_summary import (
 from vibesensor.adapters.pdf.mapping import (
     map_summary,
     prepare_report_input,
-    prepare_report_mapping_context,
     resolve_primary_report_candidate,
 )
+from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
 from vibesensor.adapters.pdf.report_data import ReportTemplateData
 from vibesensor.use_cases.diagnostics import RunAnalysis
 

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -27,7 +27,6 @@ from vibesensor.adapters.pdf.presentation import order_label_human
 from vibesensor.adapters.pdf.report_context import (
     ReportMappingContext,
     observed_signature,
-    prepare_report_mapping_context,
 )
 from vibesensor.adapters.pdf.report_data import (
     FindingPresentation,
@@ -66,7 +65,6 @@ __all__ = [
     "humanize_signatures",
     "map_summary",
     "prepare_report_input",
-    "prepare_report_mapping_context",
     "resolve_primary_report_candidate",
 ]
 
@@ -219,7 +217,7 @@ def _build_report_template_data(
     The *report* metadata and renderer payload are prepared on the history side;
     the PDF adapter only resolves final presentation details.
     """
-    context = prepare_report_mapping_context(prepared)
+    context = prepared.mapping_context
     raw_sensor_intensity = list(report_facts.active_sensor_intensity)
     primary = resolve_primary_report_candidate(
         context=context,


### PR DESCRIPTION
# Remove `prepare_report_mapping_context` indirection from `mapping.py`

Closes #1398

## Problem

The PDF report mapping pipeline in `mapping.py` introduced an unnecessary indirection layer for obtaining `ReportMappingContext`. When `_build_report_template_data()` received a fully validated `ValidatedPreparedReportInput` — which already carries a precomputed `.mapping_context` attribute — it still routed through `prepare_report_mapping_context(prepared)` from `report_context.py` to obtain the exact same object. This call path existed as a leftover from an earlier state where the context was assembled adapter-side from raw fields, but since the history-side preparation seam (`report_preparation.py`) now precomputes `ReportMappingContext` and attaches it to the prepared input, the adapter-side call was pure pass-through overhead.

This created two problems. First, it obscured the architectural intent: readers of `mapping.py` had to trace through `prepare_report_mapping_context()` to discover that it simply returns `validated.mapping_context` — a trivial accessor hidden behind a function-call boundary. Second, it maintained a coupling where `mapping.py` imported and re-exported `prepare_report_mapping_context` in its `__all__` surface, suggesting the PDF adapter owned context preparation when in fact context ownership had already migrated to the history-side seam.

## Solution

This PR makes three targeted changes to the production code in `mapping.py`:

1. **Removed the `prepare_report_mapping_context` import** from the `report_context` import block. The function is no longer needed for the production mapping path.

2. **Removed `prepare_report_mapping_context` from `__all__`**. The mapping module's public surface no longer advertises a function it does not use or own. This clarifies that context preparation is not a PDF adapter responsibility.

3. **Replaced the function call with direct attribute access** in `_build_report_template_data()`. The line `context = prepare_report_mapping_context(prepared)` became `context = prepared.mapping_context`. Since `prepared` is a `ValidatedPreparedReportInput` (the validation gate ensures `.mapping_context` is non-None), the direct access is type-safe and semantically identical.

The function `prepare_report_mapping_context()` itself is preserved in `report_context.py` where it is defined. It continues to serve as a convenience accessor for test code that needs to obtain a `ReportMappingContext` from a `PreparedReportInput` without manually calling the validation gate. This is intentional — the function has legitimate utility as a test helper, even though the production path no longer needs the indirection.

## Test import updates

Four test files previously imported `prepare_report_mapping_context` from `vibesensor.adapters.pdf.mapping` (which re-exported it). Since the re-export is removed, these imports were updated to source from the canonical location `vibesensor.adapters.pdf.report_context`:

- `tests/adapters/pdf/test_report_mapping_pipeline.py` — split the multi-import block so `prepare_report_input` and `resolve_primary_report_candidate` come from `mapping`, while `prepare_report_mapping_context` comes from `report_context`.
- `tests/adapters/pdf/test_summary_view.py` — same pattern: `prepare_report_input` from `mapping`, `prepare_report_mapping_context` from `report_context`.
- `tests/integration/test_contract_analysis_report.py` — split the four-function import so `map_summary`, `prepare_report_input`, and `resolve_primary_report_candidate` come from `mapping`, while `prepare_report_mapping_context` comes from `report_context`.
- `tests/hygiene/test_domain_report_mapping_guardrails.py` — two inline import blocks updated (one per test function) with the same split pattern.

No test logic was changed. All tests continue to exercise the same code paths with identical assertions.

## Validation

- `ruff check` passes on all 5 changed files with no lint violations.
- `mypy --config-file pyproject.toml` reports zero type errors across 347 source files.
- All 37 directly affected tests pass (targeted run of the 5 test files).
- Broader test sweep of 2,274 tests across `tests/adapters/pdf/`, `tests/use_cases/history/`, `tests/integration/`, and `tests/hygiene/` passes with zero failures and 5 expected skips.

## Acceptance criteria verification

- **`mapping.py` no longer re-assembles `ReportMappingContext`**: Confirmed — `_build_report_template_data()` uses `prepared.mapping_context` directly.
- **One clear source of truth for report context**: The history-side `report_preparation.py` precomputes `ReportMappingContext` and attaches it to `PreparedReportInput`. The PDF adapter consumes it as-is.
- **Existing report integration tests pass without behavior changes**: All 2,274 report-area tests pass identically.

## Files changed (5)

| File | Change |
|------|--------|
| `vibesensor/adapters/pdf/mapping.py` | Removed import, `__all__` entry, and function call; replaced with direct `.mapping_context` access |
| `tests/adapters/pdf/test_report_mapping_pipeline.py` | Import source: `mapping` → `report_context` |
| `tests/adapters/pdf/test_summary_view.py` | Import source: `mapping` → `report_context` |
| `tests/integration/test_contract_analysis_report.py` | Import source: `mapping` → `report_context` |
| `tests/hygiene/test_domain_report_mapping_guardrails.py` | Import source: `mapping` → `report_context` (two inline blocks) |