### PR TITLE
Separate overflow/drop policy from SignalBufferStore.ingest()

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.buffer_capacity import OverflowResult
+from vibesensor.infra.processing.buffer_store import SignalBufferStore
+from vibesensor.infra.processing.models import ProcessorConfig
+
+
+def _config(**overrides: object) -> ProcessorConfig:
+    base = {
+        "sample_rate_hz": 200,
+        "waveform_seconds": 2,
+        "waveform_display_hz": 50,
+        "fft_n": 128,
+        "spectrum_min_hz": 0.0,
+        "spectrum_max_hz": 100.0,
+        "accel_scale_g_per_lsb": None,
+    }
+    base.update(overrides)
+    return ProcessorConfig(**base)
+
+
+def test_apply_overflow_policy_keeps_full_chunk_when_it_fits(caplog) -> None:
+    store = SignalBufferStore(_config())
+    chunk = np.arange(12, dtype=np.float32).reshape(4, 3)
+
+    trimmed, overflow = store._apply_overflow_policy_unlocked(
+        "sensor-fit",
+        chunk,
+        capacity=4,
+    )
+
+    assert overflow == OverflowResult(keep_count=4, drop_count=0, start_offset=0)
+    np.testing.assert_array_equal(trimmed, chunk)
+    assert caplog.text == ""
+
+
+def test_apply_overflow_policy_trims_oldest_samples_and_warns(caplog) -> None:
+    store = SignalBufferStore(_config())
+    chunk = np.arange(18, dtype=np.float32).reshape(6, 3)
+
+    with caplog.at_level("WARNING", logger="vibesensor.infra.processing.buffer_store"):
+        trimmed, overflow = store._apply_overflow_policy_unlocked(
+            "sensor-overflow",
+            chunk,
+            capacity=4,
+        )
+
+    assert overflow == OverflowResult(keep_count=4, drop_count=2, start_offset=2)
+    np.testing.assert_array_equal(trimmed, chunk[-4:])
+    assert "exceeds buffer capacity 4" in caplog.text
+    assert "discarding 2 oldest samples" in caplog.text

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -9,6 +9,7 @@ from threading import RLock
 import numpy as np
 
 from vibesensor.infra.processing.buffer_capacity import (
+    OverflowResult,
     clamp_sample_rate,
     compute_resize_capacity,
     evaluate_overflow,
@@ -109,16 +110,11 @@ class SignalBufferStore:
             now_mono = clock()
             buf.last_ingest_mono_s = now_mono
 
-            overflow = evaluate_overflow(int(chunk.shape[0]), buf.capacity)
-            if overflow.drop_count:
-                LOGGER.warning(
-                    "Sample chunk for %s exceeds buffer capacity %d; discarding %d oldest samples "
-                    "from the incoming batch",
-                    client_id,
-                    buf.capacity,
-                    overflow.drop_count,
-                )
-                chunk = chunk[overflow.start_offset :]
+            chunk, overflow = self._apply_overflow_policy_unlocked(
+                client_id,
+                chunk,
+                capacity=buf.capacity,
+            )
             n = overflow.keep_count
             dropped_samples = overflow.drop_count
             capacity = buf.capacity
@@ -441,6 +437,25 @@ class SignalBufferStore:
 
     def _invalidate_cached_payloads_unlocked(self, buf: ClientBuffer) -> None:
         buf.invalidate_caches()
+
+    def _apply_overflow_policy_unlocked(
+        self,
+        client_id: str,
+        chunk: FloatArray,
+        *,
+        capacity: int,
+    ) -> tuple[FloatArray, OverflowResult]:
+        overflow = evaluate_overflow(int(chunk.shape[0]), capacity)
+        if overflow.drop_count:
+            LOGGER.warning(
+                "Sample chunk for %s exceeds buffer capacity %d; discarding %d oldest samples "
+                "from the incoming batch",
+                client_id,
+                capacity,
+                overflow.drop_count,
+            )
+            chunk = chunk[overflow.start_offset :]
+        return chunk, overflow
 
     def _apply_sample_rate_override_unlocked(
         self,


### PR DESCRIPTION
## Summary
This PR resolves `#1457` by separating overflow/drop policy application from the core ring-buffer write mechanics in `SignalBufferStore.ingest()`. Before this change, `ingest()` directly did three jobs in sequence inside one hot path: it evaluated whether a sample batch overflowed the client buffer, it applied the current drop-oldest policy including warning text and chunk trimming, and it then performed the actual ring-buffer writes and bookkeeping. The decision primitive was already extracted into `evaluate_overflow()`, but the policy application still lived inline inside `ingest()`.

The fix here is intentionally small. I introduced a focused helper, `_apply_overflow_policy_unlocked()`, which owns the warn-and-trim behavior for oversized chunks and returns both the trimmed chunk and the evaluated overflow result. `ingest()` now delegates through that seam before performing ring writes. This keeps the current drop-oldest semantics, warning text, and dropped-sample counts intact while reducing how much policy remains embedded in the central ingest path.

## Problem being solved
The issue was not that overflow handling was producing the wrong samples today. The problem was that overflow/drop policy was still mixed into the same method that owns sample scaling, input validation, sample-rate override application, ring-buffer writes, timestamp bookkeeping, generation updates, cache invalidation, and stats accounting. That makes a very central hot path do too much.

The repo already has a useful separation point in `evaluate_overflow()`, which answers how many samples to keep and drop for a given chunk size and capacity. But `ingest()` still applied that result inline, including warning generation and trimming behavior. That means a future change to overflow policy would still require editing the same method that owns low-level ring-buffer mechanics.

This issue asked for a small extraction, not a redesign. The right change was to make overflow/drop behavior explicit and swappable while leaving actual buffer writes and current semantics alone.

## Chosen implementation approach
I kept `evaluate_overflow()` as the policy decision primitive and extracted the policy application step into `SignalBufferStore._apply_overflow_policy_unlocked()`.

The new helper takes the client ID, incoming chunk, and effective buffer capacity. It computes the `OverflowResult`, emits the existing warning when samples must be dropped, trims the oldest incoming samples when necessary, and returns both the chunk to write and the overflow result used for later accounting.

With that helper in place, `ingest()` no longer decides overflow/drop policy inline. It now delegates to the helper and then continues with the write path using the already-prepared chunk. This keeps `ingest()` focused on orchestration, ring-buffer mutation, timestamp bookkeeping, generation updates, cache invalidation, and stats tracking.

I intentionally did not move the core `evaluate_overflow()` function or change buffer-capacity calculation. Those are already split and tested independently. The missing seam for this issue was the policy application step between the overflow decision and the buffer write.

## Main code changes by area
### `apps/server/vibesensor/infra/processing/buffer_store.py`
The production change stays local to `SignalBufferStore`.

I added `_apply_overflow_policy_unlocked()`, which now owns the warn-and-trim behavior for oversized ingest batches.

`ingest()` no longer open-codes the overflow policy. Instead, it delegates to the helper, receives the chunk that should be written plus the `OverflowResult`, and then proceeds with the same ring-buffer write and counter logic as before.

This preserves the current warning text:
- the warning still includes the client ID
- the warning still reports the effective capacity
- the warning still reports how many oldest samples from the incoming batch were discarded

It also preserves the same drop-oldest semantics by trimming `chunk[overflow.start_offset:]` when the helper reports an overflow.

### `apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py`
I added a focused test module for the extracted seam instead of expanding the broader processing regression files.

The new tests cover both sides of the overflow-policy helper:
- `test_apply_overflow_policy_keeps_full_chunk_when_it_fits()` verifies the non-overflow path returns the original chunk unchanged, returns the expected `OverflowResult`, and does not emit a warning
- `test_apply_overflow_policy_trims_oldest_samples_and_warns()` verifies the overflow path returns the trimmed latest samples, preserves the expected `OverflowResult`, and emits the same warning text that the end-to-end ingest path already relied on

This complements the existing end-to-end overflow ingest coverage that already checks stored sample windows after a real oversized ingest.

## Schema, contract, config, and documentation changes
There are no API, schema, config, or documentation changes in this PR. The change is entirely internal to the processing buffer store.

I also left sample-rate override behavior, capacity calculation, and cache invalidation alone. Those are separate concerns with their own seams and should stay isolated from this overflow-policy extraction.

## Validation and tests performed
Local validation in this container continues to be limited by the available interpreter. The container only has Python 3.11, while current `main` imports newer Python syntax from shared type modules before the pytest suite can start. Because of that, I could not run the main-based processing pytest slice locally from the latest merged `main`.

I did run targeted Ruff checks on the touched production file and the new focused test module:
- `ruff check apps/server/vibesensor/infra/processing/buffer_store.py apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py`

Those checks pass on the final branch.

The repo already had end-to-end coverage proving oversized ingests keep the latest sample window and report drop counts correctly. The new test module adds focused coverage for the extracted seam so CI can validate both the helper behavior and the unchanged end-to-end path on the authoritative main-based environment.

## Risks, tradeoffs, and edge cases considered
The main tradeoff was whether to introduce a richer policy object versus a small helper. I chose the helper because the current behavior is still one concrete policy: drop the oldest incoming samples when the batch exceeds capacity. There is not yet a second production overflow policy that would justify a more abstract strategy object.

I also kept the helper private to `SignalBufferStore` because the ownership problem was local to the ingest path. Pulling it into a wider shared module would have added indirection without a second consumer.

Finally, I avoided touching stats accounting, cache invalidation, or sample-rate override logic in the same PR. Those concerns are adjacent in `ingest()`, but this issue is specifically about separating overflow/drop policy from ring-buffer mechanics.

## Out of scope / follow-ups
This PR does not change how many samples are dropped, how warnings are worded, how capacities are calculated, or how ring-buffer writes work. It extracts the overflow/drop policy seam so the ingest hot path is easier to evolve without reopening buffer-write mechanics every time overflow behavior changes.
