### PR TITLE
Repo review chunk 008: clarify systemd unit intent

### DIFF
--- a/apps/server/systemd/vibesensor-hotspot-self-heal.service
+++ b/apps/server/systemd/vibesensor-hotspot-self-heal.service
@@ -5,5 +5,6 @@ Wants=NetworkManager.service
 
 [Service]
 Type=oneshot
+# The timer owns cadence; each run is a single health-check/heal pass.
 ExecStart=__VENV_DIR__/bin/vibesensor-hotspot-self-heal --mode check-heal --config /etc/vibesensor/config.yaml
 SyslogIdentifier=vibesensor-hotspot-selfheal

--- a/apps/server/systemd/vibesensor-hotspot-self-heal.timer
+++ b/apps/server/systemd/vibesensor-hotspot-self-heal.timer
@@ -6,6 +6,7 @@ OnBootSec=90s
 OnUnitActiveSec=2min
 AccuracySec=10s
 Unit=vibesensor-hotspot-self-heal.service
+# Catch up a missed periodic run after downtime instead of waiting for the next fresh interval.
 Persistent=true
 
 [Install]

--- a/apps/server/systemd/vibesensor-rfkill-unblock.service
+++ b/apps/server/systemd/vibesensor-rfkill-unblock.service
@@ -9,4 +9,5 @@ ExecStart=/bin/sh -c 'if command -v rfkill >/dev/null 2>&1; then rfkill unblock 
 RemainAfterExit=yes
 
 [Install]
+# Tie this preflight to NetworkManager startup so boot ordering stays explicit.
 WantedBy=NetworkManager.service


### PR DESCRIPTION
This PR covers `chunk-008` of the repository review and includes these reviewed code files:

- `apps/server/systemd/vibesensor-hotspot-self-heal.service`
- `apps/server/systemd/vibesensor-hotspot-self-heal.timer`
- `apps/server/systemd/vibesensor-hotspot.service`
- `apps/server/systemd/vibesensor-rfkill-unblock.service`
- `apps/server/systemd/vibesensor.service`

I reviewed every code file in this chunk directly. The two service units and timer already had the right behavior, so I kept the unit semantics untouched and focused on the non-obvious operational intent: that the self-heal service is a single timer-owned pass, that the timer’s `Persistent=true` setting is there to catch up after downtime, and that the rfkill-unblock unit is explicitly tied to NetworkManager startup ordering. The hotspot and main server units were reviewed and intentionally left unchanged because they already had the relevant inline explanations.

Key files changed:

- `apps/server/systemd/vibesensor-hotspot-self-heal.service`
- `apps/server/systemd/vibesensor-hotspot-self-heal.timer`
- `apps/server/systemd/vibesensor-rfkill-unblock.service`

Validation performed:

- rendered `systemd-analyze verify` with substituted install paths and temporary stub executables

Risks and skipped items:

- No systemd unit behavior, ordering, restart policy, or command line changed.
- Raw template files require placeholder substitution before verification, so validation was performed on rendered equivalents.
