### PR TITLE
test: tidy http route client tests

### DIFF
--- a/apps/server/tests/adapters/http/test_recording_endpoints.py
+++ b/apps/server/tests/adapters/http/test_recording_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests for the /api/recording/* endpoint response shapes and behavior."""
+"""HTTP client tests for the /api/recording routes."""
 
 from __future__ import annotations
 

--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -112,7 +112,6 @@ class TestDeleteCarEndpoint:
     async def test_delete_unknown_car_returns_404(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
-        assert endpoint is not None
 
         state.settings_store.get_cars.return_value = _make_cars_snapshot(
             cars=[],
@@ -127,7 +126,6 @@ class TestDeleteCarEndpoint:
     async def test_delete_known_car_calls_store(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
-        assert endpoint is not None
 
         state.settings_store.get_cars.return_value = _make_cars_snapshot()
         state.settings_store.delete_car.return_value = _make_cars_snapshot(
@@ -144,7 +142,6 @@ class TestDeleteCarEndpoint:
     async def test_delete_car_business_logic_error_returns_400(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
-        assert endpoint is not None
 
         state.settings_store.get_cars.return_value = _make_cars_snapshot()
         state.settings_store.delete_car.side_effect = ValueError("cannot delete last car")
@@ -159,7 +156,6 @@ class TestSetActiveCarEndpoint:
     async def test_unknown_car_id_raises_404(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/cars/active", "PUT")
-        assert endpoint is not None
 
         state.settings_store.set_active_car.side_effect = ValueError("Car not found")
 
@@ -191,7 +187,6 @@ class TestCarsEndpoint:
     async def test_get_cars_response_shape(self, _settings_router) -> None:
         router, _ = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/cars", "GET")
-        assert endpoint is not None
 
         result = response_payload(await endpoint())
 
@@ -203,7 +198,6 @@ class TestCarsEndpoint:
     async def test_add_car_passes_only_non_null_fields(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/cars", "POST")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import CarUpsertRequest
 
@@ -221,7 +215,6 @@ class TestSpeedSourceEndpoint:
     async def test_update_speed_source_passes_only_non_null_fields(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/speed-source", "PUT")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import SpeedSourceRequest
 
@@ -241,7 +234,6 @@ class TestSpeedSourceEndpoint:
     async def test_update_speed_source_maps_invalid_config_to_400(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/speed-source", "PUT")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import SpeedSourceRequest
 
@@ -258,7 +250,6 @@ class TestSpeedSourceEndpoint:
     async def test_speed_source_status_response_shape(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/speed-source/status", "GET")
-        assert endpoint is not None
 
         state.gps_monitor.status_snapshot.return_value = _make_speed_source_status_snapshot()
 
@@ -276,7 +267,6 @@ class TestSensorEndpoint:
     ) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/sensors/{mac}", "POST")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import SensorRequest
 
@@ -299,7 +289,6 @@ class TestSensorEndpoint:
     async def test_update_sensor_maps_duplicate_location_to_409(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/sensors/{mac}", "POST")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import SensorRequest
 
@@ -322,7 +311,6 @@ class TestSetAnalysisSettingsEndpoint:
         """PUT /api/settings/analysis with all-None body skips update_active_car_aspects."""
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/analysis", "PUT")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import AnalysisSettingsRequest
 
@@ -335,7 +323,6 @@ class TestSetAnalysisSettingsEndpoint:
     async def test_valid_changes_calls_update(self, _settings_router) -> None:
         router, state = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/analysis", "PUT")
-        assert endpoint is not None
 
         from vibesensor.adapters.http.models import AnalysisSettingsRequest
 
@@ -349,7 +336,6 @@ class TestSetAnalysisSettingsEndpoint:
     async def test_get_analysis_settings_response_shape(self, _settings_router) -> None:
         router, _ = _settings_router
         endpoint = _find_endpoint(router, "/api/settings/analysis", "GET")
-        assert endpoint is not None
 
         result = response_payload(await endpoint())
 

--- a/apps/server/tests/adapters/http/test_update_endpoints.py
+++ b/apps/server/tests/adapters/http/test_update_endpoints.py
@@ -1,3 +1,5 @@
+"""HTTP client tests for update and ESP flash endpoints."""
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary
This PR covers `chunk-014` of the sequential repository review and is intentionally limited to the second HTTP adapter test batch:

- `apps/server/tests/adapters/http/test_recording_endpoints.py`
- `apps/server/tests/adapters/http/test_recording_route_http.py`
- `apps/server/tests/adapters/http/test_request_observability.py`
- `apps/server/tests/adapters/http/test_route_registration.py`
- `apps/server/tests/adapters/http/test_settings_endpoints.py`
- `apps/server/tests/adapters/http/test_update_endpoints.py`

As required by the review run, I opened and inspected each code file in this chunk individually before making any changes. The objective for this PR is purely behavior-preserving maintainability work. No production routes, contracts, handlers, or settings logic changed. The only edits are in tests, and even there the diff stays narrow: clarify module scope where it was missing and remove assertions that were redundant given the helper behavior already under test.

## What changed
There are three changed files in this chunk.

In `test_recording_endpoints.py`, I added a module docstring that makes the file’s role clear at a glance. This file uses `FastAPI` plus `TestClient` to exercise the `/api/recording/*` endpoints through real HTTP routing, which is meaningfully different from the sibling direct-route test module. Calling that out at the top of the file makes the distinction easier to spot during later reviews.

In `test_settings_endpoints.py`, I removed repeated `assert endpoint is not None` lines that appeared immediately after `_find_endpoint(...)`. Those assertions were redundant because `_find_endpoint()` already delegates to `route_endpoint()` / `route_endpoint_with_method()`, and those helpers raise if a route cannot be found. In other words, once `_find_endpoint()` returns, the endpoint is already guaranteed to exist. Keeping the extra assertions only added visual noise between route lookup and the real behavior being tested. Removing them makes each test more direct without changing what is exercised.

In `test_update_endpoints.py`, I added a module docstring clarifying that the file covers the update and ESP flash HTTP client endpoints. Like the recording client test file, this suite benefits from a one-line description because the surrounding HTTP test modules include both direct route tests and TestClient-based end-to-end route tests.

## Why these changes were worthwhile
This chunk did not present a compelling safe refactor of the endpoint logic or the larger test structure. The existing tests already had good coverage and mostly clear arrangement. The maintainability issues were smaller, but still concrete.

The repeated `assert endpoint is not None` pattern in `test_settings_endpoints.py` is a good example. It does not make the test wrong, but it does duplicate a guarantee that the helper already provides. Removing that dead assertion pattern improves readability across the whole file because every test now moves straight from locating the route to setting up its mock behavior and asserting the outcome. That kind of noise reduction is especially valuable in a settings suite with many route variants.

The new module docstrings in the recording and update client suites serve a different purpose: orientation. This repository’s HTTP tests mix direct endpoint invocation, router wiring tests, and full `TestClient` coverage. A short module description helps future readers identify which layer they are looking at without having to infer it from imports or fixture setup.

## File-by-file review outcomes
All six code files in this chunk were reviewed directly.

`test_recording_endpoints.py` was changed to add the module-level scope description for the real HTTP client recording route tests.

`test_recording_route_http.py` was reviewed unchanged. The direct-route recording tests already separate status, start, and stop behaviors clearly, and I did not find a stronger behavior-preserving cleanup there.

`test_request_observability.py` was reviewed unchanged. Its request-ID propagation and logging-middleware assertions are already concise and purposeful.

`test_route_registration.py` was reviewed unchanged. The minimum-route-count smoke guard is intentionally small and still valuable as a coarse router wiring check.

`test_settings_endpoints.py` was changed to remove the redundant endpoint-non-null assertions after `_find_endpoint()`.

`test_update_endpoints.py` was changed to add the missing module-level scope description for the update and ESP flash client tests.

## Dependencies, dead code, and skipped changes
No dependencies were added, removed, or replaced in this PR. No production code changed.

The only “dead” code removed here was redundant test assertion code in `test_settings_endpoints.py`. Those `assert endpoint is not None` checks did not provide independent safety because the helper would already have thrown before the test got that far if a route were missing.

I deliberately did not refactor the shared recording snapshot helper shape across the two recording-related test files, even though they are adjacent, because the existing duplication is small and localized. Introducing new cross-test helpers or imports there would have increased structure and coupling more than it would have reduced maintenance burden for this chunk.

I also left `test_request_observability.py` and `test_route_registration.py` alone after direct review. They are intentionally focused, and any additional edits would have been aesthetic churn rather than a justified cleanup.

## Validation
Local validation was targeted to the entire active chunk so the changed files and their immediate neighbors were exercised together:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/test_recording_endpoints.py apps/server/tests/adapters/http/test_recording_route_http.py apps/server/tests/adapters/http/test_request_observability.py apps/server/tests/adapters/http/test_route_registration.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/adapters/http/test_update_endpoints.py`
- `git diff --check`

That batch passed with `47 passed`, confirming the cleanup preserved the existing route and middleware test coverage for this six-file slice.

## Risks, tradeoffs, and follow-ups
Risk is intentionally low because the PR only changes tests and documentation within tests. The main tradeoff is that this is a small readability-focused cleanup rather than a deeper rework, but that matches what the review actually found. The worthwhile opportunities in this chunk were minor redundant assertions and missing orientation, not broken abstractions.

There are no immediate follow-ups required within this PR. The next planned HTTP/PDF-related chunk should continue from the tracker as usual. For `chunk-014`, this PR satisfies the review-run contract: every code file in the chunk was individually inspected, the justified non-functional cleanups were made, targeted validation passed, and the resulting test files are slightly easier to scan and maintain without changing behavior.
