### PR TITLE
Extract ring-buffer ingest mutation out of SignalBufferStore

### DIFF
--- a/apps/server/tests/infra/processing/test_ring_buffer_ingest.py
+++ b/apps/server/tests/infra/processing/test_ring_buffer_ingest.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.buffers import ClientBuffer
+from vibesensor.infra.processing.ring_buffer_ingest import apply_ring_buffer_ingest
+
+
+def _make_buffer(*, capacity: int = 4, fill: float = 0.0) -> ClientBuffer:
+    return ClientBuffer(
+        data=np.full((3, capacity), fill, dtype=np.float32),
+        capacity=capacity,
+    )
+
+
+def test_apply_ring_buffer_ingest_writes_without_wraparound() -> None:
+    buf = _make_buffer(capacity=5)
+    chunk = np.array(
+        [
+            [1.0, 10.0, 100.0],
+            [2.0, 20.0, 200.0],
+            [3.0, 30.0, 300.0],
+        ],
+        dtype=np.float32,
+    )
+
+    written = apply_ring_buffer_ingest(buf, chunk, t0_us=1_000_000)
+
+    assert written == 3
+    assert buf.write_idx == 3
+    assert buf.count == 3
+    assert buf.last_t0_us == 1_000_000
+    assert buf.samples_since_t0 == 3
+    assert buf.ingest_generation == 1
+    np.testing.assert_array_equal(buf.data[:, :3], chunk.T)
+
+
+def test_apply_ring_buffer_ingest_wraps_and_saturates_count() -> None:
+    buf = _make_buffer(capacity=4, fill=-1.0)
+    buf.write_idx = 3
+    buf.count = 4
+    chunk = np.array(
+        [
+            [1.0, 10.0, 100.0],
+            [2.0, 20.0, 200.0],
+        ],
+        dtype=np.float32,
+    )
+
+    written = apply_ring_buffer_ingest(buf, chunk)
+
+    assert written == 2
+    assert buf.write_idx == 1
+    assert buf.count == 4
+    assert buf.ingest_generation == 1
+    expected = np.array(
+        [
+            [2.0, -1.0, -1.0, 1.0],
+            [20.0, -1.0, -1.0, 10.0],
+            [200.0, -1.0, -1.0, 100.0],
+        ],
+        dtype=np.float32,
+    )
+    np.testing.assert_array_equal(buf.data, expected)
+
+
+def test_apply_ring_buffer_ingest_does_not_regress_last_t0_for_older_frame() -> None:
+    buf = _make_buffer(capacity=8)
+
+    apply_ring_buffer_ingest(
+        buf,
+        np.ones((4, 3), dtype=np.float32),
+        t0_us=1_000_000,
+    )
+    apply_ring_buffer_ingest(
+        buf,
+        np.ones((2, 3), dtype=np.float32),
+        t0_us=900_000,
+    )
+
+    assert buf.last_t0_us == 1_000_000
+    assert buf.samples_since_t0 == 6
+    assert buf.ingest_generation == 2
+
+
+def test_apply_ring_buffer_ingest_clamps_samples_since_t0() -> None:
+    buf = _make_buffer(capacity=4)
+    buf.last_t0_us = 1_000_000
+    buf.samples_since_t0 = (2**28) - 1
+
+    apply_ring_buffer_ingest(buf, np.ones((2, 3), dtype=np.float32))
+
+    assert buf.last_t0_us == 1_000_000
+    assert buf.samples_since_t0 == 2**28
+    assert buf.ingest_generation == 1

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -25,6 +25,7 @@ from vibesensor.infra.processing.models import (
     ProcessorConfig,
     ProcessorStats,
 )
+from vibesensor.infra.processing.ring_buffer_ingest import apply_ring_buffer_ingest
 from vibesensor.infra.processing.snapshot_builder import (
     check_cache_hit,
     compute_snapshot_window,
@@ -37,8 +38,6 @@ from vibesensor.shared.types.payload_types import (
 from vibesensor.vibration_strength import empty_vibration_strength_metrics
 
 LOGGER = logging.getLogger(__name__)
-_MAX_SAMPLES_SINCE_T0 = 2**28
-"""Cap `samples_since_t0` so long sessions cannot grow the accumulator without bound."""
 
 
 class SignalBufferStore:
@@ -115,32 +114,9 @@ class SignalBufferStore:
                 chunk,
                 capacity=buf.capacity,
             )
-            n = overflow.keep_count
             dropped_samples = overflow.drop_count
-            capacity = buf.capacity
-
-            end = buf.write_idx + n
-            if end <= capacity:
-                buf.data[:, buf.write_idx : end] = chunk.T
-            else:
-                first = capacity - buf.write_idx
-                buf.data[:, buf.write_idx :] = chunk[:first].T
-                buf.data[:, : end % capacity] = chunk[first:].T
-
-            buf.write_idx = end % capacity
-            buf.count = min(capacity, buf.count + n)
-            if t0_us is not None and t0_us > 0:
-                next_t0_us = int(t0_us)
-                if next_t0_us > buf.last_t0_us:
-                    buf.last_t0_us = next_t0_us
-                    buf.samples_since_t0 = n
-                else:
-                    buf.samples_since_t0 = min(buf.samples_since_t0 + n, _MAX_SAMPLES_SINCE_T0)
-            else:
-                buf.samples_since_t0 = min(buf.samples_since_t0 + n, _MAX_SAMPLES_SINCE_T0)
-            buf.ingest_generation += 1
+            ingested_samples = apply_ring_buffer_ingest(buf, chunk, t0_us=t0_us)
             self._invalidate_cached_payloads_unlocked(buf)
-            ingested_samples = n
         with self.lock:
             self.stats.total_ingested_samples += ingested_samples
             self.stats.buffer_overflow_drops += dropped_samples

--- a/apps/server/vibesensor/infra/processing/ring_buffer_ingest.py
+++ b/apps/server/vibesensor/infra/processing/ring_buffer_ingest.py
@@ -1,0 +1,47 @@
+"""Ring-buffer ingest mutation helpers extracted from ``SignalBufferStore``."""
+
+from __future__ import annotations
+
+from vibesensor.infra.processing.buffers import ClientBuffer
+from vibesensor.infra.processing.models import FloatArray
+
+_MAX_SAMPLES_SINCE_T0 = 2**28
+
+
+def apply_ring_buffer_ingest(
+    buf: ClientBuffer,
+    chunk: FloatArray,
+    *,
+    t0_us: int | None = None,
+) -> int:
+    """Write a prepared chunk into ``buf`` and return the number of samples written."""
+    sample_count = int(chunk.shape[0])
+    capacity = buf.capacity
+    end = buf.write_idx + sample_count
+    if end <= capacity:
+        buf.data[:, buf.write_idx : end] = chunk.T
+    else:
+        first = capacity - buf.write_idx
+        buf.data[:, buf.write_idx :] = chunk[:first].T
+        buf.data[:, : end % capacity] = chunk[first:].T
+
+    buf.write_idx = end % capacity
+    buf.count = min(capacity, buf.count + sample_count)
+    _advance_sensor_clock(buf, sample_count, t0_us=t0_us)
+    buf.ingest_generation += 1
+    return sample_count
+
+
+def _advance_sensor_clock(
+    buf: ClientBuffer,
+    sample_count: int,
+    *,
+    t0_us: int | None,
+) -> None:
+    if t0_us is not None and t0_us > 0:
+        next_t0_us = int(t0_us)
+        if next_t0_us > buf.last_t0_us:
+            buf.last_t0_us = next_t0_us
+            buf.samples_since_t0 = sample_count
+            return
+    buf.samples_since_t0 = min(buf.samples_since_t0 + sample_count, _MAX_SAMPLES_SINCE_T0)


### PR DESCRIPTION
## Summary

Closes #1495.

This PR resolves `#1495` by extracting the ring-buffer ingest mutation path out of `SignalBufferStore.ingest()` into a focused helper module. The goal is intentionally narrow: keep `SignalBufferStore` as the orchestration layer for validation, lock usage, sample-rate overrides, overflow coordination, cache invalidation, and stats updates, while moving the per-buffer write mechanics and related ingest bookkeeping into a dedicated seam. The public behavior of ingest stays the same, and no processor API contracts change.

## Problem being solved

Before this change, `SignalBufferStore.ingest()` still carried a dense block of low-level mutation logic in the middle of a method that also owns higher-level processing concerns. After the recent extraction of capacity and resize policy into `buffer_capacity.py`, the remaining inline hot path was the part that actually mutates a locked `ClientBuffer`: circular writes into the ring buffer, `write_idx` advancement, `count` saturation, `last_t0_us` progression, `samples_since_t0` accumulation, and `ingest_generation` updates.

That left the store doing two different jobs at once. On one side it is the lifecycle/orchestration object for processing state. On the other side it still contained the raw ring-buffer write implementation details. The result was that small changes to ingest bookkeeping or buffer write behavior still required editing a central store class that also owns locking and read/query helpers. This PR narrows that class without changing the external ingest contract.

## Implementation approach

The implementation follows the same pattern as the recent runtime refactors in this backlog: extract the smallest stable seam, keep behavior unchanged, and leave the facade method in place as the public entrypoint.

I added `apps/server/vibesensor/infra/processing/ring_buffer_ingest.py` with a focused helper function, `apply_ring_buffer_ingest()`. That helper accepts a locked `ClientBuffer`, a prepared sample chunk, and the optional `t0_us` value. It owns the mutation mechanics that were previously inline inside `SignalBufferStore.ingest()`:

- circular write placement into the ring buffer
- `write_idx` advancement
- `count` saturation at capacity
- `last_t0_us` handling for fresh versus stale timestamps
- `samples_since_t0` accumulation and clamping
- `ingest_generation` increment

The helper returns the number of samples written, which is the bookkeeping value the store needs later when updating global ingest stats.

With that helper in place, `SignalBufferStore.ingest()` stays responsible for the higher-level orchestration that should remain there:

- early exit on empty input
- dtype normalization to `float32`
- optional acceleration scaling
- malformed-shape rejection
- per-client lock acquisition
- sample-rate override handling and buffer resize coordination
- overflow trimming through the already-extracted capacity policy
- cache invalidation after mutation
- global stats updates after the per-client locked section

This keeps lock ordering unchanged and avoids introducing a second store-like abstraction or a wider refactor than the issue asked for.

## Main code changes by area

In `apps/server/vibesensor/infra/processing/ring_buffer_ingest.py`, I added the new helper and moved the `_MAX_SAMPLES_SINCE_T0` clamp alongside it, because the clamp is part of the ingest bookkeeping behavior that now lives in the extracted seam. The file is intentionally narrow and only depends on the existing `ClientBuffer` type and processing array alias.

In `apps/server/vibesensor/infra/processing/buffer_store.py`, I replaced the inline mutation block with a single call to `apply_ring_buffer_ingest()`. That removes the detailed ring-buffer manipulation from the store while preserving the surrounding flow exactly where it was before.

In `apps/server/tests/infra/processing/test_ring_buffer_ingest.py`, I added focused direct unit tests for the new helper seam. The tests cover:

- non-wrapping writes
- wraparound writes with saturated `count`
- preserving `last_t0_us` when an older frame arrives later
- clamping `samples_since_t0` when accumulation would exceed the cap

These direct tests complement the existing store- and processor-level tests that already exercise ingest behavior through the public API.

## Behavior and contract preservation

This PR does not change the processor facade, the store API, or any HTTP/WebSocket payload shape. It is a refactor of internal responsibility only. Existing behavior remains the same in the places that matter most:

- overflow handling still happens before the mutation helper runs
- sample-rate overrides still happen before the write
- ingest still happens under the same per-client lock
- cache invalidation still happens after the buffer mutation and before the method exits the client lock
- global stats still update outside the per-client locked section
- `last_t0_us`, `samples_since_t0`, and `ingest_generation` keep the same semantics

Because the overflow policy still trims the chunk before it reaches the helper, the helper can use `chunk.shape[0]` as the authoritative written-sample count, which matches the prior `overflow.keep_count` usage.

## Validation performed

I validated this change in several layers.

First, I ran focused lint and tests on the touched processing surface:

- `ruff check` on:
  - `vibesensor/infra/processing/buffer_store.py`
  - `vibesensor/infra/processing/ring_buffer_ingest.py`
  - `tests/infra/processing/test_ring_buffer_ingest.py`
  - nearby ingest/cache/processing regression tests
- `pytest -q` on:
  - `tests/infra/processing/test_ring_buffer_ingest.py`
  - `tests/infra/processing/test_processing_components.py`
  - `tests/infra/processing/test_buffer_store_identity_and_rate_guards.py`
  - `tests/infra/processing/test_processing_extended.py`
  - `tests/infra/processing/test_buffer_store_cache_invalidation.py`
  - `tests/infra/processing/test_processing.py`

That focused pass completed green with `63 passed`.

Second, I widened the test surface to the broader processing area:

- `pytest -q tests/infra/processing tests/integration/test_runtime_queue_and_export_regressions.py`

That broader pass completed green with `339 passed`.

Third, I ran the broader backend quality gates:

- `make lint`
- `/home/node/.venvs/vibesensor-3.14/bin/python -m mypy --config-file pyproject.toml`

Both passed cleanly.

Fourth, I ran the required local stack smoke through the documented native fallback path because the Docker daemon is not reachable in this environment. I started `vibesensor-server` with `apps/server/config.dev.yaml`, ran `vibesensor-sim --count 3 --duration 6 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`, and verified two things:

1. the live `/api/clients` endpoint showed connected clients during simulator traffic and returned to `0` connected clients after the TTL window
2. the more relevant ingest-path endpoint `/api/debug/raw-samples/{client_id}` returned non-empty buffered sample arrays for a connected client during the simulator run

That smoke directly exercised the ingest path that this issue refactors.

I also ran a code-review pass over the final diff, and it found no meaningful issues.

## Risks, tradeoffs, and edge cases

The main risk in this refactor is changing ingest semantics while moving code. To reduce that risk, I kept the extraction intentionally small and moved only the mutation block, not the orchestration around it. That preserves lock ownership, overflow handling order, cache invalidation timing, and stats update placement.

The subtle edge cases here are wraparound writes and old `t0_us` values. Those are exactly the cases the new direct helper tests cover, and the existing higher-level processing tests continue to exercise the public ingest contract.

## Out of scope / follow-ups

This PR does not change buffer capacity policy, public processor APIs, the debug/raw sample payload shape, or the broader signal-processing pipeline. It also does not attempt a full `SignalBufferStore` rewrite. The change is intentionally limited to the ring-buffer ingest mutation seam so the refactor stays reviewable and low risk.
