### PR TITLE
Repo review chunk 009: clarify shared test fixtures

### DIFF
--- a/apps/server/tests/conftest.py
+++ b/apps/server/tests/conftest.py
@@ -232,6 +232,8 @@ class FakeState:
 
     def __post_init__(self) -> None:
         self.health_state.mark_ready()
+        # Keep router assembly tests focused on dependency wiring rather than
+        # bespoke history/export service setup in each caller.
         if self.run_service is None:
             self.run_service = ProjectedHistoryRunService(
                 HistoryRunService(
@@ -299,6 +301,7 @@ class FakeState:
 def fake_state() -> FakeState:
     """Return a fresh ``FakeState`` for each test."""
     state = FakeState()
+    # Health endpoints read a dedicated recorder health payload, not status().
     state.run_recorder.health_snapshot.return_value = {
         "write_error": None,
         "analysis_in_progress": False,


### PR DESCRIPTION
This PR covers `chunk-009` of the repository review and includes these reviewed code files:

- `apps/server/tests/_paths.py`
- `apps/server/tests/conftest.py`

I reviewed every code file in this chunk directly. `_paths.py` already read cleanly and needed no changes. In `conftest.py`, I kept behavior untouched and added two short comments that explain non-obvious fixture intent: why `FakeState` lazily builds projected history/export services for router assembly tests, and why the shared `fake_state` fixture explicitly sets a recorder health snapshot separately from the normal recorder status stub.

Key files changed:

- `apps/server/tests/conftest.py`

Validation performed:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/test_route_registration.py apps/server/tests/adapters/http/test_health_endpoint.py`

Risks and skipped items:

- No test behavior, fixture values, or dependency wiring changed.
- `apps/server/tests/_paths.py` was reviewed and intentionally left unchanged.
