### PR TITLE
docs: fix test helper guidance

### DIFF
--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -1,8 +1,8 @@
 """Shared test fixtures and helpers for the vibesensor test suite.
 
-Plain helper functions / assertion utilities live in
-``_test_helpers.py`` so they can be imported unambiguously even when
-sub-directory ``conftest.py`` files exist (which shadow this module in
+Plain helper functions / assertion utilities live in dedicated
+``_*_test_helpers.py`` modules so they can be imported unambiguously even
+when sub-directory ``conftest.py`` files exist (which shadow this module in
 ``sys.modules``).
 """
 


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-009`, which contains the two top-level backend test scaffolding files:

- `apps/server/tests/_paths.py`
- `apps/server/tests/conftest.py`

Both files were reviewed directly and individually before deciding what to change. The final diff changes only `apps/server/tests/conftest.py`, where I corrected stale module-level guidance about how shared test helper modules are organized. `apps/server/tests/_paths.py` was reviewed in full and left unchanged.

As with the earlier chunks in this repository-wide review, the goal was behavior-preserving maintainability work rather than cosmetic churn. These two files sit near the root of the backend test suite and are imported or relied on by a wide range of tests, so I kept the bar for changes intentionally high.

## What changed

### `apps/server/tests/conftest.py`

The module docstring at the top of `conftest.py` said that plain helper functions and assertion utilities live in ``_test_helpers.py`` so they can be imported unambiguously even when nested `conftest.py` files exist.

That wording no longer matches the repository. There is no root-level `apps/server/tests/_test_helpers.py`, and the helper-module pattern that exists in the test tree today is more general: helper functionality lives in dedicated helper modules such as `_report_pdf_test_helpers.py` and `_update_manager_test_helpers.py`, as well as the broader `test_support/` package. In other words, the real convention is not “there is a single `_test_helpers.py` module”; it is “use dedicated helper modules instead of stuffing ordinary helpers into `conftest.py`.”

The updated docstring now describes the actual pattern by referring to dedicated ``_*_test_helpers.py`` modules. That keeps the explanatory value of the original note while removing the stale implication that a specific root-level helper file exists.

This is documentation-only. No fixtures, mocks, `FakeState` behavior, router dependency assembly, or test import semantics changed.

## File-by-file review outcome

### `apps/server/tests/_paths.py`

Reviewed directly and left unchanged.

This module is already small, focused, and useful. It centralizes `REPO_ROOT`, `SERVER_ROOT`, and `TESTS_DIR` so tests do not need to duplicate fragile `Path(__file__).parents[N]` chains. A quick usage scan showed that many test modules across adapters, hygiene, integration, and use-case areas import these constants directly.

I considered whether any cleanup was warranted here, but the current implementation is already straightforward and the inline comments still accurately describe the directory relationships. A change would have been churn rather than an improvement, so I left the file alone.

### `apps/server/tests/conftest.py`

Reviewed directly and changed.

The bulk of the file consists of shared fixtures and mock builders used by many HTTP/router-oriented tests. I reviewed the helper constructors, the `FakeState` dataclass, the projected history service assembly, and the shared fixtures such as `fake_state` and `route_paths`.

I did not find a safe structural cleanup that clearly improved maintainability without risking behavior drift in the shared test surface. However, the module docstring did contain stale guidance. Correcting that was worthwhile because `conftest.py` is a high-visibility file that contributors are likely to read when extending the test suite.

## What did not change

This PR does not change:

- any fixture return values
- any mock defaults
- `FakeState` construction or dependency grouping
- route assembly behavior
- history/export/report service wiring
- path constant values in `_paths.py`
- pytest discovery behavior
- import paths used by existing tests

It also does not attempt to refactor `FakeState`, deduplicate mock-builder code, or change the current mix of helper modules versus fixtures. Those are larger questions and would require a stronger behavior-preserving case than I found in this chunk.

## Why this is worthwhile

Because `conftest.py` is effectively the public “front door” for shared backend test fixtures, stale guidance there has an outsized maintenance cost. Even when the stale text is small, it can send contributors looking for a file that no longer exists or suggest that the preferred helper structure is narrower than it really is.

This update keeps the intent of the original documentation intact—ordinary helper functions should live in importable helper modules rather than inside `conftest.py`—while aligning the wording with the repository’s current structure.

That matters in a long-running cleanup like this one. A behavior-preserving review should not just simplify code; it should also remove misleading maintenance breadcrumbs that make future changes harder.

## Validation

I validated this chunk with targeted checks that cover both files in practical ways.

First, I ran `git diff --check` to ensure the docstring edit introduced no whitespace or patch-format problems.

Second, I ran:

`.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/test_route_registration.py apps/server/tests/hygiene/test_ai_smoke.py`

That focused test run passed locally (`24 passed`). It was chosen deliberately:

- `test_route_registration.py` exercises the shared `fake_state`/router scaffolding exposed through `conftest.py`
- `test_ai_smoke.py` exercises `_paths.py` consumers and broad repository smoke assertions that rely on the shared path constants

Those tests gave me confidence that the shared scaffolding still imports and behaves as expected after the docstring correction.

## Risks, tradeoffs, and follow-up

Risk is minimal because the shipped diff changes documentation only.

The main tradeoff is that I deliberately did not make deeper edits inside `conftest.py`, even though it is a substantial shared test-support file. That restraint is intentional. Shared fixtures are high-blast-radius code, and a broad cleanup there would need stronger localized evidence and a wider validation plan.

For this chunk, the right outcome is narrower: review both files directly, keep the useful shared path module unchanged, fix the stale test-helper guidance in `conftest.py`, validate with focused existing tests, and move the repository review forward with clearer scaffolding and no functional change.

## Additional context from direct review

During the review I also checked where these seams are consumed across the test tree. `_paths.py` is imported from hygiene, integration, PDF, websocket, HTTP schema, and update-validation tests, which reinforced the decision to avoid unnecessary edits there. I also checked that `conftest.py` remains the shared source for `fake_state` and `route_paths`, so keeping its documentation accurate has value well beyond this one module.
