### PR TITLE
Extract startup runner, managed-job shutdown, and shutdown phases from LifecycleManager

### DIFF
--- a/apps/server/tests/infra/runtime/test_managed_job_shutdown.py
+++ b/apps/server/tests/infra/runtime/test_managed_job_shutdown.py
@@ -1,0 +1,83 @@
+"""Tests for ManagedJobShutdown (#1449)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from vibesensor.infra.runtime.managed_job_shutdown import ManagedJobShutdown
+
+
+class _FakeJobSource:
+    def __init__(self, task: asyncio.Task[None] | None = None) -> None:
+        self._task = task
+
+    @property
+    def job_task(self) -> asyncio.Task[None] | None:
+        return self._task
+
+
+class TestManagedJobShutdown:
+    @pytest.mark.asyncio
+    async def test_no_active_tasks_returns_empty(self) -> None:
+        """Sources with no active tasks produce an empty lingering list."""
+        shutdown = ManagedJobShutdown(
+            [
+                _FakeJobSource(None),
+                _FakeJobSource(None),
+            ]
+        )
+        lingering = await shutdown.cancel(timeout_s=5.0)
+        assert lingering == []
+
+    @pytest.mark.asyncio
+    async def test_cancels_active_tasks(self) -> None:
+        """Active tasks get cancelled and finish within timeout."""
+
+        async def slow_job() -> None:
+            await asyncio.sleep(100)
+
+        task = asyncio.create_task(slow_job(), name="test-update-job")
+        shutdown = ManagedJobShutdown([_FakeJobSource(task)])
+        lingering = await shutdown.cancel(timeout_s=5.0)
+        assert lingering == []
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_done_tasks_ignored(self) -> None:
+        """Already-done tasks are not included in cancellation."""
+
+        async def instant_job() -> None:
+            pass
+
+        task = asyncio.create_task(instant_job(), name="test-done-job")
+        await task  # let it finish
+        shutdown = ManagedJobShutdown([_FakeJobSource(task)])
+        lingering = await shutdown.cancel(timeout_s=5.0)
+        assert lingering == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_sources(self) -> None:
+        """Mix of None, done, and active tasks — only active gets cancelled."""
+
+        async def slow_job() -> None:
+            await asyncio.sleep(100)
+
+        async def instant_job() -> None:
+            pass
+
+        done_task = asyncio.create_task(instant_job(), name="done")
+        await done_task
+        active_task = asyncio.create_task(slow_job(), name="active")
+
+        shutdown = ManagedJobShutdown(
+            [
+                _FakeJobSource(None),
+                _FakeJobSource(done_task),
+                _FakeJobSource(active_task),
+            ]
+        )
+        lingering = await shutdown.cancel(timeout_s=5.0)
+        assert lingering == []
+        assert active_task.cancelled()

--- a/apps/server/tests/infra/runtime/test_startup_runner.py
+++ b/apps/server/tests/infra/runtime/test_startup_runner.py
@@ -1,0 +1,127 @@
+"""Tests for StartupRunner phase sequencing (#1448)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.infra.runtime.startup_runner import StartupRunner
+
+
+def _make_runner() -> tuple[StartupRunner, RuntimeHealthState, MagicMock]:
+    """Build a minimal StartupRunner with mock collaborators."""
+    health_state = RuntimeHealthState()
+
+    runtime = MagicMock()
+    runtime.udp_data_host = "0.0.0.0"
+    runtime.udp_data_port = 9000
+    runtime.udp_data_queue_maxsize = 64
+    runtime.gpsd_host = "127.0.0.1"
+    runtime.gpsd_port = 2947
+    runtime.control_plane.start = AsyncMock()
+    runtime.processing_loop.run = AsyncMock()
+    runtime.ws_hub.run = AsyncMock()
+    runtime.ws_broadcast.build_payload = MagicMock()
+    runtime.ws_broadcast.on_tick = MagicMock()
+    runtime.run_recorder.run = AsyncMock()
+    runtime.gps_monitor.run = AsyncMock()
+    runtime.update_manager.startup_recover = AsyncMock()
+
+    task_supervisor = MagicMock()
+    task_supervisor.start = MagicMock(return_value=MagicMock(spec=asyncio.Task))
+
+    background_tasks = MagicMock()
+    background_tasks.add = MagicMock()
+    background_tasks.start = MagicMock()
+
+    udp_transport = MagicMock()
+    udp_transport.startup = AsyncMock()
+
+    runner = StartupRunner(
+        runtime=runtime,
+        health_state=health_state,
+        task_supervisor=task_supervisor,
+        background_tasks=background_tasks,
+        udp_transport_lifecycle=udp_transport,
+    )
+    return runner, health_state, runtime
+
+
+class TestStartupRunnerPhases:
+    @pytest.mark.asyncio
+    async def test_phases_tracked_in_order(self) -> None:
+        """Health-state phases are set in the expected order."""
+        runner, health_state, _ = _make_runner()
+        phases_seen: list[str] = []
+
+        original_set_phase = RuntimeHealthState.set_phase
+
+        def recording_set_phase(self_hs: RuntimeHealthState, phase: str) -> None:
+            phases_seen.append(phase)
+            original_set_phase(self_hs, phase)
+
+        with patch.object(type(health_state), "set_phase", recording_set_phase):
+            await runner.run()
+
+        assert phases_seen == [
+            "starting",
+            "udp_receiver",
+            "control_plane",
+            "processing-loop",
+            "ws-broadcast",
+            "metrics-log",
+            "gps-speed",
+            "update-startup-recover",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_marks_ready_on_success(self) -> None:
+        """Health state is marked ready after all phases complete."""
+        runner, health_state, _ = _make_runner()
+
+        await runner.run()
+
+        assert health_state.startup_state == "ready"
+
+    @pytest.mark.asyncio
+    async def test_marks_failed_on_exception(self) -> None:
+        """Health state records the failing phase on exception."""
+        runner, health_state, runtime = _make_runner()
+        runtime.control_plane.start = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await runner.run()
+
+        assert health_state.startup_state == "failed"
+        assert health_state.startup_phase == "control_plane"
+
+    @pytest.mark.asyncio
+    async def test_udp_startup_called_first(self) -> None:
+        """UDP receiver starts before background tasks are created."""
+        runner, _, _ = _make_runner()
+        call_order: list[str] = []
+
+        orig_startup = runner._udp_transport_lifecycle.startup
+
+        async def recording_startup(*a, **kw):
+            call_order.append("udp_startup")
+            return await orig_startup(*a, **kw)
+
+        runner._udp_transport_lifecycle.startup = recording_startup
+
+        orig_add = runner._background_tasks.add
+
+        def recording_add(*a, **kw):
+            call_order.append("background_add")
+            return orig_add(*a, **kw)
+
+        runner._background_tasks.add = recording_add
+
+        await runner.run()
+
+        udp_idx = call_order.index("udp_startup")
+        bg_idx = call_order.index("background_add")
+        assert udp_idx < bg_idx

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -19,9 +19,8 @@ from typing import Protocol
 
 from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.task_supervisor import TaskSupervisor, task_failure_message
+from vibesensor.infra.runtime.task_supervisor import TaskSupervisor
 from vibesensor.infra.runtime.udp_transport_lifecycle import StartUdpReceiver, UdpTransportLifecycle
-from vibesensor.shared.constants.ui import UI_PUSH_HZ
 from vibesensor.shared.types.payload_types import LiveWsPayload
 
 
@@ -168,26 +167,6 @@ class LifecycleManager:
     def tasks(self, tasks: list[asyncio.Task[object]]) -> None:
         self._background_tasks.tasks = tasks
 
-    @staticmethod
-    async def _cancel_managed_tasks(
-        tasks: list[asyncio.Task[None]],
-        *,
-        timeout_s: float,
-    ) -> list[asyncio.Task[None]]:
-        for task in tasks:
-            task.cancel()
-        if not tasks:
-            return []
-        _done, _pending = await asyncio.wait(tasks, timeout=timeout_s)
-        if _pending:
-            LOGGER.warning(
-                "%d managed shutdown task(s) did not finish within the cancellation "
-                "deadline and remain pending: %s",
-                len(_pending),
-                [task.get_name() for task in _pending],
-            )
-        return [task for task in tasks if not task.done()]
-
     _LOW_DISK_THRESHOLD_MB = 100
 
     def _validate_startup(self) -> None:
@@ -213,102 +192,47 @@ class LifecycleManager:
 
     async def start(self) -> None:
         """Launch UDP receiver, control plane, and background async tasks."""
-        phase = "starting"
-        self._health_state.set_phase(phase)
+        from vibesensor.infra.runtime.startup_runner import StartupRunner
+
         self._validate_startup()
-        try:
-            phase = "udp_receiver"
-            self._health_state.set_phase(phase)
-            await self._udp_transport_lifecycle.startup(
-                host=self._runtime.udp_data_host,
-                port=self._runtime.udp_data_port,
-                registry=self._runtime.registry,
-                processor=self._runtime.processor,
-                queue_maxsize=self._runtime.udp_data_queue_maxsize,
-            )
-
-            phase = "control_plane"
-            self._health_state.set_phase(phase)
-            await self._runtime.control_plane.start()
-
-            self.tasks = []
-
-            phase = "processing-loop"
-            self._health_state.set_phase(phase)
-            self._background_tasks.add(
-                self._task_supervisor.start(
-                    lambda: self._runtime.processing_loop.run(),
-                    name=phase,
-                ),
-            )
-
-            phase = "ws-broadcast"
-            self._health_state.set_phase(phase)
-            self._background_tasks.add(
-                self._task_supervisor.start(
-                    lambda: self._runtime.ws_hub.run(
-                        UI_PUSH_HZ,
-                        self._runtime.ws_broadcast.build_payload,
-                        on_tick=self._runtime.ws_broadcast.on_tick,
-                    ),
-                    name=phase,
-                ),
-            )
-
-            phase = "metrics-log"
-            self._health_state.set_phase(phase)
-            self._background_tasks.add(
-                self._task_supervisor.start(
-                    lambda: self._runtime.run_recorder.run(),
-                    name=phase,
-                ),
-            )
-
-            phase = "gps-speed"
-            self._health_state.set_phase(phase)
-            self._background_tasks.add(
-                self._task_supervisor.start(
-                    lambda: self._runtime.gps_monitor.run(
-                        host=self._runtime.gpsd_host,
-                        port=self._runtime.gpsd_port,
-                    ),
-                    name=phase,
-                ),
-            )
-
-            phase = "update-startup-recover"
-            self._health_state.set_phase(phase)
-            self._background_tasks.start(
-                self._runtime.update_manager.startup_recover(),
-                name=phase,
-            )
-            self._health_state.mark_ready()
-        except Exception as exc:
-            self._health_state.mark_failed(phase, task_failure_message(exc))
-            raise
+        self.tasks = []
+        runner = StartupRunner(
+            runtime=self._runtime,
+            health_state=self._health_state,
+            task_supervisor=self._task_supervisor,
+            background_tasks=self._background_tasks,
+            udp_transport_lifecycle=self._udp_transport_lifecycle,
+        )
+        await runner.run()
 
     async def stop(self) -> None:
         """Graceful shutdown with explicit ingress-stop and metrics-drain phases."""
+        self._stop_ingress()
+        await self._udp_transport_lifecycle.shutdown()
+        await self._background_tasks.cancel_all(timeout_s=15.0)
+        lingering_managed = await self._cancel_managed_jobs()
+        await self._drain_analysis()
+        await self._shutdown_resources()
+        self._report_lingering_tasks(lingering_managed)
+
+    def _stop_ingress(self) -> None:
         try:
             self._runtime.control_plane.close()
         except OSError:
             LOGGER.warning("Error closing control plane", exc_info=True)
-        await self._udp_transport_lifecycle.shutdown()
 
-        await self._background_tasks.cancel_all(timeout_s=15.0)
+    async def _cancel_managed_jobs(self) -> list[asyncio.Task[None]]:
+        from vibesensor.infra.runtime.managed_job_shutdown import ManagedJobShutdown
 
-        # Cancel any in-progress update or flash jobs so cleanup
-        # (e.g. hotspot restore) can run before shutdown completes.
-        managed: list[asyncio.Task[None] | None] = [
-            self._runtime.update_manager.job_task,
-            self._runtime.esp_flash_manager.job_task,
-        ]
-        active_managed_tasks = [task for task in managed if task is not None and not task.done()]
-        lingering_managed_tasks = await self._cancel_managed_tasks(
-            active_managed_tasks,
-            timeout_s=10.0,
+        managed_shutdown = ManagedJobShutdown(
+            [
+                self._runtime.update_manager,
+                self._runtime.esp_flash_manager,
+            ]
         )
+        return await managed_shutdown.cancel(timeout_s=10.0)
 
+    async def _drain_analysis(self) -> None:
         analysis_timeout_s = self._runtime.shutdown_analysis_timeout_s
         shutdown_report = await asyncio.to_thread(
             self._runtime.run_recorder.shutdown_report,
@@ -326,6 +250,8 @@ class LifecycleManager:
                 shutdown_report.analysis_queue_oldest_age_s,
                 shutdown_report.write_error,
             )
+
+    async def _shutdown_resources(self) -> None:
         try:
             await asyncio.to_thread(self._runtime.worker_pool.shutdown, True)
         except Exception:
@@ -334,10 +260,15 @@ class LifecycleManager:
             self._runtime.history_db.close()
         except Exception:
             LOGGER.warning("Error closing history DB", exc_info=True)
-        lingering_background_tasks = self._background_tasks.retain_pending()
+
+    def _report_lingering_tasks(
+        self,
+        lingering_managed: list[asyncio.Task[None]],
+    ) -> None:
+        lingering_background = self._background_tasks.retain_pending()
         lingering_task_names = [
-            *(task.get_name() for task in lingering_background_tasks if not task.done()),
-            *(task.get_name() for task in lingering_managed_tasks if not task.done()),
+            *(task.get_name() for task in lingering_background if not task.done()),
+            *(task.get_name() for task in lingering_managed if not task.done()),
         ]
         if lingering_task_names:
             LOGGER.warning(

--- a/apps/server/vibesensor/infra/runtime/managed_job_shutdown.py
+++ b/apps/server/vibesensor/infra/runtime/managed_job_shutdown.py
@@ -1,0 +1,55 @@
+"""Managed-job shutdown helper for LifecycleManager.
+
+Owns the collection and cancellation of managed jobs (update, flash)
+previously inlined in ``LifecycleManager.stop()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Protocol
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ManagedJobSource(Protocol):
+    @property
+    def job_task(self) -> asyncio.Task[None] | None: ...
+
+
+class ManagedJobShutdown:
+    """Collect and cancel managed job tasks with a timeout."""
+
+    __slots__ = ("_sources",)
+
+    def __init__(self, sources: list[ManagedJobSource]) -> None:
+        self._sources = sources
+
+    async def cancel(self, *, timeout_s: float) -> list[asyncio.Task[None]]:
+        """Cancel all active managed tasks and return any that did not finish."""
+        tasks = [
+            s.job_task for s in self._sources if s.job_task is not None and not s.job_task.done()
+        ]
+        return await _cancel_managed_tasks(tasks, timeout_s=timeout_s)
+
+
+async def _cancel_managed_tasks(
+    tasks: list[asyncio.Task[None]],
+    *,
+    timeout_s: float,
+) -> list[asyncio.Task[None]]:
+    """Cancel a list of tasks, returning those that did not finish."""
+    for task in tasks:
+        task.cancel()
+    if not tasks:
+        return []
+    _done, _pending = await asyncio.wait(tasks, timeout=timeout_s)
+    if _pending:
+        LOGGER.warning(
+            "%d managed shutdown task(s) did not finish within the cancellation "
+            "deadline and remain pending: %s",
+            len(_pending),
+            [task.get_name() for task in _pending],
+        )
+    return [task for task in tasks if not task.done()]

--- a/apps/server/vibesensor/infra/runtime/startup_runner.py
+++ b/apps/server/vibesensor/infra/runtime/startup_runner.py
@@ -1,0 +1,137 @@
+"""Startup phase runner for LifecycleManager.
+
+Owns the named startup phase sequence and health-state reporting
+previously inlined in ``LifecycleManager.start()``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.infra.runtime.task_supervisor import task_failure_message
+
+if TYPE_CHECKING:
+    from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
+    from vibesensor.infra.runtime.lifecycle import (
+        LifecycleRuntime,
+    )
+    from vibesensor.infra.runtime.task_supervisor import TaskSupervisor
+    from vibesensor.infra.runtime.udp_transport_lifecycle import UdpTransportLifecycle
+
+
+@dataclass(frozen=True, slots=True)
+class StartupPhase:
+    """A single named startup phase."""
+
+    name: str
+    run: Callable[[], Awaitable[None]]
+
+
+class StartupRunner:
+    """Execute named startup phases with health-state tracking."""
+
+    __slots__ = (
+        "_background_tasks",
+        "_health_state",
+        "_runtime",
+        "_task_supervisor",
+        "_udp_transport_lifecycle",
+    )
+
+    def __init__(
+        self,
+        *,
+        runtime: LifecycleRuntime,
+        health_state: RuntimeHealthState,
+        task_supervisor: TaskSupervisor,
+        background_tasks: BackgroundTaskCoordinator,
+        udp_transport_lifecycle: UdpTransportLifecycle,
+    ) -> None:
+        self._runtime = runtime
+        self._health_state = health_state
+        self._task_supervisor = task_supervisor
+        self._background_tasks = background_tasks
+        self._udp_transport_lifecycle = udp_transport_lifecycle
+
+    async def run(self) -> None:
+        """Execute all startup phases in order."""
+        phase_name = "starting"
+        self._health_state.set_phase(phase_name)
+        try:
+            for phase in self._phases():
+                phase_name = phase.name
+                self._health_state.set_phase(phase_name)
+                await phase.run()
+            self._health_state.mark_ready()
+        except Exception as exc:
+            self._health_state.mark_failed(phase_name, task_failure_message(exc))
+            raise
+
+    def _phases(self) -> list[StartupPhase]:
+        from vibesensor.shared.constants.ui import UI_PUSH_HZ
+
+        r = self._runtime
+        return [
+            StartupPhase("udp_receiver", self._start_udp_receiver),
+            StartupPhase("control_plane", r.control_plane.start),
+            StartupPhase(
+                "processing-loop",
+                lambda: self._start_background(lambda: r.processing_loop.run(), "processing-loop"),
+            ),
+            StartupPhase(
+                "ws-broadcast",
+                lambda: self._start_background(
+                    lambda: r.ws_hub.run(
+                        UI_PUSH_HZ,
+                        r.ws_broadcast.build_payload,
+                        on_tick=r.ws_broadcast.on_tick,
+                    ),
+                    "ws-broadcast",
+                ),
+            ),
+            StartupPhase(
+                "metrics-log",
+                lambda: self._start_background(lambda: r.run_recorder.run(), "metrics-log"),
+            ),
+            StartupPhase(
+                "gps-speed",
+                lambda: self._start_background(
+                    lambda: r.gps_monitor.run(
+                        host=r.gpsd_host,
+                        port=r.gpsd_port,
+                    ),
+                    "gps-speed",
+                ),
+            ),
+            StartupPhase(
+                "update-startup-recover",
+                self._start_update_recovery,
+            ),
+        ]
+
+    async def _start_udp_receiver(self) -> None:
+        await self._udp_transport_lifecycle.startup(
+            host=self._runtime.udp_data_host,
+            port=self._runtime.udp_data_port,
+            registry=self._runtime.registry,
+            processor=self._runtime.processor,
+            queue_maxsize=self._runtime.udp_data_queue_maxsize,
+        )
+
+    async def _start_background(
+        self,
+        coro_factory: Callable[[], Coroutine[object, object, object]],
+        name: str,
+    ) -> None:
+        self._background_tasks.add(
+            self._task_supervisor.start(coro_factory, name=name),
+        )
+
+    async def _start_update_recovery(self) -> None:
+        self._background_tasks.start(
+            self._runtime.update_manager.startup_recover(),
+            name="update-startup-recover",
+        )


### PR DESCRIPTION
## Summary

This PR decomposes LifecycleManager's monolithic `start()` and `stop()` methods into focused, testable collaborators across three tightly related issues. The lifecycle manager — which previously owned startup phase sequencing, managed-job cancellation, analysis drain, resource cleanup, and lingering-task reporting all inline — is now a thin orchestrator that delegates to specialized modules. All 102 runtime tests pass throughout the refactoring (94 existing + 8 new), confirming behavioral equivalence at each step.

## Changes

### Extract startup phases into a dedicated runner (#1448)

`LifecycleManager.start()` previously interleaved phase tracking, startup validation, UDP/control-plane bring-up, background task creation, and update recovery in a single ~70-line method. Phase ordering was encoded by a mutable local `phase` variable and repeated `set_phase()` calls, making the startup sequence difficult to test or modify independently.

The new `StartupRunner` in `startup_runner.py` owns the phase-based startup sequence as a list of named `StartupPhase` entries. Each phase has a name and an async run callable. The runner iterates through phases, updating health-state tracking at each boundary. On success it marks ready; on failure it records the failing phase and error, then re-raises. The lifecycle manager's `start()` now runs `_validate_startup()`, initializes the task list, constructs a `StartupRunner` with all collaborators, and delegates to `runner.run()`.

Phase ordering is now explicit and testable: `starting` → `udp_receiver` → `control_plane` → `processing-loop` → `ws-broadcast` → `metrics-log` → `gps-speed` → `update-startup-recover`. Four new tests verify phase order tracking, ready marking on success, failed-phase recording on exception, and UDP-first sequencing before background tasks.

### Separate managed-job shutdown (#1449)

`LifecycleManager.stop()` previously built a hard-coded list of managed tasks from `update_manager.job_task` and `esp_flash_manager.job_task`, filtered for active ones, and called a static `_cancel_managed_tasks()` method. This mixed managed-job semantics (different timeouts, job-specific cleanup) with generic background-task cancellation.

The new `ManagedJobShutdown` class in `managed_job_shutdown.py` takes a list of `ManagedJobSource` protocol implementors and owns task collection and cancellation. The `cancel()` method filters for active tasks, cancels them, and waits with a configurable timeout, returning any lingering tasks. The static `_cancel_managed_tasks()` method is removed from LifecycleManager. The `stop()` method now constructs a `ManagedJobShutdown` with the update and flash managers and delegates to `cancel(timeout_s=10.0)`.

Four new tests cover the no-active-tasks path, active-task cancellation, already-done-task filtering, and mixed source scenarios with real asyncio tasks.

### Extract shutdown phases into focused helpers (#1450)

The remaining `stop()` body mixed five distinct shutdown concerns: ingress stop (control plane close), background task cancellation, managed-job cancellation, analysis drain with timeout reporting, resource cleanup (worker pool + history DB), and lingering-task reporting. Each concern had different error-handling needs and side effects.

`stop()` is now decomposed into named phase helpers:
- `_stop_ingress()` — closes the control plane with OSError handling
- `_cancel_managed_jobs()` — delegates to ManagedJobShutdown (from #1449)
- `_drain_analysis()` — waits for run recorder shutdown report with timeout warning
- `_shutdown_resources()` — shuts down worker pool and closes history DB with error handling
- `_report_lingering_tasks()` — collects pending background and managed tasks, logs warnings or clean-stop message

The outer `stop()` reads as clear sequencing: stop ingress → shutdown UDP → cancel background tasks → cancel managed jobs → drain analysis → shutdown resources → report lingering tasks.

## Testing

All 102 runtime tests pass at each stage. Eight new tests validate the extracted collaborators: four for `StartupRunner` (phase order, ready/failed marking, UDP-first sequencing) and four for `ManagedJobShutdown` (no tasks, active tasks, done tasks, mixed sources). No existing test modifications were needed. The existing `test_lifecycle_shutdown_consistency.py` continues to validate the full shutdown flow end-to-end.

## Files changed

- `apps/server/vibesensor/infra/runtime/startup_runner.py` — New `StartupRunner` class with named `StartupPhase` entries
- `apps/server/vibesensor/infra/runtime/managed_job_shutdown.py` — New `ManagedJobShutdown` class and `_cancel_managed_tasks()` helper
- `apps/server/vibesensor/infra/runtime/lifecycle.py` — Thin orchestrator delegating to startup runner, managed job shutdown, and named phase helpers
- `apps/server/tests/infra/runtime/test_startup_runner.py` — 4 new tests for startup phase sequencing
- `apps/server/tests/infra/runtime/test_managed_job_shutdown.py` — 4 new tests for managed job cancellation

Closes #1448, closes #1449, closes #1450.