### PR TITLE
Separate GPS message classification from stateful TPV ingestion

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
@@ -171,10 +171,10 @@ async def test_run_reconnects_on_connection_failure(
 async def test_run_does_not_swallow_processing_programming_errors() -> None:
     monitor = GPSSpeedMonitor(gps_enabled=True)
 
-    def _raise_bug(payload: dict[str, object]) -> int:
+    def _raise_bug(tpv: object) -> None:
         raise RuntimeError("bug")
 
-    monitor._tpv_mode = _raise_bug
+    monitor._transport._apply_tpv = _raise_bug  # type: ignore[assignment]
 
     async def _handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         await reader.readline()

--- a/apps/server/tests/adapters/gps/test_gpsd_message_handler.py
+++ b/apps/server/tests/adapters/gps/test_gpsd_message_handler.py
@@ -1,0 +1,130 @@
+"""Tests for GPSD message classification and field extraction."""
+
+from __future__ import annotations
+
+import math
+
+from vibesensor.adapters.gps.gpsd_message_handler import (
+    GpsdVersionInfo,
+    NormalizedTpvData,
+    classify_gpsd_message,
+    read_non_negative_metric,
+    read_tpv_mode,
+)
+
+
+class TestClassifyGpsdMessage:
+    """Message classification dispatches correctly by payload class."""
+
+    def test_version_message(self) -> None:
+        msg = classify_gpsd_message({"class": "VERSION", "rev": "3.25"})
+        assert msg == GpsdVersionInfo(revision="3.25")
+
+    def test_version_without_rev(self) -> None:
+        assert classify_gpsd_message({"class": "VERSION"}) is None
+
+    def test_version_with_non_string_rev(self) -> None:
+        assert classify_gpsd_message({"class": "VERSION", "rev": 42}) is None
+
+    def test_tpv_message(self) -> None:
+        msg = classify_gpsd_message(
+            {
+                "class": "TPV",
+                "mode": 3,
+                "speed": 12.5,
+                "epx": 1.0,
+                "epy": 2.0,
+                "epv": 3.0,
+                "device": "/dev/ttyS0",
+            }
+        )
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.mode == 3
+        assert msg.speed == 12.5
+        assert msg.epx == 1.0
+        assert msg.epy == 2.0
+        assert msg.epv == 3.0
+        assert msg.device == "/dev/ttyS0"
+
+    def test_tpv_minimal(self) -> None:
+        msg = classify_gpsd_message({"class": "TPV"})
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.mode is None
+        assert msg.speed is None
+        assert msg.device is None
+
+    def test_unsupported_class(self) -> None:
+        assert classify_gpsd_message({"class": "SKY"}) is None
+
+    def test_missing_class(self) -> None:
+        assert classify_gpsd_message({"speed": 10.0}) is None
+
+
+class TestReadTpvMode:
+    """TPV mode extraction validates type."""
+
+    def test_valid_mode(self) -> None:
+        assert read_tpv_mode({"mode": 3}) == 3
+
+    def test_bool_rejected(self) -> None:
+        assert read_tpv_mode({"mode": True}) is None
+
+    def test_float_rejected(self) -> None:
+        assert read_tpv_mode({"mode": 3.0}) is None
+
+    def test_missing_mode(self) -> None:
+        assert read_tpv_mode({}) is None
+
+
+class TestReadNonNegativeMetric:
+    """Metric extraction validates numeric range."""
+
+    def test_valid_metric(self) -> None:
+        assert read_non_negative_metric({"epx": 1.5}, "epx") == 1.5
+
+    def test_zero_accepted(self) -> None:
+        assert read_non_negative_metric({"epx": 0.0}, "epx") == 0.0
+
+    def test_negative_rejected(self) -> None:
+        assert read_non_negative_metric({"epx": -1.0}, "epx") is None
+
+    def test_nan_rejected(self) -> None:
+        assert read_non_negative_metric({"epx": math.nan}, "epx") is None
+
+    def test_inf_rejected(self) -> None:
+        assert read_non_negative_metric({"epx": math.inf}, "epx") is None
+
+    def test_bool_rejected(self) -> None:
+        assert read_non_negative_metric({"epx": True}, "epx") is None
+
+    def test_missing_field(self) -> None:
+        assert read_non_negative_metric({}, "epx") is None
+
+
+class TestNormalizedTpvDataFieldExtraction:
+    """Verify end-to-end field extraction through classify_gpsd_message."""
+
+    def test_speed_nan_normalized_to_none(self) -> None:
+        msg = classify_gpsd_message({"class": "TPV", "speed": math.nan})
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.speed is None
+
+    def test_speed_inf_normalized_to_none(self) -> None:
+        msg = classify_gpsd_message({"class": "TPV", "speed": math.inf})
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.speed is None
+
+    def test_speed_bool_normalized_to_none(self) -> None:
+        msg = classify_gpsd_message({"class": "TPV", "speed": True})
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.speed is None
+
+    def test_device_empty_string_normalized_to_none(self) -> None:
+        msg = classify_gpsd_message({"class": "TPV", "device": ""})
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.device is None
+
+    def test_device_non_string_normalized_to_none(self) -> None:
+        msg = classify_gpsd_message({"class": "TPV", "device": 42})
+        assert isinstance(msg, NormalizedTpvData)
+        assert msg.device is None

--- a/apps/server/vibesensor/adapters/gps/__init__.py
+++ b/apps/server/vibesensor/adapters/gps/__init__.py
@@ -3,6 +3,7 @@
 Sub-modules
 -----------
 - :mod:`~vibesensor.adapters.gps.gps_transport` — GPSD connection loop and TPV ingestion.
+- :mod:`~vibesensor.adapters.gps.gpsd_message_handler` — GPSD message classification.
 - :mod:`~vibesensor.adapters.gps.speed_validation` — GPS speed plausibility policy.
 - :mod:`~vibesensor.adapters.gps.speed_resolution` — manual override and stale-fallback policy.
 - :mod:`~vibesensor.adapters.gps.speed_status` — JSON-style status presentation helpers.

--- a/apps/server/vibesensor/adapters/gps/gps_speed.py
+++ b/apps/server/vibesensor/adapters/gps/gps_speed.py
@@ -7,6 +7,10 @@ from typing import Literal
 from vibesensor.adapters.gps import gps_transport as _gps_transport
 from vibesensor.adapters.gps import speed_resolution as _speed_resolution
 from vibesensor.adapters.gps.gps_transport import GPSTransportSnapshot, GPSTransportState
+from vibesensor.adapters.gps.gpsd_message_handler import (
+    read_non_negative_metric,
+    read_tpv_mode,
+)
 from vibesensor.adapters.gps.speed_resolution import (
     SpeedResolution,
     SpeedResolutionPolicy,
@@ -235,11 +239,11 @@ class GPSSpeedMonitor:
 
     @staticmethod
     def _read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
-        return GPSTransportState._read_non_negative_metric(payload, field)
+        return read_non_negative_metric(payload, field)
 
     @staticmethod
     def _tpv_mode(payload: JsonObject) -> int | None:
-        return GPSTransportState._tpv_mode(payload)
+        return read_tpv_mode(payload)
 
     def _speed_confidence(self) -> Literal["low", "medium", "high"]:
         return speed_confidence(self.last_fix_mode, self.last_epx_m, self.last_epy_m)

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -11,6 +11,13 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any, cast
 
+from vibesensor.adapters.gps.gpsd_message_handler import (
+    GpsdVersionInfo,
+    NormalizedTpvData,
+    classify_gpsd_message,
+    read_non_negative_metric,
+    read_tpv_mode,
+)
 from vibesensor.adapters.gps.speed_validation import (
     DEFAULT_SPEED_VALIDATION_CONFIG,
     evaluate_speed_sample,
@@ -266,19 +273,11 @@ class GPSTransportState:
 
     @staticmethod
     def _read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
-        value = payload.get(field)
-        if isinstance(value, NUMERIC_TYPES) and not isinstance(value, bool):
-            numeric_value = float(value)
-            if math.isfinite(numeric_value) and numeric_value >= 0:
-                return numeric_value
-        return None
+        return read_non_negative_metric(payload, field)
 
     @staticmethod
     def _tpv_mode(payload: JsonObject) -> int | None:
-        mode = payload.get("mode")
-        if isinstance(mode, int) and not isinstance(mode, bool):
-            return mode
-        return None
+        return read_tpv_mode(payload)
 
     def _accept_speed_sample(self, speed_mps: float) -> bool:
         accepted, zero_speed_streak = self._evaluate_speed_sample(self._snapshot, speed_mps)
@@ -303,15 +302,41 @@ class GPSTransportState:
         tpv_mode: TpvModeReader | None = None,
         read_metric: MetricReader | None = None,
     ) -> None:
-        payload_class = payload.get("class")
-        if payload_class == "VERSION":
-            revision = payload.get("rev")
-            if isinstance(revision, str):
-                self._replace_snapshot(device_info=f"gpsd {revision}")
+        message = classify_gpsd_message(payload)
+        if message is None:
             return
-        if payload_class != "TPV":
+        if isinstance(message, GpsdVersionInfo):
+            self._replace_snapshot(device_info=f"gpsd {message.revision}")
             return
-        self.ingest_tpv(payload, tpv_mode=tpv_mode, read_metric=read_metric)
+        self._apply_tpv(message)
+
+    def _apply_tpv(self, tpv: NormalizedTpvData) -> None:
+        """Apply normalized TPV data to the transport snapshot."""
+        snapshot = self._snapshot
+        speed_snapshot = snapshot.speed_snapshot
+        zero_speed_streak = snapshot.zero_speed_streak
+
+        if isinstance(tpv.mode, int) and tpv.mode >= 2 and tpv.speed is not None:
+            if is_speed_plausible(tpv.speed):
+                accepted, zero_speed_streak = self._evaluate_speed_sample(snapshot, tpv.speed)
+                if accepted:
+                    speed_snapshot = (tpv.speed, time.monotonic())
+            else:
+                zero_speed_streak = 0
+        else:
+            zero_speed_streak = 0
+
+        device_info = tpv.device if tpv.device else snapshot.device_info
+        self._snapshot = replace(
+            snapshot,
+            last_fix_mode=tpv.mode,
+            last_epx_m=tpv.epx,
+            last_epy_m=tpv.epy,
+            last_epv_m=tpv.epv,
+            speed_snapshot=speed_snapshot,
+            zero_speed_streak=zero_speed_streak,
+            device_info=device_info,
+        )
 
     def ingest_tpv(
         self,

--- a/apps/server/vibesensor/adapters/gps/gpsd_message_handler.py
+++ b/apps/server/vibesensor/adapters/gps/gpsd_message_handler.py
@@ -1,0 +1,104 @@
+"""GPSD message classification and typed field extraction.
+
+Separates wire-format parsing from transport-state mutation so GPSD
+protocol rules can evolve independently of ``GPSTransportState``
+snapshot updates.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
+from vibesensor.shared.types.json_types import JsonObject
+
+
+@dataclass(frozen=True, slots=True)
+class GpsdVersionInfo:
+    """Normalized VERSION message payload."""
+
+    revision: str
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedTpvData:
+    """Typed fields extracted from a GPSD TPV message."""
+
+    mode: int | None
+    speed: float | None
+    epx: float | None
+    epy: float | None
+    epv: float | None
+    device: str | None
+
+
+GpsdMessage = GpsdVersionInfo | NormalizedTpvData | None
+"""Classified result: VERSION info, normalized TPV data, or None for
+unsupported message classes."""
+
+
+def read_tpv_mode(payload: JsonObject) -> int | None:
+    """Extract the TPV fix mode as a validated integer."""
+    mode = payload.get("mode")
+    if isinstance(mode, int) and not isinstance(mode, bool):
+        return mode
+    return None
+
+
+def read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
+    """Extract a non-negative finite float metric from *payload*."""
+    value = payload.get(field)
+    if isinstance(value, NUMERIC_TYPES) and not isinstance(value, bool):
+        numeric_value = float(value)
+        if math.isfinite(numeric_value) and numeric_value >= 0:
+            return numeric_value
+    return None
+
+
+def _read_speed(payload: JsonObject) -> float | None:
+    """Extract speed as a validated finite float, or None."""
+    speed = payload.get("speed")
+    if isinstance(speed, NUMERIC_TYPES) and not isinstance(speed, bool):
+        speed_f = float(speed)
+        if math.isfinite(speed_f):
+            return speed_f
+    return None
+
+
+def _read_device(
+    payload: JsonObject,
+) -> str | None:
+    """Extract device string if present and non-empty."""
+    device = payload.get("device")
+    if isinstance(device, str) and device:
+        return device
+    return None
+
+
+def classify_gpsd_message(payload: JsonObject) -> GpsdMessage:
+    """Classify a raw GPSD JSON message and extract typed fields.
+
+    Returns a ``GpsdVersionInfo`` for VERSION messages, a
+    ``NormalizedTpvData`` for TPV messages, or ``None`` for
+    unsupported message classes.
+    """
+    payload_class = payload.get("class")
+
+    if payload_class == "VERSION":
+        revision = payload.get("rev")
+        if isinstance(revision, str):
+            return GpsdVersionInfo(revision=revision)
+        return None
+
+    if payload_class == "TPV":
+        return NormalizedTpvData(
+            mode=read_tpv_mode(payload),
+            speed=_read_speed(payload),
+            epx=read_non_negative_metric(payload, "epx"),
+            epy=read_non_negative_metric(payload, "epy"),
+            epv=read_non_negative_metric(payload, "epv"),
+            device=_read_device(payload),
+        )
+
+    return None


### PR DESCRIPTION
## Problem

`GPSTransportState.ingest_message()` and `ingest_tpv()` blend three distinct responsibilities in one flow: GPSD message classification (determining if a payload is VERSION, TPV, or unsupported), wire-format field extraction (reading mode, speed, epx, epy, epv, device from JSON), and transport-state mutation (applying validated values to the immutable snapshot). This coupling means every GPSD protocol change requires touching the transport state class, and field-extraction edge cases (NaN speed, bool mode, empty device strings) cannot be tested without constructing a `GPSTransportState` instance and running it through the full ingestion pipeline.

The static methods `_tpv_mode()` and `_read_non_negative_metric()` on `GPSTransportState` implement field-level validation that belongs to wire-format parsing, not transport state management. Their placement on the state class existed for historical reasons — they needed a home when classification, extraction, and mutation were a single flow.

Similarly, `GPSSpeedMonitor` re-delegates both functions through thin wrappers (`GPSSpeedMonitor._tpv_mode → GPSTransportState._tpv_mode`) solely because the functions were class-bound rather than module-level.

## Solution

### New module: `gpsd_message_handler.py`

Created `apps/server/vibesensor/adapters/gps/gpsd_message_handler.py` containing all GPSD message classification and field extraction logic:

**Type definitions:**
- `GpsdVersionInfo` — frozen dataclass holding the extracted `revision` string from VERSION messages
- `NormalizedTpvData` — frozen dataclass holding all typed TPV fields: `mode` (int|None), `speed` (float|None), `epx/epy/epv` (float|None), `device` (str|None)
- `GpsdMessage` — union type alias: `GpsdVersionInfo | NormalizedTpvData | None`

**Public functions:**
- `classify_gpsd_message(payload)` — classifies a raw GPSD JSON payload by its `class` field and returns normalized typed data. VERSION messages produce `GpsdVersionInfo`, TPV messages produce `NormalizedTpvData`, and unsupported classes return `None`.
- `read_tpv_mode(payload)` — extracts and validates the `mode` field as an integer, rejecting bools and non-ints
- `read_non_negative_metric(payload, field)` — extracts a named metric field as a non-negative finite float

**Internal helpers:**
- `_read_speed(payload)` — extracts speed as a finite float, rejecting NaN, infinity, and boolean values
- `_read_device(payload)` — extracts device as a non-empty string

All field-extraction functions apply the same validation guards (bool rejection, type checking, finiteness) that were previously embedded in `GPSTransportState`'s static methods.

### GPSTransportState refactoring

**`ingest_message`** now delegates classification to `classify_gpsd_message()`:
1. If the result is `None` (unsupported class), return immediately
2. If `GpsdVersionInfo`, apply `device_info = f"gpsd {info.revision}"`
3. If `NormalizedTpvData`, call the new `_apply_tpv(tpv)` method

**`_apply_tpv`** is a new method that receives pre-normalized `NormalizedTpvData` and performs only state mutation — speed validation via `is_speed_plausible()`, zero-speed transition evaluation via `_evaluate_speed_sample()`, and snapshot replacement. No JSON field reading occurs in this method.

**`_tpv_mode` and `_read_non_negative_metric`** static methods now delegate to the handler module functions (`read_tpv_mode`, `read_non_negative_metric`) instead of implementing the logic inline. These remain for backward compatibility since `GPSSpeedMonitor` references them through its `run()` callback injection.

**`ingest_tpv`** is preserved unchanged for backward compatibility — it still accepts raw payloads with injectable callbacks and performs its own field extraction. This ensures any code depending on the `ingest_tpv` interface continues working.

### GPSSpeedMonitor update

`GPSSpeedMonitor._tpv_mode` and `._read_non_negative_metric` now import directly from `gpsd_message_handler` instead of delegating through `GPSTransportState`. This removes the unnecessary double-delegation chain.

### Test updates

**New tests: `test_gpsd_message_handler.py`** — 22 focused tests organized in 4 test classes:

- `TestClassifyGpsdMessage` (6 tests): VERSION with valid/missing/non-string rev, TPV with full/minimal fields, unsupported class, missing class
- `TestReadTpvMode` (4 tests): valid int, bool rejection, float rejection, missing field
- `TestReadNonNegativeMetric` (7 tests): valid value, zero, negative, NaN, infinity, bool rejection, missing field
- `TestNormalizedTpvDataFieldExtraction` (5 tests): NaN/inf/bool speed → None, empty/non-string device → None

**Updated test:** `test_gps_speed_run_loop.py::test_run_does_not_swallow_processing_programming_errors` — changed the error injection point from `monitor._tpv_mode` (no longer in the message processing path) to `monitor._transport._apply_tpv` (the new state mutation entry point). The test's intent — verifying that programming errors propagate through the run loop — is preserved.

All 180 GPS tests pass (22 new + 158 existing). All 324 hygiene tests pass.

## Changed files

- **`apps/server/vibesensor/adapters/gps/gpsd_message_handler.py`** — New GPSD message classification module
- **`apps/server/vibesensor/adapters/gps/gps_transport.py`** — Delegates classification and field reading to handler
- **`apps/server/vibesensor/adapters/gps/gps_speed.py`** — Imports field readers from handler module
- **`apps/server/vibesensor/adapters/gps/__init__.py`** — Documents the new sub-module
- **`apps/server/tests/adapters/gps/test_gpsd_message_handler.py`** — 22 focused unit tests
- **`apps/server/tests/adapters/gps/test_gps_speed_run_loop.py`** — Updated error injection point

Closes #1409