### PR TITLE
chore: clarify setup-backend action

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -23,7 +23,7 @@ runs:
         python -m pip install -e "./apps/server[dev]"
 
     - name: Install PlatformIO dependencies
+      # Keep firmware tooling opt-in so non-firmware jobs reuse the shared backend setup.
       if: ${{ inputs.include-platformio == 'true' }}
       shell: bash
-      run: |
-        python -m pip install "platformio>=6,<7"
+      run: python -m pip install "platformio>=6,<7"


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-003`, which contains exactly one code file: `.github/actions/setup-backend/action.yml`.

Per the review workflow for this repository-wide cleanup run, I reviewed that file directly and individually before deciding whether any behavior-preserving improvement was justified. I also checked how the composite action is consumed from `.github/workflows/ci.yml` so the review would reflect the real blast radius of the shared setup step without pulling later workflow edits into this chunk. The goal here was deliberately narrow: make the shared backend setup action a little easier to read and maintain without changing CI behavior, dependency selection, installation order, or any public repository workflow.

The resulting diff is intentionally small because the file is already compact and functionally sound. After reviewing the action line by line, the only worthwhile cleanup I found was in the optional PlatformIO installation step. That step was already correct, but it combined two small maintainability issues: it used a multiline YAML block for a single command, and it did not explain why PlatformIO is optional instead of always being installed with the backend development dependencies. Those details are minor in isolation, but this action is reused across many backend-oriented CI jobs, so even a very small readability improvement in the shared setup path pays back repeatedly when future maintainers inspect or modify CI behavior.

## What changed

First, the PR collapses the PlatformIO step’s `run` entry from a block scalar into a single-line string. The command itself is unchanged: it still runs `python -m pip install "platformio>=6,<7"` only when `include-platformio` is explicitly set to `"true"`. This is a pure presentation cleanup. Using a block scalar for a one-line command added visual noise without adding expressive value, especially in a composite action that is otherwise short and easy to scan.

Second, the PR adds a brief intent comment above that same step: `Keep firmware tooling opt-in so non-firmware jobs reuse the shared backend setup.` This comment is not a restatement of the `if` condition. Instead, it captures the design reason behind the condition. Without that context, the optional PlatformIO path can look arbitrary, and a future maintainer could be tempted either to inline it into the default dependency install or to cargo-cult the pattern elsewhere without understanding why it exists. The new comment is meant to preserve intent, not narrate syntax.

## What did not change

Just as important as the actual diff is the list of things that were deliberately left alone.

The PR does not change the composite action’s inputs. `include-platformio` is still the only input, it is still optional, and its default remains `"false"`.

The PR does not change the order of operations. The action still sets up Python from `.python-version`, enables pip caching keyed from `apps/server/pyproject.toml`, upgrades pip, installs the backend editable development environment, and then conditionally installs PlatformIO.

The PR does not change the shell command text for either dependency installation step. No package versions were changed, no install flags were added or removed, and no dependency sources were modified.

The PR does not change the `actions/setup-python` version, the cache settings, or the workflow files that consume this composite action. Those adjacent files belong to later chunks in the tracker and should be reviewed on their own rather than being pulled into this PR opportunistically.

The PR also does not introduce any new dependencies, remove any dead code, or alter any CI job names or contracts.

## Review notes for the file

`.github/actions/setup-backend/action.yml` is a shared CI building block, so even though it is small, it carries more maintenance weight than its size suggests. During review I looked for safe improvements in a few categories: stale comments, avoidable formatting noise, hidden behavior, duplicated logic, and opportunities to clarify intent. I did not find dead code or unused inputs, and I did not find a behavior-preserving reason to restructure the action more aggressively.

One tempting change would have been to update the action to `actions/setup-python@v6` for version consistency with some workflow files. I intentionally did not make that change here. Even though it may be reasonable in a future pass, it is still a tool-version change rather than a pure maintainability cleanup, and that goes beyond the tight non-functional scope I wanted for this chunk.

Similarly, I did not broaden the PR into `.github/workflows/ci.yml` or `.github/workflows/main-release.yml`, even though those files sit nearby and also contain Python setup steps. The tracker already assigns those files to later chunks, and preserving chunk boundaries matters for auditability in this run.

## Validation

Local validation for this chunk matched the size and risk of the change.

I parsed `.github/actions/setup-backend/action.yml` with `yaml.safe_load` using the repository virtualenv (`.venv/bin/python`) to confirm the edited file still loads as valid YAML and that the final step still exposes the same `run` string content.

I also ran `git diff --check -- .github/actions/setup-backend/action.yml` to ensure the patch is free of whitespace or patch-format issues.

Beyond local validation, the PR will naturally exercise the real integration surface in GitHub Actions CI because this composite action is used by multiple backend jobs. That broader validation is intentionally deferred to the PR checks rather than simulated with a larger local workflow rewrite.

## Risks, tradeoffs, and follow-up

The risk level here is low because the behavioral surface is unchanged. The only meaningful tradeoff is that any added comment can become stale if the action’s purpose changes later. I think that risk is acceptable in this case because the comment captures a stable design rationale rather than a volatile implementation detail.

The main follow-up is simply to continue the planned sequential review. The next chunk already covers the surrounding workflow files, which is the right place to consider whether any broader CI cleanup is warranted after those files are individually reviewed.

In short, this PR keeps chunk `003` disciplined: one file reviewed directly, one small maintainability improvement made, behavior preserved, and validation recorded before moving on.
