### PR TITLE
review: tighten chunk 044 boundary test framing

### DIFF
--- a/apps/server/tests/shared/boundaries/__init__.py
+++ b/apps/server/tests/shared/boundaries/__init__.py
@@ -1,0 +1,1 @@
+"""Shared-boundary tests package."""

--- a/apps/server/tests/shared/boundaries/test_analysis_summary_projection.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_summary_projection.py
@@ -1,3 +1,5 @@
+"""Tests for projecting reconstructed analysis summaries back to boundary payloads."""
+
 from __future__ import annotations
 
 from test_support.findings import make_finding_payload

--- a/apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py
@@ -1,3 +1,5 @@
+"""Tests for injecting and preserving summary-warning boundary payloads."""
+
 from __future__ import annotations
 
 from typing import cast

--- a/apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py
+++ b/apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py
@@ -1,3 +1,5 @@
+"""Tests for dropping non-finite numeric values while decoding boundary payloads."""
+
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.finding import finding_from_payload

--- a/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_finding_payload_projection.py
@@ -1,3 +1,5 @@
+"""Tests for projecting domain findings into the canonical boundary payload shape."""
+
 from __future__ import annotations
 
 import vibesensor.shared.boundaries.finding as boundary_finding

--- a/apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py
+++ b/apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py
@@ -33,6 +33,8 @@ def golden_summary() -> dict:
 
 
 class TestGoldenFileReconstruction:
+    """Reconstruct a canonical summary fixture into the typed test-run model."""
+
     def test_test_run_from_summary_does_not_raise(self, golden_summary: dict) -> None:
         test_run = _reconstruct(golden_summary)
         assert test_run is not None


### PR DESCRIPTION
## Summary

This PR covers repository-review chunk `044`, a ten-file batch under `apps/server/tests/shared/boundaries/`. As with the earlier chunks in this full-repository review, every code file in the chunk was opened and reviewed directly before any changes were made, and the file-level result for each was recorded in the local tracker. The files covered are:

- `apps/server/tests/shared/boundaries/__init__.py`
- `apps/server/tests/shared/boundaries/test_analysis_summary_projection.py`
- `apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py`
- `apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py`
- `apps/server/tests/shared/boundaries/test_enrich_findings_equivalence.py`
- `apps/server/tests/shared/boundaries/test_evidence_metrics_builder.py`
- `apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py`
- `apps/server/tests/shared/boundaries/test_finding_payload_projection.py`
- `apps/server/tests/shared/boundaries/test_finding_roundtrip.py`
- `apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py`

The outcome for this chunk is deliberately modest and behavior-preserving. Four files were reviewed and left unchanged because their intent and coverage were already clearly framed. Six files received documentation-only framing improvements so the shared-boundary test package is more consistent and easier to navigate.

## What changed

The most visible cleanup is that the package marker file, `apps/server/tests/shared/boundaries/__init__.py`, now has a short package docstring. This file was previously empty. Functionally that was fine, but adding a one-line package description makes the intent of the directory explicit and aligns it with the broader theme of this repository-wide review: make the test suite easier to understand without changing behavior.

I also added module docstrings to four previously unlabelled test modules:

- `test_analysis_summary_projection.py`
- `test_analysis_summary_warnings.py`
- `test_decoder_numeric_coercion.py`
- `test_finding_payload_projection.py`

Each of those files already contained focused, useful tests, but they began immediately with imports and test functions. The new module docstrings summarize the contract each file is protecting: analysis-summary projection, warning payload preservation, non-finite numeric coercion during decoding, and canonical finding payload projection. These are exactly the kinds of small framing improvements that help future maintainers scan the shared-boundary area quickly when debugging regressions or reviewing follow-up changes.

The final edit is in `test_golden_file_reconstruction.py`, where I added a class docstring to `TestGoldenFileReconstruction`. The file already had a strong module docstring and a second class with its own summary, but the primary reconstruction class itself did not explain its role at class declaration time. The new docstring clarifies that it validates reconstruction of a canonical summary fixture into the typed test-run model.

No production code changed in this PR. No assertions changed. No payload contracts changed. No fixtures, helper semantics, or test data changed. This PR is purely about clearer framing in the shared boundary test suite.

## Review outcomes for unchanged files

The four unchanged files were still reviewed directly and were not skipped.

`test_enrich_findings_equivalence.py` already had a strong module docstring, a focused helper, and a well-framed class explaining the deduplicated contract under test. `test_evidence_metrics_builder.py` already clearly documented its branch coverage through the module and class summaries. `test_finding_legacy_aliases.py` already explained the removed legacy alias behavior with concise module and class docstrings. `test_finding_roundtrip.py` already had a strong module docstring and a class summary that made the roundtrip guarantee explicit.

In each of those files, I looked for the same kinds of safe, behavior-preserving improvements used in earlier chunks: missing framing, misleading comments, weak naming, redundant helpers, overly broad typing, or unnecessary duplication. I did not find a worthwhile edit in those files that would improve them more than it would add churn, so they remain unchanged.

That restraint is intentional. The review goal is not to generate diff volume; it is to improve maintainability where a real, low-risk opportunity exists and to leave already-readable code alone when further edits would mostly be noise.

## Why this change is useful

The shared boundary tests sit at an important seam in the backend. They protect translation between domain objects and payload shapes, and they often become the first place a maintainer looks when investigating regressions in encoding, decoding, or projection behavior. Small framing improvements matter more in this area than they might in a narrowly local helper test, because the directory contains several similarly named modules whose responsibilities are adjacent but distinct.

By adding package- and module-level summaries where they were missing, this PR makes it faster to identify which file owns which boundary contract. The class docstring added to `TestGoldenFileReconstruction` helps for the same reason inside a larger file: it gives a quick label to the main reconstruction group before a reader needs to parse the individual methods.

These edits preserve the current test layout and semantics while improving navigation and readability for future work in the shared boundary layer.

## Validation

Local validation for this chunk was completed before preparing the PR:

- `make lint`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/__init__.py apps/server/tests/shared/boundaries/test_analysis_summary_projection.py apps/server/tests/shared/boundaries/test_analysis_summary_warnings.py apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py apps/server/tests/shared/boundaries/test_enrich_findings_equivalence.py apps/server/tests/shared/boundaries/test_evidence_metrics_builder.py apps/server/tests/shared/boundaries/test_finding_legacy_aliases.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py`
- `git diff --check`

The focused pytest batch passed with `50 passed`, covering the full chunk rather than only the changed files. Given that the diff is documentation-only in tests, this is a strong local signal that the chunk remains stable.

## Risks, tradeoffs, and skipped work

The risk profile for this PR is minimal because the changes are limited to docstrings inside test files. There are no runtime changes, no dependency changes, no type or schema changes, and no production-code effects.

The main tradeoff was choosing the smallest complete improvement instead of manufacturing larger cleanup. I did not refactor helpers or rework test structure in the unchanged files because their current form already communicates the protected contract well enough. I also did not try to normalize every possible file header in the directory beyond the files that clearly lacked framing, because that would have pushed the chunk toward unnecessary style churn.

## Follow-up context

This PR completes chunk `044` only. As with earlier chunks, the local tracker records that all ten code files in this batch were individually reviewed and whether they changed or remained unchanged after inspection. Any further cleanup in neighboring shared-boundary modules should continue in their own chunk PRs so the repository-wide review accounting remains precise.
