### PR TITLE
review: tighten chunk 040 integration test framing

### DIFF
--- a/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
+++ b/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
@@ -1,3 +1,5 @@
+"""Exercise the four-sensor UDP-to-analysis-to-PDF pipeline end to end."""
+
 from __future__ import annotations
 
 import io

--- a/apps/server/tests/integration/test_review_guardrails_core_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_core_regressions.py
@@ -53,6 +53,8 @@ class TestDomainModelsPublicAPI:
 
 
 class TestBuildOrderBandsLocation:
+    """Verify order-band helpers stay in the shared module and keep basic behavior."""
+
     def test_importable_from_order_bands(self) -> None:
         assert callable(build_order_bands)
 
@@ -89,6 +91,8 @@ class TestBuildOrderBandsLocation:
 
 
 class TestWorkerPoolSubmitTiming:
+    """Verify WorkerPool.submit accumulates task counts and total runtime metrics."""
+
     def test_submit_tracks_run_time(self) -> None:
         pool = WorkerPool(max_workers=2)
         try:
@@ -119,6 +123,8 @@ class TestWorkerPoolSubmitTiming:
 
 
 class TestSanitizeName:
+    """Verify client-name sanitization strips controls and truncates by UTF-8 byte length."""
+
     def test_ascii_within_limit(self) -> None:
         assert sanitize_client_name("Hello") == "Hello"
 
@@ -145,6 +151,8 @@ class TestSanitizeName:
 
 
 class TestBoundedSampleTrim:
+    """Verify bounded_sample never exceeds max_items, including tight edge cases."""
+
     def test_never_exceeds_max_items(self) -> None:
         for total in range(1, 30):
             for max_items in range(1, 10):
@@ -168,6 +176,8 @@ class TestBoundedSampleTrim:
 
 
 class TestModuleAllExports:
+    """Verify key public modules keep non-empty __all__ exports for import guardrails."""
+
     @pytest.mark.parametrize(
         "module_path",
         [


### PR DESCRIPTION
## Summary

This PR covers repository-review chunk `040` and continues the file-by-file maintainability pass over the integration-test suite. The chunk contains ten code files, and each one was opened and reviewed directly before any edit was made. The files covered are:

- `apps/server/tests/integration/test_multi_domain_regressions.py`
- `apps/server/tests/integration/test_multi_no_transient.py`
- `apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py`
- `apps/server/tests/integration/test_multi_system_overlap.py`
- `apps/server/tests/integration/test_multi_transient.py`
- `apps/server/tests/integration/test_real_world_scenarios.py`
- `apps/server/tests/integration/test_refactor_contract_regressions.py`
- `apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py`
- `apps/server/tests/integration/test_report_pipeline.py`
- `apps/server/tests/integration/test_review_guardrails_core_regressions.py`

All ten files were individually inspected and recorded in the local review tracker before this PR was prepared. The outcome for this chunk was intentionally small and behavior-preserving: eight files were left unchanged after direct review, and two files received documentation-only framing improvements that make the suite easier to navigate without changing any assertions, fixtures, or runtime behavior.

## What changed

The first edit is in `test_multi_sensor_e2e_pipeline.py`. This module exercises a large end-to-end path: UDP ingestion, recording, analysis, and PDF generation across a four-sensor scenario. Even though the underlying tests were already solid, the file started immediately with imports and did not summarize its role at the top. I added a short module docstring that states the scope of the end-to-end pipeline being exercised. That gives future readers immediate context before they drop into the helper setup, network simulation, and PDF verification details.

The second set of edits is in `test_review_guardrails_core_regressions.py`. This module already had a clear module docstring and several well-defined grouped regression classes, but a handful of the remaining classes still relied on the test names alone to explain their purpose. I added short class docstrings for `TestBuildOrderBandsLocation`, `TestWorkerPoolSubmitTiming`, `TestSanitizeName`, `TestBoundedSampleTrim`, and `TestModuleAllExports`. These summaries do not alter the tests themselves; they simply explain why each grouped regression exists and what contract it is protecting.

No production code changed in this chunk. No test logic changed. No fixtures, assertions, helper behavior, inputs, outputs, or data contracts changed. The diff is limited to docstrings that improve readability and maintenance ergonomics for future contributors performing targeted debugging in this part of the suite.

## Review findings by file

During direct review, the other eight files were evaluated for the same kinds of safe, behavior-preserving improvements that have been applied in earlier chunks: dead code removal, duplicate helpers, misleading comments, weak naming, unnecessary compatibility layers, and opportunities to simplify test scaffolding without changing semantics. In this chunk, those opportunities did not clear the threshold for a worthwhile edit.

`test_multi_domain_regressions.py` was already well organized around bug-labeled sections and clear scenario intent. `test_multi_no_transient.py` and `test_multi_transient.py` are both long scenario matrices, but their structure and naming already make the coverage understandable without additional churn. `test_multi_system_overlap.py` was similarly readable, with comments and grouping that already explain the overlap cases. `test_real_world_scenarios.py` and `test_refactor_contract_regressions.py` already had enough framing through their module and class structure. `test_report_delivery_and_stream_resilience_regressions.py` was also clear in its current form. `test_report_pipeline.py` is one of the longer files in the chunk, so I reviewed it carefully from start to finish, including the later sections, but concluded that additional refactoring or comment movement would have introduced noise rather than real improvement.

That review outcome matters because this repository-wide pass is explicitly not a style-only sweep. If a file already communicates its purpose well enough, leaving it alone is the better maintenance decision.

## Why these changes are useful

The integration suite in this area carries high-value regression coverage across multi-sensor analysis, report generation, and review guardrails. When these tests fail, maintainers often need to understand the intent of a file or grouped class quickly before tracing a failure into helpers or backend code. Small framing improvements at the module and class level reduce that orientation cost. They also preserve the current test structure rather than forcing broader refactors into files that are already stable and working.

I specifically avoided more invasive cleanup here because the chunk’s files are integration-heavy and cover cross-cutting behavior. Even obviously mechanical changes can create unnecessary diff noise in modules that people may use for incident debugging or regression investigation. The chosen edits improve readability while keeping review risk very low.

## Validation

Local validation for this chunk was run before preparing the PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_multi_domain_regressions.py apps/server/tests/integration/test_multi_no_transient.py apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py apps/server/tests/integration/test_multi_system_overlap.py apps/server/tests/integration/test_multi_transient.py apps/server/tests/integration/test_real_world_scenarios.py apps/server/tests/integration/test_refactor_contract_regressions.py apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py apps/server/tests/integration/test_report_pipeline.py apps/server/tests/integration/test_review_guardrails_core_regressions.py`
- `git diff --check`

The focused pytest batch passed with `540 passed`, which covers the full chunk file list rather than only the two touched files. That gives a strong local signal that the documentation-only edits did not disturb this slice of the integration suite.

## Risks, tradeoffs, and skipped changes

The main tradeoff in this chunk is restraint. I found no safe dead-code removals and no simplifications that were clearly worth the churn in the larger scenario-heavy files. I deliberately skipped speculative refactors, helper extraction, or naming changes that could have expanded scope without delivering a clear maintenance gain. Because the repository-review mandate is behavior preservation first, leaving eight files unchanged after direct review was the correct outcome.

There are no dependency changes, no standard-library substitutions, and no contract changes in this PR. The only risk is the normal one associated with touching test files at all, and the focused chunk validation meaningfully reduces that risk.

## Follow-up context

This PR completes chunk `040` only. Any future cleanup in adjacent integration modules should stay within the repository-review chunk boundaries so each PR remains attributable to its reviewed file set. As with prior chunks, the local tracker records that all ten code files in this chunk were individually reviewed and whether they changed or were left unchanged after inspection.
