### PR TITLE
Repo review: websocket tests chunk 023

### DIFF
--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -1,3 +1,5 @@
+"""Coverage for WebSocket payload assembly and tick-driven payload reuse."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -1,3 +1,5 @@
+"""PayloadBuildOrchestrator coverage for caching and serialization fallbacks."""
+
 from __future__ import annotations
 
 import asyncio

--- a/apps/server/tests/adapters/websocket/test_tick_controller.py
+++ b/apps/server/tests/adapters/websocket/test_tick_controller.py
@@ -1,3 +1,5 @@
+"""BroadcastTickController coverage for tick flow, warnings, and backoff."""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary

This PR covers **chunk-023** of the full repository review and includes exactly these seven code files from `apps/server/tests/adapters/websocket/`:

- `test_build_ws_payload.py`
- `test_connection_tracker.py`
- `test_payload_orchestrator.py`
- `test_tick_controller.py`
- `test_ws_hub.py`
- `test_ws_models.py`
- `test_ws_schema_export.py`

As required by the long-running review plan, I reviewed every code file in this chunk individually before making any edits. The goal for this chunk was the same as for the earlier merged chunks: make behavior-preserving maintainability improvements only, keep the diff scoped to the active chunk, and avoid speculative refactors or any production behavior change. After direct review, I changed three files and left four files unchanged. All edits are test-only and documentation-oriented.

The actual code changes are intentionally small. `test_build_ws_payload.py`, `test_payload_orchestrator.py`, and `test_tick_controller.py` were each missing module-level context even though they cover fairly specific seams in the WebSocket stack. I added concise module docstrings that describe the responsibility of each suite: payload assembly and tick-driven reuse in the builder tests, caching and serialization fallback behavior in the orchestrator tests, and tick cadence / warning / backoff behavior in the controller tests. These docstrings do not change any assertions, helpers, fixtures, or runtime wiring; they only make the files easier to navigate when someone opens the module cold.

That small change is worthwhile here because these three files sit next to other WebSocket test modules that already have strong top-level orientation. `test_connection_tracker.py`, `test_ws_hub.py`, and `test_ws_schema_export.py` already explain themselves well at the module boundary, and `test_ws_models.py` already documents its mixed schema-export and frequency-dedup coverage. The result before this PR was a slightly uneven local test surface: some modules immediately communicated their role, while others required a reader to scan dozens of lines before understanding what seam they existed to protect. This PR tightens that inconsistency without altering test behavior.

To make that explicit at the file level: `test_build_ws_payload.py` is the chunk’s primary assembly-and-state-double suite, `test_payload_orchestrator.py` is the narrow async caching/error-fallback seam, and `test_tick_controller.py` is the timing/backoff control surface. Those were the only three files where the first lines of the module did not quickly answer “what is this file protecting?” By contrast, `test_connection_tracker.py` tells the reader immediately that it covers generation-based connection state, `test_ws_hub.py` announces hub coverage at the top and then backs it up with readable sectioning, `test_ws_models.py` already describes the schema/dedup pairing it covers, and `test_ws_schema_export.py` clearly states that it is the committed contract guard. That distinction is why this PR changes exactly three files rather than mechanically touching all seven.

The most important reviewed file in the chunk was `test_ws_hub.py`, not because it changed, but because it is the broadest regression surface in the batch. I read it directly in full, including the sections covering cached broadcast reuse, payload-build failures, NaN/Inf sanitization, send-error cleanup, selection races, and connection-count behavior. I deliberately left that file untouched because its current structure already provides clear intent through section headers, targeted helper functions, and explicit assertions around the hub’s failure modes. Making churn there just to “do something” would have reduced the signal-to-noise ratio of the review.

I made the same judgment on the other unchanged files. `test_connection_tracker.py` already has a precise docstring and focused generation-based snapshot coverage. `test_ws_models.py` already documents its schema-export check plus `multi_spectrum_payload()` frequency-axis dedup behavior, and the current assertions are explicit enough that further cleanup would have been mostly stylistic. `test_ws_schema_export.py` already uses reusable module-scoped fixtures and states the contract-sync expectations clearly, so I left it alone. The chunk therefore reflects file-by-file review discipline rather than a blanket “touch everything” approach.

No dependencies were added, removed, or swapped in this PR. No standard-library substitution was needed because the active improvements were strictly about test readability and module orientation. No dead code was removed either. I considered whether any local helper consolidation across the WebSocket tests would be worthwhile, but I intentionally skipped that. The current helpers are small, file-local, and in several cases tightly tied to the assertions in their respective modules. Extracting them just to reduce a little duplication would have created more indirection than benefit and would have pushed the chunk closer to refactor territory rather than a low-risk maintainability cleanup.

Validation for this chunk was fully local and matched the touched area. I ran `make lint` for the repo’s formatting, static guardrails, and hygiene checks. I then ran a targeted pytest batch covering exactly the seven reviewed files:

` .venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_connection_tracker.py apps/server/tests/adapters/websocket/test_payload_orchestrator.py apps/server/tests/adapters/websocket/test_tick_controller.py apps/server/tests/adapters/websocket/test_ws_hub.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/adapters/websocket/test_ws_schema_export.py `

That batch completed successfully with **82 passed**. I also ran `git diff --check` to confirm there were no whitespace or patch-hygiene issues in the final diff. Because the changes are docstring-only, these validations give high confidence that the chunk remains behavior-preserving.

The main tradeoff in this PR is that it intentionally stops short of broader reshaping. There are opportunities one could imagine in the WebSocket test area, such as extracting shared fixture factories or rebalancing mixed-purpose files like `test_ws_models.py`, but those would move beyond the smallest validated cleanup that this chunk clearly supports. Given the user’s requirement to avoid intentional behavior change and to keep exactly one PR per chunk, I chose the narrower path: add missing context where it materially improves readability, and leave already-clear modules untouched.

There are no blocking risks identified for this chunk. The follow-up is simply the next planned review unit in the tracker. Later chunks may revisit adjacent application or domain tests if they independently warrant cleanup, but this PR itself is self-contained: seven files reviewed individually, three files improved, four files confirmed as already maintainable enough, no production code touched, and no behavioral deltas introduced.
