### PR TITLE
Split location-intensity payload projection out of summary_serialization._summary

### DIFF
--- a/apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py
+++ b/apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from vibesensor.domain import (
+    LocationIntensitySummary,
+    PhaseIntensitySummary,
+    StrengthBucketDistribution,
+)
+from vibesensor.shared.boundaries.summary_serialization._location_intensity import (
+    serialize_location_intensity_rows,
+)
+
+
+def test_serialize_location_intensity_rows_projects_populated_row() -> None:
+    payload = serialize_location_intensity_rows(
+        [
+            LocationIntensitySummary(
+                location="rear-left",
+                partial_coverage=True,
+                sample_count=8,
+                sample_coverage_ratio=0.75,
+                sample_coverage_warning=True,
+                mean_intensity_db=11.5,
+                p50_intensity_db=10.0,
+                p95_intensity_db=18.0,
+                max_intensity_db=22.0,
+                dropped_frames_delta=2.0,
+                queue_overflow_drops_delta=1.0,
+                strength_bucket_distribution=StrengthBucketDistribution(
+                    total=8,
+                    counts={"l0": 2, "l1": 6},
+                    percent_time_l0=25.0,
+                    percent_time_l1=75.0,
+                ),
+                phase_intensity={
+                    "cruise": PhaseIntensitySummary(
+                        count=3,
+                        mean_intensity_db=12.0,
+                        max_intensity_db=18.0,
+                    )
+                },
+            )
+        ]
+    )
+
+    assert payload == [
+        {
+            "location": "rear-left",
+            "partial_coverage": True,
+            "sample_count": 8,
+            "sample_coverage_ratio": 0.75,
+            "sample_coverage_warning": True,
+            "mean_intensity_db": 11.5,
+            "p50_intensity_db": 10.0,
+            "p95_intensity_db": 18.0,
+            "max_intensity_db": 22.0,
+            "dropped_frames_delta": 2.0,
+            "queue_overflow_drops_delta": 1.0,
+            "strength_bucket_distribution": {
+                "total": 8,
+                "counts": {"l0": 2, "l1": 6},
+                "percent_time_l0": 25.0,
+                "percent_time_l1": 75.0,
+                "percent_time_l2": 0.0,
+                "percent_time_l3": 0.0,
+                "percent_time_l4": 0.0,
+                "percent_time_l5": 0.0,
+            },
+            "phase_intensity": {
+                "cruise": {
+                    "count": 3,
+                    "mean_intensity_db": 12.0,
+                    "max_intensity_db": 18.0,
+                }
+            },
+        }
+    ]
+
+
+def test_serialize_location_intensity_rows_projects_sparse_row_defaults() -> None:
+    payload = serialize_location_intensity_rows([LocationIntensitySummary(location="front-left")])
+
+    assert payload == [
+        {
+            "location": "front-left",
+            "partial_coverage": False,
+            "sample_count": 0,
+            "sample_coverage_ratio": 0.0,
+            "sample_coverage_warning": False,
+            "mean_intensity_db": None,
+            "p50_intensity_db": None,
+            "p95_intensity_db": None,
+            "max_intensity_db": None,
+            "dropped_frames_delta": None,
+            "queue_overflow_drops_delta": None,
+            "strength_bucket_distribution": {
+                "total": 0,
+                "counts": {},
+                "percent_time_l0": 0.0,
+                "percent_time_l1": 0.0,
+                "percent_time_l2": 0.0,
+                "percent_time_l3": 0.0,
+                "percent_time_l4": 0.0,
+                "percent_time_l5": 0.0,
+            },
+            "phase_intensity": None,
+        }
+    ]

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_location_intensity.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_location_intensity.py
@@ -1,0 +1,64 @@
+"""Focused helpers for serializing location-intensity summary rows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from vibesensor.domain import LocationIntensitySummary
+from vibesensor.shared.types.history_analysis_contracts import (
+    LocationIntensitySummaryResponse as LocationIntensitySummaryPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    PhaseIntensityStatsResponse as PhaseIntensityStatsPayload,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    StrengthBucketDistributionResponse as StrengthBucketDistributionPayload,
+)
+
+
+def _location_intensity_summary_payload(
+    row: LocationIntensitySummary,
+) -> LocationIntensitySummaryPayload:
+    bucket_distribution: StrengthBucketDistributionPayload = {
+        "total": row.strength_bucket_distribution.total,
+        "counts": dict(row.strength_bucket_distribution.counts),
+        "percent_time_l0": row.strength_bucket_distribution.percent_time_l0,
+        "percent_time_l1": row.strength_bucket_distribution.percent_time_l1,
+        "percent_time_l2": row.strength_bucket_distribution.percent_time_l2,
+        "percent_time_l3": row.strength_bucket_distribution.percent_time_l3,
+        "percent_time_l4": row.strength_bucket_distribution.percent_time_l4,
+        "percent_time_l5": row.strength_bucket_distribution.percent_time_l5,
+    }
+    phase_intensity: dict[str, PhaseIntensityStatsPayload] | None = None
+    if row.phase_intensity:
+        phase_intensity = {
+            phase: {
+                "count": stats.count,
+                "mean_intensity_db": stats.mean_intensity_db,
+                "max_intensity_db": stats.max_intensity_db,
+            }
+            for phase, stats in row.phase_intensity.items()
+        }
+    return {
+        "location": row.location,
+        "partial_coverage": row.partial_coverage,
+        "sample_count": row.sample_count,
+        "sample_coverage_ratio": row.sample_coverage_ratio,
+        "sample_coverage_warning": row.sample_coverage_warning,
+        "mean_intensity_db": row.mean_intensity_db,
+        "p50_intensity_db": row.p50_intensity_db,
+        "p95_intensity_db": row.p95_intensity_db,
+        "max_intensity_db": row.max_intensity_db,
+        "dropped_frames_delta": row.dropped_frames_delta,
+        "queue_overflow_drops_delta": row.queue_overflow_drops_delta,
+        "strength_bucket_distribution": bucket_distribution,
+        "phase_intensity": phase_intensity,
+    }
+
+
+def serialize_location_intensity_rows(
+    rows: Sequence[LocationIntensitySummary],
+) -> list[LocationIntensitySummaryPayload]:
+    """Project location-intensity domain rows into summary payload rows."""
+
+    return [_location_intensity_summary_payload(row) for row in rows]

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py
@@ -32,22 +32,13 @@ from vibesensor.shared.types.history_analysis_contracts import (
     PayloadValue,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
-    LocationIntensitySummaryResponse as LocationIntensitySummaryPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
     PhaseInfoResponse as PhaseInfoPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    PhaseIntensityStatsResponse as PhaseIntensityStatsPayload,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     PhaseTimelineEntryResponse as PhaseTimelineEntryPayload,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     SpeedStatsResponse as SpeedStatsPayload,
-)
-from vibesensor.shared.types.history_analysis_contracts import (
-    StrengthBucketDistributionResponse as StrengthBucketDistributionPayload,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     TestPlanStepResponse as TestPlanStepPayload,
@@ -57,6 +48,7 @@ from vibesensor.vibration_strength import compute_db
 
 from ._data_quality import AccelStatisticsLike, build_data_quality_dict
 from ._findings import serialize_findings
+from ._location_intensity import serialize_location_intensity_rows
 from ._plots import (
     PhaseSegmentLike,
     PhaseSpeedBreakdownRowLike,
@@ -229,46 +221,6 @@ def _phase_info_payload(phase_info: DrivingPhaseSummary) -> PhaseInfoPayload:
     }
 
 
-def _location_intensity_summary_payload(
-    row: LocationIntensitySummary,
-) -> LocationIntensitySummaryPayload:
-    bucket_distribution: StrengthBucketDistributionPayload = {
-        "total": row.strength_bucket_distribution.total,
-        "counts": dict(row.strength_bucket_distribution.counts),
-        "percent_time_l0": row.strength_bucket_distribution.percent_time_l0,
-        "percent_time_l1": row.strength_bucket_distribution.percent_time_l1,
-        "percent_time_l2": row.strength_bucket_distribution.percent_time_l2,
-        "percent_time_l3": row.strength_bucket_distribution.percent_time_l3,
-        "percent_time_l4": row.strength_bucket_distribution.percent_time_l4,
-        "percent_time_l5": row.strength_bucket_distribution.percent_time_l5,
-    }
-    phase_intensity: dict[str, PhaseIntensityStatsPayload] | None = None
-    if row.phase_intensity:
-        phase_intensity = {
-            phase: {
-                "count": stats.count,
-                "mean_intensity_db": stats.mean_intensity_db,
-                "max_intensity_db": stats.max_intensity_db,
-            }
-            for phase, stats in row.phase_intensity.items()
-        }
-    return {
-        "location": row.location,
-        "partial_coverage": row.partial_coverage,
-        "sample_count": row.sample_count,
-        "sample_coverage_ratio": row.sample_coverage_ratio,
-        "sample_coverage_warning": row.sample_coverage_warning,
-        "mean_intensity_db": row.mean_intensity_db,
-        "p50_intensity_db": row.p50_intensity_db,
-        "p95_intensity_db": row.p95_intensity_db,
-        "max_intensity_db": row.max_intensity_db,
-        "dropped_frames_delta": row.dropped_frames_delta,
-        "queue_overflow_drops_delta": row.queue_overflow_drops_delta,
-        "strength_bucket_distribution": bucket_distribution,
-        "phase_intensity": phase_intensity,
-    }
-
-
 def serialize_origin_summary(
     origin: VibrationOrigin | None,
 ) -> SuspectedVibrationOrigin:
@@ -368,9 +320,9 @@ def build_summary_payload(context: AnalysisSummaryBuildContext) -> AnalysisSumma
         "sensor_locations": context.sensor_locations,
         "sensor_locations_connected_throughout": sorted(context.connected_locations),
         "sensor_count_used": len(context.sensor_locations),
-        "sensor_intensity_by_location": [
-            _location_intensity_summary_payload(row) for row in context.sensor_intensity_by_location
-        ],
+        "sensor_intensity_by_location": serialize_location_intensity_rows(
+            context.sensor_intensity_by_location
+        ),
         "run_suitability": run_suitability_payload(context.run_suitability),
         "samples": _json_objects(context.samples),
         "data_quality": build_data_quality_dict(


### PR DESCRIPTION
## Summary
Closes #1471.

This PR extracts location-intensity payload projection out of `summary_serialization._summary` into a focused sibling module, `summary_serialization._location_intensity`, while preserving the existing summary payload contract and report-facing behavior.

Before this change, `_summary.py` still owned the nested payload projection for `sensor_intensity_by_location`, including:

- flattening `LocationIntensitySummary` domain rows into payload rows
- projecting the nested `strength_bucket_distribution`
- projecting optional per-phase intensity stats under `phase_intensity`

That meant `_summary.py` was still carrying one more substantial nested-contract concern even after the recent summary-serialization cleanup work moved other responsibilities onto focused seams. This PR leaves the top-level assembler behavior intact but moves the location-intensity shape knowledge into its own module.

## Problem being solved
The issue here is structural, not behavioral.

`apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py` is responsible for assembling the top-level `AnalysisSummary` payload. Over time it also accumulated a series of nested payload builders. The recent backlog items already started reducing that sprawl:

- `#1469` hid the internal build-context wiring behind a stable public entrypoint
- `#1470` moved `data_quality` projection into `summary_serialization/_data_quality.py`

After those changes, the remaining inlined location-intensity projector stood out as the next unrelated nested concern still living in `_summary.py`. The helper `_location_intensity_summary_payload()` knew how to translate domain `LocationIntensitySummary` rows into boundary payloads, including the bucket-distribution sub-payload and optional per-phase intensity mappings. That logic is conceptually distinct from top-level summary assembly and has its own reasons to change over time.

Keeping it inside `_summary.py` made the summary assembler a default home for unrelated shared-serialization details. The goal of this issue is to keep `_summary.py` focused on assembling the whole summary while moving the nested location-intensity contract logic behind a focused seam.

## Implementation approach
I took the same narrow extraction approach that worked well for `#1470`.

I created a new internal module:

- `apps/server/vibesensor/shared/boundaries/summary_serialization/_location_intensity.py`

This new module now owns the location-intensity payload projection logic. It contains:

- a row-level projector for one `LocationIntensitySummary`
- `serialize_location_intensity_rows(...)`, which converts a sequence of domain rows into summary payload rows

The module owns all of the payload-shape knowledge for this concern, including:

- strength bucket distribution projection
- optional phase-intensity projection
- flat row field projection for sample counts, coverage flags, p50/p95/max intensity values, and drop counters

Then, in `_summary.py`, I removed the inlined `_location_intensity_summary_payload()` helper and replaced the list comprehension logic with a single delegation to `serialize_location_intensity_rows(...)`.

That keeps the top-level summary assembly flow stable while reducing the amount of nested payload detail `_summary.py` has to carry directly.

## Main code changes by area
In `apps/server/vibesensor/shared/boundaries/summary_serialization/_location_intensity.py`, I added the new focused serializer module. It imports the domain `LocationIntensitySummary` type and the shared history-analysis response payload types needed for the nested row projection.

The main exported helper in that module is `serialize_location_intensity_rows(...)`. Internally it uses a row-level helper to construct the exact payload structure the summary contract already expects. The output fields are unchanged:

- `location`
- `partial_coverage`
- `sample_count`
- `sample_coverage_ratio`
- `sample_coverage_warning`
- `mean_intensity_db`
- `p50_intensity_db`
- `p95_intensity_db`
- `max_intensity_db`
- `dropped_frames_delta`
- `queue_overflow_drops_delta`
- `strength_bucket_distribution`
- `phase_intensity`

In `apps/server/vibesensor/shared/boundaries/summary_serialization/_summary.py`, I removed the inlined helper and the payload-only imports that were only needed for the location-intensity shape. The top-level `build_summary_payload()` function now delegates the `sensor_intensity_by_location` field assembly through the extracted module.

This keeps `_summary.py` centered on whole-summary assembly instead of nested location-intensity formatting details.

I intentionally did **not** add anything to the package-level `summary_serialization` public API. Unlike `build_data_quality_dict()`, which was already publicly exported before its extraction, the location-intensity helper was previously private and has only one caller. So the smallest maintainable change here is an internal focused module, not a broader public API addition.

## Tests and validation
Because this issue specifically calls out the nested location-intensity contract, I added a focused test module:

- `apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py`

That file covers the two key scenarios from the issue acceptance criteria.

First, it verifies a **populated** domain row projects correctly, including:

- strength bucket distribution totals and counts
- non-zero bucket percentages
- phase-intensity projection under `phase_intensity`
- the main intensity and coverage fields

Second, it verifies a **sparse/default** domain row still projects correctly, including:

- empty/default strength-bucket fields
- `phase_intensity` staying `None`
- default coverage/sample/intensity values staying intact

Then I ran targeted regressions around the summary/report seam:

- `ruff check` on the touched serializer and test files
- `pytest -q apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py apps/server/tests/use_cases/diagnostics/test_run_analysis.py apps/server/tests/adapters/pdf/test_report_sensor_location_stats.py apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py`

Those targeted tests matter because they directly exercise the new serializer seam, the public summary builder, the core diagnostics summary path, the report-facing sensor-location stats, and the phase-intensity behavior that this extraction must preserve.

I also ran broader contract validation:

- `pytest -q apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_decode_project_roundtrip.py`
- `make typecheck-backend`

These broader checks confirm the analysis summary contract, report roundtrips, and backend typing all remain stable after the extraction.

## Risks, tradeoffs, and out-of-scope items
The main tradeoff is that this PR is intentionally structural. It does not redesign the location-intensity payload or add a new package-level public API for it. That is deliberate because the issue is about isolating a concern, not broadening the shared boundary surface.

The upside is low risk: the extracted logic is the same logic, just moved to a focused module and called through a delegation point. The output contract is unchanged, and the relevant report-facing tests prove the nested payload still behaves the same for both bucket distribution and per-phase intensity data.

Out of scope for this PR:

- changing dB semantics or bucket definitions
- changing the `sensor_intensity_by_location` schema
- altering report rendering behavior beyond preserving the existing payload
- a full rewrite of summary serialization internals

So the result is a small, cohesive cleanup: `_summary.py` loses another unrelated nested-contract concern, location-intensity projection now lives in its own focused module, and the outward summary/report contract stays the same.
