### PR TITLE
Converge GPSTransportState on one TPV ingestion path

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_transport_ingestion.py
+++ b/apps/server/tests/adapters/gps/test_gps_transport_ingestion.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from vibesensor.adapters.gps.gps_transport import GPSTransportState
+from vibesensor.adapters.gps.gpsd_message_handler import NormalizedTpvData
+
+
+def test_ingest_tpv_delegates_normalized_payload_to_apply_tpv(
+    monkeypatch,
+) -> None:
+    transport = GPSTransportState(gps_enabled=True)
+    captured: list[NormalizedTpvData] = []
+
+    def _capture(tpv: NormalizedTpvData) -> None:
+        captured.append(tpv)
+
+    monkeypatch.setattr(transport, "_apply_tpv", _capture)
+
+    transport.ingest_tpv(
+        {
+            "mode": 3,
+            "speed": 12.5,
+            "epx": 1.2,
+            "epy": 2.3,
+            "epv": 3.4,
+            "device": "/dev/ttyUSB0",
+        }
+    )
+
+    assert captured == [
+        NormalizedTpvData(
+            mode=3,
+            speed=12.5,
+            epx=1.2,
+            epy=2.3,
+            epv=3.4,
+            device="/dev/ttyUSB0",
+        )
+    ]
+
+
+def test_ingest_tpv_uses_custom_readers_before_delegating(
+    monkeypatch,
+) -> None:
+    transport = GPSTransportState(gps_enabled=True)
+    captured: list[NormalizedTpvData] = []
+
+    def _capture(tpv: NormalizedTpvData) -> None:
+        captured.append(tpv)
+
+    def _mode_reader(_payload: object) -> int:
+        return 2
+
+    def _metric_reader(_payload: object, field: str) -> float:
+        return {"epx": 9.0, "epy": 8.0, "epv": 7.0}[field]
+
+    monkeypatch.setattr(transport, "_apply_tpv", _capture)
+
+    transport.ingest_tpv(
+        {
+            "mode": "ignored",
+            "speed": 6.0,
+            "epx": "ignored",
+            "epy": "ignored",
+            "epv": "ignored",
+            "device": "/dev/ttyACM0",
+        },
+        tpv_mode=_mode_reader,
+        read_metric=_metric_reader,
+    )
+
+    assert captured == [
+        NormalizedTpvData(
+            mode=2,
+            speed=6.0,
+            epx=9.0,
+            epy=8.0,
+            epv=7.0,
+            device="/dev/ttyACM0",
+        )
+    ]
+
+
+def test_ingest_tpv_matches_ingest_message_snapshot_for_equivalent_payload(
+    monkeypatch,
+) -> None:
+    raw_transport = GPSTransportState(gps_enabled=True)
+    message_transport = GPSTransportState(gps_enabled=True)
+    monotonic_value = 1234.5
+
+    monkeypatch.setattr(
+        "vibesensor.adapters.gps.gps_transport.time.monotonic",
+        lambda: monotonic_value,
+    )
+
+    raw_transport.ingest_tpv(
+        {
+            "mode": 3,
+            "speed": 18.0,
+            "epx": 1.2,
+            "epy": 2.3,
+            "epv": 3.4,
+            "device": "/dev/ttyUSB0",
+        }
+    )
+    message_transport.ingest_message(
+        {
+            "class": "TPV",
+            "mode": 3,
+            "speed": 18.0,
+            "epx": 1.2,
+            "epy": 2.3,
+            "epv": 3.4,
+            "device": "/dev/ttyUSB0",
+        }
+    )
+
+    assert raw_transport.snapshot() == message_transport.snapshot()

--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -409,6 +409,34 @@ class GPSTransportState:
             device_info=device_info,
         )
 
+    def _normalize_tpv_payload(
+        self,
+        payload: JsonObject,
+        *,
+        tpv_mode: TpvModeReader | None = None,
+        read_metric: MetricReader | None = None,
+    ) -> NormalizedTpvData:
+        read_mode = self._tpv_mode if tpv_mode is None else tpv_mode
+        metric_reader = self._read_non_negative_metric if read_metric is None else read_metric
+
+        speed = payload.get("speed")
+        normalized_speed: float | None = None
+        if isinstance(speed, NUMERIC_TYPES) and not isinstance(speed, bool):
+            speed_f = float(speed)
+            if math.isfinite(speed_f):
+                normalized_speed = speed_f
+
+        device = payload.get("device")
+        normalized_device = device if isinstance(device, str) and device else None
+        return NormalizedTpvData(
+            mode=read_mode(payload),
+            speed=normalized_speed,
+            epx=metric_reader(payload, "epx"),
+            epy=metric_reader(payload, "epy"),
+            epv=metric_reader(payload, "epv"),
+            device=normalized_device,
+        )
+
     def ingest_tpv(
         self,
         payload: JsonObject,
@@ -416,41 +444,12 @@ class GPSTransportState:
         tpv_mode: TpvModeReader | None = None,
         read_metric: MetricReader | None = None,
     ) -> None:
-        read_mode = self._tpv_mode if tpv_mode is None else tpv_mode
-        metric_reader = self._read_non_negative_metric if read_metric is None else read_metric
-        snapshot = self._state.transport
-
-        mode = read_mode(payload)
-        speed_snapshot = snapshot.speed_snapshot
-        zero_speed_streak = snapshot.zero_speed_streak
-
-        speed = payload.get("speed")
-        if (
-            isinstance(mode, int)
-            and mode >= 2
-            and isinstance(speed, NUMERIC_TYPES)
-            and not isinstance(speed, bool)
-        ):
-            speed_f = float(speed)
-            if is_speed_plausible(speed_f):
-                accepted, zero_speed_streak = self._evaluate_speed_sample(snapshot, speed_f)
-                if accepted:
-                    speed_snapshot = (speed_f, time.monotonic())
-            else:
-                zero_speed_streak = 0
-        else:
-            zero_speed_streak = 0
-
-        device = payload.get("device")
-        device_info = device if isinstance(device, str) and device else snapshot.device_info
-        self._replace_transport(
-            last_fix_mode=mode if isinstance(mode, int) else None,
-            last_epx_m=metric_reader(payload, "epx"),
-            last_epy_m=metric_reader(payload, "epy"),
-            last_epv_m=metric_reader(payload, "epv"),
-            speed_snapshot=speed_snapshot,
-            zero_speed_streak=zero_speed_streak,
-            device_info=device_info,
+        self._apply_tpv(
+            self._normalize_tpv_payload(
+                payload,
+                tpv_mode=tpv_mode,
+                read_metric=read_metric,
+            )
         )
 
     async def run(


### PR DESCRIPTION
## Summary
This PR resolves `#1455` by converging `GPSTransportState` onto a single TPV-to-snapshot mutation path. Before this change, the transport had two ways to turn TPV data into snapshot state. `ingest_message()` classified GPSD messages, normalized TPV payloads into `NormalizedTpvData`, and then delegated to `_apply_tpv()`. At the same time, `ingest_tpv()` performed its own raw-field parsing and reimplemented the snapshot update logic inline. The two paths were close enough to be equivalent today, but they were still separate owners for the same behavioral seam.

The fix here is intentionally narrow. `_apply_tpv()` remains the single authoritative place that mutates transport snapshot state from TPV data. `ingest_tpv()` now acts as a compatibility adapter: it normalizes the raw payload into `NormalizedTpvData` and delegates entirely to `_apply_tpv()` instead of rebuilding the snapshot-update rules itself. That keeps current behavior while removing the duplicated mutation logic that made future GPS changes riskier than necessary.

## Problem being solved
The issue was not that either path was obviously broken. The risk was structural drift. When two methods both own nearly the same TPV-to-snapshot behavior, small changes to accepted speed handling, fix metadata updates, or device-info propagation can land in one path and be missed in the other. That is especially easy to do when most run-loop coverage naturally exercises `ingest_message()` while a direct raw-TPV helper remains available as a second code path.

The current GPS transport cleanup work is deliberately incremental. This issue is intentionally small so the repo can remove one duplicated behavior seam without reopening the broader transport design. A full GPS parser redesign would have been unnecessary and riskier. The right change was to keep the existing public shape, preserve compatibility, and reduce the mutation surface area to one owner.

## Chosen implementation approach
I kept `_apply_tpv()` as the authoritative mutation owner and reduced `ingest_tpv()` to a thin adapter.

The new adapter step lives in `GPSTransportState._normalize_tpv_payload()`. It performs only the raw-to-normalized field extraction that `ingest_tpv()` still needs to support: mode resolution, finite speed extraction, non-negative metric reads, and optional device selection. It returns `NormalizedTpvData`, the same typed shape already used by the message-classification path.

With that in place, `ingest_tpv()` no longer updates snapshot state itself. It simply builds normalized TPV data and passes it to `_apply_tpv()`. That means there is now one authoritative TPV-to-snapshot mutation path inside `GPSTransportState`, while preserving the direct `ingest_tpv()` entrypoint for any caller or test seam that still depends on it.

I intentionally did not try to unify every normalization helper across the GPS adapter stack in this issue. The issue body targeted the mutation path specifically, not the larger normalization/classification story. Keeping the scope there makes this change easier to review and safer to land independently.

## Main code changes by area
### `apps/server/vibesensor/adapters/gps/gps_transport.py`
The production change is confined to the transport state object.

I added `_normalize_tpv_payload()`, which converts a raw TPV payload into `NormalizedTpvData` using the existing optional custom readers for mode and metrics. The helper keeps the current raw-payload compatibility surface intact.

Then I rewired `ingest_tpv()` so it delegates entirely through `_apply_tpv()` rather than reimplementing snapshot updates inline. This removes the second TPV-to-snapshot mutation owner from the transport.

Crucially, `_apply_tpv()` itself remains unchanged as the place that applies accepted speed samples, zero-speed streak updates, fix metadata, and device-info propagation to the immutable transport snapshot.

### `apps/server/tests/adapters/gps/test_gps_transport_ingestion.py`
I added a focused test module for this seam instead of expanding the existing run-loop regression files.

The new tests cover three things.

First, `test_ingest_tpv_delegates_normalized_payload_to_apply_tpv()` proves that `ingest_tpv()` now hands a fully normalized `NormalizedTpvData` object to `_apply_tpv()` rather than mutating state on its own.

Second, `test_ingest_tpv_uses_custom_readers_before_delegating()` verifies that the compatibility surface is preserved. If callers still provide custom `tpv_mode` or `read_metric` functions, `ingest_tpv()` uses them before delegation.

Third, `test_ingest_tpv_matches_ingest_message_snapshot_for_equivalent_payload()` fixes the core equivalence requirement: for the same TPV data, direct raw ingestion and GPSD message ingestion produce the same transport snapshot. I pin `time.monotonic()` so the snapshots can be compared directly without timestamp noise.

## Schema, contract, config, and documentation changes
There are no user-facing contract or config changes in this PR. The speed-status contract and GPS runtime configuration remain unchanged. This is an internal transport-seam cleanup only.

I also did not change the GPSD message classifier or the speed-validation semantics. Those are intentionally out of scope for this issue.

## Validation and tests performed
Local validation in this container was limited by the current interpreter environment. This container only has Python 3.11 available, while current `main` now imports newer Python syntax from shared type modules before the test suite can start. Because of that, I could not run the main-based pytest slice locally after branching from the latest merged `main`.

I did run targeted Ruff checks on the changed production file and the new focused test module:
- `ruff check apps/server/vibesensor/adapters/gps/gps_transport.py apps/server/tests/adapters/gps/test_gps_transport_ingestion.py`

Those checks pass on the final branch.

The new test module is designed so CI can exercise the behavioral equivalence and delegation guarantees on the authoritative main-based environment.

## Risks, tradeoffs, and edge cases considered
The main tradeoff was whether to delete `ingest_tpv()` entirely or preserve it as a delegating compatibility seam. I preserved it because the issue explicitly allows keeping a shim if it delegates fully, and that keeps the refactor safe even if non-repo callers still exist.

I also chose not to pull the raw normalization step into `gpsd_message_handler` during this issue. That could be reasonable later, but it would enlarge the scope into classifier ownership rather than just removing duplicate transport mutation logic.

One subtle point here is that the issue is about one authoritative mutation path, not necessarily one total normalization function across the whole GPS adapter stack. This PR satisfies the mutation-owner goal while staying small enough to review and validate independently.

## Out of scope / follow-ups
This PR does not change the run loop, reconnect policy, GPSD wire classification, or speed plausibility rules. It removes one duplicated TPV mutation seam so later GPS cleanup issues can build on a cleaner transport state boundary.
