### PR TITLE
Shard backend CI tests across three jobs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Commands
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
 - `act -j backend-quality -W .github/workflows/ci.yml` (run a single CI job locally via `act`; requires Docker)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
-- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests` (faster backend-focused CI subset)
+- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3` (faster backend-focused CI subset)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
 - `python3 tools/watch_pr_checks.py --pr <PR_NUMBER> --interval 30 --repo Skamba/VibeSensor`
 - `cd apps/ui && npm ci && npm run typecheck && npm run build`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,8 @@ jobs:
           cd firmware/esp
           pio test -e native
 
-  backend-tests:
-    name: Backend tests
+  backend-tests-1:
+    name: Backend tests (shard 1/3)
     needs:
       - backend-quality
       - backend-typecheck
@@ -188,19 +188,107 @@ jobs:
 
       - uses: ./.github/actions/setup-backend
 
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/vibesensor/backend-duration-cache.json
+          key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-1-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-
+            ${{ runner.os }}-backend-test-durations-
+
       - name: Prepare backend test artifacts
         run: |
           mkdir -p artifacts/ai/logs/ci
 
-      - name: Backend tests
+      - name: Backend tests shard 1/3
         run: |
-          python -m pytest -q --tb=short --junitxml artifacts/ai/logs/ci/backend-tests.xml apps/server/tests
+          python3 tools/tests/run_backend_parallel.py --shards 3 --shard-index 1 --junitxml artifacts/ai/logs/ci/backend-tests-1.xml
 
       - name: Upload backend test artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: backend-test-artifacts
+          name: backend-test-artifacts-1
+          path: artifacts/ai/logs/ci/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  backend-tests-2:
+    name: Backend tests (shard 2/3)
+    needs:
+      - backend-quality
+      - backend-typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-backend
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/vibesensor/backend-duration-cache.json
+          key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-2-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-
+            ${{ runner.os }}-backend-test-durations-
+
+      - name: Prepare backend test artifacts
+        run: |
+          mkdir -p artifacts/ai/logs/ci
+
+      - name: Backend tests shard 2/3
+        run: |
+          python3 tools/tests/run_backend_parallel.py --shards 3 --shard-index 2 --junitxml artifacts/ai/logs/ci/backend-tests-2.xml
+
+      - name: Upload backend test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-artifacts-2
+          path: artifacts/ai/logs/ci/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  backend-tests-3:
+    name: Backend tests (shard 3/3)
+    needs:
+      - backend-quality
+      - backend-typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-backend
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/vibesensor/backend-duration-cache.json
+          key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-3-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-
+            ${{ runner.os }}-backend-test-durations-
+
+      - name: Prepare backend test artifacts
+        run: |
+          mkdir -p artifacts/ai/logs/ci
+
+      - name: Backend tests shard 3/3
+        run: |
+          python3 tools/tests/run_backend_parallel.py --shards 3 --shard-index 3 --junitxml artifacts/ai/logs/ci/backend-tests-3.xml
+
+      - name: Upload backend test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-artifacts-3
           path: artifacts/ai/logs/ci/
           if-no-files-found: ignore
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
-CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests
+CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests-1 --job backend-tests-2 --job backend-tests-3
 
 help: ## Show the available make targets and what each one does
 	@awk 'BEGIN {FS = ":.*## "; printf "Available targets:\n"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -1,0 +1,87 @@
+"""Guard backend test shard planning and cache observations."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import xml.etree.ElementTree as ET
+
+from tests._paths import REPO_ROOT
+
+_RUN_BACKEND_PARALLEL = REPO_ROOT / "tools" / "tests" / "run_backend_parallel.py"
+
+
+def _load_run_backend_parallel_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_backend_parallel_local_for_tests", _RUN_BACKEND_PARALLEL
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_RUN_BACKEND_PARALLEL}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_assign_shards_uses_cached_durations_by_file() -> None:
+    module = _load_run_backend_parallel_module()
+    slow_a = "apps/server/tests/integration/test_report_pipeline.py::test_alpha"
+    slow_b = "apps/server/tests/integration/test_report_pipeline.py::test_beta"
+    fast = "apps/server/tests/app/test_app_main.py::test_fast"
+
+    shards = module._assign_shards_by_duration(
+        [fast, slow_a, slow_b],
+        2,
+        {
+            slow_a: 4.0,
+            slow_b: 3.0,
+            fast: 1.0,
+        },
+    )
+
+    assert shards[0] == ["apps/server/tests/integration/test_report_pipeline.py"]
+    assert shards[1] == ["apps/server/tests/app/test_app_main.py"]
+
+
+def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path) -> None:
+    module = _load_run_backend_parallel_module()
+    junit_path = tmp_path / "backend-shard.xml"
+    root = ET.Element("testsuite")
+    ET.SubElement(
+        root,
+        "testcase",
+        classname="tests.integration.test_report_pipeline",
+        name="test_alpha[param]",
+        time="4.25",
+    )
+    ET.SubElement(
+        root,
+        "testcase",
+        classname="tests.app.test_app_main",
+        name="test_fast",
+        time="1.75",
+    )
+    ET.ElementTree(root).write(junit_path, encoding="utf-8", xml_declaration=True)
+
+    observed = module._observed_durations_from_junit(
+        junit_path,
+        [
+            "apps/server/tests/integration/test_report_pipeline.py::test_alpha[param]",
+            "apps/server/tests/app/test_app_main.py::test_fast",
+        ],
+    )
+
+    assert observed == {
+        "apps/server/tests/integration/test_report_pipeline.py::test_alpha[param]": 4.25,
+        "apps/server/tests/app/test_app_main.py::test_fast": 1.75,
+    }
+
+
+def test_parse_args_defaults_to_single_shard(monkeypatch) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.setattr(module.sys, "argv", ["run_backend_parallel.py"])
+
+    args = module._parse_args()
+
+    assert args.shards == 1
+    assert args.shard_index == 1
+    assert args.junitxml is None

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,7 @@
 - Use `make test-ci-lite` for the non-Docker blocking-CI subset.
 - Use `make test-all` (`python3 tools/tests/run_ci_parallel.py`) for the broader local runner, including Docker-backed jobs when Docker is available.
 - The full Docker-backed verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`), which defaults to the lean backend-only `apps/server/Dockerfile.e2e` image path with static UI serving disabled.
+- `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time.
 - `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
 - Python test configuration lives in `apps/server/pyproject.toml`.
 - Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py` and run via `make lint` (or directly with `cd apps/server && python3 ../../tools/dev/verify_backend_static_guards.py`).
@@ -110,7 +111,7 @@ python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100 -
 Focused CI job groups and full-stack validation:
 
 ```bash
-python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests
+python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3
 python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
 python3 tools/tests/run_ci_parallel.py --job release-smoke
 make test-full-suite
@@ -174,7 +175,9 @@ act -W .github/workflows/ci.yml
 act -j backend-quality -W .github/workflows/ci.yml
 act -j backend-typecheck -W .github/workflows/ci.yml
 act -j frontend-typecheck -W .github/workflows/ci.yml
-act -j backend-tests -W .github/workflows/ci.yml
+act -j backend-tests-1 -W .github/workflows/ci.yml
+act -j backend-tests-2 -W .github/workflows/ci.yml
+act -j backend-tests-3 -W .github/workflows/ci.yml
 act -j ui-smoke -W .github/workflows/ci.yml
 act -j release-smoke -W .github/workflows/ci.yml
 
@@ -208,7 +211,7 @@ No secrets are currently required. If needed in the future, copy
 | `frontend-typecheck` | ✅ Fully supported | — |
 | `ui-smoke` | ✅ Fully supported | — |
 | `release-smoke` | ✅ Fully supported | — |
-| `backend-tests` | ⚠️ Mostly works | 5 update-module tests that depend on system-level features (sudo, network interfaces) may fail inside the `act` container. All other tests pass. |
+| `backend-tests-1/2/3` | ⚠️ Mostly works | 5 update-module tests that depend on system-level features (sudo, network interfaces) may fail inside the `act` container. All other tests pass. |
 | `e2e` | ❌ Not supported | Requires Docker-in-Docker. Run `make test-full-suite` or use GitHub CI instead. |
 
 ### Relationship to `run_ci_parallel.py`
@@ -248,7 +251,7 @@ The default CI-parity suite now mirrors these blocking GitHub checks:
 - `backend-typecheck`: mypy on the `vibesensor` backend package; package discovery keeps new backend files checked by default without an internal module denylist.
 - `frontend-typecheck`: `npm run typecheck` in `apps/ui/`.
 - `release-smoke`: builds packaged UI and a server wheel, then runs the release smoke validator against the built artifact.
-- `ui-smoke`, `backend-tests`, `e2e`: required test jobs.
+- `ui-smoke`, `backend-tests-1`, `backend-tests-2`, `backend-tests-3`, `e2e`: required test jobs.
 
 ## Adding or moving tests
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -88,10 +88,15 @@ def check_path_indirections() -> tuple[list[str], list[str]]:
 
 
 _MIRRORED_UI_INSTALL_JOBS = ("frontend-typecheck", "ui-smoke")
+_BACKEND_TEST_SHARD_JOBS = (
+    "backend-tests-1",
+    "backend-tests-2",
+    "backend-tests-3",
+)
 _MIRRORED_BACKEND_INSTALL_JOBS = (
     "backend-quality",
     "backend-typecheck",
-    "backend-tests",
+    *_BACKEND_TEST_SHARD_JOBS,
     "e2e",
 )
 _FIRMWARE_INSTALL_JOB = "firmware-native-tests"
@@ -723,6 +728,47 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
         errors.append(
             "ui-smoke must cache ~/.cache/ms-playwright with a package-lock-based actions/cache key."
         )
+
+    for job_name in _BACKEND_TEST_SHARD_JOBS:
+        backend_job = jobs.get(job_name) if isinstance(jobs, Mapping) else None
+        backend_steps = (
+            backend_job.get("steps") if isinstance(backend_job, Mapping) else None
+        )
+        backend_duration_cache_ok = False
+        if isinstance(backend_steps, list):
+            for step in backend_steps:
+                if not isinstance(step, Mapping):
+                    continue
+                uses = step.get("uses")
+                if not isinstance(uses, str) or not uses.startswith("actions/cache@"):
+                    continue
+                with_data = step.get("with")
+                if not isinstance(with_data, Mapping):
+                    continue
+                path = with_data.get("path")
+                key = with_data.get("key")
+                restore_keys = with_data.get("restore-keys")
+                if (
+                    isinstance(path, str)
+                    and path.strip()
+                    == "~/.cache/vibesensor/backend-duration-cache.json"
+                    and isinstance(key, str)
+                    and "backend-test-durations" in key
+                    and "run_backend_parallel.py" in key
+                    and "apps/server/tests/**/*.py" in key
+                    and "github.run_id" in key
+                    and isinstance(restore_keys, str)
+                    and "run_backend_parallel.py" in restore_keys
+                    and "${{ runner.os }}-backend-test-durations-" in restore_keys
+                ):
+                    backend_duration_cache_ok = True
+                    break
+        if not backend_duration_cache_ok:
+            errors.append(
+                f"{job_name} must cache ~/.cache/vibesensor/backend-duration-cache.json "
+                "with a restoreable actions/cache key tied to run_backend_parallel.py, "
+                "apps/server/tests, and github.run_id."
+            )
 
     e2e_job = jobs.get("e2e") if isinstance(jobs, Mapping) else None
     steps: object = None

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from collections.abc import Mapping
+from contextlib import contextmanager
+from pathlib import Path
+
+# Keep these duration-cache and JUnit helpers aligned with tools/tests/run_e2e_parallel.py.
+# They stay local here so this standalone tool can run directly without package-path setup.
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci"
+_DURATION_CACHE_ENV = "VIBESENSOR_BACKEND_DURATION_CACHE"
+_DEFAULT_DURATION = 1.0
+
+
+def _emit(line: str) -> None:
+    print(line, flush=True)
+
+
+def _parse_collected_test_ids(output: str) -> list[str]:
+    test_ids: list[str] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if "::" not in line:
+            continue
+        if line.startswith("=") or line.startswith("<"):
+            continue
+        if line.startswith("tests/"):
+            test_ids.append(f"apps/server/{line}")
+            continue
+        if line.startswith("apps/server/tests/"):
+            test_ids.append(line)
+    return test_ids
+
+
+def collect_test_ids(pytest_args: list[str]) -> list[str]:
+    cmd = [sys.executable, "-m", "pytest", "--collect-only", "-q", *pytest_args]
+    result = subprocess.run(
+        cmd, check=False, capture_output=True, text=True, cwd=str(ROOT)
+    )
+    if result.returncode != 0:
+        sys.stdout.write(result.stdout or "")
+        sys.stderr.write(result.stderr or "")
+        raise SystemExit(result.returncode)
+    return _parse_collected_test_ids(result.stdout or "")
+
+
+def _duration_cache_path(env: Mapping[str, str] | None = None) -> Path:
+    source = os.environ if env is None else env
+    raw_path = source.get(_DURATION_CACHE_ENV, "").strip()
+    if raw_path:
+        return Path(raw_path).expanduser()
+    return Path.home() / ".cache" / "vibesensor" / "backend-duration-cache.json"
+
+
+def _load_duration_cache(path: Path) -> dict[str, float]:
+    try:
+        raw_payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        _emit(f"[backend-parallel] ignoring unreadable duration cache: {path}")
+        return {}
+    if not isinstance(raw_payload, dict):
+        _emit(f"[backend-parallel] ignoring invalid duration cache payload: {path}")
+        return {}
+
+    durations: dict[str, float] = {}
+    for test_id, raw_duration in raw_payload.items():
+        if not isinstance(test_id, str):
+            continue
+        try:
+            duration = float(raw_duration)
+        except (TypeError, ValueError):
+            continue
+        if duration > 0:
+            durations[test_id] = duration
+    return durations
+
+
+def _write_duration_cache(path: Path, durations: Mapping[str, float]) -> None:
+    payload = {
+        test_id: round(duration, 3)
+        for test_id, duration in sorted(durations.items())
+        if duration > 0
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8"
+    )
+
+
+def _merge_duration_observations(
+    cached: Mapping[str, float], observed: Mapping[str, float]
+) -> dict[str, float]:
+    merged = dict(cached)
+    for test_id, duration in observed.items():
+        if duration <= 0:
+            continue
+        previous = merged.get(test_id)
+        merged[test_id] = (
+            duration if previous is None else round((previous + duration) / 2.0, 3)
+        )
+    return merged
+
+
+@contextmanager
+def _locked_duration_cache(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(f"{path.suffix}.lock")
+    with lock_path.open("w", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _update_duration_cache(path: Path, observed: Mapping[str, float]) -> None:
+    if not observed:
+        return
+    try:
+        with _locked_duration_cache(path):
+            cached = _load_duration_cache(path)
+            merged = _merge_duration_observations(cached, observed)
+            _write_duration_cache(path, merged)
+    except OSError:
+        _emit(f"[backend-parallel] failed to update duration cache: {path}")
+
+
+def _junit_case_key(test_id: str) -> tuple[str, str]:
+    path_part, *segments = test_id.split("::")
+    normalized_path = path_part.removeprefix("apps/server/").removesuffix(".py")
+    module_name = normalized_path.replace("/", ".")
+    name = segments[-1] if segments else test_id
+    classname_segments = [module_name, *segments[:-1]]
+    return ".".join(segment for segment in classname_segments if segment), name
+
+
+def _observed_durations_from_junit(
+    junit_path: Path, selected_tests: list[str]
+) -> dict[str, float]:
+    if not junit_path.exists():
+        return {}
+    try:
+        root = ET.parse(junit_path).getroot()
+    except (ET.ParseError, OSError):
+        _emit(f"[backend-parallel] ignoring unreadable junit timings: {junit_path}")
+        return {}
+
+    lookup = {_junit_case_key(test_id): test_id for test_id in selected_tests}
+    observed: dict[str, float] = {}
+    for case in root.iter("testcase"):
+        classname = case.attrib.get("classname")
+        name = case.attrib.get("name")
+        raw_time = case.attrib.get("time")
+        if not isinstance(classname, str) or not isinstance(name, str):
+            continue
+        if not isinstance(raw_time, str):
+            continue
+        test_id = lookup.get((classname, name))
+        if test_id is None:
+            continue
+        try:
+            duration = float(raw_time)
+        except ValueError:
+            continue
+        if duration >= 0:
+            observed[test_id] = duration
+    return observed
+
+
+def _group_tests_by_path(collected: list[str]) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for test_id in collected:
+        path = test_id.split("::", 1)[0]
+        grouped[path].append(test_id)
+    return dict(grouped)
+
+
+def _estimate_target_duration(
+    test_ids: list[str], durations: Mapping[str, float]
+) -> float:
+    return sum(durations.get(test_id, _DEFAULT_DURATION) for test_id in test_ids)
+
+
+def _assign_shards_by_duration(
+    collected: list[str], shard_count: int, durations: Mapping[str, float]
+) -> list[list[str]]:
+    """Assign whole test files to shards using duration-aware greedy bin-packing."""
+    grouped = _group_tests_by_path(collected)
+    weighted_targets = [
+        (path, _estimate_target_duration(test_ids, durations))
+        for path, test_ids in grouped.items()
+    ]
+    weighted_targets.sort(key=lambda item: (-item[1], item[0]))
+
+    shard_targets: list[list[str]] = [[] for _ in range(shard_count)]
+    shard_loads: list[float] = [0.0] * shard_count
+    for path, duration in weighted_targets:
+        index = min(
+            range(shard_count), key=lambda shard_index: shard_loads[shard_index]
+        )
+        shard_targets[index].append(path)
+        shard_loads[index] += duration
+    return shard_targets
+
+
+def _selected_test_ids(
+    shard_targets: list[str], grouped_tests: Mapping[str, list[str]]
+) -> list[str]:
+    selected: list[str] = []
+    for target in shard_targets:
+        selected.extend(grouped_tests.get(target, []))
+    return selected
+
+
+def _run(cmd: list[str], *, log_path: Path) -> int:
+    with log_path.open("w", encoding="utf-8") as log_file:
+        log_file.write(f"$ {shlex.join(cmd)}\n")
+        proc = subprocess.run(
+            cmd,
+            cwd=str(ROOT),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        output = proc.stdout or ""
+        if output:
+            log_file.write(output)
+            if not output.endswith("\n"):
+                log_file.write("\n")
+    return proc.returncode if proc.returncode is not None else 1
+
+
+def _tail(path: Path, lines: int = 60) -> str:
+    if not path.exists():
+        return "<missing log>"
+    content = path.read_text(encoding="utf-8").splitlines()
+    return "\n".join(content[-lines:])
+
+
+def _write_empty_junit(path: Path) -> None:
+    testsuite = ET.Element("testsuite", name="backend-tests", tests="0")
+    ET.ElementTree(testsuite).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a duration-balanced shard of apps/server/tests."
+    )
+    parser.add_argument(
+        "--shards",
+        type=int,
+        default=1,
+        help="Total number of backend test shards.",
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=1,
+        help="1-based shard index to execute.",
+    )
+    parser.add_argument(
+        "--junitxml",
+        default=None,
+        help="Optional JUnit XML output path for the selected shard.",
+    )
+    args = parser.parse_args()
+    if args.shards < 1:
+        raise SystemExit("--shards must be >= 1")
+    if not 1 <= args.shard_index <= args.shards:
+        raise SystemExit("--shard-index must be between 1 and --shards")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    collected = collect_test_ids(["apps/server/tests"])
+    grouped_tests = _group_tests_by_path(collected)
+
+    duration_cache_path = _duration_cache_path()
+    duration_cache = _load_duration_cache(duration_cache_path)
+    if duration_cache:
+        _emit(
+            f"[backend-parallel] loaded {len(duration_cache)} cached test durations from "
+            f"{duration_cache_path}"
+        )
+
+    shard_targets = _assign_shards_by_duration(collected, args.shards, duration_cache)
+    selected_targets = shard_targets[args.shard_index - 1]
+    selected_tests = _selected_test_ids(selected_targets, grouped_tests)
+
+    junit_path = (
+        Path(args.junitxml)
+        if args.junitxml is not None
+        else LOG_DIR / f"backend-tests-{args.shard_index}.xml"
+    )
+    log_path = junit_path.with_suffix(".log")
+    junit_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _emit(
+        f"[backend-parallel] collected {len(collected)} test cases across "
+        f"{len(grouped_tests)} test files; running shard {args.shard_index}/{args.shards} "
+        f"with {len(selected_targets)} files and {len(selected_tests)} test cases"
+    )
+
+    if not selected_targets:
+        _emit(
+            f"[backend-parallel] shard {args.shard_index}/{args.shards}: no files selected; skipping"
+        )
+        _write_empty_junit(junit_path)
+        return 0
+
+    pytest_cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-n",
+        "0",
+        "--tb=short",
+        "--junitxml",
+        str(junit_path),
+        *selected_targets,
+    ]
+    started = time.monotonic()
+    rc = _run(pytest_cmd, log_path=log_path)
+    elapsed = time.monotonic() - started
+
+    observed_durations = _observed_durations_from_junit(junit_path, selected_tests)
+    if observed_durations:
+        _update_duration_cache(duration_cache_path, observed_durations)
+        _emit(
+            f"[backend-parallel] updated duration cache with {len(observed_durations)} observed "
+            f"test timings at {duration_cache_path}"
+        )
+
+    if rc == 0:
+        _emit(
+            f"[backend-parallel] shard {args.shard_index}/{args.shards} passed in "
+            f"{elapsed:.1f}s log={log_path}"
+        )
+        return 0
+
+    _emit(
+        f"[backend-parallel] shard {args.shard_index}/{args.shards} failed "
+        f"(exit {rc}) in {elapsed:.1f}s tail:\n{_tail(log_path)}"
+    )
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -228,22 +228,60 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                 cwd=ROOT / "firmware" / "esp",
             ),
         ],
-        "backend-tests": [
+        "backend-tests-1": [
             Step(
                 "Prepare backend test artifacts",
                 ["mkdir", "-p", "artifacts/ai/logs/ci"],
             ),
             Step(
-                "Backend tests",
+                "Backend tests shard 1/3",
                 [
                     python_cmd,
-                    "-m",
-                    "pytest",
-                    "-q",
-                    "--tb=short",
+                    "tools/tests/run_backend_parallel.py",
+                    "--shards",
+                    "3",
+                    "--shard-index",
+                    "1",
                     "--junitxml",
-                    "artifacts/ai/logs/ci/backend-tests.xml",
-                    "apps/server/tests",
+                    "artifacts/ai/logs/ci/backend-tests-1.xml",
+                ],
+            ),
+        ],
+        "backend-tests-2": [
+            Step(
+                "Prepare backend test artifacts",
+                ["mkdir", "-p", "artifacts/ai/logs/ci"],
+            ),
+            Step(
+                "Backend tests shard 2/3",
+                [
+                    python_cmd,
+                    "tools/tests/run_backend_parallel.py",
+                    "--shards",
+                    "3",
+                    "--shard-index",
+                    "2",
+                    "--junitxml",
+                    "artifacts/ai/logs/ci/backend-tests-2.xml",
+                ],
+            ),
+        ],
+        "backend-tests-3": [
+            Step(
+                "Prepare backend test artifacts",
+                ["mkdir", "-p", "artifacts/ai/logs/ci"],
+            ),
+            Step(
+                "Backend tests shard 3/3",
+                [
+                    python_cmd,
+                    "tools/tests/run_backend_parallel.py",
+                    "--shards",
+                    "3",
+                    "--shard-index",
+                    "3",
+                    "--junitxml",
+                    "artifacts/ai/logs/ci/backend-tests-3.xml",
                 ],
             ),
         ],
@@ -302,7 +340,9 @@ def main() -> int:
             "ui-smoke",
             "release-smoke",
             "firmware-native-tests",
-            "backend-tests",
+            "backend-tests-1",
+            "backend-tests-2",
+            "backend-tests-3",
             "e2e",
         ],
         help="Run only selected job(s). Repeat to run multiple jobs.",
@@ -333,7 +373,9 @@ def main() -> int:
             "ui-smoke",
             "release-smoke",
             "firmware-native-tests",
-            "backend-tests",
+            "backend-tests-1",
+            "backend-tests-2",
+            "backend-tests-3",
             "e2e",
         ]
     )

--- a/tools/tests/run_ci_with_act.sh
+++ b/tools/tests/run_ci_with_act.sh
@@ -7,7 +7,7 @@
 #   ./tools/tests/run_ci_with_act.sh              # run all CI jobs (push event)
 #   ./tools/tests/run_ci_with_act.sh -l            # list available jobs
 #   ./tools/tests/run_ci_with_act.sh -j backend-quality   # run one job
-#   ./tools/tests/run_ci_with_act.sh -j backend-tests     # run backend tests
+#   ./tools/tests/run_ci_with_act.sh -j backend-tests-1   # run one backend test shard
 #   ./tools/tests/run_ci_with_act.sh <extra act args>     # pass-through
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- replace the single backend test CI job with three balanced shard jobs
- add `tools/tests/run_backend_parallel.py` to keep whole test files together while using cached JUnit timings for balance
- update the local CI mirror, hygiene checks, Makefile job list, and docs to match the new shard layout

## Testing
- pytest -q apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_lite_job_parity.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_docker_ci_hygiene.py apps/server/tests/hygiene/test_run_e2e_parallel.py
- make lint
- python3 tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-tests-1 --job backend-tests-2 --job backend-tests-3

## Local timing note
- local three-shard backend run completed in 79.8s wall time, with shard runtimes of 69.1s, 79.8s, and 54.1s
