### PR TITLE
Repo review chunk 001: clarify root dev workflow files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
 LINT_TARGETS := $(SERVER_DIR)/vibesensor $(SERVER_DIR)/tests tools
+# Keep this list aligned with the non-Docker blocking subset enforced in CI.
 CI_LITE_JOBS := --job backend-quality --job backend-typecheck --job frontend-typecheck --job ui-smoke --job release-smoke --job firmware-native-tests --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5
 PYTHON_VERSION := $(strip $(shell cat .python-version))
 PYTHON_MAJOR := $(word 1,$(subst ., ,$(PYTHON_VERSION)))

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   vibesensor-server:
+    # Development override uses the checked-out tree directly for live reload.
     working_dir: /workspace
     volumes:
       - .:/workspace
@@ -12,6 +13,7 @@ services:
       - /workspace/apps/server/config.docker.yaml
 
   vibesensor-ui-dev:
+    # Separate Vite container keeps frontend tooling out of the backend image.
     image: node:22-slim
     network_mode: host
     working_dir: /workspace/apps/ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   vibesensor-server:
+    # Base runtime service; docker-compose.dev.yml adds source mounts and HMR.
     build:
       context: .
       dockerfile: apps/server/Dockerfile


### PR DESCRIPTION
This PR covers `chunk-001` of the repository review and includes these reviewed code files:

- `.python-version`
- `Makefile`
- `docker-compose.dev.yml`
- `docker-compose.yml`

I reviewed every code file in this chunk directly. The only worthwhile behavior-preserving improvements here were small clarification comments in the root workflow/config files. `Makefile` now documents that `CI_LITE_JOBS` must stay aligned with the blocking non-Docker CI subset. `docker-compose.yml` now makes it explicit that the base service definition is extended by the dev override. `docker-compose.dev.yml` now explains why the repo is source-mounted for reloads and why the frontend runs in a separate Vite container.

Key files changed:

- `Makefile`
- `docker-compose.yml`
- `docker-compose.dev.yml`

Validation performed:

- `make lint`
- `make help`
- `docker-compose -f docker-compose.yml config`
- `docker-compose -f docker-compose.yml -f docker-compose.dev.yml config`

I also ran clean-baseline validation before the edit. `make typecheck-backend` passed. `make test-ci-lite` still has unrelated baseline failures in `backend-tests-1` and `backend-tests-4` (update-manager tests), so I did not treat those as regressions from this comment-only chunk.

Risks and skipped items:

- `.python-version` was reviewed and intentionally left unchanged.
- No runtime Make or Compose behavior changed in this PR.
- The existing update-manager test failures should be handled in later chunks that touch those files.
