### PR TITLE
Replace UiLiveTransportController's AppFeatureBundle dependency with narrow transport ports

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,7 +1,6 @@
-import { adaptServerPayload, type AdaptedPayload } from "../../server_payload";
+import { adaptServerPayload, type AdaptedClient, type AdaptedPayload } from "../../server_payload";
 import { runDemoMode } from "../demo_mode";
 import { WsClient } from "../../ws";
-import type { AppFeatureBundle } from "../app_feature_bundle";
 import { applySpectrumTick, type AppState } from "../ui_app_state";
 
 type UiLiveTransportControllerDeps = {
@@ -13,10 +12,17 @@ type UiLiveTransportControllerDeps = {
   updateSpectrumOverlay: () => void;
 };
 
+export interface UiTransportFeaturePorts {
+  updateClientSelection(): void;
+  maybeRenderSensorsSettingsList(force?: boolean): void;
+  renderLoggingStatus(): void;
+  renderStatus(clientRow: AdaptedClient | undefined): void;
+}
+
 export class UiLiveTransportController {
   private readonly state: AppState;
 
-  private features: AppFeatureBundle | null = null;
+  private ports: UiTransportFeaturePorts | null = null;
 
   private readonly payloadErrorMessage: () => string;
 
@@ -37,8 +43,8 @@ export class UiLiveTransportController {
     this.updateSpectrumOverlay = deps.updateSpectrumOverlay;
   }
 
-  attachFeatures(features: AppFeatureBundle): void {
-    this.features = features;
+  attachPorts(ports: UiTransportFeaturePorts): void {
+    this.ports = ports;
   }
 
   sendSelection(): void {
@@ -79,7 +85,7 @@ export class UiLiveTransportController {
   }
 
   private applyPayload(payload: unknown): void {
-    const features = this.requireFeatures();
+    const ports = this.requirePorts();
     let adapted: AdaptedPayload;
     try {
       adapted = adaptServerPayload(payload);
@@ -102,9 +108,9 @@ export class UiLiveTransportController {
       adapted.spectra,
     );
     this.state.spectrum.spectra = spectrumTick.spectra;
-    features.realtime.updateClientSelection();
-    features.realtime.maybeRenderSensorsSettingsList();
-    features.realtime.renderLoggingStatus();
+    ports.updateClientSelection();
+    ports.maybeRenderSensorsSettingsList();
+    ports.renderLoggingStatus();
     if (prevSelected !== this.state.realtime.selectedClientId) {
       this.sendSelection();
     }
@@ -117,7 +123,7 @@ export class UiLiveTransportController {
     } else {
       this.updateSpectrumOverlay();
     }
-    features.realtime.renderStatus(
+    ports.renderStatus(
       this.state.realtime.clients.find((client) => client.id === this.state.realtime.selectedClientId),
     );
   }
@@ -143,10 +149,10 @@ export class UiLiveTransportController {
     this.state.transport.ws.connect();
   }
 
-  private requireFeatures(): AppFeatureBundle {
-    if (this.features === null) {
-      throw new Error("UiLiveTransportController features used before initialization");
+  private requirePorts(): UiTransportFeaturePorts {
+    if (this.ports === null) {
+      throw new Error("UiLiveTransportController ports used before initialization");
     }
-    return this.features;
+    return this.ports;
   }
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -4,7 +4,7 @@ import { createUiDomRegistry } from "./ui_dom_registry";
 import { createAppFeatureBundle, type AppFeatureBundle } from "./app_feature_bundle";
 import type { AppState } from "./ui_app_state";
 import { createAppState } from "./ui_app_state";
-import { UiLiveTransportController } from "./runtime/ui_live_transport_controller";
+import { UiLiveTransportController, type UiTransportFeaturePorts } from "./runtime/ui_live_transport_controller";
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
 import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
@@ -69,7 +69,13 @@ export class UiAppRuntime {
       sendSelection: () => this.transport.sendSelection(),
     });
     this.shell.attachFeatures(this.features);
-    this.transport.attachFeatures(this.features);
+    const transportPorts: UiTransportFeaturePorts = {
+      updateClientSelection: () => this.features.realtime.updateClientSelection(),
+      maybeRenderSensorsSettingsList: (force) => this.features.realtime.maybeRenderSensorsSettingsList(force),
+      renderLoggingStatus: () => this.features.realtime.renderLoggingStatus(),
+      renderStatus: (clientRow) => this.features.realtime.renderStatus(clientRow),
+    };
+    this.transport.attachPorts(transportPorts);
     this.startup = new UiStartupCoordinator({
       shell: this.shell,
       transport: this.transport,

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+
+import { EXPECTED_SCHEMA_VERSION, type LiveWsPayload } from "../src/contracts/ws_payload_types";
+import { UiLiveTransportController, type UiTransportFeaturePorts } from "../src/app/runtime/ui_live_transport_controller";
+import { createAppState } from "../src/app/ui_app_state";
+
+function makeLivePayload(overrides: Partial<LiveWsPayload> = {}): LiveWsPayload {
+  return {
+    schema_version: EXPECTED_SCHEMA_VERSION,
+    server_time: "2026-01-01T00:00:00Z",
+    clients: [],
+    selected_client_id: null,
+    rotational_speeds: null,
+    speed_mps: 10,
+    ...overrides,
+  };
+}
+
+function makeClient(id: string): LiveWsPayload["clients"][number] {
+  return {
+    id,
+    name: `Sensor ${id}`,
+    connected: true,
+    mac_address: `00:11:22:33:44:${id.slice(-2).padStart(2, "0")}`,
+    location_code: "",
+    last_seen_age_ms: 0,
+    dropped_frames: 0,
+    frames_total: 1,
+    sample_rate_hz: 1600,
+    firmware_version: "1.0.0",
+  };
+}
+
+function applyPayload(controller: UiLiveTransportController, payload: LiveWsPayload): void {
+  (controller as unknown as { applyPayload(nextPayload: LiveWsPayload): void }).applyPayload(payload);
+}
+
+test.describe("UiLiveTransportController", () => {
+  test("applies payloads through narrow transport ports without an AppFeatureBundle", () => {
+    const state = createAppState();
+    const sentSelections: Array<{ client_id: string | null }> = [];
+    state.transport.ws = {
+      send(selection: { client_id: string | null }) {
+        sentSelections.push(selection);
+      },
+    } as unknown as typeof state.transport.ws;
+
+    let renderWsStateCalls = 0;
+    let renderSpeedReadoutCalls = 0;
+    let renderSpectrumCalls = 0;
+    let updateSpectrumOverlayCalls = 0;
+
+    const controller = new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+      renderWsState: () => {
+        renderWsStateCalls += 1;
+      },
+      renderSpeedReadout: () => {
+        renderSpeedReadoutCalls += 1;
+      },
+      renderSpectrum: () => {
+        renderSpectrumCalls += 1;
+      },
+      updateSpectrumOverlay: () => {
+        updateSpectrumOverlayCalls += 1;
+      },
+    });
+
+    const portCalls: string[] = [];
+    const renderedStatusIds: Array<string | null> = [];
+    const ports = {
+      updateClientSelection(): void {
+        portCalls.push("updateClientSelection");
+        state.realtime.selectedClientId = state.realtime.clients[0]?.id ?? null;
+      },
+      maybeRenderSensorsSettingsList(): void {
+        portCalls.push("maybeRenderSensorsSettingsList");
+      },
+      renderLoggingStatus(): void {
+        portCalls.push("renderLoggingStatus");
+      },
+      renderStatus(clientRow): void {
+        portCalls.push("renderStatus");
+        renderedStatusIds.push(clientRow?.id ?? null);
+      },
+    } satisfies UiTransportFeaturePorts;
+
+    controller.attachPorts(ports);
+    applyPayload(controller, makeLivePayload({
+      clients: [makeClient("client-1")],
+      speed_mps: 12,
+    }));
+
+    expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
+    expect(state.realtime.selectedClientId).toBe("client-1");
+    expect(state.realtime.speedMps).toBe(12);
+    expect(portCalls).toEqual([
+      "updateClientSelection",
+      "maybeRenderSensorsSettingsList",
+      "renderLoggingStatus",
+      "renderStatus",
+    ]);
+    expect(renderedStatusIds).toEqual(["client-1"]);
+    expect(renderWsStateCalls).toBe(1);
+    expect(renderSpeedReadoutCalls).toBe(1);
+    expect(renderSpectrumCalls).toBe(0);
+    expect(updateSpectrumOverlayCalls).toBe(1);
+    expect(sentSelections).toEqual([{ client_id: "client-1" }]);
+  });
+
+  test("throws a clear error when payloads arrive before ports are attached", () => {
+    const controller = new UiLiveTransportController({
+      state: createAppState(),
+      payloadErrorMessage: () => "payload error",
+      renderWsState: () => undefined,
+      renderSpeedReadout: () => undefined,
+      renderSpectrum: () => undefined,
+      updateSpectrumOverlay: () => undefined,
+    });
+
+    expect(() => applyPayload(controller, makeLivePayload())).toThrow(
+      "UiLiveTransportController ports used before initialization",
+    );
+  });
+});


### PR DESCRIPTION
Closes #1498

## Summary
This PR narrows the dependency surface of `UiLiveTransportController` so it no longer imports, stores, or depends on the full `AppFeatureBundle`. The controller only needs a small realtime-oriented slice of behavior when websocket payloads are applied, so the change replaces the old full-bundle handoff with an explicit `UiTransportFeaturePorts` interface and runtime wiring that passes only the callbacks transport actually uses.

The goal here is intentionally small and architectural rather than behavioral. The issue did not ask for transport payload logic to move elsewhere, for `AppState` to be redesigned, or for websocket flow to be rewritten. Instead, this change removes one unnecessary cross-feature dependency from the runtime surface while preserving the same payload application order, selection updates, render triggers, and connection-state behavior that the dashboard already relies on.

## Problem being solved
Before this patch, `UiLiveTransportController` imported `AppFeatureBundle`, stored it internally, and exposed an `attachFeatures()` hook that accepted the entire feature bundle. In practice, transport did not use most of that object. During payload application it only called four methods from the realtime feature: `updateClientSelection()`, `maybeRenderSensorsSettingsList()`, `renderLoggingStatus()`, and `renderStatus(...)`.

That mismatch created avoidable coupling. Anyone reading the transport controller had to assume it might rely on any part of the feature bundle even though the implementation only needed a narrow slice. It also made runtime wiring noisier than necessary, because `UiAppRuntime` was handing an entire multi-feature object to the controller to satisfy a much smaller dependency. The result was a less explicit runtime boundary and a controller that appeared more entangled with unrelated features than it actually was.

## Chosen implementation approach
The main constraint that shaped the fix is initialization order. `UiLiveTransportController` must already exist before `createAppFeatureBundle(...)` runs, because the realtime feature bundle depends on `sendSelection()` from transport during its own construction. That means the controller cannot simply receive the final narrow ports in its constructor unless runtime initialization is restructured more broadly, which would be out of scope for this issue.

Instead, this PR keeps the existing runtime construction order and narrows the post-construction seam. `attachFeatures()` becomes `attachPorts()`, and the controller now stores a `UiTransportFeaturePorts` object rather than the full `AppFeatureBundle`. `UiAppRuntime` constructs that port object only after the feature bundle exists, then attaches it to transport before startup proceeds. This keeps the fix small, preserves the current bootstrap ordering, and still removes the controller's dependency on unrelated features.

## Main code changes by area
In `apps/ui/src/app/runtime/ui_live_transport_controller.ts`, the controller now exports `UiTransportFeaturePorts`. The interface names exactly the callbacks transport needs from the realtime/status side of the UI. The old `AppFeatureBundle` import is gone, the internal field is now `ports` rather than `features`, and the initialization guard was updated accordingly. Payload application still follows the same sequence as before, but it now calls the narrow ports directly instead of reaching into `features.realtime`.

In `apps/ui/src/app/ui_app_runtime.ts`, runtime wiring now creates an explicit `transportPorts` object after `createAppFeatureBundle(...)` returns. That object forwards only the required realtime callbacks into transport. I kept the wiring explicit rather than passing the realtime feature object wholesale so the narrowed dependency stays obvious at the call site. One small follow-up fix forwards the optional `force` argument through `maybeRenderSensorsSettingsList(force)` so the runtime adapter matches the new interface exactly instead of silently dropping a future caller-supplied argument.

In `apps/ui/tests/ui_live_transport_controller.spec.ts`, I added focused coverage for the new seam. The main test instantiates `UiLiveTransportController` with a plain narrow ports object rather than an `AppFeatureBundle`, applies a minimal valid websocket payload, and verifies the relevant selection, render, and send-selection behavior still occurs. A second test asserts that payload processing still fails fast with a clear initialization error if transport receives payloads before ports are attached.

## Contracts, schema, config, and documentation
This change does not alter HTTP contracts, websocket payload schemas, persisted state, or user-facing copy. The external runtime behavior is intended to remain equivalent. No documentation updates were required because the affected change is an internal runtime boundary refinement rather than a user-visible workflow or contract change.

The frontend `sync:contracts` hooks still ran as part of `typecheck` and `build`, which confirmed the working tree remained consistent with generated contract artifacts, but there were no contract content changes caused by this issue.

## Validation performed
I validated the refactor locally with the same frontend command set used for the prior UI issue in this run:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_live_transport_controller.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run build`

The focused Playwright run passed all three tests, including the existing bootstrap smoke test and the two new transport-controller tests. During the smoke run, Vite still logged expected proxy `ECONNREFUSED 127.0.0.1:8000` messages for `/api/update/status` and `/api/health` because there is no backend listening in this environment, but the smoke test itself completed successfully. Linting, TypeScript checking, and production build output also completed successfully.

I also ran a code-review pass over the final diff after implementation and validation; it did not identify any substantive issues.

## Risks, tradeoffs, and edge cases considered
The primary risk here was accidentally changing transport behavior while narrowing the dependency surface. To avoid that, I kept the controller's payload application flow intact and changed only how the realtime/status callbacks are provided. The runtime still attaches dependencies before startup begins, and the controller still raises an explicit error if payloads arrive before that attachment happens.

Another consideration was whether to pass the realtime feature object directly, since it is structurally compatible with the new interface. I chose not to do that because it would make the code compile while still hiding the dependency narrowing at the runtime call site. The explicit `transportPorts` object makes it obvious which callbacks transport owns and keeps the issue's architectural intent visible to future readers.

Out of scope for this PR are the deeper follow-on refactors already queued in nearby issues, including extracting payload mutation logic itself and continuing to reduce other runtime cross-feature dependencies. This patch is meant to be one incremental step in that sequence, not the entire cleanup.
