### PR TITLE
Extract GPS reconnect lifecycle state from transport snapshot

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
@@ -157,9 +157,12 @@ async def test_run_reconnects_on_connection_failure(
 
     task = asyncio.create_task(monitor.run(host="127.0.0.1", port=9999))
     await asyncio.wait_for(enough_attempts.wait(), timeout=5.0)
+    await asyncio.sleep(0.05)
 
     assert attempt_count >= 2, f"Expected at least 2 attempts, got {attempt_count}"
     assert monitor.speed_mps is None
+    assert monitor.last_error == "mock refused"
+    assert 0.02 <= monitor.current_reconnect_delay <= 0.04
 
     task.cancel()
     await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=5.0)

--- a/apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 import pytest
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
+from vibesensor.adapters.gps.gps_transport import GPSTransportCapturedState
 
 
 def test_resolve_speed_captures_policy_and_transport_snapshots_once(
@@ -67,32 +68,46 @@ def test_status_snapshot_captures_policy_and_transport_snapshots_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monitor = GPSSpeedMonitor(gps_enabled=True)
-    base_transport = monitor._transport.snapshot()
+    base_captured = monitor._transport.captured_state()
     base_policy = monitor._policy.snapshot()
-    transport_calls = 0
+    captured_state_calls = 0
     policy_calls = 0
 
-    def _transport_snapshot():
-        nonlocal transport_calls
-        transport_calls += 1
-        if transport_calls == 1:
+    def _captured_transport_state() -> GPSTransportCapturedState:
+        nonlocal captured_state_calls
+        captured_state_calls += 1
+        if captured_state_calls == 1:
             return replace(
-                base_transport,
-                gps_enabled=True,
-                connection_state="connected",
-                speed_snapshot=(10.0, time.monotonic()),
-                device_info="/dev/ttyUSB0",
-                last_fix_mode=3,
-                last_error="old error",
+                base_captured,
+                transport=replace(
+                    base_captured.transport,
+                    gps_enabled=True,
+                    connection_state="connected",
+                    speed_snapshot=(10.0, time.monotonic()),
+                    device_info="/dev/ttyUSB0",
+                    last_fix_mode=3,
+                ),
+                lifecycle=replace(
+                    base_captured.lifecycle,
+                    last_error="old error",
+                    current_reconnect_delay=4.0,
+                ),
             )
         return replace(
-            base_transport,
-            gps_enabled=False,
-            connection_state="disabled",
-            speed_snapshot=(None, None),
-            device_info=None,
-            last_fix_mode=None,
-            last_error=None,
+            base_captured,
+            transport=replace(
+                base_captured.transport,
+                gps_enabled=False,
+                connection_state="disabled",
+                speed_snapshot=(None, None),
+                device_info=None,
+                last_fix_mode=None,
+            ),
+            lifecycle=replace(
+                base_captured.lifecycle,
+                last_error=None,
+                current_reconnect_delay=99.0,
+            ),
         )
 
     def _policy_snapshot():
@@ -112,18 +127,19 @@ def test_status_snapshot_captures_policy_and_transport_snapshots_once(
             stale_timeout_s=99.0,
         )
 
-    monkeypatch.setattr(monitor._transport, "snapshot", _transport_snapshot)
+    monkeypatch.setattr(monitor._transport, "captured_state", _captured_transport_state)
     monkeypatch.setattr(monitor._policy, "snapshot", _policy_snapshot)
 
     status = monitor.status_snapshot()
 
-    assert transport_calls == 1
+    assert captured_state_calls == 1
     assert policy_calls == 1
     assert status.gps_enabled is True
     assert status.connection_state == "connected"
     assert status.device == "/dev/ttyUSB0"
     assert status.fix_mode == 3
     assert status.raw_speed_kmh == pytest.approx(36.0, abs=0.1)
+    assert status.last_error == "old error"
     assert status.stale_timeout_s == pytest.approx(17.0)
 
 

--- a/apps/server/vibesensor/adapters/gps/gps_speed.py
+++ b/apps/server/vibesensor/adapters/gps/gps_speed.py
@@ -6,7 +6,11 @@ from typing import Literal
 
 from vibesensor.adapters.gps import gps_transport as _gps_transport
 from vibesensor.adapters.gps import speed_resolution as _speed_resolution
-from vibesensor.adapters.gps.gps_transport import GPSTransportSnapshot, GPSTransportState
+from vibesensor.adapters.gps.gps_transport import (
+    GPSTransportCapturedState,
+    GPSTransportSnapshot,
+    GPSTransportState,
+)
 from vibesensor.adapters.gps.gpsd_message_handler import (
     read_non_negative_metric,
     read_tpv_mode,
@@ -259,8 +263,15 @@ class GPSSpeedMonitor:
     ) -> tuple[GPSTransportSnapshot, SpeedResolutionPolicySnapshot]:
         return self._transport.snapshot(), self._policy.snapshot()
 
+    def _captured_status_snapshots(
+        self,
+    ) -> tuple[GPSTransportCapturedState, SpeedResolutionPolicySnapshot]:
+        return self._transport.captured_state(), self._policy.snapshot()
+
     def status_snapshot(self) -> SpeedSourceStatusSnapshot:
-        transport_snapshot, policy_snapshot = self._captured_snapshots()
+        captured_state, policy_snapshot = self._captured_status_snapshots()
+        transport_snapshot = captured_state.transport
+        lifecycle_snapshot = captured_state.lifecycle
         speed_snapshot = transport_snapshot.speed_snapshot
         resolution = self._policy.resolve(
             gps_enabled=transport_snapshot.gps_enabled,
@@ -278,8 +289,8 @@ class GPSSpeedMonitor:
             last_epv_m=transport_snapshot.last_epv_m,
             raw_speed_mps=speed_snapshot[0],
             last_update_ts=speed_snapshot[1],
-            last_error=transport_snapshot.last_error,
-            current_reconnect_delay=transport_snapshot.current_reconnect_delay,
+            last_error=lifecycle_snapshot.last_error,
+            current_reconnect_delay=lifecycle_snapshot.current_reconnect_delay,
             stale_timeout_s=policy_snapshot.stale_timeout_s,
         )
         return build_status_snapshot(

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -57,8 +57,6 @@ class GPSTransportSnapshot:
     gps_enabled: bool
     connection_state: str
     speed_snapshot: tuple[float | None, float | None] = (None, None)
-    last_error: str | None = None
-    current_reconnect_delay: float = _GPS_RECONNECT_DELAY_S
     device_info: str | None = None
     last_fix_mode: int | None = None
     last_epx_m: float | None = None
@@ -67,23 +65,79 @@ class GPSTransportSnapshot:
     zero_speed_streak: int = 0
 
 
+@dataclass(frozen=True, slots=True)
+class GPSTransportLifecycleState:
+    """Reconnect/backoff state captured alongside the observational transport snapshot."""
+
+    last_error: str | None = None
+    current_reconnect_delay: float = _GPS_RECONNECT_DELAY_S
+
+
+@dataclass(frozen=True, slots=True)
+class GPSTransportCapturedState:
+    """Atomic GPS state handoff containing both observational and lifecycle snapshots."""
+
+    transport: GPSTransportSnapshot
+    lifecycle: GPSTransportLifecycleState
+
+
+_LIFECYCLE_FIELD_NAMES = frozenset({"last_error", "current_reconnect_delay"})
+
+
 class GPSTransportState:
     """Owns GPS transport state as immutable snapshots atomically swapped by writers."""
 
     def __init__(self, gps_enabled: bool):
-        self._snapshot = GPSTransportSnapshot(
-            gps_enabled=bool(gps_enabled),
-            connection_state="disabled" if not gps_enabled else "disconnected",
+        self._state = GPSTransportCapturedState(
+            transport=GPSTransportSnapshot(
+                gps_enabled=bool(gps_enabled),
+                connection_state="disabled" if not gps_enabled else "disconnected",
+            ),
+            lifecycle=GPSTransportLifecycleState(),
         )
 
     def snapshot(self) -> GPSTransportSnapshot:
-        return self._snapshot
+        return self._state.transport
+
+    def lifecycle_snapshot(self) -> GPSTransportLifecycleState:
+        return self._state.lifecycle
+
+    def captured_state(self) -> GPSTransportCapturedState:
+        return self._state
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, GPSTransportState) and self._snapshot == other._snapshot
+        return isinstance(other, GPSTransportState) and self._state == other._state
 
-    def _replace_snapshot(self, **changes: object) -> None:
-        self._snapshot = replace(self._snapshot, **cast(dict[str, Any], changes))
+    def _replace_transport(self, **changes: object) -> None:
+        self._state = replace(
+            self._state,
+            transport=replace(self._state.transport, **cast(dict[str, Any], changes)),
+        )
+
+    def _replace_lifecycle(self, **changes: object) -> None:
+        self._state = replace(
+            self._state,
+            lifecycle=replace(self._state.lifecycle, **cast(dict[str, Any], changes)),
+        )
+
+    def _replace_captured_state(
+        self,
+        *,
+        transport_changes: dict[str, object] | None = None,
+        lifecycle_changes: dict[str, object] | None = None,
+    ) -> None:
+        self._state = GPSTransportCapturedState(
+            transport=(
+                self._state.transport
+                if transport_changes is None
+                else replace(self._state.transport, **cast(dict[str, Any], transport_changes))
+            ),
+            lifecycle=(
+                self._state.lifecycle
+                if lifecycle_changes is None
+                else replace(self._state.lifecycle, **cast(dict[str, Any], lifecycle_changes))
+            ),
+        )
 
     @staticmethod
     def _normalize_optional_float(value: object) -> float | None:
@@ -114,28 +168,57 @@ class GPSTransportState:
         )
         return verdict.accepted, verdict.zero_speed_streak
 
+    def _apply_transition_changes(self, changes: dict[str, object]) -> None:
+        transport_changes = {k: v for k, v in changes.items() if k not in _LIFECYCLE_FIELD_NAMES}
+        lifecycle_changes = {k: v for k, v in changes.items() if k in _LIFECYCLE_FIELD_NAMES}
+        self._replace_captured_state(
+            transport_changes=transport_changes or None,
+            lifecycle_changes=lifecycle_changes or None,
+        )
+
     def _mark_connected(self) -> None:
-        self._replace_snapshot(
-            **TransportLifecycle().on_connected().changes,
+        self._replace_captured_state(
+            transport_changes={"connection_state": "connected"},
+            lifecycle_changes={
+                "last_error": None,
+                "current_reconnect_delay": _GPS_RECONNECT_DELAY_S,
+            },
         )
 
     def _mark_stream_disconnected(self) -> None:
-        self._replace_snapshot(
-            **TransportLifecycle().on_stream_disconnected().changes,
+        self._replace_transport(
+            connection_state="disconnected",
+            speed_snapshot=(None, None),
+            last_fix_mode=None,
+            last_epx_m=None,
+            last_epy_m=None,
+            last_epv_m=None,
+            zero_speed_streak=0,
+            device_info=None,
         )
 
     def _mark_connection_error(self, exc: BaseException, reconnect_delay: float) -> None:
-        transition = TransportLifecycle().on_connection_error(exc)
-        # Override the delay from the caller's tracked value.
-        self._replace_snapshot(
-            **{**transition.changes, "current_reconnect_delay": reconnect_delay},
+        self._replace_captured_state(
+            transport_changes={
+                "connection_state": "disconnected",
+                "speed_snapshot": (None, None),
+                "last_fix_mode": None,
+                "last_epx_m": None,
+                "last_epy_m": None,
+                "last_epv_m": None,
+                "zero_speed_streak": 0,
+                "device_info": None,
+            },
+            lifecycle_changes={
+                "last_error": str(exc) or type(exc).__name__,
+                "current_reconnect_delay": reconnect_delay,
+            },
         )
 
     def set_enabled(self, enabled: bool) -> None:
-        snapshot = self._snapshot
+        snapshot = self._state.transport
         if not enabled:
-            self._snapshot = replace(
-                snapshot,
+            self._replace_transport(
                 gps_enabled=False,
                 connection_state="disabled",
                 speed_snapshot=(None, None),
@@ -143,17 +226,16 @@ class GPSTransportState:
             )
             return
         if snapshot.connection_state == "disabled":
-            self._snapshot = replace(
-                snapshot,
+            self._replace_transport(
                 gps_enabled=True,
                 connection_state="disconnected",
             )
             return
-        self._snapshot = replace(snapshot, gps_enabled=True)
+        self._replace_transport(gps_enabled=True)
 
     @property
     def gps_enabled(self) -> bool:
-        return self._snapshot.gps_enabled
+        return self._state.transport.gps_enabled
 
     @gps_enabled.setter
     def gps_enabled(self, value: bool) -> None:
@@ -161,104 +243,104 @@ class GPSTransportState:
 
     @property
     def connection_state(self) -> str:
-        return self._snapshot.connection_state
+        return self._state.transport.connection_state
 
     @connection_state.setter
     def connection_state(self, value: str) -> None:
-        self._replace_snapshot(connection_state=str(value))
+        self._replace_transport(connection_state=str(value))
 
     @property
     def speed_mps(self) -> float | None:
-        return self._snapshot.speed_snapshot[0]
+        return self._state.transport.speed_snapshot[0]
 
     @speed_mps.setter
     def speed_mps(self, value: float | None) -> None:
         if value is None or isinstance(value, bool) or not isinstance(value, NUMERIC_TYPES):
-            self._replace_snapshot(speed_snapshot=(None, None))
+            self._replace_transport(speed_snapshot=(None, None))
             return
         speed_f = float(value)
         if not math.isfinite(speed_f):
-            self._replace_snapshot(speed_snapshot=(None, None))
+            self._replace_transport(speed_snapshot=(None, None))
             return
-        self._replace_snapshot(speed_snapshot=(speed_f, time.monotonic()))
+        self._replace_transport(speed_snapshot=(speed_f, time.monotonic()))
 
     @property
     def _speed_snapshot(self) -> tuple[float | None, float | None]:
-        return self._snapshot.speed_snapshot
+        return self._state.transport.speed_snapshot
 
     @_speed_snapshot.setter
     def _speed_snapshot(self, value: tuple[float | None, float | None]) -> None:
-        self._replace_snapshot(speed_snapshot=self._normalize_speed_snapshot(value))
+        self._replace_transport(speed_snapshot=self._normalize_speed_snapshot(value))
 
     @property
     def last_update_ts(self) -> float | None:
-        return self._snapshot.speed_snapshot[1]
+        return self._state.transport.speed_snapshot[1]
 
     @property
     def last_error(self) -> str | None:
-        return self._snapshot.last_error
+        return self._state.lifecycle.last_error
 
     @last_error.setter
     def last_error(self, value: str | None) -> None:
-        self._replace_snapshot(last_error=(str(value) if value is not None else None))
+        self._replace_lifecycle(last_error=(str(value) if value is not None else None))
 
     @property
     def current_reconnect_delay(self) -> float:
-        return self._snapshot.current_reconnect_delay
+        return self._state.lifecycle.current_reconnect_delay
 
     @current_reconnect_delay.setter
     def current_reconnect_delay(self, value: float) -> None:
-        self._replace_snapshot(current_reconnect_delay=float(value))
+        self._replace_lifecycle(current_reconnect_delay=float(value))
 
     @property
     def device_info(self) -> str | None:
-        return self._snapshot.device_info
+        return self._state.transport.device_info
 
     @device_info.setter
     def device_info(self, value: str | None) -> None:
-        self._replace_snapshot(device_info=(str(value) if value is not None else None))
+        self._replace_transport(device_info=(str(value) if value is not None else None))
 
     @property
     def last_fix_mode(self) -> int | None:
-        return self._snapshot.last_fix_mode
+        return self._state.transport.last_fix_mode
 
     @last_fix_mode.setter
     def last_fix_mode(self, value: int | None) -> None:
-        self._replace_snapshot(
+        self._replace_transport(
             last_fix_mode=value if isinstance(value, int) and not isinstance(value, bool) else None
         )
 
     @property
     def last_epx_m(self) -> float | None:
-        return self._snapshot.last_epx_m
+        return self._state.transport.last_epx_m
 
     @last_epx_m.setter
     def last_epx_m(self, value: float | None) -> None:
-        self._replace_snapshot(last_epx_m=self._normalize_optional_float(value))
+        self._replace_transport(last_epx_m=self._normalize_optional_float(value))
 
     @property
     def last_epy_m(self) -> float | None:
-        return self._snapshot.last_epy_m
+        return self._state.transport.last_epy_m
 
     @last_epy_m.setter
     def last_epy_m(self, value: float | None) -> None:
-        self._replace_snapshot(last_epy_m=self._normalize_optional_float(value))
+        self._replace_transport(last_epy_m=self._normalize_optional_float(value))
 
     @property
     def last_epv_m(self) -> float | None:
-        return self._snapshot.last_epv_m
+        return self._state.transport.last_epv_m
 
     @last_epv_m.setter
     def last_epv_m(self, value: float | None) -> None:
-        self._replace_snapshot(last_epv_m=self._normalize_optional_float(value))
+        self._replace_transport(last_epv_m=self._normalize_optional_float(value))
 
     @property
     def _zero_speed_streak(self) -> int:
-        return self._snapshot.zero_speed_streak
+        return self._state.transport.zero_speed_streak
 
     @_zero_speed_streak.setter
     def _zero_speed_streak(self, value: int) -> None:
-        self._replace_snapshot(zero_speed_streak=max(0, int(value)))
+        self._replace_transport(zero_speed_streak=max(0, int(value)))
 
     @staticmethod
     def _read_non_negative_metric(payload: JsonObject, field: str) -> float | None:
@@ -269,12 +351,13 @@ class GPSTransportState:
         return read_tpv_mode(payload)
 
     def _accept_speed_sample(self, speed_mps: float) -> bool:
-        accepted, zero_speed_streak = self._evaluate_speed_sample(self._snapshot, speed_mps)
-        self._replace_snapshot(zero_speed_streak=zero_speed_streak)
+        transport_snapshot = self._state.transport
+        accepted, zero_speed_streak = self._evaluate_speed_sample(transport_snapshot, speed_mps)
+        self._replace_transport(zero_speed_streak=zero_speed_streak)
         return accepted
 
     def _reset_fix_metadata(self) -> None:
-        self._replace_snapshot(
+        self._replace_transport(
             last_fix_mode=None,
             last_epx_m=None,
             last_epy_m=None,
@@ -295,13 +378,13 @@ class GPSTransportState:
         if message is None:
             return
         if isinstance(message, GpsdVersionInfo):
-            self._replace_snapshot(device_info=f"gpsd {message.revision}")
+            self._replace_transport(device_info=f"gpsd {message.revision}")
             return
         self._apply_tpv(message)
 
     def _apply_tpv(self, tpv: NormalizedTpvData) -> None:
         """Apply normalized TPV data to the transport snapshot."""
-        snapshot = self._snapshot
+        snapshot = self._state.transport
         speed_snapshot = snapshot.speed_snapshot
         zero_speed_streak = snapshot.zero_speed_streak
 
@@ -316,8 +399,7 @@ class GPSTransportState:
             zero_speed_streak = 0
 
         device_info = tpv.device if tpv.device else snapshot.device_info
-        self._snapshot = replace(
-            snapshot,
+        self._replace_transport(
             last_fix_mode=tpv.mode,
             last_epx_m=tpv.epx,
             last_epy_m=tpv.epy,
@@ -336,7 +418,7 @@ class GPSTransportState:
     ) -> None:
         read_mode = self._tpv_mode if tpv_mode is None else tpv_mode
         metric_reader = self._read_non_negative_metric if read_metric is None else read_metric
-        snapshot = self._snapshot
+        snapshot = self._state.transport
 
         mode = read_mode(payload)
         speed_snapshot = snapshot.speed_snapshot
@@ -361,8 +443,7 @@ class GPSTransportState:
 
         device = payload.get("device")
         device_info = device if isinstance(device, str) and device else snapshot.device_info
-        self._snapshot = replace(
-            snapshot,
+        self._replace_transport(
             last_fix_mode=mode if isinstance(mode, int) else None,
             last_epx_m=metric_reader(payload, "epx"),
             last_epy_m=metric_reader(payload, "epy"),
@@ -403,7 +484,7 @@ class GPSTransportState:
                 writer.write(b'?WATCH={"enable":true,"json":true};\n')
                 await writer.drain()
                 transition = lifecycle.on_connected()
-                self._replace_snapshot(**transition.changes)
+                self._apply_transition_changes(transition.changes)
                 while True:
                     if not self.gps_enabled:
                         self.set_enabled(False)
@@ -411,7 +492,7 @@ class GPSTransportState:
                     line = await asyncio.wait_for(reader.readline(), timeout=_GPS_READ_TIMEOUT_S)
                     if not line:
                         transition = lifecycle.on_stream_disconnected()
-                        self._replace_snapshot(**transition.changes)
+                        self._apply_transition_changes(transition.changes)
                         break
                     try:
                         parsed = loads(line.decode("utf-8", errors="replace"))
@@ -438,7 +519,7 @@ class GPSTransportState:
                 json.JSONDecodeError,
             ) as exc:
                 transition = lifecycle.on_connection_error(exc)
-                self._replace_snapshot(**transition.changes)
+                self._apply_transition_changes(transition.changes)
                 LOGGER.warning(
                     "GPS connection lost, retrying in %gs: %s",
                     transition.sleep_before_retry,


### PR DESCRIPTION
## Summary
This PR resolves `#1454` by separating reconnect/backoff lifecycle state from the main GPS transport snapshot while preserving the outward behavior of `GPSSpeedMonitor` and the speed-source status API. Before this change, `GPSTransportSnapshot` mixed two kinds of information in one immutable structure: observational GPS state such as connection state, fix metadata, device information, and the latest speed sample, plus reconnect-oriented lifecycle state such as `last_error` and `current_reconnect_delay`. That made the snapshot broader than intended and meant reconnect-policy changes had to reshape a structure that should primarily describe observed GPS state.

The change keeps runtime behavior intact but narrows the seam. I introduced a dedicated lifecycle snapshot for reconnect-specific state, added a combined captured-state handoff so status readers can still capture a consistent transport/lifecycle view, and updated the focused GPS tests to pin the new ownership boundary. The outward result is that reconnect state no longer lives in `GPSTransportSnapshot`, while existing status consumers still receive the same last-error and reconnect-delay information through the monitor/status layer.

This PR supersedes `#1477`, which was opened from the older dirty worktree branch and later became conflicting after newer GPS refactors landed on `main`. The final branch rebases the actual `#1454` change onto current `main` from a clean sibling worktree.

## Problem being solved
The reconnect loop already worked. The issue here was structural: the transport snapshot had become the home for data with different reasons to change. Fields such as `speed_snapshot`, `last_fix_mode`, `last_epx_m`, `last_epy_m`, `last_epv_m`, and `device_info` are observational transport facts. By contrast, `last_error` and `current_reconnect_delay` exist to describe lifecycle transitions and reconnect/backoff policy. They are useful to surface in status, but they are not the same kind of state.

That distinction matters because the GPS monitor relies on immutable snapshot-style reads. If lifecycle policy state lives inside the same object as observational transport data, the transport snapshot becomes the default home for both sensor observations and reconnect mechanics. That broadens future change blast radius. The issue asked for a small, ownership-focused cleanup rather than a transport rewrite, so the right fix was to split those responsibilities while preserving behavior.

## Chosen implementation approach
I applied the split using a two-layer state model inside `GPSTransportState`.

First, I removed reconnect-specific fields from `GPSTransportSnapshot` and introduced `GPSTransportLifecycleState`, which now owns `last_error` and `current_reconnect_delay`.

Second, I introduced `GPSTransportCapturedState`, which bundles the observational transport snapshot and the reconnect lifecycle snapshot into one immutable handoff. That preserves the current “capture once, then derive status” pattern. Splitting into two unrelated attributes would have reduced ownership clarity but increased the risk of readers observing mismatched state if one side changed between reads.

I also added a small helper inside `GPSTransportState` that takes transition changes produced by the current `TransportLifecycle` helper and routes them to the correct owner: observational transport fields stay on the transport snapshot, while reconnect-oriented fields land on the lifecycle snapshot. This let the change fit the current `main` architecture cleanly instead of undoing the recent `gpsd_message_handler`, `speed_validation`, or `transport_lifecycle` refactors.

## Main code changes by area
### `apps/server/vibesensor/adapters/gps/gps_transport.py`
This is where the ownership split lives.

I introduced two new immutable dataclasses:
- `GPSTransportLifecycleState` for reconnect/backoff state
- `GPSTransportCapturedState` for one-shot captured reads of both transport and lifecycle state

`GPSTransportState` now stores a captured-state object instead of only a transport snapshot. I added focused helpers for replacing transport fields, replacing lifecycle fields, replacing both at once, and applying transition-change dictionaries while routing keys to the correct owner.

The reconnect transitions preserve current runtime behavior but update the new lifecycle seam explicitly:
- successful connect resets reconnect delay and clears `last_error`
- stream disconnect clears observational transport state without forcing lifecycle error state changes
- connection errors update both disconnect-related observational fields and reconnect lifecycle fields

I also updated TPV/version-message handling so observational fields continue to flow through the transport snapshot only.

### `apps/server/vibesensor/adapters/gps/gps_speed.py`
The monitor API remains outwardly the same, but `status_snapshot()` now reads from the split transport/lifecycle handoff instead of assuming reconnect fields live on `GPSTransportSnapshot`.

I added `_captured_status_snapshots()` so the status path captures `GPSTransportCapturedState` once together with the current speed-resolution policy snapshot. The resulting `GPSSpeedStatusState` still receives `last_error` and `current_reconnect_delay`, but those values now come from the lifecycle side of the handoff.

### Focused tests
I kept the test changes narrow and GPS-specific.

In `test_gps_speed_snapshot_consistency.py`, the status-snapshot consistency test now monkeypatches the combined captured-state seam and verifies that status generation still captures that seam once.

In `test_gps_speed_run_loop.py`, I extended the reconnect-on-failure test so it asserts that connection failures still surface the expected lifecycle-facing status data (`last_error` and reconnect delay). That ensures the refactor changed ownership without dropping the behavior the monitor reports.

## Schema, contract, config, and documentation changes
There are no user-facing schema or config changes in this PR. The speed-source status payload contract remains the same. This is an internal ownership cleanup in the GPS transport/monitor seam.

## Validation and tests performed
I validated the original issue branch with focused GPS pytest plus targeted Ruff on the touched transport/monitor files and tests. That GPS test slice passed (`140 passed`) before the move to a clean branch.

After rebasing onto the latest `main` in the clean sibling worktree, I reran targeted Ruff on the exact touched files and resolved the merge-specific import-order adjustment in `gps_speed.py`. Those targeted Ruff checks now pass on the final clean main-based branch.

I could not rerun the main-based pytest suite in this container because the local environment only has Python 3.11, while current `main` now contains newer Python syntax in shared type modules that requires a newer interpreter before tests can import the app. That interpreter mismatch is environmental, not GPS-specific, so CI is the authoritative main-based validation gate for this final branch.

## Risks, tradeoffs, and edge cases considered
The main design choice was whether to split lifecycle state into a second free-standing attribute or preserve an atomic captured handoff. I chose the captured handoff because the monitor already relies on snapshot-style reads and the issue was about ownership, not about relaxing consistency.

I also moved `last_error` together with reconnect delay because both fields describe lifecycle transitions rather than observed GPS fix data. Leaving `last_error` behind would have preserved some of the original boundary blur.

I intentionally did not redesign the reconnect algorithm, TPV parsing, stale detection, or status formatting. Those remain separate concerns and should be handled under their own issues if they change.
