### PR TITLE
Repo review chunk 002: document dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+# Weekly cadence plus per-ecosystem PR caps keep dependency churn reviewable.
 updates:
   - package-ecosystem: pip
     directory: /apps/server
@@ -21,6 +22,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # GitHub Actions updates can directly affect CI behavior.
     labels:
       - CI
       - dependencies


### PR DESCRIPTION
This PR covers `chunk-002` of the repository review and includes the single reviewed code file in that chunk:

- `.github/dependabot.yml`

I reviewed every code file in this chunk directly. The current Dependabot behavior looked intentional, so I kept the configuration itself unchanged and focused on maintainability. The diff adds short comments that explain the existing policy choices already encoded in the file: weekly update cadence, per-ecosystem pull-request caps to keep dependency churn reviewable, and the reason GitHub Actions updates carry the `CI` label.

Key file changed:

- `.github/dependabot.yml`

Validation performed:

- `python3` YAML parse of `.github/dependabot.yml`

Risks and skipped items:

- No Dependabot schedule, limit, directory, or label behavior changed.
- I intentionally did not alter PR caps or labels because that would change repository automation behavior instead of just documenting it.
- This chunk is isolated from `chunk-001`, so it can proceed independently while the earlier PR finishes its longer CI jobs.
