### PR TITLE
Increase backend CI sharding to five jobs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Commands
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
 - `act -j backend-quality -W .github/workflows/ci.yml` (run a single CI job locally via `act`; requires Docker)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
-- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3` (faster backend-focused CI subset)
+- `python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
 - `python3 tools/watch_pr_checks.py --pr <PR_NUMBER> --interval 30 --repo Skamba/VibeSensor`
 - `cd apps/ui && npm ci && npm run typecheck && npm run build`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,7 @@ jobs:
           pio test -e native
 
   backend-tests-1:
-    name: Backend tests (shard 1/3)
-    needs:
-      - backend-quality
-      - backend-typecheck
+    name: Backend tests (shard 1/5)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -200,9 +197,9 @@ jobs:
         run: |
           mkdir -p artifacts/ai/logs/ci
 
-      - name: Backend tests shard 1/3
+      - name: Backend tests shard 1/5
         run: |
-          python3 tools/tests/run_backend_parallel.py --shards 3 --shard-index 1 --junitxml artifacts/ai/logs/ci/backend-tests-1.xml
+          python3 tools/tests/run_backend_parallel.py --shards 5 --shard-index 1 --junitxml artifacts/ai/logs/ci/backend-tests-1.xml
 
       - name: Upload backend test artifacts
         if: failure()
@@ -214,10 +211,7 @@ jobs:
           retention-days: 7
 
   backend-tests-2:
-    name: Backend tests (shard 2/3)
-    needs:
-      - backend-quality
-      - backend-typecheck
+    name: Backend tests (shard 2/5)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -240,9 +234,9 @@ jobs:
         run: |
           mkdir -p artifacts/ai/logs/ci
 
-      - name: Backend tests shard 2/3
+      - name: Backend tests shard 2/5
         run: |
-          python3 tools/tests/run_backend_parallel.py --shards 3 --shard-index 2 --junitxml artifacts/ai/logs/ci/backend-tests-2.xml
+          python3 tools/tests/run_backend_parallel.py --shards 5 --shard-index 2 --junitxml artifacts/ai/logs/ci/backend-tests-2.xml
 
       - name: Upload backend test artifacts
         if: failure()
@@ -254,10 +248,7 @@ jobs:
           retention-days: 7
 
   backend-tests-3:
-    name: Backend tests (shard 3/3)
-    needs:
-      - backend-quality
-      - backend-typecheck
+    name: Backend tests (shard 3/5)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -280,15 +271,89 @@ jobs:
         run: |
           mkdir -p artifacts/ai/logs/ci
 
-      - name: Backend tests shard 3/3
+      - name: Backend tests shard 3/5
         run: |
-          python3 tools/tests/run_backend_parallel.py --shards 3 --shard-index 3 --junitxml artifacts/ai/logs/ci/backend-tests-3.xml
+          python3 tools/tests/run_backend_parallel.py --shards 5 --shard-index 3 --junitxml artifacts/ai/logs/ci/backend-tests-3.xml
 
       - name: Upload backend test artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: backend-test-artifacts-3
+          path: artifacts/ai/logs/ci/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  backend-tests-4:
+    name: Backend tests (shard 4/5)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-backend
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/vibesensor/backend-duration-cache.json
+          key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-4-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-
+            ${{ runner.os }}-backend-test-durations-
+
+      - name: Prepare backend test artifacts
+        run: |
+          mkdir -p artifacts/ai/logs/ci
+
+      - name: Backend tests shard 4/5
+        run: |
+          python3 tools/tests/run_backend_parallel.py --shards 5 --shard-index 4 --junitxml artifacts/ai/logs/ci/backend-tests-4.xml
+
+      - name: Upload backend test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-artifacts-4
+          path: artifacts/ai/logs/ci/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  backend-tests-5:
+    name: Backend tests (shard 5/5)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-backend
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/vibesensor/backend-duration-cache.json
+          key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-5-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-
+            ${{ runner.os }}-backend-test-durations-
+
+      - name: Prepare backend test artifacts
+        run: |
+          mkdir -p artifacts/ai/logs/ci
+
+      - name: Backend tests shard 5/5
+        run: |
+          python3 tools/tests/run_backend_parallel.py --shards 5 --shard-index 5 --junitxml artifacts/ai/logs/ci/backend-tests-5.xml
+
+      - name: Upload backend test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-test-artifacts-5
           path: artifacts/ai/logs/ci/
           if-no-files-found: ignore
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
 LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
-CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests-1 --job backend-tests-2 --job backend-tests-3
+CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5
 
 help: ## Show the available make targets and what each one does
 	@awk 'BEGIN {FS = ":.*## "; printf "Available targets:\n"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -111,7 +111,7 @@ python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100 -
 Focused CI job groups and full-stack validation:
 
 ```bash
-python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3
+python3 tools/tests/run_ci_parallel.py --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5
 python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
 python3 tools/tests/run_ci_parallel.py --job release-smoke
 make test-full-suite
@@ -178,6 +178,8 @@ act -j frontend-typecheck -W .github/workflows/ci.yml
 act -j backend-tests-1 -W .github/workflows/ci.yml
 act -j backend-tests-2 -W .github/workflows/ci.yml
 act -j backend-tests-3 -W .github/workflows/ci.yml
+act -j backend-tests-4 -W .github/workflows/ci.yml
+act -j backend-tests-5 -W .github/workflows/ci.yml
 act -j ui-smoke -W .github/workflows/ci.yml
 act -j release-smoke -W .github/workflows/ci.yml
 
@@ -211,7 +213,7 @@ No secrets are currently required. If needed in the future, copy
 | `frontend-typecheck` | ✅ Fully supported | — |
 | `ui-smoke` | ✅ Fully supported | — |
 | `release-smoke` | ✅ Fully supported | — |
-| `backend-tests-1/2/3` | ⚠️ Mostly works | 5 update-module tests that depend on system-level features (sudo, network interfaces) may fail inside the `act` container. All other tests pass. |
+| `backend-tests-1/2/3/4/5` | ⚠️ Mostly works | 5 update-module tests that depend on system-level features (sudo, network interfaces) may fail inside the `act` container. All other tests pass. |
 | `e2e` | ❌ Not supported | Requires Docker-in-Docker. Run `make test-full-suite` or use GitHub CI instead. |
 
 ### Relationship to `run_ci_parallel.py`
@@ -251,7 +253,7 @@ The default CI-parity suite now mirrors these blocking GitHub checks:
 - `backend-typecheck`: mypy on the `vibesensor` backend package; package discovery keeps new backend files checked by default without an internal module denylist.
 - `frontend-typecheck`: `npm run typecheck` in `apps/ui/`.
 - `release-smoke`: builds packaged UI and a server wheel, then runs the release smoke validator against the built artifact.
-- `ui-smoke`, `backend-tests-1`, `backend-tests-2`, `backend-tests-3`, `e2e`: required test jobs.
+- `ui-smoke`, `backend-tests-1`, `backend-tests-2`, `backend-tests-3`, `backend-tests-4`, `backend-tests-5`, `e2e`: required test jobs.
 
 ## Adding or moving tests
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -92,6 +92,8 @@ _BACKEND_TEST_SHARD_JOBS = (
     "backend-tests-1",
     "backend-tests-2",
     "backend-tests-3",
+    "backend-tests-4",
+    "backend-tests-5",
 )
 _MIRRORED_BACKEND_INSTALL_JOBS = (
     "backend-quality",
@@ -731,6 +733,13 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
 
     for job_name in _BACKEND_TEST_SHARD_JOBS:
         backend_job = jobs.get(job_name) if isinstance(jobs, Mapping) else None
+        if isinstance(backend_job, Mapping) and backend_job.get("needs") not in (
+            None,
+            [],
+        ):
+            errors.append(
+                f"{job_name} must not declare job needs so backend test shards can start immediately."
+            )
         backend_steps = (
             backend_job.get("steps") if isinstance(backend_job, Mapping) else None
         )

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -234,12 +234,12 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                 ["mkdir", "-p", "artifacts/ai/logs/ci"],
             ),
             Step(
-                "Backend tests shard 1/3",
+                "Backend tests shard 1/5",
                 [
                     python_cmd,
                     "tools/tests/run_backend_parallel.py",
                     "--shards",
-                    "3",
+                    "5",
                     "--shard-index",
                     "1",
                     "--junitxml",
@@ -253,12 +253,12 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                 ["mkdir", "-p", "artifacts/ai/logs/ci"],
             ),
             Step(
-                "Backend tests shard 2/3",
+                "Backend tests shard 2/5",
                 [
                     python_cmd,
                     "tools/tests/run_backend_parallel.py",
                     "--shards",
-                    "3",
+                    "5",
                     "--shard-index",
                     "2",
                     "--junitxml",
@@ -272,16 +272,54 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
                 ["mkdir", "-p", "artifacts/ai/logs/ci"],
             ),
             Step(
-                "Backend tests shard 3/3",
+                "Backend tests shard 3/5",
                 [
                     python_cmd,
                     "tools/tests/run_backend_parallel.py",
                     "--shards",
-                    "3",
+                    "5",
                     "--shard-index",
                     "3",
                     "--junitxml",
                     "artifacts/ai/logs/ci/backend-tests-3.xml",
+                ],
+            ),
+        ],
+        "backend-tests-4": [
+            Step(
+                "Prepare backend test artifacts",
+                ["mkdir", "-p", "artifacts/ai/logs/ci"],
+            ),
+            Step(
+                "Backend tests shard 4/5",
+                [
+                    python_cmd,
+                    "tools/tests/run_backend_parallel.py",
+                    "--shards",
+                    "5",
+                    "--shard-index",
+                    "4",
+                    "--junitxml",
+                    "artifacts/ai/logs/ci/backend-tests-4.xml",
+                ],
+            ),
+        ],
+        "backend-tests-5": [
+            Step(
+                "Prepare backend test artifacts",
+                ["mkdir", "-p", "artifacts/ai/logs/ci"],
+            ),
+            Step(
+                "Backend tests shard 5/5",
+                [
+                    python_cmd,
+                    "tools/tests/run_backend_parallel.py",
+                    "--shards",
+                    "5",
+                    "--shard-index",
+                    "5",
+                    "--junitxml",
+                    "artifacts/ai/logs/ci/backend-tests-5.xml",
                 ],
             ),
         ],
@@ -343,6 +381,8 @@ def main() -> int:
             "backend-tests-1",
             "backend-tests-2",
             "backend-tests-3",
+            "backend-tests-4",
+            "backend-tests-5",
             "e2e",
         ],
         help="Run only selected job(s). Repeat to run multiple jobs.",
@@ -376,6 +416,8 @@ def main() -> int:
             "backend-tests-1",
             "backend-tests-2",
             "backend-tests-3",
+            "backend-tests-4",
+            "backend-tests-5",
             "e2e",
         ]
     )


### PR DESCRIPTION
## Summary
- increase backend CI sharding from three jobs to five jobs
- remove backend shard job `needs` so the shard jobs start immediately
- keep local CI parity, hygiene enforcement, and docs aligned with the five-shard layout

## Testing
- pytest -q apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_lite_job_parity.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_docker_ci_hygiene.py apps/server/tests/hygiene/test_run_e2e_parallel.py
- make lint
- python3 tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5

## Local timing note
- the local five-shard run completed in 67.3s wall time, with shard runtimes of 52.8s, 18.6s, 31.2s, 58.4s, and 67.3s
