### PR TITLE
Extract compute snapshot caching from SignalBufferStore.snapshot_for_compute()

### DIFF
--- a/apps/server/tests/infra/processing/test_snapshot_builder.py
+++ b/apps/server/tests/infra/processing/test_snapshot_builder.py
@@ -1,0 +1,153 @@
+"""Tests for snapshot_builder: cache-hit decisions and window-size computation."""
+
+from __future__ import annotations
+
+from vibesensor.infra.processing.models import CachedMetricsHit
+from vibesensor.infra.processing.snapshot_builder import (
+    SnapshotWindow,
+    check_cache_hit,
+    compute_snapshot_window,
+)
+
+
+class TestCheckCacheHit:
+    def test_cache_hit_when_generations_and_rate_match(self) -> None:
+        metrics = {"rms_x": 0.5}
+        result = check_cache_hit(
+            ingest_generation=3,
+            compute_generation=3,
+            compute_sample_rate_hz=200,
+            effective_sample_rate_hz=200,
+            latest_metrics=metrics,
+        )
+        assert isinstance(result, CachedMetricsHit)
+        assert result.metrics is metrics
+
+    def test_cache_miss_when_generation_differs(self) -> None:
+        result = check_cache_hit(
+            ingest_generation=4,
+            compute_generation=3,
+            compute_sample_rate_hz=200,
+            effective_sample_rate_hz=200,
+            latest_metrics={"rms_x": 0.5},
+        )
+        assert result is None
+
+    def test_cache_miss_when_sample_rate_differs(self) -> None:
+        result = check_cache_hit(
+            ingest_generation=3,
+            compute_generation=3,
+            compute_sample_rate_hz=200,
+            effective_sample_rate_hz=500,
+            latest_metrics={"rms_x": 0.5},
+        )
+        assert result is None
+
+    def test_cache_miss_when_never_computed(self) -> None:
+        result = check_cache_hit(
+            ingest_generation=0,
+            compute_generation=-1,
+            compute_sample_rate_hz=0,
+            effective_sample_rate_hz=200,
+            latest_metrics={},
+        )
+        assert result is None
+
+    def test_cache_hit_with_empty_metrics(self) -> None:
+        result = check_cache_hit(
+            ingest_generation=1,
+            compute_generation=1,
+            compute_sample_rate_hz=100,
+            effective_sample_rate_hz=100,
+            latest_metrics={},
+        )
+        assert isinstance(result, CachedMetricsHit)
+        assert result.metrics == {}
+
+
+class TestComputeSnapshotWindow:
+    def test_basic_window_smaller_than_count(self) -> None:
+        result = compute_snapshot_window(
+            count=1000,
+            capacity=2000,
+            sample_rate_hz=200,
+            waveform_seconds=2,
+            fft_n=256,
+        )
+        assert result == SnapshotWindow(n_time=400, needs_separate_fft_block=False)
+
+    def test_count_limits_window(self) -> None:
+        result = compute_snapshot_window(
+            count=50,
+            capacity=2000,
+            sample_rate_hz=200,
+            waveform_seconds=2,
+            fft_n=256,
+        )
+        assert result.n_time == 50
+
+    def test_capacity_limits_window(self) -> None:
+        result = compute_snapshot_window(
+            count=500,
+            capacity=100,
+            sample_rate_hz=200,
+            waveform_seconds=2,
+            fft_n=256,
+        )
+        assert result.n_time == 100
+
+    def test_needs_separate_fft_block_when_n_time_smaller(self) -> None:
+        # count >= fft_n and n_time < fft_n → needs separate fft block
+        result = compute_snapshot_window(
+            count=512,
+            capacity=512,
+            sample_rate_hz=100,
+            waveform_seconds=1,
+            fft_n=256,
+        )
+        assert result.n_time == 100
+        assert result.needs_separate_fft_block is True
+
+    def test_separate_fft_block_true_when_small_window_large_count(self) -> None:
+        # count >= fft_n but n_time < fft_n → needs separate fft block
+        result = compute_snapshot_window(
+            count=512,
+            capacity=512,
+            sample_rate_hz=10,
+            waveform_seconds=2,
+            fft_n=256,
+        )
+        assert result.n_time == 20
+        assert result.needs_separate_fft_block is True
+
+    def test_no_separate_fft_block_when_n_time_ge_fft_n(self) -> None:
+        result = compute_snapshot_window(
+            count=1000,
+            capacity=1000,
+            sample_rate_hz=200,
+            waveform_seconds=2,
+            fft_n=256,
+        )
+        assert result.n_time == 400
+        assert result.needs_separate_fft_block is False
+
+    def test_no_separate_fft_block_when_count_lt_fft_n(self) -> None:
+        result = compute_snapshot_window(
+            count=100,
+            capacity=1000,
+            sample_rate_hz=10,
+            waveform_seconds=2,
+            fft_n=256,
+        )
+        assert result.n_time == 20
+        assert result.needs_separate_fft_block is False
+
+    def test_minimum_window_is_one(self) -> None:
+        result = compute_snapshot_window(
+            count=5,
+            capacity=100,
+            sample_rate_hz=1,
+            waveform_seconds=0,
+            fft_n=256,
+        )
+        assert result.n_time >= 1

--- a/apps/server/vibesensor/infra/processing/__init__.py
+++ b/apps/server/vibesensor/infra/processing/__init__.py
@@ -8,7 +8,8 @@ This package contains the core vibration signal processing pipeline:
   and state snapshots.
 - :mod:`~vibesensor.infra.processing.compute` — FFT cache/window ownership plus metric
   computation from immutable snapshots.
-- :mod:`~vibesensor.infra.processing.fft` — pure FFT / spectral-analysis functions.
+- :mod:`~vibesensor.infra.processing.snapshot_builder` — compute-snapshot caching and
+  window-size helpers. — pure FFT / spectral-analysis functions.
 - :mod:`~vibesensor.infra.processing.payload` — payload builders for spectrum,
   debug-spectrum, intake-stats, and time-alignment views.
 - :mod:`~vibesensor.infra.processing.time_align` — multi-sensor time-alignment utilities.

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -24,6 +24,10 @@ from vibesensor.infra.processing.models import (
     ProcessorConfig,
     ProcessorStats,
 )
+from vibesensor.infra.processing.snapshot_builder import (
+    check_cache_hit,
+    compute_snapshot_window,
+)
 from vibesensor.shared.types.payload_types import (
     IntakeStatsPayload,
     RawSamplesErrorPayload,
@@ -163,20 +167,31 @@ class SignalBufferStore:
                     resize_buffer=False,
                 )
             sr = buf.sample_rate_hz or self.config.sample_rate_hz
-            if buf.compute_generation == buf.ingest_generation and buf.compute_sample_rate_hz == sr:
-                return CachedMetricsHit(metrics=buf.latest_metrics)
 
-            desired_samples = int(max(1.0, float(sr) * float(self.config.waveform_seconds)))
-            n_time = min(buf.count, buf.capacity, max(1, desired_samples))
+            cache_hit = check_cache_hit(
+                ingest_generation=buf.ingest_generation,
+                compute_generation=buf.compute_generation,
+                compute_sample_rate_hz=buf.compute_sample_rate_hz,
+                effective_sample_rate_hz=sr,
+                latest_metrics=buf.latest_metrics,
+            )
+            if cache_hit is not None:
+                return cache_hit
+
+            window = compute_snapshot_window(
+                count=buf.count,
+                capacity=buf.capacity,
+                sample_rate_hz=sr,
+                waveform_seconds=self.config.waveform_seconds,
+                fft_n=self.config.fft_n,
+            )
+
             fft_block: FloatArray | None = None
-            if buf.count >= self.config.fft_n and n_time < self.config.fft_n:
-                # The compute path always consumes the latest overlapping suffix
-                # windows. Copy the larger FFT block once, then let the shorter
-                # time window borrow its tail view from that owned snapshot.
+            if window.needs_separate_fft_block:
                 fft_block = self.copy_latest(buf, self.config.fft_n)
-                time_window = fft_block[:, -n_time:]
+                time_window = fft_block[:, -window.n_time :]
             else:
-                time_window = self.copy_latest(buf, n_time)
+                time_window = self.copy_latest(buf, window.n_time)
                 if buf.count >= self.config.fft_n:
                     fft_block = time_window[:, -self.config.fft_n :]
             return MetricsSnapshot(

--- a/apps/server/vibesensor/infra/processing/snapshot_builder.py
+++ b/apps/server/vibesensor/infra/processing/snapshot_builder.py
@@ -1,0 +1,55 @@
+"""Compute-snapshot caching and window-size helpers.
+
+Extracted from ``SignalBufferStore.snapshot_for_compute()`` so cache-hit
+decisions and window-size arithmetic are independently testable and
+separate from lock acquisition and buffer reads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.infra.processing.models import CachedMetricsHit, ClientMetrics
+
+
+def check_cache_hit(
+    *,
+    ingest_generation: int,
+    compute_generation: int,
+    compute_sample_rate_hz: int,
+    effective_sample_rate_hz: int,
+    latest_metrics: ClientMetrics,
+) -> CachedMetricsHit | None:
+    """Return a cache hit when the buffer has already been computed at the current generation."""
+    if (
+        compute_generation == ingest_generation
+        and compute_sample_rate_hz == effective_sample_rate_hz
+    ):
+        return CachedMetricsHit(metrics=latest_metrics)
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotWindow:
+    """Computed window sizes for snapshot assembly."""
+
+    n_time: int
+    needs_separate_fft_block: bool
+
+
+def compute_snapshot_window(
+    *,
+    count: int,
+    capacity: int,
+    sample_rate_hz: int,
+    waveform_seconds: int,
+    fft_n: int,
+) -> SnapshotWindow:
+    """Compute the time-window size and FFT-block strategy for a compute snapshot."""
+    desired_samples = int(max(1.0, float(sample_rate_hz) * float(waveform_seconds)))
+    n_time = min(count, capacity, max(1, desired_samples))
+    needs_separate_fft_block = count >= fft_n and n_time < fft_n
+    return SnapshotWindow(
+        n_time=n_time,
+        needs_separate_fft_block=needs_separate_fft_block,
+    )


### PR DESCRIPTION
## Summary

`SignalBufferStore.snapshot_for_compute()` mixed generation tracking, cache reuse, window-size arithmetic, and snapshot assembly into a single method. This change extracts the cache-hit decision and window-size computation into a new `snapshot_builder.py` module, so the snapshot method delegates those pure policy decisions while retaining responsibility for lock acquisition, buffer reads, and snapshot object assembly.

Closes #1411.

## Problem

The `snapshot_for_compute()` method in `buffer_store.py` carried three distinct concerns in a single control flow: (1) generation-based cache-hit checks comparing `compute_generation` / `ingest_generation` / `compute_sample_rate_hz`, (2) window-size arithmetic involving `desired_samples`, `n_time`, and the separate-FFT-block decision, and (3) the actual buffer reads via `copy_latest`. These concerns evolve for different reasons — caching strategy changes independently of snapshot assembly, and window-size rules change independently of lock acquisition patterns.

Testing cache-hit behavior required constructing full buffer fixtures with locks, making it impractical to verify the caching decision matrix in isolation. The window-size computation similarly required live buffers when it is fundamentally an arithmetic function over a handful of integer inputs.

## Solution

### New module: `snapshot_builder.py`

Created `apps/server/vibesensor/infra/processing/snapshot_builder.py` with two focused helpers:

- **`check_cache_hit(*, ingest_generation, compute_generation, compute_sample_rate_hz, effective_sample_rate_hz, latest_metrics) → CachedMetricsHit | None`**: Evaluates whether the buffer has already been computed at the current generation and sample rate. Returns a `CachedMetricsHit` on match, `None` on miss. This encapsulates the generation-matching logic that was previously inlined in the method body.

- **`compute_snapshot_window(*, count, capacity, sample_rate_hz, waveform_seconds, fft_n) → SnapshotWindow`**: Computes the time-window sample count (`n_time`) and determines whether the compute path needs a separate FFT block copied from the buffer (when `count >= fft_n` but `n_time < fft_n`). Returns a frozen `SnapshotWindow` dataclass with `n_time` and `needs_separate_fft_block` fields.

Both functions use keyword-only parameters for clarity at call sites and are pure functions with no side effects.

### Updated: `buffer_store.py`

**`snapshot_for_compute()`** now delegates to the two new helpers:

1. After acquiring the client lock and applying any sample-rate override, it calls `check_cache_hit()` with the relevant generation counters and sample rate. If a cache hit is returned, the method returns immediately.

2. On cache miss, it calls `compute_snapshot_window()` to determine window sizes, then uses the returned `SnapshotWindow` to drive the existing buffer-read logic (`copy_latest` for FFT block and time window).

The method retains all lock acquisition, sample-rate override application, buffer reads, and `MetricsSnapshot` assembly. Only the pure decision logic was extracted.

New import added for `check_cache_hit` and `compute_snapshot_window` from `snapshot_builder`.

### Updated: `__init__.py`

Package docstring updated to include the new `snapshot_builder` module in the module catalog.

## Testing

Added `tests/infra/processing/test_snapshot_builder.py` with 13 focused tests across two test classes:

- **`TestCheckCacheHit`** (5 tests): cache hit when generations and rate match, cache miss when generation differs, cache miss when sample rate differs, cache miss when never computed (initial state), cache hit with empty metrics dict.

- **`TestComputeSnapshotWindow`** (8 tests): basic window smaller than count, count limits window, capacity limits window, needs separate FFT block when n_time smaller than fft_n, separate FFT block required when small window with large count, no separate FFT block when n_time exceeds fft_n, no separate FFT block when count below fft_n, minimum window is at least one sample.

All 328 processing tests pass. Full backend suite: 5902 passed, 5 skipped. Lint (`ruff check` + `ruff format`), mypy, and static guards all clean.

## Behavioral impact

None. Cache-hit decisions, window-size computations, and snapshot assembly produce identical results. The change is purely structural — extracting inline policy into named, testable pure functions without altering any decision outcomes or data flows.