### PR TITLE
Hide summary_serialization internals behind a stable public API

### DIFF
--- a/apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py
@@ -49,3 +49,11 @@ def test_shared_type_modules_use_focused_history_and_settings_owners() -> None:
     assert "class HistoryRunListEntry" in history_records_source
     assert "class StoredHistoryRun" in history_records_source
     assert "class SettingsSnapshotPayload" in settings_snapshot_source
+
+
+def test_summary_serialization_package_hides_internal_build_context() -> None:
+    from vibesensor.shared.boundaries import summary_serialization
+
+    assert callable(summary_serialization.build_analysis_summary)
+    assert not hasattr(summary_serialization, "AnalysisSummaryBuildContext")
+    assert not hasattr(summary_serialization, "build_summary_payload")

--- a/apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py
+++ b/apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from vibesensor.domain import DrivingPhase, DrivingPhaseInterval, LocationIntensitySummary
+from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
+from vibesensor.domain.speed_profile_summary import SpeedProfileSummary
+from vibesensor.shared.boundaries.summary_serialization import build_analysis_summary
+
+
+def test_build_analysis_summary_exposes_stable_public_entrypoint() -> None:
+    summary = build_analysis_summary(
+        file_name="run.csv",
+        run_id="run-1",
+        samples=[{"t_s": 0.0, "speed_kmh": 32.0, "vibration_strength_db": 14.0}],
+        duration_s=12.5,
+        language="en",
+        metadata={"end_time_utc": "2026-01-01T00:00:00Z"},
+        raw_sample_rate_hz=100.0,
+        speed_breakdown=[],
+        phase_speed_breakdown=[],
+        phase_segments=[],
+        run_noise_baseline_g=0.02,
+        speed_breakdown_skipped_reason=None,
+        findings=(),
+        top_causes=(),
+        most_likely_origin=None,
+        test_plan=[],
+        phase_timeline=[
+            DrivingPhaseInterval(
+                phase=DrivingPhase.CRUISE,
+                start_t_s=0.0,
+                end_t_s=12.5,
+            )
+        ],
+        speed_stats=SpeedProfileSummary(mean_kmh=32.0, sample_count=1),
+        speed_stats_by_phase={},
+        phase_info=DrivingPhaseSummary(has_cruise=True, cruise_pct=100.0),
+        sensor_locations=["front"],
+        connected_locations={"front"},
+        sensor_intensity_by_location=[
+            LocationIntensitySummary(location="front", p95_intensity_db=18.0)
+        ],
+        run_suitability=None,
+        speed_values=[32.0],
+        speed_non_null_pct=100.0,
+        accel_stats={
+            "x_mean": 0.0,
+            "x_var": 0.1,
+            "y_mean": 0.0,
+            "y_var": 0.1,
+            "z_mean": 1.0,
+            "z_var": 0.2,
+            "sensor_limit": 2.0,
+        },
+        amp_metric_values=[14.0],
+    )
+
+    assert summary["run_id"] == "run-1"
+    assert summary["rows"] == 1
+    assert summary["sensor_count_used"] == 1
+    assert summary["warnings"] == []
+    assert summary["data_quality"]["speed_coverage"]["count_non_null"] == 1

--- a/apps/server/vibesensor/shared/boundaries/analysis_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_summary.py
@@ -16,18 +16,13 @@ from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
 from vibesensor.domain.speed_profile_summary import SpeedProfileSummary
 from vibesensor.domain.vibration_origin import VibrationOrigin
 from vibesensor.shared.boundaries.summary_serialization import (
-    build_summary_payload,
-    serialize_plot_data,
-)
-from vibesensor.shared.boundaries.summary_serialization._plots import (
+    AccelStatisticsLike,
     PhaseSegmentLike,
     PhaseSpeedBreakdownRowLike,
     PlotDataResultLike,
     SpeedBreakdownRowLike,
-)
-from vibesensor.shared.boundaries.summary_serialization._summary import (
-    AccelStatisticsLike,
-    AnalysisSummaryBuildContext,
+    build_analysis_summary,
+    serialize_plot_data,
 )
 from vibesensor.shared.boundaries.summary_warning import summary_warning_payloads
 from vibesensor.shared.boundaries.test_plan_projection import step_payloads_from_plan
@@ -151,37 +146,35 @@ def analysis_summary_with_warnings(
 
 def analysis_result_to_summary(result: AnalysisResultLike) -> AnalysisSummary:
     """Serialize an app-level diagnostics result at an explicit boundary."""
-    summary = build_summary_payload(
-        AnalysisSummaryBuildContext(
-            file_name=result.file_name,
-            run_id=result.prepared.run_id,
-            samples=list(result.samples),
-            duration_s=result.prepared.duration_s,
-            language=result.language,
-            metadata=result.metadata,
-            raw_sample_rate_hz=result.prepared.raw_sample_rate_hz,
-            speed_breakdown=result.prepared.speed_breakdown,
-            phase_speed_breakdown=result.prepared.phase_speed_breakdown,
-            phase_segments=result.prepared.phase_segments,
-            run_noise_baseline_g=result.prepared.run_noise_baseline_g,
-            speed_breakdown_skipped_reason=result.prepared.speed_breakdown_skipped_reason,
-            findings=result.test_run.findings,
-            top_causes=result.test_run.top_causes,
-            most_likely_origin=result.most_likely_origin,
-            test_plan=step_payloads_from_plan(result.test_run.test_plan),
-            phase_timeline=list(result.phase_timeline),
-            speed_stats=result.summary_speed_stats,
-            speed_stats_by_phase=dict(result.prepared.speed_stats_by_phase),
-            phase_info=result.summary_phase_info,
-            sensor_locations=list(result.sensor_locations),
-            connected_locations=set(result.connected_locations),
-            sensor_intensity_by_location=list(result.sensor_intensity_by_location),
-            run_suitability=result.run_suitability,
-            speed_values=result.prepared.speed_values,
-            speed_non_null_pct=result.prepared.speed_non_null_pct,
-            accel_stats=result.accel_stats,
-            amp_metric_values=_amp_metric_values(result.accel_stats),
-        )
+    summary = build_analysis_summary(
+        file_name=result.file_name,
+        run_id=result.prepared.run_id,
+        samples=list(result.samples),
+        duration_s=result.prepared.duration_s,
+        language=result.language,
+        metadata=result.metadata,
+        raw_sample_rate_hz=result.prepared.raw_sample_rate_hz,
+        speed_breakdown=result.prepared.speed_breakdown,
+        phase_speed_breakdown=result.prepared.phase_speed_breakdown,
+        phase_segments=result.prepared.phase_segments,
+        run_noise_baseline_g=result.prepared.run_noise_baseline_g,
+        speed_breakdown_skipped_reason=result.prepared.speed_breakdown_skipped_reason,
+        findings=result.test_run.findings,
+        top_causes=result.test_run.top_causes,
+        most_likely_origin=result.most_likely_origin,
+        test_plan=step_payloads_from_plan(result.test_run.test_plan),
+        phase_timeline=list(result.phase_timeline),
+        speed_stats=result.summary_speed_stats,
+        speed_stats_by_phase=dict(result.prepared.speed_stats_by_phase),
+        phase_info=result.summary_phase_info,
+        sensor_locations=list(result.sensor_locations),
+        connected_locations=set(result.connected_locations),
+        sensor_intensity_by_location=list(result.sensor_intensity_by_location),
+        run_suitability=result.run_suitability,
+        speed_values=result.prepared.speed_values,
+        speed_non_null_pct=result.prepared.speed_non_null_pct,
+        accel_stats=result.accel_stats,
+        amp_metric_values=_amp_metric_values(result.accel_stats),
     )
     summary["warnings"] = summary_warning_payloads(
         build_summary_warnings(

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/__init__.py
@@ -1,11 +1,11 @@
-"""Summary payload serialization boundary package.
-
-This package keeps the historical import path stable while splitting the
-serialization boundary into focused modules.
-"""
+"""Stable public API for summary payload serialization helpers."""
 
 from ._findings import annotate_peaks_with_order_labels, serialize_findings
 from ._plots import (
+    PhaseSegmentLike,
+    PhaseSpeedBreakdownRowLike,
+    PlotDataResultLike,
+    SpeedBreakdownRowLike,
     serialize_peak_table,
     serialize_phase_segments,
     serialize_phase_speed_breakdown,
@@ -14,19 +14,22 @@ from ._plots import (
     serialize_speed_breakdown,
 )
 from ._summary import (
-    AnalysisSummaryBuildContext,
+    AccelStatisticsLike,
+    build_analysis_summary,
     build_data_quality_dict,
-    build_summary_payload,
     noise_baseline_db,
     serialize_origin_summary,
 )
 
 __all__ = [
-    "AnalysisSummaryBuildContext",
+    "AccelStatisticsLike",
     "annotate_peaks_with_order_labels",
+    "build_analysis_summary",
     "build_data_quality_dict",
-    "build_summary_payload",
     "noise_baseline_db",
+    "PhaseSegmentLike",
+    "PhaseSpeedBreakdownRowLike",
+    "PlotDataResultLike",
     "serialize_findings",
     "serialize_origin_summary",
     "serialize_peak_table",
@@ -35,4 +38,5 @@ __all__ = [
     "serialize_plot_data",
     "serialize_speed_breakdown",
     "serialize_spectrogram",
+    "SpeedBreakdownRowLike",
 ]

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -109,6 +109,73 @@ class AnalysisSummaryBuildContext:
     amp_metric_values: list[float]
 
 
+def build_analysis_summary(
+    *,
+    file_name: str,
+    run_id: str,
+    samples: Sequence[JsonObject],
+    duration_s: float,
+    language: str,
+    metadata: JsonObject,
+    raw_sample_rate_hz: float | None,
+    speed_breakdown: Sequence[SpeedBreakdownRowLike],
+    phase_speed_breakdown: Sequence[PhaseSpeedBreakdownRowLike],
+    phase_segments: Sequence[PhaseSegmentLike],
+    run_noise_baseline_g: float | None,
+    speed_breakdown_skipped_reason: JsonObject | None,
+    findings: tuple[DomainFinding, ...],
+    top_causes: tuple[DomainFinding, ...],
+    most_likely_origin: VibrationOrigin | None,
+    test_plan: list[TestPlanStepPayload],
+    phase_timeline: Sequence[DrivingPhaseInterval],
+    speed_stats: SpeedProfileSummary,
+    speed_stats_by_phase: Mapping[str, SpeedProfileSummary],
+    phase_info: DrivingPhaseSummary,
+    sensor_locations: list[str],
+    connected_locations: Collection[str],
+    sensor_intensity_by_location: Sequence[LocationIntensitySummary],
+    run_suitability: RunSuitability | None,
+    speed_values: list[float],
+    speed_non_null_pct: float,
+    accel_stats: AccelStatisticsLike,
+    amp_metric_values: list[float],
+) -> AnalysisSummary:
+    """Stable public entrypoint for assembling an analysis summary payload."""
+
+    return build_summary_payload(
+        AnalysisSummaryBuildContext(
+            file_name=file_name,
+            run_id=run_id,
+            samples=samples,
+            duration_s=duration_s,
+            language=language,
+            metadata=metadata,
+            raw_sample_rate_hz=raw_sample_rate_hz,
+            speed_breakdown=speed_breakdown,
+            phase_speed_breakdown=phase_speed_breakdown,
+            phase_segments=phase_segments,
+            run_noise_baseline_g=run_noise_baseline_g,
+            speed_breakdown_skipped_reason=speed_breakdown_skipped_reason,
+            findings=findings,
+            top_causes=top_causes,
+            most_likely_origin=most_likely_origin,
+            test_plan=test_plan,
+            phase_timeline=phase_timeline,
+            speed_stats=speed_stats,
+            speed_stats_by_phase=speed_stats_by_phase,
+            phase_info=phase_info,
+            sensor_locations=sensor_locations,
+            connected_locations=connected_locations,
+            sensor_intensity_by_location=sensor_intensity_by_location,
+            run_suitability=run_suitability,
+            speed_values=speed_values,
+            speed_non_null_pct=speed_non_null_pct,
+            accel_stats=accel_stats,
+            amp_metric_values=amp_metric_values,
+        )
+    )
+
+
 def _float_list(stats: AccelStatisticsLike, key: str) -> list[float]:
     value = stats.get(key)
     if not isinstance(value, list):


### PR DESCRIPTION
## Summary
Closes #1469.

This PR hides the `summary_serialization` package’s internal build-context wiring behind a stable public entrypoint. Before this change, the main caller in `shared/boundaries/analysis_summary.py` had to import `AnalysisSummaryBuildContext`, manually assemble that large dataclass, and then call `build_summary_payload()` directly. It also imported protocol types from the private `_summary.py` and `_plots.py` submodules. The result was that the package-level API exposed an internal context object and encouraged callers to know too much about the serializer’s internal assembly shape.

The fix keeps payload behavior the same while making the boundary clearer:

- `summary_serialization` now exposes a stable `build_analysis_summary(...)` entrypoint for callers.
- `analysis_summary.py` builds summaries through that entrypoint instead of constructing `AnalysisSummaryBuildContext` directly.
- The package root now exports only the stable entrypoint plus the protocol/type surfaces the caller actually needs.
- The internal `AnalysisSummaryBuildContext` and `build_summary_payload()` are no longer part of the package-level public API.

## Problem being solved
Issue #1469 called out a public-boundary leak in the summary serializer package.

`apps/server/vibesensor/shared/boundaries/summary_serialization/__init__.py` was exporting both `AnalysisSummaryBuildContext` and `build_summary_payload()`. That meant callers could, and did, rely on a large internal context dataclass whose job is really just to carry already-computed artifacts into the serializer implementation. The main external caller, `apps/server/vibesensor/shared/boundaries/analysis_summary.py`, was doing exactly that: importing the context type, importing the internal plot/stat protocols from private submodules, and manually wiring every field into the context before calling the payload builder.

That is brittle for two reasons.

First, it couples callers to internal serializer structure. Any future work to split or reshape the summary serializer would have to preserve the exact build-context contract or churn the call sites.

Second, it blurs the public seam. The package already has a stable import path and package-level exports, but the most important caller was still reaching into `_summary.py` and `_plots.py` internals. That defeats the point of the boundary package.

The issue is intentionally narrow, so this PR does not rewrite summary serialization or change the payload schema. It just puts a stable, clearer public API in front of the existing internals and moves the one real caller onto that seam.

## Implementation approach
I took the smallest complete approach that actually hides the internal build context.

In `apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py`, I added a new public helper:

- `build_analysis_summary(...)`

This function takes the already-computed summary ingredients as explicit keyword arguments and, internally, constructs `AnalysisSummaryBuildContext` before delegating to the existing `build_summary_payload()` implementation.

That choice matters because it keeps the internal dataclass intact for implementation purposes while moving callers off of it. Future serializer refactors can now change the internal context assembly without forcing callers to know about those details, as long as `build_analysis_summary(...)` keeps its outward contract.

I intentionally did not change the payload-building logic itself. `build_summary_payload()` still assembles the exact summary structure it did before; it is just no longer exported as part of the package-level API.

## Main code changes by area
In `apps/server/vibesensor/shared/boundaries/summary_serialization/__init__.py`, I narrowed and clarified the package exports.

The package now exports:

- `build_analysis_summary`
- `AccelStatisticsLike`
- `SpeedBreakdownRowLike`
- `PhaseSpeedBreakdownRowLike`
- `PhaseSegmentLike`
- `PlotDataResultLike`
- the existing serialization helpers that are still intended to be public

The package no longer exports:

- `AnalysisSummaryBuildContext`
- `build_summary_payload`

That means package consumers no longer see the internal build-context object or the lower-level assembly function as part of the supported API.

In `apps/server/vibesensor/shared/boundaries/analysis_summary.py`, I updated the imports so the module depends only on the package-level `summary_serialization` API instead of private submodules. It now imports the needed protocol types from the package root and calls `build_analysis_summary(...)` directly.

The main behavioral refactor is in `analysis_result_to_summary()`. Instead of constructing `AnalysisSummaryBuildContext(...)` inline and passing it to `build_summary_payload()`, the function now passes the same data into `build_analysis_summary(...)`. The warning replacement, report-date normalization, plot serialization, and optional sample stripping all stay exactly where they were. So the change is about boundary ownership, not about moving the rest of the result-to-summary flow.

## Tests and validation
I added two focused tests for this boundary cleanup.

In `apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py`, I added a new direct test for `build_analysis_summary(...)`. It constructs a minimal but real set of summary inputs using the domain types already used elsewhere and verifies the new public entrypoint produces a valid summary with the expected core fields.

In `apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py`, I added a hygiene assertion that the package exposes `build_analysis_summary` but no longer exposes `AnalysisSummaryBuildContext` or `build_summary_payload` at the package root. That locks in the main architectural outcome of the issue.

Then I ran targeted and broader validation:

- `ruff check` on the touched boundary and test files
- `pytest -q apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py apps/server/tests/use_cases/diagnostics/test_run_analysis.py`
- `pytest -q apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_decode_project_roundtrip.py`
- `make typecheck-backend`

These checks cover the new public entrypoint directly, guard the package API shape, exercise the main diagnostics summary path, verify the report contract and decode/project roundtrips, and ensure mypy still accepts the boundary types after the import cleanup.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff is that `build_analysis_summary(...)` still accepts a fairly large set of arguments. That is deliberate. The issue asked to hide the internal build-context object, not to redesign the entire summary input model. A thin public wrapper over the current internals is the safest way to narrow the public API now while keeping later refactors possible.

This PR also leaves the internal `AnalysisSummaryBuildContext` dataclass and `build_summary_payload()` function in place inside `_summary.py`. They are still useful implementation tools; they are just no longer presented as the supported package-level boundary.

Out of scope for this issue:

- changing any summary payload fields
- restructuring the deeper `_summary.py`, `_plots.py`, or `_findings.py` implementation internals
- changing report preparation or HTTP projection behavior

So the result is intentionally focused: callers now use a stable package-level summary-building entrypoint, the package root stops advertising its internal build context, and the outward summary/report contract stays unchanged.
