### PR TITLE
Split data-loss counters and health aggregation out of ClientRegistry

### DIFF
--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -365,6 +365,44 @@ def test_registry_retains_stale_client_until_retention_ttl(tmp_path: Path) -> No
     assert registry.get("001122334455") is None
 
 
+def test_registry_data_loss_snapshot_preserves_public_counter_shape(tmp_path: Path) -> None:
+    db = HistoryDB(tmp_path / "history.db")
+    registry = ClientRegistry(db=db)
+    client_id = bytes.fromhex("001122334455")
+    hello = HelloMessage(
+        client_id=client_id,
+        control_port=9010,
+        sample_rate_hz=800,
+        name="sensor",
+        firmware_version="fw",
+        queue_overflow_drops=2,
+    )
+    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0)
+
+    samples = np.zeros((200, 3), dtype=np.int16)
+    registry.update_from_data(
+        DataMessage(client_id=client_id, seq=0, t0_us=10, sample_count=200, samples=samples),
+        ("10.4.0.2", 50000),
+        now=2.0,
+    )
+    registry.update_from_data(
+        DataMessage(client_id=client_id, seq=2, t0_us=20, sample_count=200, samples=samples),
+        ("10.4.0.2", 50000),
+        now=3.0,
+    )
+    registry.note_parse_error("001122334455")
+    registry.note_server_queue_drop("001122334455")
+
+    assert registry.data_loss_snapshot() == {
+        "tracked_clients": 1,
+        "affected_clients": 1,
+        "frames_dropped": 1,
+        "queue_overflow_drops": 2,
+        "server_queue_drops": 1,
+        "parse_errors": 1,
+    }
+
+
 def test_registry_remove_client_clears_persisted_entry(tmp_path: Path) -> None:
     db = HistoryDB(tmp_path / "history.db")
     registry = ClientRegistry(db=db)

--- a/apps/server/tests/infra/runtime/test_registry_diagnostics.py
+++ b/apps/server/tests/infra/runtime/test_registry_diagnostics.py
@@ -1,0 +1,80 @@
+"""Direct tests for the extracted RegistryDiagnostics helper."""
+
+from __future__ import annotations
+
+from threading import RLock
+
+from vibesensor.infra.runtime.registry import ClientRecord
+from vibesensor.infra.runtime.registry_diagnostics import RegistryDiagnostics
+
+
+def _make_diagnostics() -> tuple[RegistryDiagnostics, dict[str, ClientRecord]]:
+    lock = RLock()
+    clients: dict[str, ClientRecord] = {}
+
+    def get_or_create(client_id: str) -> ClientRecord:
+        record = clients.get(client_id)
+        if record is None:
+            record = ClientRecord(client_id=client_id, name=f"client-{client_id[-4:]}")
+            clients[client_id] = record
+        return record
+
+    return (
+        RegistryDiagnostics(
+            lock=lock,
+            clients=clients,
+            get_or_create=get_or_create,
+        ),
+        clients,
+    )
+
+
+def test_note_parse_error_creates_and_normalizes_client_record() -> None:
+    diagnostics, clients = _make_diagnostics()
+
+    diagnostics.note_parse_error("AABBCCDDEEFF")
+
+    record = clients["aabbccddeeff"]
+    assert record.parse_errors == 1
+    assert record.server_queue_drops == 0
+
+
+def test_note_server_queue_drop_ignores_missing_and_invalid_client_ids() -> None:
+    diagnostics, clients = _make_diagnostics()
+
+    diagnostics.note_server_queue_drop(None)
+    diagnostics.note_server_queue_drop("not-a-client-id")
+
+    assert clients == {}
+
+
+def test_data_loss_snapshot_aggregates_counters_and_affected_clients() -> None:
+    diagnostics, clients = _make_diagnostics()
+    alpha = ClientRecord(
+        client_id="001122334455",
+        name="alpha",
+        frames_dropped=2,
+        queue_overflow_drops=3,
+        server_queue_drops=1,
+    )
+    beta = ClientRecord(
+        client_id="aabbccddeeff",
+        name="beta",
+        parse_errors=4,
+    )
+    gamma = ClientRecord(
+        client_id="112233445566",
+        name="gamma",
+    )
+    clients[alpha.client_id] = alpha
+    clients[beta.client_id] = beta
+    clients[gamma.client_id] = gamma
+
+    assert diagnostics.data_loss_snapshot() == {
+        "tracked_clients": 3,
+        "affected_clients": 2,
+        "frames_dropped": 2,
+        "queue_overflow_drops": 3,
+        "server_queue_drops": 1,
+        "parse_errors": 4,
+    }

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -21,6 +21,7 @@ from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 from vibesensor.infra.runtime.client_snapshot_projection import project_client_snapshots
 from vibesensor.infra.runtime.dedup_window import DedupWindow
+from vibesensor.infra.runtime.registry_diagnostics import RegistryDiagnostics
 from vibesensor.infra.runtime.registry_updates import (
     DataUpdateResult,
     apply_data_message_update,
@@ -162,6 +163,11 @@ class ClientRegistry:
             retention_ttl_seconds=retention_ttl_seconds,
         )
         self._clients: dict[str, ClientRecord] = {}
+        self._diagnostics = RegistryDiagnostics(
+            lock=self._lock,
+            clients=self._clients,
+            get_or_create=self._get_or_create,
+        )
         self._metadata = ClientMetadataManager(
             lock=self._lock,
             get_or_create=self._get_or_create,
@@ -260,23 +266,11 @@ class ClientRegistry:
             record.last_ack_cmd_seq = ack.cmd_seq
             record.last_ack_status = ack.status
 
-    def _note_client_counter(self, client_id: str | None, attr: str) -> None:
-        """Increment a counter attribute on a client record, creating it if needed."""
-        if not client_id:
-            return
-        try:
-            normalized = normalize_sensor_id(client_id)
-        except ValueError:
-            return
-        with self._lock:
-            record = self._get_or_create(normalized)
-            setattr(record, attr, getattr(record, attr) + 1)
-
     def note_parse_error(self, client_id: str | None) -> None:
-        self._note_client_counter(client_id, "parse_errors")
+        self._diagnostics.note_parse_error(client_id)
 
     def note_server_queue_drop(self, client_id: str | None) -> None:
-        self._note_client_counter(client_id, "server_queue_drops")
+        self._diagnostics.note_server_queue_drop(client_id)
 
     def set_name(self, client_id: str, name: str) -> ClientRecord:
         return self._metadata.set_name(client_id, name)
@@ -350,28 +344,7 @@ class ClientRegistry:
             return self._liveness_policy.active_client_ids(self._clients, mono_now)
 
     def data_loss_snapshot(self) -> dict[str, int]:
-        with self._lock:
-            snapshot: dict[str, int] = {
-                "tracked_clients": len(self._clients),
-                "affected_clients": 0,
-                "frames_dropped": 0,
-                "queue_overflow_drops": 0,
-                "server_queue_drops": 0,
-                "parse_errors": 0,
-            }
-            for record in self._clients.values():
-                snapshot["frames_dropped"] += int(record.frames_dropped)
-                snapshot["queue_overflow_drops"] += int(record.queue_overflow_drops)
-                snapshot["server_queue_drops"] += int(record.server_queue_drops)
-                snapshot["parse_errors"] += int(record.parse_errors)
-                if (
-                    record.frames_dropped > 0
-                    or record.queue_overflow_drops > 0
-                    or record.server_queue_drops > 0
-                    or record.parse_errors > 0
-                ):
-                    snapshot["affected_clients"] += 1
-            return snapshot
+        return self._diagnostics.data_loss_snapshot()
 
     def evict_stale(self, now: float | None = None, *, now_mono: float | None = None) -> list[str]:
         with self._lock:

--- a/apps/server/vibesensor/infra/runtime/registry_diagnostics.py
+++ b/apps/server/vibesensor/infra/runtime/registry_diagnostics.py
@@ -1,0 +1,73 @@
+"""Transport diagnostics and data-loss aggregation for ``ClientRegistry``."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import RLock
+from typing import TYPE_CHECKING, Literal
+
+from vibesensor.domain import normalize_sensor_id
+
+if TYPE_CHECKING:
+    from .registry import ClientRecord
+
+GetOrCreateRecord = Callable[[str], "ClientRecord"]
+CounterAttribute = Literal["parse_errors", "server_queue_drops"]
+
+__all__ = ["RegistryDiagnostics"]
+
+
+class RegistryDiagnostics:
+    """Own transport-error counter mutation and fleet-level data-loss snapshots."""
+
+    def __init__(
+        self,
+        *,
+        lock: RLock,
+        clients: dict[str, ClientRecord],
+        get_or_create: GetOrCreateRecord,
+    ) -> None:
+        self._lock = lock
+        self._clients = clients
+        self._get_or_create = get_or_create
+
+    def _note_client_counter(self, client_id: str | None, attr: CounterAttribute) -> None:
+        if not client_id:
+            return
+        try:
+            normalized = normalize_sensor_id(client_id)
+        except ValueError:
+            return
+        with self._lock:
+            record = self._get_or_create(normalized)
+            setattr(record, attr, getattr(record, attr) + 1)
+
+    def note_parse_error(self, client_id: str | None) -> None:
+        self._note_client_counter(client_id, "parse_errors")
+
+    def note_server_queue_drop(self, client_id: str | None) -> None:
+        self._note_client_counter(client_id, "server_queue_drops")
+
+    def data_loss_snapshot(self) -> dict[str, int]:
+        with self._lock:
+            snapshot: dict[str, int] = {
+                "tracked_clients": len(self._clients),
+                "affected_clients": 0,
+                "frames_dropped": 0,
+                "queue_overflow_drops": 0,
+                "server_queue_drops": 0,
+                "parse_errors": 0,
+            }
+            for record in self._clients.values():
+                snapshot["frames_dropped"] += int(record.frames_dropped)
+                snapshot["queue_overflow_drops"] += int(record.queue_overflow_drops)
+                snapshot["server_queue_drops"] += int(record.server_queue_drops)
+                snapshot["parse_errors"] += int(record.parse_errors)
+                if (
+                    record.frames_dropped > 0
+                    or record.queue_overflow_drops > 0
+                    or record.server_queue_drops > 0
+                    or record.parse_errors > 0
+                ):
+                    snapshot["affected_clients"] += 1
+            return snapshot


### PR DESCRIPTION
## Summary

This PR removes transport-diagnostics counter mutation and fleet-wide data-loss aggregation from the middle of `ClientRegistry` and moves them into a focused runtime collaborator, while preserving the public runtime seam that existing UDP adapters and health reporting already use.

Before this change, `ClientRegistry` did more than track client identity, liveness, sequence state, and transport addresses. It also owned two different diagnostics responsibilities that change for observability reasons rather than for client-lifecycle reasons:

- incrementing parse-error and server-queue-drop counters for specific clients
- aggregating a fleet-level `data_loss_snapshot()` dict for health reporting

That meant a small health or diagnostics refactor still required edits inside the same hot-path runtime class that already handles hello/data/ack bookkeeping, dedup/reset state, and snapshot orchestration. The issue asked for a small extraction that leaves behavior unchanged, so this PR keeps `ClientRegistry` as the public runtime port but pulls the diagnostics logic itself behind a dedicated helper.

## Problem being solved

The repo issue framed this as a responsibility split: `ClientRegistry` should own client state, but it should stop owning transport-error counter mutation and health-facing aggregation logic inline. The evidence was concentrated in three places:

- `_note_client_counter()`, `note_parse_error()`, and `note_server_queue_drop()` in `registry.py`
- `data_loss_snapshot()` in `registry.py`
- the downstream transport and health callers that depend on those public methods without caring how the registry implements them

The most important design constraint here was to avoid turning this into a broader health endpoint rewrite. The health endpoint and `build_system_health_snapshot()` already expect a stable `registry.data_loss_snapshot()` seam, and the UDP transport paths already call `registry.note_parse_error(...)` and `registry.note_server_queue_drop(...)`. Changing those call sites would have broadened the issue for little gain and would have started bleeding into later `ClientRegistry` cleanup issues. The right fix here is therefore an internal extraction that leaves the outward runtime contract alone.

## Implementation approach

The implementation adds a new runtime helper, `RegistryDiagnostics`, in `apps/server/vibesensor/infra/runtime/registry_diagnostics.py`. The helper is constructed with the same registry lock, the backing client-record mapping, and the registry’s `get_or_create` function. That keeps all mutations on the existing `ClientRecord` objects and under the same lock discipline, while moving the diagnostics-specific logic into its own collaborator.

The helper owns three pieces of behavior:

- normalizing client IDs and incrementing `parse_errors`
- normalizing client IDs and incrementing `server_queue_drops`
- building the aggregate `data_loss_snapshot()` payload across the current client records

This is deliberately narrow. I did not move frame-drop computation out of `registry_updates.py`, did not change the `ClientRecord` fields, and did not change any of the health payload keys. The goal is to separate ownership, not redesign the runtime model.

## Main code changes by area

### New runtime diagnostics collaborator

`apps/server/vibesensor/infra/runtime/registry_diagnostics.py` is the new module. It defines a `RegistryDiagnostics` class with:

- a private `_note_client_counter()` helper that normalizes IDs, ignores `None` or invalid IDs, and increments the selected counter under the registry lock
- public `note_parse_error()` and `note_server_queue_drop()` methods
- `data_loss_snapshot()` that preserves the existing aggregate payload shape and the existing `affected_clients` semantics

The collaborator works directly over the existing `ClientRecord` mapping, so it does not duplicate state or create a second diagnostics store.

### ClientRegistry delegation

`apps/server/vibesensor/infra/runtime/registry.py` now constructs `RegistryDiagnostics` during initialization and stores it as a private collaborator. The inline `_note_client_counter()` implementation is removed entirely. The public registry methods remain, but they are now thin delegations:

- `note_parse_error()` delegates to `self._diagnostics.note_parse_error(...)`
- `note_server_queue_drop()` delegates to `self._diagnostics.note_server_queue_drop(...)`
- `data_loss_snapshot()` delegates to `self._diagnostics.data_loss_snapshot()`

This preserves the public runtime contract for existing callers while pulling the diagnostics responsibility out of the central registry implementation.

### Tests

The PR adds a direct unit-test module, `apps/server/tests/infra/runtime/test_registry_diagnostics.py`, for the extracted helper. Those tests cover:

- client-ID normalization when incrementing parse errors
- ignoring `None` and invalid client IDs for queue-drop mutation
- aggregate snapshot building across multiple records with the correct `tracked_clients`, `affected_clients`, and counter totals

I also added a thin public regression to `apps/server/tests/infra/runtime/test_registry.py` that drives the real `ClientRegistry` through public APIs and asserts the outward `data_loss_snapshot()` payload stays the same. That regression is intentionally small: it proves the delegation still preserves the public contract without turning registry tests into helper implementation tests.

## Validation and test coverage

I validated the change at three levels.

First, I ran focused lint and pytest coverage on the directly touched area:

- `ruff check` on the touched runtime and test files
- `pytest -q tests/infra/runtime/test_registry_diagnostics.py tests/infra/runtime/test_registry.py tests/adapters/udp/test_udp_control_tx.py tests/adapters/udp/test_udp_data_rx.py tests/use_cases/test_system_health.py tests/adapters/http/test_health_endpoint.py`

That focused pytest run passed with `74 passed`.

Second, I ran the broader backend quality gates:

- `make lint`
- backend mypy via `/home/node/.venvs/vibesensor-3.14/bin/python -m mypy --config-file pyproject.toml`

Both passed cleanly.

Third, because this is a backend runtime change and the repo instructions require a local runtime smoke, I re-ran the documented native fallback smoke path. The Docker-specific smoke path is still blocked in this environment because there is no reachable Docker daemon, so I used the repo’s native server path instead:

1. started `vibesensor-server --config apps/server/config.dev.yaml`
2. confirmed `/api/health` came up and still exposed the expected `data_loss` keys
3. ran `vibesensor-sim --count 3 --duration 6 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
4. verified `/api/clients` still transitioned `0 -> 3 -> 0` connected clients before, during, and after the live TTL window

That gives confidence that the runtime still behaves normally while the health/data-loss contract remains intact.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is one more small runtime module, but it buys a cleaner responsibility split in a high-traffic class without changing the outward API. I intentionally left the following out of scope:

- changing which counters exist
- changing the `data_loss_snapshot()` payload shape
- rewriting `build_system_health_snapshot()` or degradation-reason logic
- changing UDP adapter call sites
- moving snapshot assembly out of `ClientRegistry` (that is exactly what `#1494` is about)

So this PR is intentionally conservative on behavior and focused only on ownership. The system should behave the same; the logic just lives in a better place now.
