### PR TITLE
Repo review: hygiene runners chunk 030

### DIFF
--- a/apps/server/tests/hygiene/test_shared_contracts_smoke.py
+++ b/apps/server/tests/hygiene/test_shared_contracts_smoke.py
@@ -1,3 +1,5 @@
+"""Smoke guard for canonical vibration-strength metric fields in shared contracts."""
+
 from __future__ import annotations
 
 import math

--- a/apps/server/tests/hygiene/test_type_safety_consolidation.py
+++ b/apps/server/tests/hygiene/test_type_safety_consolidation.py
@@ -1,12 +1,4 @@
-"""Chunk 4 — Type Safety & Validation Consolidation.
-
-Verifies:
-- normalize_lang is sourced from one canonical module (report_i18n)
-- SettingsStore._coerce_language handles locale variants (e.g. "nl-BE")
-- ClientRegistry uses normalize_sensor_id (no private duplicate)
-- ClassificationResult TypedDict returned from classify_peak_hz
-- mypy enforcement uses package-level discovery without internal denylist exceptions
-"""
+"""Guard language normalization and mypy package-discovery configuration."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

This PR covers **chunk 030** of the full sequential repository review and includes the following code files, each of which I reviewed individually before deciding whether to change it:

- `apps/server/tests/hygiene/test_run_backend_parallel.py`
- `apps/server/tests/hygiene/test_run_changed.py`
- `apps/server/tests/hygiene/test_run_e2e_parallel.py`
- `apps/server/tests/hygiene/test_sample_column_alignment.py`
- `apps/server/tests/hygiene/test_shared_contracts_smoke.py`
- `apps/server/tests/hygiene/test_strength_peak_parity.py`
- `apps/server/tests/hygiene/test_type_safety_consolidation.py`
- `apps/server/tests/hygiene/test_ui_smoke_contract.py`
- `apps/server/tests/hygiene/test_ui_vite_server_contract.py`

This chunk is a little smaller than the standard ten-file batch, but it follows the same review process as the earlier chunks: every file was opened directly, evaluated for behavior-preserving maintainability improvements, validated as a group after any edits, and recorded either as changed or reviewed with no change. After reviewing the full batch, only two documentation-focused cleanups were clearly worthwhile. The rest of the files were left unchanged intentionally because their existing structure and guard intent were already clear.

The first changed file is `test_shared_contracts_smoke.py`. The test itself is simple and useful: it exercises `compute_vibration_strength_db` and asserts that the canonical shared metric keys are present and produce a finite non-negative vibration strength value. That makes it a meaningful smoke guard around the shape of the shared contract and the metric names the rest of the system expects. The issue was only that the file opened without a module docstring, so a reader landing in the file did not get an immediate statement of why it exists. I added a concise module docstring describing it as a smoke guard for canonical vibration-strength metric fields in shared contracts.

The second changed file is `test_type_safety_consolidation.py`. Unlike the first file, this one already had a long module docstring, but the header had drifted and now overstated the current scope. It referenced a historical “Chunk 4” label and listed checks that are no longer present in the live file, such as coverage around `ClientRegistry` and `ClassificationResult`. The actual tests that remain in the file today cover two focused seams: language normalization behavior and mypy package-discovery configuration. I replaced the stale multi-bullet historical header with a shorter module docstring that accurately describes the file’s current guardrails. That is a documentation-accuracy fix only; the tests, imports, and assertions remain unchanged.

The other seven files in this chunk were all reviewed directly and intentionally left alone. `test_run_backend_parallel.py` is already a concise guard for backend shard planning and duration-cache observation. `test_run_changed.py` clearly documents and tests the changed-file runner’s planning logic. `test_run_e2e_parallel.py` is longer, but its helper extraction and scenario-based coverage around image preparation, shard assignment, and cleanup are already readable. `test_sample_column_alignment.py` already has one of the better module docstrings in this area and clearly explains the four-source alignment invariant it protects. `test_strength_peak_parity.py` likewise already documents the hot-path TypedDict versus dataclass parity concern well. `test_ui_smoke_contract.py` and `test_ui_vite_server_contract.py` are both focused, explicit, and already sufficiently self-describing.

No production code changed in this chunk, and no dependencies were modified. I did not remove any code or attempt to consolidate neighboring tests because the remaining files are already small, purpose-built guardrails. In several cases there is thematic adjacency across the files—runner planning, smoke contracts, UI dev server behavior—but not enough duplication to justify wider refactoring under a behavior-preserving cleanup constraint. The smallest complete improvement here was to clarify file-level intent where it was missing or stale and avoid churn elsewhere.

Validation was run across the full chunk after the edits. I used the same chunk-level local validation pattern that has been working throughout the review run:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_run_changed.py apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_sample_column_alignment.py apps/server/tests/hygiene/test_shared_contracts_smoke.py apps/server/tests/hygiene/test_strength_peak_parity.py apps/server/tests/hygiene/test_type_safety_consolidation.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/hygiene/test_ui_vite_server_contract.py`
- `git diff --check`

That targeted batch passed with **46 tests green**, and `make lint` also passed cleanly, including the backend static guard suite and the contract-sync checks. Because the diff is documentation-only and restricted to test modules, there is no expected runtime or contract risk, but I still ran the whole chunk validation so the surrounding guardrails remain exercised as a set.

The main tradeoff in this PR is restraint. It would have been easy to force broader cleanup in the runner-related tests or rewrite already-clear module headers just to create a bigger diff, but that would not have improved maintainability proportionally to the churn introduced. This chunk is a good example of the broader review principle: if a file is already readable and structurally sound, the right outcome is often to review it carefully and leave it alone.

This PR therefore completes the required file-by-file review of chunk 030, ships the two safe documentation cleanups that materially improve clarity, and records the other seven files as directly reviewed with no change needed.
