### PR TITLE
Separate SettingsStore sensor CRUD

### DIFF
--- a/apps/server/tests/infra/config/test_sensor_settings.py
+++ b/apps/server/tests/infra/config/test_sensor_settings.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import RLock
+
+import pytest
+
+from vibesensor.infra.config.sensor_settings import (
+    SensorSettingsService,
+    SensorSettingsState,
+)
+from vibesensor.infra.config.settings_transaction import update_with_rollback
+from vibesensor.shared.exceptions import PersistenceError
+
+
+def _sensor_settings_service(
+    *,
+    persist: Callable[[], None] | None = None,
+) -> SensorSettingsService:
+    lock = RLock()
+    state = SensorSettingsState()
+
+    def _persist() -> None:
+        if persist is not None:
+            persist()
+
+    def _update_with_rollback(**kwargs: object):
+        return update_with_rollback(lock=lock, persist=_persist, **kwargs)
+
+    return SensorSettingsService(
+        lock=lock,
+        state=state,
+        update_with_rollback=_update_with_rollback,
+    )
+
+
+def test_sensor_settings_set_and_get_sensor() -> None:
+    settings = _sensor_settings_service()
+
+    settings.set_sensor(
+        "aa:bb:cc:dd:ee:ff",
+        {"name": "FL Wheel", "location_code": "front_left_wheel"},
+    )
+
+    sensors = settings.get_sensors()
+    assert "aabbccddeeff" in sensors
+    assert sensors["aabbccddeeff"]["name"] == "FL Wheel"
+    assert sensors["aabbccddeeff"]["location_code"] == "front_left_wheel"
+
+
+def test_sensor_settings_rejects_duplicate_location() -> None:
+    settings = _sensor_settings_service()
+    settings.set_sensor("aa:bb:cc:dd:ee:ff", {"location_code": "front_left_wheel"})
+
+    with pytest.raises(ValueError, match="already assigned"):
+        settings.set_sensor("11:22:33:44:55:66", {"location_code": "front_left_wheel"})
+
+
+def test_sensor_settings_remove_sensor() -> None:
+    settings = _sensor_settings_service()
+    settings.set_sensor("aa:bb:cc:dd:ee:ff", {"name": "Test"})
+
+    assert settings.remove_sensor("aa:bb:cc:dd:ee:ff") is True
+    assert settings.remove_sensor("aa:bb:cc:dd:ee:ff") is False
+
+
+def test_sensor_settings_creates_entry_with_defaults() -> None:
+    settings = _sensor_settings_service()
+
+    settings.set_sensor("aa:bb:cc:dd:ee:ff", {})
+
+    sensors = settings.get_sensors()
+    assert "aabbccddeeff" in sensors
+    assert sensors["aabbccddeeff"]["name"] == "aabbccddeeff"
+
+
+def _raise_persistence_error() -> None:
+    raise PersistenceError("disk full")
+
+
+def test_sensor_settings_rolls_back_new_sensor_on_persist_error() -> None:
+    settings = _sensor_settings_service(persist=_raise_persistence_error)
+
+    with pytest.raises(PersistenceError, match="disk full"):
+        settings.set_sensor("aa:bb:cc:dd:ee:ff", {"name": "FL Wheel"})
+
+    assert settings.get_sensors() == {}

--- a/apps/server/vibesensor/infra/config/sensor_settings.py
+++ b/apps/server/vibesensor/infra/config/sensor_settings.py
@@ -1,0 +1,165 @@
+"""Sensor metadata CRUD extracted into an explicit collaborator."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from threading import RLock
+
+from vibesensor.domain import Sensor, SensorPlacement, normalize_sensor_id
+from vibesensor.infra.config.car_settings import _clamp_str, _UpdateWithRollback
+from vibesensor.infra.location_assignment_validator import (
+    AssignedLocation,
+    LocationAssignmentValidator,
+)
+from vibesensor.shared.structured_logging import log_extra
+from vibesensor.shared.types.sensor_config import (
+    SensorConfig,
+    SensorConfigUpdatePayload,
+    SensorsByMacPayload,
+)
+
+LOGGER = logging.getLogger(__name__)
+_LOCATION_VALIDATOR = LocationAssignmentValidator()
+
+
+@dataclass(slots=True)
+class SensorSettingsState:
+    """Mutable sensor-settings state owned by ``SettingsStore``."""
+
+    sensors: dict[str, SensorConfig] = field(default_factory=dict)
+
+
+def _log_sensor_settings_change(
+    *,
+    action: str,
+    before: object,
+    after: object,
+    **fields: object,
+) -> None:
+    LOGGER.info(
+        "settings_change",
+        extra=log_extra(
+            event="settings_change",
+            settings_action=action,
+            before=before,
+            after=after,
+            **fields,
+        ),
+    )
+
+
+class SensorSettingsService:
+    """Explicit sensor CRUD collaborator used by ``SettingsStore``."""
+
+    __slots__ = ("_lock", "_state", "_update_with_rollback")
+
+    def __init__(
+        self,
+        *,
+        lock: RLock,
+        state: SensorSettingsState,
+        update_with_rollback: _UpdateWithRollback,
+    ) -> None:
+        self._lock = lock
+        self._state = state
+        self._update_with_rollback = update_with_rollback
+
+    def sensors_payload_unlocked(self) -> SensorsByMacPayload:
+        return {sensor_id: cfg.to_dict() for sensor_id, cfg in self._state.sensors.items()}
+
+    def sensor_configs_snapshot_unlocked(self) -> dict[str, SensorConfig]:
+        return {
+            sensor_id: SensorConfig.from_dict(sensor_id, cfg.to_dict())
+            for sensor_id, cfg in self._state.sensors.items()
+        }
+
+    def get_sensors(self) -> SensorsByMacPayload:
+        with self._lock:
+            return self.sensors_payload_unlocked()
+
+    def sensors(self) -> list[Sensor]:
+        with self._lock:
+            return [
+                Sensor(
+                    sensor_id=cfg.sensor_id,
+                    name=cfg.name,
+                    placement=(
+                        SensorPlacement.from_code(cfg.location_code) if cfg.location_code else None
+                    ),
+                )
+                for cfg in self._state.sensors.values()
+            ]
+
+    def set_sensor(self, mac: str, data: SensorConfigUpdatePayload) -> SensorsByMacPayload:
+        sensor_id = normalize_sensor_id(mac)
+
+        def _apply(_previous: dict[str, SensorConfig]) -> bool:
+            existing = self._state.sensors.get(sensor_id)
+            if existing is None:
+                updated = SensorConfig(sensor_id=sensor_id, name=sensor_id, location_code="")
+            else:
+                updated = SensorConfig.from_dict(sensor_id, existing.to_dict())
+            if "name" in data:
+                name = _clamp_str(data["name"], 64)
+                updated.name = name or sensor_id
+            if "location_code" in data:
+                location_code = _clamp_str(data["location_code"], 64)
+                _LOCATION_VALIDATOR.validate_assignment(
+                    owner_id=sensor_id,
+                    location_code=location_code,
+                    assigned_locations=(
+                        AssignedLocation(
+                            owner_id=other_id,
+                            owner_name=other.name or other.sensor_id,
+                            location_code=other.location_code,
+                        )
+                        for other_id, other in self._state.sensors.items()
+                    ),
+                )
+                updated.location_code = location_code
+            self._state.sensors[sensor_id] = updated
+            return True
+
+        return self._update_with_rollback(
+            snapshot=self.sensor_configs_snapshot_unlocked,
+            apply=_apply,
+            restore=lambda previous: setattr(self._state, "sensors", previous),
+            audit_log=lambda previous: _log_sensor_settings_change(
+                action="set_sensor",
+                before=(
+                    previous_sensor.to_dict()
+                    if (previous_sensor := previous.get(sensor_id)) is not None
+                    else None
+                ),
+                after=self._state.sensors[sensor_id].to_dict(),
+                sensor_id=sensor_id,
+            ),
+            result=lambda: {sensor_id: self._state.sensors[sensor_id].to_dict()},
+        )
+
+    def remove_sensor(self, mac: str) -> bool:
+        sensor_id = normalize_sensor_id(mac)
+        removed = False
+
+        def _apply(_previous: dict[str, SensorConfig]) -> bool:
+            nonlocal removed
+            removed = self._state.sensors.pop(sensor_id, None) is not None
+            return removed
+
+        return self._update_with_rollback(
+            snapshot=self.sensor_configs_snapshot_unlocked,
+            apply=_apply,
+            restore=lambda previous: setattr(self._state, "sensors", previous),
+            audit_log=lambda previous: _log_sensor_settings_change(
+                action="remove_sensor",
+                before=(
+                    previous_sensor.to_dict()
+                    if (previous_sensor := previous.get(sensor_id)) is not None
+                    else None
+                ),
+                after=None,
+                sensor_id=sensor_id,
+            ),
+            result=lambda: removed,
+        )

--- a/apps/server/vibesensor/infra/config/settings_store.py
+++ b/apps/server/vibesensor/infra/config/settings_store.py
@@ -39,21 +39,18 @@ from vibesensor.domain import (
     Car,
     CarSnapshot,
     Sensor,
-    SensorPlacement,
     SpeedSource,
-    normalize_sensor_id,
 )
 from vibesensor.infra.config.car_settings import (
     CarSettingsService,
     CarSettingsState,
-    _clamp_str,
+)
+from vibesensor.infra.config.sensor_settings import (
+    SensorSettingsService,
+    SensorSettingsState,
 )
 from vibesensor.infra.config.settings_derivation import analysis_settings_snapshot_from_aspects
 from vibesensor.infra.config.settings_transaction import update_with_rollback
-from vibesensor.infra.location_assignment_validator import (
-    AssignedLocation,
-    LocationAssignmentValidator,
-)
 from vibesensor.shared.boundaries.settings_snapshot_codec import (
     coerce_language_code as _coerce_language,
 )
@@ -92,7 +89,6 @@ from vibesensor.shared.types.speed_source_config import (
 )
 
 LOGGER = logging.getLogger(__name__)
-_LOCATION_VALIDATOR = LocationAssignmentValidator()
 
 VALID_LANGUAGES: frozenset[str] = frozenset(get_args(LanguageCode))
 """Supported UI languages — derived from ``LanguageCode``."""
@@ -133,13 +129,18 @@ class SettingsStore:
         self._db = db
         self._after_speed_source_change: Callable[[], None] | None = None
         self._car_state = CarSettingsState()
+        self._sensor_state = SensorSettingsState()
         self._speed_cfg = SpeedSourceConfig.default()
         self._language: LanguageCode = "en"
         self._speed_unit: SpeedUnitCode = "kmh"
-        self._sensors: dict[str, SensorConfig] = {}
         self._car_settings = CarSettingsService(
             lock=self._lock,
             state=self._car_state,
+            update_with_rollback=self._update_with_rollback,
+        )
+        self._sensor_settings = SensorSettingsService(
+            lock=self._lock,
+            state=self._sensor_state,
             update_with_rollback=self._update_with_rollback,
         )
 
@@ -165,7 +166,7 @@ class SettingsStore:
             self._language = _coerce_language(snapshot["language"])
             self._speed_unit = _coerce_speed_unit(snapshot["speedUnit"])
 
-            self._sensors = {
+            self._sensor_state.sensors = {
                 sensor_id: SensorConfig.from_dict(sensor_id, value)
                 for sensor_id, value in snapshot["sensorsByMac"].items()
             }
@@ -219,7 +220,7 @@ class SettingsStore:
                 **self._speed_cfg.to_dict(),
                 "language": self._language,
                 "speedUnit": self._speed_unit,
-                "sensorsByMac": {sid: s.to_dict() for sid, s in self._sensors.items()},
+                "sensorsByMac": self._sensor_settings.sensors_payload_unlocked(),
             }
 
     # -- car settings -----------------------------------------------------------
@@ -263,17 +264,7 @@ class SettingsStore:
 
     def sensors(self) -> list[Sensor]:
         """Return all configured sensors as domain ``Sensor`` value objects."""
-        with self._lock:
-            return [
-                Sensor(
-                    sensor_id=cfg.sensor_id,
-                    name=cfg.name,
-                    placement=(
-                        SensorPlacement.from_code(cfg.location_code) if cfg.location_code else None
-                    ),
-                )
-                for cfg in self._sensors.values()
-            ]
+        return self._sensor_settings.sensors()
 
     # -- speed source ----------------------------------------------------------
 
@@ -306,87 +297,13 @@ class SettingsStore:
     # -- sensors ---------------------------------------------------------------
 
     def get_sensors(self) -> SensorsByMacPayload:
-        with self._lock:
-            return {sid: s.to_dict() for sid, s in self._sensors.items()}
-
-    def _sensor_configs_snapshot_unlocked(self) -> dict[str, SensorConfig]:
-        return {
-            sensor_id: SensorConfig.from_dict(sensor_id, cfg.to_dict())
-            for sensor_id, cfg in self._sensors.items()
-        }
+        return self._sensor_settings.get_sensors()
 
     def set_sensor(self, mac: str, data: SensorConfigUpdatePayload) -> SensorsByMacPayload:
-        sensor_id = normalize_sensor_id(mac)
-
-        def _apply(_previous: dict[str, SensorConfig]) -> bool:
-            existing = self._sensors.get(sensor_id)
-            if existing is None:
-                updated = SensorConfig(sensor_id=sensor_id, name=sensor_id, location_code="")
-            else:
-                updated = SensorConfig.from_dict(sensor_id, existing.to_dict())
-            if "name" in data:
-                name = _clamp_str(data["name"], 64)
-                updated.name = name or sensor_id
-            if "location_code" in data:
-                location_code = _clamp_str(data["location_code"], 64)
-                _LOCATION_VALIDATOR.validate_assignment(
-                    owner_id=sensor_id,
-                    location_code=location_code,
-                    assigned_locations=(
-                        AssignedLocation(
-                            owner_id=other_id,
-                            owner_name=other.name or other.sensor_id,
-                            location_code=other.location_code,
-                        )
-                        for other_id, other in self._sensors.items()
-                    ),
-                )
-                updated.location_code = location_code
-            self._sensors[sensor_id] = updated
-            return True
-
-        return self._update_with_rollback(
-            snapshot=self._sensor_configs_snapshot_unlocked,
-            apply=_apply,
-            restore=lambda previous: setattr(self, "_sensors", previous),
-            audit_log=lambda previous: _log_settings_change(
-                action="set_sensor",
-                before=(
-                    previous_sensor.to_dict()
-                    if (previous_sensor := previous.get(sensor_id)) is not None
-                    else None
-                ),
-                after=self._sensors[sensor_id].to_dict(),
-                sensor_id=sensor_id,
-            ),
-            result=lambda: {sensor_id: self._sensors[sensor_id].to_dict()},
-        )
+        return self._sensor_settings.set_sensor(mac, data)
 
     def remove_sensor(self, mac: str) -> bool:
-        sensor_id = normalize_sensor_id(mac)
-        removed = False
-
-        def _apply(_previous: dict[str, SensorConfig]) -> bool:
-            nonlocal removed
-            removed = self._sensors.pop(sensor_id, None) is not None
-            return removed
-
-        return self._update_with_rollback(
-            snapshot=self._sensor_configs_snapshot_unlocked,
-            apply=_apply,
-            restore=lambda previous: setattr(self, "_sensors", previous),
-            audit_log=lambda previous: _log_settings_change(
-                action="remove_sensor",
-                before=(
-                    previous_sensor.to_dict()
-                    if (previous_sensor := previous.get(sensor_id)) is not None
-                    else None
-                ),
-                after=None,
-                sensor_id=sensor_id,
-            ),
-            result=lambda: removed,
-        )
+        return self._sensor_settings.remove_sensor(mac)
 
     @property
     def language(self) -> LanguageCode:


### PR DESCRIPTION
## Summary

This PR closes #1473 by separating sensor CRUD from the central `SettingsStore` into a focused collaborator. Before this change, `SettingsStore` still owned inline sensor creation, updates, removal, duplicate-location validation, rollback snapshots, and domain sensor projection, even though the same module had already started shedding unrelated responsibilities through explicit collaborators such as `CarSettingsService`. This PR follows that existing direction instead of inventing a new pattern: sensor metadata now lives behind `SensorSettingsService`, while `SettingsStore` remains the persistence and snapshot owner.

## Problem being solved

`apps/server/vibesensor/infra/config/settings_store.py` had grown into a broad module that mixed several unrelated settings concerns: car profiles, active-car selection, speed-source updates, language and speed-unit preferences, persistence/rollback orchestration, and full sensor CRUD. The sensor section was especially self-contained: it carried its own payload copying, duplicate-location validation, deep-copy snapshotting for rollback, and sensor-to-domain-object projection. That made one high-churn settings concern depend directly on the central store implementation, which is exactly the kind of coupling this backlog cleanup is trying to reduce.

The issue is not that the behavior was wrong. The problem is ownership. Small sensor-assignment changes still required editing the same broad settings core that also persists the full settings snapshot and manages unrelated preference flows. The repo already had a precedent for fixing that shape: car CRUD was extracted into `CarSettingsService` while `SettingsStore` continued to own persistence and top-level snapshots. This PR applies that same idea to sensors.

## Implementation approach

I introduced a new module, `apps/server/vibesensor/infra/config/sensor_settings.py`, containing `SensorSettingsState` and `SensorSettingsService`. The state object holds the mutable sensor map that `SettingsStore` persists as part of its snapshot. The service owns sensor-specific behavior: projecting sensor payloads, taking rollback snapshots, validating duplicate location assignments, applying CRUD updates, and projecting configured sensors into domain `Sensor` value objects.

The important design choice here was to reuse the existing `SettingsStore._update_with_rollback` transaction seam instead of creating a second persistence path. `SensorSettingsService` receives the shared lock, the extracted sensor state, and the existing rollback helper. That means the new service still participates in the same persist → restore-on-error → audit-log sequence as before, but the sensor CRUD logic itself no longer lives inline in `SettingsStore`.

## Main code changes by area

In `apps/server/vibesensor/infra/config/sensor_settings.py`, I extracted the sensor-specific concerns that were previously embedded in `SettingsStore`. The new service now owns:
- payload snapshots used for `sensorsByMac`
- deep-copy snapshots used for rollback
- `get_sensors()`
- `set_sensor()`
- `remove_sensor()`
- conversion to domain `Sensor` objects for runtime readers
- duplicate-location validation via `LocationAssignmentValidator`

In `apps/server/vibesensor/infra/config/settings_store.py`, I replaced the inline sensor CRUD implementation with composition. `SettingsStore` now creates `SensorSettingsState` and `SensorSettingsService` during initialization, loads persisted sensor configs into the extracted state object, and delegates the public sensor surface to the new collaborator. The snapshot payload is intentionally unchanged: `snapshot()` still emits the same `sensorsByMac` structure, only now it gets that payload from the service instead of reconstructing it inline.

I intentionally did not change the HTTP settings endpoints, client-location endpoint behavior, shared sensor metadata protocols, or persisted settings schema. The external surface remains the same. The change is structural and ownership-focused, not behavioral.

## Tests and validation

This PR adds `apps/server/tests/infra/config/test_sensor_settings.py` with focused coverage for the new seam. Those tests exercise the extracted collaborator directly, covering sensor set/get behavior, duplicate-location rejection, deletion semantics, default-value creation, and rollback on persistence failure. That gives the new service its own targeted guardrails instead of relying only on broader `SettingsStore` integration tests.

I also kept the existing `SettingsStore`-level coverage in place and reran the settings-focused regressions that constrain this refactor. In particular, I re-ran:
- `apps/server/tests/infra/config/test_settings_store.py`
- `apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py`
- `apps/server/tests/integration/test_review_guardrails_extended_regressions.py`

Those tests matter because they cover not just isolated CRUD behavior, but also persistence, rollback behavior, and the broader runtime interactions that still flow through `SettingsStore`.

Local validation for this PR was:
- `pytest -q apps/server/tests/infra/config/test_sensor_settings.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py apps/server/tests/integration/test_review_guardrails_extended_regressions.py`
- `ruff check apps/server/vibesensor/infra/config/settings_store.py apps/server/vibesensor/infra/config/sensor_settings.py apps/server/tests/infra/config/test_sensor_settings.py`
- `make typecheck-backend`

All of those passed locally before opening the PR.

## Risks, tradeoffs, and edge cases considered

The main risk in a refactor like this is accidentally changing persistence semantics while moving logic around. I avoided that by keeping `SettingsStore` as the owner of `_persist()`, `_load()`, and the top-level snapshot contract. Sensor CRUD moved out, but persistence did not. The new service simply plugs into the existing rollback helper, so it still uses the same transaction behavior as the old inline implementation.

Another risk would have been introducing a second sensor state source. To avoid that, the extracted service works with `SensorSettingsState`, which is the canonical mutable state object owned by `SettingsStore`. That keeps snapshot loading, runtime reads, and sensor CRUD all pointed at the same state instead of drifting into parallel representations.

I also considered whether to widen the refactor into a more general “split every settings concern out of `SettingsStore`” change. I chose not to. The issue is intentionally small, and the repo guidance favors focused maintainable extractions over large opportunistic rewrites. This PR removes one clear concern from the store while preserving the current contract and leaving unrelated settings responsibilities untouched.

## Out of scope

This PR does not redesign the persisted settings snapshot schema, split out speed-source preferences, or change the HTTP endpoint surface. It also does not alter the sensor metadata protocols used elsewhere in the runtime. Those surfaces continue to work through `SettingsStore` as before; the difference is that the sensor behavior behind that surface now has its own explicit owner.

Closes #1473
