### PR TITLE
Split ClientSnapshot assembly out of ClientRegistry

### DIFF
--- a/apps/server/tests/infra/runtime/test_client_snapshot_assembler.py
+++ b/apps/server/tests/infra/runtime/test_client_snapshot_assembler.py
@@ -1,0 +1,81 @@
+"""Direct tests for the extracted ClientSnapshotAssembler helper."""
+
+from __future__ import annotations
+
+from threading import RLock
+from unittest.mock import MagicMock
+
+from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
+from vibesensor.infra.runtime.client_snapshot_assembler import ClientSnapshotAssembler
+from vibesensor.infra.runtime.registry import ClientRecord
+
+
+def _make_record(
+    client_id: str = "aabbccddeeff",
+    name: str = "Sensor-1",
+    last_seen: float = 1000.0,
+    last_seen_mono: float = 500.0,
+    **kwargs,
+) -> ClientRecord:
+    return ClientRecord(
+        client_id=client_id,
+        name=name,
+        last_seen=last_seen,
+        last_seen_mono=last_seen_mono,
+        **kwargs,
+    )
+
+
+def _make_metadata(known_ids: list[str], names: dict[str, str] | None = None) -> MagicMock:
+    names = names or {}
+    meta = MagicMock()
+    meta.known_client_ids.return_value = known_ids
+    meta.default_name_for.side_effect = lambda cid: names.get(cid, f"Sensor-{cid[:4]}")
+    return meta
+
+
+def test_assembler_uses_time_resolvers_and_preserves_metrics() -> None:
+    record = _make_record(last_seen=1000.0, last_seen_mono=100.0)
+    clients = {record.client_id: record}
+    metadata = _make_metadata([record.client_id])
+    policy = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0)
+    wall_calls: list[float | None] = []
+    mono_calls: list[float | None] = []
+
+    assembler = ClientSnapshotAssembler(
+        lock=RLock(),
+        clients=clients,
+        metadata=metadata,
+        policy=policy,
+        resolve_now_wall=lambda now: wall_calls.append(now) or 1002.5,
+        resolve_now_mono=lambda now: mono_calls.append(now) or 102.5,
+    )
+
+    snapshots = assembler.client_snapshots(metrics_by_client={record.client_id: {"rms": 0.5}})
+
+    assert wall_calls == [None]
+    assert mono_calls == [None]
+    assert len(snapshots) == 1
+    assert snapshots[0].client_id == record.client_id
+    assert snapshots[0].connected is True
+    assert snapshots[0].last_seen_age_ms == 2500
+    assert snapshots[0].latest_metrics == {"rms": 0.5}
+
+
+def test_assembler_includes_metadata_only_offline_clients() -> None:
+    metadata = _make_metadata(["001122334455"], {"001122334455": "Rear Sensor"})
+    assembler = ClientSnapshotAssembler(
+        lock=RLock(),
+        clients={},
+        metadata=metadata,
+        policy=ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0),
+        resolve_now_wall=lambda now: 1000.0,
+        resolve_now_mono=lambda now: 500.0,
+    )
+
+    snapshots = assembler.client_snapshots(now=1000.0, now_mono=500.0)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].client_id == "001122334455"
+    assert snapshots[0].name == "Rear Sensor"
+    assert snapshots[0].connected is False

--- a/apps/server/vibesensor/infra/runtime/client_snapshot_assembler.py
+++ b/apps/server/vibesensor/infra/runtime/client_snapshot_assembler.py
@@ -1,0 +1,58 @@
+"""ClientSnapshot assembly extracted from ``ClientRegistry``."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import RLock
+from typing import TYPE_CHECKING
+
+from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
+from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
+from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
+from vibesensor.infra.runtime.client_snapshot_projection import project_client_snapshots
+from vibesensor.shared.types.payload_types import ClientMetrics
+
+if TYPE_CHECKING:
+    from .registry import ClientRecord
+
+ResolveNow = Callable[[float | None], float]
+
+__all__ = ["ClientSnapshotAssembler"]
+
+
+class ClientSnapshotAssembler:
+    """Own the read-side assembly of transport-facing client snapshots."""
+
+    def __init__(
+        self,
+        *,
+        lock: RLock,
+        clients: dict[str, ClientRecord],
+        metadata: ClientMetadataManager,
+        policy: ClientLivenessPolicy,
+        resolve_now_wall: ResolveNow,
+        resolve_now_mono: ResolveNow,
+    ) -> None:
+        self._lock = lock
+        self._clients = clients
+        self._metadata = metadata
+        self._policy = policy
+        self._resolve_now_wall = resolve_now_wall
+        self._resolve_now_mono = resolve_now_mono
+
+    def client_snapshots(
+        self,
+        now: float | None = None,
+        *,
+        now_mono: float | None = None,
+        metrics_by_client: dict[str, ClientMetrics] | None = None,
+    ) -> list[ClientSnapshot]:
+        with self._lock:
+            return project_client_snapshots(
+                self._clients,
+                self._metadata,
+                now_wall=self._resolve_now_wall(now),
+                now_mono=self._resolve_now_mono(now_mono),
+                policy=self._policy,
+                metrics_by_client=metrics_by_client,
+            )

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -19,7 +19,7 @@ from vibesensor.infra.location_assignment_validator import (
 from vibesensor.infra.runtime.client_liveness_policy import ClientLivenessPolicy
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
-from vibesensor.infra.runtime.client_snapshot_projection import project_client_snapshots
+from vibesensor.infra.runtime.client_snapshot_assembler import ClientSnapshotAssembler
 from vibesensor.infra.runtime.dedup_window import DedupWindow
 from vibesensor.infra.runtime.registry_diagnostics import RegistryDiagnostics
 from vibesensor.infra.runtime.registry_updates import (
@@ -178,6 +178,14 @@ class ClientRegistry:
             delete_client_name=(lambda client_id: db.delete_client_name(client_id))
             if db is not None
             else None,
+        )
+        self._snapshot_assembler = ClientSnapshotAssembler(
+            lock=self._lock,
+            clients=self._clients,
+            metadata=self._metadata,
+            policy=self._liveness_policy,
+            resolve_now_wall=_resolve_now_wall,
+            resolve_now_mono=_resolve_now_mono,
         )
 
     @staticmethod
@@ -368,12 +376,8 @@ class ClientRegistry:
         metrics_by_client: dict[str, ClientMetrics] | None = None,
     ) -> list[ClientSnapshot]:
         """Return raw per-client snapshots for transport presenters."""
-        with self._lock:
-            return project_client_snapshots(
-                self._clients,
-                self._metadata,
-                now_wall=_resolve_now_wall(now),
-                now_mono=_resolve_now_mono(now_mono),
-                policy=self._liveness_policy,
-                metrics_by_client=metrics_by_client,
-            )
+        return self._snapshot_assembler.client_snapshots(
+            now=now,
+            now_mono=now_mono,
+            metrics_by_client=metrics_by_client,
+        )


### PR DESCRIPTION
## Summary

Closes #1494.

This PR resolves `#1494` by moving `ClientSnapshot` assembly out of `ClientRegistry` and into a focused runtime collaborator. The goal here was not to change the client API or WebSocket payload contract, and it was not to redesign how client records are stored. Instead, the change narrows the registry so it no longer owns both write-side client bookkeeping and read-side snapshot shaping. The registry still exposes the same public `client_snapshots()` method, but that method is now a thin delegation layer over a dedicated `ClientSnapshotAssembler`.

This issue was slightly different in practice than the original issue body suggests. The repository already had a pure projection helper in `apps/server/vibesensor/infra/runtime/client_snapshot_projection.py`, so the remaining coupling was not the low-level projection algorithm itself. The remaining concern living inside `ClientRegistry` was the orchestration around that projection: acquiring the lock, resolving wall-clock and monotonic `now` values, wiring the current `_clients` and metadata state into the projection helper, and returning the `ClientSnapshot` rows that downstream HTTP and WebSocket code consume. That orchestration is what this PR extracts.

## Problem being solved

Before this change, `ClientRegistry.client_snapshots()` mixed responsibilities that point in different directions architecturally. The registry is fundamentally a runtime mutation object: it owns client records, dedup state, hello/data/ack updates, and transport-side lifetime tracking. At the same time, its snapshot method assembled the read model that downstream presenters use. That meant a change to snapshot assembly behavior required editing the same class that owns the runtime mutation surface, even though the repo already has a separate presenter layer for converting snapshots into API rows.

That made the registry harder to reason about and kept one more read-side concern embedded in a class that has already been getting smaller through the recent extraction issues in this part of the backlog. This PR continues that narrowing without broadening the public surface or changing the payload contract.

## Implementation approach

The chosen implementation is deliberately small and conservative. I introduced `apps/server/vibesensor/infra/runtime/client_snapshot_assembler.py` with a single `ClientSnapshotAssembler` class. The assembler accepts the exact pieces of state the registry already used for snapshot generation: the shared `RLock`, the live `_clients` dictionary, the `ClientMetadataManager`, the existing `ClientLivenessPolicy`, and the same wall-clock and monotonic time resolver callables that the registry already used. Its `client_snapshots()` method acquires the same lock and then delegates to the existing `project_client_snapshots()` helper with the resolved timing inputs and any optional metrics payloads.

That preserves the existing projection logic instead of duplicating it. It also preserves the existing lock behavior instead of changing concurrency semantics as part of a refactor issue. The public `ClientRegistry.client_snapshots()` method remains in place, but it now forwards to the assembler, which makes the registry a transport-facing facade rather than the owner of the assembly logic itself.

## Main code changes by area

In `apps/server/vibesensor/infra/runtime/client_snapshot_assembler.py`, I added the new collaborator and kept it intentionally narrow. It owns the read-side assembly orchestration only. It does not mutate registry state, and it does not introduce a parallel model or new payload types. The helper is designed to be obvious about what it depends on: lock, clients, metadata, liveness policy, and time resolution.

In `apps/server/vibesensor/infra/runtime/registry.py`, I wired the registry to instantiate the assembler during initialization and delegate `client_snapshots()` through it. This removes the inline orchestration from the registry while keeping the public entrypoint stable for the rest of the runtime and transport stack.

In `apps/server/tests/infra/runtime/test_client_snapshot_assembler.py`, I added focused direct tests for the new seam. One test verifies that the assembler uses the injected time resolvers and preserves optional metrics on the projected snapshot. A second test verifies that metadata-only persisted clients still appear as offline rows, which is an important part of the current client-list behavior because API consumers need those persisted names even when the device is not actively connected.

## Contract and behavior preservation

No API fields changed in this PR. The client-list HTTP path and the WebSocket payload path continue to consume the same `ClientSnapshot` data model they used before, and the underlying projection function is still the existing `project_client_snapshots()` helper. This means live clients, offline persisted-name clients, connected flags, and attached metrics continue to be shaped through the same projection logic as before.

The practical effect of the change is architectural rather than user-visible: the registry loses one more read-model concern, while the rest of the application continues to receive the same snapshot content.

## Validation performed

I validated the change in several layers.

First, I ran focused lint and tests on the touched snapshot path and its nearest consumers:

- `ruff check` on the new assembler, the registry, and the affected runtime/API/WS tests
- `pytest -q` on:
  - `tests/infra/runtime/test_client_snapshot_assembler.py`
  - `tests/infra/runtime/test_client_snapshot_projection.py`
  - `tests/infra/runtime/test_registry.py`
  - `tests/adapters/http/test_api_ws_health_and_clients.py`
  - `tests/adapters/websocket/test_build_ws_payload.py`

That focused pass completed green with `56 passed`.

Second, I ran the broader backend quality gates:

- `make lint`
- `/home/node/.venvs/vibesensor-3.14/bin/python -m mypy --config-file pyproject.toml`

Both passed cleanly.

Third, I ran the required local stack smoke through the documented native fallback path, because the Docker daemon is not reachable in this environment. I started `vibesensor-server` with `apps/server/config.dev.yaml`, verified `/api/clients` was reachable, then ran `vibesensor-sim --count 3 --duration 6 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`. I confirmed the client endpoint moved through the expected lifecycle: `0` connected clients before simulation, `3` connected clients during live traffic, and `0` connected clients again after the simulator stopped and the live TTL expired. That is the most relevant end-to-end behavior for this extraction.

I also ran a code-review pass over the final diff, and it found no meaningful issues.

## Risks, tradeoffs, and edge cases

The main risk in a refactor like this is accidentally changing snapshot semantics while moving code around. To avoid that, this PR keeps the projection helper, the liveness policy, and the public registry API intact, and it preserves lock ownership by using the same shared `RLock` inside the assembler. Another subtle area is metadata-only offline clients; the direct tests explicitly cover that case so the extracted helper keeps emitting the same offline rows.

I intentionally did not broaden this PR into changes to `ClientRecord`, HTTP adapters, or WebSocket contracts. Those would make the diff larger without helping the narrow maintainability goal of this issue.

## Out of scope / follow-ups

This PR does not change API payload structure, WebSocket payload structure, or registry mutation behavior. It also does not remove the registry’s public snapshot method, because keeping that seam stable makes this extraction safer. Any future work in this area can now target the assembler directly if snapshot-assembly behavior needs to evolve.
