### PR TITLE
test: tighten parse manual speed cases

### DIFF
--- a/apps/server/tests/adapters/gps/test_parse_manual_speed.py
+++ b/apps/server/tests/adapters/gps/test_parse_manual_speed.py
@@ -1,4 +1,4 @@
-"""Tests for _parse_manual_speed rejecting Inf/NaN/out-of-range values."""
+"""Tests for _parse_manual_speed valid and invalid input handling."""
 
 from __future__ import annotations
 
@@ -29,11 +29,8 @@ def test_normal_values(value: float, expected: float) -> None:
         math.inf,
         -math.inf,
         math.nan,
-        float("inf"),
-        float("-inf"),
-        float("nan"),
     ],
-    ids=["inf", "neg-inf", "nan", "float-inf", "float-neg-inf", "float-nan"],
+    ids=["inf", "neg-inf", "nan"],
 )
 def test_non_finite_returns_none(value: float) -> None:
     assert _parse_manual_speed(value) is None


### PR DESCRIPTION
## Summary

This PR covers repository review `chunk-011`, the second GPS adapter test batch in the repository-wide file-by-file cleanup run. The chunk contains these five files:

- `apps/server/tests/adapters/gps/test_parse_manual_speed.py`
- `apps/server/tests/adapters/gps/test_speed_resolution_policy.py`
- `apps/server/tests/adapters/gps/test_speed_status_builder.py`
- `apps/server/tests/adapters/gps/test_speed_validation.py`
- `apps/server/tests/adapters/gps/test_transport_lifecycle.py`

All five files were opened and reviewed individually before I made any changes. Four files were reviewed and intentionally left unchanged. One file changed: `test_parse_manual_speed.py`.

The final diff is test-only and behavior-preserving. It removes redundant equivalent non-finite input cases and updates the module docstring so the file description matches the broader set of valid/invalid inputs the tests already cover.

## What changed

### `apps/server/tests/adapters/gps/test_parse_manual_speed.py`

This file tests `_parse_manual_speed` in `vibesensor.shared.types.speed_source_config`. On direct review, I found two small maintainability issues.

First, the module docstring was narrower than the actual test coverage. It said the file was for rejecting Inf/NaN/out-of-range values, but the file also explicitly covers valid values, negative values, zero, and non-numeric inputs. The tests themselves were fine; the summary at the top was simply stale and underspecified.

Second, the non-finite parametrization included duplicate constructor variants:

- `math.inf` and `float("inf")`
- `-math.inf` and `float("-inf")`
- `math.nan` and `float("nan")`

Those are not distinct behavioral cases for `_parse_manual_speed`; they are equivalent float values constructed in different ways. Keeping both versions did not provide meaningfully different coverage, but it did make the test table longer and noisier than necessary.

The cleanup therefore does two things:

- broadens the module docstring to describe valid and invalid input handling more accurately
- removes the duplicate non-finite constructor variants while preserving one clear case each for `inf`, `-inf`, and `nan`

The actual assertions remain the same: `_parse_manual_speed` still accepts valid positive numeric inputs in range and still rejects non-finite, negative, zero, out-of-range, and non-numeric values.

## File-by-file review outcome

### `test_parse_manual_speed.py`

Reviewed directly and changed.

This file had the only clear maintainability cleanup in the chunk. The underlying behavioral coverage stayed the same, but the test table is now tighter and the file description is more accurate.

### `test_speed_resolution_policy.py`

Reviewed directly and left unchanged.

This file is already compact and focused. It tests exactly two things: manual fallback resolution when GPS is stale and stale-timeout clamping. For such a small policy seam, that shape is appropriate. I did not find any dead code, misleading commentary, or unnecessary complexity to remove.

### `test_speed_status_builder.py`

Reviewed directly and left unchanged.

This file is a single focused seam test for `build_status_snapshot`. It verifies stale fallback reporting without needing the transport loop, and it does that succinctly. I did not find a stronger improvement than leaving it as-is.

### `test_speed_validation.py`

Reviewed directly and left unchanged.

This file already has a clean table-driven structure for plausibility rules and zero-speed transition behavior. It covers default config behavior, custom config behavior, bool handling, and threshold tuning without unnecessary indirection. No stale tests or redundant assertions stood out strongly enough to justify edits.

### `test_transport_lifecycle.py`

Reviewed directly and left unchanged.

This lifecycle test file is already readable and well sectioned. The transition groupings (`on_connected`, `on_stream_disconnected`, `on_connection_error`, delay reset, custom policy) make the reconnect policy easy to audit. I did not find a worthwhile behavior-preserving cleanup here.

## What did not change

This PR does not touch any production GPS code, policy code, parsing logic, lifecycle implementation, or transport behavior.

It does not change the semantics of `_parse_manual_speed`.

It does not alter the assertions for accepted positive values, negative values, zero, upper-bound rejection, or non-numeric inputs.

It also does not broaden scope into refactoring the GPS test layout, consolidating policy/status/lifecycle tests, or adding new helper modules. For this chunk, the only change worth shipping was the direct cleanup in `test_parse_manual_speed.py`.

## Why this is worthwhile

Small test cleanups matter when they reduce ambiguity instead of just shifting style around.

In this case, the redundant constructor variants for non-finite floats did not add new signal. They made the parametrization table look broader than it really was, even though `_parse_manual_speed` only cares about the resulting float value, not how it was constructed.

Likewise, the module docstring is the first thing a maintainer sees when opening the file. If that description undersells the file’s actual scope, it becomes easier to miss that the test already covers valid values, zero handling, negatives, and non-numeric inputs.

Tightening the table and correcting the summary makes the file easier to read at a glance while preserving the same real behavioral coverage.

## Validation

I validated this chunk with focused existing tests covering all five files in the batch.

First, I ran `git diff --check` to catch whitespace and patch-format problems.

Second, I ran the full chunk-011 GPS test batch locally:

`.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/gps/test_parse_manual_speed.py apps/server/tests/adapters/gps/test_speed_resolution_policy.py apps/server/tests/adapters/gps/test_speed_status_builder.py apps/server/tests/adapters/gps/test_speed_validation.py apps/server/tests/adapters/gps/test_transport_lifecycle.py`

That run passed in full: `50 passed`.

Because the change is confined to one test file but the chunk covers five related GPS test modules, validating the entire chunk batch was the right scope here.

## Risks, tradeoffs, and follow-up

Risk is minimal because the diff is test-only and narrows redundant inputs rather than changing product logic.

The main tradeoff is deliberate restraint. I did not force additional edits into the other four files just because the chunk needed a PR. They were reviewed directly, and leaving them alone was the higher-quality choice.

For this chunk, the right outcome is straightforward: review every file in the batch personally, remove a small pocket of redundant test noise where it truly exists, validate the entire five-file GPS test batch, and move the repository review forward with slightly cleaner regression coverage and no functional change.
