### PR TITLE
test: simplify http adapter endpoint tests

### DIFF
--- a/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
@@ -25,7 +25,7 @@ from vibesensor.adapters.http import create_router
 
 @pytest.mark.asyncio
 async def test_history_export_streams_zip_with_json_and_csv() -> None:
-    router, _ = make_router_and_state(language="en", sample_count=1000)
+    router, _ = make_router_and_state(language="en", sample_count=3)
     endpoint = route_endpoint(router, "/api/history/{run_id}/export")
     response = await endpoint("run-1")
     body = await read_streaming_body(response)
@@ -34,9 +34,9 @@ async def test_history_export_streams_zip_with_json_and_csv() -> None:
         assert names == {"run-1.json", "run-1_raw.csv"}
         metadata = json.loads(archive.read("run-1.json").decode("utf-8"))
         assert metadata["run_id"] == "run-1"
-        assert metadata["sample_count"] == 1000
+        assert metadata["sample_count"] == 3
         rows = list(csv.DictReader(io.StringIO(archive.read("run-1_raw.csv").decode("utf-8"))))
-        assert len(rows) == 1000
+        assert len(rows) == 3
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/adapters/http/test_api_history_route_state.py
+++ b/apps/server/tests/adapters/http/test_api_history_route_state.py
@@ -100,6 +100,7 @@ async def test_history_insights_status_and_analysis_errors(
         assert payload.status_code == 202
         body = json.loads(payload.body)
         assert body["status"] == "analyzing"
+        assert body["run_id"] == "run-1"
         return
 
     with pytest.raises(HTTPException) as exc_info:
@@ -318,21 +319,3 @@ async def test_history_run_preserves_missing_optional_analysis_fields() -> None:
     assert "samples" not in payload
     assert "plots" not in payload
     assert "analysis_metadata" not in payload
-
-
-@pytest.mark.asyncio
-async def test_history_insights_analyzing_returns_202_json_response() -> None:
-    from fastapi.responses import JSONResponse
-
-    router = make_status_router(
-        status="analyzing",
-        analysis={"status": "analyzing"},
-        include_error_message=False,
-    )
-    endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
-    result = await endpoint("run-1")
-    assert isinstance(result, JSONResponse)
-    assert result.status_code == 202
-    body = json.loads(result.body)
-    assert body["status"] == "analyzing"
-    assert body["run_id"] == "run-1"

--- a/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
+++ b/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
@@ -99,9 +99,11 @@ def test_history_routes_reject_invalid_run_ids_before_reaching_services(
 
     assert response.status_code == 400
     assert response.json() == {"detail": "Invalid run identifier"}
-    getattr(run_service, service_attr, AsyncMock()).assert_not_called()
-    getattr(report_service, service_attr, AsyncMock()).assert_not_called()
-    getattr(export_service, service_attr, AsyncMock()).assert_not_called()
+    run_service.get_run.assert_not_called()
+    run_service.get_insights.assert_not_called()
+    run_service.delete_run.assert_not_called()
+    report_service.build_pdf.assert_not_called()
+    export_service.build_export.assert_not_called()
 
 
 def test_settings_routes_reject_invalid_car_id_in_active_car_request() -> None:


### PR DESCRIPTION
## Summary
This PR covers `chunk-013` of the sequential repository review and is intentionally limited to the first ten-file HTTP adapter test batch:

- `apps/server/tests/adapters/http/_history_endpoint_helpers.py`
- `apps/server/tests/adapters/http/test_analysis_settings_request_codec.py`
- `apps/server/tests/adapters/http/test_api_history_export_endpoints.py`
- `apps/server/tests/adapters/http/test_api_history_report_endpoints.py`
- `apps/server/tests/adapters/http/test_api_history_route_state.py`
- `apps/server/tests/adapters/http/test_api_path_identifier_validation.py`
- `apps/server/tests/adapters/http/test_api_ws_health_and_clients.py`
- `apps/server/tests/adapters/http/test_health_endpoint.py`
- `apps/server/tests/adapters/http/test_helpers_exception_handling.py`
- `apps/server/tests/adapters/http/test_http_api_schema_export.py`

Per the review-run rules, I opened and inspected every code file in this chunk individually before deciding what to change. The goal remained strictly non-functional: improve maintainability and test clarity without altering production behavior, route contracts, or test intent. Most of the files in this batch were already in good shape and were left alone after direct review. The worthwhile cleanup was concentrated in three places where the tests had become slightly more repetitive or indirect than they needed to be.

## What changed
The largest category of improvement in this PR is duplication reduction inside the HTTP endpoint tests.

In `test_api_history_export_endpoints.py`, the generic archive-shape smoke test previously used the same `sample_count=1000` scale as the dedicated `test_history_export_large_run` scenario. That meant the file had two different tests paying the cost of the same large sample volume even though only one of them was actually about large-run behavior. I trimmed the general smoke test down to a small three-sample case while leaving the dedicated large-run test untouched at 1000 samples. This keeps the file’s intent clearer: one test verifies the shape of the exported archive, while the other remains the explicit large-run regression guard.

In `test_api_history_route_state.py`, the `analyzing` response path for `/api/history/{run_id}/insights` was effectively checked twice. The shared parametrized status/error test already exercised the `202` path, and a later dedicated test repeated the same JSON-response assertions. I folded the `run_id` assertion into the parametrized branch and removed the dedicated duplicate. Coverage stays intact, but the file now has one canonical place that describes what the `analyzing` response must contain.

In `test_api_path_identifier_validation.py`, the invalid-run-ID guard test used `getattr(..., AsyncMock())` fallbacks when checking that backing services were not called. That worked, but it made the test read more vaguely than necessary because two of those checks could silently target synthetic fallback mocks instead of real service methods. I replaced that pattern with explicit `assert_not_called()` checks on `run_service.get_run`, `run_service.get_insights`, `run_service.delete_run`, `report_service.build_pdf`, and `export_service.build_export`. The test now states directly what it is proving: invalid identifiers are rejected before any history, report, or export service is touched.

## File-by-file review outcomes
All ten code files in the chunk were reviewed directly.

`_history_endpoint_helpers.py` was reviewed unchanged. The fake history DB, fake websocket hub, fake state container, and route lookup helpers are purposeful scaffolding for this slice of tests and did not present a stronger safe cleanup than the active diff elsewhere in the chunk.

`test_analysis_settings_request_codec.py` was reviewed unchanged. The request-codec assertions are already compact and cover both omission of `None` values and projection of the full supported field set clearly.

`test_api_history_export_endpoints.py` was changed to separate the generic archive-shape check from the dedicated large-run check more cleanly.

`test_api_history_report_endpoints.py` was reviewed unchanged. The file already distinguishes language handling, persisted template data, cache reuse, cache invalidation, and error mapping without unnecessary overlap.

`test_api_history_route_state.py` was changed to consolidate duplicate `analyzing` response coverage.

`test_api_path_identifier_validation.py` was changed to make the guard-rail assertions explicit instead of indirect.

`test_api_ws_health_and_clients.py` was reviewed unchanged. Its websocket, identify-client, client-location, and retained-client coverage remains purposeful and readable as-is.

`test_health_endpoint.py` was reviewed unchanged. The explicit response-shape assertions are valuable here because this endpoint exposes a broad runtime-health surface.

`test_helpers_exception_handling.py` was reviewed unchanged. The exception-mapping coverage is already concise and representative.

`test_http_api_schema_export.py` was reviewed unchanged. The schema contract assertions are broad but still targeted to concrete API-shape guarantees, so further churn would not have improved maintainability.

## Dependencies, dead code, and deliberately skipped changes
No dependencies were added, removed, or replaced in this PR. No production files were touched. The only removed code was redundant test coverage in `test_api_history_route_state.py`, where the dedicated `analyzing` response test became unnecessary once the shared parametrized test asserted the full `run_id` and `status` response shape.

I deliberately did not refactor the larger helper scaffolding in `_history_endpoint_helpers.py`, even though it is sizeable, because the current fake state and service wiring are still serving multiple tests in this batch. A deeper rewrite there would have been churn-heavy and riskier than the concrete cleanup wins identified in the active diff. I also did not rename tests or reorganize modules simply for aesthetics; the edits here are limited to places where redundancy or indirection was clear.

## Validation
Local validation was targeted to the entire active chunk so the changed tests and their shared helpers were exercised together:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/_history_endpoint_helpers.py apps/server/tests/adapters/http/test_analysis_settings_request_codec.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/adapters/http/test_health_endpoint.py apps/server/tests/adapters/http/test_helpers_exception_handling.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `git diff --check`

That batch passed with `87 passed`, confirming the simplified tests still cover the intended HTTP behaviors and that the shared helper module remains compatible with the broader chunk.

## Risks, tradeoffs, and follow-ups
Risk here is intentionally low because the PR only adjusts tests. The main tradeoff is that this is targeted cleanup rather than a broader restructuring of the HTTP test support layer, but that is the right choice for this chunk: the concrete issues were overlapping assertions and an indirect service-isolation check, not a proven architectural problem.

There are no immediate follow-ups required inside this PR. The next HTTP test batch belongs to the next planned chunk, and any further cleanup should continue to respect the one-chunk/one-PR structure so the tracker remains accurate. Within the scope of `chunk-013`, this PR does what the run requires: every code file was individually reviewed, only worthwhile behavior-preserving changes were made, redundant coverage was trimmed without reducing intent, and the HTTP adapter tests are a little easier to read and maintain than before.
