### PR TITLE
Extract UDP protocol header/version checks from parse helpers

### DIFF
--- a/apps/server/vibesensor/adapters/udp/protocol.py
+++ b/apps/server/vibesensor/adapters/udp/protocol.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import struct
 from dataclasses import dataclass
+from typing import cast
 
 import numpy as np
 
@@ -104,6 +105,20 @@ BYTES_PER_SAMPLE: int = ACCEL_AXES * _SAMPLE_DTYPE.itemsize
 """Wire size of one accelerometer sample in bytes (3 axes × 2 bytes for int16)."""
 
 
+def _validate_unpacked_header(
+    *,
+    label: str,
+    header_fields: tuple[object, ...],
+    expected_msg_type: int,
+) -> None:
+    validate_header(
+        label=label,
+        msg_type=cast(int, header_fields[0]),
+        expected_msg_type=expected_msg_type,
+        version=cast(int, header_fields[1]),
+    )
+
+
 @dataclass(slots=True)
 class HelloMessage:
     """Decoded HELLO message sent by an ESP32 sensor on connect."""
@@ -197,21 +212,21 @@ def parse_client_id(client_id_text: str) -> bytes:
 def parse_hello(data: bytes) -> HelloMessage:
     """Decode a raw HELLO message into a :class:`HelloMessage`."""
     validate_minimum_size(label="HELLO", data_length=len(data), minimum=HELLO_BASE.size)
+    header = HELLO_BASE.unpack_from(data, 0)
+    _validate_unpacked_header(
+        label="HELLO",
+        header_fields=header,
+        expected_msg_type=MSG_HELLO,
+    )
     (
-        msg_type,
-        version,
+        _msg_type,
+        _version,
         client_id,
         control_port,
         sample_rate_hz,
         frame_samples,
         name_len,
-    ) = HELLO_BASE.unpack_from(data, 0)
-    validate_header(
-        label="HELLO",
-        msg_type=msg_type,
-        expected_msg_type=MSG_HELLO,
-        version=version,
-    )
+    ) = header
     validate_hello_sample_rate(sample_rate_hz)
 
     if control_port == 0:
@@ -304,13 +319,13 @@ def pack_hello(
 def parse_data(data: bytes) -> DataMessage:
     """Decode a raw DATA message into a :class:`DataMessage`."""
     validate_minimum_size(label="DATA", data_length=len(data), minimum=DATA_HEADER_BYTES)
-    msg_type, version, client_id, seq, t0_us, sample_count = DATA_HEADER.unpack_from(data, 0)
-    validate_header(
+    header = DATA_HEADER.unpack_from(data, 0)
+    _validate_unpacked_header(
         label="DATA",
-        msg_type=msg_type,
+        header_fields=header,
         expected_msg_type=MSG_DATA,
-        version=version,
     )
+    _msg_type, _version, client_id, seq, t0_us, sample_count = header
     validate_data_frame(
         sample_count=sample_count,
         data_length=len(data),
@@ -340,13 +355,13 @@ def pack_data(client_id: bytes, seq: int, t0_us: int, samples: np.ndarray) -> by
 def parse_cmd(data: bytes) -> CmdMessage:
     """Decode a raw CMD message into a :class:`CmdMessage`."""
     validate_minimum_size(label="CMD", data_length=len(data), minimum=CMD_HEADER_BYTES)
-    msg_type, version, client_id, cmd_id, cmd_seq = CMD_HEADER.unpack_from(data, 0)
-    validate_header(
+    header = CMD_HEADER.unpack_from(data, 0)
+    _validate_unpacked_header(
         label="CMD",
-        msg_type=msg_type,
+        header_fields=header,
         expected_msg_type=MSG_CMD,
-        version=version,
     )
+    _msg_type, _version, client_id, cmd_id, cmd_seq = header
     if cmd_id not in (CMD_IDENTIFY, CMD_SYNC_CLOCK):
         LOGGER.warning(
             "parse_cmd: unrecognized cmd_id=%d; continuing for forward compatibility",
@@ -387,13 +402,13 @@ def parse_hello_ack(data: bytes) -> HelloAckMessage:
     validate_fixed_message_size(
         label="HELLO_ACK", data_length=len(data), expected_size=HELLO_ACK_BYTES
     )
-    msg_type, version, client_id = HELLO_ACK_STRUCT.unpack_from(data, 0)
-    validate_header(
+    header = HELLO_ACK_STRUCT.unpack_from(data, 0)
+    _validate_unpacked_header(
         label="HELLO_ACK",
-        msg_type=msg_type,
+        header_fields=header,
         expected_msg_type=MSG_HELLO_ACK,
-        version=version,
     )
+    _msg_type, _version, client_id = header
     return HelloAckMessage(client_id=client_id)
 
 
@@ -406,13 +421,13 @@ def pack_hello_ack(client_id: bytes) -> bytes:
 def parse_ack(data: bytes) -> AckMessage:
     """Decode a raw ACK message into an :class:`AckMessage`."""
     validate_fixed_message_size(label="ACK", data_length=len(data), expected_size=ACK_BYTES)
-    msg_type, version, client_id, cmd_seq, status = ACK_STRUCT.unpack_from(data, 0)
-    validate_header(
+    header = ACK_STRUCT.unpack_from(data, 0)
+    _validate_unpacked_header(
         label="ACK",
-        msg_type=msg_type,
+        header_fields=header,
         expected_msg_type=MSG_ACK,
-        version=version,
     )
+    _msg_type, _version, client_id, cmd_seq, status = header
     return AckMessage(client_id=client_id, cmd_seq=cmd_seq, status=status)
 
 
@@ -427,13 +442,13 @@ def parse_data_ack(data: bytes) -> DataAckMessage:
     validate_fixed_message_size(
         label="DATA_ACK", data_length=len(data), expected_size=DATA_ACK_BYTES
     )
-    msg_type, version, client_id, last_seq_received = DATA_ACK_STRUCT.unpack_from(data, 0)
-    validate_header(
+    header = DATA_ACK_STRUCT.unpack_from(data, 0)
+    _validate_unpacked_header(
         label="DATA_ACK",
-        msg_type=msg_type,
+        header_fields=header,
         expected_msg_type=MSG_DATA_ACK,
-        version=version,
     )
+    _msg_type, _version, client_id, last_seq_received = header
     return DataAckMessage(client_id=client_id, last_seq_received=last_seq_received)
 
 


### PR DESCRIPTION
## Summary

This pull request resolves #1459 by extracting the repeated UDP protocol header/version validation step out of the individual parse helpers in `apps/server/vibesensor/adapters/udp/protocol.py`. Before this change, every parser followed the same pattern: unpack the binary header, pull out `msg_type` and `version`, and then immediately call `validate_header(...)` inline. That worked, but it also meant the core protocol boundary for version and message-kind validation was duplicated across six parsing paths: `parse_hello`, `parse_data`, `parse_cmd`, `parse_hello_ack`, `parse_ack`, and `parse_data_ack`.

The implementation here keeps the change intentionally small. Instead of introducing a new protocol abstraction or changing the shape of any public API, it adds a single private helper, `_validate_unpacked_header()`, and routes each parser through it after its existing struct unpack step. The result is that header/version validation is now owned in one place, while each parse helper still owns its own message-specific size checks, payload extraction, and payload-level validation.

## Problem being solved

Issue #1459 called out an important but narrow maintainability problem in the UDP protocol layer: header and version validation are semantically special, but the code treated them as repeated parse boilerplate. That makes the parsers slightly noisier than they need to be, and it obscures the fact that version mismatches are deliberately surfaced differently from generic payload-shape errors. The downstream receiver code in `udp_data_rx.py` already relies on that distinction by catching `ProtocolVersionMismatch` separately from `ProtocolError`, so the protocol module benefits from making the validation seam clearer.

The practical risk is not that the current code is broken, but that each new message type or parser adjustment has to remember to reproduce the same validation scaffolding correctly. That is small change friction, but it is exactly the kind of friction that turns protocol code into a maintenance trap over time.

## Implementation approach

I kept the solution local to `apps/server/vibesensor/adapters/udp/protocol.py`.

The new helper takes three inputs:

- the protocol label (for example `"DATA"` or `"ACK"`),
- the unpacked header tuple returned by the relevant `struct.Struct`,
- the expected message type constant.

From that tuple it reads the already-unpacked `msg_type` and `version` fields and delegates to the existing `validate_header(...)` function in `protocol_validator.py`.

That means the helper is deliberately narrow:

- it does not change how bytes are unpacked,
- it does not change any wire-format constants,
- it does not absorb message-specific size checks,
- it does not replace payload validation such as `validate_data_frame(...)` or `validate_hello_sample_rate(...)`,
- and it does not change exception types or messages.

Each parser still performs its own current steps in the same order. The only difference is that the repeated inline `validate_header(...)` call is replaced with a call to the new helper.

## Main code changes by area

In `apps/server/vibesensor/adapters/udp/protocol.py`:

- Added `_validate_unpacked_header(...)` as a private helper near the top of the module, close to the shared binary protocol constants and helpers.
- Updated `parse_hello()` to unpack once into a local `header` tuple, validate through the helper, and then unpack the same tuple into the HELLO-specific fields.
- Updated `parse_data()` to use the helper before continuing into `validate_data_frame(...)` and payload decoding.
- Updated `parse_cmd()` to use the helper before continuing into command-specific handling.
- Updated `parse_hello_ack()`, `parse_ack()`, and `parse_data_ack()` in the same way.

No other files needed functional changes because this is a pure internal seam cleanup. Callers continue to import and use the same public parser functions, and those functions continue to raise the same exceptions under the same conditions.

## Contracts, schema, and compatibility

There are no schema or contract changes in this PR.

The UDP wire formats remain byte-for-byte identical because packing code and struct definitions are unchanged. The parse functions continue to interpret the same binary layouts, and they still route validation failures through the same existing exception types:

- invalid message type continues to surface as `ProtocolError`,
- protocol version mismatch continues to surface as `ProtocolVersionMismatch`,
- payload-size and message-specific validation continue to surface exactly where they did before.

That was an explicit goal of the change. This PR is about ownership and seam clarity, not behavior changes.

## Validation and tests

I validated what this container can reliably validate on current `main` and left the broader behavioral gate to CI, consistent with the recent issue work on this backlog.

Local validation performed:

- `ruff check apps/server/vibesensor/adapters/udp/protocol.py apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_protocol_version_mismatch.py apps/server/tests/adapters/udp/test_udp_data_rx.py apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`

That passed cleanly.

I also attempted the focused UDP pytest selection:

- `python3 -m pytest -q apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_protocol_version_mismatch.py apps/server/tests/adapters/udp/test_udp_data_rx.py apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`

In this container, that still fails during import because the repository’s current backend code now includes newer `type ... = ...` syntax that is not supported by the available local Python 3.11 runtime. That is the same environment limitation encountered in earlier issues in this run, so CI remains the authoritative validation gate for parser behavior on current `main`.

I did not add new tests in this PR because the existing UDP protocol coverage already exercises the behavior that matters for this seam:

- round-trip parsing across message types,
- invalid header handling,
- explicit protocol version mismatch behavior,
- receiver-side version-mismatch logging behavior for data packets.

Since the change intentionally preserves those behaviors, existing coverage is the right regression net.

## Risks, tradeoffs, and edge cases considered

The main design tradeoff was whether to create a more ambitious shared unpacking abstraction. I intentionally did not do that. A broader helper that tried to own both unpacking and validation for all message shapes would be more invasive, more typing-heavy, and less obviously worth it for this issue. The existing message-specific struct unpack steps are still easy to read; the repetitive part was the validation call immediately after them.

So the chosen approach centralizes only the header/version validation concern and leaves everything else local. That keeps the blast radius small and makes the issue easy to review.

I also kept the implementation in `protocol.py` rather than moving anything into `protocol_validator.py`. The validator module already owns the primitive validation function. This PR just makes `protocol.py` stop repeating the same wrapper logic around it.

## Out of scope / follow-ups

This PR does not attempt to reorganize protocol packing, alter message structs, or introduce a new public parsing API. It also does not touch receiver behavior in `udp_data_rx.py` or control-path parsing in other modules beyond preserving the behavior they already depend on.

If there is future appetite to reduce additional parser boilerplate, that should be handled as a separate issue so it can be evaluated on its own merits rather than bundled into this low-risk seam cleanup.
