### PR TITLE
Repo review: domain tests chunk 025

### DIFF
--- a/apps/server/tests/domain/test_case_metadata_factories.py
+++ b/apps/server/tests/domain/test_case_metadata_factories.py
@@ -1,3 +1,5 @@
+"""Metadata-factory coverage for deriving Car and Symptom context from case inputs."""
+
 from __future__ import annotations
 
 import pytest

--- a/apps/server/tests/domain/test_location_hotspot.py
+++ b/apps/server/tests/domain/test_location_hotspot.py
@@ -1,4 +1,4 @@
-"""Tests for LocationHotspot.compute_confidence()."""
+"""Domain coverage for hotspot confidence scoring and typed intensity summaries."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

This PR covers **chunk-025** of the sequential full-repository review and includes exactly these ten code files from `apps/server/tests/domain/`:

- `test_aggregate_invariants.py`
- `test_car_domain.py`
- `test_case_metadata_factories.py`
- `test_confidence_and_planning_value_objects.py`
- `test_configuration_and_sensor_value_objects.py`
- `test_core.py`
- `test_domain_objects.py`
- `test_finding_origin_value_objects.py`
- `test_location_hotspot.py`
- `test_planning_domain_only.py`

As with every earlier chunk in this run, each code file in the list above was reviewed individually before any changes were made. The governing rules for the repository-wide audit are unchanged here: behavior-preserving improvements only, no intentional runtime or contract changes, no cross-chunk spillover, and exactly one PR for the chunk. After direct review of all ten files, I changed two files and left eight unchanged. The final diff stays entirely inside tests and is documentation-oriented.

The central theme in this batch was accuracy of module-level orientation. Most of these domain-test modules were already in strong shape. `test_aggregate_invariants.py`, `test_car_domain.py`, `test_confidence_and_planning_value_objects.py`, `test_configuration_and_sensor_value_objects.py`, `test_core.py`, `test_domain_objects.py`, `test_finding_origin_value_objects.py`, and `test_planning_domain_only.py` all already explain their scope clearly enough at the top of the file, either through an explicit module docstring or through structure that makes the domain seam obvious. Two files stood out from that baseline. `test_case_metadata_factories.py` had no module docstring at all, and `test_location_hotspot.py` had a stale docstring that only mentioned `LocationHotspot.compute_confidence()` even though the file now also covers typed location-intensity summary rows and nested summary objects.

The code changes therefore stay narrowly focused on those two gaps. In `test_case_metadata_factories.py`, I added a concise module docstring that explains the actual seam the file protects: deriving `Car` and `Symptom` context from case metadata inputs. That is useful because the file is short and straightforward, but without a top-level summary the reader has to infer intent from individual tests alone. A brief module boundary makes the purpose immediately visible.

In `test_location_hotspot.py`, I updated the existing module docstring so it reflects the real scope of the file today. The prior wording was accurate at one point in the file’s life, but it had drifted behind the code and implied that the module only exercised `compute_confidence()`. In reality, the file now also covers typed intensity-summary models such as `LocationIntensitySummary`, `LocationHotspotRow`, and `PhaseIntensitySummary`. The new wording makes that broader scope explicit without changing any assertions, helper behavior, or domain semantics.

Those edits are intentionally small, but they improve maintainability in a way that fits the user’s constraints. This directory contains several foundational domain-model tests, and a maintainer reading through it should be able to understand the role of each file from the first few lines. That was already true for most of the chunk. This PR simply brings the two outliers back into line with the rest of the domain test surface, improving navigation without introducing noisy refactors.

The most important unchanged file in the chunk is `test_domain_objects.py`, because it has the broadest surface area. I read it directly in full, including the later sections covering package-level imports, bridge methods, enrichment behavior, and report validation. Even though it touches a wide span of concepts, I chose not to refactor it in this chunk because its current sectioning and top-level explanation are already strong enough to keep the file understandable. Any broader restructuring there would have been refactor work, not the smallest validated maintainability improvement.

I made similar no-change decisions on the other eight unchanged files. `test_aggregate_invariants.py` already has a crisp invariant-focused module header and sensible grouping around impossible aggregate states. `test_car_domain.py` and `test_configuration_and_sensor_value_objects.py` are already clearly scoped to their respective value objects. `test_core.py` is well organized around `Measurement`, `VibrationReading`, `Run`, and `transition_run`. `test_finding_origin_value_objects.py` already documents its focus on finding evidence, hotspots, and vibration-origin metadata. `test_planning_domain_only.py` is intentionally small and already states its domain-only guardrail clearly. In other words, the unchanged files were reviewed, not skipped; they simply did not justify churn.

No dependencies were added, removed, or swapped in this PR. No standard-library substitution was needed, and no dead code was removed. I briefly explored a small import consolidation in `test_confidence_and_planning_value_objects.py`, but the repository’s formatter/linter restored the existing import layout, which confirmed that the current style is intentional. I left that file unchanged in the final diff rather than fighting project conventions for a purely aesthetic preference.

Validation for this chunk was targeted and complete. I ran `make lint` to exercise the repository’s formatting, hygiene, and static boundary checks. I then ran a focused pytest batch covering exactly the ten reviewed files:

` .venv/bin/python -m pytest -q -o addopts='' apps/server/tests/domain/test_aggregate_invariants.py apps/server/tests/domain/test_car_domain.py apps/server/tests/domain/test_case_metadata_factories.py apps/server/tests/domain/test_confidence_and_planning_value_objects.py apps/server/tests/domain/test_configuration_and_sensor_value_objects.py apps/server/tests/domain/test_core.py apps/server/tests/domain/test_domain_objects.py apps/server/tests/domain/test_finding_origin_value_objects.py apps/server/tests/domain/test_location_hotspot.py apps/server/tests/domain/test_planning_domain_only.py `

That batch passed with **254 passed**. I also ran `git diff --check` to confirm there were no whitespace or patch-hygiene issues. Given that the final diff is limited to module docstrings, these checks provide high confidence that the chunk is behavior-preserving.

The main tradeoff in this PR is deliberate restraint. Domain tests can tempt wider cleanup because they span many concepts, but the user asked for non-functional, behavior-preserving improvements and exactly one PR per chunk. The best fit here was to correct the missing or stale module boundaries and stop there. That keeps the chunk easy to audit and keeps the review history honest: every file was examined, the two real documentation gaps were fixed, and the already-clear files were left untouched.

There are no known blockers or follow-up fixes required for this chunk itself. The next follow-up is simply the next planned domain-test chunk in the tracker after this PR merges. For chunk `025`, the outcome is straightforward: ten files individually reviewed, two files improved, eight files confirmed as already clear enough, no production code touched, and no behavioral change introduced.
