### PR TITLE
refactor: extract ReportTemplateData field mapping into focused builder

### DIFF
--- a/apps/server/tests/adapters/pdf/test_template_builder.py
+++ b/apps/server/tests/adapters/pdf/test_template_builder.py
@@ -1,0 +1,300 @@
+"""Tests for the focused ReportTemplateData builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
+from vibesensor.adapters.pdf.report_data import (
+    DataTrustItem,
+    FindingPresentation,
+    NextStep,
+    PatternEvidence,
+    PeakRow,
+    Report,
+    SystemFindingCard,
+)
+from vibesensor.adapters.pdf.template_builder import build_template_data
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
+
+
+@dataclass
+class _StubTestRun:
+    """Minimal stand-in for a domain TestRun used only by the builder context."""
+
+    findings: list[object] = field(default_factory=list)
+
+
+def _make_context(**overrides: object):  # type: ignore[no-untyped-def]
+    from vibesensor.use_cases.history.report_preparation import ReportMappingContext
+
+    defaults = {
+        "car_name": "TestCar",
+        "car_type": "Sedan",
+        "date_str": "2026-01-01 12:00:00 UTC",
+        "origin": None,
+        "origin_location": "",
+        "sensor_locations_active": ["front", "rear"],
+        "duration_text": "60s",
+        "start_time_utc": "2026-01-01T12:00:00Z",
+        "end_time_utc": "2026-01-01T12:01:00Z",
+        "sample_rate_hz": "100",
+        "tire_spec_text": "205/55R16",
+        "sample_count": 6000,
+        "sensor_model": "MPU6050",
+        "firmware_version": "1.2.3",
+        "domain_aggregate": _StubTestRun(),
+    }
+    defaults.update(overrides)
+    return ReportMappingContext(**defaults)
+
+
+def _make_report(**overrides: object) -> Report:
+    defaults: dict = {
+        "run_id": "run-001",
+        "lang": "en",
+        "car_name": None,
+        "car_type": None,
+    }
+    defaults.update(overrides)
+    return Report(**defaults)
+
+
+def _make_primary(**overrides: object) -> PrimaryCandidateContext:
+    defaults: dict = {
+        "primary_candidate": None,
+        "primary_source": "wheel/tire",
+        "primary_system": "Wheel/Tire",
+        "primary_location": "front_left",
+        "primary_speed": "60-80",
+        "confidence": 0.85,
+        "sensor_count": 2,
+        "weak_spatial": False,
+        "has_reference_gaps": False,
+        "strength_db": 25.0,
+        "strength_text": "Moderate",
+        "strength_band_key": "moderate",
+        "certainty_key": "B",
+        "certainty_label_text": "Probable",
+        "certainty_pct": "85%",
+        "certainty_reason": "Strong match",
+        "tier": "B",
+    }
+    defaults.update(overrides)
+    return PrimaryCandidateContext(**defaults)
+
+
+def _build(**overrides: object):  # type: ignore[no-untyped-def]
+    """Build a ReportTemplateData with sensible defaults, allowing overrides."""
+    defaults: dict = {
+        "context": _make_context(),
+        "report": _make_report(),
+        "primary": _make_primary(),
+        "title": "Test Report",
+        "observed": PatternEvidence(),
+        "system_cards": [],
+        "next_steps": [],
+        "data_trust": [],
+        "pattern_evidence": PatternEvidence(),
+        "peak_rows": [],
+        "version_marker": "v1.0",
+        "findings": [],
+        "top_causes": [],
+        "sensor_intensity": [],
+        "hotspot_rows": [],
+    }
+    defaults.update(overrides)
+    return build_template_data(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Context metadata mapping
+# ---------------------------------------------------------------------------
+
+
+def test_context_metadata_maps_to_template() -> None:
+    """Context-owned run metadata fields map directly to template data."""
+    ctx = _make_context(
+        date_str="2026-03-25 10:00:00 UTC",
+        duration_text="90s",
+        start_time_utc="2026-03-25T10:00:00Z",
+        end_time_utc="2026-03-25T10:01:30Z",
+        sample_rate_hz="200",
+        tire_spec_text="225/45R17",
+        sample_count=18000,
+        sensor_model="ICM-42688",
+        firmware_version="2.0.0",
+        sensor_locations_active=["front", "rear", "trunk"],
+    )
+    result = _build(context=ctx)
+
+    assert result.run_datetime == "2026-03-25 10:00:00 UTC"
+    assert result.duration_text == "90s"
+    assert result.start_time_utc == "2026-03-25T10:00:00Z"
+    assert result.end_time_utc == "2026-03-25T10:01:30Z"
+    assert result.sample_rate_hz == "200"
+    assert result.tire_spec_text == "225/45R17"
+    assert result.sample_count == 18000
+    assert result.sensor_model == "ICM-42688"
+    assert result.firmware_version == "2.0.0"
+    assert result.sensor_locations == ["front", "rear", "trunk"]
+
+
+# ---------------------------------------------------------------------------
+# Car name/type fallback logic
+# ---------------------------------------------------------------------------
+
+
+def test_car_name_from_report_overrides_context() -> None:
+    """Report.car_name takes precedence over context.car_name."""
+    ctx = _make_context(car_name="ContextCar")
+    report = _make_report(car_name="ReportCar")
+    result = _build(context=ctx, report=report)
+
+    assert result.car_name == "ReportCar"
+
+
+def test_car_name_falls_back_to_context() -> None:
+    """When report.car_name is None, context.car_name is used."""
+    ctx = _make_context(car_name="ContextCar")
+    report = _make_report(car_name=None)
+    result = _build(context=ctx, report=report)
+
+    assert result.car_name == "ContextCar"
+
+
+def test_car_type_from_report_overrides_context() -> None:
+    """Report.car_type takes precedence over context.car_type."""
+    ctx = _make_context(car_type="ContextType")
+    report = _make_report(car_type="ReportType")
+    result = _build(context=ctx, report=report)
+
+    assert result.car_type == "ReportType"
+
+
+def test_car_type_falls_back_to_context() -> None:
+    """When report.car_type is None, context.car_type is used."""
+    ctx = _make_context(car_type="ContextType")
+    report = _make_report(car_type=None)
+    result = _build(context=ctx, report=report)
+
+    assert result.car_type == "ContextType"
+
+
+# ---------------------------------------------------------------------------
+# Primary candidate fields
+# ---------------------------------------------------------------------------
+
+
+def test_primary_sensor_count_maps_to_template() -> None:
+    """Primary candidate sensor_count maps to template sensor_count."""
+    primary = _make_primary(sensor_count=4)
+    result = _build(primary=primary)
+
+    assert result.sensor_count == 4
+
+
+def test_primary_tier_maps_to_certainty_tier_key() -> None:
+    """Primary candidate tier maps to certainty_tier_key."""
+    primary = _make_primary(tier="C")
+    result = _build(primary=primary)
+
+    assert result.certainty_tier_key == "C"
+
+
+# ---------------------------------------------------------------------------
+# Section passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_findings_passthrough() -> None:
+    """Findings list is passed through without modification."""
+    findings = [FindingPresentation(suspected_source="wheel/tire")]
+    result = _build(findings=findings)
+
+    assert result.findings == findings
+
+
+def test_top_causes_passthrough() -> None:
+    """Top causes list is passed through without modification."""
+    top_causes = [FindingPresentation(suspected_source="engine")]
+    result = _build(top_causes=top_causes)
+
+    assert result.top_causes == top_causes
+
+
+def test_sensor_intensity_passthrough() -> None:
+    """Sensor intensity list is passed through without modification."""
+    intensity = [LocationIntensitySummary(location="front", p95_intensity_db=12.5)]
+    result = _build(sensor_intensity=intensity)
+
+    assert result.sensor_intensity_by_location == intensity
+
+
+def test_hotspot_rows_passthrough() -> None:
+    """Hotspot rows are passed through without modification."""
+    rows = [LocationHotspotRow(location="front", peak_value=20.0)]
+    result = _build(hotspot_rows=rows)
+
+    assert result.location_hotspot_rows == rows
+
+
+def test_system_cards_passthrough() -> None:
+    """System cards are passed through without modification."""
+    cards = [SystemFindingCard(system_name="Engine")]
+    result = _build(system_cards=cards)
+
+    assert result.system_cards == cards
+
+
+def test_next_steps_passthrough() -> None:
+    """Next steps are passed through without modification."""
+    steps = [NextStep(action="Inspect tires")]
+    result = _build(next_steps=steps)
+
+    assert result.next_steps == steps
+
+
+def test_data_trust_passthrough() -> None:
+    """Data trust items are passed through without modification."""
+    trust = [DataTrustItem(check="GPS lock", state="pass")]
+    result = _build(data_trust=trust)
+
+    assert result.data_trust == trust
+
+
+def test_peak_rows_passthrough() -> None:
+    """Peak rows are passed through without modification."""
+    rows = [PeakRow(rank="1", system="Wheel")]
+    result = _build(peak_rows=rows)
+
+    assert result.peak_rows == rows
+
+
+# ---------------------------------------------------------------------------
+# Scalar fields
+# ---------------------------------------------------------------------------
+
+
+def test_title_and_version_map() -> None:
+    """Title and version marker are passed through."""
+    result = _build(title="My Title", version_marker="v2.0-abc123")
+
+    assert result.title == "My Title"
+    assert result.version_marker == "v2.0-abc123"
+
+
+def test_lang_comes_from_report() -> None:
+    """Language is sourced from the Report, not the context."""
+    report = _make_report(lang="sv")
+    result = _build(report=report)
+
+    assert result.lang == "sv"
+
+
+def test_run_id_comes_from_report() -> None:
+    """run_id is sourced from the Report."""
+    report = _make_report(run_id="custom-run-id")
+    result = _build(report=report)
+
+    assert result.run_id == "custom-run-id"

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -39,6 +39,7 @@ from vibesensor.adapters.pdf.report_sections import (
     build_data_trust,
     build_next_steps,
 )
+from vibesensor.adapters.pdf.template_builder import build_template_data
 from vibesensor.domain import (
     Finding,
     TestRun,
@@ -212,11 +213,7 @@ def _build_report_template_data(
     test_run: TestRun,
     report_facts: PreparedReportFacts,
 ) -> ReportTemplateData:
-    """Map a prepared report input into the final report template data structure.
-
-    The *report* metadata and renderer payload are prepared on the history side;
-    the PDF adapter only resolves final presentation details.
-    """
+    """Resolve report sections, then delegate field assignment to the builder."""
     context = prepared.mapping_context
     raw_sensor_intensity = list(report_facts.active_sensor_intensity)
     primary = resolve_primary_report_candidate(
@@ -254,24 +251,11 @@ def _build_report_template_data(
     peak_rows = build_peak_rows(prepared.renderer_payload.peak_table_rows, lang=lang, tr=tr)
     version_marker = build_version_marker()
 
-    hotspot_rows = list(report_facts.location_hotspot_rows)
-
-    return ReportTemplateData(
+    return build_template_data(
+        context=context,
+        report=report,
+        primary=primary,
         title=tr("DIAGNOSTIC_WORKSHEET"),
-        run_datetime=context.date_str,
-        run_id=report.run_id,
-        duration_text=context.duration_text,
-        start_time_utc=context.start_time_utc,
-        end_time_utc=context.end_time_utc,
-        sample_rate_hz=context.sample_rate_hz,
-        tire_spec_text=context.tire_spec_text,
-        sample_count=context.sample_count,
-        sensor_count=primary.sensor_count,
-        sensor_locations=context.sensor_locations_active,
-        sensor_model=context.sensor_model,
-        firmware_version=context.firmware_version,
-        car_name=report.car_name or context.car_name,
-        car_type=report.car_type or context.car_type,
         observed=observed,
         system_cards=system_cards,
         next_steps=next_steps,
@@ -279,12 +263,10 @@ def _build_report_template_data(
         pattern_evidence=pattern_evidence,
         peak_rows=peak_rows,
         version_marker=version_marker,
-        lang=report.lang,
-        certainty_tier_key=primary.tier,
         findings=[_finding_to_presentation(f) for f in context.domain_aggregate.findings],
         top_causes=[
             _finding_to_presentation(f) for f in context.domain_aggregate.effective_top_causes()
         ],
-        sensor_intensity_by_location=raw_sensor_intensity,
-        location_hotspot_rows=hotspot_rows,
+        sensor_intensity=raw_sensor_intensity,
+        hotspot_rows=list(report_facts.location_hotspot_rows),
     )

--- a/apps/server/vibesensor/adapters/pdf/template_builder.py
+++ b/apps/server/vibesensor/adapters/pdf/template_builder.py
@@ -1,0 +1,78 @@
+"""Focused builder for ReportTemplateData field mapping.
+
+Owns the mapping from resolved report sections and context into a
+``ReportTemplateData`` instance.  Keeps the mapping explicit and testable
+while the orchestration layer (``mapping.py``) handles section resolution.
+"""
+
+from __future__ import annotations
+
+from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
+from vibesensor.adapters.pdf.report_context import ReportMappingContext
+from vibesensor.adapters.pdf.report_data import (
+    DataTrustItem,
+    FindingPresentation,
+    NextStep,
+    PatternEvidence,
+    PeakRow,
+    Report,
+    ReportTemplateData,
+    SystemFindingCard,
+)
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
+
+
+def build_template_data(
+    *,
+    context: ReportMappingContext,
+    report: Report,
+    primary: PrimaryCandidateContext,
+    title: str,
+    observed: PatternEvidence,
+    system_cards: list[SystemFindingCard],
+    next_steps: list[NextStep],
+    data_trust: list[DataTrustItem],
+    pattern_evidence: PatternEvidence,
+    peak_rows: list[PeakRow],
+    version_marker: str,
+    findings: list[FindingPresentation],
+    top_causes: list[FindingPresentation],
+    sensor_intensity: list[LocationIntensitySummary],
+    hotspot_rows: list[LocationHotspotRow],
+) -> ReportTemplateData:
+    """Map resolved report sections into ``ReportTemplateData``.
+
+    All section resolution (candidate selection, card building, etc.) is done
+    before this function is called.  This builder only performs field
+    assignment and simple fallback defaults so it stays easily testable.
+    """
+    return ReportTemplateData(
+        title=title,
+        run_datetime=context.date_str,
+        run_id=report.run_id,
+        duration_text=context.duration_text,
+        start_time_utc=context.start_time_utc,
+        end_time_utc=context.end_time_utc,
+        sample_rate_hz=context.sample_rate_hz,
+        tire_spec_text=context.tire_spec_text,
+        sample_count=context.sample_count,
+        sensor_count=primary.sensor_count,
+        sensor_locations=context.sensor_locations_active,
+        sensor_model=context.sensor_model,
+        firmware_version=context.firmware_version,
+        car_name=report.car_name or context.car_name,
+        car_type=report.car_type or context.car_type,
+        observed=observed,
+        system_cards=system_cards,
+        next_steps=next_steps,
+        data_trust=data_trust,
+        pattern_evidence=pattern_evidence,
+        peak_rows=peak_rows,
+        version_marker=version_marker,
+        lang=report.lang,
+        certainty_tier_key=primary.tier,
+        findings=findings,
+        top_causes=top_causes,
+        sensor_intensity_by_location=sensor_intensity,
+        location_hotspot_rows=hotspot_rows,
+    )


### PR DESCRIPTION
# Extract ReportTemplateData field mapping into focused builder

Closes #1400

## Problem

The function `_build_report_template_data()` in `mapping.py` served two roles simultaneously: resolving intermediate report sections (primary candidate, observed signature, system cards, next steps, data trust, pattern evidence, peak rows) and performing the final field-by-field assignment into `ReportTemplateData`. This dual responsibility meant that adding or adjusting a template field required understanding the full orchestration flow, and the field-assignment logic could not be tested in isolation without also exercising all the section resolution code.

The function was roughly 65 lines long and mixed procedural section resolution calls with a large dataclass constructor call. The section resolution part — which calls `resolve_primary_report_candidate()`, `build_system_cards()`, `build_next_steps()`, `build_data_trust()`, `build_pattern_evidence()`, `build_peak_rows()`, and `build_version_marker()` — has clear inputs and outputs. The field-assignment part — which takes over twenty parameters from the resolved sections and maps them to `ReportTemplateData` fields, including car-name fallback logic (`report.car_name or context.car_name`) — is purely structural mapping. These are distinct responsibilities that belong in separate units.

## Solution

This PR introduces a focused builder function `build_template_data()` in a new module `template_builder.py` that owns all `ReportTemplateData` field assignment. The existing `_build_report_template_data()` is reduced to thin orchestration: it resolves the intermediate sections, then delegates field mapping to the builder.

### New module: `template_builder.py`

The builder function takes explicit keyword arguments for every resolved section and context object, then performs the field assignment. This makes the mapping explicit, self-documenting, and independently testable:

- `context: ReportMappingContext` — provides run metadata fields (date, duration, sensor locations, etc.)
- `report: Report` — provides run_id, language, and car name/type overrides
- `primary: PrimaryCandidateContext` — provides sensor_count and certainty tier
- Section passthroughs: `observed`, `system_cards`, `next_steps`, `data_trust`, `pattern_evidence`, `peak_rows`, `findings`, `top_causes`, `sensor_intensity`, `hotspot_rows`
- Scalar fields: `title`, `version_marker`

The builder contains one notable default logic: `car_name=report.car_name or context.car_name` (and similarly for `car_type`). This fallback behavior was previously buried in the large constructor call inside `_build_report_template_data()`. Now it lives in a focused, testable location.

### Refactored `mapping.py`

The `_build_report_template_data()` function is reduced from ~65 lines to ~50 lines. Its new responsibility is strictly orchestration: resolve sections from prepared input, then call `build_template_data()`. It no longer performs any field assignment directly. The function's docstring is updated to reflect this thinner role.

The import of `build_template_data` from `template_builder` is added to the existing import block. No other imports were changed in `mapping.py`.

## Tests

Eighteen focused tests in a new file `test_template_builder.py` validate the builder's field-group mappings:

**Context metadata mapping (1 test):**
- `test_context_metadata_maps_to_template` — verifies all context-owned run metadata fields (date, duration, start/end times, sample rate, tire spec, sample count, sensor model, firmware version, sensor locations) map correctly to template data.

**Car name/type fallback logic (4 tests):**
- `test_car_name_from_report_overrides_context` — Report.car_name takes precedence over context.
- `test_car_name_falls_back_to_context` — When report.car_name is None, context value is used.
- `test_car_type_from_report_overrides_context` — Same pattern for car_type.
- `test_car_type_falls_back_to_context` — Same fallback for car_type.

**Primary candidate fields (2 tests):**
- `test_primary_sensor_count_maps_to_template` — sensor_count from primary maps to template.
- `test_primary_tier_maps_to_certainty_tier_key` — tier from primary maps to certainty_tier_key.

**Section passthrough (8 tests):**
- `test_findings_passthrough`, `test_top_causes_passthrough`, `test_sensor_intensity_passthrough`, `test_hotspot_rows_passthrough`, `test_system_cards_passthrough`, `test_next_steps_passthrough`, `test_data_trust_passthrough`, `test_peak_rows_passthrough` — each verifies that the corresponding section list is passed through to the template data without modification.

**Scalar fields (3 tests):**
- `test_title_and_version_map` — title and version_marker are passed through.
- `test_lang_comes_from_report` — language is sourced from the Report, not context.
- `test_run_id_comes_from_report` — run_id is sourced from the Report.

All tests use lightweight stub objects for the domain `TestRun` to avoid coupling builder tests to domain reconstruction logic.

## Validation

- `ruff check` and `ruff format --check` clean on all 3 changed files.
- `mypy` reports zero type errors across 348 source files.
- All 18 new builder tests pass.
- Broader sweep of 2,297 tests across `tests/adapters/pdf/`, `tests/use_cases/history/`, `tests/integration/`, and `tests/hygiene/` pass with zero failures and 5 expected skips.
- All backend static guards pass.

## Files changed (3)

| File | Change |
|------|--------|
| `vibesensor/adapters/pdf/template_builder.py` | **New** — focused builder function `build_template_data()` |
| `vibesensor/adapters/pdf/mapping.py` | Reduced `_build_report_template_data()` to thin orchestration calling the builder |
| `tests/adapters/pdf/test_template_builder.py` | **New** — 18 focused builder tests |