### PR TITLE
Replace UiShellController AppFeatureBundle dependency with shell ports

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -1,8 +1,11 @@
 import * as I18N from "../../i18n";
 import { formatIntLocale } from "../../format";
-import type { AppFeatureBundle } from "../app_feature_bundle";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { AppState } from "../ui_app_state";
+import {
+  bindUiShellFeatureEvents,
+  type UiShellFeaturePorts,
+} from "./ui_shell_feature_ports";
 import {
   createUiShellLanguageRefreshModule,
   type UiShellLanguageRefreshModule,
@@ -44,7 +47,7 @@ export class UiShellController {
 
   private readonly languageRefresh: UiShellLanguageRefreshModule;
 
-  private features: AppFeatureBundle | null = null;
+  private ports: UiShellFeaturePorts | null = null;
 
   private renderSpectrumChart: (() => void) | null = null;
 
@@ -93,8 +96,8 @@ export class UiShellController {
     });
   }
 
-  attachFeatures(features: AppFeatureBundle): void {
-    this.features = features;
+  attachPorts(ports: UiShellFeaturePorts): void {
+    this.ports = ports;
   }
 
   attachSpectrumHooks(deps: {
@@ -151,7 +154,7 @@ export class UiShellController {
   }
 
   applyLanguage(forceReloadInsights = false): void {
-    this.languageRefresh.applyLanguage(this.requireFeatures(), forceReloadInsights);
+    this.languageRefresh.applyLanguage(this.requirePorts().languageRefresh, forceReloadInsights);
   }
 
   bindUiEvents(): void {
@@ -165,19 +168,13 @@ export class UiShellController {
   }
 
   private bindFeatureEvents(): void {
-    const features = this.requireFeatures();
-    features.settings.bindHandlers();
-    features.cars.bindWizardHandlers();
-    features.realtime.bindHandlers();
-    features.history.bindHandlers();
-    features.update.bindUpdateHandlers();
-    features.espFlash.bindHandlers();
+    bindUiShellFeatureEvents(this.requirePorts());
   }
 
-  private requireFeatures(): AppFeatureBundle {
-    if (this.features === null) {
-      throw new Error("UiShellController features used before initialization");
+  private requirePorts(): UiShellFeaturePorts {
+    if (this.ports === null) {
+      throw new Error("UiShellController ports used before initialization");
     }
-    return this.features;
+    return this.ports;
   }
 }

--- a/apps/ui/src/app/runtime/ui_shell_feature_ports.ts
+++ b/apps/ui/src/app/runtime/ui_shell_feature_ports.ts
@@ -1,0 +1,20 @@
+import type { UiShellLanguageRefreshFeaturePorts } from "./ui_shell_language_refresh_module";
+
+export interface UiShellFeaturePorts {
+  bindSettingsHandlers(): void;
+  bindCarWizardHandlers(): void;
+  bindRealtimeHandlers(): void;
+  bindHistoryHandlers(): void;
+  bindUpdateHandlers(): void;
+  bindEspFlashHandlers(): void;
+  languageRefresh: UiShellLanguageRefreshFeaturePorts;
+}
+
+export function bindUiShellFeatureEvents(ports: UiShellFeaturePorts): void {
+  ports.bindSettingsHandlers();
+  ports.bindCarWizardHandlers();
+  ports.bindRealtimeHandlers();
+  ports.bindHistoryHandlers();
+  ports.bindUpdateHandlers();
+  ports.bindEspFlashHandlers();
+}

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -6,6 +6,7 @@ import type { AppState } from "./ui_app_state";
 import { createAppState } from "./ui_app_state";
 import { UiLiveTransportController, type UiTransportFeaturePorts } from "./runtime/ui_live_transport_controller";
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
+import type { UiShellFeaturePorts } from "./runtime/ui_shell_feature_ports";
 import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
@@ -68,7 +69,26 @@ export class UiAppRuntime {
       renderCarSelectionWarning: () => this.shell.renderCarSelectionWarning(),
       sendSelection: () => this.transport.sendSelection(),
     });
-    this.shell.attachFeatures(this.features);
+    const shellPorts: UiShellFeaturePorts = {
+      bindSettingsHandlers: () => this.features.settings.bindHandlers(),
+      bindCarWizardHandlers: () => this.features.cars.bindWizardHandlers(),
+      bindRealtimeHandlers: () => this.features.realtime.bindHandlers(),
+      bindHistoryHandlers: () => this.features.history.bindHandlers(),
+      bindUpdateHandlers: () => this.features.update.bindUpdateHandlers(),
+      bindEspFlashHandlers: () => this.features.espFlash.bindHandlers(),
+      languageRefresh: {
+        realtime: {
+          buildLocationOptions: (codes) => this.features.realtime.buildLocationOptions(codes),
+          maybeRenderSensorsSettingsList: (force) => this.features.realtime.maybeRenderSensorsSettingsList(force),
+          renderLoggingStatus: () => this.features.realtime.renderLoggingStatus(),
+        },
+        history: {
+          renderHistoryTable: () => this.features.history.renderHistoryTable(),
+          reloadExpandedRunOnLanguageChange: () => this.features.history.reloadExpandedRunOnLanguageChange(),
+        },
+      },
+    };
+    this.shell.attachPorts(shellPorts);
     const transportPorts: UiTransportFeaturePorts = {
       updateClientSelection: () => this.features.realtime.updateClientSelection(),
       maybeRenderSensorsSettingsList: (force) => this.features.realtime.maybeRenderSensorsSettingsList(force),

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -3,6 +3,10 @@ import { expect, test } from "@playwright/test";
 import { createAppState } from "../src/app/ui_app_state";
 import type { UiDomElements } from "../src/app/ui_dom_registry";
 import {
+  bindUiShellFeatureEvents,
+  type UiShellFeaturePorts,
+} from "../src/app/runtime/ui_shell_feature_ports";
+import {
   createUiShellLanguageRefreshModule,
 } from "../src/app/runtime/ui_shell_language_refresh_module";
 import {
@@ -667,5 +671,53 @@ test.describe("createUiShellLanguageRefreshModule", () => {
     ]);
     expect(renderSpectrumCalls).toBe(0);
     expect(updateSpectrumOverlayCalls).toBe(1);
+  });
+});
+
+test.describe("bindUiShellFeatureEvents", () => {
+  test("invokes the narrow shell binding hooks without needing an AppFeatureBundle", () => {
+    const portCalls: string[] = [];
+    const ports = {
+      bindSettingsHandlers() {
+        portCalls.push("bindSettingsHandlers");
+      },
+      bindCarWizardHandlers() {
+        portCalls.push("bindCarWizardHandlers");
+      },
+      bindRealtimeHandlers() {
+        portCalls.push("bindRealtimeHandlers");
+      },
+      bindHistoryHandlers() {
+        portCalls.push("bindHistoryHandlers");
+      },
+      bindUpdateHandlers() {
+        portCalls.push("bindUpdateHandlers");
+      },
+      bindEspFlashHandlers() {
+        portCalls.push("bindEspFlashHandlers");
+      },
+      languageRefresh: {
+        realtime: {
+          buildLocationOptions: () => [],
+          maybeRenderSensorsSettingsList: () => undefined,
+          renderLoggingStatus: () => undefined,
+        },
+        history: {
+          renderHistoryTable: () => undefined,
+          reloadExpandedRunOnLanguageChange: () => undefined,
+        },
+      },
+    } satisfies UiShellFeaturePorts;
+
+    bindUiShellFeatureEvents(ports);
+
+    expect(portCalls).toEqual([
+      "bindSettingsHandlers",
+      "bindCarWizardHandlers",
+      "bindRealtimeHandlers",
+      "bindHistoryHandlers",
+      "bindUpdateHandlers",
+      "bindEspFlashHandlers",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
This pull request resolves issue #1501 by removing `UiShellController`'s dependency on the full `AppFeatureBundle` and replacing it with an explicit shell-oriented port contract. Before this change, the shell controller stored the entire feature bundle even though it only used a small, well-defined subset of that surface for two responsibilities: binding feature-owned UI handlers and delegating the language-refresh sequence to the existing shell language-refresh module. That broad dependency made the shell runtime harder to reason about because it implied the controller needed access to far more functionality than it actually consumed.

The updated implementation narrows that runtime seam without changing user-visible behavior. `UiShellController` now stores `UiShellFeaturePorts`, a focused interface that exposes exactly the six bind hooks and the language-refresh ports it needs. Runtime wiring in `UiAppRuntime` stays explicit and straightforward: it still creates the full feature bundle once, but it now adapts that bundle into the smaller shell-specific port object before attaching it to the controller. This keeps the feature bundle at the composition boundary and out of the shell controller itself.

Closes #1501.

## Problem being solved
The GitHub issue called out a structural mismatch in the UI runtime. `UiShellController` held onto the entire `AppFeatureBundle`, but its real needs were much narrower than that bundle’s total surface. The controller only needed to kick off handler binding for a fixed set of features and to hand a subset of realtime/history behavior into the already-extracted language-refresh orchestration. That meant the controller was coupled to unrelated feature implementation details purely because the wiring layer had passed it a broad object.

That kind of dependency is cheap in the short term but expensive over time. It makes the shell controller look more powerful than it is, encourages future cross-feature reach-through, and obscures which responsibilities actually belong to the shell runtime. The issue’s acceptance criteria were deliberately small and behavior-preserving: stop importing and storing `AppFeatureBundle`, keep runtime wiring explicit, preserve bind and refresh behavior, and add focused coverage around the narrower dependency seam.

## Implementation approach
I treated this as a dependency-surface narrowing change rather than a behavior rewrite. The goal was not to redesign shell orchestration or introduce a new feature registry. Instead, the goal was to keep the existing control flow intact while moving the broad dependency back to the runtime composition layer, where it belongs.

The implementation follows the same direction as the recently completed UI transport refactor: define a narrow port type at the runtime seam, let the controller depend on that interface, and keep the adapter from the full feature bundle to the port contract in `ui_app_runtime.ts`. One wrinkle here was testing. A direct Node-side test import of `UiShellController` pulls in the i18n module, which imports JSON catalogs and is fine in the browser/Vite path but awkward for this style of focused Playwright module test. To keep the new coverage tight without turning this issue into a module-loader rework, I introduced a small runtime helper file that owns the shell-port contract and the bind-hook fan-out. That makes the seam testable in isolation while leaving the production controller logic simple.

## Main code changes
The first code addition is `apps/ui/src/app/runtime/ui_shell_feature_ports.ts`. This new runtime helper file defines `UiShellFeaturePorts`, the explicit shell dependency contract. The interface contains six bind operations—settings, cars wizard, realtime, history, update, and ESP flash—and a `languageRefresh` member that reuses the already-narrow `UiShellLanguageRefreshFeaturePorts` contract. The file also exports `bindUiShellFeatureEvents()`, which centralizes the ordered bind fan-out through that narrow port surface.

`apps/ui/src/app/runtime/ui_shell_controller.ts` is the core refactor. The controller no longer imports `AppFeatureBundle`, no longer stores it, and no longer uses `requireFeatures()`. Instead it stores `UiShellFeaturePorts`, exposes `attachPorts(...)`, delegates `applyLanguage()` through `this.requirePorts().languageRefresh`, and uses `bindUiShellFeatureEvents(this.requirePorts())` for feature event binding. The rest of the controller’s responsibilities remain unchanged: navigation, notifications, preferences, status rendering, and the previously extracted language-refresh module all continue to work as before.

`apps/ui/src/app/ui_app_runtime.ts` remains the composition root for the UI runtime and now does the explicit adaptation work. After constructing the feature bundle, it creates a `shellPorts` object that forwards only the methods the shell controller needs. That object includes thin wrappers for the six bind hooks plus a nested `languageRefresh` object that forwards realtime and history operations used by the language-refresh module. This keeps the broader feature bundle available where it is legitimately needed while making the controller’s dependency boundary much clearer.

The focused test updates live in `apps/ui/tests/ui_shell_runtime_modules.spec.ts`. I kept the existing language-refresh module coverage intact and added a new binding-seam test around `bindUiShellFeatureEvents()`. That test constructs a plain object satisfying `UiShellFeaturePorts`—not an `AppFeatureBundle`—and verifies the shell binding helper invokes the narrow hooks in the expected order. That gives the issue the requested targeted coverage for the narrower dependency seam without introducing a larger test-harness or module-loading change.

## Validation performed
I ran the same frontend validation pattern used for the recent UI runtime issues in this sequence, using the implementation branch worktree:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run build`

All of those checks passed locally. During the focused Playwright run, the existing Vite proxy noise for `/api/update/status` and `/api/health` still appears because there is no local backend listening on `127.0.0.1:8000` in this environment, but that behavior is already known and the smoke test itself passed successfully. I also ran a code-review pass on the final diff, and it did not flag any substantive issues.

## Risks, tradeoffs, and edge cases
This refactor intentionally does not try to solve every runtime coupling problem at once. The shell controller still coordinates several runtime modules, and the feature bundle still exists in the composition layer. That is a deliberate tradeoff: the issue asked for a narrow dependency seam, not a wholesale runtime architecture rewrite. Keeping the change small reduces risk and makes it easier to review.

The main edge case worth preserving was initialization order. `UiShellController` now throws if ports are used before `attachPorts(...)`, just as it previously threw when features were used before initialization. `UiAppRuntime` still wires the shell controller before startup orchestration runs, so the existing initialization behavior remains intact.

## Out of scope and follow-ups
This PR does not change shell behavior, feature implementations, or `AppState`. It also does not rework the already-extracted language-refresh sequence beyond narrowing how the controller reaches it. Follow-up issues in the backlog continue the same dependency-reduction theme for other feature-to-feature seams, and this change is meant to make those next steps clearer rather than pre-solving them here.
