### PR TITLE
Extract UI startup and background-activity orchestration out of UiAppRuntime

### DIFF
--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -1,0 +1,76 @@
+import type { AppFeatureBundle } from "../app_feature_bundle";
+
+type StartupShell = {
+  bindUiEvents(): void;
+  hydratePersistedPreferences(): Promise<void>;
+  applyLanguage(forceReloadInsights?: boolean): void;
+  renderCarSelectionWarning(): void;
+  setActiveView(viewId: string): void;
+};
+
+type StartupTransport = {
+  startTransportMode(): void;
+};
+
+type StartupFeatures = Pick<AppFeatureBundle, "history" | "realtime" | "settings" | "update" | "espFlash">;
+
+type StartupWarn = (message: string, error: unknown) => void;
+
+type UiStartupCoordinatorDeps = {
+  shell: StartupShell;
+  transport: StartupTransport;
+  features: StartupFeatures;
+  defaultViewId: string;
+  warn?: StartupWarn;
+};
+
+export class UiStartupCoordinator {
+  private readonly shell: StartupShell;
+
+  private readonly transport: StartupTransport;
+
+  private readonly features: StartupFeatures;
+
+  private readonly defaultViewId: string;
+
+  private readonly warn: StartupWarn;
+
+  constructor(deps: UiStartupCoordinatorDeps) {
+    this.shell = deps.shell;
+    this.transport = deps.transport;
+    this.features = deps.features;
+    this.defaultViewId = deps.defaultViewId;
+    this.warn = deps.warn ?? ((message, error) => console.warn(message, error));
+  }
+
+  start(): void {
+    this.shell.bindUiEvents();
+    this.features.settings.syncSettingsInputs();
+    this.runAsyncTask("hydrate persisted preferences", () => this.shell.hydratePersistedPreferences());
+    this.shell.applyLanguage(false);
+    this.shell.renderCarSelectionWarning();
+    this.shell.setActiveView(this.defaultViewId);
+    this.startBackgroundActivity();
+    this.transport.startTransportMode();
+  }
+
+  private runAsyncTask(taskName: string, task: () => Promise<void>): void {
+    void task().catch((error) => {
+      this.warn(`UI startup task failed: ${taskName}`, error);
+    });
+  }
+
+  private startBackgroundActivity(): void {
+    this.runAsyncTask("refresh location options", () => this.features.realtime.refreshLocationOptions());
+    this.runAsyncTask("load speed source", () => this.features.settings.loadSpeedSourceFromServer());
+    this.runAsyncTask("load analysis settings", () =>
+      this.features.settings.loadAnalysisSettingsFromServer(),
+    );
+    this.runAsyncTask("load cars", () => this.features.settings.loadCarsFromServer());
+    this.runAsyncTask("refresh logging status", () => this.features.realtime.refreshLoggingStatus());
+    this.runAsyncTask("refresh history", () => this.features.history.refreshHistory());
+    this.features.update.startPolling();
+    this.features.espFlash.startPolling();
+    this.features.settings.startGpsStatusPolling();
+  }
+}

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -8,6 +8,7 @@ import { UiLiveTransportController } from "./runtime/ui_live_transport_controlle
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
 import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
+import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
 
 export class UiAppRuntime {
   private readonly els: UiDomElements;
@@ -21,6 +22,8 @@ export class UiAppRuntime {
   private readonly spectrum: UiSpectrumController;
 
   private readonly transport: UiLiveTransportController;
+
+  private readonly startup: UiStartupCoordinator;
 
   constructor(
     els: UiDomElements = createUiDomRegistry(),
@@ -67,34 +70,15 @@ export class UiAppRuntime {
     });
     this.shell.attachFeatures(this.features);
     this.transport.attachFeatures(this.features);
-  }
-
-  start(): void {
-    this.shell.bindUiEvents();
-    this.features.settings.syncSettingsInputs();
-    this.runAsyncTask("hydrate persisted preferences", () => this.shell.hydratePersistedPreferences());
-    this.shell.applyLanguage(false);
-    this.shell.renderCarSelectionWarning();
-    this.shell.setActiveView(DEFAULT_SHELL_VIEW_ID);
-    this.startBackgroundActivity();
-    this.transport.startTransportMode();
-  }
-
-  private runAsyncTask(taskName: string, task: () => Promise<void>): void {
-    void task().catch((error) => {
-      console.warn(`UI startup task failed: ${taskName}`, error);
+    this.startup = new UiStartupCoordinator({
+      shell: this.shell,
+      transport: this.transport,
+      features: this.features,
+      defaultViewId: DEFAULT_SHELL_VIEW_ID,
     });
   }
 
-  private startBackgroundActivity(): void {
-    this.runAsyncTask("refresh location options", () => this.features.realtime.refreshLocationOptions());
-    this.runAsyncTask("load speed source", () => this.features.settings.loadSpeedSourceFromServer());
-    this.runAsyncTask("load analysis settings", () => this.features.settings.loadAnalysisSettingsFromServer());
-    this.runAsyncTask("load cars", () => this.features.settings.loadCarsFromServer());
-    this.runAsyncTask("refresh logging status", () => this.features.realtime.refreshLoggingStatus());
-    this.runAsyncTask("refresh history", () => this.features.history.refreshHistory());
-    this.features.update.startPolling();
-    this.features.espFlash.startPolling();
-    this.features.settings.startGpsStatusPolling();
+  start(): void {
+    this.startup.start();
   }
 }

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "@playwright/test";
+
+import { UiStartupCoordinator } from "../src/app/runtime/ui_startup_coordinator";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushAsyncWork(rounds = 12): Promise<void> {
+  for (let index = 0; index < rounds; index += 1) {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+function createCoordinatorHarness() {
+  const calls: string[] = [];
+  const warnings: Array<{ message: string; error: unknown }> = [];
+  const hydrate = createDeferred<void>();
+  const refreshLocationOptions = createDeferred<void>();
+  const loadSpeedSource = createDeferred<void>();
+  const loadAnalysisSettings = createDeferred<void>();
+  const loadCars = createDeferred<void>();
+  const refreshLoggingStatus = createDeferred<void>();
+  const refreshHistory = createDeferred<void>();
+
+  const coordinator = new UiStartupCoordinator({
+    shell: {
+      bindUiEvents(): void {
+        calls.push("shell.bindUiEvents");
+      },
+      hydratePersistedPreferences(): Promise<void> {
+        calls.push("shell.hydratePersistedPreferences");
+        return hydrate.promise;
+      },
+      applyLanguage(forceReloadInsights = false): void {
+        calls.push(`shell.applyLanguage:${String(forceReloadInsights)}`);
+      },
+      renderCarSelectionWarning(): void {
+        calls.push("shell.renderCarSelectionWarning");
+      },
+      setActiveView(viewId: string): void {
+        calls.push(`shell.setActiveView:${viewId}`);
+      },
+    },
+    features: {
+      history: {
+        refreshHistory(): Promise<void> {
+          calls.push("history.refreshHistory");
+          return refreshHistory.promise;
+        },
+      },
+      realtime: {
+        refreshLocationOptions(): Promise<void> {
+          calls.push("realtime.refreshLocationOptions");
+          return refreshLocationOptions.promise;
+        },
+        refreshLoggingStatus(): Promise<void> {
+          calls.push("realtime.refreshLoggingStatus");
+          return refreshLoggingStatus.promise;
+        },
+      },
+      settings: {
+        syncSettingsInputs(): void {
+          calls.push("settings.syncSettingsInputs");
+        },
+        loadSpeedSourceFromServer(): Promise<void> {
+          calls.push("settings.loadSpeedSourceFromServer");
+          return loadSpeedSource.promise;
+        },
+        loadAnalysisSettingsFromServer(): Promise<void> {
+          calls.push("settings.loadAnalysisSettingsFromServer");
+          return loadAnalysisSettings.promise;
+        },
+        loadCarsFromServer(): Promise<void> {
+          calls.push("settings.loadCarsFromServer");
+          return loadCars.promise;
+        },
+        startGpsStatusPolling(): void {
+          calls.push("settings.startGpsStatusPolling");
+        },
+      },
+      update: {
+        startPolling(): void {
+          calls.push("update.startPolling");
+        },
+      },
+      espFlash: {
+        startPolling(): void {
+          calls.push("espFlash.startPolling");
+        },
+      },
+    },
+    transport: {
+      startTransportMode(): void {
+        calls.push("transport.startTransportMode");
+      },
+    },
+    defaultViewId: "dashboardView",
+    warn(message: string, error: unknown): void {
+      warnings.push({ message, error });
+    },
+  });
+
+  return {
+    calls,
+    warnings,
+    hydrate,
+    refreshLocationOptions,
+    loadSpeedSource,
+    loadAnalysisSettings,
+    loadCars,
+    refreshLoggingStatus,
+    refreshHistory,
+    coordinator,
+  };
+}
+
+test.describe("UiStartupCoordinator", () => {
+  test("runs startup and background activity in the expected order", () => {
+    const harness = createCoordinatorHarness();
+
+    harness.coordinator.start();
+
+    expect(harness.calls).toEqual([
+      "shell.bindUiEvents",
+      "settings.syncSettingsInputs",
+      "shell.hydratePersistedPreferences",
+      "shell.applyLanguage:false",
+      "shell.renderCarSelectionWarning",
+      "shell.setActiveView:dashboardView",
+      "realtime.refreshLocationOptions",
+      "settings.loadSpeedSourceFromServer",
+      "settings.loadAnalysisSettingsFromServer",
+      "settings.loadCarsFromServer",
+      "realtime.refreshLoggingStatus",
+      "history.refreshHistory",
+      "update.startPolling",
+      "espFlash.startPolling",
+      "settings.startGpsStatusPolling",
+      "transport.startTransportMode",
+    ]);
+  });
+
+  test("async startup failures warn without blocking later startup work", async () => {
+    const harness = createCoordinatorHarness();
+    const hydrateError = new Error("hydrate failed");
+    const historyError = new Error("history failed");
+
+    harness.coordinator.start();
+    harness.hydrate.reject(hydrateError);
+    harness.refreshHistory.reject(historyError);
+    harness.refreshLocationOptions.resolve();
+    harness.loadSpeedSource.resolve();
+    harness.loadAnalysisSettings.resolve();
+    harness.loadCars.resolve();
+    harness.refreshLoggingStatus.resolve();
+
+    await flushAsyncWork();
+
+    expect(harness.calls).toContain("transport.startTransportMode");
+    expect(harness.warnings).toEqual([
+      {
+        message: "UI startup task failed: hydrate persisted preferences",
+        error: hydrateError,
+      },
+      {
+        message: "UI startup task failed: refresh history",
+        error: historyError,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1497.

This PR resolves `#1497` by extracting the UI startup and background-activity sequencing out of `UiAppRuntime` into a focused `UiStartupCoordinator`. The goal is to narrow `UiAppRuntime` so it remains the composition root and public browser entrypoint, while the coordinator owns the operational workflow of startup: event binding, preference hydration kickoff, initial shell rendering, background refresh scheduling, polling startup, and transport activation. The startup order and behavior remain intentionally unchanged.

## Problem being solved

Before this change, `UiAppRuntime` did two jobs at once.

First, it was the composition root. It created the DOM registry, app state, shell controller, spectrum controller, transport controller, and the app feature bundle. That is the right responsibility for a top-level runtime class.

Second, it also owned the inline startup workflow in `start()` and `startBackgroundActivity()`. That workflow included UI event binding, settings input sync, async persisted-preference hydration, language application, warning/view setup, six background fetch tasks, three long-running polling starts, and transport activation. That sequencing logic is operational workflow rather than dependency composition.

Keeping those startup details inline in the composition root made even small startup-order changes require editing the top-level runtime wiring directly. It also made the startup sequence harder to test in isolation, because there was no focused seam for asserting order and failure handling.

## Implementation approach

I introduced `apps/ui/src/app/runtime/ui_startup_coordinator.ts` with a `UiStartupCoordinator` class that owns the startup orchestration previously embedded inside `UiAppRuntime`.

The coordinator receives only the dependencies it needs:

- shell startup hooks
- transport startup hook
- the subset of feature bundle responsibilities needed during startup
- the default view id
- an optional warning callback, defaulting to `console.warn`

Its `start()` method preserves the current startup sequence:

1. bind UI events
2. sync settings inputs
3. kick off persisted-preference hydration with async warning isolation
4. apply language
5. render car-selection warning
6. set the default active view
7. start background activity
8. start transport mode

The background-activity portion also keeps the existing order and behavior:

- refresh location options
- load speed source
- load analysis settings
- load cars
- refresh logging status
- refresh history
- start update polling
- start ESP flash polling
- start GPS status polling

The coordinator keeps the same async failure-handling shape the runtime had before: each startup task is launched and isolated through a `runAsyncTask()` helper that warns but does not block later startup work.

With that in place, `UiAppRuntime` becomes visibly smaller. It still constructs the runtime dependencies and remains the public `start()` entrypoint, but it now delegates startup workflow to the extracted coordinator.

## Main code changes by area

In `apps/ui/src/app/runtime/ui_startup_coordinator.ts`, I added the new coordinator and its small dependency contract. I kept the dependency surface method-focused so the coordinator is easy to unit test with small stubs instead of needing a fully constructed runtime.

In `apps/ui/src/app/ui_app_runtime.ts`, I instantiated the coordinator after all runtime dependencies were fully wired and replaced the inline startup implementation with a single delegation call in `start()`.

In `apps/ui/tests/ui_startup_coordinator.spec.ts`, I added focused tests for the new seam:

- a startup-order test that asserts the sequence of shell calls, background task scheduling, polling starts, and transport activation
- an async failure-handling test that verifies rejected startup tasks emit warnings without blocking later startup work, including transport activation

These tests cover the coordinator directly, while the existing bootstrap smoke continues to validate the public runtime entrypoint end to end.

## Behavior preservation

This refactor does not change:

- the public `startUiApp()` entrypoint
- the public `UiAppRuntime.start()` method
- the startup order
- the background polling set
- the startup warning message format
- feature/controller public APIs
- transport startup behavior

The startup workflow is intentionally the same workflow in a better home. The coordinator still defaults to `console.warn(message, error)` so warning behavior remains equivalent in production, while tests can inject a capture function.

## Validation performed

I validated this change in several layers.

First, I ran focused frontend lint and type checks:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`

Both passed.

Second, I ran focused Playwright coverage for the extracted seam and the existing bootstrap contract:

- `cd apps/ui && npx playwright test tests/ui_startup_coordinator.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`

That run completed green with `3 passed`.

Those tests validate both the new isolated coordinator behavior and the end-to-end bootstrap flow that still goes through `startUiApp()` and `UiAppRuntime.start()`.

Third, I ran a production UI build:

- `cd apps/ui && npm run build`

That passed cleanly.

I also ran a code-review pass over the final diff, and it found no meaningful issues.

## Why this is the smallest maintainable seam

I intentionally kept the extraction focused on sequencing and orchestration only. The shell controller, transport controller, and feature bundle implementations all stay where they are. This matters because those classes already own real behavior and state transitions; this issue is about removing orchestration from the composition root, not redistributing feature logic across the frontend.

That makes `UiStartupCoordinator` a narrow workflow object rather than the beginning of a broader UI architecture rewrite. It is a straightforward improvement that makes future startup changes easier to reason about and easier to test.

## Risks, tradeoffs, and edge cases

The main risk in this refactor is silently changing startup order, since even a small reorder could affect initial rendering or background polling. To reduce that risk, I preserved the existing sequence exactly and added a direct order assertion in the new coordinator test.

Another subtle area is async failure handling. The current app intentionally warns but continues startup when background tasks fail. The new coordinator preserves that behavior and tests it explicitly so a rejection does not block later startup work.

The coordinator now owns a small method-based dependency contract. That is a deliberate tradeoff: it adds one more runtime collaborator, but it removes orchestration details from the top-level runtime and creates a real unit-test seam for startup behavior.

## Out of scope / follow-ups

This PR does not change polling intervals, feature logic, transport logic, or overall UI architecture. It also does not redesign startup error reporting beyond preserving the current warning behavior in a testable form. The change is intentionally scoped to startup/background orchestration so the refactor stays reviewable and low risk.
