### PR TITLE
review: tighten chunk 041 regression framing

### DIFF
--- a/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
@@ -53,6 +53,8 @@ def _make_control_plane() -> UDPControlPlane:
 
 
 class TestRemoveSensorRollback:
+    """Verify sensor removal rolls back in-memory state when persistence fails."""
+
     def test_remove_sensor_rolls_back_on_persist_failure(self) -> None:
         store = _make_store_with_sensor()
         assert "aabbccddeeff" in store.get_sensors()
@@ -83,6 +85,8 @@ class TestRemoveSensorRollback:
 
 
 class TestNonWheelTokensModuleLevel:
+    """Verify non-wheel classification tokens stay module-scoped and effective."""
+
     def test_non_wheel_tokens_is_module_constant(self) -> None:
         assert hasattr(locations_mod, "_NON_WHEEL_TOKENS")
         assert isinstance(locations_mod._NON_WHEEL_TOKENS, tuple)
@@ -107,6 +111,8 @@ class TestNonWheelTokensModuleLevel:
 
 
 class TestResolveSpeedAtomicSnapshot:
+    """Verify GPS speed resolution reads from and updates the atomic snapshot."""
+
     def test_speed_mps_property_reads_from_snapshot(self) -> None:
         m = _make_gps_monitor()
         assert m.speed_mps is None
@@ -147,6 +153,8 @@ class TestResolveSpeedAtomicSnapshot:
 
 
 class TestCarLibraryCopies:
+    """Verify car-library query helpers return copies rather than mutable internals."""
+
     def test_get_models_returns_copies(self) -> None:
         if not CAR_LIBRARY:
             pytest.skip("No car library data loaded")
@@ -182,6 +190,8 @@ class TestCarLibraryCopies:
 
 
 class TestCmdSeqLock:
+    """Verify UDP control sequence generation remains lock-protected and monotonic."""
+
     def test_udp_control_plane_has_cmd_seq_lock(self) -> None:
         cp = _make_control_plane()
         assert hasattr(cp, "_cmd_seq_lock")
@@ -202,6 +212,8 @@ class TestCmdSeqLock:
 
 
 class TestWSDebugLazy:
+    """Verify WebSocket debug mode is determined from the environment at call time."""
+
     def test_ws_debug_function_exists(self) -> None:
         assert callable(_ws_debug_enabled)
 
@@ -227,6 +239,8 @@ class TestWSDebugLazy:
 
 
 class TestWorkerPoolAliveProtection:
+    """Verify WorkerPool shutdown state is enforced through the locked alive flag."""
+
     def test_submit_checks_alive_under_lock(self) -> None:
         pool = WorkerPool(max_workers=1)
         pool.shutdown()
@@ -247,6 +261,8 @@ class TestWorkerPoolAliveProtection:
 
 
 class TestAsFloatOrNoneImport:
+    """Verify order-band float parsing remains exposed without extra alias layers."""
+
     def test_as_float_or_none_accessible_from_order_bands(self) -> None:
         assert order_bands_as_float_or_none(3.14) == 3.14
         assert order_bands_as_float_or_none(None) is None
@@ -258,6 +274,8 @@ class TestAsFloatOrNoneImport:
 
 
 class TestUdpControlTxAll:
+    """Verify udp_control_tx keeps the intended public __all__ surface."""
+
     def test_has_all_export(self) -> None:
         assert hasattr(udp_control_tx_mod, "__all__")
         assert "UDPControlPlane" in udp_control_tx_mod.__all__

--- a/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
@@ -112,6 +112,8 @@ def test_ring_buffer_wraparound_returns_correct_latest_data() -> None:
 
 
 class TestBoundedSample:
+    """Verify bounded_sample handles small inputs, halving, and total_hint cases."""
+
     @pytest.mark.parametrize(
         ("n_items", "max_items", "total_hint", "exp_total", "exp_len", "exp_stride"),
         [

--- a/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
@@ -12,6 +12,8 @@ from vibesensor.infra.processing import SignalProcessor
 # Fix 1 – SQLite busy_timeout is set
 # ---------------------------------------------------------------------------
 class TestSQLiteBusyTimeout:
+    """Verify HistoryDB configures a nonzero SQLite busy timeout on connect."""
+
     def test_busy_timeout_is_set(self, tmp_path: Path) -> None:
         """HistoryDB must set PRAGMA busy_timeout to avoid immediate SQLITE_BUSY."""
         db = HistoryDB(tmp_path / "test.db")
@@ -27,6 +29,8 @@ class TestSQLiteBusyTimeout:
 # Fix 2 – flush_client_buffer bumps ingest_generation
 # ---------------------------------------------------------------------------
 class TestFlushBumpsGeneration:
+    """Verify flush_client_buffer invalidates cached metrics via generation bumps."""
+
     def test_flush_increments_ingest_generation(self) -> None:
         """Flushing a buffer must bump ingest_generation to invalidate stale caches."""
         proc = SignalProcessor(

--- a/apps/server/tests/integration/test_scenario_ground_truth_invariants.py
+++ b/apps/server/tests/integration/test_scenario_ground_truth_invariants.py
@@ -38,6 +38,8 @@ class _FakeSimClient:
 
 
 class TestSimulatorDeterminism:
+    """Verify simulator command helpers keep stable per-sensor scenario contracts."""
+
     def test_road_fixed_scenario_applies_stable_gains(self) -> None:
         from vibesensor.adapters.simulator.commands import apply_road_fixed_scenario
 
@@ -126,6 +128,8 @@ class TestSimulatorDeterminism:
 
 
 class TestLanguageSelectionPrecedence:
+    """Verify report-language selection prefers explicit inputs over fallback metadata."""
+
     def test_explicit_lang_overrides_metadata(self) -> None:
         summary = summarize_run_data(
             standard_metadata(language="nl"),
@@ -190,6 +194,8 @@ class TestLanguageSelectionPrecedence:
 
 
 class TestSpeedBandMixedPhase:
+    """Verify mixed-phase runs report the dominant fault speed band rather than setup phases."""
+
     def test_ramp_then_cruise_fault_reports_cruise_band(self) -> None:
         samples: list[dict[str, Any]] = []
         t = 0.0
@@ -324,6 +330,8 @@ class TestSpeedBandMixedPhase:
 
 
 class TestConfidenceGuardrails:
+    """Verify confidence stays bounded across clear, diffuse, and short-lived faults."""
+
     def test_clear_single_sensor_fault_has_reasonable_confidence(self) -> None:
         summary = summarize_run_data(
             standard_metadata(),


### PR DESCRIPTION
## Summary

This PR covers repository-review chunk `041`, which contains ten integration-test files from `apps/server/tests/integration/`. In keeping with the repository-wide review rules for this run, every code file in the chunk was opened and reviewed directly before any changes were made, and the outcome for each file was recorded in the local review tracker. The reviewed files are:

- `apps/server/tests/integration/test_review_guardrails_extended_regressions.py`
- `apps/server/tests/integration/test_runtime_fallbacks_regressions.py`
- `apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `apps/server/tests/integration/test_runtime_quality_pass_regressions.py`
- `apps/server/tests/integration/test_runtime_queue_and_export_regressions.py`
- `apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py`
- `apps/server/tests/integration/test_scenario_ground_truth_front_axle.py`
- `apps/server/tests/integration/test_scenario_ground_truth_invariants.py`
- `apps/server/tests/integration/test_scenario_ground_truth_nuisance.py`
- `apps/server/tests/integration/test_scenario_ground_truth_rear_axle.py`

The resulting code changes are intentionally behavior-preserving and narrowly scoped. Six files were left unchanged after direct review because they already had sufficient framing and structure for their current role. Four files received documentation-only class-level framing improvements to make grouped regression coverage easier to scan during future maintenance, debugging, and review work.

## What changed

The largest change is in `test_review_guardrails_extended_regressions.py`. That module already had section headers and a helpful module docstring, but many of the grouped regression classes still depended entirely on method names to communicate intent. I added class docstrings for the remove-sensor rollback, non-wheel token classification, GPS atomic snapshot, car-library copy semantics, command-sequence locking, lazy WebSocket debug flag evaluation, worker-pool alive protection, order-band float parsing, and `__all__` export guardrails. These additions do not alter assertions or behavior; they simply make the purpose of each regression group visible at class declaration time.

In `test_runtime_quality_pass_regressions.py`, I added a class docstring to `TestBoundedSample`. That file already separates its issue groups with strong section comments, but the bounded-sample tests were the only grouped class in the file without a short summary of what edge cases it covered. The new docstring aligns that class with the surrounding framing and makes it faster to understand why the parameterized cases are grouped together.

In `test_runtime_queue_and_export_regressions.py`, I added class docstrings to `TestSQLiteBusyTimeout` and `TestFlushBumpsGeneration`. This module is short, but because it contains two distinct fix regressions, the class docstrings help future readers understand the contract of each group immediately rather than inferring it from the method bodies.

In `test_scenario_ground_truth_invariants.py`, I added class docstrings to `TestSimulatorDeterminism`, `TestLanguageSelectionPrecedence`, `TestSpeedBandMixedPhase`, and `TestConfidenceGuardrails`. That file covers several different invariant families in one place, so the extra class framing makes the transitions between simulator behavior, language precedence, speed-band interpretation, and confidence rules much easier to follow.

No production files changed. No assertions changed. No scenario data changed. No fixtures changed. No helper semantics changed. This PR is limited to readability improvements inside the test suite.

## Review outcomes for unchanged files

The other six files in the chunk were still reviewed in full and were not skipped. `test_runtime_fallbacks_regressions.py`, `test_runtime_nan_and_update_guard_regressions.py`, and `test_runtime_validation_and_schema_regressions.py` were already clearly structured with module docstrings and class-level summaries that explain each regression grouping. `test_scenario_ground_truth_front_axle.py`, `test_scenario_ground_truth_nuisance.py`, and `test_scenario_ground_truth_rear_axle.py` are more scenario-spec-driven than class-driven, and their current structure is already concise and readable. In those modules, adding more comments or reshaping assertions would have created churn without a meaningful maintainability gain.

That restraint is important for this full-repository review. The goal is not to force edits into every file; it is to improve files where a clearly useful, behavior-preserving change exists and to leave already-readable files alone when additional touch points would mostly be noise.

## Why this helps

These integration modules serve as contract documentation as much as executable verification. When a future change breaks a regression in one of these files, maintainers often need to orient themselves quickly around which grouped contract failed before tracing into helper code or production modules. Module docstrings and section headers help, but class-level summaries provide a second, faster index inside longer files. The changes in this PR make those group boundaries more explicit without changing the tests themselves.

This is especially useful in the two longer files touched here: `test_review_guardrails_extended_regressions.py` and `test_scenario_ground_truth_invariants.py`. Both files intentionally collect multiple distinct regression or invariant families. Adding a small amount of class-level framing makes the grouped test design easier to understand and maintain while preserving the current file layout and all existing semantics.

## Validation

Local validation was completed before opening this PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_review_guardrails_extended_regressions.py apps/server/tests/integration/test_runtime_fallbacks_regressions.py apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py apps/server/tests/integration/test_runtime_quality_pass_regressions.py apps/server/tests/integration/test_runtime_queue_and_export_regressions.py apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py apps/server/tests/integration/test_scenario_ground_truth_front_axle.py apps/server/tests/integration/test_scenario_ground_truth_invariants.py apps/server/tests/integration/test_scenario_ground_truth_nuisance.py apps/server/tests/integration/test_scenario_ground_truth_rear_axle.py`
- `git diff --check`

The focused pytest batch for the full chunk passed with `137 passed`, which covers all ten reviewed files rather than only the four changed ones. That provides a strong local check that the documentation-only changes did not disturb the surrounding regression coverage.

## Risks, tradeoffs, and skipped work

The risk in this PR is minimal because the diff is documentation-only inside tests. The main tradeoff was deciding not to do more. I considered whether any helper extraction, scenario reshaping, or naming changes in the longer ground-truth modules would clearly improve maintenance, but those files are already fairly direct and any larger rewrite would have introduced unnecessary churn. I also found no safe dead-code removals or dependency changes relevant to this chunk.

There are no standard-library substitutions, no configuration changes, no API or schema changes, and no behavior changes in this PR. The deliberate choice here was to keep the diff small, clear, and attributable to the exact reviewed file set.

## Follow-up context

This PR completes chunk `041` only. Any additional cleanup in adjacent integration modules should stay in their own chunk PRs so the file-by-file review accounting remains intact. As with previous chunks in this repository-wide pass, the local tracker records that all ten code files in the chunk were individually reviewed and whether they were changed or left unchanged after inspection.
