### PR TITLE
Extract SettingsStore rollback transaction into reusable helper

### DIFF
--- a/apps/server/tests/infra/config/test_settings_transaction.py
+++ b/apps/server/tests/infra/config/test_settings_transaction.py
@@ -1,0 +1,119 @@
+"""Tests for the standalone settings update-with-rollback transaction helper."""
+
+from __future__ import annotations
+
+from threading import RLock
+
+import pytest
+
+from vibesensor.infra.config.settings_transaction import update_with_rollback
+from vibesensor.shared.exceptions import PersistenceError
+
+
+def _make_state() -> dict[str, int]:
+    return {"value": 1}
+
+
+class TestUpdateWithRollback:
+    """Exercise the generic snapshot→apply→persist→audit→restore flow."""
+
+    def test_successful_update(self) -> None:
+        state = _make_state()
+        audit_calls: list[dict[str, int]] = []
+
+        got = update_with_rollback(
+            lock=RLock(),
+            persist=lambda: None,
+            snapshot=lambda: dict(state),
+            apply=lambda prev: (state.update(value=10), True)[1],
+            restore=lambda prev: state.update(prev),
+            audit_log=lambda prev: audit_calls.append(prev),
+            result=lambda: state["value"],
+        )
+
+        assert got == 10
+        assert audit_calls == [{"value": 1}]
+
+    def test_noop_skips_persist(self) -> None:
+        persist_calls: list[bool] = []
+
+        got = update_with_rollback(
+            lock=RLock(),
+            persist=lambda: persist_calls.append(True),
+            snapshot=lambda: {},
+            apply=lambda _prev: False,
+            restore=lambda _prev: None,
+            result=lambda: "unchanged",
+        )
+
+        assert got == "unchanged"
+        assert persist_calls == []
+
+    def test_rollback_on_persistence_error(self) -> None:
+        state = _make_state()
+
+        def bad_persist() -> None:
+            raise PersistenceError("disk full")
+
+        with pytest.raises(PersistenceError, match="disk full"):
+            update_with_rollback(
+                lock=RLock(),
+                persist=bad_persist,
+                snapshot=lambda: dict(state),
+                apply=lambda prev: (state.update(value=99), True)[1],
+                restore=lambda prev: state.update(prev),
+                result=lambda: state["value"],
+            )
+
+        assert state == {"value": 1}, "state must be restored after failure"
+
+    def test_after_persist_called(self) -> None:
+        side_effects: list[str] = []
+
+        update_with_rollback(
+            lock=RLock(),
+            persist=lambda: None,
+            snapshot=lambda: {},
+            apply=lambda _prev: True,
+            restore=lambda _prev: None,
+            after_persist=lambda: side_effects.append("done"),
+            result=lambda: None,
+        )
+
+        assert side_effects == ["done"]
+
+    def test_after_persist_not_called_on_failure(self) -> None:
+        side_effects: list[str] = []
+
+        with pytest.raises(PersistenceError):
+            update_with_rollback(
+                lock=RLock(),
+                persist=_raise_persistence_error,
+                snapshot=lambda: {},
+                apply=lambda _prev: True,
+                restore=lambda _prev: None,
+                after_persist=lambda: side_effects.append("should not happen"),
+                result=lambda: None,
+            )
+
+        assert side_effects == []
+
+    def test_audit_log_not_called_on_failure(self) -> None:
+        audit_calls: list[object] = []
+
+        with pytest.raises(PersistenceError):
+            update_with_rollback(
+                lock=RLock(),
+                persist=_raise_persistence_error,
+                snapshot=lambda: "snap",
+                apply=lambda _prev: True,
+                restore=lambda _prev: None,
+                audit_log=lambda prev: audit_calls.append(prev),
+                result=lambda: None,
+            )
+
+        assert audit_calls == []
+
+
+def _raise_persistence_error() -> None:
+    raise PersistenceError("boom")

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -49,6 +49,7 @@ from vibesensor.infra.config.car_settings import (
     _clamp_str,
 )
 from vibesensor.infra.config.settings_derivation import analysis_settings_snapshot_from_aspects
+from vibesensor.infra.config.settings_transaction import update_with_rollback
 from vibesensor.infra.location_assignment_validator import (
     AssignedLocation,
     LocationAssignmentValidator,
@@ -189,21 +190,16 @@ class SettingsStore:
         after_persist: Callable[[], None] | None = None,
         result: Callable[[], _SettingsResultT],
     ) -> _SettingsResultT:
-        with self._lock:
-            previous = snapshot()
-            changed = apply(previous)
-            if not changed:
-                return result()
-            try:
-                self._persist()
-            except PersistenceError:
-                restore(previous)
-                raise
-            if audit_log is not None:
-                audit_log(previous)
-            if after_persist is not None:
-                after_persist()
-            return result()
+        return update_with_rollback(
+            lock=self._lock,
+            persist=self._persist,
+            snapshot=snapshot,
+            apply=apply,
+            restore=restore,
+            audit_log=audit_log,
+            after_persist=after_persist,
+            result=result,
+        )
 
     def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
         """Return the current typed analysis snapshot derived from the active car."""

--- a/apps/server/vibesensor/infra/config/settings_transaction.py
+++ b/apps/server/vibesensor/infra/config/settings_transaction.py
@@ -1,0 +1,56 @@
+"""Reusable settings update-with-rollback transaction helper.
+
+Owns the generic snapshot → apply → persist → audit → restore-on-failure
+sequencing used by all settings update paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import RLock
+from typing import TypeVar
+
+from vibesensor.shared.exceptions import PersistenceError
+
+_SnapshotT = TypeVar("_SnapshotT")
+_ResultT = TypeVar("_ResultT")
+
+
+def update_with_rollback(
+    *,
+    lock: RLock,
+    persist: Callable[[], None],
+    snapshot: Callable[[], _SnapshotT],
+    apply: Callable[[_SnapshotT], bool],
+    restore: Callable[[_SnapshotT], None],
+    audit_log: Callable[[_SnapshotT], None] | None = None,
+    after_persist: Callable[[], None] | None = None,
+    result: Callable[[], _ResultT],
+) -> _ResultT:
+    """Execute an atomic settings update with rollback on persistence failure.
+
+    1. Acquire *lock*.
+    2. Take a *snapshot* of the current state.
+    3. *apply* the change; if it returns ``False`` (no-op), return *result*
+       immediately.
+    4. *persist* the updated state.
+    5. On ``PersistenceError``, *restore* the previous snapshot and re-raise.
+    6. Call *audit_log* (if supplied) after successful persistence.
+    7. Call *after_persist* (if supplied) for post-commit side effects.
+    8. Return *result*.
+    """
+    with lock:
+        previous = snapshot()
+        changed = apply(previous)
+        if not changed:
+            return result()
+        try:
+            persist()
+        except PersistenceError:
+            restore(previous)
+            raise
+        if audit_log is not None:
+            audit_log(previous)
+        if after_persist is not None:
+            after_persist()
+        return result()

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -536,20 +536,29 @@ def _check_summary_payload_uses_build_context() -> list[str]:
 def _check_settings_store_uses_shared_update_helper() -> list[str]:
     settings_path = VIBESENSOR_DIR / "infra" / "config" / "settings_store.py"
     car_settings_path = VIBESENSOR_DIR / "infra" / "config" / "car_settings.py"
+    transaction_path = VIBESENSOR_DIR / "infra" / "config" / "settings_transaction.py"
     settings_source = _read_text(settings_path)
     car_settings_source = _read_text(car_settings_path)
+    transaction_source = _read_text(transaction_path)
     failures: list[str] = []
-    if "def _update_with_rollback(" not in settings_source:
+    if (
+        "from vibesensor.infra.config.settings_transaction import update_with_rollback"
+        not in settings_source
+    ):
         failures.append(
-            f"{settings_path.relative_to(REPO_ROOT)} must define the shared _update_with_rollback helper"
+            f"{settings_path.relative_to(REPO_ROOT)} must import update_with_rollback from settings_transaction"
         )
-    if settings_source.count("except PersistenceError") != 1:
+    if "except PersistenceError" in settings_source:
         failures.append(
-            f"{settings_path.relative_to(REPO_ROOT)} must keep PersistenceError rollback handling in one helper"
+            f"{settings_path.relative_to(REPO_ROOT)} must not handle PersistenceError directly; delegate to settings_transaction"
+        )
+    if transaction_source.count("except PersistenceError") != 1:
+        failures.append(
+            f"{transaction_path.relative_to(REPO_ROOT)} must keep PersistenceError rollback handling in one helper"
         )
     if "except PersistenceError" in car_settings_source:
         failures.append(
-            f"{car_settings_path.relative_to(REPO_ROOT)} must delegate rollback handling to SettingsStore._update_with_rollback"
+            f"{car_settings_path.relative_to(REPO_ROOT)} must delegate rollback handling to settings_transaction"
         )
     return failures
 


### PR DESCRIPTION
## Problem

The `SettingsStore._update_with_rollback` method implements a generic transactional pattern — snapshot the current state, apply a mutation, persist, and roll back on failure — but that pattern is embedded directly in the `SettingsStore` class. This couples a reusable concurrency/persistence safety mechanism to one specific store implementation, making it impossible to unit-test the transaction logic in isolation from the full `SettingsStore` initialization machinery (database binding, config loading, sensor hydration, etc.).

The method currently lives at approximately 20 lines of carefully sequenced lock acquisition, snapshot capture, mutation application, persistence, rollback-on-error, audit logging, and post-persist side effects. While the sequencing is correct and well-proven by the existing `test_settings_store.py` suite (46+ tests), the fact that it's a private method on a large class means testing it requires constructing a full `SettingsStore` instance — an expensive and fragile test setup that conflates "does the transaction pattern work correctly" with "does the store initialize properly."

This extraction was identified during the domain-model review (issue #1407) as a straightforward improvement to the infra/config boundary: the transaction helper is a generic coordination primitive that happens to live on a specific store class.

## Solution

### New module: `settings_transaction.py`

Created `apps/server/vibesensor/infra/config/settings_transaction.py` containing a standalone `update_with_rollback()` function. The function accepts all behavioral components as keyword-only callable parameters:

- **`lock`**: The `RLock` to acquire for the entire transaction scope
- **`persist`**: Zero-argument callable that writes current state to durable storage (may raise `PersistenceError`)
- **`snapshot`**: Creates a copy of the current state for rollback purposes
- **`apply`**: Applies the mutation to current state; returns `bool` indicating whether a change occurred
- **`restore`**: Reverts state to the snapshot on persistence failure
- **`audit_log`** (optional): Called with the previous snapshot after successful persistence
- **`after_persist`** (optional): Post-commit side effects (e.g., notifying runtime subscribers)
- **`result`**: Zero-argument callable that produces the return value

The function is fully generic via `TypeVar` bounds on both the snapshot type (`_SnapshotT`) and result type (`_ResultT`), preserving the exact same type relationships the original method had.

### SettingsStore delegation

`SettingsStore._update_with_rollback` is now a thin wrapper that delegates to the standalone function, passing `self._lock` and `self._persist` as the infrastructure dependencies. The method signature is unchanged, so `CarSettingsService` — which receives it via the `_UpdateWithRollback` Protocol — requires zero modifications. All existing callers within `SettingsStore` continue to work identically.

The `PersistenceError` import remains in `settings_store.py` because `_persist()` still raises it. The `except PersistenceError` handling has moved entirely into `settings_transaction.py`.

### Static guard update

The static guard `_check_settings_store_uses_shared_update_helper()` in `verify_backend_static_guards.py` was updated to enforce the new boundary:

1. **settings_store.py** must import `update_with_rollback` from `settings_transaction` (verifies delegation)
2. **settings_store.py** must not contain any `except PersistenceError` (rollback handling fully extracted)
3. **settings_transaction.py** must contain exactly one `except PersistenceError` (single rollback location)
4. **car_settings.py** must not contain `except PersistenceError` (unchanged — delegates via Protocol)

This is a stricter guard than before: previously it allowed one `except PersistenceError` in settings_store.py; now it requires zero, ensuring the extraction cannot regress.

### Test coverage

Added 6 focused tests in `test_settings_transaction.py` that exercise the standalone helper directly without any `SettingsStore` dependency:

1. **`test_successful_update`** — Verifies full happy path: snapshot captured, mutation applied, persist called, audit_log receives the previous snapshot, result returned
2. **`test_noop_skips_persist`** — When `apply` returns `False`, persist is never called and result returns immediately
3. **`test_rollback_on_persistence_error`** — On `PersistenceError`, restore is called with the snapshot, state is reverted, and the error re-raises
4. **`test_after_persist_called`** — The optional `after_persist` callback fires after successful persistence
5. **`test_after_persist_not_called_on_failure`** — `after_persist` is skipped when persistence fails
6. **`test_audit_log_not_called_on_failure`** — `audit_log` is skipped when persistence fails

All 52 infra/config tests pass (6 new + 46 existing), and all 383 hygiene tests pass including the updated static guard.

## Changed files

- **`apps/server/vibesensor/infra/config/settings_transaction.py`** — New standalone transaction helper
- **`apps/server/vibesensor/infra/config/settings_store.py`** — Thin delegation wrapper replacing inline logic
- **`tools/dev/verify_backend_static_guards.py`** — Updated guard to enforce the extraction boundary
- **`apps/server/tests/infra/config/test_settings_transaction.py`** — 6 focused unit tests

Closes #1407