### PR TITLE
Split UDP datagram parsing from processing dispatch

### DIFF
--- a/apps/server/tests/adapters/udp/test_udp_data_rx_seams.py
+++ b/apps/server/tests/adapters/udp/test_udp_data_rx_seams.py
@@ -28,7 +28,7 @@ def test_dispatch_data_message_logs_processing_error_without_parse_step(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     registry = Mock()
-    registry.update_from_data.side_effect = RuntimeError("boom")
+    registry.update_from_data.side_effect = ValueError("boom")
     processor = Mock()
     proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
     proto.connection_made(fake_transport)

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -111,12 +111,12 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
             client_id = extract_client_id_hex(data)
             LOGGER.warning("DATA version mismatch from %s (client=%s): %s", addr, client_id, exc)
             self.registry.note_parse_error(client_id)
-            return
+            return None
         except ProtocolError as exc:
             client_id = extract_client_id_hex(data)
             LOGGER.debug("DATA parse error from %s (client=%s): %s", addr, client_id, exc)
             self.registry.note_parse_error(client_id)
-            return
+            return None
 
     def _dispatch_data_message(self, msg: DataMessage, addr: tuple[str, int]) -> None:
         client_id = msg.client_id.hex()


### PR DESCRIPTION
## Summary
This PR resolves `#1458` by splitting UDP datagram parsing from runtime dispatch in `DataDatagramProtocol._process_datagram()`. Before this change, `_process_datagram()` performed both sides of the UDP ingest boundary in one method: it parsed the raw datagram and handled protocol-specific parse failures, then immediately shifted into registry updates, reset detection, processor ingestion, and ACK sending. That meant protocol handling and runtime-processing side effects still shared a single hot-path seam.

The change is intentionally small. `_process_datagram()` is now a thin coordinator over two explicit helpers: `_parse_data_message()` for protocol parsing and parse-error handling, and `_dispatch_data_message()` for registry/processor/ACK side effects once a typed `DataMessage` exists. The result is the same outward behavior, but with a clearer transport boundary that is easier to test and evolve independently.

## Problem being solved
The issue here was not missing functionality. The existing UDP receiver already parsed packets, noted parse errors, handled duplicate and reset-detected frames, ingested samples, and sent acknowledgments. The problem was that those concerns still lived in one method.

That combined seam increases change risk in two directions. First, protocol parsing changes have to be made in a method that also owns runtime side effects. Second, processing-pipeline changes have to pass through a method that still contains protocol-specific parse failure branches. When those responsibilities sit together, even small adjustments broaden the blast radius of the hot ingest entrypoint.

The issue asked for a deliberately narrow refactor: create distinct parse and dispatch seams without changing wire format or runtime semantics. That makes the UDP boundary easier to reason about while preserving the current behavior already covered by the existing tests.

## Chosen implementation approach
I split `_process_datagram()` into two focused helpers with one thin coordinator method left behind.

`_parse_data_message()` now owns raw datagram parsing plus protocol-specific failure handling. It calls `parse_data()`, catches `ProtocolVersionMismatch` and `ProtocolError`, logs at the same levels as before, notes the parse error in the registry, and returns `None` when the datagram cannot be parsed into a `DataMessage`.

`_dispatch_data_message()` now owns the runtime side effects that occur after parsing succeeds. It updates registry state, handles reset detection, flushes the processor buffer when required, ingests samples for non-duplicate frames, and sends the DATA_ACK when a transport is available.

`_process_datagram()` itself is now just the coordinator: parse the datagram, return early on parse failure, otherwise dispatch the typed message.

This keeps the behavior the same but creates the seam the issue was asking for: protocol parsing can now be exercised independently from downstream processing dispatch.

## Main code changes by area
### `apps/server/vibesensor/adapters/udp/udp_data_rx.py`
The production change is concentrated in the UDP data receiver.

I imported `DataMessage` so the new dispatch helper can work on a typed parsed message rather than a raw datagram.

Then I split the original method into:
- `_parse_data_message(data, addr) -> DataMessage | None`
- `_dispatch_data_message(msg, addr) -> None`
- a reduced `_process_datagram(data, addr)` that coordinates between them

The parse helper preserves the existing behavior for version mismatches and general protocol errors:
- version mismatches still log a warning
- protocol errors still log at debug level
- both still note registry parse errors and return early

The dispatch helper preserves the current runtime behavior for valid data messages:
- duplicates still skip ingest but still reach ACK logic
- reset-detected packets still flush the processor buffer before ingest
- non-duplicate frames still ingest with the latest registry sample rate and `t0_us`
- ACK sending remains tied to successful dispatch when a transport exists

### `apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`
I added a focused test module rather than pushing more cases into the existing broader UDP receiver tests.

The new tests cover the two new seams directly.

`test_parse_data_message_marks_registry_on_protocol_error()` verifies the parse helper handles protocol errors independently: it returns `None`, records a registry parse error, does not touch registry update flow, and does not send an ACK.

`test_dispatch_data_message_logs_processing_error_without_parse_step()` verifies the dispatch helper can be exercised independently with a typed `DataMessage`. It forces a runtime processing failure via `registry.update_from_data`, confirms that ingest is skipped, and checks that the logged warning still includes the client identifier.

These new seam tests complement the existing UDP receiver tests that already cover duplicate handling, reset detection, version mismatches, queue behavior, and end-to-end ACK behavior.

## Schema, contract, config, and documentation changes
There are no wire-format, schema, config, or documentation changes in this PR. The UDP protocol, ACK behavior, and runtime processing contract remain the same. This is a structural seam extraction only.

I also did not change duplicate handling, reset detection semantics, or how parse errors are recorded in the registry. Those behaviors are intentionally preserved.

## Validation and tests performed
Local validation in this container remains constrained by the available interpreter. The container only has Python 3.11, while current `main` now imports newer Python syntax from shared type modules before the pytest suite can start. Because of that, I could not run the main-based UDP pytest slice locally from the latest merged `main`.

I did run targeted Ruff checks on the touched production file and the new focused seam test module:
- `ruff check apps/server/vibesensor/adapters/udp/udp_data_rx.py apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`

Those checks pass on the final branch.

The repository already had broader UDP tests covering duplicate, reset, version mismatch, and queue behavior. The new seam-focused tests are intended to let CI validate the split directly in the authoritative main-based environment.

## Risks, tradeoffs, and edge cases considered
The main tradeoff was whether to introduce additional transport abstractions beyond the two helper methods. I deliberately kept the refactor at the method-seam level because the issue is about separating parse and dispatch stages, not redesigning the entire UDP ingest stack.

I also kept the dispatch error handling exactly where it already was, inside the runtime-side helper, so parse-only failures and dispatch failures remain distinct without changing the observed logging and error swallowing behavior.

Finally, I avoided touching protocol parsing helpers in `protocol.py` during this issue. Those ownership questions are related, but this issue specifically targets the receiver’s mixed parse/dispatch seam, not the lower-level protocol module.

## Out of scope / follow-ups
This PR does not change the UDP wire format, registry duplicate/reset logic, ACK semantics, or queue backpressure behavior. It separates the parse and dispatch stages inside the UDP data receiver so the transport boundary is easier to test and maintain without reopening the whole ingest pipeline.
