### PR TITLE
Chunk 039: clarify integration regression groups

### DIFF
--- a/apps/server/tests/integration/test_concurrency_generation_guard_regressions.py
+++ b/apps/server/tests/integration/test_concurrency_generation_guard_regressions.py
@@ -124,6 +124,8 @@ class TestAutoStopGenerationGuard:
 
 
 class TestDeleteRunIfSafe:
+    """Cover safe-delete outcomes for complete, active, analyzing, missing, and error runs."""
+
     def test_delete_complete_run(self, tmp_path: Path) -> None:
         db = HistoryDB(tmp_path / "h.db")
         db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
@@ -176,6 +178,8 @@ class TestDeleteRunIfSafe:
 
 
 class TestFinalizeRunWithMetadata:
+    """Cover metadata updates on finalize_run and the no-op path after status changes."""
+
     def test_atomic_metadata_and_status(self, tmp_path: Path) -> None:
         db = HistoryDB(tmp_path / "h.db")
         db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))

--- a/apps/server/tests/integration/test_coverage_gap_audit_round2.py
+++ b/apps/server/tests/integration/test_coverage_gap_audit_round2.py
@@ -210,6 +210,8 @@ class TestMultiSpectrumAlignment:
 
 
 class TestWorkerPoolExtended:
+    """Cover direct submit behavior, runtime stats, worker clamping, and wait-free shutdown."""
+
     def test_submit_returns_future(self) -> None:
         pool = WorkerPool(max_workers=2)
         try:
@@ -312,6 +314,8 @@ class TestWSHubRunLoop:
 
 
 class TestGPSFallbackSettings:
+    """Cover fallback timeout clamping, non-finite overrides, and manual-source toggles."""
+
     def test_set_fallback_settings_clamps_stale_timeout(self) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
         m.set_fallback_settings(stale_timeout_s=0.1)
@@ -346,6 +350,8 @@ class TestGPSFallbackSettings:
 
 
 class TestGPSReconnectBackoff:
+    """Cover reconnect delay growth/capping and VERSION-message device-info capture."""
+
     @pytest.mark.asyncio
     async def test_reconnect_delay_doubles_and_caps(self, monkeypatch: pytest.MonkeyPatch) -> None:
         m = GPSSpeedMonitor(gps_enabled=True)
@@ -417,6 +423,8 @@ class TestGPSReconnectBackoff:
 
 
 class TestHistoryDBAnalysisIdempotency:
+    """Cover store_analysis idempotency, error transitions, and stored-analysis readback."""
+
     def test_store_analysis_twice_keeps_first(self, history_db: HistoryDB) -> None:
         history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
         history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
@@ -459,6 +467,8 @@ class TestHistoryDBAnalysisIdempotency:
 
 
 class TestHistoryDBFinalizeNoOp:
+    """Cover finalize_run no-op behavior for complete, missing, and non-recording runs."""
+
     def test_finalize_run_noop_on_already_complete(self, history_db: HistoryDB) -> None:
         history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
         history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
@@ -504,6 +514,8 @@ class TestHistoryDBFinalizeNoOp:
 
 
 class TestFlattenForCSV:
+    """Cover CSV flattening for nested known fields and omission of unknown extras."""
+
     def test_nested_dict_serialised_as_json(self) -> None:
         row = {"top_peaks": [{"hz": 30, "amp": 0.1}], "accel_x_g": 0.5}
         flat = _flatten_for_csv(row)
@@ -538,6 +550,8 @@ class TestFlattenForCSV:
 
 
 class TestSafeFilename:
+    """Cover exact sanitization outputs, special-character replacement, and truncation."""
+
     @pytest.mark.parametrize(
         ("input_name", "expected"),
         [


### PR DESCRIPTION
## Summary

This PR covers **chunk-039** of the full sequential repository review. I reviewed each of the following ten integration test files directly before deciding what to change:

- `apps/server/tests/integration/test_api_history_processing_regressions.py`
- `apps/server/tests/integration/test_concurrency_generation_guard_regressions.py`
- `apps/server/tests/integration/test_contract_analysis_persistence_http.py`
- `apps/server/tests/integration/test_contract_analysis_report.py`
- `apps/server/tests/integration/test_contract_persistence_analysis.py`
- `apps/server/tests/integration/test_coverage_gap_audit_round2.py`
- `apps/server/tests/integration/test_decode_project_roundtrip.py`
- `apps/server/tests/integration/test_exception_discipline.py`
- `apps/server/tests/integration/test_io_and_time_guard_regressions.py`
- `apps/server/tests/integration/test_messy_real_world.py`

The goal for the chunk, consistent with the review rules for the overall run, was to make only behavior-preserving maintainability improvements. This PR stays entirely in tests. No production integration boundaries, adapters, schemas, or runtime logic changed.

## What changed

Two files changed in this chunk.

In `test_concurrency_generation_guard_regressions.py`, I added class docstrings to the previously unlabeled `TestDeleteRunIfSafe` and `TestFinalizeRunWithMetadata` groups. The module was already organized into numbered sections, and two of its four grouped scenario classes already had explicit summaries. The remaining two classes were still understandable from their test names, but the file reads more cleanly when every major regression family is labeled at the class boundary as well as in the surrounding section comments.

In `test_coverage_gap_audit_round2.py`, I added class docstrings to the remaining unlabeled grouped scenario classes: `TestWorkerPoolExtended`, `TestGPSFallbackSettings`, `TestGPSReconnectBackoff`, `TestHistoryDBAnalysisIdempotency`, `TestHistoryDBFinalizeNoOp`, `TestFlattenForCSV`, and `TestSafeFilename`. This file is intentionally broad and sectioned by topic, covering processing helpers, worker-pool behavior, WebSocket loops, GPS fallback and reconnect behavior, history DB edge cases, and CSV / filename export helpers. Because of that breadth, missing class-level framing created avoidable scanning friction. The added docstrings make it clearer which behavior family each class protects without changing any assertions or helper behavior.

## Files reviewed and left unchanged

The other eight files were reviewed directly and intentionally left unchanged:

- `test_api_history_processing_regressions.py`
- `test_contract_analysis_persistence_http.py`
- `test_contract_analysis_report.py`
- `test_contract_persistence_analysis.py`
- `test_decode_project_roundtrip.py`
- `test_exception_discipline.py`
- `test_io_and_time_guard_regressions.py`
- `test_messy_real_world.py`

I did not force changes into those files simply because they were in scope for the chunk. Each one already had good module-level framing, clear function or class naming, or both. In particular, `test_exception_discipline.py` and `test_io_and_time_guard_regressions.py` already had class-level summaries across their grouped scenarios, and `test_messy_real_world.py` is already heavily documented at the module and individual-test level. Likewise, the contract-bridge files and the decode/project round-trip file were already concise and readable enough that additional cleanup would mostly have been churn.

## Categories of improvement

The primary category of improvement in this PR is **test discoverability and structural clarity**. These integration files are not random collections of assertions; they encode high-value regression knowledge at subsystem boundaries. Making the grouped scenario classes self-describing reduces the amount of code a maintainer has to read before understanding what a given section is supposed to guarantee.

That matters especially in chunk-039 because several of these files are deliberately wide in scope. `test_coverage_gap_audit_round2.py`, for example, is designed as a sweep across previously identified coverage gaps. Without consistent class-level framing, the reader has to infer the category boundary from comments, helper names, and the first few test methods. The added docstrings make those boundaries explicit and lower the cost of navigating the file later.

## What I deliberately did not change

I considered whether to split the broad audit modules into smaller files or to normalize helper naming across the whole chunk. I decided against that. Those would be much larger refactors, and while they could potentially be reasonable in isolation, they would introduce unnecessary churn for a review pass that is supposed to preserve behavior and keep each chunk narrowly scoped.

I also did not remove any tests or helpers as dead code. The reviewed integration files remain actively meaningful: they cover contract bridges, concurrency fixes, exception-discipline rules, real-world edge cases, and regression audits that still match important behavior surfaces in the codebase.

No dependencies were added, removed, or updated in this chunk. No standard-library substitutions were warranted because the changes were limited to test framing rather than implementation utilities.

## Validation

I validated the chunk locally with:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_api_history_processing_regressions.py apps/server/tests/integration/test_concurrency_generation_guard_regressions.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_contract_persistence_analysis.py apps/server/tests/integration/test_coverage_gap_audit_round2.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/integration/test_exception_discipline.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_messy_real_world.py`
- `git diff --check`

The focused integration batch passed with **233 tests passing**.

## Risks, tradeoffs, and follow-up

Risk is low because the diff stays entirely inside tests and only adds docstrings. There is no executable behavior change in this chunk.

The main tradeoff is that I kept the cleanup intentionally small relative to the size of the review set. That was deliberate. The right move for this chunk was not to maximize line churn, but to apply the smallest real maintainability improvements after direct review of each file. Two modules still had unlabeled scenario groups; those groups now have explicit framing. The other eight files did not justify additional safe cleanup, so they stayed as they were.

There are no special cross-chunk follow-ups introduced by this PR. Once CI is green, the next step is simply to merge chunk-039 and continue into chunk-040.

One additional note on review discipline for this chunk: I did not treat the unchanged files as implicitly approved because they sat next to the two changed modules. Each file was opened and inspected directly. That mattered here because the integration directory mixes several styles of regression coverage: narrowly targeted bridge tests, large audit sweeps, and broad scenario matrices. A blanket cleanup rule would have produced unnecessary churn in files that were already well documented, while missing the specific modules where grouped scenario boundaries were still implicit. The final diff reflects that file-by-file judgment: only the classes that genuinely benefited from extra framing were touched, and the modules that were already sufficiently self-explanatory were left alone. That keeps the PR behavior-preserving, reviewable, and aligned with the “smallest worthwhile complete cleanup” goal of the overall run.
