### PR TITLE
Extract client liveness and stale-retention policy from ClientRegistry

### DIFF
--- a/apps/server/tests/infra/runtime/test_client_liveness_policy.py
+++ b/apps/server/tests/infra/runtime/test_client_liveness_policy.py
@@ -1,0 +1,63 @@
+"""Tests for the extracted ClientLivenessPolicy helper."""
+
+from __future__ import annotations
+
+from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
+from vibesensor.infra.runtime.registry import ClientRecord
+
+
+def _make_record(
+    client_id: str,
+    *,
+    last_seen_mono: float,
+) -> ClientRecord:
+    return ClientRecord(
+        client_id=client_id,
+        name=f"Sensor-{client_id[:4]}",
+        last_seen_mono=last_seen_mono,
+    )
+
+
+def test_policy_clamps_retention_ttl_to_live_ttl() -> None:
+    policy = ClientLivenessPolicy(live_ttl_seconds=5.0, retention_ttl_seconds=1.0)
+
+    assert policy.live_ttl_seconds == 5.0
+    assert policy.retention_ttl_seconds == 5.0
+
+
+def test_is_live_uses_live_ttl_boundary() -> None:
+    policy = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
+    record = _make_record("001122334455", last_seen_mono=100.0)
+
+    assert policy.is_live(record, 110.0) is True
+    assert policy.is_live(record, 110.1) is False
+
+
+def test_is_retained_uses_retention_ttl_boundary() -> None:
+    policy = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
+    record = _make_record("001122334455", last_seen_mono=100.0)
+
+    assert policy.is_retained(record, 130.0) is True
+    assert policy.is_retained(record, 130.1) is False
+
+
+def test_active_client_ids_returns_live_records_in_mapping_order() -> None:
+    policy = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
+    clients = {
+        "001122334455": _make_record("001122334455", last_seen_mono=100.0),
+        "aabbccddeeff": _make_record("aabbccddeeff", last_seen_mono=90.0),
+        "112233445566": _make_record("112233445566", last_seen_mono=104.0),
+    }
+
+    assert policy.active_client_ids(clients, 105.0) == ["001122334455", "112233445566"]
+
+
+def test_stale_client_ids_ignores_never_seen_records_and_preserves_order() -> None:
+    policy = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
+    clients = {
+        "001122334455": _make_record("001122334455", last_seen_mono=60.0),
+        "aabbccddeeff": _make_record("aabbccddeeff", last_seen_mono=0.0),
+        "112233445566": _make_record("112233445566", last_seen_mono=90.0),
+    }
+
+    assert policy.stale_client_ids(clients, 100.0) == ["001122334455"]

--- a/apps/server/tests/infra/runtime/test_client_snapshot_projection.py
+++ b/apps/server/tests/infra/runtime/test_client_snapshot_projection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
 from vibesensor.infra.runtime.client_snapshot_projection import project_client_snapshots
 from vibesensor.infra.runtime.registry import ClientRecord
 
@@ -32,6 +33,9 @@ def _make_metadata(known_ids: list[str], names: dict[str, str] | None = None) ->
     return meta
 
 
+_POLICY = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
+
+
 class TestProjectClientSnapshots:
     def test_connected_record(self) -> None:
         """Active record with recent mono time → connected=True."""
@@ -39,7 +43,11 @@ class TestProjectClientSnapshots:
         clients = {rec.client_id: rec}
         meta = _make_metadata([rec.client_id])
         snaps = project_client_snapshots(
-            clients, meta, now_wall=1001.0, now_mono=105.0, live_ttl_seconds=10.0
+            clients,
+            meta,
+            now_wall=1001.0,
+            now_mono=105.0,
+            policy=_POLICY,
         )
         assert len(snaps) == 1
         assert snaps[0].connected is True
@@ -51,7 +59,11 @@ class TestProjectClientSnapshots:
         clients = {rec.client_id: rec}
         meta = _make_metadata([rec.client_id])
         snaps = project_client_snapshots(
-            clients, meta, now_wall=1100.0, now_mono=200.0, live_ttl_seconds=10.0
+            clients,
+            meta,
+            now_wall=1100.0,
+            now_mono=200.0,
+            policy=_POLICY,
         )
         assert snaps[0].connected is False
 
@@ -60,7 +72,11 @@ class TestProjectClientSnapshots:
         cid = "aabbccddeeff"
         meta = _make_metadata([cid], {cid: "My Sensor"})
         snaps = project_client_snapshots(
-            {}, meta, now_wall=1000.0, now_mono=500.0, live_ttl_seconds=10.0
+            {},
+            meta,
+            now_wall=1000.0,
+            now_mono=500.0,
+            policy=_POLICY,
         )
         assert len(snaps) == 1
         assert snaps[0].connected is False
@@ -76,7 +92,7 @@ class TestProjectClientSnapshots:
             meta,
             now_wall=1001.0,
             now_mono=105.0,
-            live_ttl_seconds=10.0,
+            policy=_POLICY,
             metrics_by_client=metrics,
         )
         assert snaps[0].latest_metrics == {"rms": 0.5}
@@ -86,6 +102,10 @@ class TestProjectClientSnapshots:
         clients = {rec.client_id: rec}
         meta = _make_metadata([rec.client_id])
         snaps = project_client_snapshots(
-            clients, meta, now_wall=1002.5, now_mono=102.5, live_ttl_seconds=10.0
+            clients,
+            meta,
+            now_wall=1002.5,
+            now_mono=102.5,
+            policy=_POLICY,
         )
         assert snaps[0].last_seen_age_ms == 2500

--- a/apps/server/vibesensor/infra/runtime/client_liveness_policy.py
+++ b/apps/server/vibesensor/infra/runtime/client_liveness_policy.py
@@ -1,0 +1,55 @@
+"""Client liveness and stale-retention policy for runtime registry state."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .registry import ClientRecord
+
+__all__ = ["ClientLivenessPolicy"]
+
+
+@dataclass(frozen=True, slots=True)
+class ClientLivenessPolicy:
+    """Own the live/retained/stale time windows for tracked clients."""
+
+    live_ttl_seconds: float = 10.0
+    retention_ttl_seconds: float = 120.0
+
+    def __post_init__(self) -> None:
+        live_ttl_seconds = max(1.0, float(self.live_ttl_seconds))
+        retention_ttl_seconds = max(live_ttl_seconds, float(self.retention_ttl_seconds))
+        object.__setattr__(self, "live_ttl_seconds", live_ttl_seconds)
+        object.__setattr__(self, "retention_ttl_seconds", retention_ttl_seconds)
+
+    def is_live(self, record: ClientRecord, mono_now: float) -> bool:
+        return bool(
+            record.last_seen_mono and (mono_now - record.last_seen_mono) <= self.live_ttl_seconds,
+        )
+
+    def is_retained(self, record: ClientRecord, mono_now: float) -> bool:
+        return bool(
+            record.last_seen_mono
+            and (mono_now - record.last_seen_mono) <= self.retention_ttl_seconds,
+        )
+
+    def active_client_ids(
+        self,
+        clients: Mapping[str, ClientRecord],
+        mono_now: float,
+    ) -> list[str]:
+        return [record.client_id for record in clients.values() if self.is_live(record, mono_now)]
+
+    def stale_client_ids(
+        self,
+        clients: Mapping[str, ClientRecord],
+        mono_now: float,
+    ) -> list[str]:
+        return [
+            client_id
+            for client_id, record in clients.items()
+            if record.last_seen_mono and not self.is_retained(record, mono_now)
+        ]

--- a/apps/server/vibesensor/infra/runtime/client_snapshot_projection.py
+++ b/apps/server/vibesensor/infra/runtime/client_snapshot_projection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 from vibesensor.shared.types.payload_types import ClientMetrics
@@ -24,7 +25,7 @@ def project_client_snapshots(
     *,
     now_wall: float,
     now_mono: float,
-    live_ttl_seconds: float,
+    policy: ClientLivenessPolicy,
     metrics_by_client: dict[str, ClientMetrics] | None = None,
 ) -> list[ClientSnapshot]:
     """Build transport-facing ``ClientSnapshot`` rows from registry state."""
@@ -41,9 +42,7 @@ def project_client_snapshots(
             )
             continue
         age_ms = int(max(0.0, now_wall - record.last_seen) * 1000) if record.last_seen else None
-        connected = bool(
-            record.last_seen_mono and (now_mono - record.last_seen_mono) <= live_ttl_seconds,
-        )
+        connected = policy.is_live(record, now_mono)
         snapshots.append(
             ClientSnapshot(
                 client_id=record.client_id,

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -16,6 +16,7 @@ from vibesensor.infra.location_assignment_validator import (
     AssignedLocation,
     LocationAssignmentValidator,
 )
+from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 from vibesensor.infra.runtime.client_snapshot_projection import project_client_snapshots
@@ -156,8 +157,10 @@ class ClientRegistry:
         retention_ttl_seconds: float = 120.0,
     ):
         self._lock = RLock()
-        self._live_ttl_seconds = max(1.0, live_ttl_seconds)
-        self._retention_ttl_seconds = max(self._live_ttl_seconds, retention_ttl_seconds)
+        self._liveness_policy = ClientLivenessPolicy(
+            live_ttl_seconds=live_ttl_seconds,
+            retention_ttl_seconds=retention_ttl_seconds,
+        )
         self._clients: dict[str, ClientRecord] = {}
         self._metadata = ClientMetadataManager(
             lock=self._lock,
@@ -174,17 +177,6 @@ class ClientRegistry:
     @staticmethod
     def _normalize_wire_client_id(client_id: bytes) -> str:
         return normalize_sensor_id(client_id.hex())
-
-    def _is_live_unlocked(self, record: ClientRecord, mono_now: float) -> bool:
-        return bool(
-            record.last_seen_mono and (mono_now - record.last_seen_mono) <= self._live_ttl_seconds,
-        )
-
-    def _is_retained_unlocked(self, record: ClientRecord, mono_now: float) -> bool:
-        return bool(
-            record.last_seen_mono
-            and (mono_now - record.last_seen_mono) <= self._retention_ttl_seconds,
-        )
 
     def _get_or_create(self, client_id: str) -> ClientRecord:
         normalized = normalize_sensor_id(client_id)
@@ -355,11 +347,7 @@ class ClientRegistry:
     ) -> list[str]:
         with self._lock:
             mono_now = _resolve_now_mono(now_mono)
-            return [
-                record.client_id
-                for record in self._clients.values()
-                if self._is_live_unlocked(record, mono_now)
-            ]
+            return self._liveness_policy.active_client_ids(self._clients, mono_now)
 
     def data_loss_snapshot(self) -> dict[str, int]:
         with self._lock:
@@ -388,11 +376,7 @@ class ClientRegistry:
     def evict_stale(self, now: float | None = None, *, now_mono: float | None = None) -> list[str]:
         with self._lock:
             mono_now = _resolve_now_mono(now_mono)
-            stale_ids = [
-                client_id
-                for client_id, record in self._clients.items()
-                if record.last_seen_mono and not self._is_retained_unlocked(record, mono_now)
-            ]
+            stale_ids = self._liveness_policy.stale_client_ids(self._clients, mono_now)
             for client_id in stale_ids:
                 self._clients.pop(client_id, None)
             return stale_ids
@@ -417,6 +401,6 @@ class ClientRegistry:
                 self._metadata,
                 now_wall=_resolve_now_wall(now),
                 now_mono=_resolve_now_mono(now_mono),
-                live_ttl_seconds=self._live_ttl_seconds,
+                policy=self._liveness_policy,
                 metrics_by_client=metrics_by_client,
             )


### PR DESCRIPTION
## Summary

This PR extracts the client liveness and stale-retention time policy out of `ClientRegistry` and moves it behind a focused runtime helper without changing the observable live/stale behavior of the registry, the processing loop, or the transport-facing client snapshots.

Before this change, the same liveness rule was encoded in two places. `ClientRegistry` owned inline TTL logic for `active_client_ids()` and `evict_stale()`, while `client_snapshot_projection.py` separately recalculated whether each snapshot should be marked `connected`. That duplication made a small TTL-policy change risky because the hot-path registry methods and the presenter path could drift. This issue asked for the smallest maintainable extraction, not a broader runtime redesign, so the fix keeps the public `ClientRegistry` API unchanged while centralizing the shared policy rule set.

## Problem being solved

The runtime already started moving focused concerns out of `ClientRegistry` into dedicated collaborators such as `ClientMetadataManager` and `registry_updates`. Liveness and stale-retention were still left inline in the registry itself, even though they are a pure policy decision over existing client state. The repo issue called out four specific expectations:

- the live/retained/stale rule should no longer live inline in `ClientRegistry`
- `active_client_ids()` must keep returning the same live clients it returned before
- `evict_stale()` must keep evicting the same stale clients it evicted before
- focused tests should cover the extracted policy directly

During issue investigation I also found a nearby blast-radius detail: `client_snapshot_projection.py` had its own duplicate live-TTL check for the `connected` field. Leaving that copy in place would have satisfied the registry extraction only partially and would have preserved two sources of truth for “live” status. Because that duplication is directly coupled to the issue’s policy concern, I treated it as in-scope and routed it through the same helper.

## Implementation approach

The implementation introduces a new immutable helper, `ClientLivenessPolicy`, in `apps/server/vibesensor/infra/runtime/client_liveness_policy.py`. The helper owns four closely related pieces of behavior:

- clamping the configured TTL values so live TTL stays at least `1.0` second and retention TTL stays at least as large as live TTL
- deciding whether an individual record is currently live
- deciding whether an individual record is still retained
- selecting the live client IDs and stale client IDs from the registry mapping while preserving existing iteration order

This keeps the policy logic together but stops short of introducing a broader service object or changing storage ownership. `ClientRegistry` still owns locking, record mutation, persistence-aware name metadata, and snapshot orchestration. The new helper only owns the liveness decision rules.

## Main code changes by area

### Runtime policy extraction

`apps/server/vibesensor/infra/runtime/client_liveness_policy.py` is the new focused module. It defines a frozen, slotted dataclass so the policy is immutable after construction and safe to share anywhere the registry needs to ask live/stale questions. The class exposes `is_live()`, `is_retained()`, `active_client_ids()`, and `stale_client_ids()`.

### ClientRegistry delegation

`apps/server/vibesensor/infra/runtime/registry.py` now constructs one `ClientLivenessPolicy` instance during initialization and stores it on the registry. The inline `_live_ttl_seconds`, `_retention_ttl_seconds`, `_is_live_unlocked()`, and `_is_retained_unlocked()` logic is removed. Instead:

- `active_client_ids()` resolves `now_mono` once and delegates the selection to `self._liveness_policy.active_client_ids(...)`
- `evict_stale()` resolves `now_mono` once and delegates stale-ID selection to `self._liveness_policy.stale_client_ids(...)` before removing those IDs from the backing dict
- `client_snapshots()` passes the same shared policy into the snapshot projector

This keeps the lock boundaries and public method signatures unchanged, so all existing runtime callers continue to use the same API surface.

### Snapshot projection

`apps/server/vibesensor/infra/runtime/client_snapshot_projection.py` now accepts the shared policy object instead of a raw `live_ttl_seconds` float. The `connected` field is derived by calling `policy.is_live(record, now_mono)`. That means the presenter path now uses the exact same liveness rule as `active_client_ids()` instead of recalculating it locally.

## Tests and validation

The change adds direct coverage for the extracted seam in `apps/server/tests/infra/runtime/test_client_liveness_policy.py`. Those tests cover TTL clamping, live boundary behavior, retained boundary behavior, live client selection order, and stale client selection while ignoring never-seen records.

I also updated `apps/server/tests/infra/runtime/test_client_snapshot_projection.py` so the projection tests now exercise the new policy-fed signature while preserving the existing expectations for connected/disconnected rows, attached metrics, and age calculation.

Existing registry behavior was intentionally left intact, so I reran `apps/server/tests/infra/runtime/test_registry.py` unchanged. I then widened validation beyond the new helper to cover nearby consumers of `active_client_ids()` and client snapshot state:

- focused Ruff checks on the touched runtime and test files
- `pytest -q tests/infra/runtime/test_client_liveness_policy.py tests/infra/runtime/test_client_snapshot_projection.py tests/infra/runtime/test_registry.py`
- `pytest -q tests/infra/runtime/test_processing_loop.py tests/infra/processing/test_sample_builder.py tests/adapters/http/test_api_ws_health_and_clients.py tests/adapters/websocket/test_build_ws_payload.py`
- `make lint`
- backend mypy via `/home/node/.venvs/vibesensor-3.14/bin/python -m mypy --config-file pyproject.toml`

## Local runtime smoke and environment notes

Repository instructions also require a local stack smoke after backend changes. I first attempted the documented Docker path with `docker compose build --pull && docker compose up -d`, but the environment here does not have a reachable Docker daemon, so that exact smoke path is blocked externally rather than by the code in this PR.

To still verify runtime behavior end to end, I used the documented native fallback path:

1. built and synced the server-served UI bundle with `python3 tools/build_ui_static.py`
2. started `vibesensor-server --config apps/server/config.dev.yaml`
3. drove the server with `vibesensor-sim --count 3 --duration 6 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
4. checked `/api/clients` before traffic, during simulator traffic, and after waiting out the live TTL window

The observed connected-client counts were `0 -> 3 -> 0`, which is the exact behavioral contract this refactor needed to preserve.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is introducing a small new runtime module for a narrow concern, but that is the explicit point of the issue and keeps future TTL-policy changes from touching both registry internals and presenter code. I intentionally did not change TTL values, health aggregation, processing-loop semantics, or the registry’s underlying storage model. Those are either explicitly out of scope for this issue or already tracked by nearby follow-up issues such as `#1493` and `#1494`.

There are no schema, API contract, or configuration-file changes in this PR. The public behavior should remain the same; the improvement is that the policy now has one home instead of two.
