### PR TITLE
Repo review: domain hygiene chunk 028

### DIFF
--- a/apps/server/tests/hygiene/test_diagnostic_case_boundary_roles.py
+++ b/apps/server/tests/hygiene/test_diagnostic_case_boundary_roles.py
@@ -1,3 +1,5 @@
+"""Guard diagnostic-case boundary ownership versus domain and use-case factories."""
+
 from __future__ import annotations
 
 from vibesensor.domain import Car, SpeedProfile, Symptom

--- a/apps/server/tests/hygiene/test_domain_model_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_model_guardrails.py
@@ -1,7 +1,6 @@
-"""Domain model guardrails — snapshot enum members, graph relationships,
-analysis machinery boundaries, and typed-concept conformance.
+"""Domain model guardrails for graph relationships and typed-concept conformance.
 
-Covers migration-plan items T02, T03, T05, T06, and T07.
+Covers the migration-plan seams that this file still enforces directly: T03 and T07.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

This PR covers **chunk 028** of the full sequential repository review and includes the following ten code files, each of which I opened and reviewed individually before deciding whether to change it:

- `apps/server/tests/hygiene/test_diagnostic_case_boundary_roles.py`
- `apps/server/tests/hygiene/test_docker_ci_hygiene.py`
- `apps/server/tests/hygiene/test_domain_boundary_parity.py`
- `apps/server/tests/hygiene/test_domain_exceptions.py`
- `apps/server/tests/hygiene/test_domain_exports_guardrails.py`
- `apps/server/tests/hygiene/test_domain_finding_guardrails.py`
- `apps/server/tests/hygiene/test_domain_graph_and_lifecycle_guardrails.py`
- `apps/server/tests/hygiene/test_domain_migration_guardrails.py`
- `apps/server/tests/hygiene/test_domain_model_completeness.py`
- `apps/server/tests/hygiene/test_domain_model_guardrails.py`

As with the earlier review chunks, this PR is intentionally behavior-preserving. The goal was to inspect the entire batch directly, identify any safe maintainability improvements that would make the code easier to understand or less likely to drift, apply only the improvements that clearly met that bar, validate the full chunk locally, and leave the remaining files explicitly recorded as reviewed with no change. After reviewing all ten files, only two changes were justified: one missing module docstring and one stale module header that no longer accurately described the guardrails in the file.

The first changed file is `test_diagnostic_case_boundary_roles.py`. The assertions in this file were already fine: they protect the ownership boundary between domain factories, shared boundary helpers, and use-case modules by making sure legacy or duplicate factory-style helpers do not reappear in the wrong places. The only issue was that the file opened without a module docstring, which made the purpose of the guard implicit until the reader worked through the imports and negative-attribute assertions. I added a concise module docstring stating that the file guards diagnostic-case boundary ownership versus domain and use-case factories. That change does not affect collection, execution, or assertions; it simply improves first-read clarity.

The second changed file is `test_domain_model_guardrails.py`. Unlike the first file, this one already had a module docstring, but the description had drifted from the code it actually contains today. The old header claimed the file covered snapshot enum members, graph relationships, analysis machinery boundaries, and a larger set of migration-plan work items. After direct review, the live file scope is narrower and clearer: it primarily enforces domain graph relationship expectations and typed-concept conformance, with section markers corresponding to T03 and T07. I updated the module docstring and the migration-plan note so they match the assertions that are still present rather than describing historical or broader scope. This is a pure documentation-accuracy fix, but in a guardrail file that matters because stale headers make maintainers look for checks that are no longer there.

The remaining eight files were all reviewed directly and intentionally left unchanged. `test_docker_ci_hygiene.py` is already a compact wrapper around the shared hygiene check entrypoint. `test_domain_boundary_parity.py` is a larger file, but its dataclass-vs-TypedDict parity structure is already explicit and well documented. `test_domain_exceptions.py` clearly verifies the single-base exception hierarchy. `test_domain_exports_guardrails.py` and `test_domain_model_completeness.py` do have some overlap in the export/completeness space, but both are still readable and each guards a slightly different drift vector, so I did not force a consolidation just to create a diff. `test_domain_finding_guardrails.py` remains a focused set of ownership and immutability checks. `test_domain_graph_and_lifecycle_guardrails.py` is already explicit about canonical relationships and mutability rules. `test_domain_migration_guardrails.py` is also doing useful work in a readable way by protecting against regressions to removed compatibility paths.

No dependencies were added, removed, or changed in this chunk. No production files were modified. No dead code removal was attempted because the files in this batch are largely narrow regression guards, and I did not find any obviously unused or misleading logic that could be removed with high confidence. The improvements here are intentionally small because the review standard is not “make a change in every chunk”; it is “make the worthwhile behavior-preserving changes you can justify after reviewing every file.” In this chunk, that meant clarifying file-level intent where it was absent or stale and leaving the rest untouched.

Validation was run across the whole chunk after the edits. I used the same chunk-scoped validation pattern as previous review PRs:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_diagnostic_case_boundary_roles.py apps/server/tests/hygiene/test_docker_ci_hygiene.py apps/server/tests/hygiene/test_domain_boundary_parity.py apps/server/tests/hygiene/test_domain_exceptions.py apps/server/tests/hygiene/test_domain_exports_guardrails.py apps/server/tests/hygiene/test_domain_finding_guardrails.py apps/server/tests/hygiene/test_domain_graph_and_lifecycle_guardrails.py apps/server/tests/hygiene/test_domain_migration_guardrails.py apps/server/tests/hygiene/test_domain_model_completeness.py apps/server/tests/hygiene/test_domain_model_guardrails.py`
- `git diff --check`

That targeted pytest batch passed with **147 tests green**, and the repository lint/static-guard suite also passed cleanly. Because the changes are documentation-only in test modules, there is no expected behavioral risk, but I still ran the full chunk validation so that the surrounding hygiene guardrails are confirmed healthy on the final diff.

The main deliberate tradeoff in this PR is restraint. There are places in this batch where additional consolidation could be imagined, especially around adjacent domain export/completeness checks, but those changes would widen scope for relatively small gain and would risk turning a behavior-preserving cleanup into unnecessary test churn. Given the full-repo review constraint and the requirement to keep each chunk surgical, I chose the smallest complete set of improvements that materially improves maintainability without changing semantics.

This PR therefore completes the required file-by-file review of chunk 028, records the unchanged decisions for the eight untouched files, and ships the two documentation-accuracy fixes that were clearly worth making.
