### PR TITLE
Repo review: infra processing chunk 033

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py
@@ -1,3 +1,5 @@
+"""Verify buffer-store mutations invalidate cached spectrum payload state."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py
@@ -1,3 +1,5 @@
+"""Guard buffer-store cache identity and sample-rate invalidation behavior."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py
@@ -1,3 +1,5 @@
+"""Exercise buffer-store overflow trimming and warning behavior."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_compute_filtering.py
+++ b/apps/server/tests/infra/processing/test_compute_filtering.py
@@ -1,3 +1,5 @@
+"""Ensure compute filtering reuses or isolates FFT inputs without double filtering."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_debug_queries.py
+++ b/apps/server/tests/infra/processing/test_debug_queries.py
@@ -1,3 +1,5 @@
+"""Cover debug-query defaults and raw-sample projection behavior."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_payload_builders.py
+++ b/apps/server/tests/infra/processing/test_payload_builders.py
@@ -1,3 +1,5 @@
+"""Exercise processing payload builders for debug spectra, intake stats, and alignment."""
+
 from __future__ import annotations
 
 import math


### PR DESCRIPTION
## Summary

This PR covers **chunk 033** of the full sequential repository review. I directly reviewed every code file assigned to the chunk before making any edits. The chunk contains the following ten infra-processing test modules:

- `apps/server/tests/infra/processing/test_buffer_capacity.py`
- `apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py`
- `apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py`
- `apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py`
- `apps/server/tests/infra/processing/test_buffers_repr_and_fastpath.py`
- `apps/server/tests/infra/processing/test_clipping_and_saturation.py`
- `apps/server/tests/infra/processing/test_compute_filtering.py`
- `apps/server/tests/infra/processing/test_debug_queries.py`
- `apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py`
- `apps/server/tests/infra/processing/test_payload_builders.py`

These files collectively cover the lower-level processing infrastructure: buffer sizing and overflow policy, cache invalidation inside the buffer store, identity and sample-rate guards for cached metrics, `ClientBuffer` representation and invalidate-caches fast paths, clipping and saturation edge cases, compute-path filtering behavior, debug-query projections, mixed regression coverage for metrics caching and settings rollback, and payload-building helpers for debug, intake stats, and time alignment.

After direct review, the dominant maintainability issue in this chunk was again inconsistency in module-level framing. Four of the ten files already had useful module docstrings or sufficiently descriptive headers:

- `test_buffer_capacity.py`
- `test_buffers_repr_and_fastpath.py`
- `test_clipping_and_saturation.py`
- `test_metrics_cache_and_settings_regressions.py`

Those modules were left unchanged after review because their file-level purpose was already easy to understand and I did not find any other behavior-preserving cleanup that clearly improved them without introducing unnecessary churn.

The remaining six files were all clear at the individual test level but opened without a short summary of the boundary being protected. In this repository’s test suite, especially in hygiene, infra, and adapter areas, concise module docstrings have become an important part of maintainability: they help future readers understand the seam under test before they work through helper setup or individual function names. For that reason, this PR adds module docstrings to the following files:

- `test_buffer_store_cache_invalidation.py`
- `test_buffer_store_identity_and_rate_guards.py`
- `test_buffer_store_overflow_policy.py`
- `test_compute_filtering.py`
- `test_debug_queries.py`
- `test_payload_builders.py`

Each new header was written to be specific rather than generic. For example, `test_buffer_store_cache_invalidation.py` now says explicitly that it verifies buffer-store mutations invalidate cached spectrum payload state. `test_compute_filtering.py` now frames the module as ensuring FFT filtering reuses or isolates inputs correctly without double filtering. `test_payload_builders.py` now states that it exercises payload builders for debug spectra, intake stats, and alignment. These additions make the modules easier to scan and easier to place mentally within the processing subsystem, especially because several of the files use private or semi-internal processing seams where context matters.

No production code changed in this PR. No test assertions changed, no helper logic changed, and no new abstractions or dependencies were introduced. This is intentionally a behavior-preserving readability cleanup only.

I also considered whether there were larger changes justified within scope. I did not find dead code that was safe to remove, duplicate helpers whose consolidation would clearly reduce maintenance burden without broadening the diff, or misleading assertions that required correction. The tests in this chunk are already fairly focused and, aside from the missing file headers, were generally in good shape. Under the repository-review rule set, the right move here was to improve discoverability and consistency, not to churn stable tests for cosmetic reasons.

Validation was completed locally before opening the PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/processing/test_buffer_capacity.py apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py apps/server/tests/infra/processing/test_buffers_repr_and_fastpath.py apps/server/tests/infra/processing/test_clipping_and_saturation.py apps/server/tests/infra/processing/test_compute_filtering.py apps/server/tests/infra/processing/test_debug_queries.py apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py apps/server/tests/infra/processing/test_payload_builders.py`
- `git diff --check`

That focused pytest batch passed with **152 tests passing**, and `make lint` passed cleanly, including the project’s backend static guards and contract-sync checks. Given that the diff is limited to test-module docstrings, the practical risk is minimal, but the same chunk-level validation standard was still applied to keep the audit run disciplined and consistent.

There were no dependency substitutions, no standard-library rewrites, and no behavior-affecting test refactors in this chunk. There are also no new follow-up requirements created by this PR. It is intentionally scoped to the reviewed files in chunk 033 and does not pull in any later-chunk processing tests.

The tradeoff, as with several recent chunks, is that the actual code change is smaller than the review effort. That is expected and appropriate for this run. The goal is not to manufacture larger diffs; it is to review every file individually and make only the maintainability improvements that are clearly worthwhile and behavior-preserving. In this chunk, that meant improving module-level clarity across six files while leaving the already-clear modules untouched.

This PR therefore completes the required individual review of all ten code files in chunk 033, improves consistency and scanability in the infra-processing test area, and preserves all existing behavior.
