### PR TITLE
Remove realtime-to-history refresh dependency

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -7,6 +7,7 @@ import { createSettingsFeature, type SettingsFeature } from "./features/settings
 import { createUpdateFeature, type UpdateFeature } from "./features/update_feature";
 import type { AppState } from "./ui_app_state";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
+import { createUiRecordingHistoryRefresh } from "./runtime/ui_recording_history_refresh";
 import type { AdaptedClient } from "../server_payload";
 
 export interface AppFeatureBundle {
@@ -50,6 +51,9 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     fmtTs,
     formatInt,
   });
+  const recordingHistoryRefresh = createUiRecordingHistoryRefresh({
+    refreshHistory: () => history.refreshHistory(),
+  });
 
   const realtime = createRealtimeFeature({
     realtime: state.realtime,
@@ -62,7 +66,7 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     setPillState: deps.setPillState,
     setStatValue: deps.setStatValue,
     sendSelection: deps.sendSelection,
-    refreshHistory: () => history.refreshHistory(),
+    onRecordingStatusChanged: () => recordingHistoryRefresh.onRecordingStatusChanged(),
   });
 
   const settings = createSettingsFeature({

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -26,7 +26,7 @@ export interface RealtimeFeatureDeps extends FeatureDepsBase {
   setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
   setStatValue: (container: HTMLElement | null, value: string | number) => void;
   sendSelection: () => void;
-  refreshHistory: () => Promise<void>;
+  onRecordingStatusChanged: () => Promise<void>;
 }
 
 export interface RealtimeFeature {
@@ -165,7 +165,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     try {
       realtime.loggingStatus = await startLoggingRun();
       renderLoggingStatus();
-      await ctx.refreshHistory();
+      await ctx.onRecordingStatusChanged();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setPillState(els.loggingStatus, "bad", msg || t("status.unavailable"));
@@ -176,7 +176,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     try {
       realtime.loggingStatus = await stopLoggingRun();
       renderLoggingStatus();
-      await ctx.refreshHistory();
+      await ctx.onRecordingStatusChanged();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setPillState(els.loggingStatus, "bad", msg || t("status.unavailable"));

--- a/apps/ui/src/app/runtime/ui_recording_history_refresh.ts
+++ b/apps/ui/src/app/runtime/ui_recording_history_refresh.ts
@@ -1,0 +1,17 @@
+export interface UiRecordingHistoryRefreshDeps {
+  refreshHistory: () => Promise<void>;
+}
+
+export interface UiRecordingHistoryRefresh {
+  onRecordingStatusChanged(): Promise<void>;
+}
+
+export function createUiRecordingHistoryRefresh(
+  deps: UiRecordingHistoryRefreshDeps,
+): UiRecordingHistoryRefresh {
+  return {
+    onRecordingStatusChanged(): Promise<void> {
+      return deps.refreshHistory();
+    },
+  };
+}

--- a/apps/ui/tests/ui_recording_history_refresh.spec.ts
+++ b/apps/ui/tests/ui_recording_history_refresh.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+import { createUiRecordingHistoryRefresh } from "../src/app/runtime/ui_recording_history_refresh";
+
+test.describe("createUiRecordingHistoryRefresh", () => {
+  test("delegates post-recording refresh through the narrow runtime seam", async () => {
+    const calls: string[] = [];
+    const refresh = createUiRecordingHistoryRefresh({
+      refreshHistory: async () => {
+        calls.push("refreshHistory");
+      },
+    });
+
+    await refresh.onRecordingStatusChanged();
+
+    expect(calls).toEqual(["refreshHistory"]);
+  });
+
+  test("preserves refresh failures so realtime can surface them", async () => {
+    const error = new Error("history refresh failed");
+    const refresh = createUiRecordingHistoryRefresh({
+      refreshHistory: async () => {
+        throw error;
+      },
+    });
+
+    await expect(refresh.onRecordingStatusChanged()).rejects.toThrow(error);
+  });
+});


### PR DESCRIPTION
## Summary
This pull request resolves issue #1503 by removing the direct `RealtimeFeature -> HistoryFeature.refreshHistory()` dependency and replacing it with a narrower runtime-owned post-recording refresh seam. Before this change, the realtime feature named and invoked a concrete history-feature method whenever logging started or stopped successfully. That coupling was small, but it was still an explicit feature-to-feature link in the runtime wiring. The feature only needed to know that “something should happen after recording status changes successfully”; it did not need to know that the current implementation of that behavior happens to be a history refresh.

The updated implementation keeps the behavior the same while shifting ownership of that coordination back to the composition layer. A dedicated runtime helper now owns the post-recording refresh seam, and `app_feature_bundle.ts` wires it explicitly from the history feature into the realtime feature. From the realtime feature’s perspective, the dependency is now a purpose-specific callback—`onRecordingStatusChanged()`—instead of a direct history method.

Closes #1503.

## Problem being solved
The GitHub issue called out one of the remaining explicit cross-feature links in the UI runtime. `createAppFeatureBundle()` wired `RealtimeFeature` directly to `HistoryFeature.refreshHistory()` so the run list would refresh after start and stop logging actions. That worked, but it exposed an implementation detail across feature boundaries. The realtime feature did not actually need “history” as a concept here; it only needed a post-success reaction after recording status changed.

That distinction matters because direct cross-feature method calls gradually make the composition root harder to understand and maintain. The individual dependency is small, but the pattern scales badly if left alone. The issue’s acceptance criteria were deliberately narrow: stop depending directly on `HistoryFeature.refreshHistory()`, preserve equivalent history-refresh behavior after start and stop logging, keep runtime ownership explicit, and add focused coverage for the new seam.

## Implementation approach
I kept this change intentionally small. Unlike the previous issue, which had a longer workflow to extract, this dependency was already just one post-success callback. That meant the cleanest fix was not a large refactor of either feature, but a purpose-specific runtime helper that makes the seam explicit and testable.

The implementation introduces `createUiRecordingHistoryRefresh(...)` in `apps/ui/src/app/runtime/ui_recording_history_refresh.ts`. That helper accepts a single dependency, `refreshHistory`, and exposes a semantically narrower method, `onRecordingStatusChanged()`. The helper does not add new business logic; its job is to move ownership of the post-recording coordination into a runtime-owned seam outside both features. That keeps the composition layer honest about what it is wiring while letting the realtime feature depend only on the meaning of the callback rather than on the history feature API.

On the realtime side, I renamed the dependency from `refreshHistory` to `onRecordingStatusChanged`. The start and stop logging paths now call that purpose-specific callback after successful logging state updates. This preserves the original success path and error behavior: realtime still updates the logging status, still renders the new status first, and still routes any thrown error through the same existing status-pill error handling.

## Main code changes
`apps/ui/src/app/runtime/ui_recording_history_refresh.ts` is the new runtime seam. It defines a tiny helper with one responsibility: translate a narrow post-recording callback into the underlying history refresh call. The helper returns `onRecordingStatusChanged()` and intentionally preserves promise propagation rather than swallowing errors, because the realtime feature already owns the user-facing error response when the post-success refresh fails.

`apps/ui/src/app/app_feature_bundle.ts` now creates `recordingHistoryRefresh` immediately after constructing `HistoryFeature`. The bundle wiring remains explicit: the helper is built with `refreshHistory: () => history.refreshHistory()`, and the realtime feature receives `onRecordingStatusChanged: () => recordingHistoryRefresh.onRecordingStatusChanged()`. This makes it obvious that the composition layer—not the realtime feature—owns the knowledge that the current post-recording side effect is a history refresh.

`apps/ui/src/app/features/realtime_feature.ts` no longer declares `refreshHistory` in `RealtimeFeatureDeps`. Instead it depends on `onRecordingStatusChanged()`. Both `startLogging()` and `stopLogging()` continue to update `realtime.loggingStatus`, render the logging UI, and then await the post-recording callback. The error-handling behavior is unchanged: if any step in that block throws, the feature still sets the logging pill to a failure state using the existing message logic.

Focused coverage lives in `apps/ui/tests/ui_recording_history_refresh.spec.ts`. One test verifies that the helper delegates to `refreshHistory()` exactly once, which is the core contract this issue introduces. The second test verifies that refresh failures are propagated instead of swallowed, which preserves the current behavior where realtime owns surfacing the failure state.

## Validation performed
I ran the following local validation from the UI app directory:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_recording_history_refresh.spec.ts tests/smoke.bootstrap.spec.ts --config=playwright.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run build`

All of those checks passed locally. The bootstrap smoke still logs the known local Vite proxy `ECONNREFUSED 127.0.0.1:8000` messages for `/api/update/status` and `/api/health` because there is no backend listening in this environment, but that is already expected here and the smoke test itself passed. I also ran a code-review pass over the final diff, and it did not flag any substantive issues.

## Risks, tradeoffs, and edge cases
This PR intentionally does not try to generalize post-recording behavior into a broader event system. There is only one concrete consumer today, so a tiny runtime-owned helper is easier to understand and lower risk than introducing additional abstraction machinery.

I also kept error propagation intact. The helper does not catch refresh failures because the realtime feature already owns the surrounding try/catch and the current UX for surfaced failures. That keeps the behavior equivalent while still moving the dependency to the right architectural boundary.

## Out of scope and follow-ups
This PR does not change logging UX, history rendering, or the startup-time history refresh path in `UiStartupCoordinator`; that startup coordination is a separate concern and already belongs outside the realtime feature. The goal here is only to remove the explicit realtime-to-history dependency cleanly. With this change in place, the remaining UI runtime wiring is simpler and the current backlog’s frontend dependency-reduction sequence is complete.
