### PR TITLE
test: clarify gps stale fallback coverage

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_status.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_status.py
@@ -114,15 +114,13 @@ class TestFallback:
         assert m.fallback_active is False
 
     def test_stale_gps_triggers_manual_fallback(self) -> None:
-        """When GPS data is stale and an override_speed_mps is set,
-        effective_speed_mps returns the override (since override always wins).
-        When no override is set, stale GPS triggers fallback → None.
-        """
+        """When GPS is primary and stale, a manual override becomes the fallback."""
         m = GPSSpeedMonitor(gps_enabled=True)
+        m.manual_source_selected = False
         m.speed_mps = 10.0
         set_gps_snapshot_age(m, age_s=999)
-        # No override set → stale GPS → fallback path → None
-        assert m.effective_speed_mps is None
+        m.override_speed_mps = 25.0
+        assert m.effective_speed_mps == pytest.approx(25.0)
         assert m.fallback_active is True
 
     def test_stale_gps_no_override_returns_none(self) -> None:


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-010`, the first GPS adapter test batch in the repository-wide file-by-file cleanup run. The chunk contains these ten files:

- `apps/server/tests/adapters/gps/test_gps_iris4_fixes.py`
- `apps/server/tests/adapters/gps/test_gps_speed.py`
- `apps/server/tests/adapters/gps/test_gps_speed_extended.py`
- `apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py`
- `apps/server/tests/adapters/gps/test_gps_speed_run_loop.py`
- `apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py`
- `apps/server/tests/adapters/gps/test_gps_speed_status.py`
- `apps/server/tests/adapters/gps/test_gps_transport_ingestion.py`
- `apps/server/tests/adapters/gps/test_gpsd_message_handler.py`
- `apps/server/tests/adapters/gps/test_issue_148_speed_window.py`

All ten files were opened and reviewed individually before I decided what to change. Nine files were reviewed and intentionally left untouched. One file changed: `test_gps_speed_status.py`.

The change is behavior-preserving and test-only. It corrects a mislabeled fallback test so the scenario under test now matches the test name and docstring instead of duplicating the adjacent “no override” case.

## What changed

### `apps/server/tests/adapters/gps/test_gps_speed_status.py`

This file already had two neighboring stale-GPS fallback tests in the `TestFallback` section:

- `test_stale_gps_triggers_manual_fallback`
- `test_stale_gps_no_override_returns_none`

On direct review, I found that the first test did not actually exercise manual fallback at all. Its name and docstring described the case where stale GPS data falls back to a manual override, but the body never set an override and instead asserted the same no-override outcome that the next test already covered.

In other words, the file had a mislabeled test plus redundant coverage of the no-override path.

I corrected that by making `test_stale_gps_triggers_manual_fallback` actually test the manual-fallback scenario:

- GPS is enabled
- GPS remains the primary source (`manual_source_selected = False`)
- GPS data is made stale
- a manual override is supplied
- `effective_speed_mps` now resolves to the manual override
- `fallback_active` remains `True`

That aligns the implementation with the test name and docstring, preserves the adjacent no-override case, and makes the fallback section easier to trust when someone reads it later.

## File-by-file review outcome

### `test_gps_iris4_fixes.py`

Reviewed directly and left unchanged. This is an issue-focused regression file with explicit section headers tied to the GPS fixes it is guarding. Even though some scenarios overlap broader GPS tests, that overlap appears intentional and useful for preserving the wave-specific regression history.

### `test_gps_speed.py`

Reviewed directly and left unchanged. This file still serves as a readable baseline for speed resolution, override priority, stale fallback behavior, and parser guardrails. I did not find a cleanup that improved it more than simply keeping the current structure.

### `test_gps_speed_extended.py`

Reviewed directly and left unchanged. The file mixes async cancellation behavior with setter edge cases, but the sections are still coherent and the assertions are explicit. I avoided refactoring async coverage just for style.

### `test_gps_speed_no_mutation.py`

Reviewed directly and left unchanged. This is a larger regression file, but the helper factories and sectioning still make the no-mutation guarantees understandable. A larger refactor here would have created unnecessary churn in a high-value regression suite.

### `test_gps_speed_run_loop.py`

Reviewed directly and left unchanged. The mock gpsd server helpers, reconnect assertions, malformed JSON handling, and zero-speed filtering scenarios are already well organized for an async transport test file.

### `test_gps_speed_snapshot_consistency.py`

Reviewed directly and left unchanged. This file is already compact and focused on snapshot-seam consistency. No safe cleanup stood out.

### `test_gps_speed_status.py`

Reviewed directly and changed. The file had the only concrete maintainability issue in the chunk: a mislabeled test that duplicated the next scenario instead of covering the fallback path it claimed to cover. That mismatch is now corrected.

### `test_gps_transport_ingestion.py`

Reviewed directly and left unchanged. The ingestion/delegation seam tests are small and precise; no cleanup was warranted.

### `test_gpsd_message_handler.py`

Reviewed directly and left unchanged. This parser/classification file is already a straightforward list of normalization expectations, which is exactly what it should be.

### `test_issue_148_speed_window.py`

Reviewed directly and left unchanged. The regression remains concise and uses a small local observation helper appropriately. I did not find a change that would improve clarity without sliding into churn.

## What did not change

This PR does not modify any production GPS code. It does not change speed resolution policy, stale detection, GPS transport behavior, message normalization, fallback logic, or location-analysis math.

It also does not delete broad GPS test overlap simply because similar scenarios appear elsewhere. For this chunk I treated overlap as suspicious only when it produced an actual mismatch or redundancy problem inside the reviewed file. The only case that crossed that threshold was the mislabeled fallback test in `test_gps_speed_status.py`.

## Why this is worthwhile

Test suites are only as trustworthy as their names and assertions line up. A misleading test is worse than a missing comment because it gives readers false confidence about which scenario is being protected.

Here, a test named `test_stale_gps_triggers_manual_fallback` was actually proving the no-override path. The next test already covered that no-override case, so the file was paying maintenance cost for duplicated intent while leaving the named manual-fallback case underrepresented in that section.

Correcting the scenario makes the file easier to read, reduces confusion during future GPS-policy changes, and preserves the kind of direct behavioral signal that regression tests are meant to provide.

## Validation

I validated this chunk with the existing test suite, focused on the exact ten files in the chunk.

First, I ran `git diff --check` to catch whitespace and patch-format problems.

Second, I ran the full chunk-010 GPS batch locally:

`.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/gps/test_gps_iris4_fixes.py apps/server/tests/adapters/gps/test_gps_speed.py apps/server/tests/adapters/gps/test_gps_speed_extended.py apps/server/tests/adapters/gps/test_gps_speed_no_mutation.py apps/server/tests/adapters/gps/test_gps_speed_run_loop.py apps/server/tests/adapters/gps/test_gps_speed_snapshot_consistency.py apps/server/tests/adapters/gps/test_gps_speed_status.py apps/server/tests/adapters/gps/test_gps_transport_ingestion.py apps/server/tests/adapters/gps/test_gpsd_message_handler.py apps/server/tests/adapters/gps/test_issue_148_speed_window.py`

That run passed in full: `141 passed`.

## Risks, tradeoffs, and follow-up

Risk is minimal because the diff changes a test only, not the implementation.

The tradeoff is deliberate restraint. I did not attempt to consolidate all overlapping GPS tests across the batch, because much of that overlap appears intentional for issue-specific regression tracking and transport/state/view separation. Removing it without a stronger case would have been risky cleanup rather than careful maintenance.

For this chunk, the right outcome is narrower: review every file directly, correct the one test whose name and body had drifted apart, validate the entire GPS test batch, and move on with clearer regression coverage and no production behavior change.
