### PR TITLE
Extract websocket payload application logic from UiLiveTransportController into a pure helper

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,7 +1,7 @@
 import { adaptServerPayload, type AdaptedClient, type AdaptedPayload } from "../../server_payload";
 import { runDemoMode } from "../demo_mode";
 import { WsClient } from "../../ws";
-import { applySpectrumTick, type AppState } from "../ui_app_state";
+import { applyLivePayloadUpdate, type AppState } from "../ui_app_state";
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
@@ -100,32 +100,24 @@ export class UiLiveTransportController {
     this.state.transport.payloadError = null;
     this.renderWsState();
 
-    const prevSelected = this.state.realtime.selectedClientId;
-    this.state.realtime.clients = adapted.clients;
-    const spectrumTick = applySpectrumTick(
-      this.state.spectrum.spectra,
-      this.state.spectrum.hasSpectrumData,
-      adapted.spectra,
-    );
-    this.state.spectrum.spectra = spectrumTick.spectra;
-    ports.updateClientSelection();
+    const update = applyLivePayloadUpdate({
+      realtime: this.state.realtime,
+      spectrum: this.state.spectrum,
+      adaptedPayload: adapted,
+      updateClientSelection: () => ports.updateClientSelection(),
+    });
     ports.maybeRenderSensorsSettingsList();
     ports.renderLoggingStatus();
-    if (prevSelected !== this.state.realtime.selectedClientId) {
+    if (update.hasSelectedClientChanged) {
       this.sendSelection();
     }
-    this.state.realtime.speedMps = adapted.speed_mps;
-    this.state.realtime.rotationalSpeeds = adapted.rotational_speeds;
-    this.state.spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
     this.renderSpeedReadout();
-    if (spectrumTick.hasNewSpectrumFrame) {
+    if (update.hasNewSpectrumFrame) {
       this.renderSpectrum();
     } else {
       this.updateSpectrumOverlay();
     }
-    ports.renderStatus(
-      this.state.realtime.clients.find((client) => client.id === this.state.realtime.selectedClientId),
-    );
+    ports.renderStatus(update.selectedClient);
   }
 
   private connectWs(): void {

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -1,7 +1,7 @@
 import type { SpectrumChart } from "../spectrum";
 import type { WsClient } from "../ws";
 import type { StrengthMetricsPayload } from "../contracts/ws_payload_types";
-import type { AdaptedClient, RotationalSpeeds } from "../server_payload";
+import type { AdaptedClient, AdaptedPayload, RotationalSpeeds } from "../server_payload";
 import { defaultLocationCodes } from "../constants";
 import type {
   CarRecord,
@@ -61,6 +61,19 @@ export interface SpectrumTickUpdate {
   hasNewSpectrumFrame: boolean;
 }
 
+export interface LivePayloadUpdateDeps {
+  realtime: RealtimeState;
+  spectrum: SpectrumState;
+  adaptedPayload: AdaptedPayload;
+  updateClientSelection: () => void;
+}
+
+export interface LivePayloadUpdateResult {
+  hasSelectedClientChanged: boolean;
+  selectedClient: AdaptedClient | undefined;
+  hasNewSpectrumFrame: boolean;
+}
+
 export function applySpectrumTick(
   previousSpectra: { clients: Record<string, SpectrumClientData> },
   previousHasSpectrumData: boolean,
@@ -80,6 +93,23 @@ export function applySpectrumTick(
     spectra: incomingSpectra,
     hasSpectrumData,
     hasNewSpectrumFrame: true,
+  };
+}
+
+export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayloadUpdateResult {
+  const { realtime, spectrum, adaptedPayload, updateClientSelection } = deps;
+  const previousSelectedClientId = realtime.selectedClientId;
+  realtime.clients = adaptedPayload.clients;
+  const spectrumTick = applySpectrumTick(spectrum.spectra, spectrum.hasSpectrumData, adaptedPayload.spectra);
+  spectrum.spectra = spectrumTick.spectra;
+  updateClientSelection();
+  realtime.speedMps = adaptedPayload.speed_mps;
+  realtime.rotationalSpeeds = adaptedPayload.rotational_speeds;
+  spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
+  return {
+    hasSelectedClientChanged: previousSelectedClientId !== realtime.selectedClientId,
+    selectedClient: realtime.clients.find((client) => client.id === realtime.selectedClientId),
+    hasNewSpectrumFrame: spectrumTick.hasNewSpectrumFrame,
   };
 }
 

--- a/apps/ui/tests/ui_live_payload_application.spec.ts
+++ b/apps/ui/tests/ui_live_payload_application.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+import type { AdaptedPayload } from "../src/server_payload";
+import { createAppState, applyLivePayloadUpdate } from "../src/app/ui_app_state";
+
+function makeAdaptedPayload(overrides: Partial<AdaptedPayload> = {}): AdaptedPayload {
+  return {
+    clients: [],
+    speed_mps: 10,
+    rotational_speeds: null,
+    spectra: null,
+    ...overrides,
+  };
+}
+
+function makeClient(id: string) {
+  return {
+    id,
+    name: `Sensor ${id}`,
+    connected: true,
+    mac_address: `00:11:22:33:44:${id.slice(-2).padStart(2, "0")}`,
+    location_code: "",
+    last_seen_age_ms: 0,
+    dropped_frames: 0,
+    frames_total: 1,
+    sample_rate_hz: 1600,
+    firmware_version: "1.0.0",
+  };
+}
+
+test.describe("applyLivePayloadUpdate", () => {
+  test("applies client, speed, spectrum, and selection changes and reports side-effect decisions", () => {
+    const state = createAppState();
+
+    const update = applyLivePayloadUpdate({
+      realtime: state.realtime,
+      spectrum: state.spectrum,
+      adaptedPayload: makeAdaptedPayload({
+        clients: [makeClient("client-1")],
+        speed_mps: 12,
+        spectra: {
+          clients: {
+            "client-1": {
+              freq: [10, 20, 30],
+              combined: [0.1, 0.2, 0.15],
+              strength_metrics: {
+                vibration_strength_db: 12,
+                peak_amp_g: 0,
+                noise_floor_amp_g: 0,
+                strength_bucket: null,
+                top_peaks: [],
+              },
+            },
+          },
+        },
+      }),
+      updateClientSelection: () => {
+        state.realtime.selectedClientId = state.realtime.clients[0]?.id ?? null;
+      },
+    });
+
+    expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
+    expect(state.realtime.selectedClientId).toBe("client-1");
+    expect(state.realtime.speedMps).toBe(12);
+    expect(state.spectrum.spectra.clients["client-1"]?.freq).toEqual([10, 20, 30]);
+    expect(state.spectrum.hasSpectrumData).toBe(true);
+    expect(update.hasSelectedClientChanged).toBe(true);
+    expect(update.hasNewSpectrumFrame).toBe(true);
+    expect(update.selectedClient?.id).toBe("client-1");
+  });
+
+  test("preserves the previous spectrum frame when the adapted payload omits spectra", () => {
+    const state = createAppState();
+    state.realtime.selectedClientId = "client-1";
+    state.spectrum.spectra = {
+      clients: {
+        "client-1": {
+          freq: [1, 2, 3],
+          combined: [0.01, 0.02, 0.03],
+          strength_metrics: {
+            vibration_strength_db: 5,
+            peak_amp_g: 0,
+            noise_floor_amp_g: 0,
+            strength_bucket: null,
+            top_peaks: [],
+          },
+        },
+      },
+    };
+    state.spectrum.hasSpectrumData = true;
+
+    const update = applyLivePayloadUpdate({
+      realtime: state.realtime,
+      spectrum: state.spectrum,
+      adaptedPayload: makeAdaptedPayload({
+        clients: [makeClient("client-1")],
+        speed_mps: 14,
+        spectra: null,
+      }),
+      updateClientSelection: () => {
+        state.realtime.selectedClientId = "client-1";
+      },
+    });
+
+    expect(state.spectrum.spectra.clients["client-1"]?.freq).toEqual([1, 2, 3]);
+    expect(state.spectrum.hasSpectrumData).toBe(true);
+    expect(state.realtime.speedMps).toBe(14);
+    expect(update.hasSelectedClientChanged).toBe(false);
+    expect(update.hasNewSpectrumFrame).toBe(false);
+    expect(update.selectedClient?.id).toBe("client-1");
+  });
+});


### PR DESCRIPTION
Closes #1499

## Summary
This PR extracts the adapted-payload application and state-transition sequence out of `UiLiveTransportController.applyPayload()` into a focused helper, `applyLivePayloadUpdate(...)`, while keeping websocket lifecycle, payload parsing, and render scheduling inside the controller. The goal is to stop transport code from owning most of the higher-level UI state mutation logic inline without changing the observable behavior of selection sync, speed updates, spectrum handling, or status rendering.

This is intentionally a small architectural cleanup. It does not replace websocket transport, alter payload contracts, or redesign the runtime. Instead, it gives the payload-application path a direct test seam, follows the same general pattern already used by `applySpectrumTick(...)`, and makes later transport/runtime cleanup safer because the controller no longer has to inline the entire adapted-payload transition flow.

## Problem being solved
Before this patch, `UiLiveTransportController.applyPayload()` mixed several responsibilities in one place. After validating/adapting the websocket payload, it directly replaced the client list, applied spectrum tick logic, updated selection, triggered several realtime/status callbacks, synchronized speed and rotational-speed values, toggled spectrum data flags, decided whether to send selection back to the server, and decided whether to render a new spectrum frame or only update the overlay.

That made the controller responsible for more than just transport and scheduling concerns. The logic was not especially large, but it blended state mutation, UI decisions, and transport orchestration tightly enough that it was harder to test directly and harder to refactor safely. The repo already had a precedent for isolating payload-related state transitions in `applySpectrumTick(...)`, but the higher-level live payload application sequence was still embedded in the controller.

The issue asked for that inline logic to move behind a focused helper so the transport controller remains about websocket behavior and rendering cadence, while the state-transition rules get a direct, testable seam of their own.

## Chosen implementation approach
I kept the change scoped around the adapted payload, not the raw websocket payload. `UiLiveTransportController` still calls `adaptServerPayload(...)` itself and still handles payload-error behavior inline, because validation/parsing failures are transport-facing concerns and should remain close to the websocket entrypoint. The extracted helper begins after payload adaptation succeeds.

The new helper, `applyLivePayloadUpdate(...)`, lives in `apps/ui/src/app/ui_app_state.ts` next to `applySpectrumTick(...)`. That placement keeps the state-transition helper with the UI state definitions and existing pure-ish state helpers instead of introducing another runtime module for a narrow piece of mutation logic. The helper is not completely pure because selection normalization still belongs to the realtime feature, so it accepts an `updateClientSelection()` callback. That keeps the extraction small and avoids duplicating feature-owned selection rules in the new helper.

The helper returns only the simple side-effect decisions that the controller still needs to act on: whether the selected client changed, which client should be rendered in the status panel, and whether a new spectrum frame arrived. Everything else stays inside the state-update helper or inside the controller, depending on who truly owns it.

## Main code changes by area
In `apps/ui/src/app/ui_app_state.ts`, this PR adds `LivePayloadUpdateDeps`, `LivePayloadUpdateResult`, and `applyLivePayloadUpdate(...)`. The helper now owns the adapted-payload mutation sequence: replacing `realtime.clients`, applying the spectrum tick, updating `spectrum.spectra`, invoking the provided selection-normalization callback, syncing `speedMps` and `rotationalSpeeds`, updating `hasSpectrumData`, and computing the follow-on decisions the caller needs.

In `apps/ui/src/app/runtime/ui_live_transport_controller.ts`, `applyPayload()` is now shorter and more focused. The controller still performs payload adaptation and preserves the same error handling path for invalid payloads. After a payload adapts successfully, it delegates the higher-level state-transition sequence to `applyLivePayloadUpdate(...)`, then performs the same side effects as before based on the helper result: render websocket state, refresh sensors/logging views, send selection when the selected client changed, update the speed readout, choose spectrum render versus overlay refresh, and render the current client status.

In `apps/ui/tests/ui_live_payload_application.spec.ts`, I added direct tests for the new helper. The main test verifies the full happy path: clients update, selection normalization runs, speed and spectrum state update correctly, and the returned side-effect decisions match the new state. The second test covers the no-spectrum path and confirms the helper preserves the previous spectrum frame while still updating the rest of the adapted realtime state. Existing controller coverage in `apps/ui/tests/ui_live_transport_controller.spec.ts` remains in place so there is still controller-level protection around the narrowed ports seam added in the previous issue.

## Contracts, schema, config, and documentation
This PR does not change HTTP responses, websocket payload schemas, persisted state, or user-facing UI copy. No documentation changes were needed because the change is an internal refactor of frontend runtime logic rather than a user-visible feature or workflow adjustment.

The standard frontend contract-sync hooks still ran during `typecheck` and `build`, confirming that the UI's generated contract artifacts remained in sync, but this issue did not introduce any contract or schema deltas.

## Validation performed
I validated the extracted helper and the preserved controller behavior with the following frontend command set:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_live_payload_application.spec.ts tests/ui_live_transport_controller.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run build`

The focused Playwright run passed all five tests: the new helper tests, the existing live transport controller tests, and the existing bootstrap smoke test. As with the prior UI issues in this run, the smoke execution logged expected Vite proxy `ECONNREFUSED 127.0.0.1:8000` messages for `/api/update/status` and `/api/health` because there is no backend listening in this local environment, but the smoke scenario itself still passed. Lint, TypeScript checking, and the production build also completed successfully.

I also ran a code-review pass over the final diff after local validation. That review did not identify any substantive issues.

## Risks, tradeoffs, and edge cases considered
The biggest risk was accidentally moving too much into the helper and blurring the boundary between transport concerns and UI state concerns. To avoid that, I kept payload adaptation, invalid-payload handling, websocket lifecycle, and render scheduling in the controller. The helper only begins once the payload is already adapted and focuses on the state-transition sequence that was previously embedded inline.

Another tradeoff was whether the new helper should be fully pure. Making it completely pure would have required duplicating selection-update rules that still belong to the realtime feature. Passing `updateClientSelection()` into the helper keeps those rules in their current home while still giving the payload-application path a much better extraction seam. That keeps the change small and behavior-safe while still meeting the issue's goal.

Out of scope for this PR are deeper follow-up cleanups, such as extracting more controller-side side effects or reworking render scheduling. Those can land later on top of this smaller seam now that the adapted-payload mutation sequence has its own direct tests and a clearer ownership boundary.
