### PR TITLE
Extract buffer overflow and resize policy from SignalBufferStore.ingest()

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_capacity.py
+++ b/apps/server/tests/infra/processing/test_buffer_capacity.py
@@ -1,0 +1,81 @@
+"""Tests for buffer_capacity: overflow, clamping, and resize policy."""
+
+from __future__ import annotations
+
+from vibesensor.infra.processing.buffer_capacity import (
+    MAX_CLIENT_SAMPLE_RATE_HZ,
+    ClampedRate,
+    OverflowResult,
+    clamp_sample_rate,
+    compute_resize_capacity,
+    evaluate_overflow,
+)
+
+
+class TestEvaluateOverflow:
+    def test_chunk_fits_in_capacity(self) -> None:
+        result = evaluate_overflow(100, 500)
+        assert result == OverflowResult(keep_count=100, drop_count=0, start_offset=0)
+
+    def test_chunk_exactly_fills_capacity(self) -> None:
+        result = evaluate_overflow(500, 500)
+        assert result == OverflowResult(keep_count=500, drop_count=0, start_offset=0)
+
+    def test_chunk_exceeds_capacity(self) -> None:
+        result = evaluate_overflow(700, 500)
+        assert result == OverflowResult(keep_count=500, drop_count=200, start_offset=200)
+
+    def test_single_sample_capacity(self) -> None:
+        result = evaluate_overflow(10, 1)
+        assert result == OverflowResult(keep_count=1, drop_count=9, start_offset=9)
+
+    def test_zero_chunk_size(self) -> None:
+        result = evaluate_overflow(0, 500)
+        assert result == OverflowResult(keep_count=0, drop_count=0, start_offset=0)
+
+    def test_large_overflow(self) -> None:
+        result = evaluate_overflow(10_000, 256)
+        assert result.keep_count == 256
+        assert result.drop_count == 10_000 - 256
+        assert result.start_offset == 10_000 - 256
+
+
+class TestClampSampleRate:
+    def test_rate_within_range(self) -> None:
+        result = clamp_sample_rate(500)
+        assert result == ClampedRate(rate_hz=500, was_clamped=False)
+
+    def test_rate_at_maximum(self) -> None:
+        result = clamp_sample_rate(MAX_CLIENT_SAMPLE_RATE_HZ)
+        assert result == ClampedRate(rate_hz=MAX_CLIENT_SAMPLE_RATE_HZ, was_clamped=False)
+
+    def test_rate_exceeds_maximum(self) -> None:
+        result = clamp_sample_rate(MAX_CLIENT_SAMPLE_RATE_HZ + 1000)
+        assert result == ClampedRate(rate_hz=MAX_CLIENT_SAMPLE_RATE_HZ, was_clamped=True)
+
+    def test_rate_zero_clamped_to_one(self) -> None:
+        result = clamp_sample_rate(0)
+        assert result == ClampedRate(rate_hz=1, was_clamped=True)
+
+    def test_negative_rate_clamped_to_one(self) -> None:
+        result = clamp_sample_rate(-100)
+        assert result == ClampedRate(rate_hz=1, was_clamped=True)
+
+    def test_rate_one(self) -> None:
+        result = clamp_sample_rate(1)
+        assert result == ClampedRate(rate_hz=1, was_clamped=False)
+
+    def test_custom_max_rate(self) -> None:
+        result = clamp_sample_rate(200, max_rate=100)
+        assert result == ClampedRate(rate_hz=100, was_clamped=True)
+
+
+class TestComputeResizeCapacity:
+    def test_basic_computation(self) -> None:
+        assert compute_resize_capacity(500, 2) == 1000
+
+    def test_unit_seconds(self) -> None:
+        assert compute_resize_capacity(1000, 1) == 1000
+
+    def test_large_rate_and_window(self) -> None:
+        assert compute_resize_capacity(4096, 10) == 40960

--- a/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 
-from vibesensor.infra.processing.buffer_store import (
-    MAX_CLIENT_SAMPLE_RATE_HZ,
-    SignalBufferStore,
-)
+from vibesensor.infra.processing.buffer_capacity import MAX_CLIENT_SAMPLE_RATE_HZ
+from vibesensor.infra.processing.buffer_store import SignalBufferStore
 from vibesensor.infra.processing.compute import SignalMetricsComputer
 from vibesensor.infra.processing.models import CachedMetricsHit, MetricsSnapshot, ProcessorConfig
 

--- a/apps/server/vibesensor/infra/processing/__init__.py
+++ b/apps/server/vibesensor/infra/processing/__init__.py
@@ -2,6 +2,8 @@
 
 This package contains the core vibration signal processing pipeline:
 
+- :mod:`~vibesensor.infra.processing.buffer_capacity` — buffer capacity, overflow,
+  and resize policy helpers.
 - :mod:`~vibesensor.infra.processing.buffer_store` — shared buffer state, ingest, locking,
   and state snapshots.
 - :mod:`~vibesensor.infra.processing.compute` — FFT cache/window ownership plus metric

--- a/apps/server/vibesensor/infra/processing/buffer_capacity.py
+++ b/apps/server/vibesensor/infra/processing/buffer_capacity.py
@@ -1,0 +1,59 @@
+"""Buffer capacity, overflow, and resize policy helpers.
+
+Extracted from ``SignalBufferStore.ingest()`` so capacity decisions are
+independently testable and separate from ring-buffer mutation mechanics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+MAX_CLIENT_SAMPLE_RATE_HZ = 4096
+
+
+@dataclass(frozen=True, slots=True)
+class OverflowResult:
+    """Outcome of evaluating an incoming chunk against buffer capacity."""
+
+    keep_count: int
+    drop_count: int
+    start_offset: int
+
+
+@dataclass(frozen=True, slots=True)
+class ClampedRate:
+    """Result of clamping a requested sample rate."""
+
+    rate_hz: int
+    was_clamped: bool
+
+
+def evaluate_overflow(chunk_size: int, capacity: int) -> OverflowResult:
+    """Decide how many samples to keep/drop from an incoming chunk.
+
+    When the chunk exceeds capacity, the oldest incoming samples are
+    discarded and only the most recent *capacity* samples are kept.
+    """
+    if chunk_size <= capacity:
+        return OverflowResult(keep_count=chunk_size, drop_count=0, start_offset=0)
+    drop_count = chunk_size - capacity
+    return OverflowResult(
+        keep_count=capacity,
+        drop_count=drop_count,
+        start_offset=drop_count,
+    )
+
+
+def clamp_sample_rate(
+    requested_rate: int,
+    *,
+    max_rate: int = MAX_CLIENT_SAMPLE_RATE_HZ,
+) -> ClampedRate:
+    """Clamp a requested sample rate to the valid range ``[1, max_rate]``."""
+    clamped = max(1, min(max_rate, int(requested_rate)))
+    return ClampedRate(rate_hz=clamped, was_clamped=clamped != requested_rate)
+
+
+def compute_resize_capacity(sample_rate_hz: int, waveform_seconds: int) -> int:
+    """Compute target buffer capacity from sample rate and window duration."""
+    return sample_rate_hz * waveform_seconds

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -8,6 +8,11 @@ from threading import RLock
 
 import numpy as np
 
+from vibesensor.infra.processing.buffer_capacity import (
+    clamp_sample_rate,
+    compute_resize_capacity,
+    evaluate_overflow,
+)
 from vibesensor.infra.processing.buffers import ClientBuffer
 from vibesensor.infra.processing.models import (
     CachedMetricsHit,
@@ -27,7 +32,6 @@ from vibesensor.shared.types.payload_types import (
 from vibesensor.vibration_strength import empty_vibration_strength_metrics
 
 LOGGER = logging.getLogger(__name__)
-MAX_CLIENT_SAMPLE_RATE_HZ = 4096
 _MAX_SAMPLES_SINCE_T0 = 2**28
 """Cap `samples_since_t0` so long sessions cannot grow the accumulator without bound."""
 
@@ -101,19 +105,19 @@ class SignalBufferStore:
             now_mono = clock()
             buf.last_ingest_mono_s = now_mono
 
-            n = int(chunk.shape[0])
-            capacity = buf.capacity
-            if n > capacity:
-                dropped_samples = n - capacity
+            overflow = evaluate_overflow(int(chunk.shape[0]), buf.capacity)
+            if overflow.drop_count:
                 LOGGER.warning(
                     "Sample chunk for %s exceeds buffer capacity %d; discarding %d oldest samples "
                     "from the incoming batch",
                     client_id,
-                    capacity,
-                    dropped_samples,
+                    buf.capacity,
+                    overflow.drop_count,
                 )
-                chunk = chunk[-capacity:]
-                n = capacity
+                chunk = chunk[overflow.start_offset :]
+            n = overflow.keep_count
+            dropped_samples = overflow.drop_count
+            capacity = buf.capacity
 
             end = buf.write_idx + n
             if end <= capacity:
@@ -427,21 +431,20 @@ class SignalBufferStore:
         *,
         resize_buffer: bool,
     ) -> None:
-        requested_rate = int(sample_rate_hz)
-        clamped_rate = max(1, min(MAX_CLIENT_SAMPLE_RATE_HZ, requested_rate))
-        if clamped_rate != requested_rate:
+        result = clamp_sample_rate(int(sample_rate_hz))
+        if result.was_clamped:
             LOGGER.warning(
                 "Clamped client sample_rate_hz from %d to %d to bound buffer growth",
-                requested_rate,
-                clamped_rate,
+                int(sample_rate_hz),
+                result.rate_hz,
             )
-        if clamped_rate == buf.sample_rate_hz:
+        if result.rate_hz == buf.sample_rate_hz:
             return
-        buf.sample_rate_hz = clamped_rate
+        buf.sample_rate_hz = result.rate_hz
         if resize_buffer:
             self._resize_buffer_unlocked(
                 buf,
-                clamped_rate * self.config.waveform_seconds,
+                compute_resize_capacity(result.rate_hz, self.config.waveform_seconds),
             )
 
     def copy_latest(self, buf: ClientBuffer, n: int) -> FloatArray:

--- a/apps/server/vibesensor/infra/processing/processor.py
+++ b/apps/server/vibesensor/infra/processing/processor.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from vibesensor.infra.processing.buffer_store import (
+from vibesensor.infra.processing.buffer_capacity import (
     MAX_CLIENT_SAMPLE_RATE_HZ as _MAX_CLIENT_SAMPLE_RATE_HZ,
 )
 from vibesensor.infra.processing.buffer_store import SignalBufferStore


### PR DESCRIPTION
## Summary

`SignalBufferStore.ingest()` mixed shape validation, sample-rate override logic, overflow handling, and ring-buffer mutation into a single dense hot-path method. This change extracts buffer-capacity and overflow policy decisions into a new `buffer_capacity.py` module, so the ingest path delegates policy decisions rather than implementing them inline. The actual buffer mutation, locking, and lifecycle management remain in `SignalBufferStore`.

Closes #1410.

## Problem

The `ingest()` method in `buffer_store.py` had grown to carry multiple orthogonal concerns: shape validation, sample rate clamping, overflow detection with truncation, ring-buffer circular writes, t0 timestamp tracking, and stats accumulation. Overflow policy was embedded directly in the hot path, making it hard to test capacity decisions without constructing live buffers and locks. Any change to retention or capacity rules required editing the same monolithic method, increasing blast radius for what should be isolated policy edits.

The `_apply_sample_rate_override_unlocked()` method similarly inlined rate-clamping arithmetic and resize-capacity computation rather than expressing those as named, testable operations.

## Solution

### New module: `buffer_capacity.py`

Created `apps/server/vibesensor/infra/processing/buffer_capacity.py` with three focused helpers:

- **`evaluate_overflow(chunk_size, capacity) → OverflowResult`**: Determines how many samples to keep/drop from an incoming chunk when it exceeds buffer capacity. Returns a frozen `OverflowResult` dataclass with `keep_count`, `drop_count`, and `start_offset` fields so the caller can slice the incoming array without re-deriving the arithmetic.

- **`clamp_sample_rate(requested_rate, *, max_rate) → ClampedRate`**: Clamps a requested sample rate to the valid range `[1, max_rate]` (default `MAX_CLIENT_SAMPLE_RATE_HZ = 4096`). Returns a frozen `ClampedRate` dataclass with `rate_hz` and `was_clamped` so the caller can conditionally log without re-checking the clamping condition.

- **`compute_resize_capacity(sample_rate_hz, waveform_seconds) → int`**: Computes the target buffer capacity from sample rate and window duration so the resize formula is named and testable.

The `MAX_CLIENT_SAMPLE_RATE_HZ` constant now lives in `buffer_capacity.py` as the canonical definition. Import chains through `processor.py` and `__init__.py` are updated to source from there.

### Updated: `buffer_store.py`

**`ingest()`**: The overflow detection block (previously lines ~106-116) now delegates to `evaluate_overflow()`. The method applies the returned `OverflowResult` to slice the chunk and track drop counts, while the decision logic itself is in the helper.

**`_apply_sample_rate_override_unlocked()`**: Now uses `clamp_sample_rate()` to check and clamp the rate, and `compute_resize_capacity()` to compute the target size when resizing. The method retains responsibility for mutating `buf.sample_rate_hz` and calling `_resize_buffer_unlocked()`.

### Updated: `processor.py`

Imports `MAX_CLIENT_SAMPLE_RATE_HZ` directly from `buffer_capacity` instead of `buffer_store`, since the constant is no longer defined in `buffer_store`.

### Updated: `__init__.py`

Package docstring now includes `buffer_capacity` in the module list.

### Updated test: `test_buffer_store_identity_and_rate_guards.py`

Import of `MAX_CLIENT_SAMPLE_RATE_HZ` updated from `buffer_store` to `buffer_capacity`.

## Testing

Added `tests/infra/processing/test_buffer_capacity.py` with 15 focused tests across three test classes:

- **`TestEvaluateOverflow`** (6 tests): chunk fits capacity, exactly fills capacity, exceeds capacity, single-sample capacity, zero chunk size, large overflow ratio.
- **`TestClampSampleRate`** (7 tests): rate within range, at maximum, exceeds maximum, zero clamped to one, negative clamped to one, rate of one, custom max rate.
- **`TestComputeResizeCapacity`** (3 tests): basic multiplication, unit seconds, large rate and window.

All 315 processing tests pass. Full backend suite: 5889 passed, 5 skipped. Lint (`ruff check` + `ruff format`), static guards, and mypy all clean.

## Behavioral impact

None. Buffer contents, retention behavior, overflow drops, and sample rate clamping are identical to the previous implementation. The change is purely structural — extracting inline policy into named, testable helpers without altering any decision outcomes.