### PR TITLE
Replace bare object warnings typing in analysis_summary.py

### DIFF
--- a/apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import cast
+
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.shared.boundaries.analysis_summary import analysis_summary_with_warnings
+from vibesensor.shared.run_context_warning import RunContextWarning
+from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummary,
+    SummaryWarningResponse,
+)
+
+
+def _warning_model() -> RunContextWarning:
+    return RunContextWarning(
+        code="reference_context_incomplete",
+        severity="warn",
+        applies_to="order_analysis",
+        title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+        detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+    )
+
+
+def _warning_payload() -> SummaryWarningResponse:
+    return {
+        "code": "reference_context_incomplete",
+        "severity": "warn",
+        "applies_to": "order_analysis",
+        "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+        "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+    }
+
+
+def test_analysis_summary_with_warnings_replaces_warning_payloads() -> None:
+    summary = cast(AnalysisSummary, minimal_summary())
+
+    updated = analysis_summary_with_warnings(summary, [_warning_model()])
+
+    assert updated["warnings"] == [_warning_payload()]
+    assert summary["warnings"] == []
+
+
+def test_analysis_summary_with_warnings_accepts_persisted_warning_payloads() -> None:
+    summary = cast(AnalysisSummary, minimal_summary())
+
+    updated = analysis_summary_with_warnings(summary, [_warning_payload()])
+
+    assert updated["warnings"] == [_warning_payload()]

--- a/apps/server/tests/shared/boundaries/test_summary_warning.py
+++ b/apps/server/tests/shared/boundaries/test_summary_warning.py
@@ -55,3 +55,31 @@ def test_localize_warning_list_resolves_run_context_warning_models() -> None:
             ),
         }
     ]
+
+
+def test_localize_warning_list_resolves_persisted_warning_payloads() -> None:
+    warnings = [
+        {
+            "code": "reference_context_incomplete",
+            "severity": "warn",
+            "applies_to": "order_analysis",
+            "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+            "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+        }
+    ]
+
+    assert localize_warning_list(warnings, lang="nl") == [
+        {
+            "code": "reference_context_incomplete",
+            "severity": "warn",
+            "applies_to": "order_analysis",
+            "title": "De referentiecontext voor ordeanalyse was onvolledig voor deze run",
+            "detail": (
+                "Voor deze run ontbreekt een deel van de wiel-/motorreferentie die "
+                "nodig is voor betrouwbare ordeanalyse. Ordegebaseerde bevindingen "
+                "kunnen nog steeds worden getoond, maar behandel ze als voorlopig "
+                "totdat de run met volledige voertuigreferentiegegevens wordt "
+                "herhaald."
+            ),
+        }
+    ]

--- a/apps/server/vibesensor/adapters/history.py
+++ b/apps/server/vibesensor/adapters/history.py
@@ -22,7 +22,7 @@ from vibesensor.shared.boundaries.report_payload_gate import has_projectable_rep
 from vibesensor.shared.boundaries.summary_warning import localize_warning_list
 from vibesensor.shared.ports import ActiveCarReader
 from vibesensor.shared.types.history_records import StoredHistoryRun
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_array
 from vibesensor.use_cases.history.exports import (
     EXPORT_SPOOL_THRESHOLD,
     HistoryExportContext,
@@ -131,8 +131,9 @@ class ProjectedHistoryRunService:
             return None
         projected = project_history_insights(result)
         if self._current_car_reader is not None:
+            raw_warnings = projected.get("warnings")
             overlay_warnings = add_current_context_warnings(
-                projected.get("warnings"),
+                raw_warnings if is_json_array(raw_warnings) else None,
                 metadata=projected.get("metadata"),
                 current_active_car_snapshot=self._current_car_reader.active_car_snapshot(),
             )

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -31,7 +31,10 @@ from vibesensor.shared.boundaries.summary_serialization._summary import (
 )
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.boundaries.test_plan_projection import step_payloads_from_plan
-from vibesensor.shared.run_context_warning import build_summary_warnings
+from vibesensor.shared.run_context_warning import (
+    RunContextWarningsInput,
+    build_summary_warnings,
+)
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.json_types import JsonObject
@@ -137,7 +140,7 @@ def _amp_metric_values(accel_stats: AccelStatisticsLike) -> list[float]:
 
 def analysis_summary_with_warnings(
     summary: AnalysisSummary,
-    warnings: object,
+    warnings: RunContextWarningsInput,
 ) -> AnalysisSummary:
     """Return a typed summary copy with report-facing warning payloads replaced."""
 

--- a/apps/server/vibesensor/shared/boundaries/report_facts_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/report_facts_projection.py
@@ -7,12 +7,14 @@ from collections.abc import Mapping
 from vibesensor.domain.run_suitability import RunSuitability
 from vibesensor.shared.boundaries.run_suitability import run_suitability_payload
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
+from vibesensor.shared.run_context_warning import RunContextWarningsInput
 from vibesensor.shared.types.history_analysis_contracts import (
     RunSuitabilityCheck,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     SummaryWarningResponse as SummaryWarningPayload,
 )
+from vibesensor.shared.types.json_types import is_json_array
 
 __all__ = [
     "report_suitability_checks",
@@ -29,7 +31,9 @@ def report_suitability_checks(
 def report_warning_payloads(
     payload: Mapping[str, object],
     *,
-    warnings: object | None = None,
+    warnings: RunContextWarningsInput = None,
 ) -> tuple[SummaryWarningPayload, ...]:
-    raw_warnings = warnings if warnings is not None else payload.get("warnings")
-    return tuple(summary_warning_payloads(raw_warnings))
+    if warnings is not None:
+        return tuple(summary_warning_payloads(warnings))
+    raw_warnings = payload.get("warnings")
+    return tuple(summary_warning_payloads(raw_warnings if is_json_array(raw_warnings) else None))

--- a/apps/server/vibesensor/shared/boundaries/summary_warning.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_warning.py
@@ -8,6 +8,7 @@ from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.json_utils import payload_value_from_json
 from vibesensor.shared.run_context_warning import (
     RunContextWarning,
+    RunContextWarningsInput,
     normalize_run_context_warnings,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
@@ -28,7 +29,9 @@ def summary_warning_payload(warning: RunContextWarning) -> SummaryWarningPayload
     return payload
 
 
-def summary_warning_payloads(warnings: object) -> list[SummaryWarningPayload]:
+def summary_warning_payloads(
+    warnings: RunContextWarningsInput,
+) -> list[SummaryWarningPayload]:
     """Serialize warning models into the summary payload list shape."""
     return [
         summary_warning_payload(warning) for warning in normalize_run_context_warnings(warnings)
@@ -36,7 +39,7 @@ def summary_warning_payloads(warnings: object) -> list[SummaryWarningPayload]:
 
 
 def localize_warning_list(
-    warnings: object,
+    warnings: RunContextWarningsInput,
     *,
     lang: str,
 ) -> list[JsonObject]:

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal, cast
 
@@ -25,6 +25,9 @@ class RunContextWarning:
     detail: JsonValue | None = None
 
 
+type RunContextWarningsInput = Sequence[RunContextWarning | JsonValue] | None
+
+
 def build_summary_warnings(
     metadata: Mapping[str, object],
     *,
@@ -45,8 +48,10 @@ def build_summary_warnings(
     return warnings
 
 
-def normalize_run_context_warnings(warnings: object) -> list[RunContextWarning]:
-    if not isinstance(warnings, list):
+def normalize_run_context_warnings(
+    warnings: RunContextWarningsInput,
+) -> list[RunContextWarning]:
+    if warnings is None:
         return []
     normalized: list[RunContextWarning] = []
     for warning in warnings:

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -8,7 +8,9 @@ from dataclasses import dataclass
 from vibesensor.domain import RunStatus
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.run_context_warning import RunContextWarningsInput
 from vibesensor.shared.types.history_records import StoredHistoryRun
+from vibesensor.shared.types.json_types import is_json_array
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.history.helpers import (
@@ -29,7 +31,7 @@ class HistoryReportRequest:
     filename: str
     language: str
     analysis: PersistedAnalysis
-    warnings: object
+    warnings: RunContextWarningsInput
 
 
 class HistoryReportRequestLoader:
@@ -59,7 +61,8 @@ class HistoryReportRequestLoader:
             raise AnalysisNotReadyError("No analysis available for this run")
 
         requested_lang = self._analysis_language(run, requested_lang)
-        warnings = analysis.get("warnings")
+        raw_warnings = analysis.get("warnings")
+        warnings = raw_warnings if is_json_array(raw_warnings) else None
         cache_key = self._report_pdf_cache_key(
             run,
             run_id,

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -37,6 +37,7 @@ from vibesensor.shared.boundaries.report_renderer_payload import (
     build_report_renderer_payload,
 )
 from vibesensor.shared.boundaries.test_run_reconstruction import test_run_from_summary
+from vibesensor.shared.run_context_warning import RunContextWarningsInput
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary,
     RunSuitabilityCheck,
@@ -159,7 +160,7 @@ def _prepare_report_facts(
     payload: Mapping[str, object],
     *,
     test_run: TestRun,
-    warnings: object | None = None,
+    warnings: RunContextWarningsInput = None,
 ) -> PreparedReportFacts:
     metadata = summary_metadata(payload)
     sensor_locations_active = active_sensor_locations(payload)
@@ -209,7 +210,7 @@ def _build_prepared_report_input(
     filename: str | None,
     language: str | None,
     cache_key: ReportPdfCacheKey | None,
-    warnings: object | None = None,
+    warnings: RunContextWarningsInput = None,
 ) -> PreparedReportInput:
     domain_test_run = _reconstruct_report_test_run(payload)
     prepared_language = str(normalize_lang(language or payload.get("lang")))
@@ -248,7 +249,7 @@ def prepare_report_input(
 def prepare_persisted_report_input(
     analysis: PersistedAnalysis,
     *,
-    warnings: object | None = None,
+    warnings: RunContextWarningsInput = None,
     filename: str | None = None,
     language: str | None = None,
     cache_key: ReportPdfCacheKey | None = None,

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -10,7 +10,7 @@ from vibesensor.shared.boundaries.summary_warning import localize_warning_list
 from vibesensor.shared.exceptions import AnalysisNotReadyError, RunNotFoundError
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_array
 from vibesensor.use_cases.history.helpers import (
     async_require_run,
     require_analysis_ready,
@@ -46,9 +46,13 @@ class HistoryRunService:
         raw_analysis = require_analysis_ready(run)
         analysis = strip_internal_fields(raw_analysis.to_json_object())
         response_lang = resolve_run_language(run, requested_lang)
+        raw_warnings = analysis.get("warnings")
         analysis["warnings"] = cast(
             JsonValue,
-            localize_warning_list(analysis.get("warnings"), lang=response_lang),
+            localize_warning_list(
+                raw_warnings if is_json_array(raw_warnings) else None,
+                lang=response_lang,
+            ),
         )
         analysis["run_id"] = run.run_id or run_id
         analysis["status"] = RunStatus.COMPLETE.value

--- a/apps/server/vibesensor/use_cases/run/run_context.py
+++ b/apps/server/vibesensor/use_cases/run/run_context.py
@@ -15,6 +15,7 @@ from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.run_context_warning import (
     WARNING_CODE_CAR_SETTINGS_CHANGED,
     RunContextWarning,
+    RunContextWarningsInput,
     normalize_run_context_warnings,
 )
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
@@ -71,7 +72,7 @@ def order_reference_context_complete(metadata: Mapping[str, object]) -> bool:
 
 
 def add_current_context_warnings(
-    warnings: object,
+    warnings: RunContextWarningsInput,
     *,
     metadata: object,
     current_active_car_snapshot: CarSnapshot | None,


### PR DESCRIPTION
## Summary
Closes #1466.

`analysis_summary_with_warnings()` was still accepting `warnings: object`, which left one of the repository's shared summary boundaries structurally vague even though the warning model and warning payload shape were already defined elsewhere. This PR replaces that raw seam with an explicit warning-input contract, propagates the same type through the nearby shared/report/history helpers that consume warning lists, and keeps the outward warning payload shape exactly the same. The only runtime behavior change is better type narrowing at the raw JSON call sites; serialized warnings, report payloads, and localized history responses are intentionally unchanged.

## Problem being solved
The issue was not that warning payloads were broken at runtime. The problem was that the boundary typing had drifted behind the actual design of the code.

The repo already has a canonical app-level warning model in `RunContextWarning` and a canonical persisted/API payload shape in `SummaryWarningResponse`. Despite that, `analysis_summary_with_warnings()` in `apps/server/vibesensor/shared/boundaries/analysis_summary.py` still accepted `warnings: object`, and the same broad shape had leaked into adjacent helpers like `summary_warning_payloads()`, `localize_warning_list()`, `add_current_context_warnings()`, and parts of the persisted-report path.

That created two maintenance problems:

- the public signatures of shared helpers no longer described what the functions actually expected
- type-checking could not help trace warning-shape changes across report/history boundaries because arbitrary `object` values were allowed through those seams

In practice the code was only designed to handle two kinds of inputs:

- app-level `RunContextWarning` models
- persisted/raw JSON warning arrays that can be normalized back into `RunContextWarning`

This PR makes that design explicit instead of continuing to rely on a catch-all `object` type.

## Implementation approach
I kept the change intentionally small and additive. The goal of `#1466` is to close the vague warning seam, not to redesign warning serialization or move warning ownership around.

The core choice was to define one reusable input alias in `apps/server/vibesensor/shared/run_context_warning.py` rather than inventing a new family of helper models. The repo already had the right primitives:

- `RunContextWarning` for the app-level warning model
- `JsonValue` / `JsonArray` semantics for persisted raw payloads
- `SummaryWarningResponse` for the outward payload shape
- `normalize_run_context_warnings()` as the existing bridge between raw payloads and models

So instead of introducing new dataclasses or TypedDicts, I defined `RunContextWarningsInput` as the shared contract for warning-list inputs and then threaded that same alias through the small group of helpers that normalize, serialize, localize, enrich, or forward warnings.

I also kept the dynamic/raw boundary handling at the actual JSON-entry points rather than inside every shared helper. Where history/report code reads `warnings` out of a generic payload mapping, the code now narrows through `is_json_array(...)` before passing the value into the typed helper. That preserves the existing tolerant runtime behavior while removing the `object`-typed public seam.

## Main code changes by area
In `shared/run_context_warning.py`, I added `RunContextWarningsInput` and changed `normalize_run_context_warnings()` to accept that alias instead of bare `object`. This file is the right place for the alias because it already owns the warning model and the normalization step.

In `shared/boundaries/summary_warning.py`, both `summary_warning_payloads()` and `localize_warning_list()` now accept `RunContextWarningsInput`. Nothing about the serialized or localized output changed; only the accepted input contract is now explicit.

In `shared/boundaries/analysis_summary.py`, `analysis_summary_with_warnings()` now accepts the shared alias instead of `object`. This closes the exact issue seam without changing the logic that deep-copies the summary and replaces the `warnings` field with payload-shaped warnings.

In `use_cases/run/run_context.py`, `add_current_context_warnings()` now accepts the same typed warning input. That keeps the enrichment path aligned with the shared normalization contract rather than widening it back to `object`.

In the persisted report/history flow, I propagated the contract through the helpers that still touched raw warning payloads:

- `shared/boundaries/report_facts_projection.py`
- `use_cases/history/report_preparation.py`
- `use_cases/history/report_loader.py`

The report loader now narrows `analysis.get("warnings")` with `is_json_array(...)` before storing it on `HistoryReportRequest`, so the request dataclass no longer preserves a raw `object` warning field.

In the history delivery paths, `adapters/history.py` and `use_cases/history/runs.py` now do the same narrow-at-the-boundary step before calling `add_current_context_warnings()` or `localize_warning_list()`. This keeps the raw JSON tolerance where it belongs while letting the shared helpers describe their actual contract.

## Tests and validation
I added a new focused test module: `apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py`.

That file covers the exact seam from the issue:

1. `analysis_summary_with_warnings()` converts app-level `RunContextWarning` models into the existing wire payload shape
2. it still accepts persisted warning payload dictionaries and preserves the outward payload exactly
3. the original summary input is not mutated during that conversion

I also extended `apps/server/tests/shared/boundaries/test_summary_warning.py` with a persisted-warning localization regression so the history/localization path remains covered after the signature tightening.

Local validation completed before opening this PR:

- `ruff check` on all touched backend and test files
- `pytest -q apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py apps/server/tests/shared/boundaries/test_summary_warning.py apps/server/tests/shared/boundaries/test_report_facts_projection.py apps/server/tests/shared/test_run_context_warning.py apps/server/tests/use_cases/run/test_run_context.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/use_cases/history/test_history_service_edges.py`
- broader contract coverage with `pytest -q apps/server/tests/use_cases/diagnostics/test_run_analysis.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/integration/test_contract_analysis_report.py`
- `make typecheck-backend`

These checks matter for this issue because the whole change is about type information surviving across shared boundaries without changing payload behavior. The focused tests prove the warning payloads/localization still look the same, the broader tests cover the downstream analysis/report/history contracts, and `make typecheck-backend` confirms the last `object` seam really is gone from the affected paths.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff is that the new alias still allows raw JSON warning arrays in addition to app-level `RunContextWarning` models. That is deliberate. Persisted history/report code genuinely needs to round-trip previously serialized warning payloads, so the correct fix is not to force every caller onto the dataclass immediately. The fix is to make the accepted input shape explicit and narrow the raw JSON reads at the actual boundary.

This PR does not change the outward `warnings` payload shape, warning localization text, warning codes, or the logic that decides which warnings exist. It also does not introduce a new serializer or new warning registry. Those are separate concerns; here I focused only on making the existing contract explicit and type-safe.

So the net effect is intentionally narrow: one explicit warning-input alias, a handful of signatures aligned to that alias, raw JSON narrowing where history/report code reads generic payload maps, and focused regressions that lock the outward behavior in place.
