### PR TITLE
Move report payload extraction helpers out of report_preparation.py

### DIFF
--- a/apps/server/tests/shared/boundaries/test_report_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload_projection.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.report_payload_projection import (
+    active_sensor_locations,
+    coerce_count,
+    peak_table_rows,
+    report_duration_s,
+    sensor_intensity_payload,
+    summary_metadata,
+    summary_warnings,
+)
+
+
+def test_summary_metadata_defaults_to_empty_mapping() -> None:
+    assert summary_metadata({}) == {}
+    assert summary_metadata({"metadata": "not-a-dict"}) == {}
+
+
+def test_active_sensor_locations_prefers_connected_locations() -> None:
+    payload = {
+        "sensor_locations_connected_throughout": [" front-left ", "", "rear-right"],
+        "sensor_locations": ["fallback-only"],
+    }
+
+    assert active_sensor_locations(payload) == ("front-left", "rear-right")
+
+
+def test_active_sensor_locations_falls_back_to_sensor_locations() -> None:
+    payload = {
+        "sensor_locations_connected_throughout": [],
+        "sensor_locations": [" front-left ", "", "rear-right"],
+    }
+
+    assert active_sensor_locations(payload) == ("front-left", "rear-right")
+
+
+def test_summary_warnings_prefers_explicit_override() -> None:
+    payload = {"warnings": [{"code": "PAYLOAD", "severity": "warn", "applies_to": "report"}]}
+    override = [{"code": "OVERRIDE", "severity": "warn", "applies_to": "report"}]
+
+    warnings = summary_warnings(payload, warnings=override)
+
+    assert [warning["code"] for warning in warnings] == ["OVERRIDE"]
+
+
+def test_report_duration_s_returns_none_for_invalid_values() -> None:
+    assert report_duration_s({}) is None
+    assert report_duration_s({"duration_s": "bad"}) is None
+    assert report_duration_s({"duration_s": "12.5"}) == 12.5
+
+
+def test_peak_table_rows_returns_only_mapping_rows() -> None:
+    payload = {
+        "plots": {
+            "peaks_table": [
+                {"rank": 1, "strength_db": 12.0},
+                "skip-me",
+                {"rank": 2, "strength_db": 8.5},
+            ]
+        }
+    }
+
+    rows = peak_table_rows(payload)
+
+    assert rows == (
+        {"rank": 1, "strength_db": 12.0},
+        {"rank": 2, "strength_db": 8.5},
+    )
+
+
+def test_sensor_intensity_payload_defaults_to_empty_tuple() -> None:
+    assert sensor_intensity_payload({}) == ()
+    assert sensor_intensity_payload({"sensor_intensity_by_location": "bad"}) == ()
+
+
+def test_sensor_intensity_payload_returns_tuple_copy() -> None:
+    payload = {"sensor_intensity_by_location": [{"location": "front-left"}]}
+
+    assert sensor_intensity_payload(payload) == ({"location": "front-left"},)
+
+
+def test_coerce_count_defaults_invalid_values_to_zero() -> None:
+    assert coerce_count(None) == 0
+    assert coerce_count("bad") == 0
+    assert coerce_count("17") == 17

--- a/apps/server/vibesensor/shared/boundaries/report_payload_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/report_payload_projection.py
@@ -1,0 +1,84 @@
+"""Project low-level report payload fields into normalized helper values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+from vibesensor.domain import coerce_float, coerce_int
+from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
+from vibesensor.shared.types.analysis_views import PeakTableRow
+from vibesensor.shared.types.history_analysis_contracts import (
+    SummaryWarningResponse as SummaryWarningPayload,
+)
+
+__all__ = [
+    "active_sensor_locations",
+    "coerce_count",
+    "peak_table_rows",
+    "report_duration_s",
+    "sensor_intensity_payload",
+    "summary_metadata",
+    "summary_warnings",
+]
+
+
+def summary_metadata(payload: Mapping[str, object]) -> Mapping[str, object]:
+    metadata = payload.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def active_sensor_locations(payload: Mapping[str, object]) -> tuple[str, ...]:
+    connected = payload.get("sensor_locations_connected_throughout")
+    locations = connected if isinstance(connected, list) else []
+    active = tuple(str(loc).strip() for loc in locations if str(loc).strip())
+    if active:
+        return active
+    fallback = payload.get("sensor_locations")
+    fallback_locations = fallback if isinstance(fallback, list) else []
+    return tuple(str(loc).strip() for loc in fallback_locations if str(loc).strip())
+
+
+def summary_warnings(
+    payload: Mapping[str, object],
+    *,
+    warnings: object | None = None,
+) -> tuple[SummaryWarningPayload, ...]:
+    raw_warnings = warnings if warnings is not None else payload.get("warnings")
+    return tuple(summary_warning_payloads(raw_warnings))
+
+
+def report_duration_s(payload: Mapping[str, object]) -> float | None:
+    duration_s_raw = payload.get("duration_s")
+    if duration_s_raw is None:
+        return None
+    try:
+        return coerce_float(duration_s_raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def peak_table_rows(payload: Mapping[str, object]) -> tuple[PeakTableRow, ...]:
+    plots = payload.get("plots")
+    if not isinstance(plots, Mapping):
+        return ()
+    raw_peaks = plots.get("peaks_table")
+    if not isinstance(raw_peaks, list):
+        return ()
+    return tuple(cast(PeakTableRow, row) for row in raw_peaks if isinstance(row, Mapping))
+
+
+def sensor_intensity_payload(payload: Mapping[str, object]) -> tuple[object, ...]:
+    raw_sensor_intensity = payload.get("sensor_intensity_by_location")
+    if not isinstance(raw_sensor_intensity, list):
+        return ()
+    return tuple(raw_sensor_intensity)
+
+
+def coerce_count(value: object) -> int:
+    if value is None:
+        return 0
+    try:
+        return coerce_int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -4,15 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import (
     LocationHotspotRow,
     LocationIntensitySummary,
     RecommendedAction,
     VibrationOrigin,
-    coerce_float,
-    coerce_int,
 )
 from vibesensor.report_i18n import normalize_lang
 from vibesensor.shared.boundaries.report_interpretation import (
@@ -24,8 +22,16 @@ from vibesensor.shared.boundaries.report_interpretation import (
     resolve_report_origin,
     tire_spec_text,
 )
+from vibesensor.shared.boundaries.report_payload_projection import (
+    active_sensor_locations,
+    coerce_count,
+    peak_table_rows,
+    report_duration_s,
+    sensor_intensity_payload,
+    summary_metadata,
+    summary_warnings,
+)
 from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
-from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.boundaries.test_run_reconstruction import test_run_from_summary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.time_utils import utc_now_iso
@@ -54,67 +60,6 @@ def _default_report_filename(payload: Mapping[str, object]) -> str:
     return f"{safe_filename(run_id)}_report.pdf"
 
 
-def _summary_metadata(payload: Mapping[str, object]) -> Mapping[str, object]:
-    metadata = payload.get("metadata")
-    return metadata if isinstance(metadata, dict) else {}
-
-
-def _active_sensor_locations(payload: Mapping[str, object]) -> tuple[str, ...]:
-    connected = payload.get("sensor_locations_connected_throughout")
-    locations = connected if isinstance(connected, list) else []
-    active = tuple(str(loc).strip() for loc in locations if str(loc).strip())
-    if active:
-        return active
-    fallback = payload.get("sensor_locations")
-    fallback_locations = fallback if isinstance(fallback, list) else []
-    return tuple(str(loc).strip() for loc in fallback_locations if str(loc).strip())
-
-
-def _summary_warnings(
-    payload: Mapping[str, object],
-    *,
-    warnings: object | None = None,
-) -> tuple[SummaryWarningPayload, ...]:
-    raw_warnings = warnings if warnings is not None else payload.get("warnings")
-    return tuple(summary_warning_payloads(raw_warnings))
-
-
-def _report_duration_s(payload: Mapping[str, object]) -> float | None:
-    duration_s_raw = payload.get("duration_s")
-    if duration_s_raw is None:
-        return None
-    try:
-        return coerce_float(duration_s_raw)
-    except (TypeError, ValueError):
-        return None
-
-
-def _peak_table_rows(payload: Mapping[str, object]) -> tuple[PeakTableRow, ...]:
-    plots = payload.get("plots")
-    if not isinstance(plots, Mapping):
-        return ()
-    raw_peaks = plots.get("peaks_table")
-    if not isinstance(raw_peaks, list):
-        return ()
-    return tuple(cast(PeakTableRow, row) for row in raw_peaks if isinstance(row, Mapping))
-
-
-def _sensor_intensity_payload(payload: Mapping[str, object]) -> tuple[object, ...]:
-    raw_sensor_intensity = payload.get("sensor_intensity_by_location")
-    if not isinstance(raw_sensor_intensity, list):
-        return ()
-    return tuple(raw_sensor_intensity)
-
-
-def _coerce_count(value: object) -> int:
-    if value is None:
-        return 0
-    try:
-        return coerce_int(value)
-    except (TypeError, ValueError):
-        return 0
-
-
 @dataclass(frozen=True, slots=True)
 class PreparedReportRendererPayload:
     """Minimal renderer-edge payload prepared from summary or persisted analysis."""
@@ -130,11 +75,11 @@ class PreparedReportRendererPayload:
 
 
 def _build_renderer_payload(payload: Mapping[str, object]) -> PreparedReportRendererPayload:
-    metadata = _summary_metadata(payload)
+    metadata = summary_metadata(payload)
     rows = payload.get("rows")
-    sample_count = _coerce_count(rows)
+    sample_count = coerce_count(rows)
     sensor_count_raw = payload.get("sensor_count_used")
-    sensor_count = _coerce_count(sensor_count_raw)
+    sensor_count = coerce_count(sensor_count_raw)
     report_date = payload.get("report_date")
     report_date_str = str(report_date).strip() or None if isinstance(report_date, str) else None
     return PreparedReportRendererPayload(
@@ -142,10 +87,10 @@ def _build_renderer_payload(payload: Mapping[str, object]) -> PreparedReportRend
         car_name=str(metadata.get("car_name") or "").strip() or None,
         car_type=str(metadata.get("car_type") or "").strip() or None,
         report_date=report_date_str,
-        duration_s=_report_duration_s(payload),
+        duration_s=report_duration_s(payload),
         sample_count=sample_count,
         sensor_count=sensor_count,
-        peak_table_rows=_peak_table_rows(payload),
+        peak_table_rows=peak_table_rows(payload),
     )
 
 
@@ -348,14 +293,14 @@ def _prepare_report_facts(
     test_run: TestRun,
     warnings: object | None = None,
 ) -> PreparedReportFacts:
-    metadata = _summary_metadata(payload)
-    sensor_locations_active = _active_sensor_locations(payload)
+    metadata = summary_metadata(payload)
+    sensor_locations_active = active_sensor_locations(payload)
     origin = resolve_report_origin(test_run)
     origin_location = normalize_origin_location(origin)
     config_snap = test_run.capture.setup.configuration_snapshot
     active_sensor_intensity = tuple(
         filter_active_sensor_intensity(
-            _sensor_intensity_payload(payload),
+            sensor_intensity_payload(payload),
             sensor_locations_active,
         )
     )
@@ -386,7 +331,7 @@ def _prepare_report_facts(
         primary_candidate_facts=primary_candidate_facts,
         recommended_actions=test_run.recommended_actions,
         suitability_checks=tuple(run_suitability_payload(test_run.suitability)),
-        warnings=_summary_warnings(payload, warnings=warnings),
+        warnings=summary_warnings(payload, warnings=warnings),
     )
 
 


### PR DESCRIPTION
## Summary

This pull request resolves #1460 by moving the low-level report payload extraction/coercion helpers out of `apps/server/vibesensor/use_cases/history/report_preparation.py` and into a dedicated boundary module, `apps/server/vibesensor/shared/boundaries/report_payload_projection.py`.

Before this change, `report_preparation.py` opened with a run of thin helper functions that were not really report orchestration. They were mostly schema-adjacent payload readers and coercers: reading metadata, selecting active sensor locations, normalizing summary warnings, coercing counts, pulling duration, extracting peak-table rows, and reading raw sensor-intensity payloads. Those helpers were small, but they mixed low-level payload projection responsibilities into the same seam that also reconstructs the domain test run, prepares semantic report facts, assembles mapping context, and returns the prepared handoff used by the PDF pipeline.

This PR makes a deliberately narrow cut. It extracts the pure payload readers/coercers into a focused boundary module and updates `report_preparation.py` to import and use them. It does **not** change report reconstruction, prepared-input validation, PDF mapping, or any report-facing behavior.

## Problem being solved

Issue #1460 called out that history-side report preparation still starts with several helpers that are really about reading raw summary/persisted payload fields, not about orchestrating report preparation itself. That creates two kinds of friction.

First, the top of `report_preparation.py` is noisier than it needs to be. To understand the real flow of report preparation, a reader has to page past helpers that are closer to boundary projection than to orchestration.

Second, schema-adjacent changes to fields like metadata, duration, counts, warnings, peak rows, or sensor-location fallbacks still require editing the same module that also owns higher-level history/report preparation logic. That is a small but real ownership blur, and it makes future cleanup of `report_preparation.py` harder than it should be.

The goal here is not a broad rewrite. It is just to pull one layer of low-level payload reads into a seam that matches their responsibility.

## Implementation approach

The extraction target is a new shared boundary module:

- `apps/server/vibesensor/shared/boundaries/report_payload_projection.py`

That module now owns the pure payload readers/coercers that can be shared safely without crossing layer boundaries:

- `summary_metadata(...)`
- `active_sensor_locations(...)`
- `summary_warnings(...)`
- `report_duration_s(...)`
- `peak_table_rows(...)`
- `sensor_intensity_payload(...)`
- `coerce_count(...)`

These helpers are all small, data-oriented projections from the summary/persisted payload shape into normalized values that history-side report preparation can consume.

I intentionally **did not** move two helpers:

- `_has_projectable_payload(...)`
- `_default_report_filename(...)`

`_has_projectable_payload(...)` is the local projectable-payload gate that controls whether report preparation reconstructs a domain test run at all, so it still belongs in `report_preparation.py`.

`_default_report_filename(...)` stays local because it depends on `use_cases.history.helpers.safe_filename`. Moving that function into `shared/boundaries` would invert the backend layer dependency direction (`shared -> use_cases`), which this repository explicitly does not allow.

So the resulting split is deliberate: pure payload projection moved, orchestration and use-case-local filename policy stayed put.

## Main code changes by area

### 1. New shared boundary module

`apps/server/vibesensor/shared/boundaries/report_payload_projection.py` now contains the extracted payload helpers. The functions preserve the current fallback behavior exactly:

- metadata still falls back to `{}`
- active sensor locations still prefer `sensor_locations_connected_throughout` and then fall back to `sensor_locations`
- warnings still prefer an explicit `warnings=` override before reading from the payload
- duration still returns `None` for missing or invalid values
- peak rows still only accept mapping-like entries from `plots["peaks_table"]`
- sensor-intensity payload still falls back to an empty tuple
- counts still coerce invalid or missing values to `0`

### 2. Smaller `report_preparation.py`

`apps/server/vibesensor/use_cases/history/report_preparation.py` now imports those helpers instead of defining them inline. The changes are intentionally mechanical:

- `_build_renderer_payload()` now uses `summary_metadata`, `coerce_count`, `report_duration_s`, and `peak_table_rows`
- `_prepare_report_facts()` now uses `summary_metadata`, `active_sensor_locations`, `sensor_intensity_payload`, and `summary_warnings`

Nothing about reconstruction, report-facts assembly, or mapping-context creation changed beyond those call sites.

### 3. Direct tests for the extracted seam

I added:

- `apps/server/tests/shared/boundaries/test_report_payload_projection.py`

These tests directly cover the extracted helper module’s fallback and normalization behavior for metadata, active sensor locations, warnings override preference, duration coercion, peak-row filtering, sensor-intensity payload extraction, and count coercion.

## Behavior, contracts, and compatibility

This PR does not change any persisted schema, HTTP contract, report-renderer payload contract, or PDF mapping contract.

The change is internal seam ownership only. `prepare_report_input(...)`, `prepare_persisted_report_input(...)`, and `validate_prepared_report_input(...)` keep the same inputs, outputs, and behavior. The extracted helpers are just now owned by a module that better matches their role.

That also means current fallback behavior is intentionally preserved. This issue is about making the report-preparation seam easier to reason about, not about tightening or reinterpreting payload semantics.

## Validation and tests

Local validation performed:

- `ruff check apps/server/vibesensor/shared/boundaries/report_payload_projection.py apps/server/vibesensor/use_cases/history/report_preparation.py apps/server/tests/shared/boundaries/test_report_payload_projection.py`
- `python3 -m py_compile apps/server/vibesensor/shared/boundaries/report_payload_projection.py apps/server/vibesensor/use_cases/history/report_preparation.py apps/server/tests/shared/boundaries/test_report_payload_projection.py`

Both passed.

I also attempted a direct pytest run for the new projection tests, but this container still only has Python 3.11 available. Importing the current repository package graph reaches newer `type ... = ...` syntax under `vibesensor.shared`, which fails before pytest can execute the tests. That is the same environment limitation encountered in the recent backlog work, so CI remains the authoritative behavioral validation gate for this branch.

## Risks and tradeoffs considered

The main tradeoff was whether to keep everything in `use_cases/history` versus moving the extraction helpers into `shared/boundaries`.

I chose `shared/boundaries` because these functions are clearly boundary projections rather than history orchestration, and the repository already has that pattern for adjacent seams like `report_interpretation.py`, `analysis_summary_projection.py`, and `test_plan_projection.py`.

The main risk would have been accidentally moving use-case-specific helpers that would create a layer-boundary inversion. That is why `_default_report_filename(...)` intentionally remains in `report_preparation.py`.

## Out of scope

This PR does not:

- change report reconstruction
- change prepared-input validation
- change PDF mapping
- change report interpretation logic
- change warning serialization semantics
- attempt a broader decomposition of `report_preparation.py`

That broader cleanup can continue in later issues, but this PR keeps #1460 small and reviewable by only moving the low-level payload projection layer.
