### PR TITLE
Extract language-refresh orchestration from UiShellController.applyLanguage

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -4,6 +4,10 @@ import type { AppFeatureBundle } from "../app_feature_bundle";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { AppState } from "../ui_app_state";
 import {
+  createUiShellLanguageRefreshModule,
+  type UiShellLanguageRefreshModule,
+} from "./ui_shell_language_refresh_module";
+import {
   createUiShellNavigationModule,
   type UiShellNavigationModule,
 } from "./ui_shell_navigation_module";
@@ -37,6 +41,8 @@ export class UiShellController {
   private readonly preferences: UiShellPreferencesModule;
 
   private readonly status: UiShellStatusModule;
+
+  private readonly languageRefresh: UiShellLanguageRefreshModule;
 
   private features: AppFeatureBundle | null = null;
 
@@ -74,6 +80,16 @@ export class UiShellController {
       applyLanguage: (forceReloadInsights = false) => this.applyLanguage(forceReloadInsights),
       renderSpeedReadout: () => this.status.renderSpeedReadout(),
       showError: (message) => this.showError(message),
+    });
+    this.languageRefresh = createUiShellLanguageRefreshModule({
+      state: this.state,
+      els: this.els,
+      t: (key, vars) => this.t(key, vars),
+      renderSpeedReadout: () => this.renderSpeedReadout(),
+      renderWsState: () => this.renderWsState(),
+      renderCarSelectionWarning: () => this.renderCarSelectionWarning(),
+      renderSpectrum: () => this.renderSpectrumChart?.(),
+      updateSpectrumOverlay: () => this.updateSpectrumOverlayState?.(),
     });
   }
 
@@ -135,31 +151,7 @@ export class UiShellController {
   }
 
   applyLanguage(forceReloadInsights = false): void {
-    const features = this.requireFeatures();
-    document.documentElement.lang = this.state.shell.lang;
-    document.querySelectorAll("[data-i18n]").forEach((element) => {
-      const key = element.getAttribute("data-i18n");
-      if (key) element.textContent = this.t(key);
-    });
-    if (this.els.languageSelect) this.els.languageSelect.value = this.state.shell.lang;
-    if (this.els.speedUnitSelect) this.els.speedUnitSelect.value = this.state.shell.speedUnit;
-    this.state.realtime.locationOptions = features.realtime.buildLocationOptions(this.state.realtime.locationCodes);
-    this.state.realtime.sensorsSettingsSignature = "";
-    features.realtime.maybeRenderSensorsSettingsList(true);
-    this.renderSpeedReadout();
-    features.realtime.renderLoggingStatus();
-    features.history.renderHistoryTable();
-    this.renderWsState();
-    this.renderCarSelectionWarning();
-    if (this.state.spectrum.spectrumPlot) {
-      this.state.spectrum.spectrumPlot.destroy();
-      this.state.spectrum.spectrumPlot = null;
-      this.renderSpectrumChart?.();
-    }
-    if (forceReloadInsights) {
-      features.history.reloadExpandedRunOnLanguageChange();
-    }
-    this.updateSpectrumOverlayState?.();
+    this.languageRefresh.applyLanguage(this.requireFeatures(), forceReloadInsights);
   }
 
   bindUiEvents(): void {

--- a/apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts
@@ -1,0 +1,63 @@
+import type { HistoryFeature } from "../features/history_feature";
+import type { RealtimeFeature } from "../features/realtime_feature";
+import type { UiDomElements } from "../ui_dom_registry";
+import type { AppState } from "../ui_app_state";
+
+export interface UiShellLanguageRefreshFeaturePorts {
+  realtime: Pick<RealtimeFeature, "buildLocationOptions" | "maybeRenderSensorsSettingsList" | "renderLoggingStatus">;
+  history: Pick<HistoryFeature, "renderHistoryTable" | "reloadExpandedRunOnLanguageChange">;
+}
+
+export interface UiShellLanguageRefreshModuleDeps {
+  state: AppState;
+  els: UiDomElements;
+  t: (key: string, vars?: Record<string, unknown>) => string;
+  renderSpeedReadout: () => void;
+  renderWsState: () => void;
+  renderCarSelectionWarning: () => void;
+  renderSpectrum: () => void;
+  updateSpectrumOverlay: () => void;
+}
+
+export interface UiShellLanguageRefreshModule {
+  applyLanguage(features: UiShellLanguageRefreshFeaturePorts, forceReloadInsights?: boolean): void;
+}
+
+export function createUiShellLanguageRefreshModule(
+  deps: UiShellLanguageRefreshModuleDeps,
+): UiShellLanguageRefreshModule {
+  return {
+    applyLanguage(features: UiShellLanguageRefreshFeaturePorts, forceReloadInsights = false): void {
+      document.documentElement.lang = deps.state.shell.lang;
+      document.querySelectorAll("[data-i18n]").forEach((element) => {
+        const key = element.getAttribute("data-i18n");
+        if (key) {
+          element.textContent = deps.t(key);
+        }
+      });
+      if (deps.els.languageSelect) {
+        deps.els.languageSelect.value = deps.state.shell.lang;
+      }
+      if (deps.els.speedUnitSelect) {
+        deps.els.speedUnitSelect.value = deps.state.shell.speedUnit;
+      }
+      deps.state.realtime.locationOptions = features.realtime.buildLocationOptions(deps.state.realtime.locationCodes);
+      deps.state.realtime.sensorsSettingsSignature = "";
+      features.realtime.maybeRenderSensorsSettingsList(true);
+      deps.renderSpeedReadout();
+      features.realtime.renderLoggingStatus();
+      features.history.renderHistoryTable();
+      deps.renderWsState();
+      deps.renderCarSelectionWarning();
+      if (deps.state.spectrum.spectrumPlot) {
+        deps.state.spectrum.spectrumPlot.destroy();
+        deps.state.spectrum.spectrumPlot = null;
+        deps.renderSpectrum();
+      }
+      if (forceReloadInsights) {
+        features.history.reloadExpandedRunOnLanguageChange();
+      }
+      deps.updateSpectrumOverlay();
+    },
+  };
+}

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -3,6 +3,9 @@ import { expect, test } from "@playwright/test";
 import { createAppState } from "../src/app/ui_app_state";
 import type { UiDomElements } from "../src/app/ui_dom_registry";
 import {
+  createUiShellLanguageRefreshModule,
+} from "../src/app/runtime/ui_shell_language_refresh_module";
+import {
   DEFAULT_SHELL_VIEW_ID,
   createUiShellNavigationModule,
 } from "../src/app/runtime/ui_shell_navigation_module";
@@ -143,6 +146,15 @@ function createTextElement(): HTMLElement {
   } as unknown as HTMLElement;
 }
 
+function createI18nElement(key: string): Element {
+  return {
+    textContent: "",
+    getAttribute(name: string) {
+      return name === "data-i18n" ? key : null;
+    },
+  } as unknown as Element;
+}
+
 function createShellDeps(overrides?: Partial<UiDomElements>): {
   els: UiDomElements;
   dashboardView: HTMLElement;
@@ -211,6 +223,26 @@ function jsonResponse(body: unknown): Response {
 
 function testTranslation(key: string, vars?: Record<string, unknown>): string {
   return vars ? `${key}:${JSON.stringify(vars)}` : key;
+}
+
+function installShellDocument(elements: Element[]) {
+  const originalDocument = (globalThis as { document?: Document }).document;
+  const documentElement = { lang: "" } as HTMLElement;
+  (globalThis as { document?: Document }).document = {
+    documentElement,
+    querySelectorAll(selector: string) {
+      if (selector === "[data-i18n]") {
+        return elements;
+      }
+      return [];
+    },
+  } as unknown as Document;
+  return {
+    documentElement,
+    restore() {
+      (globalThis as { document?: Document }).document = originalDocument;
+    },
+  };
 }
 
 test.describe("createUiShellNavigationModule", () => {
@@ -463,5 +495,177 @@ test.describe("createUiShellStatusModule", () => {
     expect(speed.textContent).toContain("\"unit\":\"speed.unit.kmh\"");
     expect(carSelectionBanner.hidden).toBe(false);
     expect(carSelectionBanner.textContent).toContain("header.no_car_selected");
+  });
+});
+
+test.describe("createUiShellLanguageRefreshModule", () => {
+  test("applies the cross-feature language refresh sequence", () => {
+    const state = createAppState();
+    state.shell.lang = "nl";
+    state.shell.speedUnit = "mps";
+    state.realtime.locationCodes = ["front_left_wheel"];
+    state.realtime.sensorsSettingsSignature = "stale";
+    let destroyCalls = 0;
+    state.spectrum.spectrumPlot = {
+      destroy() {
+        destroyCalls += 1;
+      },
+    } as unknown as NonNullable<typeof state.spectrum.spectrumPlot>;
+
+    const { els, languageSelect, speedUnitSelect } = createShellDeps();
+    const documentHarness = installShellDocument([
+      createI18nElement("header.title"),
+      createI18nElement("nav.history"),
+    ]);
+    const i18nElements = documentHarness.documentElement
+      ? ((globalThis as { document?: Document }).document?.querySelectorAll("[data-i18n]") ?? [])
+      : [];
+
+    let renderSpeedReadoutCalls = 0;
+    let renderWsStateCalls = 0;
+    let renderCarSelectionWarningCalls = 0;
+    let renderSpectrumCalls = 0;
+    let updateSpectrumOverlayCalls = 0;
+    const portCalls: string[] = [];
+
+    const module = createUiShellLanguageRefreshModule({
+      state,
+      els,
+      t: testTranslation,
+      renderSpeedReadout: () => {
+        renderSpeedReadoutCalls += 1;
+      },
+      renderWsState: () => {
+        renderWsStateCalls += 1;
+      },
+      renderCarSelectionWarning: () => {
+        renderCarSelectionWarningCalls += 1;
+      },
+      renderSpectrum: () => {
+        renderSpectrumCalls += 1;
+      },
+      updateSpectrumOverlay: () => {
+        updateSpectrumOverlayCalls += 1;
+      },
+    });
+
+    try {
+      module.applyLanguage({
+        realtime: {
+          buildLocationOptions(codes) {
+            portCalls.push("buildLocationOptions");
+            return codes.map((code) => ({ code, label: `${code}-label` }));
+          },
+          maybeRenderSensorsSettingsList(force = false) {
+            portCalls.push(`maybeRenderSensorsSettingsList:${String(force)}`);
+          },
+          renderLoggingStatus() {
+            portCalls.push("renderLoggingStatus");
+          },
+        },
+        history: {
+          renderHistoryTable() {
+            portCalls.push("renderHistoryTable");
+          },
+          reloadExpandedRunOnLanguageChange() {
+            portCalls.push("reloadExpandedRunOnLanguageChange");
+          },
+        },
+      }, true);
+    } finally {
+      documentHarness.restore();
+    }
+
+    expect(documentHarness.documentElement.lang).toBe("nl");
+    expect(Array.from(i18nElements, (element) => element.textContent)).toEqual([
+      "header.title",
+      "nav.history",
+    ]);
+    expect(languageSelect.value).toBe("nl");
+    expect(speedUnitSelect.value).toBe("mps");
+    expect(state.realtime.locationOptions).toEqual([
+      { code: "front_left_wheel", label: "front_left_wheel-label" },
+    ]);
+    expect(state.realtime.sensorsSettingsSignature).toBe("");
+    expect(portCalls).toEqual([
+      "buildLocationOptions",
+      "maybeRenderSensorsSettingsList:true",
+      "renderLoggingStatus",
+      "renderHistoryTable",
+      "reloadExpandedRunOnLanguageChange",
+    ]);
+    expect(renderSpeedReadoutCalls).toBe(1);
+    expect(renderWsStateCalls).toBe(1);
+    expect(renderCarSelectionWarningCalls).toBe(1);
+    expect(destroyCalls).toBe(1);
+    expect(state.spectrum.spectrumPlot).toBeNull();
+    expect(renderSpectrumCalls).toBe(1);
+    expect(updateSpectrumOverlayCalls).toBe(1);
+  });
+
+  test("skips spectrum rebuild and history reload when not needed", () => {
+    const state = createAppState();
+    state.shell.lang = "en";
+    state.shell.speedUnit = "kmh";
+    state.realtime.locationCodes = ["rear_left_wheel"];
+    state.spectrum.spectrumPlot = null;
+
+    const { els } = createShellDeps();
+    const documentHarness = installShellDocument([createI18nElement("status.ready")]);
+
+    let renderSpectrumCalls = 0;
+    let updateSpectrumOverlayCalls = 0;
+    const portCalls: string[] = [];
+
+    const module = createUiShellLanguageRefreshModule({
+      state,
+      els,
+      t: testTranslation,
+      renderSpeedReadout: () => undefined,
+      renderWsState: () => undefined,
+      renderCarSelectionWarning: () => undefined,
+      renderSpectrum: () => {
+        renderSpectrumCalls += 1;
+      },
+      updateSpectrumOverlay: () => {
+        updateSpectrumOverlayCalls += 1;
+      },
+    });
+
+    try {
+      module.applyLanguage({
+        realtime: {
+          buildLocationOptions(codes) {
+            portCalls.push("buildLocationOptions");
+            return codes.map((code) => ({ code, label: code }));
+          },
+          maybeRenderSensorsSettingsList(force = false) {
+            portCalls.push(`maybeRenderSensorsSettingsList:${String(force)}`);
+          },
+          renderLoggingStatus() {
+            portCalls.push("renderLoggingStatus");
+          },
+        },
+        history: {
+          renderHistoryTable() {
+            portCalls.push("renderHistoryTable");
+          },
+          reloadExpandedRunOnLanguageChange() {
+            portCalls.push("reloadExpandedRunOnLanguageChange");
+          },
+        },
+      });
+    } finally {
+      documentHarness.restore();
+    }
+
+    expect(portCalls).toEqual([
+      "buildLocationOptions",
+      "maybeRenderSensorsSettingsList:true",
+      "renderLoggingStatus",
+      "renderHistoryTable",
+    ]);
+    expect(renderSpectrumCalls).toBe(0);
+    expect(updateSpectrumOverlayCalls).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #1500

## Summary
This PR extracts the cross-feature language-refresh sequence out of `UiShellController.applyLanguage()` into a dedicated shell runtime module, `createUiShellLanguageRefreshModule(...)`. The change keeps `UiShellController` as the facade that coordinates shell behavior, but it no longer owns the full inline orchestration for document i18n updates, select syncing, realtime/history refresh work, spectrum teardown/rebuild, and related overlay/status refreshes.

The goal is intentionally narrow: pull a controller-sized refresh block behind a focused helper/coordinator without changing the user-visible result of changing languages. The issue did not ask for translation changes, a navigation redesign, or a shell feature-boundary overhaul. Instead, it asked for a safer seam around a sequence that already touches multiple state slices and feature modules from one method.

## Problem being solved
Before this patch, `UiShellController.applyLanguage()` directly performed a long refresh sequence inline. After requiring the attached features, it updated `document.documentElement.lang`, rewrote every `[data-i18n]` node, synchronized the language and speed-unit selects, rebuilt realtime location labels, reset the sensors settings signature, forced a sensors-settings rerender, refreshed speed/logging/history/websocket/car-warning UI state, tore down and recreated the spectrum plot when one existed, optionally reloaded expanded history insights, and refreshed the spectrum overlay.

That logic was not incorrect, but it was doing too much inside a single controller method. The controller already delegates several narrower concerns to focused shell modules such as navigation, notifications, preferences, and status. In contrast, the language-refresh path remained a dense cross-feature block embedded directly in the controller. That made the controller harder to scan, made the orchestration harder to test directly, and increased the chance that future shell cleanup would have to refactor this large inline sequence again.

## Chosen implementation approach
I followed the same architectural direction already present in the shell runtime: move a focused orchestration seam into its own module rather than introducing another ad hoc private helper method inside the controller. The extracted module is `apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts`, which exports `createUiShellLanguageRefreshModule(...)` plus a narrow feature contract for the pieces of the realtime and history features it actually needs.

I deliberately kept the controller's broader `AppFeatureBundle` storage unchanged in this issue. There is a separate queued issue about narrowing `UiShellController`'s feature dependency surface, and I did not want this refactor to silently absorb that future scope. In this patch, `UiShellController` still owns the attached feature bundle and still exposes the same public `applyLanguage()` entrypoint, but the orchestration itself now lives behind the dedicated module.

The extracted module continues to use the live `document` because the refresh sequence is fundamentally about DOM synchronization. Instead of over-engineering DOM abstractions, I kept the production implementation simple and wrote focused tests with a small stubbed document. That preserves clarity in the runtime code while still giving the orchestration path direct test coverage.

## Main code changes by area
In `apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts`, this PR introduces the new language-refresh module. It owns the full refresh sequence that previously lived inline: updating the document language, rewriting `[data-i18n]` text, syncing the shell selects, rebuilding realtime location options, clearing the sensors-settings signature and forcing a rerender, refreshing speed/logging/history/websocket/car-warning surfaces, tearing down and recreating the spectrum plot when present, optionally reloading expanded history insights, and always refreshing the spectrum overlay at the end.

In `apps/ui/src/app/runtime/ui_shell_controller.ts`, the controller now constructs the module in its constructor and delegates `applyLanguage()` straight through to it. This makes the controller visibly smaller and more orchestration-focused, which is the exact direction the issue called for. The controller still provides the translation function and the render callbacks the module needs, but it no longer owns the refresh sequence line-by-line.

In `apps/ui/tests/ui_shell_runtime_modules.spec.ts`, I added focused coverage for the extracted language-refresh module. The first test exercises the full path: language/i18n updates, select syncing, realtime/history callbacks, spectrum plot destruction and rebuild, optional history insight reload, and overlay refresh. The second test covers the branch where there is no spectrum plot and no forced insight reload, verifying that the module still refreshes the required surfaces but skips the unnecessary work. I placed these tests in the existing shell-runtime module spec because that file already contains the shell DOM stubs and is the natural home for testing a new shell runtime module.

## Contracts, schema, config, and documentation
This PR does not change HTTP contracts, websocket payload contracts, persisted settings payloads, or any user-facing translation content. No documentation changes were required because the refactor is internal to the frontend runtime and does not change how the UI is operated or configured.

The standard frontend contract-sync hooks still ran during `typecheck` and `build`, which confirmed the generated UI contract artifacts remained up to date, but the issue itself does not introduce any schema or contract changes.

## Validation performed
I validated the extracted shell module and preserved UI behavior with the following frontend command set:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run build`

The focused Playwright run passed all eleven tests, including the new language-refresh module coverage and the existing bootstrap smoke test. As with the previous UI issues in this run, the smoke execution logged expected Vite proxy `ECONNREFUSED 127.0.0.1:8000` messages for `/api/update/status` and `/api/health` because there is no backend listening in this local environment, but the smoke path itself completed successfully. Linting, TypeScript checking, and the production build also completed successfully.

I also launched a review pass over the final diff. At the time of opening this PR, the local implementation and validation are green; if the review pass surfaces anything substantive, I will address it on this same branch.

## Risks, tradeoffs, and edge cases considered
The biggest risk was accidentally changing the ordering of the refresh sequence, since this path touches both DOM updates and multiple feature-owned surfaces. To minimize that risk, the extracted module preserves the original ordering closely rather than trying to redesign the workflow while moving it. That includes preserving the forced sensors-settings rerender, the conditional spectrum teardown/rebuild, the optional history insight reload, and the final overlay refresh.

Another tradeoff was whether to split the extracted logic further immediately. For example, one could imagine separate helpers for DOM i18n rewriting, realtime refresh, and spectrum handling. I chose not to do that here because the issue asks for one focused orchestration seam, not a multi-step shell architecture rewrite. The new module is a clear improvement in structure while staying safely within scope.

Out of scope for this PR are broader shell dependency cleanups, especially the future work around replacing `UiShellController`'s full feature-bundle dependency with narrower ports. This PR should make that later change easier, but it does not attempt to complete it preemptively.
