### PR TITLE
Repo review chunk 011: clarify GPS lifecycle tests

### DIFF
--- a/apps/server/tests/adapters/gps/test_transport_lifecycle.py
+++ b/apps/server/tests/adapters/gps/test_transport_lifecycle.py
@@ -12,102 +12,102 @@ from vibesensor.adapters.gps.transport_lifecycle import (
 
 class TestOnConnected:
     def test_returns_connected_state(self) -> None:
-        lc = TransportLifecycle()
-        t = lc.on_connected()
-        assert t.changes["connection_state"] == "connected"
-        assert t.changes["last_error"] is None
-        assert t.changes["current_reconnect_delay"] == GPS_RECONNECT_DELAY_S
-        assert t.sleep_before_retry is None
+        lifecycle = TransportLifecycle()
+        transition = lifecycle.on_connected()
+        assert transition.changes["connection_state"] == "connected"
+        assert transition.changes["last_error"] is None
+        assert transition.changes["current_reconnect_delay"] == GPS_RECONNECT_DELAY_S
+        assert transition.sleep_before_retry is None
 
     def test_resets_backoff_delay(self) -> None:
-        lc = TransportLifecycle(initial_delay=1.0)
+        lifecycle = TransportLifecycle(initial_delay=1.0)
         # Advance backoff first.
-        lc.on_connection_error(RuntimeError("boom"))
-        assert lc.reconnect_delay > 1.0
+        lifecycle.on_connection_error(RuntimeError("boom"))
+        assert lifecycle.reconnect_delay > 1.0
         # on_connected resets it.
-        lc.on_connected()
-        assert lc.reconnect_delay == 1.0
+        lifecycle.on_connected()
+        assert lifecycle.reconnect_delay == 1.0
 
 
 class TestOnStreamDisconnected:
     def test_returns_disconnected_fields(self) -> None:
-        lc = TransportLifecycle()
-        t = lc.on_stream_disconnected()
-        assert t.changes["connection_state"] == "disconnected"
-        assert t.changes["speed_snapshot"] == (None, None)
-        assert t.changes["last_fix_mode"] is None
-        assert t.changes["device_info"] is None
-        assert t.changes["zero_speed_streak"] == 0
-        assert t.sleep_before_retry is None
+        lifecycle = TransportLifecycle()
+        transition = lifecycle.on_stream_disconnected()
+        assert transition.changes["connection_state"] == "disconnected"
+        assert transition.changes["speed_snapshot"] == (None, None)
+        assert transition.changes["last_fix_mode"] is None
+        assert transition.changes["device_info"] is None
+        assert transition.changes["zero_speed_streak"] == 0
+        assert transition.sleep_before_retry is None
 
     def test_resets_backoff_delay(self) -> None:
-        lc = TransportLifecycle(initial_delay=0.5)
-        lc.on_connection_error(RuntimeError("x"))
-        lc.on_stream_disconnected()
-        assert lc.reconnect_delay == 0.5
+        lifecycle = TransportLifecycle(initial_delay=0.5)
+        lifecycle.on_connection_error(RuntimeError("x"))
+        lifecycle.on_stream_disconnected()
+        assert lifecycle.reconnect_delay == 0.5
 
 
 class TestOnConnectionError:
     def test_returns_disconnected_plus_error(self) -> None:
-        lc = TransportLifecycle(initial_delay=2.0)
+        lifecycle = TransportLifecycle(initial_delay=2.0)
         exc = OSError("network down")
-        t = lc.on_connection_error(exc)
-        assert t.changes["connection_state"] == "disconnected"
-        assert t.changes["last_error"] == "network down"
-        assert t.changes["current_reconnect_delay"] == 2.0
-        assert t.sleep_before_retry == 2.0
+        transition = lifecycle.on_connection_error(exc)
+        assert transition.changes["connection_state"] == "disconnected"
+        assert transition.changes["last_error"] == "network down"
+        assert transition.changes["current_reconnect_delay"] == 2.0
+        assert transition.sleep_before_retry == 2.0
 
     def test_error_str_fallback_to_type_name(self) -> None:
-        lc = TransportLifecycle()
-        t = lc.on_connection_error(ConnectionError())
-        assert t.changes["last_error"] == "ConnectionError"
+        lifecycle = TransportLifecycle()
+        transition = lifecycle.on_connection_error(ConnectionError())
+        assert transition.changes["last_error"] == "ConnectionError"
 
     def test_exponential_backoff(self) -> None:
-        lc = TransportLifecycle(initial_delay=1.0, max_delay=10.0, backoff_factor=2.0)
-        t1 = lc.on_connection_error(RuntimeError("a"))
-        assert t1.sleep_before_retry == 1.0
-        t2 = lc.on_connection_error(RuntimeError("b"))
-        assert t2.sleep_before_retry == 2.0
-        t3 = lc.on_connection_error(RuntimeError("c"))
-        assert t3.sleep_before_retry == 4.0
-        t4 = lc.on_connection_error(RuntimeError("d"))
-        assert t4.sleep_before_retry == 8.0
+        lifecycle = TransportLifecycle(initial_delay=1.0, max_delay=10.0, backoff_factor=2.0)
+        first_transition = lifecycle.on_connection_error(RuntimeError("a"))
+        assert first_transition.sleep_before_retry == 1.0
+        second_transition = lifecycle.on_connection_error(RuntimeError("b"))
+        assert second_transition.sleep_before_retry == 2.0
+        third_transition = lifecycle.on_connection_error(RuntimeError("c"))
+        assert third_transition.sleep_before_retry == 4.0
+        fourth_transition = lifecycle.on_connection_error(RuntimeError("d"))
+        assert fourth_transition.sleep_before_retry == 8.0
         # Capped at max.
-        t5 = lc.on_connection_error(RuntimeError("e"))
-        assert t5.sleep_before_retry == 10.0
+        fifth_transition = lifecycle.on_connection_error(RuntimeError("e"))
+        assert fifth_transition.sleep_before_retry == 10.0
 
     def test_clears_gps_metadata(self) -> None:
-        lc = TransportLifecycle()
-        t = lc.on_connection_error(TimeoutError())
-        assert t.changes["last_epx_m"] is None
-        assert t.changes["last_epy_m"] is None
-        assert t.changes["last_epv_m"] is None
-        assert t.changes["last_fix_mode"] is None
+        lifecycle = TransportLifecycle()
+        transition = lifecycle.on_connection_error(TimeoutError())
+        assert transition.changes["last_epx_m"] is None
+        assert transition.changes["last_epy_m"] is None
+        assert transition.changes["last_epv_m"] is None
+        assert transition.changes["last_fix_mode"] is None
 
 
 class TestResetDelay:
     def test_resets_after_backoff(self) -> None:
-        lc = TransportLifecycle(initial_delay=0.1)
-        lc.on_connection_error(RuntimeError("x"))
-        lc.on_connection_error(RuntimeError("y"))
-        assert lc.reconnect_delay > 0.1
-        lc.reset_delay()
-        assert lc.reconnect_delay == pytest.approx(0.1)
+        lifecycle = TransportLifecycle(initial_delay=0.1)
+        lifecycle.on_connection_error(RuntimeError("x"))
+        lifecycle.on_connection_error(RuntimeError("y"))
+        assert lifecycle.reconnect_delay > 0.1
+        lifecycle.reset_delay()
+        assert lifecycle.reconnect_delay == pytest.approx(0.1)
 
 
 class TestCustomPolicy:
     def test_custom_initial_and_max(self) -> None:
-        lc = TransportLifecycle(initial_delay=0.5, max_delay=2.0, backoff_factor=3.0)
-        t1 = lc.on_connection_error(RuntimeError("a"))
-        assert t1.sleep_before_retry == 0.5
-        t2 = lc.on_connection_error(RuntimeError("b"))
-        assert t2.sleep_before_retry == 1.5
+        lifecycle = TransportLifecycle(initial_delay=0.5, max_delay=2.0, backoff_factor=3.0)
+        first_transition = lifecycle.on_connection_error(RuntimeError("a"))
+        assert first_transition.sleep_before_retry == 0.5
+        second_transition = lifecycle.on_connection_error(RuntimeError("b"))
+        assert second_transition.sleep_before_retry == 1.5
         # Next would be 4.5 but capped at 2.0.
-        t3 = lc.on_connection_error(RuntimeError("c"))
-        assert t3.sleep_before_retry == 2.0
+        third_transition = lifecycle.on_connection_error(RuntimeError("c"))
+        assert third_transition.sleep_before_retry == 2.0
 
     def test_defaults_match_module_constants(self) -> None:
-        lc = TransportLifecycle()
-        assert lc.reconnect_delay == GPS_RECONNECT_DELAY_S
-        t = lc.on_connected()
-        assert t.changes["current_reconnect_delay"] == GPS_RECONNECT_DELAY_S
+        lifecycle = TransportLifecycle()
+        assert lifecycle.reconnect_delay == GPS_RECONNECT_DELAY_S
+        transition = lifecycle.on_connected()
+        assert transition.changes["current_reconnect_delay"] == GPS_RECONNECT_DELAY_S


### PR DESCRIPTION
This PR covers repo review chunk 011 and only the following files: `apps/server/tests/adapters/gps/test_parse_manual_speed.py`, `apps/server/tests/adapters/gps/test_speed_resolution_policy.py`, `apps/server/tests/adapters/gps/test_speed_status_builder.py`, `apps/server/tests/adapters/gps/test_speed_validation.py`, and `apps/server/tests/adapters/gps/test_transport_lifecycle.py`.

I reviewed every code file in this chunk individually. Four of the five files were already concise and readable, so the only behavior-preserving improvement here was in `test_transport_lifecycle.py`. That module used repeated `lc` and `t` shorthand across lifecycle and transition assertions, which made the tests slightly harder to scan than the surrounding GPS adapter suite. This change expands those locals to `lifecycle`, `transition`, and similarly explicit names without changing any assertions, coverage, or control flow.

Key changed file: `apps/server/tests/adapters/gps/test_transport_lifecycle.py`.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/gps/test_parse_manual_speed.py apps/server/tests/adapters/gps/test_speed_resolution_policy.py apps/server/tests/adapters/gps/test_speed_status_builder.py apps/server/tests/adapters/gps/test_speed_validation.py apps/server/tests/adapters/gps/test_transport_lifecycle.py`

Risk is minimal because the diff is test-only and naming-only. I did not force edits into the other four reviewed files once inspection showed no clearer behavior-preserving maintainability win.
