### PR TITLE
chore: clarify server config overlay comments

### DIFF
--- a/apps/server/config.dev.yaml
+++ b/apps/server/config.dev.yaml
@@ -1,5 +1,5 @@
 # Development overrides — only fields that differ from defaults.
-# Uses local relative paths instead of system paths.
+# Keeps local development on port 8000 without depending on gpsd.
 
 server:
   port: 8000

--- a/apps/server/config.docker.yaml
+++ b/apps/server/config.docker.yaml
@@ -1,5 +1,5 @@
 # Docker overrides — only fields that differ from Pi defaults.
-# Uses local relative paths inside the container working directory.
+# Disables Pi-only services and keeps rollback data in container-local storage.
 
 ap:
   self_heal:


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-005`, which contains six code files:

- `apps/server/Dockerfile`
- `apps/server/Dockerfile.e2e`
- `apps/server/config.dev.yaml`
- `apps/server/config.docker.yaml`
- `apps/server/config.pi.yaml`
- `apps/server/pyproject.toml`

All six files were reviewed directly and individually before I decided what to change. The final diff is intentionally small: it updates the top-of-file comments in `config.dev.yaml` and `config.docker.yaml` so they describe the current overrides accurately. The other four files in the chunk were reviewed and intentionally left unchanged.

That outcome deserves a little context, because during review I initially found what looked like a possible cleanup in the two Dockerfiles. Both files repeat the absolute `/app/apps/server` path after `WORKDIR /app` is already set, so a relative-path simplification appeared reasonable at first glance. Before treating that as a maintainability win, I ran the existing repository hygiene checks that already cover this area. Those checks intentionally enforce the explicit absolute install path in both Dockerfiles. Once I confirmed that the convention was deliberate and guarded, I abandoned the Dockerfile edit rather than pushing a style preference against the repo’s own safety rail.

That is why the final PR is comment-only even though the chunk included packaging and container files: the review found one safe cleanup that truly improved clarity, and it also found one tempting change that should not be made in this repository without first changing the underlying rule.

## What changed

The actual code changes in this PR are limited to two YAML comment updates.

In `apps/server/config.dev.yaml`, the existing top comment claimed that the development overlay uses local relative paths instead of system paths. That is no longer what the file does. The file currently overrides the HTTP port and disables GPS for developer machines that do not run `gpsd`. The old comment had drifted away from the actual contents and could mislead someone skimming the file for environment-specific behavior. I rewrote it to say that the development config keeps local development on port `8000` without depending on `gpsd`, which reflects the live overrides accurately.

In `apps/server/config.docker.yaml`, the top comment similarly claimed that the overlay uses local relative paths inside the container working directory. That description was also stale. The file currently disables Pi-specific services such as AP self-heal and GPS, and it overrides the rollback path to a container-local location. I rewrote the comment so it describes those real container-specific behaviors instead of talking about relative paths that are not what the file actually expresses.

No YAML values changed. No ports, paths, booleans, or runtime settings were modified. This is strictly a documentation accuracy cleanup inside the config files themselves.

## File-by-file review outcome

### `apps/server/Dockerfile`

Reviewed directly. I considered simplifying repeated absolute paths after `WORKDIR /app`, but the repo’s hygiene guard explicitly requires `python -m pip install --no-cache-dir /app/apps/server` and related direct-path conventions. Because that rule is intentional and already tested, I left the file unchanged.

### `apps/server/Dockerfile.e2e`

Reviewed directly. The same reasoning applies here: an apparent relative-path cleanup would have violated the existing Docker hygiene rule. I left the file unchanged to preserve the repository’s enforced packaging convention.

### `apps/server/config.dev.yaml`

Reviewed directly and changed. Its descriptive comment had become stale relative to the actual overrides. The new comment now matches the real development-only behavior.

### `apps/server/config.docker.yaml`

Reviewed directly and changed. Its descriptive comment also described a path style that is no longer the important thing about the file. The new comment captures the real Docker-specific service and storage overrides.

### `apps/server/config.pi.yaml`

Reviewed directly and left unchanged. It is short, accurate, and its deployment-path comment still matches the current install flow.

### `apps/server/pyproject.toml`

Reviewed directly and left unchanged. The packaging metadata, pytest configuration, and mypy/Ruff settings remain internally consistent, and the existing comments correctly capture the current Python 3.14 and type-checking constraints.

## What did not change

This PR does not modify Docker build behavior, package installation commands, base images, runtime environment variables, or server startup commands.

It does not modify any config values, default ports, GPS behavior, AP behavior, rollback paths, or Pi deployment paths.

It does not change build-system requirements, runtime dependencies, optional dependency groups, scripts, pytest defaults, mypy discovery, or Ruff settings.

It also does not relax, replace, or bypass the Docker hygiene guard. In fact, one of the important review outcomes of this chunk is confirming that the guard is active and that the Dockerfiles are expected to follow it.

## Validation

I validated this chunk in a few different ways.

First, I parsed `config.dev.yaml`, `config.docker.yaml`, and `config.pi.yaml` with `yaml.safe_load` and parsed `pyproject.toml` with `tomllib` using the repository virtualenv (`.venv/bin/python`). That confirmed the edited config files and unchanged packaging config remained structurally valid.

Second, I ran `git diff --check` across all chunk files to catch whitespace or patch-format issues.

Third, I ran the existing targeted tests that cover this chunk’s responsibilities:

- `apps/server/tests/hygiene/test_docker_ci_hygiene.py`
- `apps/server/tests/app/test_config.py::test_dev_and_docker_configs_equivalent`
- `apps/server/tests/app/test_config.py::test_dev_and_docker_override_server_port_to_8000`
- `apps/server/tests/use_cases/diagnostics/test_single_source_of_truth.py::test_server_dockerfile_is_real_build_recipe`
- `apps/server/tests/hygiene/test_type_safety_consolidation.py::TestMypyEnforcement`

Those checks passed locally with `.venv/bin/python -m pytest -q -o addopts='' ...`.

I also attempted to run `python -m build --wheel apps/server` as an extra packaging validation step, but the `build` module is not installed in this local virtualenv. I did not treat that missing optional tool as a chunk failure, because the repo-owned validations above already covered the touched files and the actual diff did not change packaging behavior.

## Risks, tradeoffs, and follow-up

Risk is very low because the shipped diff is comment-only and the new comments are more accurate than the old ones.

The most relevant tradeoff is that I deliberately did not force a Dockerfile cleanup once the hygiene guard showed that the explicit absolute path convention is intentional in this repo. If someone wants to revisit that convention later, it should happen in a dedicated change that updates both the Dockerfiles and the hygiene rule together.

For this chunk, the right move was narrower: review every file directly, keep the enforced Docker conventions intact, correct the stale config comments, validate the area, and move on without changing runtime behavior.
