### PR TITLE
Repo review: app tests chunk 024

### DIFF
--- a/apps/server/tests/app/test_app_lifecycle.py
+++ b/apps/server/tests/app/test_app_lifecycle.py
@@ -1,3 +1,5 @@
+"""App lifespan coverage for shutting down runtime resources cleanly."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -1,3 +1,5 @@
+"""CLI/bootstrap main-entry coverage for port fallback and reload wiring."""
+
 from __future__ import annotations
 
 import errno

--- a/apps/server/tests/app/test_config.py
+++ b/apps/server/tests/app/test_config.py
@@ -1,3 +1,5 @@
+"""Config-loader coverage for deep merge, path resolution, and AP self-heal defaults."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/apps/server/tests/app/test_config_extended.py
+++ b/apps/server/tests/app/test_config_extended.py
@@ -1,3 +1,5 @@
+"""Additional config coverage for logging defaults and network validation edges."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/apps/server/tests/app/test_container.py
+++ b/apps/server/tests/app/test_container.py
@@ -1,3 +1,5 @@
+"""Container wiring coverage for history-db startup recovery and retention hooks."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/apps/server/tests/app/test_import_purity.py
+++ b/apps/server/tests/app/test_import_purity.py
@@ -1,3 +1,5 @@
+"""Import-purity guardrails for the app package and bootstrap module."""
+
 from __future__ import annotations
 
 import os

--- a/apps/server/tests/app/test_preflight_cli.py
+++ b/apps/server/tests/app/test_preflight_cli.py
@@ -1,3 +1,5 @@
+"""CLI coverage for config preflight defaults, argument errors, and JSON output."""
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary

This PR covers **chunk-024** of the sequential full-repository review and includes exactly these nine code files from `apps/server/tests/app/`:

- `test_ap_self_heal_validation.py`
- `test_app_lifecycle.py`
- `test_app_main.py`
- `test_config.py`
- `test_config_extended.py`
- `test_config_validation.py`
- `test_container.py`
- `test_import_purity.py`
- `test_preflight_cli.py`

As with the earlier merged chunks in this run, every code file in this batch was reviewed individually before any edits were made. The governing constraint for the repository-wide review remains unchanged: behavior-preserving maintainability improvements only, no intentional product or contract changes, and exactly one PR per chunk. After direct review of the nine app-level test modules in this chunk, I changed seven files and left two files unchanged. All edits are test-only and documentation-focused.

The common pattern in this batch was uneven module-level orientation. `test_ap_self_heal_validation.py` and `test_config_validation.py` already open with clear module docstrings and structured internal sections, so a maintainer can understand their scope immediately. By contrast, the other seven files began directly with imports or fixtures even though each of them protects a distinct application-level seam: app lifespan shutdown behavior, bootstrap CLI behavior, config loader helpers, extended config validation edges, history-container startup wiring, import-side-effect guardrails, and the preflight CLI contract. None of those files needed new assertions or refactors, but several did benefit from the same top-level context that nearby tests already provide.

The concrete code changes therefore stay intentionally small. I added concise module docstrings to `test_app_lifecycle.py`, `test_app_main.py`, `test_config.py`, `test_config_extended.py`, `test_container.py`, `test_import_purity.py`, and `test_preflight_cli.py`. Each docstring names the seam that the file exists to protect rather than restating obvious mechanics. For example, the lifecycle test now declares that it is about runtime-resource shutdown, the main-entry tests now advertise their bind-fallback and reload wiring focus, and the import-purity test now clearly reads as a guardrail against side effects during package import. This makes the app-level test surface easier to scan without changing a single runtime behavior or test expectation.

That may sound minor, but the value is real in this directory. These files sit close to the application entrypoints and bootstrap/config code, which are exactly the areas where new contributors often start reading. Without top-level context, a reader has to infer intent from monkeypatches and helper setup. With the new docstrings in place, the purpose of each module is visible at the first line, which reduces the amount of local code spelunking needed before making a safe change. This is the same style of maintainability improvement applied in several earlier chunks: add missing context where it improves navigability, but avoid churn in files that are already self-explanatory.

Two files were intentionally left unchanged after direct review. `test_ap_self_heal_validation.py` already has a detailed module docstring that explains the underlying validation bug and the regression seam around `APSelfHealConfig`. `test_config_validation.py` already carries a clear module docstring plus section headers that break the file into `ProcessingConfig`, `ServerConfig`, `UDPConfig`, `LoggingConfig`, buffer-bound, and accel-scale validation areas. In both cases, further edits would have been mostly cosmetic, so I preserved them as-is after recording the review result in the tracker.

The most important unchanged file in the chunk is probably `test_config_validation.py`, because it covers the densest set of configuration clamping and validation rules. I read it directly in full and left it alone because its current organization is already strong: it separates direct dataclass validation from `load_config()` integration expectations and uses clear class-level grouping for related settings. Similarly, `test_ap_self_heal_validation.py` already serves as a readable regression narrative with a strong top-level explanation. Keeping those files stable was a deliberate choice to preserve clarity rather than a sign that they were skipped.

No dependencies were added, removed, or replaced in this PR. No standard-library substitution was relevant, and no dead code was removed. I considered whether to consolidate the small YAML-writing helpers shared by `test_config.py`, `test_config_extended.py`, and `test_config_validation.py`, but I chose not to do that here. The helpers are tiny, local, and tailored to the specific test modules. Extracting them would have introduced additional indirection for very little payoff and would have increased the risk of turning a focused documentation cleanup into a broader refactor.

Validation was targeted and complete for the touched area. I ran `make lint` to exercise formatting, static guardrails, and repository hygiene checks. I then ran a focused pytest batch covering exactly the nine files in this chunk:

` .venv/bin/python -m pytest -q -o addopts='' apps/server/tests/app/test_ap_self_heal_validation.py apps/server/tests/app/test_app_lifecycle.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_config.py apps/server/tests/app/test_config_extended.py apps/server/tests/app/test_config_validation.py apps/server/tests/app/test_container.py apps/server/tests/app/test_import_purity.py apps/server/tests/app/test_preflight_cli.py `

That batch passed with **114 passed**. I also ran `git diff --check` to confirm the patch is clean. Because the diff is limited to module docstrings, these validations provide strong confidence that the chunk is behavior-preserving.

The main tradeoff in this PR is restraint. There are adjacent cleanups one could imagine, especially around helper consolidation or deeper reshaping of mixed-purpose config test files, but those are not necessary to satisfy the user’s “no intentional behavior change” requirement and would have expanded the scope of the chunk beyond the smallest complete maintainability win. This PR instead keeps a clear boundary: every file was reviewed, missing module context was added where it materially helped, already-clear files were left alone, and the resulting diff stays easy to audit.

There are no known blockers or follow-up fixes required for this chunk itself. The next follow-up is the next planned review unit in the tracker after this PR merges. For chunk `024`, the result is straightforward: nine app-level test files individually reviewed, seven improved with clearer top-level orientation, two confirmed as already maintainable enough, no production code touched, and no change to runtime behavior, CLI behavior, or configuration contracts.
