### PR TITLE
Repo review: infra config chunk 032

### DIFF
--- a/apps/server/tests/infra/config/test_sensor_settings.py
+++ b/apps/server/tests/infra/config/test_sensor_settings.py
@@ -1,3 +1,5 @@
+"""Cover sensor settings service mutations, defaults, and rollback behavior."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/apps/server/tests/infra/config/test_settings_audit_logging.py
+++ b/apps/server/tests/infra/config/test_settings_audit_logging.py
@@ -1,3 +1,5 @@
+"""Verify settings-store audit logs capture key language and car mutations."""
+
 from __future__ import annotations
 
 import logging

--- a/apps/server/tests/infra/config/test_settings_derivation.py
+++ b/apps/server/tests/infra/config/test_settings_derivation.py
@@ -1,3 +1,5 @@
+"""Exercise config-derivation defaults and active-car projection behavior."""
+
 from __future__ import annotations
 
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot

--- a/apps/server/tests/infra/config/test_settings_runtime.py
+++ b/apps/server/tests/infra/config/test_settings_runtime.py
@@ -1,3 +1,5 @@
+"""Guard runtime speed-source synchronization between settings and the monitor."""
+
 from __future__ import annotations
 
 import pytest

--- a/apps/server/tests/infra/config/test_settings_store.py
+++ b/apps/server/tests/infra/config/test_settings_store.py
@@ -1,3 +1,5 @@
+"""Cover settings-store validation, persistence, and runtime sync behavior."""
+
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

This PR covers **chunk 032** of the full sequential repository review. I individually reviewed each code file assigned to this chunk before making any edits, and the chunk consists of the following six infra-config test modules:

- `apps/server/tests/infra/config/test_sensor_settings.py`
- `apps/server/tests/infra/config/test_settings_audit_logging.py`
- `apps/server/tests/infra/config/test_settings_derivation.py`
- `apps/server/tests/infra/config/test_settings_runtime.py`
- `apps/server/tests/infra/config/test_settings_store.py`
- `apps/server/tests/infra/config/test_settings_transaction.py`

The focus of this chunk was maintainability-only cleanup inside the infra config test suite. These files exercise several closely related seams in the backend configuration layer: sensor settings mutation and rollback behavior, audit logging for settings changes, derivation of analysis settings from the active car, synchronization of speed-source settings into runtime monitoring, the broader `SettingsStore` lifecycle and persistence behavior, and the shared `update_with_rollback()` transaction helper.

After direct review, I found that the assertions and helper structure across the chunk were already in good shape. The tests are focused, behaviorally meaningful, and do not contain obvious dead code or redundant complexity worth changing under the “no intentional functional changes” rule for this repo-wide review. The main maintainability gap was consistency at the module boundary: five of the six files still opened without a short module docstring, while the surrounding test suite has increasingly standardized on concise file-level summaries that explain what boundary or invariant a module protects.

Accordingly, the changes in this PR are intentionally narrow. I added module docstrings to these five files:

- `test_sensor_settings.py`
- `test_settings_audit_logging.py`
- `test_settings_derivation.py`
- `test_settings_runtime.py`
- `test_settings_store.py`

Each docstring summarizes the specific scope of the module so a maintainer can understand the purpose of the file immediately while scanning the infra config test directory. For example, the `test_sensor_settings.py` header now makes it obvious that the module covers sensor settings mutations, defaults, and rollback behavior. The `test_settings_runtime.py` header now explicitly frames the module as guarding the runtime synchronization seam between stored settings and the speed-source monitor. And the large `test_settings_store.py` module now starts with a concise description of its broad validation, persistence, and runtime synchronization responsibilities, which is especially helpful because that file aggregates a wide range of store-level regression coverage.

I left `test_settings_transaction.py` unchanged after review. It already had a clear module docstring and a well-scoped `TestUpdateWithRollback` class-level description, so there was no maintainability win in changing it further. I also chose not to churn existing assertions, helper names, or section comments elsewhere in the chunk because they were still doing useful work and any additional edits would have been cosmetic rather than materially clarifying.

No production code changed in this PR. No tests changed behavior. No new helpers, dependencies, or abstractions were introduced. This is strictly a behavior-preserving readability pass on the test modules themselves.

Validation for the chunk was completed locally before opening the PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/config/test_sensor_settings.py apps/server/tests/infra/config/test_settings_audit_logging.py apps/server/tests/infra/config/test_settings_derivation.py apps/server/tests/infra/config/test_settings_runtime.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/infra/config/test_settings_transaction.py`
- `git diff --check`

That targeted pytest batch completed with **64 passing tests**, and `make lint` passed cleanly, including the repo’s static guardrails and contract-sync checks. Because the diff is documentation-only and confined to test modules, the practical risk is negligible, but I still ran the full chunk-level validation workflow to stay consistent with the broader audit run.

There were no dependency or standard-library substitutions in this chunk. I did not find dead code that was safe to remove. I also did not find any stale compatibility shim, obsolete helper, or structurally confusing test pattern that justified refactoring. The tests already map well to the configuration subsystem they exercise. The best behavior-preserving improvement here was to make the file purposes more discoverable without perturbing stable coverage.

The main tradeoff in this PR is that it is intentionally small relative to the number of files reviewed. That is by design. This repository review is chunk-driven and requires exactly one PR per chunk, but the standard should still be “smallest worthwhile improvement” rather than forcing churn simply to make a PR look larger. In this chunk, adding module-level framing improved readability across multiple files while keeping the diff low-risk and easy to audit.

As a result, this PR completes the required individual review of all six code files in chunk 032, improves consistency within the infra config test area, and leaves runtime behavior, test logic, and public contracts unchanged.
