### PR TITLE
Repo review: processing tests chunk 034

### DIFF
--- a/apps/server/tests/infra/processing/test_processing.py
+++ b/apps/server/tests/infra/processing/test_processing.py
@@ -1,3 +1,5 @@
+"""Exercise end-to-end processor behavior around ingest, locking, spectra, and overlap helpers."""
+
 from __future__ import annotations
 
 import math

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -1,3 +1,5 @@
+"""Cover snapshot, cache, and FFT-parameter behavior across processing components."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_processing_extended.py
+++ b/apps/server/tests/infra/processing/test_processing_extended.py
@@ -1,3 +1,5 @@
+"""Guard extended processor edge cases for ingest, payload reuse, spectra, and eviction."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_ring_buffer_ingest.py
+++ b/apps/server/tests/infra/processing/test_ring_buffer_ingest.py
@@ -1,3 +1,5 @@
+"""Verify ring-buffer ingest writes, wraparound, and timestamp tracking behavior."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/apps/server/tests/infra/processing/test_sensor_units.py
+++ b/apps/server/tests/infra/processing/test_sensor_units.py
@@ -1,3 +1,5 @@
+"""Guard the shared sensor model and acceleration-scale constants."""
+
 from __future__ import annotations
 
 from vibesensor.shared.sensor_units import ADXL345_SCALE_G_PER_LSB, SENSOR_MODEL


### PR DESCRIPTION
## Summary

This PR covers **chunk 034** of the full sequential repository review. I directly reviewed each code file in the chunk before making any edits. The chunk contains the following ten processing-related test modules:

- `apps/server/tests/infra/processing/test_processing.py`
- `apps/server/tests/infra/processing/test_processing_buffers.py`
- `apps/server/tests/infra/processing/test_processing_components.py`
- `apps/server/tests/infra/processing/test_processing_extended.py`
- `apps/server/tests/infra/processing/test_processing_fft.py`
- `apps/server/tests/infra/processing/test_processing_time_align.py`
- `apps/server/tests/infra/processing/test_report_signal_filtering_regressions.py`
- `apps/server/tests/infra/processing/test_ring_buffer_ingest.py`
- `apps/server/tests/infra/processing/test_sample_builder.py`
- `apps/server/tests/infra/processing/test_sensor_units.py`

This group spans several adjacent seams in the backend processing stack: processor-level ingest and compute behavior, `ClientBuffer` coverage, component-level snapshot and cache behavior, extended processor edge cases, the pure FFT and time-alignment helpers, filtering regressions, ring-buffer ingest behavior, run sample-building helpers, and the shared sensor-units constants.

As with the previous few chunks, the individual tests were generally solid after direct review. Assertions were specific, the helper code was proportionate to the cases under test, and I did not find obvious dead code or duplicated test logic worth refactoring in a behavior-preserving review pass. The main maintainability gap was again consistency in module-level framing.

Five modules already had clear top-level documentation or were otherwise sufficiently self-framing and were therefore left unchanged after review:

- `test_processing_buffers.py`
- `test_processing_fft.py`
- `test_processing_time_align.py`
- `test_report_signal_filtering_regressions.py`
- `test_sample_builder.py`

Those files already explain their scope well, either through explicit module docstrings or through structured introductory text that makes the boundary under test easy to understand.

The remaining five files opened without a module docstring even though they cover distinct and useful seams within the processing subsystem. This PR adds concise, boundary-specific module docstrings to those files:

- `test_processing.py`
- `test_processing_components.py`
- `test_processing_extended.py`
- `test_ring_buffer_ingest.py`
- `test_sensor_units.py`

Each new docstring is intentionally specific. `test_processing.py` now makes it clear that the module exercises end-to-end processor behavior involving ingest, locking, spectra, and overlap helpers. `test_processing_components.py` now states that it covers snapshot, cache, and FFT-parameter behavior across processing components, which is especially useful because the file bridges `SignalBufferStore` and `SignalMetricsComputer`. `test_processing_extended.py` now signals that it exists for extended edge cases such as payload reuse and eviction behavior. `test_ring_buffer_ingest.py` now clearly frames its wraparound and timestamp-tracking intent. `test_sensor_units.py`, though very small, now states directly that it guards the shared sensor model and acceleration-scale constants.

No assertions changed in this PR. No production code changed. No helper behavior changed. No dependencies were added or removed. This is a behavior-preserving readability and maintainability cleanup only.

I specifically chose not to do more than that because the surrounding test code was already reasonably clear. For example, I considered whether any of the broader processor tests should be split or renamed, but those moves would introduce more churn than value in the context of this strict repository-review run. The better outcome here was to improve discoverability at the file boundary and stop there.

Validation for the chunk was completed locally before the PR was opened:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/processing/test_processing.py apps/server/tests/infra/processing/test_processing_buffers.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/infra/processing/test_processing_time_align.py apps/server/tests/infra/processing/test_report_signal_filtering_regressions.py apps/server/tests/infra/processing/test_ring_buffer_ingest.py apps/server/tests/infra/processing/test_sample_builder.py apps/server/tests/infra/processing/test_sensor_units.py`
- `git diff --check`

That focused pytest batch completed with **126 passing tests**, and `make lint` passed cleanly, including the repository’s static guardrails and contract-sync checks. Because the diff is restricted to test module headers, the risk is effectively negligible, but I still ran the full chunk-local validation pattern for consistency and traceability.

There were no dead-code removals, no library or standard-library substitutions, and no behavior-affecting test refactors in this chunk. I also did not find any immediate follow-up work that needed to be pulled forward from later chunks. The change set is limited to the reviewed files in chunk 034 and preserves the one-PR-per-chunk discipline for the overall run.

The tradeoff is again that the implementation diff is smaller than the review effort. That is intentional and correct under the rules of this run. The objective is not to force larger diffs; it is to inspect every code file individually and make only the maintainability improvements that are clearly worthwhile and behavior-preserving. In this chunk, that meant improving the scanability and consistency of the processing test area while leaving already well-framed modules unchanged.

This PR therefore completes the required individual review of all ten code files in chunk 034, improves clarity across five processing-related test modules, and leaves runtime behavior, public contracts, and test semantics unchanged.
