### PR TITLE
Separate renderer payload assembly from history-side report preparation

### DIFF
--- a/apps/server/tests/shared/boundaries/test_report_renderer_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_renderer_payload.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.report_renderer_payload import (
+    PreparedReportRendererPayload,
+    build_report_renderer_payload,
+)
+
+
+def test_build_report_renderer_payload_cleans_metadata_and_date() -> None:
+    payload = {
+        "run_id": "run-123",
+        "metadata": {"car_name": "  Track Car  ", "car_type": " coupe "},
+        "report_date": " 2026-03-25T10:00:00Z ",
+    }
+
+    renderer_payload = build_report_renderer_payload(payload)
+
+    assert renderer_payload == PreparedReportRendererPayload(
+        run_id="run-123",
+        car_name="Track Car",
+        car_type="coupe",
+        report_date="2026-03-25T10:00:00Z",
+        duration_s=None,
+        sample_count=0,
+        sensor_count=0,
+        peak_table_rows=(),
+    )
+
+
+def test_build_report_renderer_payload_coerces_counts_and_duration() -> None:
+    payload = {
+        "run_id": "counts",
+        "rows": "18",
+        "sensor_count_used": "3",
+        "duration_s": "12.5",
+    }
+
+    renderer_payload = build_report_renderer_payload(payload)
+
+    assert renderer_payload.sample_count == 18
+    assert renderer_payload.sensor_count == 3
+    assert renderer_payload.duration_s == 12.5
+
+
+def test_build_report_renderer_payload_defaults_invalid_values() -> None:
+    payload = {
+        "rows": "bad",
+        "sensor_count_used": "",
+        "duration_s": "bad",
+        "metadata": "bad",
+        "report_date": "",
+    }
+
+    renderer_payload = build_report_renderer_payload(payload)
+
+    assert renderer_payload.run_id == "unknown"
+    assert renderer_payload.car_name is None
+    assert renderer_payload.car_type is None
+    assert renderer_payload.report_date is None
+    assert renderer_payload.duration_s is None
+    assert renderer_payload.sample_count == 0
+    assert renderer_payload.sensor_count == 0
+    assert renderer_payload.peak_table_rows == ()
+
+
+def test_build_report_renderer_payload_keeps_peak_table_rows() -> None:
+    payload = {
+        "run_id": "peaks",
+        "plots": {
+            "peaks_table": [
+                {"rank": 1, "strength_db": 12.0},
+                {"rank": 2, "strength_db": 8.5},
+            ]
+        },
+    }
+
+    renderer_payload = build_report_renderer_payload(payload)
+
+    assert renderer_payload.peak_table_rows == (
+        {"rank": 1, "strength_db": 12.0},
+        {"rank": 2, "strength_db": 8.5},
+    )

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -8,8 +8,10 @@ from test_support.findings import make_finding_payload
 from vibesensor.adapters.pdf import mapping as pdf_mapping
 from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
 from vibesensor.shared.boundaries import report_interpretation as shared_report_interpretation
+from vibesensor.shared.boundaries import report_renderer_payload as shared_report_renderer_payload
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportInput,
+    PreparedReportRendererPayload,
     PrimaryReportFacts,
     ValidatedPreparedReportInput,
     prepare_report_input,
@@ -133,6 +135,13 @@ def test_map_summary_fails_before_pdf_mapping_for_missing_mapping_context(
 
 def test_report_preparation_imports_primary_report_facts_from_shared_boundaries() -> None:
     assert PrimaryReportFacts is shared_report_interpretation.PrimaryReportFacts
+
+
+def test_report_preparation_imports_renderer_payload_from_shared_boundaries() -> None:
+    assert (
+        PreparedReportRendererPayload
+        is shared_report_renderer_payload.PreparedReportRendererPayload
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -24,7 +24,7 @@ __all__ = [
 from dataclasses import dataclass, field
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
-from vibesensor.use_cases.history.report_preparation import PreparedReportRendererPayload
+from vibesensor.shared.boundaries.report_renderer_payload import PreparedReportRendererPayload
 
 # ---------------------------------------------------------------------------
 # Data model

--- a/apps/server/vibesensor/shared/boundaries/report_renderer_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/report_renderer_payload.py
@@ -1,0 +1,55 @@
+"""Build the prepared renderer-edge payload for report mapping."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.report_payload_projection import (
+    coerce_count,
+    peak_table_rows,
+    report_duration_s,
+    summary_metadata,
+)
+from vibesensor.shared.types.analysis_views import PeakTableRow
+
+__all__ = [
+    "PreparedReportRendererPayload",
+    "build_report_renderer_payload",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedReportRendererPayload:
+    """Minimal renderer-edge payload prepared from summary or persisted analysis."""
+
+    run_id: str
+    car_name: str | None
+    car_type: str | None
+    report_date: str | None
+    duration_s: float | None
+    sample_count: int
+    sensor_count: int
+    peak_table_rows: tuple[PeakTableRow, ...]
+
+
+def build_report_renderer_payload(
+    payload: Mapping[str, object],
+) -> PreparedReportRendererPayload:
+    metadata = summary_metadata(payload)
+    rows = payload.get("rows")
+    sample_count = coerce_count(rows)
+    sensor_count_raw = payload.get("sensor_count_used")
+    sensor_count = coerce_count(sensor_count_raw)
+    report_date = payload.get("report_date")
+    report_date_str = str(report_date).strip() or None if isinstance(report_date, str) else None
+    return PreparedReportRendererPayload(
+        run_id=str(payload.get("run_id") or "unknown") or "unknown",
+        car_name=str(metadata.get("car_name") or "").strip() or None,
+        car_type=str(metadata.get("car_type") or "").strip() or None,
+        report_date=report_date_str,
+        duration_s=report_duration_s(payload),
+        sample_count=sample_count,
+        sensor_count=sensor_count,
+        peak_table_rows=peak_table_rows(payload),
+    )

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -24,18 +24,18 @@ from vibesensor.shared.boundaries.report_interpretation import (
 )
 from vibesensor.shared.boundaries.report_payload_projection import (
     active_sensor_locations,
-    coerce_count,
-    peak_table_rows,
-    report_duration_s,
     sensor_intensity_payload,
     summary_metadata,
     summary_warnings,
+)
+from vibesensor.shared.boundaries.report_renderer_payload import (
+    PreparedReportRendererPayload,
+    build_report_renderer_payload,
 )
 from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
 from vibesensor.shared.boundaries.test_run_reconstruction import test_run_from_summary
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary,
     RunSuitabilityCheck,
@@ -58,40 +58,6 @@ def _has_projectable_payload(payload: Mapping[str, object]) -> bool:
 def _default_report_filename(payload: Mapping[str, object]) -> str:
     run_id = str(payload.get("run_id") or payload.get("file_name") or "report")
     return f"{safe_filename(run_id)}_report.pdf"
-
-
-@dataclass(frozen=True, slots=True)
-class PreparedReportRendererPayload:
-    """Minimal renderer-edge payload prepared from summary or persisted analysis."""
-
-    run_id: str
-    car_name: str | None
-    car_type: str | None
-    report_date: str | None
-    duration_s: float | None
-    sample_count: int
-    sensor_count: int
-    peak_table_rows: tuple[PeakTableRow, ...]
-
-
-def _build_renderer_payload(payload: Mapping[str, object]) -> PreparedReportRendererPayload:
-    metadata = summary_metadata(payload)
-    rows = payload.get("rows")
-    sample_count = coerce_count(rows)
-    sensor_count_raw = payload.get("sensor_count_used")
-    sensor_count = coerce_count(sensor_count_raw)
-    report_date = payload.get("report_date")
-    report_date_str = str(report_date).strip() or None if isinstance(report_date, str) else None
-    return PreparedReportRendererPayload(
-        run_id=str(payload.get("run_id") or "unknown") or "unknown",
-        car_name=str(metadata.get("car_name") or "").strip() or None,
-        car_type=str(metadata.get("car_type") or "").strip() or None,
-        report_date=report_date_str,
-        duration_s=report_duration_s(payload),
-        sample_count=sample_count,
-        sensor_count=sensor_count,
-        peak_table_rows=peak_table_rows(payload),
-    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -345,7 +311,7 @@ def _build_prepared_report_input(
 ) -> PreparedReportInput:
     domain_test_run = _reconstruct_report_test_run(payload)
     prepared_language = str(normalize_lang(language or payload.get("lang")))
-    renderer_payload = _build_renderer_payload(payload)
+    renderer_payload = build_report_renderer_payload(payload)
     report_facts = (
         _prepare_report_facts(payload, test_run=domain_test_run, warnings=warnings)
         if domain_test_run is not None


### PR DESCRIPTION
## Summary

This pull request resolves #1461 by separating renderer payload assembly from `apps/server/vibesensor/use_cases/history/report_preparation.py` and moving that concern into a dedicated shared boundary module: `apps/server/vibesensor/shared/boundaries/report_renderer_payload.py`.

After the previous cleanup in #1460, `report_preparation.py` was already smaller, but it still owned one clearly renderer-edge concern: the `PreparedReportRendererPayload` dataclass plus the `_build_renderer_payload()` helper that assembled it. That builder was still doing presentation-edge field assembly from report payload data: collecting run metadata, cleaning date strings, coercing sample/sensor counts, and carrying peak-table rows to the PDF-facing handoff.

This PR makes a small, focused move: it gives that renderer payload and its builder a single boundary owner, updates history-side report preparation to delegate to it, updates the PDF adapter to import the payload type from the new boundary seam, and adds focused tests for the builder itself.

## Problem being solved

Issue #1461 is about ownership, not behavior. The renderer payload is part of the history-to-PDF handoff, but before this change the assembly lived inline in `report_preparation.py`, alongside domain reconstruction, prepared report facts, mapping-context assembly, and prepared-input validation.

That was workable, but it blurred two different responsibilities:

- history-side orchestration of report preparation
- assembly of the renderer-edge payload consumed by the PDF layer

Because those lived in the same module, small changes to presentation-edge fields still broadened the history/report preparation seam. It also meant the PDF adapter’s data model (`adapters/pdf/report_data.py`) depended on a type that was still defined inside history-side orchestration rather than in a boundary module that more clearly represents the handoff.

The goal of this PR is to separate just that one seam without redesigning the payload or changing PDF mapping behavior.

## Implementation approach

I created a new shared boundary module:

- `apps/server/vibesensor/shared/boundaries/report_renderer_payload.py`

That module now owns:

- `PreparedReportRendererPayload`
- `build_report_renderer_payload(...)`

The new builder remains intentionally simple. It still uses the already-extracted low-level payload readers/coercers from `report_payload_projection.py` for:

- metadata cleanup
- count coercion
- duration coercion
- peak-table extraction

That means #1461 stays small and builds directly on the boundary cleanup from #1460 instead of duplicating projection logic.

I did **not** redesign the payload, expand its fields, or move other report-preparation seams at the same time. This PR is only about giving the renderer payload assembly a clearer owner.

## Main code changes by area

### 1. New shared boundary module for renderer payload assembly

`apps/server/vibesensor/shared/boundaries/report_renderer_payload.py` now contains the renderer payload contract and its assembly logic.

The module exports:

- `PreparedReportRendererPayload`
- `build_report_renderer_payload(...)`

The builder preserves the current behavior for:

- `run_id` fallback to `"unknown"`
- metadata trimming for `car_name` and `car_type`
- blank `report_date` normalization to `None`
- `duration_s` coercion via the existing projection helper
- `rows` / `sensor_count_used` coercion to integer counts with invalid values becoming `0`
- `peak_table_rows` extraction from `plots["peaks_table"]`

### 2. History-side report preparation now delegates

In `apps/server/vibesensor/use_cases/history/report_preparation.py`:

- Removed the inline `PreparedReportRendererPayload` dataclass definition
- Removed the inline `_build_renderer_payload()` helper
- Imported `PreparedReportRendererPayload` and `build_report_renderer_payload(...)` from the new shared boundary module
- Updated `_build_prepared_report_input()` to call `build_report_renderer_payload(payload)` instead of assembling the renderer payload locally

This keeps `report_preparation.py` focused more tightly on:

- projectable-payload gating
- filename policy
- report-facts preparation
- mapping-context assembly
- validated prepared-input handoff

### 3. PDF adapter now imports the renderer payload from the boundary seam

In `apps/server/vibesensor/adapters/pdf/report_data.py`:

- Updated the import of `PreparedReportRendererPayload` so the PDF adapter consumes the shared boundary type directly instead of importing it from history-side orchestration

That is the key architectural improvement here: the adapter now depends on the handoff boundary rather than on a use-case module that happens to define the type.

### 4. Focused tests for the new builder seam

I added:

- `apps/server/tests/shared/boundaries/test_report_renderer_payload.py`

These tests directly cover the extracted builder behavior for:

- metadata trimming and report-date cleanup
- sample/sensor count coercion
- duration coercion
- default behavior for missing/invalid values
- peak-table row preservation

I also extended:

- `apps/server/tests/use_cases/history/test_report_preparation_contract.py`

with a contract assertion proving that `PreparedReportRendererPayload` is now imported from the shared boundary seam, matching the existing pattern already used there for `PrimaryReportFacts`.

## Contracts and behavior

This PR does not change the renderer payload shape, the prepared report input contract, or the PDF mapping contract.

`PreparedReportInput.renderer_payload` still carries the same fields, and `adapters/pdf/report_data.py::build_report_from_renderer_payload(...)` continues to consume that payload exactly as before.

The behavior is intentionally preserved. The purpose of the change is to clarify ownership and narrow the report-preparation seam, not to reinterpret renderer payload values.

## Validation and tests

Local validation performed:

- `ruff check apps/server/vibesensor/shared/boundaries/report_renderer_payload.py apps/server/vibesensor/use_cases/history/report_preparation.py apps/server/vibesensor/adapters/pdf/report_data.py apps/server/tests/shared/boundaries/test_report_renderer_payload.py apps/server/tests/use_cases/history/test_report_preparation_contract.py`
- `python3 -m py_compile apps/server/vibesensor/shared/boundaries/report_renderer_payload.py apps/server/vibesensor/use_cases/history/report_preparation.py apps/server/vibesensor/adapters/pdf/report_data.py apps/server/tests/shared/boundaries/test_report_renderer_payload.py apps/server/tests/use_cases/history/test_report_preparation_contract.py`

Both passed.

As with the earlier issues in this run, direct pytest execution in this container remains limited by the available Python 3.11 runtime. Importing the current repository package graph reaches newer syntax elsewhere in the repo before pytest can execute the tests. Because of that, CI remains the authoritative behavioral validation gate for this PR.

## Risks and tradeoffs considered

The main tradeoff was whether to move only the builder or both the builder and its dataclass. I chose to move both together, because separating them would leave the new builder assembling a type still owned by `report_preparation.py`, which would weaken the ownership improvement this issue is targeting.

I also kept the destination in `shared/boundaries` rather than `adapters/pdf` or `shared/types`:

- not `adapters/pdf`, because the PDF layer should consume the handoff, not own it
- not `shared/types`, because the builder logic is part of the seam and should live with the type it assembles

That makes the boundary both explicit and usable from both history-side preparation and adapter-side consumption.

## Out of scope

This PR does not:

- redesign `PreparedReportRendererPayload`
- change PDF mapping behavior
- change report facts or mapping-context assembly
- change filename policy
- continue broader `report_preparation.py` decomposition beyond the renderer payload seam

Those can proceed in later issues, but #1461 stays intentionally small by moving only the renderer payload contract and builder into a single dedicated boundary owner.
