### PR TITLE
docs: clarify systemd service intent

### DIFF
--- a/apps/server/systemd/vibesensor-hotspot.service
+++ b/apps/server/systemd/vibesensor-hotspot.service
@@ -6,6 +6,8 @@ Wants=NetworkManager.service
 [Service]
 Type=oneshot
 Environment=VIBESENSOR_CONFIG_PATH=/etc/vibesensor/config.yaml
+# Keep a local rfkill preflight so manual restarts can still recover even
+# after the boot-only rfkill unblock unit has already run.
 ExecStartPre=/bin/sh -c 'if command -v rfkill >/dev/null 2>&1; then rfkill unblock wifi || rfkill unblock all || true; fi'
 ExecStart=__PI_DIR__/scripts/hotspot_nmcli.sh --config /etc/vibesensor/config.yaml
 TimeoutStartSec=300

--- a/apps/server/systemd/vibesensor.service
+++ b/apps/server/systemd/vibesensor.service
@@ -11,6 +11,8 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE 
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_FOWNER CAP_AUDIT_WRITE
 WorkingDirectory=__PI_DIR__
 ExecStartPre=/usr/bin/test -r /etc/vibesensor/config.yaml
+# Updates can touch the release tree and state paths as root, so reassert
+# service-user ownership at startup instead of relying only on install-time chown.
 ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ __PI_DIR__
 ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ /var/log/vibesensor /var/lib/vibesensor
 ExecStartPre=/usr/bin/test -w /var/log/vibesensor


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-008`, which contains the following four backend systemd unit templates:

- `apps/server/systemd/vibesensor-hotspot-self-heal.service`
- `apps/server/systemd/vibesensor-hotspot.service`
- `apps/server/systemd/vibesensor-rfkill-unblock.service`
- `apps/server/systemd/vibesensor.service`

As required by the repository-wide review run, I opened and reviewed each file directly before deciding what to change. Two files changed in this chunk, both through comment-only clarifications that preserve behavior exactly. The other two unit files were reviewed in full and intentionally left untouched.

The goal of this chunk was not to “improve” the services by rewriting ordering, restart behavior, capability settings, or boot-time dependencies. Those are operationally sensitive areas. Instead, the worthwhile maintainability gain here was to explain two non-obvious behaviors that are easy to misread as accidental when scanning the unit files in isolation.

## What changed

### `apps/server/systemd/vibesensor-hotspot.service`

I added a short intent comment above the `ExecStartPre` rfkill preflight.

That preflight can look redundant at first glance because this chunk also contains `vibesensor-rfkill-unblock.service`, a separate oneshot unit dedicated to unblocking Wi-Fi before `NetworkManager` starts. Without context, a maintainer could reasonably assume the `ExecStartPre` line in the hotspot unit is leftover duplication and remove it during a future cleanup.

The comment explains why that is not safe: the service-local preflight matters for manual restarts and recovery cases after boot, while the dedicated rfkill unit is tied to boot-time ordering. The service behavior itself did not change. The exact `ExecStartPre` command, startup timeout, restart policy, syslog identifier, and install target all remain unchanged.

### `apps/server/systemd/vibesensor.service`

I added a short intent comment above the ownership-repair `ExecStartPre` lines.

Those `chown` steps are also easy to misread as suspiciously heavy-handed or as something that should only happen in the install script. However, the wider backend setup and smoke tests make it clear that update/install flows can leave the release tree or writable state paths owned by `root`, and the service reasserts ownership at startup so the configured service user can keep writing logs, state, and updater-managed content.

Again, behavior is unchanged. The unit still checks config readability, still repairs ownership in the same paths, still verifies writability, still launches the same console script entrypoint, and still keeps the same capabilities, restart policy, working directory, and stop behavior.

## File-by-file review outcome

### `apps/server/systemd/vibesensor-hotspot-self-heal.service`

Reviewed directly and left unchanged. This template is already compact and explicit. It depends on `NetworkManager`, runs one console entrypoint, and assigns a syslog identifier. I did not find a cleanup strong enough to justify touching behavior or log-tagging in a periodic remediation path.

### `apps/server/systemd/vibesensor-hotspot.service`

Reviewed directly and changed. The change is comment-only and documents why the service retains its own rfkill preflight even though a separate rfkill unblock unit also exists.

### `apps/server/systemd/vibesensor-rfkill-unblock.service`

Reviewed directly and left unchanged. This file is intentionally small, and its boot-order relationship with `NetworkManager` is operationally sensitive. I did not change the unblock command, `RemainAfterExit`, or the somewhat unusual `WantedBy=NetworkManager.service` wiring because those choices are the actual behavior of the Pi image/bootstrap path.

### `apps/server/systemd/vibesensor.service`

Reviewed directly and changed. The change is comment-only and documents why the unit reasserts ownership of the repo/state paths on every start instead of relying solely on install-time setup.

## What did not change

This PR does not alter any systemd unit ordering, dependencies, install targets, restart policies, capabilities, service users, working directories, or command lines.

It does not change the hotspot bring-up flow, the self-heal command, the rfkill fallback logic, or the server process entrypoint.

It does not change how `install_pi.sh` renders these templates into `/etc/systemd/system`, how those units are enabled, or how the Pi image validation checks for their presence.

It also does not rename the hotspot self-heal syslog identifier or make speculative cleanup to `WantedBy=NetworkManager.service`, because both would cross from maintainability cleanup into operational behavior judgment.

## Why this is worthwhile

In a repository-wide behavior-preserving review, comments are only worth adding when they prevent likely future mistakes. These two do.

Both changed areas are exactly the sort of thing a well-meaning maintainer might delete after a quick scan:

- the duplicated-looking rfkill unblock in the hotspot unit
- the repeated ownership repair in the main server unit

In both cases, the surrounding repository provides the rationale, but the rationale is distributed across install scripts, smoke tests, and operational expectations. Adding a concise explanation at the point of use reduces that maintenance burden and lowers the chance of a future “cleanup” accidentally stripping out recovery behavior or update resilience.

## Validation

I validated this chunk with the existing repository guardrails relevant to these files.

First, I ran `git diff --check` to catch whitespace or patch-format issues.

Second, I ran:

`.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py`

That smoke suite passed locally (`23 passed`) and is relevant here because it already asserts key invariants connected to this chunk, including the presence of the split Pi image files and the server unit’s console-script `ExecStart`.

I also cross-checked usage and installation wiring in `apps/server/scripts/install_pi.sh`, plus references in repo tests and Pi-image validation, before deciding to keep the behavior untouched.

## Risks, tradeoffs, and follow-up

Risk is minimal because the shipped diff only adds comments.

The main tradeoff is restraint: there are broader questions one could ask about some unit details, especially boot ordering and NetworkManager integration, but those would require behavioral judgment and broader operational validation. That is outside scope for this run.

For this chunk, the right outcome is narrower and safer: review every unit template individually, keep the operational behavior intact, explain the two non-obvious behaviors that are most likely to be “cleaned up” incorrectly later, validate with existing smoke checks, and move on to the next chunk with clearer service templates and no functional change.
