### PR TITLE
test: clarify hotspot test module docs

### DIFF
--- a/apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py
@@ -1,3 +1,5 @@
+"""CLI regression tests for hotspot-config fallback behavior."""
+
 from __future__ import annotations
 
 import sys

--- a/apps/server/tests/adapters/hotspot/test_hotspot_parsers.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_parsers.py
@@ -1,4 +1,4 @@
-"""Tests for hotspot_parsers text-parsing helpers."""
+"""Tests for hotspot parser helpers and HealStateStore behavior."""
 
 from __future__ import annotations
 

--- a/apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py
@@ -1,3 +1,5 @@
+"""Tests for hotspot health collection and self-heal remediation flows."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py
@@ -1,3 +1,5 @@
+"""CLI smoke test for hotspot self-heal diagnostics mode."""
+
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
This PR covers `chunk-012` of the sequential repository review and is intentionally limited to the four hotspot adapter test modules listed below:

- `apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py`
- `apps/server/tests/adapters/hotspot/test_hotspot_parsers.py`
- `apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py`
- `apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py`

As required by the review run, I opened and inspected each code file in this chunk individually before making any edits. The goal for this batch was the same as the broader run: keep behavior unchanged while improving maintainability anywhere a low-risk cleanup was clearly warranted. In this chunk, the strongest improvement was not in assertions or helper logic, but in the file-level guidance that tells future readers what each module actually covers.

## What changed
The actual code diff is intentionally small and behavior-preserving. I added or corrected module docstrings so each hotspot test file now states its scope up front.

In `test_hotspot_config_cli.py`, I added a module docstring that explains the file is a CLI regression test for hotspot-config fallback behavior. This is a very small test module, but without a top-level description it took a moment longer than necessary to understand why it exists and what edge it is protecting. The new docstring makes that intent immediate.

In `test_hotspot_parsers.py`, I broadened the existing docstring. The previous text described the file as covering text-parsing helpers, but the module also contains `HealStateStore` tests. That meant the docstring had drifted out of sync with the file’s real contents. The updated wording now accurately reflects both parser coverage and the cooldown-state-store behavior verified at the bottom of the file.

In `test_hotspot_self_heal.py`, I added a module docstring describing the combined scope of the file: hotspot health collection plus self-heal remediation flows. This file is the largest and most scenario-heavy module in the chunk, so a top-level description provides useful orientation before readers dive into the local fake runner, response tables, and end-to-end remediation assertions.

In `test_hotspot_self_heal_cli.py`, I added a module docstring clarifying that the file is a CLI smoke test for diagnostics mode. Like the config CLI test, this module is concise, but giving it a one-line description makes the test layer easier to scan when someone is navigating the hotspot adapter suite.

## Why this improvement was worth making
This chunk did not present a compelling behavior-safe refactor of the test logic itself. The assertions, helper structure, and scenario coverage were already reasonably direct, and changing them further would have risked churn without a clear maintenance payoff. The documentation issues, on the other hand, were concrete and low risk.

Module docstrings are small, but in a test suite they provide real value. They help reviewers quickly decide whether they are looking at a parser-focused test file, a CLI-focused smoke test, or a higher-level remediation-flow suite. That matters in this repository because the hotspot area spans parsing, health collection, remediation, and command-line entrypoints. Making those boundaries explicit at the file level reduces the time needed to reorient during later reviews or bug hunts.

The `test_hotspot_parsers.py` correction is especially important because it removes misleading guidance. Calling the file only a parser-helper test module understated its actual scope and could send a future maintainer looking elsewhere for `HealStateStore` coverage. Updating the docstring keeps the documentation aligned with reality instead of forcing readers to infer that from the test classes.

## File-by-file review outcomes
Every code file in the chunk was reviewed directly.

`test_hotspot_config_cli.py` was changed to add scope documentation. No assertion or helper changes were needed.

`test_hotspot_parsers.py` was changed to fix a stale module description. The parser and state-store tests themselves were reviewed and left structurally unchanged.

`test_hotspot_self_heal.py` was changed to add a scope-setting docstring. The fake command runner, helper constructors, health collection scenarios, and remediation assertions were reviewed with no logic changes.

`test_hotspot_self_heal_cli.py` was changed to add a concise description of the diagnostics smoke test. The patched CLI flow and exit-code assertions were reviewed and preserved as-is.

## Dependencies, dead code, and skipped changes
No dependencies were added, removed, or replaced in this PR. No standard-library substitutions were needed. I also did not remove any dead code because nothing in this chunk met the confidence bar for deletion; the helper code that exists in the self-heal test module is actively used to express the command-runner scenarios and remains appropriate for the file.

I deliberately skipped broader stylistic rewrites, test parametrization changes, or helper extraction because they would have increased churn without clearly improving correctness or maintainability. In a repository-wide sequential review like this one, keeping diffs surgical is important when the existing logic is already readable.

## Validation
Local validation for this chunk was targeted to the files under review:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py apps/server/tests/adapters/hotspot/test_hotspot_parsers.py apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py`
- `git diff --check`

The pytest batch passed with `51 passed`, which confirms the docstring cleanup did not disturb the hotspot test modules. `git diff --check` also passed, confirming there are no whitespace or patch-hygiene issues in the diff.

## Risks, tradeoffs, and follow-ups
Risk here is intentionally minimal because the PR changes documentation only. The main tradeoff is that this is a small cleanup rather than a deeper refactor, but that is the right choice for this chunk: the review found documentation drift and missing orientation, not a strong candidate for safe behavioral cleanup.

There are no immediate follow-ups required within this chunk. Any larger cleanup in nearby hotspot or adapter tests should be handled in their own assigned chunks so the repo-review tracker keeps one PR mapped cleanly to one chunk. This PR therefore does exactly what the run requires: it records the individual review of every code file in `chunk-012`, applies the worthwhile behavior-preserving improvements that were actually justified, and leaves the hotspot tests slightly easier to understand without changing how they execute.
