### PR TITLE
Chunk 037: clarify runtime registry test coverage

### DIFF
--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -1,3 +1,5 @@
+"""Cover registry protocol updates, persistence, deduplication, and snapshot behavior."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/apps/server/tests/infra/runtime/test_registry_thread_safety.py
+++ b/apps/server/tests/infra/runtime/test_registry_thread_safety.py
@@ -1,3 +1,5 @@
+"""Verify registry snapshots stay frozen and point-in-time safe for callers."""
+
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError

--- a/apps/server/tests/infra/runtime/test_rotational_speeds.py
+++ b/apps/server/tests/infra/runtime/test_rotational_speeds.py
@@ -1,3 +1,5 @@
+"""Guard rotational-basis speed-source selection across fallback and GPS states."""
+
 from __future__ import annotations
 
 from vibesensor.infra.runtime.rotational_speeds import rotational_basis_speed_source

--- a/apps/server/tests/infra/runtime/test_startup_runner.py
+++ b/apps/server/tests/infra/runtime/test_startup_runner.py
@@ -33,9 +33,14 @@ def _make_runner() -> tuple[StartupRunner, RuntimeHealthState, MagicMock]:
     task_supervisor = MagicMock()
     task_supervisor.start = MagicMock(return_value=MagicMock(spec=asyncio.Task))
 
+    def _start_background_task(coro, *, name: str) -> MagicMock:
+        del name
+        coro.close()
+        return MagicMock(spec=asyncio.Task)
+
     background_tasks = MagicMock()
     background_tasks.add = MagicMock()
-    background_tasks.start = MagicMock()
+    background_tasks.start = MagicMock(side_effect=_start_background_task)
 
     udp_transport = MagicMock()
     udp_transport.startup = AsyncMock()
@@ -51,6 +56,8 @@ def _make_runner() -> tuple[StartupRunner, RuntimeHealthState, MagicMock]:
 
 
 class TestStartupRunnerPhases:
+    """Cover startup phase ordering, success, failure, and UDP-before-background sequencing."""
+
     @pytest.mark.asyncio
     async def test_phases_tracked_in_order(self) -> None:
         """Health-state phases are set in the expected order."""

--- a/apps/server/tests/infra/runtime/test_task_supervisor.py
+++ b/apps/server/tests/infra/runtime/test_task_supervisor.py
@@ -1,3 +1,5 @@
+"""Exercise supervised task restart, terminal failure recording, and backoff caps."""
+
 from __future__ import annotations
 
 import asyncio

--- a/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
+++ b/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
@@ -1,3 +1,5 @@
+"""Verify UDP transport startup wiring and shutdown cleanup behavior."""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary

This PR covers **chunk-037** of the full sequential repository review and includes the following files, each of which I reviewed individually before making any changes:

- `apps/server/tests/infra/runtime/test_registry.py`
- `apps/server/tests/infra/runtime/test_registry_diagnostics.py`
- `apps/server/tests/infra/runtime/test_registry_location_cap.py`
- `apps/server/tests/infra/runtime/test_registry_thread_safety.py`
- `apps/server/tests/infra/runtime/test_rotational_speeds.py`
- `apps/server/tests/infra/runtime/test_runtime.py`
- `apps/server/tests/infra/runtime/test_startup_runner.py`
- `apps/server/tests/infra/runtime/test_task_supervisor.py`
- `apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py`

The goal for this chunk, consistent with the overall review rules for the run, was to make only behavior-preserving maintainability improvements. No production runtime code was changed in this PR. The diff is limited to test readability and test-harness correctness. Six of the nine reviewed files changed, while three files were reviewed directly and intentionally left untouched because they were already clear enough and did not justify safe cleanup.

## What changed

The largest file in the chunk was `test_registry.py`. It already contained broad coverage for registry updates, deduplication, naming, location handling, eviction, and snapshot behavior, but because it had no module-level framing it was harder to scan quickly than it needed to be. I added a concise module docstring so future maintainers can understand the scope of the file before dropping into the individual tests.

I made similar module-level clarifications in `test_registry_thread_safety.py`, `test_rotational_speeds.py`, `test_task_supervisor.py`, and `test_udp_transport_lifecycle.py`. In each case the problem was the same: the file already had solid assertions, but the overall purpose of the grouped regression coverage was implicit instead of explicit. The new docstrings make the scope easier to recognize without changing any assertions, fixtures, or execution flow.

`test_startup_runner.py` received two closely related cleanups. First, I added a class docstring to `TestStartupRunnerPhases` so the grouped startup-phase scenarios are easier to understand at a glance. Second, while validating the chunk I found that the existing `background_tasks.start` mock in `_make_runner()` accepted the `startup_recover()` coroutine without consuming it. The production `BackgroundTaskCoordinator.start()` method schedules that coroutine immediately, so the old test double left an unawaited coroutine behind and surfaced runtime warnings in the focused pytest run. I updated the mock to close the coroutine it receives and return a task-shaped mock. That keeps the tests behavior-preserving while aligning the helper with the real contract closely enough to eliminate the warning.

## Files reviewed and left unchanged

I reviewed `test_registry_diagnostics.py`, `test_registry_location_cap.py`, and `test_runtime.py` directly and left them unchanged.

`test_registry_diagnostics.py` already had clear module framing and focused test naming for its liveness, metadata, and snapshot reporting scenarios. `test_registry_location_cap.py` already explained its registry-assigned-name and capacity-regression focus well enough through its existing structure and names. `test_runtime.py` already had a useful module docstring and straightforward helper structure around `LifecycleRuntime` defaults and wiring. I did not force stylistic churn into those files just to make every reviewed file change.

## Categories of improvement

The first category here is straightforward test discoverability. The added module and class docstrings reduce the amount of source a maintainer needs to read before understanding why a given file exists and what behavior family it protects. That is especially helpful in the runtime test area, where many modules are regression-oriented and several files exercise closely related lifecycle concepts.

The second category is test-harness alignment. The `test_startup_runner.py` adjustment does not change what the startup runner is expected to do, but it does make the test double behave more like the production background-task coordinator by consuming the coroutine it is handed. This removes noisy warnings from the focused validation run and makes the helper less misleading for future edits.

## Dependency, dead-code, and scope notes

No dependencies were added, removed, or upgraded in this chunk. No standard-library substitution was needed because the code under review did not contain custom utility logic that warranted replacement.

I also did not remove any dead code in this chunk. The reviewed files are active regression tests, and none of the currently covered scenarios looked obsolete enough to remove confidently without changing the maintenance contract of the test suite. Where a file was already clear, I left it unchanged.

I deliberately avoided broader refactors in the runtime testing area. For example, there may be future opportunities to reorganize some runtime regression coverage by theme, but doing so here would create unnecessary churn across multiple files and would go beyond the smallest safe, behavior-preserving cleanup for this chunk.

## Validation

I validated the chunk locally with:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_diagnostics.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/infra/runtime/test_registry_thread_safety.py apps/server/tests/infra/runtime/test_rotational_speeds.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/infra/runtime/test_startup_runner.py apps/server/tests/infra/runtime/test_task_supervisor.py apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py`
- `git diff --check`

The focused pytest batch passed with **69 tests passing** after the startup-runner mock adjustment removed the unawaited-coroutine warning.

## Risks, tradeoffs, and follow-up

Risk is low because the diff stays inside tests and mostly adds framing text. The only executable change is in the startup-runner test helper, and that change narrows the gap between the helper and the production coordinator instead of widening it.

The main tradeoff is that I intentionally kept the cleanup modest. I did not try to normalize every runtime test file to an identical structure, and I did not collapse or rename tests that were already clear. That was deliberate: the purpose of this PR is to improve maintainability without introducing semantic risk or broad churn.

No immediate cross-chunk dependency was introduced. The next review unit remains chunk-038.

One additional note on review discipline for this chunk: I did not infer quality from neighboring files or from prior runtime chunks. Each file listed above was opened and inspected directly, including the unchanged files. That mattered here because the only non-docstring issue in the chunk was subtle and lived in test support code rather than in an assertion body: the unconsumed `startup_recover()` coroutine warning only became obvious during focused validation after the direct review. Without checking the whole file and then following up on the warning, it would have been easy to merge a “documentation-only” PR that still left noisy runtime warnings in place. The final diff therefore reflects both file-by-file review and validation-driven cleanup, while still staying strictly within behavior-preserving scope.
