### PR TITLE
Repo review: domain hygiene chunk 029

### DIFF
--- a/apps/server/tests/hygiene/test_packaged_runtime_data_sync.py
+++ b/apps/server/tests/hygiene/test_packaged_runtime_data_sync.py
@@ -1,3 +1,5 @@
+"""Guard packaged server runtime data copies against drift from canonical sources."""
+
 from __future__ import annotations
 
 from _paths import SERVER_ROOT

--- a/apps/server/tests/hygiene/test_pi_gen_artifact_selection.py
+++ b/apps/server/tests/hygiene/test_pi_gen_artifact_selection.py
@@ -1,3 +1,5 @@
+"""Guard pi-gen artifact selection priority and legacy artifact-name rejection."""
+
 from __future__ import annotations
 
 import shlex


### PR DESCRIPTION
## Summary

This PR covers **chunk 029** of the full sequential repository review and includes the following ten code files, each of which I reviewed individually before deciding whether to change it:

- `apps/server/tests/hygiene/test_domain_new_types.py`
- `apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py`
- `apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py`
- `apps/server/tests/hygiene/test_domain_test_run_guardrails.py`
- `apps/server/tests/hygiene/test_frontend_metric_fields_sync.py`
- `apps/server/tests/hygiene/test_history_db_mixins.py`
- `apps/server/tests/hygiene/test_location_codes_sync.py`
- `apps/server/tests/hygiene/test_main_release_workflow.py`
- `apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `apps/server/tests/hygiene/test_pi_gen_artifact_selection.py`

As with earlier chunks in this repo-wide review, the objective here was not to force a change into every file. The objective was to directly inspect the entire batch, identify worthwhile behavior-preserving maintainability improvements, apply only the changes that clearly help, validate the whole chunk, and explicitly record the files that were reviewed but left unchanged. After reviewing all ten files, the only changes that met that bar were two module docstrings for small hygiene tests whose purpose was still implicit at file open.

The first changed file is `test_packaged_runtime_data_sync.py`. The test itself is already straightforward and valuable: it compares packaged runtime data copies against the canonical source files under `apps/server/data`, making sure the checked-in runtime bundle does not silently drift from the source data. The issue was simply that the file opened without any module-level statement of what invariant it protects. In a repository where many of these hygiene files are intentionally self-describing at module open, that made the test slightly harder to understand in isolation than it needed to be. I added a short module docstring clarifying that the file guards packaged server runtime data copies against drift from their canonical sources.

The second changed file is `test_pi_gen_artifact_selection.py`. This file verifies the behavior of the pi-gen artifact selection helper, including the priority order among `.img`, `.img.xz`, and zip outputs and the rejection of legacy non-image zip names. The assertions were already concise and useful, but again the file started without a module docstring. I added one that explains the two things the file is guarding: artifact selection priority and rejection of legacy artifact naming patterns that should no longer be accepted. As with the other changed file, this is documentation-only cleanup; it does not alter imports, execution, or assertions.

The remaining eight files were all reviewed directly and intentionally left unchanged. `test_domain_new_types.py` is a larger file, but its construction, immutability, invariant, and factory coverage for the newer typed domain concepts is already explicit and well structured. `test_domain_report_mapping_guardrails.py` already communicates the domain-first report mapping invariant clearly. `test_domain_summary_boundary_guardrails.py` is concise and focused on boundary ownership. `test_domain_test_run_guardrails.py` already reads clearly as a guardrail file for `TestRun` as the canonical post-analysis aggregate. `test_frontend_metric_fields_sync.py` is minimal and sufficiently descriptive as-is. `test_history_db_mixins.py` already has a clear composition-focused structure for the split history persistence layer. `test_location_codes_sync.py` and `test_main_release_workflow.py` are both already explicit about the drift they are preventing.

No production code changed in this chunk. No dependencies were added, removed, or upgraded. No standard-library substitutions were needed because there was no custom logic here that would be meaningfully simplified by changing libraries or helpers. I also did not attempt any dead-code removal in this batch. Several of the files are narrowly scoped regression guards, and while there is some thematic overlap between neighboring hygiene tests, I did not find any duplication so obvious and low-risk that removing or consolidating it would clearly improve the code without widening scope unnecessarily.

Validation for this PR was run across the entire chunk after the edits. I used the same chunk-level validation pattern as in the preceding PRs:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_domain_new_types.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py apps/server/tests/hygiene/test_domain_test_run_guardrails.py apps/server/tests/hygiene/test_frontend_metric_fields_sync.py apps/server/tests/hygiene/test_history_db_mixins.py apps/server/tests/hygiene/test_location_codes_sync.py apps/server/tests/hygiene/test_main_release_workflow.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py apps/server/tests/hygiene/test_pi_gen_artifact_selection.py`
- `git diff --check`

That targeted pytest batch passed with **62 tests green**, and `make lint` also passed cleanly, including the repo’s static guardrails and contract-sync checks. Because the actual code changes are documentation-only and restricted to test modules, there is no expected runtime risk, but the targeted validation still matters because these files are part of the repo’s hygiene and architecture guard suite.

The most important deliberate choice in this chunk was to avoid cosmetic churn in already-clear guardrails. Several files here are short and purpose-built. Even where additional extraction or consolidation could theoretically be done, the gain would be small and the resulting diff would be larger than the value delivered. Since the review goal is to make the repository materially cleaner without changing behavior, I treated restraint as part of the quality bar and only changed the places where readability was meaningfully improved.

This PR therefore completes the required file-by-file review of chunk 029, records the unchanged decisions for the eight files that did not warrant edits, and ships the two safe documentation cleanups that make the remaining small hygiene tests easier to understand at a glance.
