### PR TITLE
Split debug/raw/recent-data read queries out of SignalBufferStore

### DIFF
--- a/apps/server/tests/infra/processing/test_debug_queries.py
+++ b/apps/server/tests/infra/processing/test_debug_queries.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.buffer_store import SignalBufferStore
+from vibesensor.infra.processing.debug_queries import DebugQueryReader
+from vibesensor.infra.processing.models import DebugSpectrumRequest, ProcessorConfig
+
+
+def _config(**overrides: object) -> ProcessorConfig:
+    base = {
+        "sample_rate_hz": 200,
+        "waveform_seconds": 2,
+        "waveform_display_hz": 50,
+        "fft_n": 128,
+        "spectrum_min_hz": 0.0,
+        "spectrum_max_hz": 100.0,
+        "accel_scale_g_per_lsb": None,
+    }
+    base.update(overrides)
+    return ProcessorConfig(**base)
+
+
+def test_debug_request_returns_empty_request_for_missing_client() -> None:
+    store = SignalBufferStore(_config(fft_n=256, sample_rate_hz=400))
+    queries = DebugQueryReader(store)
+
+    request = queries.debug_request("missing")
+
+    assert request == DebugSpectrumRequest(
+        client_id="missing",
+        sample_rate_hz=400,
+        count=0,
+        fft_block=None,
+    )
+
+
+def test_debug_request_uses_client_sample_rate_and_fft_block() -> None:
+    store = SignalBufferStore(_config(fft_n=8, sample_rate_hz=200))
+    queries = DebugQueryReader(store)
+    client_id = "sensor-1"
+    samples = np.arange(48, dtype=np.float32).reshape(16, 3)
+    store.ingest(client_id, samples, sample_rate_hz=400)
+
+    request = queries.debug_request(client_id)
+
+    assert request.client_id == client_id
+    assert request.sample_rate_hz == 400
+    assert request.count == 16
+    assert request.fft_block is not None
+    np.testing.assert_array_equal(request.fft_block.T, samples[-8:])
+
+
+def test_raw_samples_returns_error_for_missing_data() -> None:
+    store = SignalBufferStore(_config())
+    queries = DebugQueryReader(store)
+
+    result = queries.raw_samples("missing", n_samples=32)
+
+    assert result == {"error": "no data", "count": 0}
+
+
+def test_raw_samples_caps_requested_count_to_available_samples() -> None:
+    store = SignalBufferStore(_config(sample_rate_hz=800))
+    queries = DebugQueryReader(store)
+    client_id = "sensor-2"
+    samples = np.arange(30, dtype=np.float32).reshape(10, 3)
+    store.ingest(client_id, samples, sample_rate_hz=800)
+
+    result = queries.raw_samples(client_id, n_samples=999)
+
+    assert result["client_id"] == client_id
+    assert result["sample_rate_hz"] == 800
+    assert result["n_samples"] == 10
+    assert result["x"] == [float(value) for value in samples[:, 0]]
+    assert result["y"] == [float(value) for value in samples[:, 1]]
+    assert result["z"] == [float(value) for value in samples[:, 2]]

--- a/apps/server/vibesensor/infra/processing/buffer_store.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store.py
@@ -18,7 +18,6 @@ from vibesensor.infra.processing.buffers import ClientBuffer
 from vibesensor.infra.processing.models import (
     CachedMetricsHit,
     ClientMetrics,
-    DebugSpectrumRequest,
     FloatArray,
     MetricsComputationResult,
     MetricsSnapshot,
@@ -32,8 +31,6 @@ from vibesensor.infra.processing.snapshot_builder import (
 )
 from vibesensor.shared.types.payload_types import (
     IntakeStatsPayload,
-    RawSamplesErrorPayload,
-    RawSamplesPayload,
 )
 from vibesensor.vibration_strength import empty_vibration_strength_metrics
 
@@ -237,51 +234,6 @@ class SignalBufferStore:
                 if buf is not None and buf.latest_metrics:
                     result[cid] = buf.latest_metrics
             return result
-
-    def debug_request(self, client_id: str) -> DebugSpectrumRequest:
-        with self.locked_client_buffer(client_id) as buf:
-            if buf is None:
-                return DebugSpectrumRequest(
-                    client_id=client_id,
-                    sample_rate_hz=self.config.sample_rate_hz,
-                    count=0,
-                    fft_block=None,
-                )
-            sr = buf.sample_rate_hz or self.config.sample_rate_hz
-            if buf.count < self.config.fft_n:
-                return DebugSpectrumRequest(
-                    client_id=client_id,
-                    sample_rate_hz=sr,
-                    count=buf.count,
-                    fft_block=None,
-                )
-            return DebugSpectrumRequest(
-                client_id=client_id,
-                sample_rate_hz=sr,
-                count=buf.count,
-                fft_block=self.copy_latest(buf, self.config.fft_n),
-            )
-
-    def raw_samples(
-        self,
-        client_id: str,
-        *,
-        n_samples: int,
-    ) -> RawSamplesPayload | RawSamplesErrorPayload:
-        with self.locked_client_buffer(client_id) as buf:
-            if buf is None or buf.count == 0:
-                return {"error": "no data", "count": 0}
-            sr = buf.sample_rate_hz or self.config.sample_rate_hz
-            n = min(n_samples, buf.count)
-            block = self.copy_latest(buf, n)
-        return {
-            "client_id": client_id,
-            "sample_rate_hz": sr,
-            "n_samples": n,
-            "x": [float(v) for v in block[0].tolist()],
-            "y": [float(v) for v in block[1].tolist()],
-            "z": [float(v) for v in block[2].tolist()],
-        }
 
     def clients_with_recent_data(
         self,

--- a/apps/server/vibesensor/infra/processing/debug_queries.py
+++ b/apps/server/vibesensor/infra/processing/debug_queries.py
@@ -1,0 +1,61 @@
+"""Read-only debug/raw buffer queries extracted from ``SignalBufferStore``."""
+
+from __future__ import annotations
+
+from vibesensor.infra.processing.buffer_store import SignalBufferStore
+from vibesensor.infra.processing.models import DebugSpectrumRequest
+from vibesensor.shared.types.payload_types import RawSamplesErrorPayload, RawSamplesPayload
+
+__all__ = ["DebugQueryReader"]
+
+
+class DebugQueryReader:
+    """Own debug/raw read queries against locked processing buffers."""
+
+    def __init__(self, store: SignalBufferStore) -> None:
+        self._store = store
+
+    def debug_request(self, client_id: str) -> DebugSpectrumRequest:
+        with self._store.locked_client_buffer(client_id) as buf:
+            if buf is None:
+                return DebugSpectrumRequest(
+                    client_id=client_id,
+                    sample_rate_hz=self._store.config.sample_rate_hz,
+                    count=0,
+                    fft_block=None,
+                )
+            sample_rate_hz = buf.sample_rate_hz or self._store.config.sample_rate_hz
+            if buf.count < self._store.config.fft_n:
+                return DebugSpectrumRequest(
+                    client_id=client_id,
+                    sample_rate_hz=sample_rate_hz,
+                    count=buf.count,
+                    fft_block=None,
+                )
+            return DebugSpectrumRequest(
+                client_id=client_id,
+                sample_rate_hz=sample_rate_hz,
+                count=buf.count,
+                fft_block=self._store.copy_latest(buf, self._store.config.fft_n),
+            )
+
+    def raw_samples(
+        self,
+        client_id: str,
+        *,
+        n_samples: int,
+    ) -> RawSamplesPayload | RawSamplesErrorPayload:
+        with self._store.locked_client_buffer(client_id) as buf:
+            if buf is None or buf.count == 0:
+                return {"error": "no data", "count": 0}
+            sample_rate_hz = buf.sample_rate_hz or self._store.config.sample_rate_hz
+            count = min(n_samples, buf.count)
+            block = self._store.copy_latest(buf, count)
+        return {
+            "client_id": client_id,
+            "sample_rate_hz": sample_rate_hz,
+            "n_samples": count,
+            "x": [float(value) for value in block[0].tolist()],
+            "y": [float(value) for value in block[1].tolist()],
+            "z": [float(value) for value in block[2].tolist()],
+        }

--- a/apps/server/vibesensor/infra/processing/processor.py
+++ b/apps/server/vibesensor/infra/processing/processor.py
@@ -23,6 +23,7 @@ from vibesensor.infra.processing.buffer_capacity import (
 from vibesensor.infra.processing.buffer_store import SignalBufferStore
 from vibesensor.infra.processing.buffers import ClientBuffer
 from vibesensor.infra.processing.compute import SignalMetricsComputer
+from vibesensor.infra.processing.debug_queries import DebugQueryReader
 from vibesensor.infra.processing.models import (
     CachedMetricsHit,
     ClientMetrics,
@@ -92,6 +93,7 @@ class SignalProcessor:
         self.max_samples = self._config.max_samples
 
         self._store = SignalBufferStore(self._config)
+        self._debug_queries = DebugQueryReader(self._store)
         self._metrics = SignalMetricsComputer(self._config)
         self._worker_pool = worker_pool
 
@@ -191,7 +193,7 @@ class SignalProcessor:
         return self._store.all_latest_metrics(client_ids)
 
     def debug_spectrum(self, client_id: str) -> DebugSpectrumPayload | DebugSpectrumErrorPayload:
-        request = self._store.debug_request(client_id)
+        request = self._debug_queries.debug_request(client_id)
         return build_debug_spectrum_payload(request, self._store.config, self._metrics)
 
     def raw_samples(
@@ -199,7 +201,7 @@ class SignalProcessor:
         client_id: str,
         n_samples: int = 2048,
     ) -> RawSamplesPayload | RawSamplesErrorPayload:
-        return self._store.raw_samples(client_id, n_samples=n_samples)
+        return self._debug_queries.raw_samples(client_id, n_samples=n_samples)
 
     def clients_with_recent_data(self, client_ids: list[str], max_age_s: float = 3.0) -> list[str]:
         return self._store.clients_with_recent_data(client_ids, max_age_s=max_age_s)


### PR DESCRIPTION
## Summary

Closes #1496.

This PR resolves `#1496` by extracting the read-only debug/raw query logic out of `SignalBufferStore` into a focused helper used by `SignalProcessor`. The important scope decision here is that the actual maintainable seam is narrower than the issue title might imply. The clearly read-only debug query logic was `debug_request()` and `raw_samples()`. By contrast, `clients_with_recent_data()` remains part of the production `SignalSource` contract and is used by runtime freshness filtering, so it stays in `SignalBufferStore`. The result is a smaller, reviewable refactor that narrows the store without moving the wrong responsibility.

## Problem being solved

Before this change, `SignalBufferStore` still owned a mixture of responsibilities. It already carries the core buffer lifecycle, ingest mutation, compute snapshot handling, cache invalidation, and stats bookkeeping. On top of that, it also implemented read-only debug query helpers that exist primarily to support the processor’s debug/raw APIs:

- `debug_request()`
- `raw_samples()`

Those methods are conceptually different from the store’s core job. They are read-only query assembly logic, not shared-state mutation or lifecycle management. Keeping them inline in the store meant that debug API changes still required editing the same class that owns the hot ingest path and locking primitives.

At first glance, the issue title also suggests moving `clients_with_recent_data()`, but inspection of the live code showed that method is not just a debug helper. It is part of the `SignalSource` protocol and is used in production runtime flows such as the processing loop and WebSocket broadcast freshness filtering. Moving it out together with the debug methods would have blurred the production contract instead of clarifying it.

## Implementation approach

I introduced `apps/server/vibesensor/infra/processing/debug_queries.py` with a small `DebugQueryReader` collaborator that owns the two read-only query paths:

- `debug_request()`
- `raw_samples()`

The helper is intentionally simple. It receives the existing `SignalBufferStore`, reuses the store’s locking and `copy_latest()` behavior, and builds the same `DebugSpectrumRequest` / raw-sample payloads that the previous inline methods returned. This preserves lock behavior exactly where it matters: the buffer is still read under the existing per-client lock, and copied data is materialized while the lock is held.

Then I updated `SignalProcessor` to instantiate the helper and delegate its public `debug_spectrum()` and `raw_samples()` methods through that collaborator. The public processor API stays unchanged, which means the HTTP debug routes continue to call the same processor methods they did before.

Finally, I removed the inline `debug_request()` and `raw_samples()` methods from `SignalBufferStore`, leaving `clients_with_recent_data()` where it belongs. That keeps the store focused on lifecycle, locking, snapshots, and the production-facing freshness query that still belongs to the `SignalSource` abstraction.

## Main code changes by area

In `apps/server/vibesensor/infra/processing/debug_queries.py`, I added the new `DebugQueryReader` class. It owns:

- construction of `DebugSpectrumRequest` for missing clients, insufficient-sample cases, and full FFT blocks
- construction of raw-sample payloads and error payloads
- reuse of `SignalBufferStore.locked_client_buffer()` and `SignalBufferStore.copy_latest()`

In `apps/server/vibesensor/infra/processing/processor.py`, I added `_debug_queries = DebugQueryReader(self._store)` and updated:

- `debug_spectrum()` to request the copied debug block through the helper
- `raw_samples()` to request the raw-sample payload through the helper

In `apps/server/vibesensor/infra/processing/buffer_store.py`, I removed the inline `debug_request()` and `raw_samples()` implementations. `clients_with_recent_data()` remains unchanged.

In `apps/server/tests/infra/processing/test_debug_queries.py`, I added focused direct tests for the new helper seam:

- missing-client debug request
- debug request with enough data and a client-specific sample rate
- raw-sample error when no data exists
- raw-sample count capping to available buffer data

These are intentionally direct unit tests for the new collaborator, while existing processor/integration tests continue to validate the stable public surface.

## Scope clarification: what stayed in SignalBufferStore and why

The main scope choice in this PR is worth calling out explicitly. I did **not** move `clients_with_recent_data()` out of `SignalBufferStore`, even though it appears next to the debug/raw query methods in the class. After tracing usage, that method clearly serves a different role:

- it is part of `vibesensor.shared.ports.SignalSource`
- it is used by the runtime processing loop
- it is used by WebSocket broadcast freshness filtering

That makes it a production read/query surface, not just a debug helper. Keeping it in the store preserves the existing contract and avoids over-extracting responsibilities that still belong with the shared buffer state abstraction.

## Behavior and contract preservation

This PR does not change:

- HTTP debug route paths
- raw sample payload shape
- debug spectrum payload shape
- `SignalProcessor` public method names or signatures
- lock ordering or lock ownership
- `clients_with_recent_data()` behavior

The debug/raw methods still read under the same per-client lock and still use the same copied buffer data. The only change is where that read-query logic lives.

## Validation performed

I validated this refactor in several layers.

First, I ran focused lint and tests on the changed surface:

- `ruff check` on:
  - `vibesensor/infra/processing/debug_queries.py`
  - `vibesensor/infra/processing/buffer_store.py`
  - `vibesensor/infra/processing/processor.py`
  - `tests/infra/processing/test_debug_queries.py`
  - `tests/integration/test_coverage_gap_audit_round2.py`
  - `tests/infra/processing/test_processing.py`
- `pytest -q` on:
  - `tests/infra/processing/test_debug_queries.py`
  - `tests/integration/test_coverage_gap_audit_round2.py`
  - `tests/infra/processing/test_processing.py`

That focused pass completed green with `61 passed`.

Second, I widened the test surface to the broader processing/debug area:

- `pytest -q tests/infra/processing tests/integration/test_coverage_gap_audit_round2.py tests/adapters/http/test_http_api_schema_export.py`

That broader pass completed green with `391 passed`.

Third, I ran the broader backend quality gates:

- `make lint`
- `/home/node/.venvs/vibesensor-3.14/bin/python -m mypy --config-file pyproject.toml`

Both passed cleanly.

Fourth, I ran the required local stack smoke through the documented native fallback path because the Docker daemon is not reachable in this environment. I started `vibesensor-server` with `apps/server/config.dev.yaml`, ran `vibesensor-sim --count 3 --duration 6 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`, and verified:

1. `/api/debug/raw-samples/{client_id}` returned non-empty axis arrays for a live connected client
2. `/api/debug/spectrum/{client_id}` returned a real payload rather than an error during the same simulator run
3. `/api/clients` returned to `0` connected clients after the simulator stopped and the TTL window expired

That smoke directly exercises the query methods this issue moved.

I also ran a code-review pass over the final diff, and it found no meaningful issues.

## Risks, tradeoffs, and edge cases

The biggest risk here was moving too much instead of too little. The issue title could reasonably be read as “move all read queries,” but doing that would have swept `clients_with_recent_data()` out of the store even though it still belongs to the production `SignalSource` contract. I intentionally avoided that.

The other key risk is lock behavior. To avoid any regression there, the new helper reuses the store’s existing lock/context-manager and `copy_latest()` behavior rather than reimplementing buffer access. That keeps thread-safety behavior identical.

## Out of scope / follow-ups

This PR does not change debug endpoint payload schemas, WebSocket payloads, processor public APIs, or the production recent-data query contract. It also does not attempt a broader `SignalBufferStore` decomposition beyond the read-only debug/raw seam that was clearly separable in the live code.
