### PR TITLE
Repo review chunk 005: clarify server packaging config

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -8,6 +8,7 @@ COPY apps/ui/package*.json ./
 RUN npm ci
 
 RUN mkdir -p /app/tools/config /app/apps/server/vibesensor/shared
+# Copy the shared-code inputs early so UI rebuilds only invalidate when these contracts change.
 COPY tools/config/sync_shared_contracts_to_ui.mjs /app/tools/config/sync_shared_contracts_to_ui.mjs
 COPY tools/config/generate_ui_shared_constants.py /app/tools/config/generate_ui_shared_constants.py
 COPY apps/server/vibesensor/shared/locations.py /app/apps/server/vibesensor/shared/locations.py

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -68,6 +68,7 @@ include = ["vibesensor*"]
 addopts = "-n auto --dist worksteal"
 asyncio_mode = "auto"
 timeout = 120
+# Keep tests/ importable so shared helpers use `from test_support...` short imports.
 pythonpath = [".", "tests"]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
This PR covers `chunk-005` of the repository review and includes these reviewed code files:

- `apps/server/Dockerfile`
- `apps/server/config.dev.yaml`
- `apps/server/config.docker.yaml`
- `apps/server/config.pi.yaml`
- `apps/server/pyproject.toml`

I reviewed every code file in this chunk directly. The three config overlays already read clearly and were left unchanged. The two worthwhile behavior-preserving improvements were explanatory comments in the server Docker image build and backend packaging config: one comment documents why the shared contract inputs are copied before the full UI tree in the Docker build, and one documents why pytest adds `tests` to `pythonpath` for the repository’s short-form `test_support` imports.

Key files changed:

- `apps/server/Dockerfile`
- `apps/server/pyproject.toml`

Validation performed:

- `python3` `tomllib` parse of `apps/server/pyproject.toml`
- `make lint`
- attempted `docker build -f apps/server/Dockerfile ...`, which was blocked locally because the Docker daemon is unavailable in this environment

Risks and skipped items:

- No Docker build steps, package metadata, dependency pins, or config values changed.
- The three config overlay files were reviewed and intentionally left unchanged.
