### PR TITLE
refactor: simplify root Makefile paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .DEFAULT_GOAL := help
 .PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
 
-LINT_TARGETS := apps/server/vibesensor apps/server/tests tools
+SERVER_DIR := apps/server
+UI_DIR := apps/ui
+LINT_TARGETS := $(SERVER_DIR)/vibesensor $(SERVER_DIR)/tests tools
 CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5
 PYTHON_VERSION := $(strip $(shell cat .python-version))
 PYTHON_MAJOR := $(word 1,$(subst ., ,$(PYTHON_VERSION)))
@@ -11,6 +13,8 @@ PYTHON_BOOTSTRAP := python$(PYTHON_MAJOR_MINOR)
 VENV_DIR := $(CURDIR)/.venv
 VENV_PYTHON := $(VENV_DIR)/bin/python
 
+# Prefer the repo venv after setup, but still allow bootstrap targets to run
+# against the pinned host interpreter before `.venv` exists.
 define RESOLVE_PYTHON
 PYTHON="$(VENV_PYTHON)"; \
 if [ ! -x "$$PYTHON" ]; then PYTHON="$(PYTHON_BOOTSTRAP)"; fi;
@@ -31,7 +35,7 @@ setup: ## Install backend dev dependencies and UI node_modules
 	@if [ ! -x "$(VENV_PYTHON)" ]; then "$(PYTHON_BOOTSTRAP)" -m venv "$(VENV_DIR)"; fi
 	"$(VENV_PYTHON)" -m pip install --upgrade pip
 	"$(VENV_PYTHON)" -m pip install -e "./apps/server[dev]"
-	cd apps/ui && npm ci
+	cd $(UI_DIR) && npm ci
 	git config --local core.hooksPath .githooks
 
 dev: ## Start the source-mounted Docker dev stack with backend reload + Vite HMR
@@ -46,17 +50,17 @@ lint: ## Run repo hygiene, static guards, docs lint, and contract drift checks
 	"$$PYTHON" -m ruff check $(LINT_TARGETS) && \
 	"$$PYTHON" -m ruff format --check $(LINT_TARGETS) && \
 	"$$PYTHON" tools/dev/check_hygiene.py && \
-	cd apps/server && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
-	cd "$(CURDIR)" && "$$PYTHON" -m vibesensor.cli.preflight apps/server/config.dev.yaml && \
-	"$$PYTHON" -m vibesensor.cli.preflight apps/server/config.docker.yaml && \
-	"$$PYTHON" -m vibesensor.cli.preflight apps/server/config.pi.yaml && \
+	cd $(SERVER_DIR) && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
+	cd "$(CURDIR)" && "$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.dev.yaml && \
+	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.docker.yaml && \
+	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.pi.yaml && \
 	"$$PYTHON" tools/dev/docs_lint.py && \
 	"$$PYTHON" -m vibesensor.cli.ws_schema_export --check && \
 	"$$PYTHON" -m vibesensor.cli.http_api_schema_export --check
 
 typecheck-backend: ## Run backend mypy checks
 	@$(RESOLVE_PYTHON) \
-	cd apps/server && "$$PYTHON" -m mypy --config-file pyproject.toml
+	cd $(SERVER_DIR) && "$$PYTHON" -m mypy --config-file pyproject.toml
 
 typecheck: ## Run backend and UI type checks
 typecheck: typecheck-backend ui-typecheck
@@ -82,7 +86,7 @@ test-full-suite: ## Run the full Docker-backed end-to-end suite locally
 	"$$PYTHON" tools/tests/run_e2e_parallel.py --shards 1
 
 sync-contracts: ## Regenerate shared frontend HTTP/WS/contracts artifacts
-	cd apps/ui && npm run sync:contracts
+	cd $(UI_DIR) && npm run sync:contracts
 
 regen-contracts: ## Sync contracts and rebuild the contract reference doc
 regen-contracts: sync-contracts
@@ -91,7 +95,7 @@ regen-contracts: sync-contracts
 
 coverage: ## Run backend coverage with optional COV_OPTS overrides
 	@$(RESOLVE_PYTHON) \
-	cd apps/server && "$$PYTHON" -m pytest -q --cov=vibesensor --cov-report=term-missing:skip-covered $(COV_OPTS) tests
+	cd $(SERVER_DIR) && "$$PYTHON" -m pytest -q --cov=vibesensor --cov-report=term-missing:skip-covered $(COV_OPTS) tests
 
 smoke: ## Run simulator and websocket smoke checks against a local server
 	@$(RESOLVE_PYTHON) \
@@ -107,7 +111,7 @@ docs-lint: ## Run docs lint without the broader lint suite
 	"$$PYTHON" tools/dev/docs_lint.py
 
 ui-lint: ## Run UI lint checks
-	cd apps/ui && npm run lint
+	cd $(UI_DIR) && npm run lint
 
 ui-typecheck: ## Run UI contract freshness, lint, and TypeScript type checking
-	cd apps/ui && npm run check:contracts && npm run lint && npm run typecheck
+	cd $(UI_DIR) && npm run check:contracts && npm run lint && npm run typecheck


### PR DESCRIPTION
## Summary

This PR covers **chunk-001** of the full repository review run and is intentionally limited to the seven root-level workflow and repository-configuration files assigned to that chunk: `.gitattributes`, `.gitignore`, `.nvmrc`, `.python-version`, `Makefile`, `docker-compose.dev.yml`, and `docker-compose.yml`.

Every code/config file in this chunk was reviewed individually before any changes were made. Only one file required a behavior-preserving cleanup in this pass: `Makefile`. The remaining six files were left unchanged on purpose after direct inspection because the available edits were either purely cosmetic or would have altered workflow behavior rather than improving maintainability safely.

The main cleanup in this PR is small but deliberate. The top-level `Makefile` repeated the same root-relative `apps/server` and `apps/ui` path literals across multiple targets, which makes future path changes and command audits harder than they need to be. It also relied on implicit knowledge for the `RESOLVE_PYTHON` macro, where the repo prefers the checked-out virtual environment once it exists but falls back to the pinned host interpreter before bootstrap has created `.venv`. This PR centralizes the repeated root paths into `SERVER_DIR` and `UI_DIR` variables and adds a short explanatory comment above the resolver macro so that the bootstrap-versus-post-setup behavior is obvious when reading the file.

## Chunk coverage and individual review results

I reviewed all seven files in the chunk directly.

`.gitattributes` was inspected for obvious line-ending or normalization cleanups. I considered extending the explicit LF rules to additional file types such as TypeScript and `.mjs`, since the repo contains a large amount of TS code. I intentionally did **not** do that here because it would change checkout and normalization behavior across the repository. Under the “no intentional functional/workflow changes” rule for this run, that belongs in an explicit workflow-focused change, not in a cleanup-only PR.

`.gitignore` was also reviewed in detail. At first glance, the `artifacts/` section looks duplicative because it contains both specific ignore rules and a later generic `artifacts/**` block. I validated the current behavior with `git check-ignore -v --no-index` and confirmed that the duplicate-looking rules are not harmless repetition: their current ordering affects placeholder-file semantics. Because simplifying that section would change ignore behavior rather than preserve it exactly, I left it alone and recorded that decision in the review tracker.

`.nvmrc` and `.python-version` are intentionally minimal single-source version pins. There was no safe cleanup to apply without creating churn for essentially no maintenance gain, so both were reviewed and left unchanged.

`docker-compose.dev.yml` and `docker-compose.yml` were inspected for maintainability wins in the root orchestration setup. Both files are already compact and readable. The possible edits I found were limited to comment-only churn or stylistic reshaping of existing YAML, which would not materially improve maintainability enough to justify a diff. Both were therefore reviewed and left unchanged.

That left `Makefile` as the only file where a real, safe improvement was clearly worthwhile.

## What changed in `Makefile`

The diff is intentionally narrow. I introduced `SERVER_DIR := apps/server` and `UI_DIR := apps/ui` near the top of the file, then reused those variables in the targets that were previously spelling out the same root-relative paths repeatedly. This keeps the commands readable while removing a small but persistent maintenance hazard: when these paths appear in many separate command blocks, future edits have more places to drift or become inconsistent.

I also updated `LINT_TARGETS` to reuse `$(SERVER_DIR)` for the backend path entries. That keeps the file internally consistent with the new root path variables rather than partially deduplicating the path handling.

Finally, I added a short two-line comment above `RESOLVE_PYTHON`. That macro has subtle but intentional behavior: after setup it prefers the repo-local virtualenv interpreter, but before setup it falls back to the pinned host interpreter from `.python-version` so bootstrap-oriented targets can still run. That behavior was already present and remains unchanged. The new comment is there to make that intent obvious to future maintainers without forcing them to reconstruct it from the shell fragment.

## What this PR intentionally does **not** change

This PR does not alter command behavior, target names, validation flow, environment expectations, or runtime configuration. It does not introduce new tools, new targets, or new dependencies. It does not attempt to fix the previously observed `tools/dev/check_prerequisites.py` missing-`.venv` path handling issue because that would be a behavior change outside the scope of this chunk and outside the “non-functional improvements only” rule for this review run.

It also does not “clean up” `.gitignore` or `.gitattributes` in ways that would subtly change ignore semantics or line-ending normalization rules. Those are exactly the kinds of changes that look tidy in a diff but can alter workflows for contributors and CI. In this run, I am deliberately treating those as explicit follow-up candidates instead of silently folding them into a cleanup PR.

## Validation performed

Because this chunk touches the repo’s top-level Makefile and root workflow entrypoints, I validated the change through the commands most directly affected by the refactor rather than relying on static inspection alone.

I ran:

- `make help`
- `make lint`
- `make typecheck-backend`
- `make ui-typecheck`

All of those commands completed successfully after the Makefile cleanup. This gives confidence that the path-variable refactor did not break the key backend and frontend validation entrypoints that the file orchestrates.

Separately, while reviewing `.gitignore`, I used `git check-ignore -v --no-index` spot checks to confirm that the artifact ignore rules currently have meaningful ordering semantics and should not be simplified under a behavior-preserving review pass.

## Risks, tradeoffs, and follow-ups

The main tradeoff in this PR is restraint. Several files in the chunk invited “small cleanup” edits that would have produced a larger diff, but most of those edits either changed behavior at the tooling/workflow level or amounted to comment-only churn. I intentionally left those out.

The most relevant follow-up discovered during this chunk is outside the chunk boundary: `tools/dev/check_prerequisites.py` appears to mishandle the case where the repo-local `.venv` path is absent by trying to execute the missing absolute path before falling back to the host interpreter. That looks like a real bug, but it is not a no-behavior-change cleanup, so I recorded it for later rather than folding it into this PR.

For the broader repo-review run, this PR also establishes the review pattern I’ll use for later chunks: inspect every file directly, apply only changes that are clearly behavior-preserving, validate with the commands most relevant to the touched files, and explicitly document why nearby tempting edits were skipped when they would cross the no-behavior-change boundary.
