### PR TITLE
Repo review: processing alignment chunk 035

### DIFF
--- a/apps/server/tests/infra/processing/test_snapshot_builder.py
+++ b/apps/server/tests/infra/processing/test_snapshot_builder.py
@@ -11,6 +11,8 @@ from vibesensor.infra.processing.snapshot_builder import (
 
 
 class TestCheckCacheHit:
+    """Cover snapshot-builder cache-hit eligibility based on generations and sample rate."""
+
     def test_cache_hit_when_generations_and_rate_match(self) -> None:
         metrics = {"rms_x": 0.5}
         result = check_cache_hit(
@@ -66,6 +68,8 @@ class TestCheckCacheHit:
 
 
 class TestComputeSnapshotWindow:
+    """Exercise snapshot-window sizing and whether a separate FFT block is needed."""
+
     def test_basic_window_smaller_than_count(self) -> None:
         result = compute_snapshot_window(
             count=1000,

--- a/apps/server/tests/infra/processing/test_time_alignment.py
+++ b/apps/server/tests/infra/processing/test_time_alignment.py
@@ -64,6 +64,8 @@ def _fill_sensor(
 
 
 class TestAnalysisTimeRange:
+    """Cover per-sensor time-window derivation before overlap is computed."""
+
     def test_empty_buffer_returns_none(self) -> None:
         proc = _make_processor()
         info = proc.time_alignment_info(["no_such_sensor"])
@@ -94,6 +96,8 @@ class TestAnalysisTimeRange:
 
 
 class TestTimeAlignmentInfoAligned:
+    """Verify multi-sensor windows are marked aligned when overlap stays sufficient."""
+
     def test_two_sensors_same_time(self) -> None:
         proc = _make_processor(sample_rate_hz=200, waveform_seconds=2)
         _fill_sensor(proc, "s1", mono_time=100.0)
@@ -131,6 +135,8 @@ class TestTimeAlignmentInfoAligned:
 
 
 class TestTimeAlignmentInfoMisaligned:
+    """Verify stale or offset sensor windows report partial or zero alignment correctly."""
+
     def test_stale_sensor_not_aligned(self) -> None:
         proc = _make_processor(sample_rate_hz=200, waveform_seconds=2)
         _fill_sensor(proc, "s1", mono_time=100.0)
@@ -167,6 +173,8 @@ class TestTimeAlignmentInfoMisaligned:
 
 
 class TestMultiSpectrumPayloadAlignment:
+    """Ensure multi-sensor spectrum payloads surface the expected alignment metadata."""
+
     def test_alignment_included_when_multiple_sensors(self) -> None:
         proc = _make_processor(sample_rate_hz=200, fft_n=128, waveform_seconds=2)
         _fill_sensor(proc, "s1", n_samples=300, mono_time=100.0)
@@ -202,6 +210,8 @@ class TestMultiSpectrumPayloadAlignment:
 
 
 class TestDriftSimulation:
+    """Cover drift and restart scenarios that should still surface sane alignment metadata."""
+
     def test_gradual_drift_stays_aligned(self) -> None:
         """Sensors ingesting data with small monotonic jitter remain aligned."""
         proc = _make_processor(sample_rate_hz=200, waveform_seconds=2)
@@ -230,6 +240,8 @@ class TestDriftSimulation:
 
 
 class TestCmdSyncClockProtocol:
+    """Verify the sync-clock UDP command round-trip and struct sizing stay consistent."""
+
     def test_pack_and_parse_sync_clock(self) -> None:
         from vibesensor.adapters.udp.protocol import (
             CMD_SYNC_CLOCK,


### PR DESCRIPTION
## Summary

This PR covers **chunk 035** of the full sequential repository review. I directly reviewed every code file in the chunk before making any edits. The chunk consists of the following five processing-related test modules:

- `apps/server/tests/infra/processing/test_snapshot_builder.py`
- `apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py`
- `apps/server/tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py`
- `apps/server/tests/infra/processing/test_time_align_edge_cases.py`
- `apps/server/tests/infra/processing/test_time_alignment.py`

These files sit around two closely related areas of the processing stack: snapshot selection / cache-hit behavior and spectrum / time-alignment regressions. Together they cover cache-hit decisions in the snapshot builder, window-size computation, smoothing and last-bin peak-selection regressions, runtime strength bucketing and noise-floor behavior, edge cases in `analysis_time_range()` / `compute_overlap()`, and the broader multi-sensor alignment flow including `CMD_SYNC_CLOCK` protocol handling.

All five files were opened and reviewed individually. Three of them were already in good shape and were left unchanged after review:

- `test_spectrum_and_peak_selection_regressions.py`
- `test_strength_and_spectrum_runtime_regressions.py`
- `test_time_align_edge_cases.py`

Those modules already have clear module docstrings, focused regression-oriented class docstrings, and readable assertion structure. I did not find dead code, misleading naming, stale comments, or safe refactors that would clearly improve maintainability without introducing unnecessary churn.

The two files that did benefit from a maintainability pass were:

- `test_snapshot_builder.py`
- `test_time_alignment.py`

Both modules already had useful module-level framing, but each contained multiple grouped test classes without class-level summaries. In practice that made the files somewhat harder to scan than neighboring processing test modules, especially because both files group related-but-distinct seams within a single module. In `test_snapshot_builder.py`, the two grouped concerns are cache-hit eligibility and snapshot-window sizing. In `test_time_alignment.py`, the grouped concerns include per-sensor window derivation, aligned and misaligned multi-sensor cases, multi-spectrum alignment metadata, drift simulation, sync-clock protocol round-tripping, and synced-clock edge conditions.

To address that, this PR adds concise class docstrings to the previously undocumented grouped test classes in those two files. In `test_snapshot_builder.py`, `TestCheckCacheHit` now explicitly states that it covers cache-hit eligibility based on generations and sample rate, and `TestComputeSnapshotWindow` now states that it exercises snapshot-window sizing and the separate-FFT-block decision. In `test_time_alignment.py`, the previously undocumented grouped classes now each declare their responsibility directly, making it much easier to scan the file and understand the logical structure before reading the individual test methods.

This is a behavior-preserving readability improvement only. No assertions changed, no helper logic changed, no production code changed, and no new abstractions or dependencies were introduced. The goal here was not to manufacture a larger diff but to make the reviewed files more self-explanatory while leaving the already-clear modules untouched.

I also considered whether the large `test_time_alignment.py` module should be split or otherwise restructured. I chose not to do that in this chunk because it would have expanded the scope beyond a clear behavior-preserving cleanup and introduced avoidable churn into a dense regression file that already has stable, meaningful coverage. Under the rules of this repository-review run, the correct move was to improve navigation and intent signaling inside the existing structure rather than refactor a stable file without a stronger maintainability payoff.

No dependency or standard-library substitutions were made in this chunk. No compatibility logic was removed. No dead-code deletions were justified. I likewise did not pull any later-chunk files forward: this PR is limited to the files assigned to chunk 035 and preserves the one-PR-per-chunk execution model required for the full repository review.

Validation was completed locally before opening the PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/processing/test_snapshot_builder.py apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py apps/server/tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py apps/server/tests/infra/processing/test_time_align_edge_cases.py apps/server/tests/infra/processing/test_time_alignment.py`
- `git diff --check`

That targeted pytest batch completed with **63 passing tests**, and `make lint` passed cleanly, including the repository’s static guardrails and contract-sync checks. Given that the diff is documentation-only within test code, the practical risk is very low, but the full chunk-local validation flow was still applied for consistency and traceability.

The main tradeoff in this PR is that the implementation diff is small relative to the amount of review work. That is expected and intentional. This review run is file-by-file and chunk-by-chunk, not diff-size driven. The standard is to inspect every code file and make only the changes that clearly improve maintainability without altering behavior. For chunk 035, that meant preserving three already clear regression modules as-is and tightening the internal scanability of two broader grouped test modules.

As a result, this PR completes the required individual review of all five code files in chunk 035, improves class-level discoverability in the snapshot-builder and time-alignment test coverage, and leaves behavior unchanged.
