### PR TITLE
Move ReportMappingContext assembly into a PDF-owned factory

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_context.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_context.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import pytest
+from test_support.findings import make_finding_payload
 
 from vibesensor.adapters.pdf import report_context
 from vibesensor.adapters.pdf.mapping import (
     PrimaryCandidateContext,
     ReportMappingContext,
+    prepare_report_input,
 )
 from vibesensor.domain import Finding, LocationIntensitySummary, TestRun
 from vibesensor.domain.run_capture import RunCapture
@@ -184,6 +186,71 @@ class TestTypedMetadata:
         assert context.sample_count == 500
         assert context.sensor_model == "ESP32"
         assert context.firmware_version == "1.0.0"
+
+
+class TestPrepareReportMappingContext:
+    def test_maps_renderer_and_report_fact_fields(self) -> None:
+        finding = make_finding_payload(finding_id="F001")
+        prepared = prepare_report_input(
+            {
+                "run_id": "report-context-metadata",
+                "lang": "en",
+                "metadata": {"car_name": "Track Car", "car_type": "coupe"},
+                "report_date": "2026-03-25T10:00:00Z",
+                "record_length": "5m",
+                "start_time_utc": "2026-03-25T09:55:00Z",
+                "end_time_utc": "2026-03-25T10:00:00Z",
+                "sensor_locations": ["front-left", "rear-right"],
+                "sensor_locations_connected_throughout": ["rear-right"],
+                "sensor_intensity_by_location": [],
+                "most_likely_origin": {
+                    "location": "rear-right",
+                    "suspected_source": "wheel/tire",
+                },
+                "run_suitability": [],
+                "findings": [finding],
+                "top_causes": [finding],
+            }
+        )
+        assert prepared.report_facts is not None
+
+        context = report_context.prepare_report_mapping_context(prepared)
+
+        assert context.car_name == "Track Car"
+        assert context.car_type == "coupe"
+        assert context.date_str == "2026-03-25 10:00:00 UTC"
+        assert context.origin is prepared.report_facts.origin
+        assert context.origin_location == prepared.report_facts.origin_location
+        assert context.sensor_locations_active == ["rear-right"]
+
+    def test_falls_back_to_current_utc_time_when_report_date_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(report_context, "utc_now_iso", lambda: "2026-04-02T03:04:05Z")
+        finding = make_finding_payload(finding_id="F001")
+        prepared = prepare_report_input(
+            {
+                "run_id": "report-context-fallback-date",
+                "lang": "en",
+                "metadata": {},
+                "report_date": "",
+                "record_length": "",
+                "start_time_utc": "",
+                "end_time_utc": "",
+                "sensor_locations": [],
+                "sensor_locations_connected_throughout": [],
+                "sensor_intensity_by_location": [],
+                "most_likely_origin": {},
+                "run_suitability": [],
+                "findings": [finding],
+                "top_causes": [finding],
+            }
+        )
+
+        context = report_context.prepare_report_mapping_context(prepared)
+
+        assert context.date_str == "2026-04-02 03:04:05 UTC"
 
 
 def test_report_context_module_no_longer_reexports_pdf_helper_facade() -> None:

--- a/apps/server/tests/adapters/pdf/test_template_builder.py
+++ b/apps/server/tests/adapters/pdf/test_template_builder.py
@@ -26,7 +26,7 @@ class _StubTestRun:
 
 
 def _make_context(**overrides: object):  # type: ignore[no-untyped-def]
-    from vibesensor.use_cases.history.report_preparation import ReportMappingContext
+    from vibesensor.adapters.pdf.report_context import ReportMappingContext
 
     defaults = {
         "car_name": "TestCar",

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -6,7 +6,10 @@ import pytest
 from test_support.findings import make_finding_payload
 
 from vibesensor.adapters.pdf import mapping as pdf_mapping
-from vibesensor.adapters.pdf.report_context import prepare_report_mapping_context
+from vibesensor.adapters.pdf.report_context import (
+    ReportMappingContext,
+    prepare_report_mapping_context,
+)
 from vibesensor.shared.boundaries import report_interpretation as shared_report_interpretation
 from vibesensor.shared.boundaries import report_renderer_payload as shared_report_renderer_payload
 from vibesensor.use_cases.history.report_preparation import (
@@ -65,13 +68,6 @@ def test_validate_prepared_report_input_rejects_missing_report_facts() -> None:
         validate_prepared_report_input(prepared)
 
 
-def test_validate_prepared_report_input_rejects_missing_mapping_context() -> None:
-    prepared = replace(_prepared_report_input(), mapping_context=None)
-
-    with pytest.raises(ValueError, match="mapping_context"):
-        validate_prepared_report_input(prepared)
-
-
 def test_validate_prepared_report_input_is_idempotent() -> None:
     prepared = _prepared_report_input()
     validated = validate_prepared_report_input(prepared)
@@ -87,15 +83,29 @@ def test_validate_prepared_report_input_returns_mapping_ready_handoff() -> None:
     assert isinstance(validated, ValidatedPreparedReportInput)
     assert validated.domain_test_run is not None
     assert validated.report_facts is not None
-    assert prepared.mapping_context is not None
-    assert validated.mapping_context is prepared.mapping_context
+    assert not hasattr(prepared, "mapping_context")
+    assert not hasattr(validated, "mapping_context")
 
 
-def test_prepare_report_mapping_context_returns_precomputed_context() -> None:
+def test_prepare_report_mapping_context_builds_adapter_owned_context() -> None:
     prepared = _prepared_report_input()
+    context = prepare_report_mapping_context(prepared)
 
-    assert prepared.mapping_context is not None
-    assert prepare_report_mapping_context(prepared) is prepared.mapping_context
+    assert isinstance(context, ReportMappingContext)
+    assert context.domain_aggregate is prepared.domain_test_run
+    assert context.origin is prepared.report_facts.origin
+    assert context.origin_location == prepared.report_facts.origin_location
+    assert context.sensor_locations_active == list(prepared.report_facts.sensor_locations_active)
+    assert context.car_name == prepared.renderer_payload.car_name
+    assert context.car_type == prepared.renderer_payload.car_type
+
+
+def test_prepare_report_mapping_context_accepts_validated_input() -> None:
+    validated = validate_prepared_report_input(_prepared_report_input())
+    context = prepare_report_mapping_context(validated)
+
+    assert context.domain_aggregate is validated.domain_test_run
+    assert context.origin is validated.report_facts.origin
 
 
 def test_prepare_report_mapping_context_rejects_invalid_input() -> None:
@@ -120,7 +130,7 @@ def test_prepare_report_input_keeps_non_projectable_payload_unprepared() -> None
 
     assert prepared.domain_test_run is None
     assert prepared.report_facts is None
-    assert prepared.mapping_context is None
+    assert not hasattr(prepared, "mapping_context")
 
 
 def test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input(
@@ -137,20 +147,6 @@ def test_map_summary_fails_before_pdf_mapping_for_invalid_prepared_input(
         pdf_mapping.map_summary(prepared)
 
 
-def test_map_summary_fails_before_pdf_mapping_for_missing_mapping_context(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    prepared = replace(_prepared_report_input(), mapping_context=None)
-
-    def _explode(*_args: object, **_kwargs: object) -> object:
-        raise AssertionError("map_summary should validate the prepared handoff before mapping")
-
-    monkeypatch.setattr(pdf_mapping, "_build_report_template_data", _explode)
-
-    with pytest.raises(ValueError, match="mapping_context"):
-        pdf_mapping.map_summary(prepared)
-
-
 def test_report_preparation_imports_primary_report_facts_from_shared_boundaries() -> None:
     assert PrimaryReportFacts is shared_report_interpretation.PrimaryReportFacts
 
@@ -160,95 +156,3 @@ def test_report_preparation_imports_renderer_payload_from_shared_boundaries() ->
         PreparedReportRendererPayload
         is shared_report_renderer_payload.PreparedReportRendererPayload
     )
-
-
-# ---------------------------------------------------------------------------
-# Cross-object consistency validation
-# ---------------------------------------------------------------------------
-
-
-def test_validate_rejects_mismatched_domain_aggregate() -> None:
-    """mapping_context.domain_aggregate must be the same TestRun as domain_test_run."""
-    prepared = _prepared_report_input()
-    assert prepared.mapping_context is not None
-    # Build a second, distinct TestRun from the same payload
-    second_run = prepare_report_input(
-        {
-            "run_id": "other-run",
-            "findings": [make_finding_payload(finding_id="F002")],
-            "top_causes": [make_finding_payload(finding_id="F002")],
-            "lang": "en",
-            "metadata": {},
-            "report_date": "",
-            "record_length": "",
-            "start_time_utc": "",
-            "end_time_utc": "",
-            "sensor_locations": [],
-            "sensor_locations_connected_throughout": [],
-            "most_likely_origin": {},
-            "run_suitability": [],
-        }
-    )
-    assert second_run.domain_test_run is not None
-    # Replace mapping_context with one pointing at a different domain_aggregate
-    mismatched_context = replace(
-        prepared.mapping_context, domain_aggregate=second_run.domain_test_run
-    )
-    bad = replace(prepared, mapping_context=mismatched_context)
-
-    with pytest.raises(ValueError, match="domain_aggregate"):
-        validate_prepared_report_input(bad)
-
-
-def test_validate_rejects_mismatched_origin() -> None:
-    """mapping_context.origin must match report_facts.origin."""
-    from vibesensor.domain import VibrationOrigin, VibrationSource
-
-    prepared = _prepared_report_input()
-    assert prepared.mapping_context is not None
-    different_origin = VibrationOrigin(
-        suspected_source=VibrationSource.ENGINE,
-        speed_band="60-80",
-        dominance_ratio=0.9,
-    )
-    mismatched_context = replace(prepared.mapping_context, origin=different_origin)
-    bad = replace(prepared, mapping_context=mismatched_context)
-
-    with pytest.raises(ValueError, match="origin"):
-        validate_prepared_report_input(bad)
-
-
-def test_validate_rejects_mismatched_sensor_locations() -> None:
-    """mapping_context.sensor_locations_active must match report_facts."""
-    prepared = _prepared_report_input()
-    assert prepared.mapping_context is not None
-    mismatched_context = replace(
-        prepared.mapping_context,
-        sensor_locations_active=["front_left", "rear_right"],
-    )
-    bad = replace(prepared, mapping_context=mismatched_context)
-
-    with pytest.raises(ValueError, match="sensor_locations_active"):
-        validate_prepared_report_input(bad)
-
-
-def test_validate_rejects_mismatched_renderer_car_name() -> None:
-    """mapping_context.car_name must match renderer_payload.car_name."""
-    prepared = _prepared_report_input()
-    assert prepared.mapping_context is not None
-    mismatched_context = replace(prepared.mapping_context, car_name="Different Car")
-    bad = replace(prepared, mapping_context=mismatched_context)
-
-    with pytest.raises(ValueError, match="car_name"):
-        validate_prepared_report_input(bad)
-
-
-def test_validate_rejects_mismatched_renderer_car_type() -> None:
-    """mapping_context.car_type must match renderer_payload.car_type."""
-    prepared = _prepared_report_input()
-    assert prepared.mapping_context is not None
-    mismatched_context = replace(prepared.mapping_context, car_type="SUV")
-    bad = replace(prepared, mapping_context=mismatched_context)
-
-    with pytest.raises(ValueError, match="car_type"):
-        validate_prepared_report_input(bad)

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -1,9 +1,9 @@
 """report_mapping – thin mapper from prepared report inputs to template data.
 
-Context preparation now happens on the history side, while this module keeps
-focused PDF mapping logic plus the final renderer-facing orchestration. It
-receives an explicit prepared report input and maps it to
-:class:`ReportTemplateData` for the PDF renderer.
+Context preparation now happens on the PDF side from the validated prepared
+report-input seam, while this module keeps focused PDF mapping logic plus the
+final renderer-facing orchestration. It receives an explicit prepared report
+input and maps it to :class:`ReportTemplateData` for the PDF renderer.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ from vibesensor.adapters.pdf.presentation import order_label_human
 from vibesensor.adapters.pdf.report_context import (
     ReportMappingContext,
     observed_signature,
+    prepare_report_mapping_context,
 )
 from vibesensor.adapters.pdf.report_data import (
     FindingPresentation,
@@ -172,6 +173,7 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
     report facts already guaranteed.
     """
     validated = validate_prepared_report_input(prepared)
+    context = prepare_report_mapping_context(validated)
     lang = str(normalize_lang(validated.language))
     report = build_report_from_renderer_payload(
         validated.renderer_payload,
@@ -183,6 +185,7 @@ def map_summary(prepared: PreparedReportInput) -> ReportTemplateData:
 
     return _build_report_template_data(
         validated,
+        context=context,
         report=report,
         lang=lang,
         tr=tr,
@@ -207,6 +210,7 @@ def _finding_to_presentation(f: Finding) -> FindingPresentation:
 def _build_report_template_data(
     prepared: ValidatedPreparedReportInput,
     *,
+    context: ReportMappingContext,
     report: Report,
     lang: str,
     tr: Callable[..., str],
@@ -214,7 +218,6 @@ def _build_report_template_data(
     report_facts: PreparedReportFacts,
 ) -> ReportTemplateData:
     """Resolve report sections, then delegate field assignment to the builder."""
-    context = prepared.mapping_context
     raw_sensor_intensity = list(report_facts.active_sensor_intensity)
     primary = resolve_primary_report_candidate(
         context=context,

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -1,25 +1,94 @@
-"""PDF-side bridge helpers for the precomputed report mapping context."""
+"""PDF-side factory and bridge helpers for report mapping context."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.report_data import PatternEvidence
+from vibesensor.shared.json_utils import as_float_or_none as _as_float
+from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportInput,
-    ReportMappingContext,
     ValidatedPreparedReportInput,
     validate_prepared_report_input,
 )
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf._candidate_resolver import PrimaryCandidateContext
+    from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, VibrationOrigin
 
 __all__ = [
     "ReportMappingContext",
     "observed_signature",
     "prepare_report_mapping_context",
 ]
+
+
+@dataclass(frozen=True)
+class ReportMappingContext:
+    """Normalized structural context assembled on the PDF side for report mapping."""
+
+    car_name: str | None
+    car_type: str | None
+    date_str: str
+    origin: VibrationOrigin | None
+    origin_location: str
+    sensor_locations_active: list[str]
+    duration_text: str | None
+    start_time_utc: str | None
+    end_time_utc: str | None
+    sample_rate_hz: str | None
+    tire_spec_text: str | None
+    sample_count: int
+    sensor_model: str | None
+    firmware_version: str | None
+    domain_aggregate: TestRun
+
+    def top_report_candidate(self) -> Finding | None:
+        """Return the primary report candidate (first effective top cause or finding)."""
+        effective = self.domain_aggregate.effective_top_causes()
+        if effective:
+            return effective[0]
+        non_ref = self.domain_aggregate.non_reference_findings
+        if non_ref:
+            return non_ref[0]
+        all_findings = self.domain_aggregate.findings
+        return all_findings[0] if all_findings else None
+
+    def has_significant_location_intensity(
+        self,
+        sensor_intensity: list[LocationIntensitySummary],
+    ) -> bool:
+        """Whether any sensor location shows significant above-noise intensity."""
+        for row in sensor_intensity:
+            p95 = _as_float(row.p95_intensity_db)
+            if p95 is not None and p95 > 0:
+                return True
+        return False
+
+
+def _build_report_mapping_context(validated: ValidatedPreparedReportInput) -> ReportMappingContext:
+    report_facts = validated.report_facts
+    report_date = validated.renderer_payload.report_date or utc_now_iso()
+    date_str = str(report_date)[:19].replace("T", " ") + " UTC"
+    return ReportMappingContext(
+        car_name=validated.renderer_payload.car_name,
+        car_type=validated.renderer_payload.car_type,
+        date_str=date_str,
+        origin=report_facts.origin,
+        origin_location=report_facts.origin_location,
+        sensor_locations_active=list(report_facts.sensor_locations_active),
+        duration_text=report_facts.duration_text,
+        start_time_utc=report_facts.start_time_utc,
+        end_time_utc=report_facts.end_time_utc,
+        sample_rate_hz=report_facts.sample_rate_hz,
+        tire_spec_text=report_facts.tire_spec_text,
+        sample_count=report_facts.sample_count,
+        sensor_model=report_facts.sensor_model,
+        firmware_version=report_facts.firmware_version,
+        domain_aggregate=validated.domain_test_run,
+    )
 
 
 def observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
@@ -39,6 +108,6 @@ def observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
 def prepare_report_mapping_context(
     prepared: PreparedReportInput | ValidatedPreparedReportInput,
 ) -> ReportMappingContext:
-    """Return the precomputed report mapping context from the validated handoff."""
+    """Build the adapter-owned report mapping context from the validated handoff."""
     validated = validate_prepared_report_input(prepared)
-    return validated.mapping_context
+    return _build_report_mapping_context(validated)

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -37,8 +37,6 @@ from vibesensor.shared.boundaries.report_renderer_payload import (
     build_report_renderer_payload,
 )
 from vibesensor.shared.boundaries.test_run_reconstruction import test_run_from_summary
-from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary,
     RunSuitabilityCheck,
@@ -51,7 +49,7 @@ from vibesensor.use_cases.history.helpers import safe_filename
 from vibesensor.use_cases.history.report_cache import ReportPdfCacheKey
 
 if TYPE_CHECKING:
-    from vibesensor.domain import Finding, TestRun
+    from vibesensor.domain import TestRun
 
 
 def _default_report_filename(payload: Mapping[str, object]) -> str:
@@ -82,49 +80,6 @@ class PreparedReportFacts:
     warnings: tuple[SummaryWarningPayload, ...]
 
 
-@dataclass(frozen=True)
-class ReportMappingContext:
-    """Normalized structural context prepared on the history side for PDF mapping."""
-
-    car_name: str | None
-    car_type: str | None
-    date_str: str
-    origin: VibrationOrigin | None
-    origin_location: str
-    sensor_locations_active: list[str]
-    duration_text: str | None
-    start_time_utc: str | None
-    end_time_utc: str | None
-    sample_rate_hz: str | None
-    tire_spec_text: str | None
-    sample_count: int
-    sensor_model: str | None
-    firmware_version: str | None
-    domain_aggregate: TestRun
-
-    def top_report_candidate(self) -> Finding | None:
-        """Return the primary report candidate (first effective top cause or finding)."""
-        effective = self.domain_aggregate.effective_top_causes()
-        if effective:
-            return effective[0]
-        non_ref = self.domain_aggregate.non_reference_findings
-        if non_ref:
-            return non_ref[0]
-        all_findings = self.domain_aggregate.findings
-        return all_findings[0] if all_findings else None
-
-    def has_significant_location_intensity(
-        self,
-        sensor_intensity: list[LocationIntensitySummary],
-    ) -> bool:
-        """Whether any sensor location shows significant above-noise intensity."""
-        for row in sensor_intensity:
-            p95 = _as_float(row.p95_intensity_db)
-            if p95 is not None and p95 > 0:
-                return True
-        return False
-
-
 @dataclass(frozen=True, slots=True)
 class PreparedReportInput:
     """Resolved report input ready for PDF mapping and rendering.
@@ -136,11 +91,12 @@ class PreparedReportInput:
       needs so it does not have to call back into history-layer interpretation.
     - ``renderer_payload`` contains only the minimal final-edge payload that the
       PDF mapper still needs after domain/report preparation is complete.
+    - ``ReportMappingContext`` is adapter-owned and derived later inside
+      ``vibesensor.adapters.pdf.report_context`` from this validated handoff.
     - ``language`` is canonicalized once so the renderer consumes one
       consistent locale choice.
     - ``domain_test_run`` and ``report_facts`` may still be ``None`` for
-      non-projectable inputs; ``mapping_context`` is likewise absent until the
-      report handoff is projectable and validated for PDF mapping.
+      non-projectable inputs.
     """
 
     renderer_payload: PreparedReportRendererPayload
@@ -149,7 +105,6 @@ class PreparedReportInput:
     domain_test_run: TestRun | None
     cache_key: ReportPdfCacheKey | None = None
     report_facts: PreparedReportFacts | None = None
-    mapping_context: ReportMappingContext | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,7 +112,7 @@ class ValidatedPreparedReportInput:
     """Prepared report handoff validated for PDF mapping.
 
     This mapping-ready shape guarantees the domain aggregate and prepared report
-    facts are both present before adapter-side mapping begins.
+    facts are both present before adapter-side context assembly and mapping begin.
     """
 
     renderer_payload: PreparedReportRendererPayload
@@ -165,35 +120,7 @@ class ValidatedPreparedReportInput:
     filename: str
     domain_test_run: TestRun
     report_facts: PreparedReportFacts
-    mapping_context: ReportMappingContext
     cache_key: ReportPdfCacheKey | None = None
-
-
-def _build_report_mapping_context(
-    *,
-    renderer_payload: PreparedReportRendererPayload,
-    report_facts: PreparedReportFacts,
-    test_run: TestRun,
-) -> ReportMappingContext:
-    report_date = renderer_payload.report_date or utc_now_iso()
-    date_str = str(report_date)[:19].replace("T", " ") + " UTC"
-    return ReportMappingContext(
-        car_name=renderer_payload.car_name,
-        car_type=renderer_payload.car_type,
-        date_str=date_str,
-        origin=report_facts.origin,
-        origin_location=report_facts.origin_location,
-        sensor_locations_active=list(report_facts.sensor_locations_active),
-        duration_text=report_facts.duration_text,
-        start_time_utc=report_facts.start_time_utc,
-        end_time_utc=report_facts.end_time_utc,
-        sample_rate_hz=report_facts.sample_rate_hz,
-        tire_spec_text=report_facts.tire_spec_text,
-        sample_count=report_facts.sample_count,
-        sensor_model=report_facts.sensor_model,
-        firmware_version=report_facts.firmware_version,
-        domain_aggregate=test_run,
-    )
 
 
 def validate_prepared_report_input(
@@ -211,29 +138,6 @@ def validate_prepared_report_input(
         raise ValueError("PreparedReportInput must include a domain_test_run for report mapping")
     if prepared.report_facts is None:
         raise ValueError("PreparedReportInput must include report_facts for report mapping")
-    if prepared.mapping_context is None:
-        raise ValueError("PreparedReportInput must include mapping_context for report mapping")
-
-    # Cross-object consistency: mapping_context must reference the same TestRun
-    if prepared.mapping_context.domain_aggregate is not prepared.domain_test_run:
-        raise ValueError(
-            "mapping_context.domain_aggregate must be the same TestRun as domain_test_run"
-        )
-    # Cross-object consistency: origin must agree between mapping_context and report_facts
-    if prepared.mapping_context.origin is not prepared.report_facts.origin:
-        raise ValueError("mapping_context.origin must match report_facts.origin")
-    # Cross-object consistency: active sensor locations must agree
-    facts_locations = list(prepared.report_facts.sensor_locations_active)
-    if facts_locations != prepared.mapping_context.sensor_locations_active:
-        raise ValueError(
-            "mapping_context.sensor_locations_active must match "
-            "report_facts.sensor_locations_active"
-        )
-    # Cross-object consistency: renderer payload car metadata must agree with mapping_context
-    if prepared.renderer_payload.car_name != prepared.mapping_context.car_name:
-        raise ValueError("mapping_context.car_name must match renderer_payload.car_name")
-    if prepared.renderer_payload.car_type != prepared.mapping_context.car_type:
-        raise ValueError("mapping_context.car_type must match renderer_payload.car_type")
 
     return ValidatedPreparedReportInput(
         renderer_payload=prepared.renderer_payload,
@@ -241,7 +145,6 @@ def validate_prepared_report_input(
         filename=prepared.filename,
         domain_test_run=prepared.domain_test_run,
         report_facts=prepared.report_facts,
-        mapping_context=prepared.mapping_context,
         cache_key=prepared.cache_key,
     )
 
@@ -316,15 +219,6 @@ def _build_prepared_report_input(
         if domain_test_run is not None
         else None
     )
-    mapping_context = (
-        _build_report_mapping_context(
-            renderer_payload=renderer_payload,
-            report_facts=report_facts,
-            test_run=domain_test_run,
-        )
-        if domain_test_run is not None and report_facts is not None
-        else None
-    )
     return PreparedReportInput(
         renderer_payload=renderer_payload,
         language=prepared_language,
@@ -332,7 +226,6 @@ def _build_prepared_report_input(
         domain_test_run=domain_test_run,
         cache_key=cache_key,
         report_facts=report_facts,
-        mapping_context=mapping_context,
     )
 
 


### PR DESCRIPTION
## Summary
Closes #1464.

History-side report preparation was still materializing `ReportMappingContext` even though that type is only consumed by the PDF adapter. This PR moves both the context type and the context-assembly logic into `apps/server/vibesensor/adapters/pdf/report_context.py`, then narrows the prepared-report handoff so history validates and returns only the domain aggregate plus the prepared semantic facts that the PDF side actually needs. The result is that the history layer no longer stores a precomputed adapter structure, while the PDF adapter still receives the same effective context content for mapping and rendering.

## Problem being solved
The open issue was specifically about ownership drift around `ReportMappingContext`. After the recent report-preparation cleanups, `apps/server/vibesensor/use_cases/history/report_preparation.py` still defined the context dataclass and still built a PDF-facing object inside `_build_prepared_report_input()`. That meant a presentation-adjacent adapter shape was living in the history layer, and any future PDF context change would require editing a use-case module that otherwise exists to reconstruct the domain run, derive report facts, and prepare the cross-layer handoff.

There was also a subtle architectural constraint here: the issue body suggests letting history delegate directly to a PDF-owned factory, but the backend layer rules do not allow `use_cases` to import `adapters`. Rather than punching a hole in those boundaries, this change makes the prepared-input seam narrower and cleaner: history prepares validated ingredients, and the PDF adapter builds its own `ReportMappingContext` on demand from those already-validated values.

## Implementation approach
I treated the prepared report seam as the stable contract and moved the adapter-specific piece behind the adapter boundary. Concretely, the PR keeps `PreparedReportInput` and `ValidatedPreparedReportInput` as the handoff objects between history preparation and PDF mapping, but removes the stored `mapping_context` field from both dataclasses. `validate_prepared_report_input()` now validates the presence of `domain_test_run` and `report_facts` and returns the validated handoff without trying to carry or cross-check a separate adapter object.

On the adapter side, `apps/server/vibesensor/adapters/pdf/report_context.py` now owns the `ReportMappingContext` dataclass and a private `_build_report_mapping_context()` helper. `prepare_report_mapping_context()` is no longer a thin bridge over a precomputed field; it validates the prepared input, builds the context from `renderer_payload`, `report_facts`, and `domain_test_run`, and returns the adapter-owned context immediately before mapping uses it.

## Main code changes by area
In `apps/server/vibesensor/use_cases/history/report_preparation.py`, I removed the old `ReportMappingContext` definition and deleted `_build_report_mapping_context()`. I also updated the prepared-input docstrings so they explicitly describe `ReportMappingContext` as adapter-owned, not history-owned. The handoff dataclasses now stop at `renderer_payload`, `domain_test_run`, `report_facts`, language, filename, and cache key. That leaves history responsible for reconstruction and semantic preparation, but not for building presentation-specific context wrappers.

In `apps/server/vibesensor/adapters/pdf/report_context.py`, I moved the full `ReportMappingContext` structure and its behavior helpers (`top_report_candidate()` and `has_significant_location_intensity()`) into the PDF module. The new factory logic there preserves the existing context content: car metadata still comes from `renderer_payload`, origin and origin location still come from `report_facts`, active sensor locations still prefer the connected-throughout projection when present, and the report date continues to be normalized into the same `YYYY-MM-DD HH:MM:SS UTC` string shape, with the same UTC fallback when no explicit report date exists.

In `apps/server/vibesensor/adapters/pdf/mapping.py`, `map_summary()` now validates the prepared input, asks `prepare_report_mapping_context()` for the adapter-owned context, and passes that context into `_build_report_template_data()`. This keeps the mapping flow explicit and avoids reaching back into history-owned state for an adapter-owned object.

## Tests and contract updates
I updated the focused report-preparation contract tests to match the new seam rather than pinning the old implementation detail. `apps/server/tests/use_cases/history/test_report_preparation_contract.py` now asserts that prepared inputs no longer expose `mapping_context`, that validation still rejects missing `domain_test_run` or `report_facts`, and that `prepare_report_mapping_context()` can build a `ReportMappingContext` from both unvalidated and already-validated handoffs.

I also strengthened `apps/server/tests/adapters/pdf/test_report_mapping_context.py` with direct adapter-owned factory coverage. The new tests check that the moved factory maps car metadata, origin data, and connected sensor locations into the context correctly, and that the report-date fallback still uses the current UTC timestamp when the payload does not provide `report_date`. `apps/server/tests/adapters/pdf/test_template_builder.py` was updated to import `ReportMappingContext` from the PDF module instead of the history-preparation module, which locks in the new ownership boundary.

One intentional effect of this change is that the old “cross-object consistency” validation tests around `mapping_context` were removed. Those tests were useful when history stored a second object that could drift away from `renderer_payload`, `report_facts`, or `domain_test_run`. With the context now being built directly from those validated ingredients inside the adapter, that drift surface no longer exists, so the stronger guarantee comes from eliminating the redundant stored object entirely.

## Validation
Local validation performed for this PR:

- `ruff format apps/server/vibesensor/use_cases/history/report_preparation.py apps/server/vibesensor/adapters/pdf/report_context.py apps/server/vibesensor/adapters/pdf/mapping.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_template_builder.py`
- `ruff check apps/server/vibesensor/use_cases/history/report_preparation.py apps/server/vibesensor/adapters/pdf/report_context.py apps/server/vibesensor/adapters/pdf/mapping.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_template_builder.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/integration/test_contract_analysis_report.py`
- `python3 -m py_compile` on the same touched production and focused test files

I also attempted a focused `pytest -q` run over the report-preparation / PDF mapping tests. That run is still blocked in this container before test startup because the repository now imports Python-3.12-style `type` aliases from `apps/server/vibesensor/shared/types/json_types.py`, while the local environment only has Python 3.11. CI remains the authoritative behavioral gate for that reason, and the PR leaves that broader environment mismatch unchanged.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff is that `prepare_report_mapping_context()` now builds the context when called instead of reading a precomputed field. That is a tiny amount of repeated work, but it buys cleaner ownership and removes a whole class of synchronization checks. I kept the scope intentionally narrow: this PR does not redesign `PreparedReportFacts`, change template mapping behavior, or reopen the rest of the report pipeline. It only moves the adapter-owned context seam to the adapter that actually owns it and updates the prepared-input contract to stop carrying redundant adapter state.
