### PR TITLE
chore: simplify ci workflow shell steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
       - uses: ./.github/actions/setup-backend
 
       - name: Validate dependency consistency
-        run: |
-          python -m pip check
+        run: python -m pip check
 
       - name: Backend quality checks
         run: make lint
@@ -45,8 +44,7 @@ jobs:
         working-directory: apps/server
         env:
           MYPYPATH: .
-        run: |
-          python -m mypy --config-file pyproject.toml
+        run: python -m mypy --config-file pyproject.toml
 
   frontend-typecheck:
     name: Frontend type check
@@ -65,23 +63,20 @@ jobs:
           cache-dependency-path: apps/ui/package-lock.json
 
       - name: Install UI dependencies
-        run: |
-          cd apps/ui && npm ci
+        working-directory: apps/ui
+        run: npm ci
 
       - name: UI contract sync check
-        run: |
-          cd apps/ui
-          npm run check:contracts
+        working-directory: apps/ui
+        run: npm run check:contracts
 
       - name: UI lint
-        run: |
-          cd apps/ui
-          npm run lint
+        working-directory: apps/ui
+        run: npm run lint
 
       - name: UI typecheck
-        run: |
-          cd apps/ui
-          npm run typecheck
+        working-directory: apps/ui
+        run: npm run typecheck
 
   ui-smoke:
     name: UI smoke tests
@@ -109,12 +104,12 @@ jobs:
             ${{ runner.os }}-ms-playwright-
 
       - name: Install UI dependencies
-        run: |
-          cd apps/ui && npm ci
+        working-directory: apps/ui
+        run: npm ci
 
       - name: UI smoke tests
+        working-directory: apps/ui
         run: |
-          cd apps/ui
           npx playwright install chromium
           npm run test:smoke
 
@@ -145,8 +140,7 @@ jobs:
           cache-dependency-path: apps/server/pyproject.toml
 
       - name: Release smoke validation
-        run: |
-          python3 tools/tests/run_release_smoke.py
+        run: python3 tools/tests/run_release_smoke.py
 
   firmware-native-tests:
     name: Firmware native tests
@@ -165,13 +159,11 @@ jobs:
           include-platformio: "true"
 
       - name: Verify firmware protocol fixtures
-        run: |
-          python tools/firmware/generate_protocol_contract_fixtures.py --check
+        run: python tools/firmware/generate_protocol_contract_fixtures.py --check
 
       - name: Firmware native tests
-        run: |
-          cd firmware/esp
-          pio test -e native
+        working-directory: firmware/esp
+        run: pio test -e native
 
   backend-tests-1:
     name: Backend tests (shard 1/5)
@@ -194,8 +186,7 @@ jobs:
             ${{ runner.os }}-backend-test-durations-
 
       - name: Prepare backend test artifacts
-        run: |
-          mkdir -p artifacts/ai/logs/ci
+        run: mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests shard 1/5
         run: |
@@ -231,8 +222,7 @@ jobs:
             ${{ runner.os }}-backend-test-durations-
 
       - name: Prepare backend test artifacts
-        run: |
-          mkdir -p artifacts/ai/logs/ci
+        run: mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests shard 2/5
         run: |
@@ -268,8 +258,7 @@ jobs:
             ${{ runner.os }}-backend-test-durations-
 
       - name: Prepare backend test artifacts
-        run: |
-          mkdir -p artifacts/ai/logs/ci
+        run: mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests shard 3/5
         run: |
@@ -305,8 +294,7 @@ jobs:
             ${{ runner.os }}-backend-test-durations-
 
       - name: Prepare backend test artifacts
-        run: |
-          mkdir -p artifacts/ai/logs/ci
+        run: mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests shard 4/5
         run: |
@@ -342,8 +330,7 @@ jobs:
             ${{ runner.os }}-backend-test-durations-
 
       - name: Prepare backend test artifacts
-        run: |
-          mkdir -p artifacts/ai/logs/ci
+        run: mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests shard 5/5
         run: |
@@ -391,8 +378,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Docker-backed e2e suite (skip already-owned checks)
-        run: |
-          python3 tools/tests/run_e2e_parallel.py --fast-e2e --shards 6
+        run: python3 tools/tests/run_e2e_parallel.py --fast-e2e --shards 6
 
       - name: Upload e2e failure artifacts
         if: failure()


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-004`, which contains the following three code files:

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/main-release.yml`

As required by the review workflow for this repository-wide cleanup run, I reviewed all three files directly and individually before deciding what, if anything, to change. Only one file needed a maintainability edit in this chunk: `.github/workflows/ci.yml`. The other two workflow files were reviewed in full and intentionally left unchanged because I did not find a worthwhile behavior-preserving improvement that would do more than create churn.

The theme of this chunk is workflow readability through native GitHub Actions structure. The existing CI workflow was already correct, but it repeated small amounts of shell bookkeeping that made the file noisier to scan than necessary. In particular, several steps used single-command block-scalar `run` entries, and the UI and firmware steps repeatedly changed directories inside shell blocks instead of letting the workflow declare the working directory directly. None of that was broken, but it made a high-traffic workflow a little harder to maintain.

## What changed in `ci.yml`

The change set in `.github/workflows/ci.yml` is intentionally structural rather than behavioral.

First, the PR collapses obvious one-line `run: |` blocks into single-line `run:` entries where the command is already a single shell line. Examples include dependency consistency validation, the release smoke command, repeated artifact-directory setup commands, and the Docker-backed e2e launcher. This keeps the workflow compact and avoids the visual overhead of multiline shell blocks where they are not needed.

Second, the PR replaces repeated `cd apps/ui` and `cd firmware/esp` shell boilerplate with GitHub Actions’ native `working-directory` field. That affects the frontend typecheck steps, the UI smoke workflow steps, and the firmware native test step. The commands themselves are unchanged. The point is simply to move directory selection out of ad hoc shell state and into declarative workflow structure that is easier to scan and less error-prone to edit later.

Third, the PR leaves longer multiline shell scripts alone. I did not flatten multi-command blocks or reformat steps whose readability depends on vertical structure. The cleanup is targeted to places where the workflow already expressed a single command or a clear single-directory context. That keeps the diff disciplined and avoids turning a maintainability pass into a style rewrite.

## File-by-file review outcome

### `.github/workflows/ci.yml`

This file was reviewed line by line and was the only workflow in the chunk that warranted changes. The file is long and operationally important, so small readability wins are valuable here. The main issue was repeated shell ceremony rather than duplicated business logic: directory changes embedded in shell commands, plus several block scalars that wrapped a single command. The fix keeps all job names, dependencies, caches, action versions, artifact paths, and command text intact while making the workflow easier to read as a workflow instead of as a series of tiny shell scripts.

### `.github/workflows/codeql.yml`

This file was reviewed directly and left unchanged. It is already compact, explicit, and easy to follow. The job definition is small enough that any cleanup I considered would have been stylistic churn rather than a real maintainability improvement. I did not want to pad the chunk with edits that look active but do not actually help future maintenance.

### `.github/workflows/main-release.yml`

This file was also reviewed directly and left unchanged. It is more complex than `codeql.yml`, but the complexity comes from real release-building and packaging logic rather than avoidable shell noise. The multiline shell blocks in this file are purposeful and encode real sequencing, state, and validation. A broader cleanup here would risk mixing presentational edits with release semantics, which would violate the narrow behavior-preserving scope I wanted for this chunk.

## What did not change

This PR does not change the CI job graph, names, dependencies, timeout settings, caches, matrix configuration, artifact uploads, or release triggers.

It does not change the command text used for linting, mypy, npm tasks, release smoke, firmware verification, backend shard execution, or e2e execution.

It does not change any action versions, introduce new composite actions, add dependencies, remove dependencies, or alter any repository automation contracts.

It also does not change `.github/workflows/codeql.yml` or `.github/workflows/main-release.yml`, despite those files being part of the reviewed chunk. Their inclusion here reflects direct review, not mandatory modification.

## Validation

Because workflow files materially affect repository automation, I used stronger validation here than for the earlier one-file workflow chunks.

First, I parsed all three files in the chunk with `yaml.safe_load` using the repository virtualenv (`.venv/bin/python`) to confirm the edited YAML remained structurally valid.

Second, I ran `git diff --check` against the chunk files to catch whitespace or patch-format issues.

Third, I ran the existing targeted hygiene tests that already cover the touched workflow area:

- `apps/server/tests/hygiene/test_ci_command_parity.py`
- `apps/server/tests/hygiene/test_ci_job_parity.py`
- `apps/server/tests/hygiene/test_main_release_workflow.py`

Those tests passed locally when run with the repo virtualenv’s Python and `-o addopts=''` to bypass inherited local pytest parallel flags that are not available in this container outside the standard CI setup. That override did not reduce the actual test coverage; it only prevented local command-line option leakage from blocking the test run.

## Risks, tradeoffs, and follow-up

The main risk in workflow cleanup is accidental semantic drift through shell behavior changes. I specifically avoided that by preserving every command string and only moving directory selection into `working-directory` where the command already assumed a fixed directory. I also limited the block-scalar cleanup to true one-liners.

The tradeoff is that this PR does not try to solve every possible source of duplication in `ci.yml`. There are larger refactors one could imagine, such as extracting repeated shard patterns into reusable components, but those would be much more invasive and are not appropriate for a behavior-preserving cleanup pass of this chunk.

Follow-up, if any, belongs to later chunks that review the backing scripts and tests themselves. For this chunk, the goal was simpler: review all three workflow files individually, make the smallest worthwhile cleanup in the one file that justified it, validate the result, and move on with repository behavior unchanged.
