### PR TITLE
chore: frame shared boundary tests

### DIFF
--- a/apps/server/tests/shared/boundaries/test_report_facts_projection.py
+++ b/apps/server/tests/shared/boundaries/test_report_facts_projection.py
@@ -1,3 +1,5 @@
+"""Tests for report-facts projection helpers that prepare warnings and suitability payloads."""
+
 from __future__ import annotations
 
 from vibesensor.domain import RunSuitability, SuitabilityCheck

--- a/apps/server/tests/shared/boundaries/test_report_payload_gate.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload_gate.py
@@ -1,3 +1,5 @@
+"""Tests for the report-payload projection gate helper."""
+
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.report_payload_gate import has_projectable_report_payload

--- a/apps/server/tests/shared/boundaries/test_report_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload_projection.py
@@ -1,3 +1,5 @@
+"""Tests for lightweight report-payload projection helper functions."""
+
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.report_payload_projection import (

--- a/apps/server/tests/shared/boundaries/test_report_renderer_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_renderer_payload.py
@@ -1,3 +1,5 @@
+"""Tests for building the normalized renderer payload used by report rendering."""
+
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.report_renderer_payload import (

--- a/apps/server/tests/shared/boundaries/test_run_log.py
+++ b/apps/server/tests/shared/boundaries/test_run_log.py
@@ -1,3 +1,5 @@
+"""Tests for JSONL run-log parsing, normalization, and metadata helpers."""
+
 from __future__ import annotations
 
 import json

--- a/apps/server/tests/shared/boundaries/test_run_suitability.py
+++ b/apps/server/tests/shared/boundaries/test_run_suitability.py
@@ -1,3 +1,5 @@
+"""Tests for converting run-suitability checks to and from boundary payloads."""
+
 from __future__ import annotations
 
 from vibesensor.domain import RunSuitability, SuitabilityCheck

--- a/apps/server/tests/shared/boundaries/test_summary_data_quality_serialization.py
+++ b/apps/server/tests/shared/boundaries/test_summary_data_quality_serialization.py
@@ -1,3 +1,5 @@
+"""Tests for serializing summary data-quality payloads from typed inputs."""
+
 from __future__ import annotations
 
 from vibesensor.domain.speed_profile_summary import SpeedProfileSummary

--- a/apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py
+++ b/apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py
@@ -1,3 +1,5 @@
+"""Tests for serializing location-intensity summary rows into payload dictionaries."""
+
 from __future__ import annotations
 
 from vibesensor.domain import (


### PR DESCRIPTION
## Summary
This PR covers `chunk-045` of the sequential full-repository review and includes exactly the ten code files assigned to that chunk:

- `apps/server/tests/shared/boundaries/test_has_ref_gaps_regression.py`
- `apps/server/tests/shared/boundaries/test_report_facts_projection.py`
- `apps/server/tests/shared/boundaries/test_report_payload_gate.py`
- `apps/server/tests/shared/boundaries/test_report_payload_projection.py`
- `apps/server/tests/shared/boundaries/test_report_renderer_payload.py`
- `apps/server/tests/shared/boundaries/test_run_log.py`
- `apps/server/tests/shared/boundaries/test_run_suitability.py`
- `apps/server/tests/shared/boundaries/test_strength_db_precedence.py`
- `apps/server/tests/shared/boundaries/test_summary_data_quality_serialization.py`
- `apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py`

I directly opened and reviewed every file in the chunk before making changes. The result was a deliberately small, behavior-preserving cleanup pass focused on test-module framing. Eight of the ten files already carried clear, focused assertions but did not begin with a concise summary of the boundary helper contract they protect. This PR adds those missing module docstrings so the files read more cleanly in isolation and fit the same maintainability standard already used throughout neighboring shared-boundary tests. Two files in the chunk were individually reviewed and intentionally left unchanged because they already had effective framing and no safer cleanup opportunity stood out.

## What changed
The actual diff is limited to top-level module docstrings in the following eight files:

- `test_report_facts_projection.py`
- `test_report_payload_gate.py`
- `test_report_payload_projection.py`
- `test_report_renderer_payload.py`
- `test_run_log.py`
- `test_run_suitability.py`
- `test_summary_data_quality_serialization.py`
- `test_summary_location_intensity_serialization.py`

Each new docstring is short and specific. Rather than adding generic prose, the wording names the helper family or payload boundary under test so a maintainer can understand the file’s responsibility without first scanning its imports or internal test names. In this area of the repository, the code under test lives behind fairly small projection and serialization seams, so a one-line summary materially improves readability when navigating the suite by filename.

This chunk did not change any test logic, assertions, fixtures, imports, helper calls, or payload shapes. It also did not broaden coverage, move tests, or alter naming within the test bodies. The goal was narrower: improve readability and maintenance ergonomics while preserving behavior exactly.

## File-by-file review outcomes
Two files were reviewed and kept as-is:

- `test_has_ref_gaps_regression.py` already had strong module framing and a focused regression shape, so I left it alone.
- `test_strength_db_precedence.py` already explained its precedence tiers clearly and did not need additional framing or restructuring.

The remaining eight files all shared the same small issue: they guarded useful boundary seams but started immediately with imports and tests, which made them slightly harder to identify quickly when read out of context. Adding module docstrings resolved that consistently across the chunk.

The most important changed files are `test_run_log.py` and the four report-oriented modules. `test_run_log.py` covers parsing, normalization, and metadata helpers that span several narrow behaviors, so the new summary helps anchor the reader before they step through its cases. The report-oriented modules now each state whether they protect a payload gate, payload projection helpers, report facts projection, or the renderer payload builder. Likewise, the two summary serialization modules now explicitly describe the typed-to-payload serialization contracts they validate.

## Why this is worthwhile
These are small tests, but the repository review is intentionally file-by-file and maintainability-focused. In dense test areas like `apps/server/tests/shared/boundaries/`, the cost of missing module framing accumulates because many files cover similarly named payload or projection helpers. A concise summary at the top of the file reduces lookup time, lowers the chance of opening the wrong test while tracing a boundary issue, and keeps this directory aligned with the clearer framing already present in nearby chunks.

I considered whether there were larger behavior-preserving cleanups available here, such as collapsing helpers, renaming tests, or tightening annotations. After direct review, none of those options were clearly stronger than the current structure without risking churn that outweighed the benefit. The module docstrings were the best fit for the chunk’s review findings because they improve readability without disturbing stable tests.

## Dependencies and dead code
No dependencies were added, removed, or replaced in this chunk. No standard-library substitutions were needed because the files were already straightforward test modules. No dead code or obsolete branches were removed: the reviewed test bodies remain intact because they still express live boundary expectations and no unreachable or clearly unused scaffolding was present.

## Documentation impact
Although the diff only touches test modules, this is still a documentation improvement in the practical sense: the added module docstrings document intent at the point where future maintainers will actually look first. I did not touch broader repository docs because the cleanup is local to these test files and does not change workflows, contracts, or setup.

## Validation
I ran the standard local validation appropriate to this chunk before preparing the PR:

- `make lint`
- focused pytest for all ten files in `chunk-045`
- `git diff --check`

The focused pytest batch passed with `85 passed`, and the lint and diff checks were clean. Because the diff is limited to docstrings, these validations are sufficient and directly tied to the touched area.

## Risks, tradeoffs, and skipped work
Risk here is intentionally very low because no executable logic changed. The main tradeoff was deciding not to force a larger cleanup just to make the PR feel bigger. I deliberately skipped any naming or structure churn that would have been subjective rather than clearly valuable. I also did not try to normalize every neighboring test file outside this chunk, because the review rules require exactly one PR per planned chunk and no cross-chunk spillover.

## Follow-up
If later chunks uncover similar framing gaps in adjacent shared-boundary tests, they can be handled in those chunks using the same pattern. For this chunk specifically, the work is complete: all ten code files were individually reviewed, the worthwhile behavior-preserving cleanup has been applied, and local validation passed before PR creation.
