### PR TITLE
Refactor HistoryInsightsResponse to wrap shared summary contracts

### DIFF
--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -173,6 +173,9 @@ from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummary as BoundaryAnalysisSummary,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
+    AnalysisSummaryCoreResponse as BoundaryAnalysisSummaryCoreResponse,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummaryResponse as ApiAnalysisSummaryResponse,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
@@ -324,3 +327,9 @@ def test_http_history_models_do_not_reexport_shared_summary_wrappers() -> None:
     assert not hasattr(history_models, "AnalysisSummaryCoreResponse")
     assert not hasattr(history_models, "AnalysisSummaryResponse")
     assert not hasattr(http_models, "AnalysisSummaryResponse")
+
+
+def test_history_insights_response_is_http_owned_wrapper() -> None:
+    from vibesensor.adapters.http.models.history import HistoryInsightsResponse
+
+    assert BoundaryAnalysisSummaryCoreResponse not in HistoryInsightsResponse.__bases__

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -9,7 +9,7 @@ localized response models.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Required, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -41,6 +41,7 @@ from vibesensor.shared.types.history_analysis_contracts import (
     AmplitudeMetric,
     FindingPayload,
     LocationIntensitySummaryResponse,
+    PayloadObject,
     PhaseInfoResponse,
     PhaseIntensityStatsResponse,
     PhaseSegmentSummaryResponse,
@@ -51,9 +52,6 @@ from vibesensor.shared.types.history_analysis_contracts import (
     SummaryWarningResponse,
     SuspectedVibrationOriginPayload,
     TestPlanStepResponse,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    AnalysisSummaryCoreResponse as _SharedAnalysisSummaryCoreResponse,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummaryResponse as _SharedAnalysisSummaryResponse,
@@ -144,7 +142,54 @@ class HistoryInsightsAnalyzingResponse(BaseModel):
     status: Literal["analyzing"]
 
 
-class HistoryInsightsResponse(_SharedAnalysisSummaryCoreResponse, total=False):
+class _HistoryInsightsCoreResponse(TypedDict, total=False):
+    """HTTP-owned core field wrapper for the localized history insights payload."""
+
+    file_name: Required[str]
+    run_id: Required[str]
+    case_id: str | None
+    rows: Required[int]
+    duration_s: Required[float]
+    record_length: Required[str]
+    lang: Required[str]
+    report_date: str | None
+    start_time_utc: str | None
+    end_time_utc: str | None
+    sensor_model: str | None
+    firmware_version: str | None
+    raw_sample_rate_hz: Required[float | None]
+    feature_interval_s: Required[float | None]
+    fft_window_size_samples: int | None
+    fft_window_type: str | None
+    peak_picker_method: str | None
+    accel_scale_g_per_lsb: Required[float | None]
+    incomplete_for_order_analysis: Required[bool]
+    metadata: Required[PayloadObject]
+    speed_breakdown: Required[list[SpeedBreakdownRow]]
+    phase_speed_breakdown: Required[list[PhaseSpeedBreakdownRow]]
+    phase_segments: Required[list[PhaseSegmentSummaryResponse]]
+    run_noise_baseline_db: Required[float | None]
+    speed_breakdown_skipped_reason: Required[PayloadObject | None]
+    findings: Required[list[FindingPayload]]
+    top_causes: Required[list[FindingPayload]]
+    most_likely_origin: Required[SuspectedVibrationOriginPayload]
+    test_plan: Required[list[TestPlanStepResponse]]
+    phase_timeline: Required[list[PhaseTimelineEntryResponse]]
+    speed_stats: Required[SpeedStatsResponse]
+    speed_stats_by_phase: Required[dict[str, SpeedStatsResponse]]
+    phase_info: Required[PhaseInfoResponse]
+    sensor_locations: Required[list[str]]
+    sensor_locations_connected_throughout: Required[list[str]]
+    sensor_count_used: Required[int]
+    sensor_intensity_by_location: Required[list[LocationIntensitySummaryResponse]]
+    run_suitability: Required[list[RunSuitabilityCheck]]
+    data_quality: Required[DataQualityResponse]
+    samples: list[PayloadObject]
+    plots: PlotDataResult | None
+    analysis_metadata: PayloadObject
+
+
+class HistoryInsightsResponse(_HistoryInsightsCoreResponse, total=False):
     """Response body for the localized history insights endpoint payload."""
 
     status: Annotated[Literal["complete"], Field(default="complete")]


### PR DESCRIPTION
## Summary
Closes #1467.

`HistoryInsightsResponse` was still inheriting directly from the shared `AnalysisSummaryCoreResponse` TypedDict, which meant the HTTP model for the localized history insights endpoint was structurally tied to a shared boundary wrapper instead of being owned by the HTTP adapter layer. This PR makes that model adapter-owned by replacing the direct shared-core inheritance with a local HTTP wrapper core that mirrors the same outward fields, while preserving the generated schema and runtime payload shape exactly. The refactor is intentionally narrow: ownership changes, not behavior.

## Problem being solved
The issue here was a type-ownership seam rather than a broken endpoint.

`apps/server/vibesensor/adapters/http/models/history.py` already carries a clear module-level rule: stable shared analysis/history view shapes live in the shared contracts module, while adapter-local wrappers should remain local to the HTTP models layer. `HistoryInsightsResponse` was the exception. It imported the shared `AnalysisSummaryCoreResponse` privately, but then inherited from it directly:

- shared core fields came from the boundary-owned TypedDict
- HTTP-only additions (`status` and localized `warnings`) lived on the adapter type
- the resulting outward model was partly shared-owned and partly adapter-owned

That blurred the ownership boundary in exactly the way the issue described. If a future HTTP-only field or localized concern needed to be added, the current inheritance pattern made it too easy for adapter concerns to keep leaning on the shared wrapper instead of keeping the HTTP surface explicitly local.

The goal of this PR is not to rename payload fields, change the endpoint response, or duplicate the whole history-summary ecosystem across layers. The goal is simply to make `HistoryInsightsResponse` an HTTP-owned wrapper model while leaving the public schema and the shared component field types unchanged.

## Implementation approach
I chose the smallest refactor that changes ownership without changing behavior.

Instead of introducing a new BaseModel or changing the shape of the response, I kept `HistoryInsightsResponse` as a TypedDict-based response model and replaced its direct inheritance from the shared `AnalysisSummaryCoreResponse` with a private HTTP-local core TypedDict inside `adapters/http/models/history.py`.

That local core mirrors the same field set and same field-level types used by the shared core:

- the same required summary fields remain required
- the same optional fields remain optional
- the same shared component payload types are reused for findings, phase rows, speed stats, suitability checks, data quality, plot data, and payload objects

Then `HistoryInsightsResponse` inherits from that HTTP-local core and adds the two HTTP-specific fields it already owned:

- `status`
- localized `warnings`

That means the response model is now adapter-owned at the wrapper level, but it still composes the exact shared component field types that should remain canonical elsewhere.

## Main code changes by area
In `apps/server/vibesensor/adapters/http/models/history.py`, I removed the direct dependency on `_SharedAnalysisSummaryCoreResponse` and replaced it with a private `_HistoryInsightsCoreResponse` TypedDict defined in the HTTP models module.

The new private core copies the same field surface as `AnalysisSummaryCoreResponse`, including the `Required[...]` annotations and the same shared payload/component types for nested data. Importantly, I kept the payload-object fields aligned to the shared `PayloadObject` type rather than the HTTP-local `ApiPayloadObject` alias after verifying that this was necessary to keep the OpenAPI schema byte-stable. Early in the implementation I used `ApiPayloadObject` for those copied fields, and the schema tests immediately showed the component refs drifting from `PayloadObject` to `ApiPayloadObject`. I corrected that so the refactor changes ownership but not schema output.

`HistoryInsightsResponse` now inherits from `_HistoryInsightsCoreResponse` and continues to add the localized HTTP-specific fields on top. The `_configure_pydantic_schema()` helper is still applied so extra fields remain forbidden exactly as before.

In `apps/server/tests/hygiene/test_api_model_boundary_parity.py`, I added one explicit guardrail: `HistoryInsightsResponse` must no longer directly inherit from the shared `AnalysisSummaryCoreResponse`. This is the precise ownership rule the issue is about, so the hygiene suite now locks that seam in place instead of only asserting that the shared wrappers are not re-exported by the HTTP model module.

I did not change `adapters/history.py`, `adapters/http/history.py`, or the route/service layers because they already treat `HistoryInsightsResponse` as the adapter-owned outward model. The TypeAdapter validation path and the response model references remain intact.

## Why this stays behavior-safe
This refactor deliberately preserves the two things that would be most risky to change:

1. the outward `HistoryInsightsResponse` field set
2. the generated OpenAPI schema for that response

The history insights endpoint still returns the same structure, the same finding refs, the same localized warning list shape, and the same field nullability/requiredness. The change is only that the HTTP layer now owns its wrapper type directly rather than inheriting a shared wrapper and layering localized HTTP fields on top.

That distinction matters for future maintenance even though the runtime payload is unchanged. After this PR, changes to the HTTP response wrapper have an explicit home in the adapter layer, while the shared contracts can continue to own the canonical nested summary components they are supposed to own.

## Tests and validation
I validated this change in the places most likely to catch an accidental schema or ownership regression.

First, I ran targeted static and schema checks:

- `ruff check apps/server/vibesensor/adapters/http/models/history.py apps/server/tests/hygiene/test_api_model_boundary_parity.py`
- `pytest -q apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `python -m vibesensor.cli.http_api_schema_export --check --out apps/ui/src/contracts/http_api_schema.json`

Those checks matter because the entire value of this refactor is lost if the HTTP wrapper ownership improves but the committed schema drifts. The schema export tests caught the one real issue during implementation, which was the temporary `ApiPayloadObject` reference mismatch.

After fixing that, I ran broader history/report validation:

- `pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/integration/test_contract_analysis_report.py`
- `make typecheck-backend`

That broader pass confirmed the refactor still satisfies the history service flow, the cross-layer persistence/HTTP contract, the report contract path, and backend mypy.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff is some intentional duplication of the summary-core field declarations inside the HTTP models layer. That is not ideal in the abstract, but it is the smallest direct way to make the wrapper adapter-owned without changing the endpoint shape or inventing a more complex translation layer. For this issue, explicit duplication is preferable to another indirect abstraction that would obscure ownership again.

This PR does not change `HistoryRunResponse.analysis`; that is still tracked separately by `#1468`. It also does not move the nested shared component types like `FindingPayload`, `SpeedStatsResponse`, or `DataQualityResponse` out of their current shared owners. Those remain canonical shared contracts and should continue to be reused.

So the net effect is intentionally focused: `HistoryInsightsResponse` is now an HTTP-owned wrapper/composed type, the schema stays the same, the route/adapter behavior stays the same, and the hygiene suite now enforces the ownership boundary that this issue was meant to clarify.
