### PR TITLE
test: clarify history db regression suites

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py
@@ -1,3 +1,5 @@
+"""HistoryDB backup-creation and index/query-plan regression coverage."""
+
 from __future__ import annotations
 
 import sqlite3

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
@@ -1,3 +1,5 @@
+"""HistoryDB connection-mode and transaction-cleanup regression coverage."""
+
 from __future__ import annotations
 
 import sqlite3

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -1,3 +1,5 @@
+"""Lifecycle, pruning, corruption, and metadata CRUD coverage for HistoryDB."""
+
 from __future__ import annotations
 
 import logging

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -1,3 +1,5 @@
+"""Structured sample-storage and v2 row retrieval coverage for HistoryDB."""
+
 from __future__ import annotations
 
 import sqlite3

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
@@ -1,3 +1,5 @@
+"""HistoryDB input sanitization, integrity checks, and warning-path coverage."""
+
 from __future__ import annotations
 
 import json

--- a/apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py
@@ -115,7 +115,7 @@ class _FakeProcessor:
         return list(client_ids)
 
 
-def _make_logger(history_db, tmp_path: Path) -> RunRecorder:
+def _make_logger(history_db, _tmp_path: Path) -> RunRecorder:
     reg = _FakeRegistry()
     return RunRecorder(
         RunRecorderConfig(
@@ -193,7 +193,7 @@ class TestPersistentCreateRunFailureStopsRetrying:
         db.create_run.side_effect = OSError("persistent failure")
         logger = _make_logger(db, tmp_path)
 
-        run_id, start_utc, _start_mono = _start_and_snapshot(logger)
+        run_id, start_utc, start_mono = _start_and_snapshot(logger)
 
         for _ in range(_MAX_HISTORY_CREATE_RETRIES + 3):
             logger._persistence.ensure_history_run(

--- a/apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py
@@ -1,3 +1,5 @@
+"""Low-level samples_v2 row encoding and decoding coverage."""
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary

This pull request covers `chunk-020` of the repository-wide sequential review. The chunk contains eight history-database test modules, and each one was reviewed directly and recorded individually in the local tracker before I made any edits:

- `apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py`
- `apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py`
- `apps/server/tests/adapters/persistence/history_db/test_schema_migration.py`

As with the previous chunks in this run, the scope is intentionally behavior-preserving. No production HistoryDB code changed. No schema or migration logic changed. No persistence contracts changed. The diff is entirely in tests, and it focuses on two maintainability themes that came out of the file-by-file review: missing module-level context in several regression-heavy test files, and one very small naming cleanup in the write-error test suite to make it clearer which snapshot values are truly used.

## What changed

Six of the eight files in this chunk were missing module docstrings even though they each cover distinct parts of the HistoryDB surface:

- backup creation and query-plan/index regressions
- read/write connection semantics and transaction cleanup
- broad lifecycle, pruning, corruption, and metadata CRUD behavior
- structured sample storage and v2 sample retrieval
- sanitization, integrity checks, and warning-path coverage
- low-level sample row encoding/decoding helpers

Those files now have concise top-level docstrings:

- `test_history_db_backup_and_indexes.py`
- `test_history_db_connections.py`
- `test_history_db_lifecycle.py`
- `test_history_db_structured_storage.py`
- `test_history_db_validation.py`
- `test_sample_row_decoding.py`

This is a small textual change, but it is useful in this part of the tree because the history-db test area is broad and the file names alone do not always tell you whether you are looking at lifecycle behavior, schema behavior, low-level row codecs, or validation-only guards. A one-line entry-point description reduces scan time and makes the suite easier to navigate when chasing a persistence regression.

The only non-docstring change is in `test_history_write_errors.py`. While reviewing that file, I found a minor naming mismatch around `_start_and_snapshot()` tuple unpacking. Some tests genuinely pass the monotonic timestamp into `_sample_flush.append_records()`, while others only need the run ID and UTC timestamp. I adjusted the local names so the helper parameter that is never used is explicitly `_tmp_path`, and the tuple bindings now make the used versus unused monotonic timestamps clearer. This does not change any logic; it just removes a little ambiguity from the write-error tests.

## Files reviewed with no code changes

One file in the chunk was reviewed directly and intentionally left unchanged: `test_schema_migration.py`.

That file is long, but it is already well structured. It opens with a clear module docstring, groups its helper database constructors by historical schema version, and then moves through the migration scenarios in a readable order: unsupported old versions, v8 migration behavior, settings snapshot migrations, chain-migration backups, v10 analysis storage migration, backup restoration on failure, newer-version rejection, and the current-version no-op path. I did not find a behavior-preserving cleanup that would improve it enough to justify churn.

Leaving that file unchanged is part of the review result, not an omission. The review instructions for this run require direct inspection and explicit per-file decisions. In this case, the right decision for the migration suite was “reviewed, no change.”

## Why these changes are safe

Everything in this PR is test-only and behavior-preserving. The added module docstrings do not alter imports, fixtures, helper logic, or assertions. The naming cleanup in `test_history_write_errors.py` only makes the local variable intent clearer; it does not alter the values passed into the flush helper, the retry loops, or the mocked failure behavior.

There are no new helper abstractions, no dependency changes, no schema fixtures removed, and no assertion expectations weakened. The tests still exercise the same HistoryDB and RunRecorder seams they did before this PR.

That minimalism is deliberate. In this chunk, most of the engineering value came from confirming that the existing regression coverage is strong and then making the smallest improvements that make the suite easier for future maintainers to scan and modify safely.

## Validation

I validated this chunk locally with the repository’s existing commands only:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py apps/server/tests/adapters/persistence/history_db/test_schema_migration.py`
- `git diff --check`

The targeted pytest batch completed with `93 passed`.

I also updated the tracker before PR creation so each file in the chunk now has an explicit review outcome, purpose summary, validation record, and PR linkage placeholder. That matters in this long-running repo review because it keeps progress durable and unambiguous across chunks, PRs, and context compaction.

## Risks, tradeoffs, and follow-ups

The main tradeoff in this PR is that the diff is again intentionally modest. That is appropriate for the state of the files. The history-db tests in this area are already doing real work, and a larger refactor would have risked turning a clean review pass into churn without improving correctness or maintainability enough to justify it.

The clearest improvement opportunity in the chunk was discoverability: six substantial modules had no top-level description even though they each guarded different seams of the persistence layer. The tiny variable-naming cleanup in the write-error tests was the other worthwhile win because it removes a small amount of local ambiguity without changing behavior.

For later chunks, I will keep applying the same bar here: direct file-by-file review, explicit no-change decisions where appropriate, and only the smallest validated improvement that materially improves clarity while preserving semantics.

A smaller but still useful outcome here is consistency across the history-db test surface. Adding module-boundary context where it was missing makes this area easier to navigate without inventing new helper layers or moving assertions around. The result is a clearer test tree with the same behavior, the same coverage, and less guesswork for the next maintainer reading it.
