### PR TITLE
Repo review chunk 007: clarify server helper scripts

### DIFF
--- a/apps/server/scripts/hotspot_nmcli.sh
+++ b/apps/server/scripts/hotspot_nmcli.sh
@@ -59,6 +59,7 @@ dump_cmd() {
   local rc=$?
   set -e
   echo "[dump] ${name}: rc=${rc} file=${out_file}"
+  # Diagnostics are best-effort; collection failures should not mask the main error.
   return 0
 }
 

--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -106,6 +106,7 @@ sed \
   "${HOTSPOT_HEAL_TIMER_TEMPLATE}" | run_as_root tee /etc/systemd/system/vibesensor-hotspot-self-heal.timer >/dev/null
 
 if [ "${SKIP_SERVICE_START}" = "1" ]; then
+  # Image-build and chroot installs cannot start services, so enable them via symlinks only.
   run_as_root systemctl daemon-reload >/dev/null 2>&1 || true
   if ! run_as_root systemctl enable vibesensor.service >/dev/null 2>&1; then
     run_as_root install -d /etc/systemd/system/multi-user.target.wants

--- a/apps/server/scripts/run_dev.sh
+++ b/apps/server/scripts/run_dev.sh
@@ -17,6 +17,7 @@ python -m pip install -e ".[dev]"
 vibesensor-server --reload --config "${PI_DIR}/config.dev.yaml" &
 SERVER_PID=$!
 
+# Let the simulator exit naturally; this script stays attached to the server lifecycle.
 vibesensor-sim --count 5 --server-host 127.0.0.1 &
 SIM_PID=$!
 

--- a/apps/server/scripts/wifi_export_logs.sh
+++ b/apps/server/scripts/wifi_export_logs.sh
@@ -17,6 +17,7 @@ fi
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "${tmp_dir}"' EXIT
 
+# Stage files outside LOG_DIR so the output archive never includes itself recursively.
 cp -a "${LOG_DIR}"/. "${tmp_dir}"/ 2>/dev/null || true
 (
   cd "${tmp_dir}"


### PR DESCRIPTION
This PR covers `chunk-007` of the repository review and includes these reviewed code files:

- `apps/server/scripts/hotspot_nmcli.sh`
- `apps/server/scripts/install_pi.sh`
- `apps/server/scripts/run_dev.sh`
- `apps/server/scripts/vibesensor_update_sudo.sh`
- `apps/server/scripts/wifi_export_logs.sh`

I reviewed every code file in this chunk directly. The safe changes here are all comment-only clarifications in the operational scripts: best-effort diagnostics in the hotspot helper, the enable-only path for image/chroot installs, the lifecycle relationship between the dev server and simulator, and why Wi-Fi logs are staged before zipping. `vibesensor_update_sudo.sh` was also reviewed, but I intentionally left it unchanged because any hardening to its command-resolution behavior would be a functional security change rather than a behavior-preserving cleanup.

Key files changed:

- `apps/server/scripts/hotspot_nmcli.sh`
- `apps/server/scripts/install_pi.sh`
- `apps/server/scripts/run_dev.sh`
- `apps/server/scripts/wifi_export_logs.sh`

Validation performed:

- `bash -n` syntax checks for all five scripts in the chunk

Risks and skipped items:

- No script command flow or shell behavior changed.
- `vibesensor_update_sudo.sh` remains a follow-up candidate for a separate security-focused change set.
