### PR TITLE
Repo review: runtime tests chunk 036

### DIFF
--- a/apps/server/tests/infra/runtime/test_background_task_coordinator.py
+++ b/apps/server/tests/infra/runtime/test_background_task_coordinator.py
@@ -1,3 +1,5 @@
+"""Exercise background task supervision and cancellation timeout behavior."""
+
 from __future__ import annotations
 
 import asyncio

--- a/apps/server/tests/infra/runtime/test_client_metadata.py
+++ b/apps/server/tests/infra/runtime/test_client_metadata.py
@@ -1,3 +1,5 @@
+"""Cover runtime client-name persistence, clearing, and advertised-name application."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/apps/server/tests/infra/runtime/test_client_snapshot_projection.py
+++ b/apps/server/tests/infra/runtime/test_client_snapshot_projection.py
@@ -37,6 +37,8 @@ _POLICY = ClientLivenessPolicy(live_ttl_seconds=10.0, retention_ttl_seconds=30.0
 
 
 class TestProjectClientSnapshots:
+    """Cover connected/offline projection, ages, and optional metrics attachment."""
+
     def test_connected_record(self) -> None:
         """Active record with recent mono time → connected=True."""
         rec = _make_record(last_seen_mono=100.0)

--- a/apps/server/tests/infra/runtime/test_dedup_window.py
+++ b/apps/server/tests/infra/runtime/test_dedup_window.py
@@ -1,3 +1,5 @@
+"""Guard dedup-window recording, pruning, duplicate detection, and reset behavior."""
+
 from __future__ import annotations
 
 from vibesensor.infra.runtime.dedup_window import DedupWindow

--- a/apps/server/tests/infra/runtime/test_lifecycle.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle.py
@@ -52,6 +52,8 @@ def _make_lifecycle(db_path: str | None) -> tuple[LifecycleManager, RuntimeHealt
 
 
 class TestValidateStartupDiskCheck:
+    """Exercise low-disk warnings and startup skip branches around the history DB path."""
+
     def test_low_disk_appends_warning(self, tmp_path: Path) -> None:
         """Free space below threshold appends a warning to startup_warnings."""
         db_path = str(tmp_path / "vibesensor.db")

--- a/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
@@ -1,3 +1,5 @@
+"""Verify lifecycle shutdown logs lingering background and managed tasks consistently."""
+
 from __future__ import annotations
 
 import asyncio

--- a/apps/server/tests/infra/runtime/test_managed_job_shutdown.py
+++ b/apps/server/tests/infra/runtime/test_managed_job_shutdown.py
@@ -19,6 +19,8 @@ class _FakeJobSource:
 
 
 class TestManagedJobShutdown:
+    """Verify managed-job shutdown ignores inactive sources and cancels active tasks."""
+
     @pytest.mark.asyncio
     async def test_no_active_tasks_returns_empty(self) -> None:
         """Sources with no active tasks produce an empty lingering list."""

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -130,6 +130,8 @@ async def _run_loop(loop: ProcessingLoop, *, max_ticks: int) -> None:
 
 
 class TestProcessingLoopFailureTracking:
+    """Cover failure accounting, fatal backoff, and recovery transitions in the loop state."""
+
     @pytest.mark.asyncio
     async def test_single_failure_records_category_and_count(self) -> None:
         """A single ProcessingLoopError records category and increments failure count."""
@@ -229,6 +231,8 @@ class TestProcessingLoopFailureTracking:
 
 
 class TestProcessingLoopMismatchDetection:
+    """Verify sync-clock handling and configuration mismatch tracking during run ticks."""
+
     @pytest.mark.asyncio
     async def test_sync_clock_uses_control_plane_broadcaster(self) -> None:
         """Sync-clock ticks use the injected control-plane broadcaster seam."""
@@ -324,6 +328,8 @@ class TestProcessingLoopMismatchDetection:
 
 
 class TestProcessingLoopCleanup:
+    """Ensure eviction cleanup still runs around compute failures and disappearing clients."""
+
     @pytest.mark.asyncio
     async def test_compute_all_failure_still_evicts_using_fresh_active_ids(self) -> None:
         class _RefreshingRegistry(_StubRegistry):


### PR DESCRIPTION
## Summary

This PR covers **chunk 036** of the full sequential repository review. I directly reviewed every code file in the chunk before making any edits. The chunk contains the following ten runtime-focused test modules:

- `apps/server/tests/infra/runtime/test_background_task_coordinator.py`
- `apps/server/tests/infra/runtime/test_client_liveness_policy.py`
- `apps/server/tests/infra/runtime/test_client_metadata.py`
- `apps/server/tests/infra/runtime/test_client_snapshot_assembler.py`
- `apps/server/tests/infra/runtime/test_client_snapshot_projection.py`
- `apps/server/tests/infra/runtime/test_dedup_window.py`
- `apps/server/tests/infra/runtime/test_lifecycle.py`
- `apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py`
- `apps/server/tests/infra/runtime/test_managed_job_shutdown.py`
- `apps/server/tests/infra/runtime/test_processing_loop.py`

This chunk is centered on runtime orchestration and state-management seams: background task supervision, client liveness policy, runtime client metadata, snapshot assembly and projection, de-duplication windows, startup validation, shutdown consistency, managed background-job shutdown, and processing-loop failure / mismatch handling.

All ten files were opened and reviewed individually. Two files were already clear enough to leave untouched:

- `test_client_liveness_policy.py`
- `test_client_snapshot_assembler.py`

Both already had good file-level framing and compact, focused tests that were easy to scan. I did not find dead code, confusing helper structure, or any behavior-preserving refactor that would have been a better outcome than leaving them alone.

The remaining eight files all benefited from a small clarity pass. In some cases the gap was a missing module docstring; in others it was a missing class docstring around a grouped set of tests. This mattered especially in this runtime area because many of the files exercise “policy” or “orchestration” seams rather than a single straightforward function, so having explicit framing at the file or class boundary materially improves readability.

Concretely, this PR adds module docstrings to:

- `test_background_task_coordinator.py`
- `test_client_metadata.py`
- `test_dedup_window.py`
- `test_lifecycle_shutdown_consistency.py`

Those files previously opened straight into imports and helper code. The new headers make it immediately obvious what runtime behavior each file protects: supervision and cancellation-timeout handling for background tasks, runtime client-name persistence and advertised-name application, de-duplication window behavior, and shutdown logging consistency for lingering tasks.

This PR also adds class docstrings to grouped test classes in:

- `test_client_snapshot_projection.py`
- `test_lifecycle.py`
- `test_managed_job_shutdown.py`
- `test_processing_loop.py`

These files already had useful module-level framing, but grouped tests inside them were not always self-describing when scanned in isolation. The added class docstrings make the internal organization of the files more legible. For example, `test_processing_loop.py` now makes its major sections explicit: failure accounting and recovery, mismatch detection, and cleanup behavior around failures or disappearing clients. Similarly, `test_lifecycle.py` now signals that its grouped tests are specifically about startup low-disk warnings and skip branches, and `test_managed_job_shutdown.py` now states directly that it verifies the behavior around inactive sources versus active task cancellation.

No production code changed in this PR. No assertions changed. No helper logic changed. No new abstractions or dependencies were introduced. This is a documentation-and-structure-only maintainability pass inside runtime test modules.

I considered whether some of these files, especially `test_processing_loop.py`, would benefit from being split further. I intentionally did not do that here. While there is enough content in that module to imagine a broader refactor, there was not a strong enough behavior-preserving payoff to justify the churn in this chunk. The better outcome for the current review pass was to improve scanability and intent signaling within the existing, stable structure rather than restructure a well-functioning regression file.

I also did not find any safe dead-code removals, compatibility-layer removals, or utility consolidations that clearly reduced maintenance burden without broadening scope. The runtime tests themselves were already doing meaningful work; the missing piece was mostly consistent framing.

Validation was completed locally before opening the PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/runtime/test_background_task_coordinator.py apps/server/tests/infra/runtime/test_client_liveness_policy.py apps/server/tests/infra/runtime/test_client_metadata.py apps/server/tests/infra/runtime/test_client_snapshot_assembler.py apps/server/tests/infra/runtime/test_client_snapshot_projection.py apps/server/tests/infra/runtime/test_dedup_window.py apps/server/tests/infra/runtime/test_lifecycle.py apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py apps/server/tests/infra/runtime/test_managed_job_shutdown.py apps/server/tests/infra/runtime/test_processing_loop.py`
- `git diff --check`

That targeted pytest batch completed with **49 passing tests**, and `make lint` passed cleanly, including the repository’s static guardrails and contract-sync checks. Because the diff is limited to documentation inside test files, the practical risk is extremely low, but the same chunk-level validation pattern was applied for consistency and auditability.

There were no dependency substitutions, no standard-library rewrites, and no behavior-affecting refactors in this chunk. There are also no new follow-up requirements introduced by the PR. The change set stays tightly aligned with the chunk assignment and preserves the one-PR-per-chunk rule for the full repository review.

The tradeoff is, again, that the diff is smaller than the review effort behind it. That is expected and appropriate for this run. The goal is to review every code file and apply only the improvements that are clearly worthwhile and behavior-preserving, not to maximize diff size. For chunk 036, that meant improving readability and internal navigation across the runtime test suite while leaving already-clear files untouched.

This PR therefore completes the required individual review of all ten code files in chunk 036, improves the readability of eight runtime test modules, and preserves all behavior.
