### PR TITLE
test: document car library persistence suites

### DIFF
--- a/apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py
+++ b/apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py
@@ -1,3 +1,5 @@
+"""Regression coverage for the BMW variant and ratio-source corrections."""
+
 from __future__ import annotations
 
 import json

--- a/apps/server/tests/adapters/persistence/test_car_library.py
+++ b/apps/server/tests/adapters/persistence/test_car_library.py
@@ -1,3 +1,5 @@
+"""Core structural and API-shape checks for the bundled car library."""
+
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

This pull request covers `chunk-019` of the repository-wide sequential review and is intentionally limited to the following six persistence-facing test modules, each of which was reviewed directly and recorded individually in the tracker before I made any edits:

- `apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py`
- `apps/server/tests/adapters/persistence/test_car_library.py`
- `apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py`
- `apps/server/tests/adapters/persistence/test_car_library_routes.py`
- `apps/server/tests/adapters/persistence/test_car_profile_variations.py`
- `apps/server/tests/adapters/persistence/test_car_variants.py`

As with the earlier chunks in this review run, the goal here is strictly behavior-preserving maintainability work. No production car-library logic changed. No bundled data changed. No API responses changed. No assertions were weakened or removed. The resulting diff is intentionally small because most of the value in this chunk came from direct review and explicit confirmation that four of the six files were already in solid shape.

## What changed

The only code changes in this PR are the addition of concise module docstrings to two files that were missing top-level context:

- `test_bmw_car_library_mismatches.py`
- `test_car_library.py`

`test_bmw_car_library_mismatches.py` covers a fairly specific but important slice of the car-library regression surface: BMW variant-scope corrections, explicit transmission behavior for the F45 Active Tourer, EV variants that should no longer inherit ICE gearbox data, source-document alignment for corrected BMW rows, and the issue-specific ratio-source metadata checks that accompany those manual fixes. The file was readable once you stepped through its helper functions and parameterized cases, but it did not announce that purpose at the module boundary. Adding a single descriptive docstring improves orientation without touching any test logic.

`test_car_library.py` is the inverse: it is the broad baseline guardrail for the car-library bundle and accessor helpers. It checks entry presence, brand/type/model selectors, required fields, tire and wheel-size sanity ranges, tire-option shape, Pydantic compatibility for HTTP model responses, and malformed-file fallback behavior. That makes it one of the first files a future maintainer is likely to inspect when debugging the library data surface, so it benefits from a top-level sentence that describes its role immediately.

These changes are deliberately modest, but they are still worthwhile because they improve readability at the exact points where a reader enters the file. That is especially useful in a large test tree where neighboring files can be very domain-specific.

## Files reviewed and left unchanged

Four files in the chunk were reviewed directly and intentionally left unchanged:

- `test_car_library_ratio_sources.py`
- `test_car_library_routes.py`
- `test_car_profile_variations.py`
- `test_car_variants.py`

That restraint was not accidental. `test_car_library_ratio_sources.py` is already cleanly scoped: it has a precise module docstring, focused helpers for walking nested metadata, and straightforward assertions around verification states, unresolved items, and one-to-one coverage with the library rows. I did not see a lower-risk cleanup that would make it clearer than it already is.

`test_car_library_routes.py` also already advertises its coverage area clearly. Its long-form module docstring makes the direct-endpoint intent obvious, and the helper/fixture structure is small enough that additional churn would have been aesthetic rather than meaningful.

`test_car_profile_variations.py` is larger, but it is deliberately narrative. The P1–P5 sectioning is doing real work there: it organizes a broad matrix of profile- and speed-based injection scenarios into readable groups. I considered whether to tighten local typing or helper structure, but nothing beat the current clarity without introducing unnecessary diff noise.

`test_car_variants.py` already has strong structure as well. It separates JSON structural checks, helper tests, Pydantic-model validation, persistence behavior, and JSON integrity into explicit sections, and its module docstring already sets the right scope. The right choice there was “reviewed, no change.”

## Why these changes are safe

This PR is completely test-only. The docstrings do not alter imports, fixtures, helper behavior, assertion bodies, or test data. They exist solely to make the intent of the two touched modules easier to understand when scanning the persistence/car-library test surface.

Because no production modules or bundled data files changed, there is no user-visible behavior risk here. The PR also does not introduce new dependencies, shared helpers, or abstractions. It is the smallest complete improvement I found after directly reviewing all six files.

Just as importantly, the absence of broader changes is itself part of the review result. The repository-review instructions for this run require every code file to be personally inspected and individually recorded, not merely changed when convenient. Marking four files as reviewed with no edits is an explicit engineering choice backed by direct inspection, not a skipped step.

## Validation

I validated the chunk locally using existing repository commands only:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py apps/server/tests/adapters/persistence/test_car_library_routes.py apps/server/tests/adapters/persistence/test_car_profile_variations.py apps/server/tests/adapters/persistence/test_car_variants.py`
- `git diff --check`

The targeted pytest batch completed with `154 passed`.

I also updated the local tracker before opening this PR so each file in the chunk now has an explicit per-file outcome, purpose summary, review rationale, validation record, and PR linkage placeholder. That bookkeeping matters in this long-running audit because it keeps the review state durable and unambiguous across compaction and merge boundaries.

## Risks, tradeoffs, and follow-ups

The main tradeoff here is that this PR is intentionally lightweight. That is appropriate for the state of the files. I did not want to manufacture refactors in already-clear test modules just to make the diff look larger. The only worthwhile, behavior-preserving improvement in scope was better top-level context for the two modules that were missing it.

A smaller but still useful outcome is consistency with the surrounding test tree. Recent chunks in adjacent test areas have added concise module docstrings where files lacked an entry-point description, especially in regression-heavy suites where the intent is easier to lose over time. This PR continues that cleanup pattern without forcing structure changes where they are not needed.

For later chunks, I will keep applying the same bar: direct file-by-file review, explicit no-change decisions where appropriate, and only the smallest validated cleanup that makes the codebase measurably easier to maintain while preserving behavior.
