### PR TITLE
Remove cars-to-settings car creation dependency

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -6,6 +6,7 @@ import { createRealtimeFeature, type RealtimeFeature } from "./features/realtime
 import { createSettingsFeature, type SettingsFeature } from "./features/settings_feature";
 import { createUpdateFeature, type UpdateFeature } from "./features/update_feature";
 import type { AppState } from "./ui_app_state";
+import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
 import type { AdaptedClient } from "../server_payload";
 
 export interface AppFeatureBundle {
@@ -76,6 +77,13 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     renderSpeedReadout: deps.renderSpeedReadout,
     onCarSelectionStateChange: deps.renderCarSelectionWarning,
   });
+  const carCreation = createUiCarCreationCommand({
+    getVehicleSettings: () => state.settings.vehicleSettings,
+    syncCarsPayload: (payload) => settings.syncCarsPayload(payload),
+    syncActiveCarToInputs: () => settings.syncActiveCarToInputs(),
+    renderCarList: () => settings.renderCarList(),
+    renderSpectrum: deps.renderSpectrum,
+  });
 
   const cars = createCarsFeature({
     els,
@@ -83,7 +91,8 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     escapeHtml,
     showError: deps.showError,
     fmt,
-    addCarFromWizard: settings.addCarFromWizard,
+    addCarFromWizard: (name, carType, aspects, variant) =>
+      carCreation.addCarFromWizard(name, carType, aspects, variant),
   });
 
   const update = createUpdateFeature({ els, t, escapeHtml, showError: deps.showError });

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,8 +1,7 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
-import type { CarUpsertRequest, CarsPayload } from "../../api/types";
+import type { CarsPayload } from "../../api/types";
 import {
-  addSettingsCar,
   deleteSettingsCar,
   getSettingsCars,
   setActiveSettingsCar,
@@ -42,11 +41,11 @@ export interface SettingsFeature {
   loadAnalysisSettingsFromServer(): Promise<void>;
   loadCarsFromServer(): Promise<void>;
   renderCarList(): void;
+  syncCarsPayload(payload: CarsPayload): void;
   syncActiveCarToInputs(): void;
   saveAnalysisFromInputs(): void;
   saveSpeedSourceFromInputs(): void;
   saveHeaderManualSpeedFromInput(): void;
-  addCarFromWizard(name: string, carType: string, aspects: Record<string, number>, variant?: string): Promise<void>;
   startGpsStatusPolling(): void;
   stopGpsStatusPolling(): void;
 }
@@ -105,7 +104,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     renderSpeedReadout: ctx.renderSpeedReadout,
   });
 
-  function applyCarsPayload(payload: CarsPayload): void {
+  function syncCarsPayload(payload: CarsPayload): void {
     settings.cars = payload.cars;
     const requestedActiveCarId = payload.active_car_id;
     const hasRequestedActive = requestedActiveCarId
@@ -118,7 +117,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   async function loadCarsFromServer(): Promise<void> {
     try {
       const payload = await getSettingsCars();
-      applyCarsPayload(payload);
+      syncCarsPayload(payload);
       renderCarList();
       syncActiveCarToInputs();
     } catch (_err) { /* ignore */ }
@@ -128,7 +127,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     if (!carId) return;
     try {
       const result = await setActiveSettingsCar(carId);
-      applyCarsPayload(result);
+      syncCarsPayload(result);
       syncActiveCarToInputs();
       renderCarList();
       ctx.renderSpectrum();
@@ -144,7 +143,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     if (!ok) return;
     try {
       const result = await deleteSettingsCar(carId);
-      applyCarsPayload(result);
+      syncCarsPayload(result);
       syncActiveCarToInputs();
       renderCarList();
       ctx.renderSpectrum();
@@ -208,31 +207,6 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     speedSourceModule.bindHandlers();
   }
 
-  async function addCarFromWizard(
-    name: string,
-    carType: string,
-    aspects: Record<string, number>,
-    variant?: string,
-  ): Promise<void> {
-    try {
-      const fullAspects = { ...settings.vehicleSettings, ...aspects };
-      const payload: CarUpsertRequest = { name, type: carType, aspects: fullAspects };
-      if (variant) payload.variant = variant;
-      const result = await addSettingsCar(payload);
-      if (Array.isArray(result.cars)) {
-        applyCarsPayload(result);
-        const newCar = settings.cars[settings.cars.length - 1];
-        if (newCar) {
-          const setResult = await setActiveSettingsCar(newCar.id);
-          applyCarsPayload(setResult);
-        }
-        syncActiveCarToInputs();
-        renderCarList();
-        ctx.renderSpectrum();
-      }
-    } catch (_err) { /* ignore */ }
-  }
-
   return {
     bindHandlers,
     syncSettingsInputs: analysisModule.syncSettingsInputs,
@@ -240,11 +214,11 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     loadAnalysisSettingsFromServer: analysisModule.loadAnalysisSettingsFromServer,
     loadCarsFromServer,
     renderCarList,
+    syncCarsPayload,
     syncActiveCarToInputs,
     saveAnalysisFromInputs: analysisModule.saveAnalysisFromInputs,
     saveSpeedSourceFromInputs: speedSourceModule.saveSpeedSourceFromInputs,
     saveHeaderManualSpeedFromInput: speedSourceModule.saveHeaderManualSpeedFromInput,
-    addCarFromWizard,
     startGpsStatusPolling: gpsStatusModule.startGpsStatusPolling,
     stopGpsStatusPolling: gpsStatusModule.stopGpsStatusPolling,
   };

--- a/apps/ui/src/app/runtime/ui_car_creation_command.ts
+++ b/apps/ui/src/app/runtime/ui_car_creation_command.ts
@@ -1,0 +1,61 @@
+import { addSettingsCar as addSettingsCarApi, setActiveSettingsCar as setActiveSettingsCarApi } from "../../api";
+import type { CarUpsertRequest, CarsPayload } from "../../api/types";
+
+export interface UiCarCreationCommandDeps {
+  getVehicleSettings: () => Record<string, number>;
+  syncCarsPayload: (payload: CarsPayload) => void;
+  syncActiveCarToInputs: () => void;
+  renderCarList: () => void;
+  renderSpectrum: () => void;
+  addSettingsCar?: (payload: CarUpsertRequest) => Promise<CarsPayload>;
+  setActiveSettingsCar?: (carId: string) => Promise<CarsPayload>;
+}
+
+export interface UiCarCreationCommand {
+  addCarFromWizard(
+    name: string,
+    carType: string,
+    aspects: Record<string, number>,
+    variant?: string,
+  ): Promise<void>;
+}
+
+export function createUiCarCreationCommand(
+  deps: UiCarCreationCommandDeps,
+): UiCarCreationCommand {
+  const addSettingsCar = deps.addSettingsCar ?? addSettingsCarApi;
+  const setActiveSettingsCar = deps.setActiveSettingsCar ?? setActiveSettingsCarApi;
+
+  return {
+    async addCarFromWizard(
+      name: string,
+      carType: string,
+      aspects: Record<string, number>,
+      variant?: string,
+    ): Promise<void> {
+      try {
+        const fullAspects = { ...deps.getVehicleSettings(), ...aspects };
+        const payload: CarUpsertRequest = { name, type: carType, aspects: fullAspects };
+        if (variant) {
+          payload.variant = variant;
+        }
+        const result = await addSettingsCar(payload);
+        if (!Array.isArray(result.cars)) {
+          return;
+        }
+        deps.syncCarsPayload(result);
+        const newCar = result.cars[result.cars.length - 1];
+        if (newCar) {
+          const setResult = await setActiveSettingsCar(newCar.id);
+          deps.syncCarsPayload(setResult);
+        }
+        deps.syncActiveCarToInputs();
+        deps.renderCarList();
+        deps.renderSpectrum();
+      } catch (_err) {
+        // Preserve the current silent wizard failure behavior while removing
+        // the cross-feature dependency from CarsFeature to SettingsFeature.
+      }
+    },
+  };
+}

--- a/apps/ui/tests/ui_car_creation_command.spec.ts
+++ b/apps/ui/tests/ui_car_creation_command.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "@playwright/test";
+
+import { createUiCarCreationCommand } from "../src/app/runtime/ui_car_creation_command";
+import type { CarUpsertRequest, CarsPayload } from "../src/api/types";
+
+test.describe("createUiCarCreationCommand", () => {
+  test("creates a car through the narrow runtime seam and preserves the activate-and-sync flow", async () => {
+    const payloadCalls: CarsPayload[] = [];
+    const lifecycleCalls: string[] = [];
+    const addRequests: CarUpsertRequest[] = [];
+    const setActiveRequests: string[] = [];
+    const createdCarsPayload: CarsPayload = {
+      cars: [
+        {
+          id: "car-1",
+          name: "Existing",
+          type: "Hatchback",
+          variant: "Stock",
+          aspects: { tire_width_mm: 205 },
+        },
+        {
+          id: "car-2",
+          name: "Volvo XC40 Recharge",
+          type: "SUV",
+          variant: "Twin Motor",
+          aspects: { tire_width_mm: 235, final_drive_ratio: 9.1 },
+        },
+      ],
+      active_car_id: "car-1",
+    };
+    const activatedCarsPayload: CarsPayload = {
+      ...createdCarsPayload,
+      active_car_id: "car-2",
+    };
+    const command = createUiCarCreationCommand({
+      getVehicleSettings: () => ({
+        tire_width_mm: 205,
+        tire_aspect_pct: 55,
+        rim_in: 16,
+        final_drive_ratio: 3.9,
+        current_gear_ratio: 0.82,
+      }),
+      syncCarsPayload: (payload) => {
+        payloadCalls.push(payload);
+        lifecycleCalls.push(`syncCarsPayload:${payload.active_car_id ?? "none"}`);
+      },
+      syncActiveCarToInputs: () => {
+        lifecycleCalls.push("syncActiveCarToInputs");
+      },
+      renderCarList: () => {
+        lifecycleCalls.push("renderCarList");
+      },
+      renderSpectrum: () => {
+        lifecycleCalls.push("renderSpectrum");
+      },
+      addSettingsCar: async (payload) => {
+        addRequests.push(payload);
+        return createdCarsPayload;
+      },
+      setActiveSettingsCar: async (carId) => {
+        setActiveRequests.push(carId);
+        return activatedCarsPayload;
+      },
+    });
+
+    await command.addCarFromWizard(
+      "Volvo XC40 Recharge",
+      "SUV",
+      {
+        tire_width_mm: 235,
+        tire_aspect_pct: 45,
+        rim_in: 19,
+        final_drive_ratio: 9.1,
+        current_gear_ratio: 0.71,
+      },
+      "Twin Motor",
+    );
+
+    expect(addRequests).toEqual([
+      {
+        name: "Volvo XC40 Recharge",
+        type: "SUV",
+        variant: "Twin Motor",
+        aspects: {
+          tire_width_mm: 235,
+          tire_aspect_pct: 45,
+          rim_in: 19,
+          final_drive_ratio: 9.1,
+          current_gear_ratio: 0.71,
+        },
+      },
+    ]);
+    expect(setActiveRequests).toEqual(["car-2"]);
+    expect(payloadCalls).toEqual([createdCarsPayload, activatedCarsPayload]);
+    expect(lifecycleCalls).toEqual([
+      "syncCarsPayload:car-1",
+      "syncCarsPayload:car-2",
+      "syncActiveCarToInputs",
+      "renderCarList",
+      "renderSpectrum",
+    ]);
+  });
+
+  test("preserves the current silent failure behavior when creation fails", async () => {
+    const lifecycleCalls: string[] = [];
+    const command = createUiCarCreationCommand({
+      getVehicleSettings: () => ({
+        tire_width_mm: 205,
+      }),
+      syncCarsPayload: () => {
+        lifecycleCalls.push("syncCarsPayload");
+      },
+      syncActiveCarToInputs: () => {
+        lifecycleCalls.push("syncActiveCarToInputs");
+      },
+      renderCarList: () => {
+        lifecycleCalls.push("renderCarList");
+      },
+      renderSpectrum: () => {
+        lifecycleCalls.push("renderSpectrum");
+      },
+      addSettingsCar: async () => {
+        throw new Error("network failed");
+      },
+    });
+
+    await command.addCarFromWizard("My Car", "Custom", { tire_width_mm: 225 });
+
+    expect(lifecycleCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
This pull request resolves issue #1502 by removing the direct `CarsFeature -> SettingsFeature.addCarFromWizard()` dependency and replacing it with a runtime-owned car-creation command. Before this change, the cars wizard reached into a concrete settings-feature implementation detail even though it only needed one narrow capability: create a new car from wizard inputs, activate it, and preserve the existing settings-side synchronization flow. That dependency meant the cars feature was coupled to a much broader settings implementation surface than it actually needed.

The new implementation keeps the behavior the same while moving ownership of that workflow to the runtime composition layer. A dedicated helper in `apps/ui/src/app/runtime/ui_car_creation_command.ts` now owns the create-and-activate sequence. `app_feature_bundle.ts` constructs that helper from a narrow set of settings-facing ports, then passes only the resulting command into `CarsFeature`. `SettingsFeature` no longer exposes `addCarFromWizard()` at all; instead it exposes the smaller `syncCarsPayload()` seam that the runtime command uses to preserve the existing state and UI update flow.

Closes #1502.

## Problem being solved
The issue described an explicit cross-feature dependency in the UI composition root. `createAppFeatureBundle()` wired `CarsFeature` directly to `SettingsFeature.addCarFromWizard()`, so the cars wizard depended on a concrete settings-feature method rather than on a small car-creation capability. That was a maintenance smell for two reasons.

First, it blurred ownership. The cars wizard is responsible for gathering the user’s car selection inputs, but it should not need to know that the settings feature currently owns the persistence and active-car synchronization workflow. Second, it made future changes riskier. Any refactor of settings-side car persistence or settings-side UI synchronization had an unnecessary chance of rippling into the cars wizard simply because one feature was calling into the other directly.

The acceptance criteria were intentionally modest: remove the direct dependency, preserve add-car behavior including active-car sync, make the wiring clearer about who owns the workflow, and add focused coverage for the narrower seam. I kept the change scoped to that exact request rather than trying to reorganize all feature composition at once.

## Implementation approach
I treated this as a runtime wiring problem, not a feature rewrite. The existing behavior was already correct; the coupling was the problem. So the goal was to move the car-creation orchestration behind a small runtime-owned command while preserving the same sequence of API calls and state/UI updates.

The implementation introduces `createUiCarCreationCommand(...)` in a new runtime helper file. That command accepts only the capabilities it actually needs: access to the current vehicle settings, a way to synchronize incoming cars payloads into settings state, the existing settings-side active-car/input sync, car-list rendering, spectrum rendering, and the two API calls involved in the flow. With those narrow dependencies, it can perform the exact same workflow the old `SettingsFeature.addCarFromWizard()` method performed before: merge wizard aspects into current vehicle settings, create the car, sync the returned payload, activate the newest car, sync the activation payload, and then refresh the settings-side UI.

That leaves `CarsFeature` with a single narrow dependency again: “add this car from wizard inputs.” It no longer needs to know or care whether settings, runtime, or some later dedicated service owns the underlying workflow.

## Main code changes
`apps/ui/src/app/runtime/ui_car_creation_command.ts` is the new core seam. It owns the create-and-activate workflow that was previously embedded inside `SettingsFeature`. The helper accepts narrow ports rather than a broad feature object, which keeps the dependency explicit and testable. The sequence intentionally mirrors the prior implementation: it merges current vehicle settings with wizard-provided aspects, calls `addSettingsCar`, applies the returned cars payload, activates the newest car if one exists, applies the activation payload, and finally refreshes the settings inputs, car list, and spectrum. It also preserves the existing silent failure behavior by catching errors and not surfacing new user-visible error handling in this issue.

`apps/ui/src/app/app_feature_bundle.ts` now owns the composition of that workflow. After building `SettingsFeature`, it creates the runtime car-creation command with narrow settings-facing ports and then passes `carCreation.addCarFromWizard(...)` into `createCarsFeature(...)`. This keeps the feature bundle as the composition boundary while making it clear that the workflow is runtime-owned rather than a direct feature-to-feature call.

`apps/ui/src/app/features/settings_feature.ts` is smaller and more focused after the change. The old `addCarFromWizard()` implementation is gone. In its place, the feature now exposes `syncCarsPayload()` as the narrow state/UI synchronization seam needed by the runtime command. That method preserves the behavior of the old internal `applyCarsPayload()` helper by updating cars state, reconciling the active-car id, and triggering the dependent settings UI state change. The rest of the settings feature’s responsibilities—loading cars, activating cars, deleting cars, syncing active car inputs, rendering the list, and handling analysis/speed-source concerns—remain unchanged.

Focused coverage lives in `apps/ui/tests/ui_car_creation_command.spec.ts`. The first test verifies that the new runtime command preserves the intended sequence: merged aspects are sent to `addSettingsCar`, the created car is activated, cars payloads are synchronized in order, and the settings-side sync/render hooks run at the end. The second test explicitly preserves the current silent-failure behavior by asserting that if car creation throws, no sync or render lifecycle callbacks are triggered.

## Validation performed
I ran the following local validation from the UI app directory:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_car_creation_command.spec.ts tests/smoke.cars.spec.ts tests/smoke.settings.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run build`

All of those checks passed locally. The smoke runs still log the known Vite proxy `ECONNREFUSED 127.0.0.1:8000` messages for `/api/update/status` and `/api/health` because there is no local backend listening in this environment, but the tests themselves passed and this remains an expected local condition. I also ran a code-review pass over the final diff, and it did not surface any substantive concerns.

## Risks, tradeoffs, and edge cases
This refactor intentionally preserves the existing silent failure behavior from the wizard add-car path. That behavior is not ideal in the abstract, but changing it would alter product behavior and broaden the issue beyond its stated scope. I added an explicit regression test for that behavior so the refactor does not change it accidentally.

I also deliberately kept `CarsFeature`’s dependency shape small rather than introducing a more generic registry or command bus. There is only one concrete consumer for this workflow today, so a direct runtime-owned command is clearer and lower risk than adding more abstraction machinery.

## Out of scope and follow-ups
This PR does not redesign the car wizard UI, change car payload formats, or reorganize all feature wiring in one pass. It removes one concrete cross-feature dependency cleanly, which is the exact cut the issue asked for. The remaining frontend dependency-reduction issues in the backlog can now build on the same pattern without this PR trying to pre-solve them.
