### PR TITLE
Extract cache invalidation policy from SignalBufferStore

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.buffer_store import SignalBufferStore
+from vibesensor.infra.processing.models import (
+    MetricsComputationResult,
+    MetricsSnapshot,
+    ProcessorConfig,
+)
+
+
+def _config(**overrides: object) -> ProcessorConfig:
+    base = {
+        "sample_rate_hz": 200,
+        "waveform_seconds": 2,
+        "waveform_display_hz": 50,
+        "fft_n": 128,
+        "spectrum_min_hz": 0.0,
+        "spectrum_max_hz": 100.0,
+        "accel_scale_g_per_lsb": None,
+    }
+    base.update(overrides)
+    return ProcessorConfig(**base)
+
+
+def _seed_cached_payload(store: SignalBufferStore, client_id: str) -> None:
+    with store.locked_client_buffer(client_id, create=True) as buf:
+        assert buf is not None
+        buf.cached_spectrum_payload = {"freq": [1.0, 2.0]}
+        buf.cached_spectrum_payload_generation = 5
+
+
+def test_flush_client_buffer_invalidates_cached_payloads() -> None:
+    store = SignalBufferStore(_config())
+    client_id = "sensor-flush"
+
+    store.ingest(client_id, np.ones((16, 3), dtype=np.float32), sample_rate_hz=200)
+    _seed_cached_payload(store, client_id)
+
+    store.flush_client_buffer(client_id)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.cached_spectrum_payload is None
+        assert buf.cached_spectrum_payload_generation == -1
+
+
+def test_ingest_invalidates_cached_payloads() -> None:
+    store = SignalBufferStore(_config())
+    client_id = "sensor-ingest"
+
+    store.ingest(client_id, np.ones((16, 3), dtype=np.float32), sample_rate_hz=200)
+    _seed_cached_payload(store, client_id)
+
+    store.ingest(client_id, np.full((8, 3), 2.0, dtype=np.float32), sample_rate_hz=200)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.cached_spectrum_payload is None
+        assert buf.cached_spectrum_payload_generation == -1
+
+
+def test_store_metrics_result_invalidates_cached_payloads() -> None:
+    store = SignalBufferStore(_config())
+    client_id = "sensor-store"
+
+    store.ingest(client_id, np.ones((256, 3), dtype=np.float32), sample_rate_hz=200)
+    _seed_cached_payload(store, client_id)
+
+    plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(plan, MetricsSnapshot)
+
+    store.store_metrics_result(
+        MetricsComputationResult(
+            client_id=client_id,
+            sample_rate_hz=plan.sample_rate_hz,
+            ingest_generation=plan.ingest_generation,
+            metrics={"combined": {"vib_mag_rms": 1.0, "vib_mag_p2p": 2.0, "peaks": []}},
+            spectrum_by_axis={},
+            strength_metrics={},
+            has_fft_data=False,
+            duration_s=0.01,
+            buffer_epoch=plan.buffer_epoch,
+        )
+    )
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.cached_spectrum_payload is None
+        assert buf.cached_spectrum_payload_generation == -1

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -69,7 +69,7 @@ class SignalBufferStore:
             buf.latest_metrics = {}
             buf.latest_spectrum = {}
             buf.latest_strength_metrics = empty_vibration_strength_metrics()
-            buf.invalidate_caches()
+            self._invalidate_cached_payloads_unlocked(buf)
             buf.ingest_generation += 1
         LOGGER.info("Flushed signal buffer for client %s (%s)", client_id, reason)
 
@@ -143,7 +143,7 @@ class SignalBufferStore:
             else:
                 buf.samples_since_t0 = min(buf.samples_since_t0 + n, _MAX_SAMPLES_SINCE_T0)
             buf.ingest_generation += 1
-            buf.invalidate_caches()
+            self._invalidate_cached_payloads_unlocked(buf)
             ingested_samples = n
         with self.lock:
             self.stats.total_ingested_samples += ingested_samples
@@ -221,7 +221,7 @@ class SignalBufferStore:
                     buf.latest_spectrum = {}
                     buf.latest_strength_metrics = empty_vibration_strength_metrics()
                 buf.spectrum_generation += 1
-                buf.invalidate_caches()
+                self._invalidate_cached_payloads_unlocked(buf)
         with self.lock:
             self.stats.last_compute_duration_s = result.duration_s
             self.stats.total_compute_calls += 1
@@ -438,6 +438,9 @@ class SignalBufferStore:
         buf.capacity = new_capacity
         buf.write_idx = latest.shape[1] % new_capacity
         buf.count = min(latest.shape[1], new_capacity)
+
+    def _invalidate_cached_payloads_unlocked(self, buf: ClientBuffer) -> None:
+        buf.invalidate_caches()
 
     def _apply_sample_rate_override_unlocked(
         self,


### PR DESCRIPTION
## Summary
This PR resolves `#1456` by extracting cache invalidation in `SignalBufferStore` into one explicit seam instead of open-coding `buf.invalidate_caches()` across multiple unrelated mutation paths. Before this change, cache invalidation happened as an implicit side effect during buffer flush, ingest, and metrics-store operations. Each path mutated different state for different reasons, but each also carried its own direct cache invalidation call. That made cache lifecycle rules harder to see and increased the chance that future cache behavior changes would require duplicative edits across multiple hot-path methods.

The fix is intentionally small. I introduced a focused private helper, `_invalidate_cached_payloads_unlocked()`, and routed the existing flush, ingest, and metrics-store paths through it. That makes the cache lifecycle seam explicit without changing cache-hit logic, snapshot building, or any of the adjacent sample-rate and overflow behavior queued in later issues. I also added a new focused processing test module that pins invalidation behavior for all three paths.

## Problem being solved
The underlying problem here was hidden ownership, not incorrect results. `SignalBufferStore` already invalidated caches when its shared state changed, but that invalidation was embedded directly inside three different mutation methods that otherwise exist for different purposes:
- `flush_client_buffer()` resets per-client buffer state
- `ingest()` appends raw samples and advances generations
- `store_metrics_result()` commits compute results back into shared state

When cache invalidation is open-coded inside each of those methods, the store’s mutation logic and cache lifecycle rules become coupled by repetition instead of by an explicit seam. That increases change friction. If the cache invalidation contract changes later, the maintainer has to rediscover each call site and update them consistently. The issue asked for an intentionally small step that makes invalidation explicit before any larger processing-pipeline work, so the right solution was a seam extraction rather than a broader refactor.

## Chosen implementation approach
I kept the behavior the same and moved only the invalidation side effect behind one helper.

The new helper lives on `SignalBufferStore` as `_invalidate_cached_payloads_unlocked(buf)`. It is deliberately simple today: it delegates to `buf.invalidate_caches()`. The value of the change is not that it introduces new logic right away, but that it creates one explicit place where cache invalidation policy now lives. Flush, ingest, and metrics-store paths no longer need to know how cached payloads are invalidated; they simply route through the helper after making the state mutation that requires cache invalidation.

That is the right level of change for this issue. The repo evidence showed repeated invalidation side effects, not a need to redesign the cache mechanism itself. By keeping the seam local and private to `SignalBufferStore`, this PR makes future cache changes more maintainable without broadening scope into snapshot-builder behavior, cache-hit detection, or processing result formats.

## Main code changes by area
### `apps/server/vibesensor/infra/processing/buffer_store.py`
The production diff is intentionally concentrated in this file.

I added `_invalidate_cached_payloads_unlocked()` as the explicit cache invalidation seam for per-buffer mutations.

Then I replaced the three open-coded invalidation sites with calls to that helper:
- `flush_client_buffer()` now routes invalidation through the helper after clearing buffer state and cached metrics/spectra fields
- `ingest()` now routes invalidation through the helper after appending samples and advancing ingest generation
- `store_metrics_result()` now routes invalidation through the helper after committing metrics/spectrum results and advancing spectrum generation

This leaves the surrounding mutation behavior intact while making cache lifecycle ownership explicit.

### `apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py`
I added a focused test module rather than growing one of the larger existing processing regression files.

The new tests cover the exact three mutation paths called out by the issue:
- `test_flush_client_buffer_invalidates_cached_payloads()`
- `test_ingest_invalidates_cached_payloads()`
- `test_store_metrics_result_invalidates_cached_payloads()`

Each test seeds a non-empty cached spectrum payload on the client buffer, triggers one mutation path, and then asserts that the cached payload fields are cleared. That keeps the coverage behavioral and directly tied to the issue acceptance criteria.

## Schema, contract, config, and documentation changes
There are no user-facing API, schema, or config changes in this PR. The compute cache contract remains the same, and there are no documentation updates because the change is an internal processing seam cleanup with no operator-facing effect.

I also intentionally left `ClientBuffer.invalidate_caches()` unchanged. This issue is about extracting the buffer-store invalidation seam, not redesigning the underlying buffer cache object.

## Validation and tests performed
Local validation in this container remains limited by the current interpreter environment. The container only has Python 3.11 available, while current `main` now imports newer Python syntax from shared type modules before the full pytest suite can start. Because of that, I could not run the main-based processing pytest slice locally after branching from the latest merged `main`.

I did run targeted Ruff checks on the touched production file and the new focused test module:
- `ruff check apps/server/vibesensor/infra/processing/buffer_store.py apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py`

Those checks pass on the final branch.

The new test module is designed so CI can provide the authoritative behavioral validation for the main-based environment.

## Risks, tradeoffs, and edge cases considered
The main tradeoff was whether to introduce a richer policy object versus a small private helper. I chose the helper because the current issue is about extracting the seam, not inventing new invalidation modes. A policy object here would have added structure without additional behavior to justify it.

I also kept the helper private and local to `SignalBufferStore` because the issue evidence showed a store-level ownership problem. There was no sign that other processing modules needed to share this invalidation seam yet.

Finally, I avoided mixing in sample-rate override invalidation, overflow handling, or result commit redesign. Those are adjacent concerns with their own backlog issues. Keeping them out of this change makes the PR safer and easier to review.

## Out of scope / follow-ups
This PR does not change cache-hit detection, snapshot building, compute result semantics, or buffer resizing behavior. It makes cache invalidation explicit in `SignalBufferStore` so later processing cleanups can evolve buffer mutation and cache lifecycle behavior more independently.
