### PR TITLE
Repo review chunk 004: clarify workflow intent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/vibesensor/backend-duration-cache.json
+          # Keep each run's write key distinct while still restoring from the stable test-history prefix.
           key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-1-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Current CodeQL coverage targets the Python backend.
         language:
           - python
     steps:

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # workflow_run releases must build the exact commit that completed CI successfully.
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Compute version


### PR DESCRIPTION
This PR covers `chunk-004` of the repository review and includes these reviewed code files:

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/main-release.yml`

I reviewed every code file in this chunk directly. The workflow behavior itself already looked intentional, so this PR keeps execution unchanged and focuses on maintainability. The added comments document three places where the current behavior is easy to misread from YAML alone: why the CI backend-duration cache writes use a run-specific key while restores use a stable prefix, that the current CodeQL configuration is intentionally scoped to the Python backend, and that release builds triggered from `workflow_run` must check out the exact commit that actually passed CI.

Key files changed:

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/main-release.yml`

Validation performed:

- `python3` YAML parse of all three workflow files
- `make lint`

Risks and skipped items:

- No workflow triggers, jobs, versions, caches, or command behavior changed.
- I intentionally avoided deduplicating repeated shard jobs because that would alter workflow structure and risk behavior drift.
