### PR TITLE
chore: dedupe ratio source lookups

### DIFF
--- a/apps/server/data/car_library_ratio_sources.json
+++ b/apps/server/data/car_library_ratio_sources.json
@@ -53,12 +53,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F20+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F20+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -123,12 +118,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F40+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F40+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -178,12 +168,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F22+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F22+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -249,12 +234,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G42+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G42+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -336,12 +316,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F45+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F45+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -405,12 +380,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F30+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F30+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -475,12 +445,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G20+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G20+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -543,12 +508,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F32+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F32+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -605,12 +565,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G22+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G22+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -658,12 +613,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F10+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F10+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -711,12 +661,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G30+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G30+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -779,12 +724,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G60+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G60+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -841,12 +781,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F06+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F06+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -898,12 +833,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G32+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G32+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -954,12 +884,7 @@
         "official_lookup_attempts": [
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F01+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F01+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1003,12 +928,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G11+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G11+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1071,12 +991,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G70+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G70+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1120,12 +1035,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G15+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G15+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1169,12 +1079,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G14+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G14+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1218,12 +1123,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G16+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G16+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1267,12 +1167,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F48+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F48+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1316,12 +1211,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=U11+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=U11+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1365,12 +1255,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F39+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F39+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1414,12 +1299,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=U10+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=U10+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1463,12 +1343,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F25+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F25+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1512,12 +1387,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G01+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G01+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1561,12 +1431,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G45+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G45+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1610,12 +1475,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F26+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F26+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1659,12 +1519,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G02+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G02+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1708,12 +1563,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F15+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F15+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1757,12 +1607,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G05+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G05+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1806,12 +1651,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F16+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F16+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1855,12 +1695,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G06+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G06+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1904,12 +1739,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G07+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G07+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -1953,12 +1783,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G29+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G29+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2002,12 +1827,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F80+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F80+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2051,12 +1871,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G80+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G80+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2100,12 +1915,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F82+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F82+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2149,12 +1959,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G82+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G82+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2198,12 +2003,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=F90+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=F90+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2247,12 +2047,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=I20+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=I20+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2296,12 +2091,7 @@
           },
           {
             "url": "https://www.press.bmwgroup.com/global/article/search?query=G26+technical+data&language=en",
-            "note": "BMW Group official press search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.press.bmwgroup.com/global/article/search?query=G26+technical+data&language=en",
-            "note": "BMW Group official PressClub search for model-code technical data documents.",
+            "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
             "confidence": "medium"
           },
           {
@@ -2345,12 +2135,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8X",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8X",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2394,12 +2179,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=GB",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=GB",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2443,12 +2223,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8V",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8V",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2492,12 +2267,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8Y",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8Y",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2541,12 +2311,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=B8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2620,12 +2385,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=B8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2704,17 +2464,12 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C7",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-s6-avant-c7-v8-comfort-for-every-journey-127765",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=C7",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2758,17 +2513,12 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2812,17 +2562,12 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C7",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-s6-avant-c7-v8-comfort-for-every-journey-127765",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=C7",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2866,17 +2611,12 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2920,12 +2660,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=D4",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=D4",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -2969,12 +2704,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=D5",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=D5",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3018,7 +2748,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=GA",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3044,11 +2774,6 @@
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-e-gas-plant-9865",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=GA",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3092,12 +2817,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8U",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8U",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3141,12 +2861,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=F3",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=F3",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3190,12 +2905,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8R",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8R",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3269,12 +2979,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4M",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=4M",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3318,12 +3023,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4M8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=4M8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3367,12 +3067,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8J",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8J",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3416,12 +3111,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8S",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8S",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3465,12 +3155,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=4S",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=4S",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3514,12 +3199,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=8V%2F8Y",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=8V%2F8Y",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3563,12 +3243,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B9",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=B9",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3612,12 +3287,7 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=B9",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=B9",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3661,17 +3331,12 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {
@@ -3715,17 +3380,12 @@
           },
           {
             "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search page used in second-pass lookup.",
+            "note": "Audi MediaCenter official search page used in second-pass lookup for model-code technical releases.",
             "confidence": "medium"
           },
           {
             "url": "https://www.audi-mediacenter.com/en/photos/detail/audi-a6-avant-c8-modern-efficient-ready-for-any-destination-127766",
             "note": "Audi MediaCenter official detail page discovered in second pass.",
-            "confidence": "medium"
-          },
-          {
-            "url": "https://www.audi-mediacenter.com/en/search?query=C8",
-            "note": "Audi MediaCenter official search for model-code technical releases.",
             "confidence": "medium"
           },
           {


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-006`, which contains three server data files:

- `apps/server/data/car_library.json`
- `apps/server/data/car_library_ratio_sources.json`
- `apps/server/data/report_i18n.json`

All three files were reviewed directly and individually before I made any changes. Only one file changed in this chunk: `car_library_ratio_sources.json`. The other two files were intentionally left untouched because they are live runtime data, and any content edits there would risk changing behavior or user-visible output.

That distinction matters. `car_library.json` feeds the runtime car library and related HTTP behavior. `report_i18n.json` feeds report translation text and is therefore directly user-facing. By contrast, `car_library_ratio_sources.json` is a provenance artifact that documents how ratio-related car-library rows were researched and classified. It is important, but it is not the same kind of runtime contract. That made it the only safe place in this chunk to apply a maintainability cleanup without affecting application behavior.

## What changed

The cleanup in `car_library_ratio_sources.json` removes repeated official lookup rows from many `official_lookup_attempts` lists.

Across the artifact, BMW and Audi entries often recorded the exact same official search URL twice in the same list, once with a note like “official search page used in second-pass lookup” and again with a note like “official search for model-code technical data documents” or “technical releases.” The URLs were the same, the confidence was the same, and the two notes were describing the same lookup path from slightly different angles.

That duplication created a lot of visual noise in a file whose main job is already to preserve research context. It made the provenance ledger harder to scan because the reader had to mentally collapse repeated search URLs before getting to the genuinely distinct evidence sources.

This PR replaces each of those repeated URL pairs with a single entry that keeps the same URL and confidence while merging the note into one clearer sentence. The result is a much shorter and easier-to-review provenance artifact without changing any actual ratio values, car rows, verification statuses, unresolved items, or runtime translations.

In concrete terms, the diff collapses 68 duplicated official lookup URL pairs across the artifact. The end state preserves source coverage while removing redundant rows.

## File-by-file review outcome

### `apps/server/data/car_library.json`

Reviewed directly and left unchanged. This is live runtime car-library data that feeds the server’s car library behavior. A maintainability pass here has to be extremely conservative because even a “small” data edit could alter API responses, report preparation, or downstream vehicle-specific calculations. I did not find a behavior-preserving cleanup that was strong enough to justify touching runtime values in this chunk.

### `apps/server/data/car_library_ratio_sources.json`

Reviewed directly and changed. This file is the provenance ledger for the car-library ratio work. The most useful maintainability improvement I found here was the duplicated official lookup rows. They did not add distinct evidence; they repeated the same lookup URL with near-duplicate phrasing. Collapsing those pairs makes the artifact smaller, clearer, and easier to maintain while preserving the lookup trail.

### `apps/server/data/report_i18n.json`

Reviewed directly and left unchanged. This file is live runtime translation data used for reports and PDF output. Any wording change here would be user-visible and therefore outside the scope of this no-behavior-change review pass unless it were part of a deliberate product/content correction. I did not make that kind of change in this chunk.

## What did not change

This PR does not modify any car-library runtime values, vehicle variants, gear ratios, tire dimensions, or model metadata in `car_library.json`.

It does not modify any translation keys or translated strings in `report_i18n.json`.

It does not change verification status classifications, unresolved decision items, or the set of covered cars in `car_library_ratio_sources.json`.

It also does not add or remove source groups. The cleanup is specifically about duplicated entries inside existing `official_lookup_attempts` lists.

In other words, the diff is large in line count because repeated JSON objects were removed across many rows, not because the underlying car-library or report behavior changed.

## Why this is behavior-preserving

The key reason this cleanup stays within scope is that it only touches non-runtime provenance metadata. The server does not use `car_library_ratio_sources.json` as the live source of car library values or report translations. The artifact supports maintenance, auditability, and guardrail tests, but it is not the runtime contract that the application serves to users.

Even within that artifact, the cleanup is intentionally narrow. I did not rewrite conclusions, unresolved items, or source categories. I only collapsed duplicated search-URL pairs where the URL and confidence matched and the paired notes followed one of the two uniform BMW/Audi patterns already present across the file.

## Validation

I validated this chunk in multiple ways.

First, I parsed all three files in the chunk with `json.loads` using the repository virtualenv (`.venv/bin/python`) to confirm that the JSON remained structurally valid.

Second, I ran `git diff --check` against the chunk files to catch whitespace or patch-format issues.

Third, I ran targeted existing tests that cover the changed provenance artifact and the unchanged runtime data files:

- `apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py`
- `apps/server/tests/hygiene/test_car_library_artifact_sync.py`
- `apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `apps/server/tests/adapters/persistence/test_car_library.py`
- `apps/server/tests/adapters/pdf/test_report_i18n.py`

Those tests passed locally with `.venv/bin/python -m pytest -q -o addopts='' ...`.

I also used a local inspection script to confirm that the duplicated `official_lookup_attempts` URLs targeted by this cleanup were gone after the rewrite and that the transformation only affected the known BMW and Audi duplicate-note patterns.

## Risks, tradeoffs, and follow-up

Risk is low because the runtime data files were left unchanged and the edited file is a maintenance artifact rather than the application’s live data source.

The main tradeoff is that I deliberately chose not to “improve” `car_library.json` or `report_i18n.json` even though they were in the same chunk. That restraint is intentional. In this repository, those two files are too close to live behavior to justify speculative cleanup during a behavior-preserving review pass.

If future work wants to revise car values or report wording, that should happen as an explicit data/content change with user-facing review. This PR is narrower: it reviews all three files directly, improves the provenance artifact where redundancy was obvious, validates the affected area, and leaves runtime behavior alone.
