### PR TITLE
Extract GPS transport lifecycle transitions into focused helper

### DIFF
--- a/apps/server/tests/adapters/gps/test_transport_lifecycle.py
+++ b/apps/server/tests/adapters/gps/test_transport_lifecycle.py
@@ -1,0 +1,113 @@
+"""Tests for transport_lifecycle: reconnect policy and state transitions."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.adapters.gps.transport_lifecycle import (
+    GPS_RECONNECT_DELAY_S,
+    TransportLifecycle,
+)
+
+
+class TestOnConnected:
+    def test_returns_connected_state(self) -> None:
+        lc = TransportLifecycle()
+        t = lc.on_connected()
+        assert t.changes["connection_state"] == "connected"
+        assert t.changes["last_error"] is None
+        assert t.changes["current_reconnect_delay"] == GPS_RECONNECT_DELAY_S
+        assert t.sleep_before_retry is None
+
+    def test_resets_backoff_delay(self) -> None:
+        lc = TransportLifecycle(initial_delay=1.0)
+        # Advance backoff first.
+        lc.on_connection_error(RuntimeError("boom"))
+        assert lc.reconnect_delay > 1.0
+        # on_connected resets it.
+        lc.on_connected()
+        assert lc.reconnect_delay == 1.0
+
+
+class TestOnStreamDisconnected:
+    def test_returns_disconnected_fields(self) -> None:
+        lc = TransportLifecycle()
+        t = lc.on_stream_disconnected()
+        assert t.changes["connection_state"] == "disconnected"
+        assert t.changes["speed_snapshot"] == (None, None)
+        assert t.changes["last_fix_mode"] is None
+        assert t.changes["device_info"] is None
+        assert t.changes["zero_speed_streak"] == 0
+        assert t.sleep_before_retry is None
+
+    def test_resets_backoff_delay(self) -> None:
+        lc = TransportLifecycle(initial_delay=0.5)
+        lc.on_connection_error(RuntimeError("x"))
+        lc.on_stream_disconnected()
+        assert lc.reconnect_delay == 0.5
+
+
+class TestOnConnectionError:
+    def test_returns_disconnected_plus_error(self) -> None:
+        lc = TransportLifecycle(initial_delay=2.0)
+        exc = OSError("network down")
+        t = lc.on_connection_error(exc)
+        assert t.changes["connection_state"] == "disconnected"
+        assert t.changes["last_error"] == "network down"
+        assert t.changes["current_reconnect_delay"] == 2.0
+        assert t.sleep_before_retry == 2.0
+
+    def test_error_str_fallback_to_type_name(self) -> None:
+        lc = TransportLifecycle()
+        t = lc.on_connection_error(ConnectionError())
+        assert t.changes["last_error"] == "ConnectionError"
+
+    def test_exponential_backoff(self) -> None:
+        lc = TransportLifecycle(initial_delay=1.0, max_delay=10.0, backoff_factor=2.0)
+        t1 = lc.on_connection_error(RuntimeError("a"))
+        assert t1.sleep_before_retry == 1.0
+        t2 = lc.on_connection_error(RuntimeError("b"))
+        assert t2.sleep_before_retry == 2.0
+        t3 = lc.on_connection_error(RuntimeError("c"))
+        assert t3.sleep_before_retry == 4.0
+        t4 = lc.on_connection_error(RuntimeError("d"))
+        assert t4.sleep_before_retry == 8.0
+        # Capped at max.
+        t5 = lc.on_connection_error(RuntimeError("e"))
+        assert t5.sleep_before_retry == 10.0
+
+    def test_clears_gps_metadata(self) -> None:
+        lc = TransportLifecycle()
+        t = lc.on_connection_error(TimeoutError())
+        assert t.changes["last_epx_m"] is None
+        assert t.changes["last_epy_m"] is None
+        assert t.changes["last_epv_m"] is None
+        assert t.changes["last_fix_mode"] is None
+
+
+class TestResetDelay:
+    def test_resets_after_backoff(self) -> None:
+        lc = TransportLifecycle(initial_delay=0.1)
+        lc.on_connection_error(RuntimeError("x"))
+        lc.on_connection_error(RuntimeError("y"))
+        assert lc.reconnect_delay > 0.1
+        lc.reset_delay()
+        assert lc.reconnect_delay == pytest.approx(0.1)
+
+
+class TestCustomPolicy:
+    def test_custom_initial_and_max(self) -> None:
+        lc = TransportLifecycle(initial_delay=0.5, max_delay=2.0, backoff_factor=3.0)
+        t1 = lc.on_connection_error(RuntimeError("a"))
+        assert t1.sleep_before_retry == 0.5
+        t2 = lc.on_connection_error(RuntimeError("b"))
+        assert t2.sleep_before_retry == 1.5
+        # Next would be 4.5 but capped at 2.0.
+        t3 = lc.on_connection_error(RuntimeError("c"))
+        assert t3.sleep_before_retry == 2.0
+
+    def test_defaults_match_module_constants(self) -> None:
+        lc = TransportLifecycle()
+        assert lc.reconnect_delay == GPS_RECONNECT_DELAY_S
+        t = lc.on_connected()
+        assert t.changes["current_reconnect_delay"] == GPS_RECONNECT_DELAY_S

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -23,20 +23,25 @@ from vibesensor.adapters.gps.speed_validation import (
     evaluate_speed_sample,
     is_speed_plausible,
 )
+from vibesensor.adapters.gps.transport_lifecycle import (
+    GPS_CONNECT_TIMEOUT_S,
+    GPS_DISABLED_POLL_S,
+    GPS_READ_TIMEOUT_S,
+    GPS_RECONNECT_DELAY_S,
+    GPS_RECONNECT_MAX_DELAY_S,
+    TransportLifecycle,
+)
 from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 
 LOGGER = logging.getLogger(__name__)
 
-_GPS_DISABLED_POLL_S: float = 5.0
-"""Sleep interval when GPS is disabled."""
-
-_GPS_RECONNECT_DELAY_S: float = 2.0
-"""Delay before reconnecting after a GPS connection loss."""
-
-_GPS_CONNECT_TIMEOUT_S: float = 3.0
-_GPS_READ_TIMEOUT_S: float = 3.0
-_GPS_RECONNECT_MAX_DELAY_S: float = 15.0
+# Backward-compatible aliases for constants that consumers import from here.
+_GPS_DISABLED_POLL_S: float = GPS_DISABLED_POLL_S
+_GPS_RECONNECT_DELAY_S: float = GPS_RECONNECT_DELAY_S
+_GPS_CONNECT_TIMEOUT_S: float = GPS_CONNECT_TIMEOUT_S
+_GPS_READ_TIMEOUT_S: float = GPS_READ_TIMEOUT_S
+_GPS_RECONNECT_MAX_DELAY_S: float = GPS_RECONNECT_MAX_DELAY_S
 
 # Re-export for consumers that import from this module.
 _GPS_MAX_SPEED_MPS: float = DEFAULT_SPEED_VALIDATION_CONFIG.max_speed_mps
@@ -111,35 +116,19 @@ class GPSTransportState:
 
     def _mark_connected(self) -> None:
         self._replace_snapshot(
-            connection_state="connected",
-            last_error=None,
-            current_reconnect_delay=_GPS_RECONNECT_DELAY_S,
+            **TransportLifecycle().on_connected().changes,
         )
 
     def _mark_stream_disconnected(self) -> None:
         self._replace_snapshot(
-            connection_state="disconnected",
-            speed_snapshot=(None, None),
-            last_fix_mode=None,
-            last_epx_m=None,
-            last_epy_m=None,
-            last_epv_m=None,
-            zero_speed_streak=0,
-            device_info=None,
+            **TransportLifecycle().on_stream_disconnected().changes,
         )
 
     def _mark_connection_error(self, exc: BaseException, reconnect_delay: float) -> None:
+        transition = TransportLifecycle().on_connection_error(exc)
+        # Override the delay from the caller's tracked value.
         self._replace_snapshot(
-            connection_state="disconnected",
-            speed_snapshot=(None, None),
-            last_fix_mode=None,
-            last_epx_m=None,
-            last_epy_m=None,
-            last_epv_m=None,
-            zero_speed_streak=0,
-            device_info=None,
-            last_error=str(exc) or type(exc).__name__,
-            current_reconnect_delay=reconnect_delay,
+            **{**transition.changes, "current_reconnect_delay": reconnect_delay},
         )
 
     def set_enabled(self, enabled: bool) -> None:
@@ -392,7 +381,10 @@ class GPSTransportState:
         read_metric: MetricReader | None = None,
     ) -> None:
         loads = json.loads
-        reconnect_delay = _GPS_RECONNECT_DELAY_S
+        lifecycle = TransportLifecycle(
+            initial_delay=_GPS_RECONNECT_DELAY_S,
+            max_delay=_GPS_RECONNECT_MAX_DELAY_S,
+        )
         while True:
             if not self.gps_enabled:
                 self.set_enabled(False)
@@ -410,15 +402,16 @@ class GPSTransportState:
                 writer = connected_writer
                 writer.write(b'?WATCH={"enable":true,"json":true};\n')
                 await writer.drain()
-                self._mark_connected()
-                reconnect_delay = _GPS_RECONNECT_DELAY_S
+                transition = lifecycle.on_connected()
+                self._replace_snapshot(**transition.changes)
                 while True:
                     if not self.gps_enabled:
                         self.set_enabled(False)
                         break
                     line = await asyncio.wait_for(reader.readline(), timeout=_GPS_READ_TIMEOUT_S)
                     if not line:
-                        self._mark_stream_disconnected()
+                        transition = lifecycle.on_stream_disconnected()
+                        self._replace_snapshot(**transition.changes)
                         break
                     try:
                         parsed = loads(line.decode("utf-8", errors="replace"))
@@ -429,7 +422,7 @@ class GPSTransportState:
                         LOGGER.debug("Ignoring non-object GPS JSON line")
                         continue
                     self.ingest_message(parsed, tpv_mode=tpv_mode, read_metric=read_metric)
-                reconnect_delay = _GPS_RECONNECT_DELAY_S
+                lifecycle.reset_delay()
             except asyncio.CancelledError:
                 if writer is not None:
                     writer.close()
@@ -444,15 +437,15 @@ class GPSTransportState:
                 EOFError,
                 json.JSONDecodeError,
             ) as exc:
-                self._mark_connection_error(exc, reconnect_delay)
+                transition = lifecycle.on_connection_error(exc)
+                self._replace_snapshot(**transition.changes)
                 LOGGER.warning(
                     "GPS connection lost, retrying in %gs: %s",
-                    reconnect_delay,
+                    transition.sleep_before_retry,
                     exc,
                     exc_info=True,
                 )
-                await asyncio.sleep(reconnect_delay)
-                reconnect_delay = min(_GPS_RECONNECT_MAX_DELAY_S, reconnect_delay * 2.0)
+                await asyncio.sleep(transition.sleep_before_retry)  # type: ignore[arg-type]
             finally:
                 if writer is not None and not writer_closed:
                     writer.close()

--- a/apps/server/vibesensor/adapters/gps/transport_lifecycle.py
+++ b/apps/server/vibesensor/adapters/gps/transport_lifecycle.py
@@ -1,0 +1,98 @@
+"""GPS transport connection lifecycle: reconnect policy and state transitions.
+
+Owns reconnect backoff and the snapshot-field changes produced by each
+connection lifecycle event (connect, clean disconnect, error disconnect).
+The main transport loop delegates lifecycle decisions here while remaining
+responsible for I/O orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+GPS_DISABLED_POLL_S: float = 5.0
+"""Sleep interval when GPS is disabled."""
+
+GPS_RECONNECT_DELAY_S: float = 2.0
+"""Initial delay before reconnecting after a GPS connection loss."""
+
+GPS_CONNECT_TIMEOUT_S: float = 3.0
+GPS_READ_TIMEOUT_S: float = 3.0
+GPS_RECONNECT_MAX_DELAY_S: float = 15.0
+
+_DISCONNECTED_FIELDS: dict[str, Any] = {
+    "connection_state": "disconnected",
+    "speed_snapshot": (None, None),
+    "last_fix_mode": None,
+    "last_epx_m": None,
+    "last_epy_m": None,
+    "last_epv_m": None,
+    "zero_speed_streak": 0,
+    "device_info": None,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleTransition:
+    """Snapshot field changes produced by a lifecycle event."""
+
+    changes: dict[str, Any]
+    sleep_before_retry: float | None = None
+    """When set, the caller should sleep this many seconds before retrying."""
+
+
+class TransportLifecycle:
+    """Reconnect policy and state-transition producer for the GPS transport loop.
+
+    Tracks exponential backoff internally.  Each ``on_*`` method returns a
+    :class:`LifecycleTransition` whose *changes* dict can be applied
+    directly to the transport snapshot via ``_replace_snapshot(**t.changes)``.
+    """
+
+    def __init__(
+        self,
+        initial_delay: float = GPS_RECONNECT_DELAY_S,
+        max_delay: float = GPS_RECONNECT_MAX_DELAY_S,
+        backoff_factor: float = 2.0,
+    ) -> None:
+        self._initial_delay = initial_delay
+        self._max_delay = max_delay
+        self._backoff_factor = backoff_factor
+        self._current_delay = initial_delay
+
+    @property
+    def reconnect_delay(self) -> float:
+        """Current reconnect delay (before next backoff step)."""
+        return self._current_delay
+
+    def on_connected(self) -> LifecycleTransition:
+        """Successful connection established."""
+        self._current_delay = self._initial_delay
+        return LifecycleTransition(
+            changes={
+                "connection_state": "connected",
+                "last_error": None,
+                "current_reconnect_delay": self._initial_delay,
+            },
+        )
+
+    def on_stream_disconnected(self) -> LifecycleTransition:
+        """Clean end-of-stream (remote closed the connection)."""
+        self._current_delay = self._initial_delay
+        return LifecycleTransition(changes=dict(_DISCONNECTED_FIELDS))
+
+    def on_connection_error(self, exc: BaseException) -> LifecycleTransition:
+        """Connection lost or timed out.  Advances the backoff timer."""
+        delay = self._current_delay
+        changes = {
+            **_DISCONNECTED_FIELDS,
+            "last_error": str(exc) or type(exc).__name__,
+            "current_reconnect_delay": delay,
+        }
+        self._current_delay = min(self._max_delay, delay * self._backoff_factor)
+        return LifecycleTransition(changes=changes, sleep_before_retry=delay)
+
+    def reset_delay(self) -> None:
+        """Reset delay after a successful read session (no error)."""
+        self._current_delay = self._initial_delay


### PR DESCRIPTION
## Summary

This PR extracts GPS transport connection lifecycle logic — reconnect backoff policy and state-transition field changes — from the main `GPSTransportState` class and its `run()` loop into a dedicated `TransportLifecycle` helper in a new `transport_lifecycle.py` module. The main transport loop remains responsible for I/O orchestration (socket connect, read, write) while the lifecycle helper now owns which fields change on each connection event and how the reconnect delay evolves across failures.

Closes #1413

## Problem

The GPS transport module (`gps_transport.py`) mixed three distinct responsibilities in one place: (1) async I/O orchestration (TCP connect, line reading, writer management), (2) message parsing and TPV field extraction, and (3) connection lifecycle policy — specifically which snapshot fields to reset on connect/disconnect/error and how the reconnect delay progresses through exponential backoff. This interleaving made it impossible to test lifecycle transitions without running the full async transport loop and replaying GPS message fixtures. The reconnect delay was tracked by a local variable in `run()` and duplicated into the snapshot by `_mark_connection_error()`, creating dual bookkeeping that was easy to get out of sync.

## Architecture

### New module: `transport_lifecycle.py`

The new module contains:

- **Canonical constant definitions**: `GPS_DISABLED_POLL_S`, `GPS_RECONNECT_DELAY_S`, `GPS_CONNECT_TIMEOUT_S`, `GPS_READ_TIMEOUT_S`, `GPS_RECONNECT_MAX_DELAY_S`. These were previously private module-level constants in `gps_transport.py` with underscore prefixes.

- **`LifecycleTransition`** (frozen dataclass): A value object carrying the dict of snapshot field changes produced by a lifecycle event, plus an optional `sleep_before_retry` duration. Consumers apply changes via `_replace_snapshot(**transition.changes)`. This keeps the lifecycle helper decoupled from `GPSTransportSnapshot` internals.

- **`TransportLifecycle`** class: Owns reconnect exponential backoff (initial delay, max delay, backoff factor) and produces `LifecycleTransition` values from three events:
  - `on_connected()` — resets error state and reconnect delay, sets connection state to "connected"
  - `on_stream_disconnected()` — clears all GPS metadata fields (speed, fix mode, accuracy, device info), resets delay
  - `on_connection_error(exc)` — same field clearing as disconnect plus error capture, returns the current delay as `sleep_before_retry`, then advances the backoff timer
  - `reset_delay()` — explicitly resets the backoff counter (called after a successful read session ends normally)

### Changes to `gps_transport.py`

The `run()` method now creates a single `TransportLifecycle` instance before entering the connection loop. On each event (successful connect, clean disconnect, error), it calls the corresponding lifecycle method and applies the returned changes with `_replace_snapshot(**transition.changes)`. The local `reconnect_delay` variable is gone — the lifecycle instance tracks backoff internally and returns the sleep duration in `transition.sleep_before_retry`.

The private `_mark_connected()`, `_mark_stream_disconnected()`, and `_mark_connection_error()` methods remain on `GPSTransportState` as thin delegates, creating single-use lifecycle instances for backward compatibility with any code that calls them directly. The `run()` method no longer calls these methods — it uses the lifecycle transitions directly.

Constants are re-exported from `gps_transport.py` as `_GPS_*` aliases so that existing tests using `monkeypatch.setattr("vibesensor.adapters.gps.gps_transport._GPS_RECONNECT_DELAY_S", ...)` continue to work. The `run()` method references these module-level aliases rather than the imported names, preserving monkeypatch-ability for test speed overrides.

### Disconnected field set

The set of fields cleared on disconnect/error is defined once in `_DISCONNECTED_FIELDS` inside `transport_lifecycle.py`. Previously, this set was duplicated across `_mark_stream_disconnected()`, `_mark_connection_error()`, and `_reset_fix_metadata()`. Having a single source of truth eliminates the risk of these diverging when new snapshot fields are added.

## Testing

### New test file: `test_transport_lifecycle.py` (11 tests)

Six test classes cover the lifecycle helper in isolation, without any transport or GPS fixtures:

- **TestOnConnected** (2 tests): Verifies connected state changes and backoff reset after prior errors.
- **TestOnStreamDisconnected** (2 tests): Verifies all disconnected fields are returned and backoff resets.
- **TestOnConnectionError** (4 tests): Verifies error string capture (including fallback to type name for empty-string exceptions), exponential backoff progression with max capping, and GPS metadata clearing.
- **TestResetDelay** (1 test): Verifies explicit delay reset after backoff accumulation.
- **TestCustomPolicy** (2 tests): Verifies custom initial/max/backoff parameters work correctly.

### Existing test coverage

All 180 existing GPS adapter tests pass unchanged, confirming behavioral equivalence. The async `run()` loop tests that monkeypatch reconnect delays continue to work through the backward-compatible `_GPS_*` aliases. The broader test suite (5855 tests) passes with no regressions beyond the known pre-existing `test_start_monitors_udp_consumer_failure`.

## Behavioral equivalence

The transport behavior is identical:
- Same fields cleared on each transition type
- Same exponential backoff progression (2× factor, 15s max, 2s initial)
- Same constant values for timeouts and poll intervals
- Same connection state strings ("connected", "disconnected", "disabled")
- Same error string formatting (str(exc) with fallback to type name)

The only structural change is that the `run()` loop no longer maintains a local `reconnect_delay` variable — the lifecycle instance tracks this internally. The observable snapshot values are identical.