### PR TITLE
refactor: extract data-quality diagnostic contracts into focused module

### DIFF
--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -148,6 +148,24 @@ from vibesensor.shared.types.analysis_views import (
 from vibesensor.shared.types.analysis_views import (
     SpeedBreakdownRow as BoundarySpeedBreakdownRow,
 )
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualityAccelSanityResponse as BoundaryDataQualityAccelSanityPayload,
+)
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualityOutliersResponse as BoundaryDataQualityOutliersPayload,
+)
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualityRequiredMissingPctResponse as BoundaryDataQualityRequiredMissingPctPayload,
+)
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualityResponse as BoundaryDataQualityPayload,
+)
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualitySpeedCoverageResponse as BoundaryDataQualitySpeedCoveragePayload,
+)
+from vibesensor.shared.types.data_quality_contracts import (
+    OutlierSummaryResponse as BoundaryOutlierSummaryPayload,
+)
 from vibesensor.shared.types.history_analysis_contracts import (
     AmplitudeMetric as BoundaryAmplitudeMetric,
 )
@@ -158,28 +176,10 @@ from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummaryResponse as ApiAnalysisSummaryResponse,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
-    DataQualityAccelSanityResponse as BoundaryDataQualityAccelSanityPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    DataQualityOutliersResponse as BoundaryDataQualityOutliersPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    DataQualityRequiredMissingPctResponse as BoundaryDataQualityRequiredMissingPctPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    DataQualityResponse as BoundaryDataQualityPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    DataQualitySpeedCoverageResponse as BoundaryDataQualitySpeedCoveragePayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
     FindingPayload as BoundaryFindingPayload,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     LocationIntensitySummaryResponse as BoundaryLocationIntensitySummaryPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    OutlierSummaryResponse as BoundaryOutlierSummaryPayload,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     PhaseInfoResponse as BoundaryPhaseInfoPayload,

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -29,16 +29,18 @@ from vibesensor.shared.types.analysis_views import (
     SpectrogramResult,
     SpeedBreakdownRow,
 )
-from vibesensor.shared.types.history_analysis_contracts import (
-    AmplitudeMetric,
+from vibesensor.shared.types.data_quality_contracts import (
     DataQualityAccelSanityResponse,
     DataQualityOutliersResponse,
     DataQualityRequiredMissingPctResponse,
     DataQualityResponse,
     DataQualitySpeedCoverageResponse,
+    OutlierSummaryResponse,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    AmplitudeMetric,
     FindingPayload,
     LocationIntensitySummaryResponse,
-    OutlierSummaryResponse,
     PhaseInfoResponse,
     PhaseIntensityStatsResponse,
     PhaseSegmentSummaryResponse,

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -27,19 +27,19 @@ from vibesensor.shared.json_utils import (
 )
 from vibesensor.shared.statistics_utils import _outlier_summary, _percent_missing
 from vibesensor.shared.time_utils import format_duration_mm_ss
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualityResponse as DataQualityPayload,
+)
+from vibesensor.shared.types.data_quality_contracts import (
+    OutlierSummaryResponse as OutlierSummaryPayload,
+)
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary,
     PayloadObject,
     PayloadValue,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
-    DataQualityResponse as DataQualityPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
     LocationIntensitySummaryResponse as LocationIntensitySummaryPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    OutlierSummaryResponse as OutlierSummaryPayload,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     PhaseInfoResponse as PhaseInfoPayload,

--- a/apps/server/vibesensor/shared/types/data_quality_contracts.py
+++ b/apps/server/vibesensor/shared/types/data_quality_contracts.py
@@ -1,0 +1,78 @@
+"""Data-quality diagnostic contracts shared by boundary and HTTP layers.
+
+Extracted from ``history_analysis_contracts`` so data-quality diagnostics can
+evolve independently of finding, summary, and warning wrappers.
+"""
+
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+__all__ = [
+    "DataQualityAccelSanityResponse",
+    "DataQualityOutliersResponse",
+    "DataQualityRequiredMissingPctResponse",
+    "DataQualityResponse",
+    "DataQualitySpeedCoverageResponse",
+    "OutlierSummaryResponse",
+]
+
+
+class OutlierSummaryResponse(TypedDict):
+    """Response body for an outlier-summary bucket."""
+
+    count: int
+    outlier_count: int
+    outlier_pct: float
+    lower_bound: float | None
+    upper_bound: float | None
+
+
+class DataQualityRequiredMissingPctResponse(TypedDict):
+    """Response body for required-field missing percentages."""
+
+    t_s: float
+    speed_kmh: float
+    accel_x: float
+    accel_y: float
+    accel_z: float
+
+
+class DataQualitySpeedCoverageResponse(TypedDict):
+    """Response body for summarized speed-coverage statistics."""
+
+    non_null_pct: float
+    min_kmh: float | None
+    max_kmh: float | None
+    mean_kmh: float | None
+    stddev_kmh: float | None
+    count_non_null: int
+
+
+class DataQualityAccelSanityResponse(TypedDict):
+    """Response body for acceleration sanity diagnostics."""
+
+    x_mean: float | None
+    x_variance: float | None
+    y_mean: float | None
+    y_variance: float | None
+    z_mean: float | None
+    z_variance: float | None
+    sensor_limit: float | None
+    saturation_count: int | None
+
+
+class DataQualityOutliersResponse(TypedDict):
+    """Response body for grouped outlier summaries."""
+
+    accel_magnitude: OutlierSummaryResponse
+    amplitude_metric: OutlierSummaryResponse
+
+
+class DataQualityResponse(TypedDict):
+    """Response body for run-level data-quality diagnostics."""
+
+    required_missing_pct: DataQualityRequiredMissingPctResponse
+    speed_coverage: DataQualitySpeedCoverageResponse
+    accel_sanity: DataQualityAccelSanityResponse
+    outliers: DataQualityOutliersResponse

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -24,6 +24,14 @@ from vibesensor.shared.types.analysis_views import (
     PlotDataResult,
     SpeedBreakdownRow,
 )
+from vibesensor.shared.types.data_quality_contracts import (
+    DataQualityAccelSanityResponse,
+    DataQualityOutliersResponse,
+    DataQualityRequiredMissingPctResponse,
+    DataQualityResponse,
+    DataQualitySpeedCoverageResponse,
+    OutlierSummaryResponse,
+)
 from vibesensor.shared.types.finding_payload_parts import AmplitudeMetric, FindingPayload
 from vibesensor.shared.types.json_types import (
     JsonSchemaObject,
@@ -143,66 +151,6 @@ class PhaseInfoResponse(TypedDict):
     cruise_pct: float
     idle_pct: float
     speed_unknown_pct: float
-
-
-class OutlierSummaryResponse(TypedDict):
-    """Response body for an outlier-summary bucket."""
-
-    count: int
-    outlier_count: int
-    outlier_pct: float
-    lower_bound: float | None
-    upper_bound: float | None
-
-
-class DataQualityRequiredMissingPctResponse(TypedDict):
-    """Response body for required-field missing percentages."""
-
-    t_s: float
-    speed_kmh: float
-    accel_x: float
-    accel_y: float
-    accel_z: float
-
-
-class DataQualitySpeedCoverageResponse(TypedDict):
-    """Response body for summarized speed-coverage statistics."""
-
-    non_null_pct: float
-    min_kmh: float | None
-    max_kmh: float | None
-    mean_kmh: float | None
-    stddev_kmh: float | None
-    count_non_null: int
-
-
-class DataQualityAccelSanityResponse(TypedDict):
-    """Response body for acceleration sanity diagnostics."""
-
-    x_mean: float | None
-    x_variance: float | None
-    y_mean: float | None
-    y_variance: float | None
-    z_mean: float | None
-    z_variance: float | None
-    sensor_limit: float | None
-    saturation_count: int | None
-
-
-class DataQualityOutliersResponse(TypedDict):
-    """Response body for grouped outlier summaries."""
-
-    accel_magnitude: OutlierSummaryResponse
-    amplitude_metric: OutlierSummaryResponse
-
-
-class DataQualityResponse(TypedDict):
-    """Response body for run-level data-quality diagnostics."""
-
-    required_missing_pct: DataQualityRequiredMissingPctResponse
-    speed_coverage: DataQualitySpeedCoverageResponse
-    accel_sanity: DataQualityAccelSanityResponse
-    outliers: DataQualityOutliersResponse
 
 
 class StrengthBucketDistributionResponse(TypedDict):


### PR DESCRIPTION
# Split data-quality diagnostics contracts out of `history_analysis_contracts.py`

Closes #1403

## Problem

`history_analysis_contracts.py` was acting as a catch-all for analysis/history wrapper contracts AND data-quality diagnostic TypedDicts. This mixed two distinct concern families in one 349-line module: finding/summary/warning wrappers (which evolve with analysis output) and data-quality diagnostics (which evolve with sample-level quality checks). Changes to either concern forced developers to scan the full module and risked unrelated merge conflicts, making both ownership and change isolation harder to reason about.

The data-quality cluster — `OutlierSummaryResponse`, `DataQualityRequiredMissingPctResponse`, `DataQualitySpeedCoverageResponse`, `DataQualityAccelSanityResponse`, `DataQualityOutliersResponse`, and `DataQualityResponse` — forms a self-contained family: `DataQualityResponse` composes the other four, `DataQualityOutliersResponse` uses `OutlierSummaryResponse`, and nothing outside this cluster depends on their internals. This makes extraction clean and complete.

## Solution

### New focused module: `shared/types/data_quality_contracts.py`

Created a dedicated module that owns the complete data-quality diagnostic TypedDict family:

- **`OutlierSummaryResponse`** — response body for an outlier-summary bucket (count, outlier_count, outlier_pct, lower_bound, upper_bound). Used as a sub-type inside `DataQualityOutliersResponse`.
- **`DataQualityRequiredMissingPctResponse`** — response body for required-field missing percentages (t_s, speed_kmh, accel_x/y/z). Tracks ingestion completeness per required column.
- **`DataQualitySpeedCoverageResponse`** — response body for summarized speed-coverage statistics (non_null_pct, min/max/mean/stddev_kmh, count_non_null). Captures how much of the run has usable speed data.
- **`DataQualityAccelSanityResponse`** — response body for acceleration sanity diagnostics (per-axis mean/variance, sensor_limit, saturation_count). Validates sensor-level data integrity.
- **`DataQualityOutliersResponse`** — response body for grouped outlier summaries, referencing `OutlierSummaryResponse` for both accel_magnitude and amplitude_metric channels.
- **`DataQualityResponse`** — top-level response body composing required_missing_pct, speed_coverage, accel_sanity, and outliers into the single `data_quality` field used by `AnalysisSummaryCoreResponse`.

The module has an explicit `__all__` exporting all six types.

### Updated `history_analysis_contracts.py`

Replaced inline class definitions with imports from the new module. The module still re-exports the types through its `__all__` so `AnalysisSummaryCoreResponse.data_quality` field typing resolves naturally. The pydantic `_IGNORE_EXTRA_TYPEDDICT_CONFIG` loop still includes these types since they're imported at module scope and the pydantic schema configuration needs to apply to them for OpenAPI generation.

### Consumer import updates

Three consumer files were updated to import data-quality contracts from the focused module instead of the catch-all:

1. **`shared/boundaries/summary_serialization/_summary.py`** — `DataQualityResponse as DataQualityPayload` and `OutlierSummaryResponse as OutlierSummaryPayload` now import from `data_quality_contracts`. Other summary-related imports (LocationIntensitySummaryResponse, PhaseInfoResponse, etc.) remain on `history_analysis_contracts` since those are summary/wrapper concerns.

2. **`adapters/http/models/history.py`** — All six data-quality types (`DataQualityAccelSanityResponse`, `DataQualityOutliersResponse`, `DataQualityRequiredMissingPctResponse`, `DataQualityResponse`, `DataQualitySpeedCoverageResponse`, `OutlierSummaryResponse`) now import from the focused module. The remaining 13 types still import from `history_analysis_contracts`.

3. **`tests/hygiene/test_api_model_boundary_parity.py`** — All six boundary-side data-quality imports updated to use `data_quality_contracts`. This test validates that shared boundary TypedDicts and API model re-exports have matching field sets, so the import source change keeps the parity assertions valid.

## Validation

- `ruff check` and `ruff format --check` clean on all 5 changed files.
- All backend static guards pass (50+ architectural checks).
- 3706 tests pass across hygiene, shared, use_cases, and integration test areas.
- 555 PDF adapter tests pass.
- No behavioral changes — only import source changes. The types remain structurally identical.

## Acceptance criteria verification

- **The data-quality diagnostic contract family no longer lives inline in `history_analysis_contracts.py`** — Confirmed: all 6 class definitions removed, replaced with imports from `data_quality_contracts.py`.
- **Boundary and HTTP callers import the extracted data-quality contracts from the focused module** — Confirmed: `_summary.py`, `history.py`, and `test_api_model_boundary_parity.py` all updated.
- **Existing analysis/history contract tests continue to pass with unchanged external behavior** — Confirmed: 4261 tests pass across all relevant areas.

## Files changed (5)

| File | Change |
|------|--------|
| `vibesensor/shared/types/data_quality_contracts.py` | **New** — focused module owning 6 data-quality TypedDicts |
| `vibesensor/shared/types/history_analysis_contracts.py` | Replaced 6 inline class definitions with imports from new module |
| `vibesensor/shared/boundaries/summary_serialization/_summary.py` | Updated 2 imports to use new module |
| `vibesensor/adapters/http/models/history.py` | Updated 6 imports to use new module |
| `tests/hygiene/test_api_model_boundary_parity.py` | Updated 6 boundary imports to use new module |