### PR TITLE
Replace HistoryRunResponse.analysis with a local HTTP wrapper type

### DIFF
--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -333,3 +333,11 @@ def test_history_insights_response_is_http_owned_wrapper() -> None:
     from vibesensor.adapters.http.models.history import HistoryInsightsResponse
 
     assert BoundaryAnalysisSummaryCoreResponse not in HistoryInsightsResponse.__bases__
+
+
+def test_history_run_response_analysis_uses_local_http_alias() -> None:
+    from vibesensor.adapters.http.models.history import HistoryRunResponse
+
+    annotation = HistoryRunResponse.__annotations__["analysis"]
+    assert "_SharedAnalysisSummaryResponse" not in annotation
+    assert "_HistoryRunAnalysisResponse" in annotation

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -114,6 +114,12 @@ class HistoryListResponse(BaseModel):
     runs: list[HistoryListEntryResponse]
 
 
+# Keep plain assignment so ``HistoryRunResponse.analysis`` can name a local HTTP
+# alias while preserving the shared ``AnalysisSummaryResponse`` runtime/schema
+# identity for OpenAPI generation.
+_HistoryRunAnalysisResponse = _SharedAnalysisSummaryResponse
+
+
 class HistoryRunResponse(_StrictBase):
     """Response body for a single history run with metadata and optional analysis."""
 
@@ -122,7 +128,7 @@ class HistoryRunResponse(_StrictBase):
     sample_count: int
     error_message: str | None = None
     metadata: ApiPayloadObject = Field(default_factory=dict)
-    analysis: _SharedAnalysisSummaryResponse | None = None
+    analysis: _HistoryRunAnalysisResponse | None = None
 
 
 class HistoryInsightWarningResponse(BaseModel):


### PR DESCRIPTION
## Summary
Closes #1468.

`HistoryRunResponse` was still exposing the privately imported shared `AnalysisSummaryResponse` wrapper directly on its public `analysis` field. This PR replaces that direct field annotation with a local HTTP-owned alias inside `adapters/http/models/history.py`, while intentionally preserving the underlying runtime/schema identity so the serialized response and generated OpenAPI stay unchanged. The refactor is deliberately small: it clarifies ownership at the HTTP model seam without renaming contracts, changing payload content, or adding another translation layer.

## Problem being solved
The issue here was a type-ownership leak in a public HTTP model.

`apps/server/vibesensor/adapters/http/models/history.py` already tries to keep shared contracts and adapter-local wrappers separate. Shared nested shapes like findings, speed stats, phase summaries, and the canonical persisted summary wrappers are imported privately, while adapter-local response models live in the HTTP module. `HistoryRunResponse` was the exception. Its `analysis` field was annotated directly as `_SharedAnalysisSummaryResponse | None`, where `_SharedAnalysisSummaryResponse` is a private import of the shared `AnalysisSummaryResponse` TypedDict.

That creates a small but real maintenance problem:

- the HTTP model surface is directly naming a private shared wrapper type
- ownership of the outward field becomes ambiguous at the source level
- future HTTP-specific shaping work around the `analysis` field would start from a leaked shared wrapper instead of an adapter-owned seam

This is closely related to `#1467`, but smaller. `#1467` fixed the localized history insights response, which needed a fully HTTP-owned wrapper core because it adds HTTP-localized warnings and status. `#1468` is more constrained: `HistoryRunResponse.analysis` should stop naming the private shared wrapper directly, but the outward schema should still stay anchored to the shared `AnalysisSummaryResponse` component because the payload itself is still the canonical projected summary object.

## Implementation approach
I chose the smallest approach that changes source-level ownership without perturbing behavior.

Rather than introducing a new wrapper TypedDict or BaseModel, I added a local alias in `adapters/http/models/history.py`:

- `_HistoryRunAnalysisResponse = _SharedAnalysisSummaryResponse`

Then `HistoryRunResponse.analysis` now uses `_HistoryRunAnalysisResponse | None` instead of `_SharedAnalysisSummaryResponse | None`.

The important detail is that this alias is a **plain assignment**, not a new TypedDict subclass and not a `type` statement alias that would risk changing how pydantic/openapi names the schema component. I left a comment in the file explaining why: the goal is to let the HTTP model name a local adapter-owned alias while preserving the runtime and schema identity of the underlying shared `AnalysisSummaryResponse` type.

That distinction matters here. If I had created a new wrapper class for the field, the OpenAPI export likely would have switched from the existing `AnalysisSummaryResponse` component ref to a new HTTP-local component name. That would be larger than the issue asked for and would create unnecessary schema churn. The local alias gives the HTTP layer its own seam in source while keeping the generated API contract byte-stable.

## Main code changes by area
In `apps/server/vibesensor/adapters/http/models/history.py`, the only behavioral model change is on `HistoryRunResponse`:

- before: `analysis: _SharedAnalysisSummaryResponse | None = None`
- after: `analysis: _HistoryRunAnalysisResponse | None = None`

I also added a short comment above the alias describing why the alias is intentionally a plain assignment: it exists to make the field adapter-owned in the HTTP module without changing the schema component identity that OpenAPI generation sees.

No route code, adapter projection code, or persistence logic needed to change. The history-run response builder already produces the same projected analysis payload, and the `HistoryRunResponse` model already validates that shape. This issue is only about making the field’s outward ownership clearer in the HTTP layer.

In `apps/server/tests/hygiene/test_api_model_boundary_parity.py`, I added a small hygiene assertion that checks the source-level annotation string on `HistoryRunResponse.analysis`. The test ensures that:

- the annotation no longer names `_SharedAnalysisSummaryResponse` directly
- it now names `_HistoryRunAnalysisResponse`

This is the most direct guardrail for the issue. Runtime type identity is intentionally unchanged, so a runtime `is` check would not help here. The point is to lock in the source-level ownership seam, and the annotation string does exactly that.

## Why this stays behavior-safe
This change does not alter the response payload itself. `HistoryRunResponse.analysis` still validates the same projected summary object it did before, and because the alias preserves the underlying shared type identity, the generated schema still references the same `AnalysisSummaryResponse` component.

That behavior stability is important because this route is part of the committed API contract used by schema export tests and the generated frontend types. The issue asked for an ownership clarification, not a contract rename. By using a local alias instead of a new wrapper class, the change stays confined to the HTTP model source without causing downstream schema churn.

## Tests and validation
I validated this in the places that matter for a source-level ownership cleanup.

First, I ran the targeted model and schema checks:

- `ruff check apps/server/vibesensor/adapters/http/models/history.py apps/server/tests/hygiene/test_api_model_boundary_parity.py`
- `pytest -q apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `python -m vibesensor.cli.http_api_schema_export --check --out apps/ui/src/contracts/http_api_schema.json`

These checks prove the local alias does not change the exported schema, and they also ensure the new hygiene guard behaves as intended.

Then I ran broader downstream validation:

- `pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/integration/test_contract_analysis_report.py`
- `make typecheck-backend`

Those broader tests confirm the history HTTP service flow, the persisted analysis to HTTP contract, the report contract path, and backend mypy all continue to work with the local alias in place.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff is that this is intentionally modest. It does not create a brand-new wrapper structure for the `analysis` field. That is deliberate because the payload itself is still canonically the shared `AnalysisSummaryResponse` shape. The issue only calls for the HTTP model to stop naming the private shared wrapper directly.

The upside of the alias approach is that it solves the ownership leak with almost no behavioral risk. The downside is that the runtime type behind the alias remains the shared summary wrapper, so this is not a deep decoupling. That is acceptable here because deeper decoupling would likely require a new schema component and broader contract churn, which would exceed the scope of this issue.

This PR also does not change `HistoryInsightsResponse`; that was already addressed in `#1467`. And it does not rename or relocate the canonical shared `AnalysisSummaryResponse` contract itself. It simply ensures the public `HistoryRunResponse` model now names a local HTTP alias instead of directly exposing a private shared import on its field definition.
