### PR TITLE
docs+tests: formalize strength_db fallback precedence in PrimaryReportFacts

### DIFF
--- a/apps/server/tests/shared/boundaries/test_strength_db_precedence.py
+++ b/apps/server/tests/shared/boundaries/test_strength_db_precedence.py
@@ -1,0 +1,128 @@
+"""Tests for strength_db fallback precedence in resolve_primary_report_facts."""
+
+from __future__ import annotations
+
+from vibesensor.domain import Finding, LocationIntensitySummary, RunCapture, TestRun
+from vibesensor.shared.boundaries.report_interpretation import (
+    resolve_primary_report_facts,
+    sensor_fallback_strength_db,
+)
+
+
+def _make_test_run(
+    *,
+    strength_db: float | None = None,
+    findings: tuple[Finding, ...] | None = None,
+) -> TestRun:
+    """Build a minimal TestRun with an optional finding that carries strength_db."""
+    if findings is not None:
+        f_list = findings
+    elif strength_db is not None:
+        f_list = (
+            Finding(
+                finding_id="F001",
+                confidence=0.80,
+                suspected_source="wheel/tire",
+                vibration_strength_db=strength_db,
+            ),
+        )
+    else:
+        f_list = (
+            Finding(
+                finding_id="F001",
+                confidence=0.80,
+                suspected_source="wheel/tire",
+            ),
+        )
+    return TestRun(
+        capture=RunCapture(run_id="precedence-test"),
+        findings=f_list,
+        top_causes=f_list[:1],
+    )
+
+
+def _sensor_intensity(p95: float) -> list[LocationIntensitySummary]:
+    return [LocationIntensitySummary(location="front", p95_intensity_db=p95)]
+
+
+# ---------------------------------------------------------------------------
+# Precedence tier 1: domain-derived strength takes priority
+# ---------------------------------------------------------------------------
+
+
+def test_domain_strength_takes_precedence_over_sensor_fallback() -> None:
+    """When domain aggregate provides strength_db, sensor fallback is ignored."""
+    run = _make_test_run(strength_db=25.0)
+    facts = resolve_primary_report_facts(
+        aggregate=run,
+        origin_location="",
+        sensor_locations_active=["front"],
+        sensor_intensity=_sensor_intensity(18.0),
+    )
+
+    assert facts.strength_db == 25.0
+
+
+# ---------------------------------------------------------------------------
+# Precedence tier 2: sensor fallback when domain has no strength
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_fallback_used_when_domain_strength_is_none() -> None:
+    """When no finding has vibration_strength_db, sensor p95 is the fallback."""
+    run = _make_test_run(strength_db=None)
+    facts = resolve_primary_report_facts(
+        aggregate=run,
+        origin_location="",
+        sensor_locations_active=["front"],
+        sensor_intensity=_sensor_intensity(18.0),
+    )
+
+    assert facts.strength_db == 18.0
+
+
+# ---------------------------------------------------------------------------
+# Precedence tier 3: both sources absent → None
+# ---------------------------------------------------------------------------
+
+
+def test_strength_db_is_none_when_both_sources_absent() -> None:
+    """When neither domain nor sensor provides strength_db, result is None."""
+    run = _make_test_run(strength_db=None)
+    facts = resolve_primary_report_facts(
+        aggregate=run,
+        origin_location="",
+        sensor_locations_active=["front"],
+        sensor_intensity=[],
+    )
+
+    assert facts.strength_db is None
+
+
+# ---------------------------------------------------------------------------
+# sensor_fallback_strength_db edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_fallback_returns_max_p95() -> None:
+    """sensor_fallback_strength_db returns the maximum p95 across locations."""
+    intensity = [
+        LocationIntensitySummary(location="front", p95_intensity_db=15.0),
+        LocationIntensitySummary(location="rear", p95_intensity_db=22.0),
+        LocationIntensitySummary(location="trunk", p95_intensity_db=10.0),
+    ]
+    assert sensor_fallback_strength_db(intensity) == 22.0
+
+
+def test_sensor_fallback_skips_none_values() -> None:
+    """sensor_fallback_strength_db ignores locations with None p95."""
+    intensity = [
+        LocationIntensitySummary(location="front", p95_intensity_db=None),
+        LocationIntensitySummary(location="rear", p95_intensity_db=12.0),
+    ]
+    assert sensor_fallback_strength_db(intensity) == 12.0
+
+
+def test_sensor_fallback_returns_none_for_empty_input() -> None:
+    """sensor_fallback_strength_db returns None for empty sensor list."""
+    assert sensor_fallback_strength_db([]) is None

--- a/apps/server/vibesensor/shared/boundaries/report_interpretation.py
+++ b/apps/server/vibesensor/shared/boundaries/report_interpretation.py
@@ -140,7 +140,18 @@ def resolve_primary_report_facts(
     sensor_locations_active: Sequence[str],
     sensor_intensity: Sequence[LocationIntensitySummary],
 ) -> PrimaryReportFacts:
-    """Resolve the domain-derived facts for the report's primary candidate."""
+    """Resolve the domain-derived facts for the report's primary candidate.
+
+    **strength_db precedence** (first non-None wins):
+
+    1. Domain-derived: ``aggregate.top_strength_db()`` — the
+       ``vibration_strength_db`` of the first effective top-cause finding,
+       or the first finding with a non-None strength if no top-cause has one.
+    2. Sensor-fallback: ``sensor_fallback_strength_db(sensor_intensity)`` —
+       the maximum ``p95_intensity_db`` across all active sensor locations.
+    3. None: if neither source provides a value, ``strength_db`` is ``None``
+       and downstream tier/label logic must handle the absence.
+    """
     effective = aggregate.effective_top_causes()
     domain_primary = effective[0] if effective else aggregate.primary_finding
 


### PR DESCRIPTION
# Formalize strength-dB fallback precedence in PrimaryReportFacts

Closes #1402

## Problem

The `resolve_primary_report_facts()` function in `shared/boundaries/report_interpretation.py` uses a two-tier `strength_db` fallback chain, but the precedence between domain-derived strength and sensor-summary fallback was implicit. The code executed `aggregate.top_strength_db()` first, then fell back to `sensor_fallback_strength_db(sensor_intensity)` if the result was `None`, but there was no documentation explaining this contract. This mattered because confidence and tier gating in the PDF adapter depend on `strength_db`, so hidden precedence rules could silently change visible report output if either source's behavior changed.

The existing test file `test_report_data_strength_db_source.py` exercised some fallback scenarios at the integration level (through `map_summary`), but it did not explicitly lock the precedence contract at the `resolve_primary_report_facts()` level where the decision is actually made. A developer modifying the fallback order would not see a test failure naming the contract violation.

## Solution

### Documentation

Added a structured docstring to `resolve_primary_report_facts()` that explicitly documents the three-tier `strength_db` precedence:

1. **Domain-derived** — `aggregate.top_strength_db()`: returns the `vibration_strength_db` of the first effective top-cause finding, or the first finding with a non-None strength if no top-cause has one. This is the primary/preferred source because domain findings carry analyzed, semantically meaningful strength values.

2. **Sensor-fallback** — `sensor_fallback_strength_db(sensor_intensity)`: returns the maximum `p95_intensity_db` across all active sensor locations. This is a raw-measurement fallback used when findings lack computed strength values, ensuring the report still has a strength reference for tier and label resolution.

3. **None** — if neither source provides a value, `strength_db` is `None` and downstream tier/label logic must handle the absence. This is the explicit failure mode rather than a silent zero or default.

### Tests

Six focused tests in a new file `tests/shared/boundaries/test_strength_db_precedence.py` that directly exercise `resolve_primary_report_facts()` with controlled domain objects:

**Precedence tier 1 — domain-derived strength:**
- `test_domain_strength_takes_precedence_over_sensor_fallback` — Constructs a `TestRun` with a finding that has `vibration_strength_db=25.0` and passes sensor intensity at `18.0`. Asserts `facts.strength_db == 25.0`, confirming domain-derived strength wins over sensor fallback.

**Precedence tier 2 — sensor fallback:**
- `test_sensor_fallback_used_when_domain_strength_is_none` — Constructs a `TestRun` with a finding that has no `vibration_strength_db` and passes sensor intensity at `18.0`. Asserts `facts.strength_db == 18.0`, confirming sensor fallback is used when domain strength is absent.

**Precedence tier 3 — both absent:**
- `test_strength_db_is_none_when_both_sources_absent` — Constructs a `TestRun` with no strength and empty sensor intensity. Asserts `facts.strength_db is None`, confirming the explicit None failure mode.

**sensor_fallback_strength_db edge cases:**
- `test_sensor_fallback_returns_max_p95` — Three locations with different p95 values; asserts the maximum (22.0) is returned.
- `test_sensor_fallback_skips_none_values` — One location with `p95_intensity_db=None` and one with a value; asserts the non-None value is returned.
- `test_sensor_fallback_returns_none_for_empty_input` — Empty sensor list; asserts `None` is returned.

All tests construct lightweight domain objects directly (using `Finding`, `RunCapture`, `TestRun`, `LocationIntensitySummary`) rather than going through the full analysis pipeline, keeping them fast and focused on the precedence contract.

## Validation

- `ruff check` and `ruff format --check` clean on both changed files.
- All 6 new precedence tests pass.
- Broader sweep of 803 tests across `tests/shared/`, `tests/adapters/pdf/`, and `tests/use_cases/history/` pass with zero failures.

## Acceptance criteria verification

- **The `strength_db` fallback chain is documented in the code where it is resolved** — Confirmed: structured docstring on `resolve_primary_report_facts()` with the three tiers.
- **Focused tests explicitly verify precedence and failure-mode behavior** — Confirmed: 6 tests covering all three precedence tiers plus edge cases.
- **Existing report output remains unchanged** — Confirmed: no behavioral changes, only documentation and additive tests.

## Files changed (2)

| File | Change |
|------|--------|
| `vibesensor/shared/boundaries/report_interpretation.py` | Added structured docstring documenting strength_db precedence |
| `tests/shared/boundaries/test_strength_db_precedence.py` | **New** — 6 focused precedence tests |