### PR TITLE
refactor: extract evidence-metrics builder from finding_encoder

### DIFF
--- a/apps/server/tests/shared/boundaries/test_evidence_metrics_builder.py
+++ b/apps/server/tests/shared/boundaries/test_evidence_metrics_builder.py
@@ -1,0 +1,136 @@
+"""Tests for the evidence-metrics builder extracted from finding_encoder."""
+
+from __future__ import annotations
+
+from vibesensor.domain import Finding, FindingEvidence, VibrationSource
+from vibesensor.shared.boundaries.evidence_metrics_builder import build_evidence_metrics
+
+
+class TestBuildEvidenceMetrics:
+    """build_evidence_metrics covers the three branches: evidence, strength-only, none."""
+
+    def test_returns_none_when_no_evidence_and_no_strength(self) -> None:
+        finding = Finding(finding_id="F1", suspected_source=VibrationSource.UNKNOWN)
+        assert build_evidence_metrics(finding) is None
+
+    def test_returns_strength_only_when_no_evidence(self) -> None:
+        finding = Finding(
+            finding_id="F2",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            vibration_strength_db=18.5,
+        )
+        result = build_evidence_metrics(finding)
+        assert result == {"vibration_strength_db": 18.5}
+
+    def test_returns_full_metrics_from_evidence(self) -> None:
+        evidence = FindingEvidence(
+            match_rate=0.75,
+            presence_ratio=0.85,
+            burstiness=0.12,
+            spatial_concentration=0.6,
+            frequency_correlation=0.7,
+            speed_uniformity=0.5,
+            spatial_uniformity=0.4,
+            snr_db=14.0,
+            vibration_strength_db=20.0,
+        )
+        finding = Finding(
+            finding_id="F3",
+            suspected_source=VibrationSource.DRIVELINE,
+            evidence=evidence,
+        )
+        result = build_evidence_metrics(finding)
+        assert result is not None
+        assert result["match_rate"] == 0.75
+        assert result["presence_ratio"] == 0.85
+        assert result["burstiness"] == 0.12
+        assert result["spatial_concentration"] == 0.6
+        assert result["frequency_correlation"] == 0.7
+        assert result["speed_uniformity"] == 0.5
+        assert result["spatial_uniformity"] == 0.4
+        assert result["snr_db"] == 14.0
+        assert result["vibration_strength_db"] == 20.0
+
+    def test_evidence_strength_falls_back_to_finding_strength(self) -> None:
+        evidence = FindingEvidence(
+            match_rate=0.6,
+            presence_ratio=0.7,
+            burstiness=0.2,
+            spatial_concentration=0.5,
+            frequency_correlation=0.4,
+            speed_uniformity=0.3,
+            spatial_uniformity=0.2,
+        )
+        finding = Finding(
+            finding_id="F4",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            vibration_strength_db=22.3,
+            evidence=evidence,
+        )
+        result = build_evidence_metrics(finding)
+        assert result is not None
+        assert result["vibration_strength_db"] == 22.3
+
+    def test_optional_fields_omitted_when_none(self) -> None:
+        evidence = FindingEvidence(
+            match_rate=0.5,
+            presence_ratio=0.6,
+            burstiness=0.1,
+            spatial_concentration=0.4,
+            frequency_correlation=0.3,
+            speed_uniformity=0.2,
+            spatial_uniformity=0.1,
+        )
+        finding = Finding(
+            finding_id="F5",
+            suspected_source=VibrationSource.UNKNOWN,
+            evidence=evidence,
+        )
+        result = build_evidence_metrics(finding)
+        assert result is not None
+        assert "global_match_rate" not in result
+        assert "focused_speed_band" not in result
+        assert "mean_relative_error" not in result
+        assert "mean_noise_floor_db" not in result
+        assert "possible_samples" not in result
+        assert "matched_samples" not in result
+        assert "snr_db" not in result
+        assert "vibration_strength_db" not in result
+        assert "phases_with_evidence" not in result
+        assert "per_phase_confidence" not in result
+
+    def test_optional_fields_present_when_set(self) -> None:
+        evidence = FindingEvidence(
+            match_rate=0.8,
+            global_match_rate=0.7,
+            focused_speed_band="60-80 km/h",
+            mean_relative_error=0.02,
+            mean_noise_floor_db=5.0,
+            possible_samples=100,
+            matched_samples=80,
+            snr_db=12.0,
+            vibration_strength_db=18.0,
+            presence_ratio=0.9,
+            burstiness=0.05,
+            spatial_concentration=0.8,
+            frequency_correlation=0.9,
+            speed_uniformity=0.7,
+            spatial_uniformity=0.6,
+            phases_with_evidence=3,
+            phase_confidences=(("cruise", 0.9), ("accel", 0.7)),
+        )
+        finding = Finding(
+            finding_id="F6",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            evidence=evidence,
+        )
+        result = build_evidence_metrics(finding)
+        assert result is not None
+        assert result["global_match_rate"] == 0.7
+        assert result["focused_speed_band"] == "60-80 km/h"
+        assert result["mean_relative_error"] == 0.02
+        assert result["mean_noise_floor_db"] == 5.0
+        assert result["possible_samples"] == 100
+        assert result["matched_samples"] == 80
+        assert result["phases_with_evidence"] == 3
+        assert result["per_phase_confidence"] == {"cruise": 0.9, "accel": 0.7}

--- a/apps/server/vibesensor/shared/boundaries/evidence_metrics_builder.py
+++ b/apps/server/vibesensor/shared/boundaries/evidence_metrics_builder.py
@@ -1,0 +1,60 @@
+"""Build FindingEvidenceMetrics payloads from domain Finding + FindingEvidence."""
+
+from __future__ import annotations
+
+from vibesensor.domain import Finding, FindingEvidence
+from vibesensor.shared.types.analysis_views import FindingEvidenceMetrics
+
+
+def build_evidence_metrics(
+    finding: Finding,
+) -> FindingEvidenceMetrics | None:
+    """Build evidence metrics payload from a domain Finding.
+
+    Returns the fully populated ``FindingEvidenceMetrics`` dict when evidence
+    exists, a minimal dict with only ``vibration_strength_db`` when the finding
+    carries strength but no evidence, or ``None`` when neither is present.
+    """
+    if finding.evidence is not None:
+        return _metrics_from_evidence(finding.evidence, finding)
+    if finding.vibration_strength_db is not None:
+        return {"vibration_strength_db": finding.vibration_strength_db}
+    return None
+
+
+def _metrics_from_evidence(
+    ev: FindingEvidence,
+    finding: Finding,
+) -> FindingEvidenceMetrics:
+    metrics: FindingEvidenceMetrics = {
+        "match_rate": ev.match_rate,
+        "presence_ratio": ev.presence_ratio,
+        "burstiness": ev.burstiness,
+        "spatial_concentration": ev.spatial_concentration,
+        "frequency_correlation": ev.frequency_correlation,
+        "speed_uniformity": ev.speed_uniformity,
+        "spatial_uniformity": ev.spatial_uniformity,
+    }
+    if ev.global_match_rate is not None:
+        metrics["global_match_rate"] = ev.global_match_rate
+    if ev.focused_speed_band is not None:
+        metrics["focused_speed_band"] = ev.focused_speed_band
+    if ev.mean_relative_error is not None:
+        metrics["mean_relative_error"] = ev.mean_relative_error
+    if ev.mean_noise_floor_db is not None:
+        metrics["mean_noise_floor_db"] = ev.mean_noise_floor_db
+    if ev.possible_samples is not None:
+        metrics["possible_samples"] = ev.possible_samples
+    if ev.matched_samples is not None:
+        metrics["matched_samples"] = ev.matched_samples
+    if ev.snr_db is not None:
+        metrics["snr_db"] = ev.snr_db
+    if ev.vibration_strength_db is not None:
+        metrics["vibration_strength_db"] = ev.vibration_strength_db
+    elif finding.vibration_strength_db is not None:
+        metrics["vibration_strength_db"] = finding.vibration_strength_db
+    if ev.phases_with_evidence is not None:
+        metrics["phases_with_evidence"] = ev.phases_with_evidence
+    if ev.phase_confidences:
+        metrics["per_phase_confidence"] = dict(ev.phase_confidences)
+    return metrics

--- a/apps/server/vibesensor/shared/boundaries/finding_encoder.py
+++ b/apps/server/vibesensor/shared/boundaries/finding_encoder.py
@@ -6,9 +6,9 @@ from typing import cast
 
 from vibesensor.domain import Finding
 from vibesensor.domain.order_match import OrderMatchObservation
+from vibesensor.shared.boundaries.evidence_metrics_builder import build_evidence_metrics
 from vibesensor.shared.json_utils import i18n_ref, payload_value_from_json
 from vibesensor.shared.types.analysis_views import (
-    FindingEvidenceMetrics,
     LocationHotspotPayload,
     MatchedPoint,
     PhaseEvidence,
@@ -73,42 +73,9 @@ def _finding_core_payload_from_domain(finding: Finding) -> FindingCorePayload:
             matched_point_from_observation(point) for point in finding.matched_points
         ]
 
-    if finding.evidence is not None:
-        ev = finding.evidence
-        metrics: FindingEvidenceMetrics = {
-            "match_rate": ev.match_rate,
-            "presence_ratio": ev.presence_ratio,
-            "burstiness": ev.burstiness,
-            "spatial_concentration": ev.spatial_concentration,
-            "frequency_correlation": ev.frequency_correlation,
-            "speed_uniformity": ev.speed_uniformity,
-            "spatial_uniformity": ev.spatial_uniformity,
-        }
-        if ev.global_match_rate is not None:
-            metrics["global_match_rate"] = ev.global_match_rate
-        if ev.focused_speed_band is not None:
-            metrics["focused_speed_band"] = ev.focused_speed_band
-        if ev.mean_relative_error is not None:
-            metrics["mean_relative_error"] = ev.mean_relative_error
-        if ev.mean_noise_floor_db is not None:
-            metrics["mean_noise_floor_db"] = ev.mean_noise_floor_db
-        if ev.possible_samples is not None:
-            metrics["possible_samples"] = ev.possible_samples
-        if ev.matched_samples is not None:
-            metrics["matched_samples"] = ev.matched_samples
-        if ev.snr_db is not None:
-            metrics["snr_db"] = ev.snr_db
-        if ev.vibration_strength_db is not None:
-            metrics["vibration_strength_db"] = ev.vibration_strength_db
-        elif finding.vibration_strength_db is not None:
-            metrics["vibration_strength_db"] = finding.vibration_strength_db
-        if ev.phases_with_evidence is not None:
-            metrics["phases_with_evidence"] = ev.phases_with_evidence
-        if ev.phase_confidences:
-            metrics["per_phase_confidence"] = dict(ev.phase_confidences)
-        payload["evidence_metrics"] = metrics
-    elif finding.vibration_strength_db is not None:
-        payload["evidence_metrics"] = {"vibration_strength_db": finding.vibration_strength_db}
+    evidence_metrics = build_evidence_metrics(finding)
+    if evidence_metrics is not None:
+        payload["evidence_metrics"] = evidence_metrics
 
     if finding.cruise_fraction > 0.0 or finding.phases_detected:
         phase_evidence: PhaseEvidence = {"cruise_fraction": finding.cruise_fraction}


### PR DESCRIPTION
# Extract finding evidence-metrics building from `finding_encoder.py`

Closes #1406

## Problem

`finding_encoder.py` was responsible for multiple concerns: matched-point projection, amplitude metadata, evidence-metrics building, phase evidence, location hotspot assembly, and the higher-level payload composition flow. The evidence-metrics building block was the largest inline section (~35 lines) and followed a distinct pattern — iterating through `FindingEvidence` attributes, conditionally including optional fields, and handling a strength-db fallback — that changed for different reasons than the rest of the encoder. This mixed concern made the encoder harder to reason about and harder to test the metrics-building branch conditions independently.

The `FindingEvidenceMetrics` TypedDict already existed in `analysis_views.py` as a separate shared type, which highlighted that the data it describes is semantically distinct from the rest of the payload assembly. The inline builder stood out as an extraction candidate because it has clear inputs (a `Finding` with optional `FindingEvidence`) and a clear output (a `FindingEvidenceMetrics` dict or `None`).

## Solution

### New focused module: `shared/boundaries/evidence_metrics_builder.py`

Created a builder module with two public/private functions:

- **`build_evidence_metrics(finding: Finding) -> FindingEvidenceMetrics | None`** — the public entry point. Handles three branches:
  1. **Evidence present** → delegates to `_metrics_from_evidence()` for full metrics assembly
  2. **No evidence, but finding has `vibration_strength_db`** → returns a minimal dict `{"vibration_strength_db": value}`
  3. **Neither** → returns `None`

- **`_metrics_from_evidence(ev: FindingEvidence, finding: Finding) -> FindingEvidenceMetrics`** — private helper that builds the complete metrics dict. Always includes the 7 core fields (match_rate, presence_ratio, burstiness, spatial_concentration, frequency_correlation, speed_uniformity, spatial_uniformity). Conditionally includes optional fields (global_match_rate, focused_speed_band, mean_relative_error, mean_noise_floor_db, possible_samples, matched_samples, snr_db, vibration_strength_db, phases_with_evidence, per_phase_confidence) only when non-None. Preserves the existing strength-db fallback: if `ev.vibration_strength_db` is None but `finding.vibration_strength_db` is not, the finding-level strength propagates into the metrics.

### Updated `finding_encoder.py`

Replaced the inline ~35-line evidence-metrics block with a 3-line delegation:

```python
evidence_metrics = build_evidence_metrics(finding)
if evidence_metrics is not None:
    payload["evidence_metrics"] = evidence_metrics
```

Removed the `FindingEvidenceMetrics` import (no longer directly referenced). Added the `build_evidence_metrics` import from the new module.

### Focused builder tests: `test_evidence_metrics_builder.py`

Six tests covering all builder branches and representative evidence combinations:

1. **`test_returns_none_when_no_evidence_and_no_strength`** — Finding with no evidence and no vibration_strength_db returns `None`. Validates the "neither source" branch.

2. **`test_returns_strength_only_when_no_evidence`** — Finding with `vibration_strength_db=18.5` but no evidence returns `{"vibration_strength_db": 18.5}`. Validates the minimal fallback branch.

3. **`test_returns_full_metrics_from_evidence`** — Finding with complete evidence (including snr_db and vibration_strength_db on evidence) returns all expected fields. Validates the full evidence assembly branch.

4. **`test_evidence_strength_falls_back_to_finding_strength`** — Evidence has no vibration_strength_db, but finding has `22.3`. Result includes `vibration_strength_db=22.3`. Validates the fallback precedence within the evidence branch.

5. **`test_optional_fields_omitted_when_none`** — Evidence with only core fields (all optional fields at default None). Asserts that optional keys are absent from the result dict.

6. **`test_optional_fields_present_when_set`** — Evidence with all optional fields populated. Asserts every optional key is present with correct values, including `per_phase_confidence` as a dict from tuples.

## Validation

- `ruff check` and `ruff format --check` clean on all 3 changed files.
- All 6 new builder tests pass.
- 3283 tests pass across shared/boundaries, integration, and use_cases test areas.
- No behavioral changes — the encoder produces identical payloads before and after extraction. Existing roundtrip tests (`test_finding_roundtrip.py`), projection tests (`test_finding_payload_projection.py`), and legacy alias tests (`test_finding_legacy_aliases.py`) all pass unchanged.

## Acceptance criteria verification

- **`finding_encoder.py` no longer assembles evidence metrics inline** — Confirmed: replaced with 3-line delegation to `build_evidence_metrics()`.
- **The extracted helper has focused tests for representative evidence payload combinations** — Confirmed: 6 tests covering all branches plus optional field presence/absence.
- **Existing finding encoder and contract tests continue to pass with unchanged outward behavior** — Confirmed: all 3283 relevant tests pass.

## Files changed (3)

| File | Change |
|------|--------|
| `vibesensor/shared/boundaries/evidence_metrics_builder.py` | **New** — focused evidence-metrics builder |
| `vibesensor/shared/boundaries/finding_encoder.py` | Replaced inline metrics block with delegation |
| `tests/shared/boundaries/test_evidence_metrics_builder.py` | **New** — 6 focused builder tests |