### PR TITLE
test: clarify simulator adapter coverage

### DIFF
--- a/apps/server/tests/adapters/simulator/test_server_http.py
+++ b/apps/server/tests/adapters/simulator/test_server_http.py
@@ -1,7 +1,10 @@
+"""Simulator HTTP helper coverage for speed-override requests."""
+
 from __future__ import annotations
 
 import json
 from typing import Any
+from urllib.request import Request
 
 from vibesensor.adapters.simulator.server_http import set_server_speed_override_kmh
 
@@ -23,7 +26,7 @@ class _FakeResponse:
 def test_set_server_speed_override_uses_http_api_snake_case(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
-    def fake_urlopen(req, timeout: float):  # type: ignore[no-untyped-def]
+    def fake_urlopen(req: Request, timeout: float) -> _FakeResponse:
         captured["url"] = req.full_url
         captured["method"] = req.get_method()
         captured["timeout"] = timeout

--- a/apps/server/tests/adapters/simulator/test_sim_client.py
+++ b/apps/server/tests/adapters/simulator/test_sim_client.py
@@ -1,3 +1,5 @@
+"""Deterministic frame-generation coverage for the simulator client."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/adapters/simulator/test_sim_scene.py
+++ b/apps/server/tests/adapters/simulator/test_sim_scene.py
@@ -1,3 +1,5 @@
+"""Road-scene controller coverage for single-active simulator behavior."""
+
 from __future__ import annotations
 
 import numpy as np


### PR DESCRIPTION
## Summary

This pull request covers `chunk-021` of the repository-wide sequential review and is intentionally limited to the following three simulator adapter test modules, each of which was reviewed directly and recorded individually in the tracker before I made any edits:

- `apps/server/tests/adapters/simulator/test_server_http.py`
- `apps/server/tests/adapters/simulator/test_sim_client.py`
- `apps/server/tests/adapters/simulator/test_sim_scene.py`

As with the earlier chunks in this audit run, the goal here is strictly behavior-preserving maintainability work. No simulator runtime code changed. No HTTP behavior changed. No client-frame generation behavior changed. No road-scene logic changed. This PR is entirely test-only and focuses on two small but worthwhile cleanups that came out of directly reviewing all three files: missing module-level context in a tiny simulator test area, and the removal of one remaining local typing suppression in the HTTP helper coverage.

## What changed

All three files in this chunk received concise module docstrings.

`test_server_http.py` now opens with a short description that explains it covers simulator HTTP helper behavior for speed-override requests. That matters because the file is narrowly focused on one transport seam: issuing a request to `/api/settings/speed-source`, using the snake_case API contract, and interpreting the returned settings payload correctly. Without a module docstring, a future reader has to infer that scope from the fake response and the assertion block.

`test_sim_client.py` now has a module docstring that states it covers deterministic frame generation and noise-floor behavior in the simulator client. That file is only two tests long, but they guard an important property of the simulator: identical seeds should produce identical frames, and zeroing the scene gains should not collapse the generated frame to silence because the modeled noise floor still needs to exist.

`test_sim_scene.py` also now has a module docstring describing the single-active road-scene behavior seam. Again, the file is small, but the top-level context helps because the test is intentionally narrow: it verifies that the single-active scenario does not starve the non-active clients of enough scene gain and common-event energy to keep them alive.

The only non-docstring change is in `test_server_http.py`. That file previously used a local `# type: ignore[no-untyped-def]` suppression on the `fake_urlopen()` stub. I replaced the suppression with an actual `urllib.request.Request` type annotation and an explicit `_FakeResponse` return type. This is still a local test helper, but it is clearer for readers and tooling, and it removes one more unnecessary inline suppression from the test tree.

## Why these changes are safe

This PR is completely behavior-preserving. The module docstrings do not alter test inputs, helper behavior, monkeypatch targets, or assertions. The `fake_urlopen()` cleanup is also non-behavioral: the stub still captures the same request URL, HTTP method, timeout, and JSON body, and it still returns the same fake payload that drives the `set_server_speed_override_kmh()` assertion.

No new imports affect runtime code paths. The only added import is `Request` from the standard library, and it is used solely for the local stub annotation inside the test module. There are no dependency changes, no fixture changes, and no changes to simulator runtime contracts.

This is exactly the kind of small, low-risk cleanup the review rules for this run are meant to capture: remove avoidable friction, improve readability, and tighten local typing where it is already obvious, all without changing semantics.

## File-by-file review outcomes

All three code files in the chunk were changed, but each change was intentionally light.

For `test_server_http.py`, the worthwhile improvement was twofold: add the missing top-level context and replace the local suppression with a real type annotation. That file is small enough that more aggressive refactoring would have been pointless churn.

For `test_sim_client.py`, the module docstring was the only change that met the bar. The two tests are already direct and readable: one covers deterministic output under the same seed, and the other verifies that zeroed scene gains still preserve the noise floor. There was no better helper extraction or naming cleanup to make there.

For `test_sim_scene.py`, the same reasoning applied. The file contains one focused regression test with explicit assertions about the active profile assignment and the minimum scene/common-event gains for the non-active clients. The correct cleanup was to describe that seam at the file boundary, not to restructure the test.

The fact that this PR remains small after direct review of all three files is intentional. The review instructions for this run require personal inspection and explicit recording of outcomes, not large diffs for their own sake.

## Validation

I validated this chunk locally with existing repository commands only:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/simulator/test_server_http.py apps/server/tests/adapters/simulator/test_sim_client.py apps/server/tests/adapters/simulator/test_sim_scene.py`
- `git diff --check`

The targeted pytest batch completed with `4 passed`.

I also updated the tracker before PR creation so each file in the chunk now has an explicit review result, purpose summary, validation record, and PR linkage placeholder. That bookkeeping is part of the contract for this long-running audit and ensures the simulator area does not end up with any implied or ambiguous review state later.

## Risks, tradeoffs, and follow-ups

The main tradeoff here is that the diff is tiny. That is appropriate for the files as they exist today. These simulator tests are already focused and concise, so a larger refactor would have added churn without materially improving maintainability.

The real value in this chunk is clarity and consistency. Adding module-boundary context makes the simulator test area easier to scan alongside the larger adapter test tree, and replacing the local suppression in `test_server_http.py` keeps the code honest about the types it already knows.

For later chunks, I will continue applying the same standard: review every file directly, keep no-change decisions explicit where they are warranted, and only land the smallest validated cleanup that actually makes the code easier to maintain without altering behavior.
