### PR TITLE
Repo review: hygiene tests chunk 027

### DIFF
--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -1,3 +1,5 @@
+"""Smoke guards for critical AI-facing runtime and image-build entrypoints."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock

--- a/apps/server/tests/hygiene/test_api_model_boundary_parity.py
+++ b/apps/server/tests/hygiene/test_api_model_boundary_parity.py
@@ -1,3 +1,5 @@
+"""Guard shared analysis/history TypedDict ownership between HTTP and boundary layers."""
+
 from __future__ import annotations
 
 from typing import Protocol


### PR DESCRIPTION
## Summary

This PR covers **chunk 027** of the full sequential repository review and includes the following ten code files, each of which I reviewed individually before deciding whether to change it:

- `apps/server/tests/hygiene/test_ai_smoke.py`
- `apps/server/tests/hygiene/test_analysis_settings_sync.py`
- `apps/server/tests/hygiene/test_api_model_boundary_parity.py`
- `apps/server/tests/hygiene/test_car_library_artifact_sync.py`
- `apps/server/tests/hygiene/test_ci_command_parity.py`
- `apps/server/tests/hygiene/test_ci_job_parity.py`
- `apps/server/tests/hygiene/test_ci_lite_job_parity.py`
- `apps/server/tests/hygiene/test_ci_parallel_bootstrap.py`
- `apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py`
- `apps/server/tests/hygiene/test_dev_workflow.py`

As with the previous review chunks, the goal here was not to change product behavior, test behavior, or public contracts. The goal was to inspect the full batch directly, identify safe behavior-preserving maintainability improvements, apply the worthwhile ones, and leave the other files explicitly recorded as reviewed with no change. After reviewing all ten files, the only edits that cleared that bar were two module-level documentation cleanups that make the guard intent of the files obvious on first read without altering runtime behavior or test coverage.

The two files changed in this PR are `test_ai_smoke.py` and `test_api_model_boundary_parity.py`. In both cases, the tests themselves were already useful and correctly targeted, but the file opened without a module docstring even though the surrounding hygiene suite generally uses one to document the boundary or invariant being guarded. `test_ai_smoke.py` contains broad smoke coverage across health-route registration, hotspot packaging constraints, pi-gen build wrapper invariants, systemd entrypoints, offline firmware packaging, and installer requirements. That breadth makes the file much easier to navigate when it starts with a short statement of what category of behavior is being protected. I added a module docstring that describes it as a smoke-guard file for critical AI-facing runtime and image-build entrypoints.

The second change is similar but for a different seam. `test_api_model_boundary_parity.py` is a structural guard that enforces single ownership of shared analysis and history TypedDict contracts between the HTTP adapter models and the shared boundary types. The assertions were already strong, but without a module docstring the reason this file exists was only visible after reading down into the large import list and parametrized alias parity test. I added a short module docstring that makes the ownership rule explicit up front: this file protects TypedDict ownership between the HTTP and boundary layers so drift and duplication are caught early. That is a documentation-only maintainability improvement and does not change what the file tests.

The other eight files in the chunk were reviewed directly and intentionally left unchanged. `test_analysis_settings_sync.py` already communicates its UI/backend default-sync guard clearly. `test_car_library_artifact_sync.py` already has a strong module boundary and readable helper structure for comparing the JSON, ratio ledger, and variant-source documentation. The three small `check_hygiene.py` wrapper tests for CI command parity, CI-lite parity, and dependency reproducibility are already minimal and appropriately explicit. `test_ci_job_parity.py` already reads cleanly as a local-vs-workflow drift guard. `test_ci_parallel_bootstrap.py` already has focused fixtures and coverage around bootstrap lock hashing and skip-bootstrap race prevention. `test_dev_workflow.py` is the largest file in the chunk, but its helper extraction and scenario-based coverage for the Docker dev UI workflow are already well-structured and easy to follow, so I did not introduce churn there just to make a diff.

No dependencies were added or changed in this chunk. No standard-library substitution was needed because the existing implementations were already using straightforward standard-library or existing project helpers where appropriate. Likewise, there was no dead code removal in this batch: I checked for obviously stale helpers, unused branches, and redundant assertions, but the hygiene files are mostly sharp guardrails with little excess structure. Where I did not see a clearly behavior-preserving simplification, I left the file alone and recorded that decision in the review tracker rather than forcing cosmetic churn.

Validation for this PR was intentionally scoped to the files and guardrails touched by the chunk. I ran:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py apps/server/tests/hygiene/test_analysis_settings_sync.py apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/hygiene/test_car_library_artifact_sync.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_ci_lite_job_parity.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py apps/server/tests/hygiene/test_dev_workflow.py`
- `git diff --check`

That targeted pytest batch passed with all 76 tests green, and the repo lint/static-guard run also passed. Because the code changes are documentation-only and limited to two test modules, there is no broader behavioral risk expected from this PR.

The main tradeoff in this chunk is that I deliberately skipped more aggressive refactoring of repeated helper-loading patterns across some hygiene tests. There is repetition in the small wrappers that load `tools/dev/check_hygiene.py`, but extracting that today would either introduce an additional shared test helper or reshape several already-clear files for limited payoff. Given the repo-review constraint to prefer the smallest complete behavior-preserving improvement, I chose not to widen scope when the current repetition is shallow and readable.

This PR therefore serves two purposes: it completes the required file-by-file review of chunk 027, and it slightly improves the readability of the two files whose intent was still implicit at module open. Everything else in the chunk was examined and intentionally preserved as-is.
