### PR TITLE
Repo review: domain tests chunk 026

### DIFF
--- a/apps/server/tests/domain/test_test_planning_service.py
+++ b/apps/server/tests/domain/test_test_planning_service.py
@@ -1,3 +1,5 @@
+"""Domain-facing planning-service coverage for action selection and fallback plans."""
+
 from __future__ import annotations
 
 from vibesensor.domain import (

--- a/apps/server/tests/domain/test_test_run_value_objects.py
+++ b/apps/server/tests/domain/test_test_run_value_objects.py
@@ -112,43 +112,43 @@ class TestFindingWithValueObjects:
         assert f.evidence.snr_db == 15.0
         assert f.evidence.vibration_strength_db == 25.3
 
-        def test_promote_near_tie_marks_hotspot_ambiguous(self) -> None:
-            hotspot = LocationHotspot.from_analysis_inputs(strongest_location="front_left")
-            promoted = hotspot.promote_near_tie(
-                alternative_location="rear_right",
-                top_confidence=0.8,
-                alternative_confidence=0.6,
-            )
-            assert promoted.ambiguous is True
-            assert promoted.weak_spatial_separation is True
-            assert promoted.supporting_locations == ("rear_right",)
-
-        def test_promote_near_tie_ignores_distant_second_finding(self) -> None:
-            hotspot = LocationHotspot.from_analysis_inputs(strongest_location="front_left")
-            promoted = hotspot.promote_near_tie(
-                alternative_location="rear_right",
-                top_confidence=0.9,
-                alternative_confidence=0.3,
-            )
-            assert promoted == hotspot
-
-        def test_with_adaptive_weak_spatial_promotes_below_threshold(self) -> None:
-            hotspot = LocationHotspot.from_analysis_inputs(
-                strongest_location="front_left",
-                dominance_ratio=1.3,
-            )
-            promoted = hotspot.with_adaptive_weak_spatial(3)
-            assert promoted.weak_spatial_separation is True
-
-        def test_with_adaptive_weak_spatial_leaves_strong_separation_unchanged(self) -> None:
-            hotspot = LocationHotspot.from_analysis_inputs(
-                strongest_location="front_left",
-                dominance_ratio=1.5,
-            )
-            promoted = hotspot.with_adaptive_weak_spatial(3)
-            assert promoted == hotspot
-
         assert f.vibration_strength_db == 25.3  # still extracted directly too
+
+    def test_promote_near_tie_marks_hotspot_ambiguous(self) -> None:
+        hotspot = LocationHotspot.from_analysis_inputs(strongest_location="front_left")
+        promoted = hotspot.promote_near_tie(
+            alternative_location="rear_right",
+            top_confidence=0.8,
+            alternative_confidence=0.6,
+        )
+        assert promoted.ambiguous is True
+        assert promoted.weak_spatial_separation is True
+        assert promoted.supporting_locations == ("rear_right",)
+
+    def test_promote_near_tie_ignores_distant_second_finding(self) -> None:
+        hotspot = LocationHotspot.from_analysis_inputs(strongest_location="front_left")
+        promoted = hotspot.promote_near_tie(
+            alternative_location="rear_right",
+            top_confidence=0.9,
+            alternative_confidence=0.3,
+        )
+        assert promoted == hotspot
+
+    def test_with_adaptive_weak_spatial_promotes_below_threshold(self) -> None:
+        hotspot = LocationHotspot.from_analysis_inputs(
+            strongest_location="front_left",
+            dominance_ratio=1.3,
+        )
+        promoted = hotspot.with_adaptive_weak_spatial(3)
+        assert promoted.weak_spatial_separation is True
+
+    def test_with_adaptive_weak_spatial_leaves_strong_separation_unchanged(self) -> None:
+        hotspot = LocationHotspot.from_analysis_inputs(
+            strongest_location="front_left",
+            dominance_ratio=1.5,
+        )
+        promoted = hotspot.with_adaptive_weak_spatial(3)
+        assert promoted == hotspot
 
     def test_finding_from_payload_extracts_location(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary

This PR covers **chunk-026** of the sequential full-repository review and includes exactly these seven code files from `apps/server/tests/domain/`:

- `test_run_capture.py`
- `test_run_setup.py`
- `test_snapshots.py`
- `test_speed_profile_and_run_suitability.py`
- `test_strength_metrics.py`
- `test_test_planning_service.py`
- `test_test_run_value_objects.py`

As with the earlier chunks in this long-running review, I reviewed every code file in this batch individually before making any edits. The chunk stays inside the same overall rules as the rest of the run: behavior-preserving improvements only, exactly one PR for the chunk, no cross-chunk edits, and careful local validation before opening the PR. After direct review, I changed two files and left five unchanged. The changes are test-only.

One of the two edits is straightforward documentation maintenance. `test_test_planning_service.py` covered a clear domain-facing seam—planning-service action selection, prioritization, deduplication, and fallback planning—but the file had no module docstring. I added a concise top-level summary so the role of the module is obvious without reading the individual assertions first. This brings it in line with the rest of the domain test surface, where most files already advertise their scope at the module boundary.

The more important change in this chunk is in `test_test_run_value_objects.py`. While reviewing the file directly, I found four functions named like tests that were accidentally indented inside `test_finding_from_payload_extracts_evidence()`. Because of that nesting, pytest never collected or executed them. The affected checks covered `LocationHotspot.promote_near_tie()` and `LocationHotspot.with_adaptive_weak_spatial()`, including both the promotion path and the no-op path. In other words, the file appeared to document those behaviors, but the assertions were effectively dead because they were defined as inner functions rather than actual tests.

This PR repairs that structure by promoting those nested functions to real test methods at class scope. I did not rewrite their intent, change their assertions, or move them across files. I simply restored them to a form that pytest will execute. That keeps the change tightly focused on test correctness and maintainability rather than turning the chunk into a larger refactor. After the fix, the targeted test batch passed locally, which confirms that the domain behavior those tests describe already matches the asserted expectations.

I want to call out why I treated that as in-scope for a “behavior-preserving” repository review. The underlying production behavior is unchanged. What changed is the test harness accuracy: assertions that looked like active regression coverage are now genuinely active regression coverage. This is closely aligned with the user’s goal of making the repository materially cleaner and easier to maintain without introducing intentional product changes. Leaving obviously unreachable tests in place would have preserved a misleading state rather than a maintainable one.

The other five files in the chunk were reviewed directly and left unchanged for concrete reasons. `test_run_capture.py` is already concise and clearly scoped to `RunCapture` construction and immutability. `test_run_setup.py` already explains its value-object focus. `test_snapshots.py` is broad, but it uses strong sectioning for `AnalysisSettingsSnapshot`, `RunContextSnapshot`, `SpeedProfileSummary`, and `DrivingPhaseSummary`. `test_speed_profile_and_run_suitability.py` already has a clear top-level summary and detailed coverage of speed profiles, suitability checks, and aggregate suitability behavior. `test_strength_metrics.py` is similarly clean and well-scoped around `StrengthPeak` and `StrengthMetrics` parsing. Those files were not skipped; they simply did not warrant churn after direct review.

The most meaningful unchanged file in the batch is probably `test_snapshots.py`, because it covers several domain snapshot types in one module. I read it end to end and chose not to split or reshape it in this chunk because its current layout is already understandable: each snapshot family has its own clearly labeled section and the assertions are explicit. A larger reorganization there would have crossed from maintainability cleanup into refactor territory without delivering enough benefit to justify the extra risk.

No dependencies were added, removed, or changed in this PR. No standard-library substitution was needed. No dead production code was removed. The only “dead” code addressed here was dead test structure: nested test definitions that pytest could not collect. Fixing that is a stronger improvement than cosmetic reformatting because it makes the existing intended assertions real without changing the production contract.

Validation was targeted and complete for the chunk. I ran `make lint` to exercise repository formatting, static boundary checks, and hygiene guards. I then ran a focused pytest batch covering exactly the seven files in this chunk:

` .venv/bin/python -m pytest -q -o addopts='' apps/server/tests/domain/test_run_capture.py apps/server/tests/domain/test_run_setup.py apps/server/tests/domain/test_snapshots.py apps/server/tests/domain/test_speed_profile_and_run_suitability.py apps/server/tests/domain/test_strength_metrics.py apps/server/tests/domain/test_test_planning_service.py apps/server/tests/domain/test_test_run_value_objects.py `

That batch passed with **136 passed**. I also ran `git diff --check` to verify patch hygiene. The passing total is relevant here because it confirms not only that the docstring addition is harmless, but also that the newly activated hotspot tests succeed alongside the surrounding test-run and finding-value-object coverage.

The main tradeoff in this PR is that it does slightly more than a pure docstring pass. That is intentional and justified. The nested-test issue was not just a style nit; it was a real maintainability and correctness problem in the test suite. I kept the fix as small as possible by preserving the original assertions and only changing the structure required for pytest collection. Beyond that, I stayed conservative: five files reviewed unchanged, no broader refactors, and no production-code edits.

There are no known blockers or follow-up fixes required for this chunk itself. The next follow-up is simply the next planned review unit in the tracker after this PR merges. For chunk `026`, the outcome is: seven files individually reviewed, one missing module boundary added, one unreachable-test bug repaired, five already-clear files left untouched, local validation green, and no intentional runtime behavior change introduced.
