### PR TITLE
Repo review chunk 003: clarify backend setup action

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -20,6 +20,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
+        # Reuse the backend dev extra so CI matches the local editable setup.
         python -m pip install -e "./apps/server[dev]"
 
     - name: Install PlatformIO dependencies


### PR DESCRIPTION
This PR covers `chunk-003` of the repository review and includes the single reviewed code file in that chunk:

- `.github/actions/setup-backend/action.yml`

I reviewed every code file in this chunk directly. The composite action’s behavior already looked correct, so I kept the setup flow unchanged and limited the diff to a short clarifying comment. The added note explains why CI installs the backend package with the editable `dev` extra instead of a narrower dependency set: it keeps the shared CI bootstrap aligned with the local developer workflow and preserves the same entry points and extras across jobs.

Key file changed:

- `.github/actions/setup-backend/action.yml`

Validation performed:

- `python3` YAML parse of `.github/actions/setup-backend/action.yml`

Risks and skipped items:

- No GitHub Actions behavior, inputs, cache settings, or dependency versions changed.
- I intentionally left the optional PlatformIO step untouched because it already had a clear comment and any behavior change there would affect CI job setup.
- This chunk is isolated from the currently open dependency-policy PR, so it can proceed independently while earlier CI continues.
