### PR TITLE
Extract GPS reconnect lifecycle state from transport snapshot

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
@@ -157,9 +157,12 @@ async def test_run_reconnects_on_connection_failure(
 
     task = asyncio.create_task(monitor.run(host="127.0.0.1", port=9999))
     await asyncio.wait_for(enough_attempts.wait(), timeout=5.0)
+    await asyncio.sleep(0.05)
 
     assert attempt_count >= 2, f"Expected at least 2 attempts, got {attempt_count}"
     assert monitor.speed_mps is None
+    assert monitor.last_error == "mock refused"
+    assert 0.02 <= monitor.current_reconnect_delay <= 0.04
 
     task.cancel()
     await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=5.0)

--- a/apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 import pytest
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+from vibesensor.adapters.gps.gps_transport import GPSTransportCapturedState
 
 
 def test_resolve_speed_captures_policy_and_transport_snapshots_once(
@@ -67,32 +68,46 @@ def test_status_snapshot_captures_policy_and_transport_snapshots_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monitor = GPSSpeedMonitor(gps_enabled=True)
-    base_transport = monitor._transport.snapshot()
+    base_captured = monitor._transport.captured_state()
     base_policy = monitor._policy.snapshot()
-    transport_calls = 0
+    captured_state_calls = 0
     policy_calls = 0
 
-    def _transport_snapshot():
-        nonlocal transport_calls
-        transport_calls += 1
-        if transport_calls == 1:
+    def _captured_transport_state() -> GPSTransportCapturedState:
+        nonlocal captured_state_calls
+        captured_state_calls += 1
+        if captured_state_calls == 1:
             return replace(
-                base_transport,
-                gps_enabled=True,
-                connection_state="connected",
-                speed_snapshot=(10.0, time.monotonic()),
-                device_info="/dev/ttyUSB0",
-                last_fix_mode=3,
-                last_error="old error",
+                base_captured,
+                transport=replace(
+                    base_captured.transport,
+                    gps_enabled=True,
+                    connection_state="connected",
+                    speed_snapshot=(10.0, time.monotonic()),
+                    device_info="/dev/ttyUSB0",
+                    last_fix_mode=3,
+                ),
+                lifecycle=replace(
+                    base_captured.lifecycle,
+                    last_error="old error",
+                    current_reconnect_delay=4.0,
+                ),
             )
         return replace(
-            base_transport,
-            gps_enabled=False,
-            connection_state="disabled",
-            speed_snapshot=(None, None),
-            device_info=None,
-            last_fix_mode=None,
-            last_error=None,
+            base_captured,
+            transport=replace(
+                base_captured.transport,
+                gps_enabled=False,
+                connection_state="disabled",
+                speed_snapshot=(None, None),
+                device_info=None,
+                last_fix_mode=None,
+            ),
+            lifecycle=replace(
+                base_captured.lifecycle,
+                last_error=None,
+                current_reconnect_delay=99.0,
+            ),
         )
 
     def _policy_snapshot():
@@ -112,18 +127,19 @@ def test_status_snapshot_captures_policy_and_transport_snapshots_once(
             stale_timeout_s=99.0,
         )
 
-    monkeypatch.setattr(monitor._transport, "snapshot", _transport_snapshot)
+    monkeypatch.setattr(monitor._transport, "captured_state", _captured_transport_state)
     monkeypatch.setattr(monitor._policy, "snapshot", _policy_snapshot)
 
     status = monitor.status_snapshot()
 
-    assert transport_calls == 1
+    assert captured_state_calls == 1
     assert policy_calls == 1
     assert status.gps_enabled is True
     assert status.connection_state == "connected"
     assert status.device == "/dev/ttyUSB0"
     assert status.fix_mode == 3
     assert status.raw_speed_kmh == pytest.approx(36.0, abs=0.1)
+    assert status.last_error == "old error"
     assert status.stale_timeout_s == pytest.approx(17.0)
 
 

--- a/apps/server/vibesensor/adapters/gps/gps_speed.py
+++ b/apps/server/vibesensor/adapters/gps/gps_speed.py
@@ -6,7 +6,11 @@ from typing import Literal
 
 from vibesensor.adapters.gps import gps_transport as _gps_transport
 from vibesensor.adapters.gps import speed_resolution as _speed_resolution
-from vibesensor.adapters.gps.gps_transport import GPSTransportSnapshot, GPSTransportState
+from vibesensor.adapters.gps.gps_transport import (
+    GPSTransportCapturedState,
+    GPSTransportSnapshot,
+    GPSTransportState,
+)
 from vibesensor.adapters.gps.speed_resolution import (
     SpeedResolution,
     SpeedResolutionPolicy,
@@ -255,8 +259,15 @@ class GPSSpeedMonitor:
     ) -> tuple[GPSTransportSnapshot, SpeedResolutionPolicySnapshot]:
         return self._transport.snapshot(), self._policy.snapshot()
 
+    def _captured_status_snapshots(
+        self,
+    ) -> tuple[GPSTransportCapturedState, SpeedResolutionPolicySnapshot]:
+        return self._transport.captured_state(), self._policy.snapshot()
+
     def status_snapshot(self) -> SpeedSourceStatusSnapshot:
-        transport_snapshot, policy_snapshot = self._captured_snapshots()
+        captured_state, policy_snapshot = self._captured_status_snapshots()
+        transport_snapshot = captured_state.transport
+        lifecycle_snapshot = captured_state.lifecycle
         speed_snapshot = transport_snapshot.speed_snapshot
         resolution = self._policy.resolve(
             gps_enabled=transport_snapshot.gps_enabled,
@@ -274,8 +285,8 @@ class GPSSpeedMonitor:
             last_epv_m=transport_snapshot.last_epv_m,
             raw_speed_mps=speed_snapshot[0],
             last_update_ts=speed_snapshot[1],
-            last_error=transport_snapshot.last_error,
-            current_reconnect_delay=transport_snapshot.current_reconnect_delay,
+            last_error=lifecycle_snapshot.last_error,
+            current_reconnect_delay=lifecycle_snapshot.current_reconnect_delay,
             stale_timeout_s=policy_snapshot.stale_timeout_s,
         )
         return build_status_snapshot(

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -41,8 +41,6 @@ class GPSTransportSnapshot:
     gps_enabled: bool
     connection_state: str
     speed_snapshot: tuple[float | None, float | None] = (None, None)
-    last_error: str | None = None
-    current_reconnect_delay: float = _GPS_RECONNECT_DELAY_S
     device_info: str | None = None
     last_fix_mode: int | None = None
     last_epx_m: float | None = None
@@ -51,23 +49,76 @@ class GPSTransportSnapshot:
     zero_speed_streak: int = 0
 
 
+@dataclass(frozen=True, slots=True)
+class GPSTransportLifecycleState:
+    """Reconnect/backoff state captured alongside the observational transport snapshot."""
+
+    last_error: str | None = None
+    current_reconnect_delay: float = _GPS_RECONNECT_DELAY_S
+
+
+@dataclass(frozen=True, slots=True)
+class GPSTransportCapturedState:
+    """Atomic GPS state handoff containing both observational and lifecycle snapshots."""
+
+    transport: GPSTransportSnapshot
+    lifecycle: GPSTransportLifecycleState
+
+
 class GPSTransportState:
     """Owns GPS transport state as immutable snapshots atomically swapped by writers."""
 
     def __init__(self, gps_enabled: bool):
-        self._snapshot = GPSTransportSnapshot(
-            gps_enabled=bool(gps_enabled),
-            connection_state="disabled" if not gps_enabled else "disconnected",
+        self._state = GPSTransportCapturedState(
+            transport=GPSTransportSnapshot(
+                gps_enabled=bool(gps_enabled),
+                connection_state="disabled" if not gps_enabled else "disconnected",
+            ),
+            lifecycle=GPSTransportLifecycleState(),
         )
 
     def snapshot(self) -> GPSTransportSnapshot:
-        return self._snapshot
+        return self._state.transport
+
+    def lifecycle_snapshot(self) -> GPSTransportLifecycleState:
+        return self._state.lifecycle
+
+    def captured_state(self) -> GPSTransportCapturedState:
+        return self._state
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, GPSTransportState) and self._snapshot == other._snapshot
+        return isinstance(other, GPSTransportState) and self._state == other._state
 
-    def _replace_snapshot(self, **changes: object) -> None:
-        self._snapshot = replace(self._snapshot, **cast(dict[str, Any], changes))
+    def _replace_transport(self, **changes: object) -> None:
+        self._state = replace(
+            self._state,
+            transport=replace(self._state.transport, **cast(dict[str, Any], changes)),
+        )
+
+    def _replace_lifecycle(self, **changes: object) -> None:
+        self._state = replace(
+            self._state,
+            lifecycle=replace(self._state.lifecycle, **cast(dict[str, Any], changes)),
+        )
+
+    def _replace_captured_state(
+        self,
+        *,
+        transport_changes: dict[str, object] | None = None,
+        lifecycle_changes: dict[str, object] | None = None,
+    ) -> None:
+        self._state = GPSTransportCapturedState(
+            transport=(
+                self._state.transport
+                if transport_changes is None
+                else replace(self._state.transport, **cast(dict[str, Any], transport_changes))
+            ),
+            lifecycle=(
+                self._state.lifecycle
+                if lifecycle_changes is None
+                else replace(self._state.lifecycle, **cast(dict[str, Any], lifecycle_changes))
+            ),
+        )
 
     @staticmethod
     def _normalize_optional_float(value: object) -> float | None:
@@ -103,14 +154,16 @@ class GPSTransportState:
         return True, 0
 
     def _mark_connected(self) -> None:
-        self._replace_snapshot(
-            connection_state="connected",
-            last_error=None,
-            current_reconnect_delay=_GPS_RECONNECT_DELAY_S,
+        self._replace_captured_state(
+            transport_changes={"connection_state": "connected"},
+            lifecycle_changes={
+                "last_error": None,
+                "current_reconnect_delay": _GPS_RECONNECT_DELAY_S,
+            },
         )
 
     def _mark_stream_disconnected(self) -> None:
-        self._replace_snapshot(
+        self._replace_transport(
             connection_state="disconnected",
             speed_snapshot=(None, None),
             last_fix_mode=None,
@@ -122,24 +175,27 @@ class GPSTransportState:
         )
 
     def _mark_connection_error(self, exc: BaseException, reconnect_delay: float) -> None:
-        self._replace_snapshot(
-            connection_state="disconnected",
-            speed_snapshot=(None, None),
-            last_fix_mode=None,
-            last_epx_m=None,
-            last_epy_m=None,
-            last_epv_m=None,
-            zero_speed_streak=0,
-            device_info=None,
-            last_error=str(exc) or type(exc).__name__,
-            current_reconnect_delay=reconnect_delay,
+        self._replace_captured_state(
+            transport_changes={
+                "connection_state": "disconnected",
+                "speed_snapshot": (None, None),
+                "last_fix_mode": None,
+                "last_epx_m": None,
+                "last_epy_m": None,
+                "last_epv_m": None,
+                "zero_speed_streak": 0,
+                "device_info": None,
+            },
+            lifecycle_changes={
+                "last_error": str(exc) or type(exc).__name__,
+                "current_reconnect_delay": reconnect_delay,
+            },
         )
 
     def set_enabled(self, enabled: bool) -> None:
-        snapshot = self._snapshot
+        snapshot = self._state.transport
         if not enabled:
-            self._snapshot = replace(
-                snapshot,
+            self._replace_transport(
                 gps_enabled=False,
                 connection_state="disabled",
                 speed_snapshot=(None, None),
@@ -147,17 +203,16 @@ class GPSTransportState:
             )
             return
         if snapshot.connection_state == "disabled":
-            self._snapshot = replace(
-                snapshot,
+            self._replace_transport(
                 gps_enabled=True,
                 connection_state="disconnected",
             )
             return
-        self._snapshot = replace(snapshot, gps_enabled=True)
+        self._replace_transport(gps_enabled=True)
 
     @property
     def gps_enabled(self) -> bool:
-        return self._snapshot.gps_enabled
+        return self._state.transport.gps_enabled
 
     @gps_enabled.setter
     def gps_enabled(self, value: bool) -> None:
@@ -165,104 +220,104 @@ class GPSTransportState:
 
     @property
     def connection_state(self) -> str:
-        return self._snapshot.connection_state
+        return self._state.transport.connection_state
 
     @connection_state.setter
     def connection_state(self, value: str) -> None:
-        self._replace_snapshot(connection_state=str(value))
+        self._replace_transport(connection_state=str(value))
 
     @property
     def speed_mps(self) -> float | None:
-        return self._snapshot.speed_snapshot[0]
+        return self._state.transport.speed_snapshot[0]
 
     @speed_mps.setter
     def speed_mps(self, value: float | None) -> None:
         if value is None or isinstance(value, bool) or not isinstance(value, NUMERIC_TYPES):
-            self._replace_snapshot(speed_snapshot=(None, None))
+            self._replace_transport(speed_snapshot=(None, None))
             return
         speed_f = float(value)
         if not math.isfinite(speed_f):
-            self._replace_snapshot(speed_snapshot=(None, None))
+            self._replace_transport(speed_snapshot=(None, None))
             return
-        self._replace_snapshot(speed_snapshot=(speed_f, time.monotonic()))
+        self._replace_transport(speed_snapshot=(speed_f, time.monotonic()))
 
     @property
     def _speed_snapshot(self) -> tuple[float | None, float | None]:
-        return self._snapshot.speed_snapshot
+        return self._state.transport.speed_snapshot
 
     @_speed_snapshot.setter
     def _speed_snapshot(self, value: tuple[float | None, float | None]) -> None:
-        self._replace_snapshot(speed_snapshot=self._normalize_speed_snapshot(value))
+        self._replace_transport(speed_snapshot=self._normalize_speed_snapshot(value))
 
     @property
     def last_update_ts(self) -> float | None:
-        return self._snapshot.speed_snapshot[1]
+        return self._state.transport.speed_snapshot[1]
 
     @property
     def last_error(self) -> str | None:
-        return self._snapshot.last_error
+        return self._state.lifecycle.last_error
 
     @last_error.setter
     def last_error(self, value: str | None) -> None:
-        self._replace_snapshot(last_error=(str(value) if value is not None else None))
+        self._replace_lifecycle(last_error=(str(value) if value is not None else None))
 
     @property
     def current_reconnect_delay(self) -> float:
-        return self._snapshot.current_reconnect_delay
+        return self._state.lifecycle.current_reconnect_delay
 
     @current_reconnect_delay.setter
     def current_reconnect_delay(self, value: float) -> None:
-        self._replace_snapshot(current_reconnect_delay=float(value))
+        self._replace_lifecycle(current_reconnect_delay=float(value))
 
     @property
     def device_info(self) -> str | None:
-        return self._snapshot.device_info
+        return self._state.transport.device_info
 
     @device_info.setter
     def device_info(self, value: str | None) -> None:
-        self._replace_snapshot(device_info=(str(value) if value is not None else None))
+        self._replace_transport(device_info=(str(value) if value is not None else None))
 
     @property
     def last_fix_mode(self) -> int | None:
-        return self._snapshot.last_fix_mode
+        return self._state.transport.last_fix_mode
 
     @last_fix_mode.setter
     def last_fix_mode(self, value: int | None) -> None:
-        self._replace_snapshot(
+        self._replace_transport(
             last_fix_mode=value if isinstance(value, int) and not isinstance(value, bool) else None
         )
 
     @property
     def last_epx_m(self) -> float | None:
-        return self._snapshot.last_epx_m
+        return self._state.transport.last_epx_m
 
     @last_epx_m.setter
     def last_epx_m(self, value: float | None) -> None:
-        self._replace_snapshot(last_epx_m=self._normalize_optional_float(value))
+        self._replace_transport(last_epx_m=self._normalize_optional_float(value))
 
     @property
     def last_epy_m(self) -> float | None:
-        return self._snapshot.last_epy_m
+        return self._state.transport.last_epy_m
 
     @last_epy_m.setter
     def last_epy_m(self, value: float | None) -> None:
-        self._replace_snapshot(last_epy_m=self._normalize_optional_float(value))
+        self._replace_transport(last_epy_m=self._normalize_optional_float(value))
 
     @property
     def last_epv_m(self) -> float | None:
-        return self._snapshot.last_epv_m
+        return self._state.transport.last_epv_m
 
     @last_epv_m.setter
     def last_epv_m(self, value: float | None) -> None:
-        self._replace_snapshot(last_epv_m=self._normalize_optional_float(value))
+        self._replace_transport(last_epv_m=self._normalize_optional_float(value))
 
     @property
     def _zero_speed_streak(self) -> int:
-        return self._snapshot.zero_speed_streak
+        return self._state.transport.zero_speed_streak
 
     @_zero_speed_streak.setter
     def _zero_speed_streak(self, value: int) -> None:
-        self._replace_snapshot(zero_speed_streak=max(0, int(value)))
+        self._replace_transport(zero_speed_streak=max(0, int(value)))
 
     @staticmethod
     def _read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
@@ -281,12 +336,13 @@ class GPSTransportState:
         return None
 
     def _accept_speed_sample(self, speed_mps: float) -> bool:
-        accepted, zero_speed_streak = self._evaluate_speed_sample(self._snapshot, speed_mps)
-        self._replace_snapshot(zero_speed_streak=zero_speed_streak)
+        transport_snapshot = self._state.transport
+        accepted, zero_speed_streak = self._evaluate_speed_sample(transport_snapshot, speed_mps)
+        self._replace_transport(zero_speed_streak=zero_speed_streak)
         return accepted
 
     def _reset_fix_metadata(self) -> None:
-        self._replace_snapshot(
+        self._replace_transport(
             last_fix_mode=None,
             last_epx_m=None,
             last_epy_m=None,
@@ -322,7 +378,7 @@ class GPSTransportState:
     ) -> None:
         read_mode = self._tpv_mode if tpv_mode is None else tpv_mode
         metric_reader = self._read_non_negative_metric if read_metric is None else read_metric
-        snapshot = self._snapshot
+        snapshot = self._state.transport
 
         mode = read_mode(payload)
         speed_snapshot = snapshot.speed_snapshot
@@ -347,8 +403,7 @@ class GPSTransportState:
 
         device = payload.get("device")
         device_info = device if isinstance(device, str) and device else snapshot.device_info
-        self._snapshot = replace(
-            snapshot,
+        self._replace_transport(
             last_fix_mode=mode if isinstance(mode, int) else None,
             last_epx_m=metric_reader(payload, "epx"),
             last_epy_m=metric_reader(payload, "epy"),


### PR DESCRIPTION
## Summary
This PR resolves `#1454` by separating reconnect/backoff state from the main GPS transport snapshot while preserving the observable behavior of `GPSSpeedMonitor` and the status API. Before this change, `GPSTransportSnapshot` carried two different kinds of data in one immutable structure: observational GPS state such as connection status, fix metadata, device information, and the latest speed sample, plus reconnect-oriented lifecycle data such as `current_reconnect_delay` and `last_error`. That made the core transport snapshot broader than it needed to be and forced reconnect-policy changes to reshape a structure that is otherwise meant to describe observed GPS state.

The implementation keeps the public monitor/status behavior intact but narrows the ownership boundary. I introduced a dedicated lifecycle snapshot for reconnect-oriented fields, added a combined captured-state handoff so the monitor can still read transport and lifecycle data together, and updated the focused GPS tests to pin the split seam. The outward result is that reconnect state no longer lives in `GPSTransportSnapshot`, while callers such as `GPSSpeedMonitor.status_snapshot()` still expose the same `last_error` and reconnect-delay information through the existing status model.

## Problem being solved
The issue here was not that GPS reconnect handling was failing functionally; it was that the transport snapshot had become a mixed seam. `GPSTransportSnapshot` was carrying data with different reasons to change. Fields like `speed_snapshot`, `last_fix_mode`, `last_epx_m`, `last_epy_m`, and `device_info` are observational transport facts. By contrast, `last_error` and `current_reconnect_delay` describe reconnect/backoff lifecycle behavior. Grouping them together meant the transport snapshot was no longer solely about “what the GPS transport currently observes.”

That matters because the GPS monitor treats the transport snapshot as a captured, read-once state handoff. If reconnect-policy state lives inside the same object, any future reconnect-policy change broadens the blast radius of code that only wants observational data. The issue asked for a narrow cleanup, not a redesign of the GPS loop, so the goal here was to split the state without changing reconnect semantics, status payloads, or enable/disable behavior.

## Chosen implementation approach
I used a two-layer state model inside `GPSTransportState`.

First, I removed `last_error` and `current_reconnect_delay` from `GPSTransportSnapshot` and introduced a new immutable `GPSTransportLifecycleState` dataclass that owns those reconnect-oriented fields.

Second, to preserve the existing “capture once, then read” pattern, I introduced `GPSTransportCapturedState`, which bundles the observational transport snapshot and the lifecycle snapshot into one immutable handoff. This matters because simply splitting the fields into two unrelated attributes would make it easier for readers to observe mismatched state if one snapshot changed between two separate reads. With the combined captured state, `GPSSpeedMonitor` can still capture one consistent transport+lifecycle view for status generation.

I intentionally kept this change narrow. I did not redesign the reconnect loop, did not introduce a new transport-policy subsystem, and did not touch TPV parsing rules. The loop still uses the same reconnect-delay progression, still resets delay on connect, still records errors on connection failures, and still clears speed/fix metadata on disconnect or failure.

## Main code changes by area
### `apps/server/vibesensor/adapters/gps/gps_transport.py`
This is where most of the refactor happened.

I introduced `GPSTransportLifecycleState` to own `last_error` and `current_reconnect_delay`, and `GPSTransportCapturedState` to bundle the transport and lifecycle snapshots together.

`GPSTransportState` now stores a captured-state object instead of a single transport snapshot. I added focused helpers for replacing the transport snapshot, replacing the lifecycle snapshot, and replacing both atomically when a transition needs to update both sides at once.

The main transition helpers were then rewritten around the split state:
- `_mark_connected()` now updates transport connection state and resets lifecycle error/delay together.
- `_mark_stream_disconnected()` only touches observational transport fields.
- `_mark_connection_error()` updates disconnect-related observational fields and lifecycle error/delay together.

All public properties continue to exist, but `last_error` and `current_reconnect_delay` now delegate to the lifecycle snapshot instead of the observational snapshot.

### `apps/server/vibesensor/adapters/gps/gps_speed.py`
The monitor still exposes the same properties and public behavior, but `status_snapshot()` now captures the combined transport/lifecycle state and feeds the status builder from the correct owner for each field.

I added a dedicated `_captured_status_snapshots()` helper so the status path reads the combined transport/lifecycle state once along with the speed-resolution policy snapshot. The status builder still receives `last_error` and `current_reconnect_delay`, but they now come from the lifecycle side of the captured state rather than from `GPSTransportSnapshot`.

### Focused tests
I updated the GPS tests instead of adding broad unrelated coverage.

In `test_gps_speed_snapshot_consistency.py`, the status-snapshot consistency test now monkeypatches the combined captured state instead of only the transport snapshot. This pins the new split seam directly and verifies that status generation still captures state once.

In `test_gps_speed_run_loop.py`, I extended the reconnect-on-failure test so it asserts that reconnect failures still update the externally visible lifecycle fields (`last_error` and reconnect delay). That makes sure the refactor did not preserve the type shape while dropping the behavior.

## Schema, contract, config, and documentation impact
There are no schema, configuration, or documentation changes in this PR. The public status payload contract is intentionally unchanged. This is an internal state-ownership cleanup inside the GPS transport/monitor seam.

## Validation performed
I validated the change set with:
- `pytest -q apps/server/tests/adapters/gps/`
- `ruff check --fix apps/server/vibesensor/adapters/gps/gps_speed.py`
- `ruff check apps/server/vibesensor/adapters/gps/gps_transport.py apps/server/vibesensor/adapters/gps/gps_speed.py apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py apps/server/tests/adapters/gps/test_gps_speed_run_loop.py`

The full GPS adapter test slice passed (`140 passed`). The targeted Ruff checks also passed after fixing the import-order adjustment introduced by the refactor.

I also attempted a broader `make lint` run. That surfaced unrelated pre-existing import-order failures in other dirty-worktree files outside this PR’s diff. I did not modify those unrelated files as part of this issue. The clean PR branch diff itself is limited to the GPS transport/monitor seam and its focused tests.

## Risks, tradeoffs, and edge cases considered
The main design tradeoff here was whether to split lifecycle state into a second attribute with separate reads or to preserve an atomic combined handoff. I chose the latter because the monitor already relies on snapshot-style reads, and I did not want the refactor to introduce subtle mismatches between observational transport data and reconnect lifecycle data.

I also chose to move `last_error` together with reconnect delay because it is transition-oriented state with the same lifecycle owner. Leaving it behind in the observational snapshot would have preserved some of the original blur.

What I did not do is redesign the reconnect algorithm, TPV handling, stale detection, or status presentation rules. Those are separate concerns and should be changed under their own issues if needed.

## Out of scope / follow-ups
This PR intentionally does not change the TPV ingestion path, does not alter reconnect timing rules, and does not touch the higher-level status contract. Follow-up transport issues in the backlog can build on this narrower ownership seam without having to first undo a mixed snapshot structure.
