### PR TITLE
Repo review chunk 012: clarify hotspot self-heal tests

### DIFF
--- a/apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py
@@ -178,7 +178,7 @@ def _healthy_responses(ap: APConfig) -> dict[tuple[str, ...], list[CommandResult
 def _collect_health_for(
     tmp_path: Path,
     overrides: dict[tuple[str, ...], list[CommandResult]] | None = None,
-):
+) -> HealthState:
     """Create default AP config, apply response overrides, return health state."""
     ap = _ap_cfg(tmp_path)
     responses = _healthy_responses(ap)
@@ -306,7 +306,7 @@ def test_run_self_heal_restarts_networkmanager_when_stopped(tmp_path: Path) -> N
     responses[("systemctl", "restart", "NetworkManager")] = [_ok("")]
     runner = _FakeRunner(responses)
 
-    result = run_self_heal_once(
+    exit_code = run_self_heal_once(
         ap,
         ap.self_heal,
         runner,
@@ -314,7 +314,7 @@ def test_run_self_heal_restarts_networkmanager_when_stopped(tmp_path: Path) -> N
         diagnostics_only=False,
     )
 
-    assert result == 0
+    assert exit_code == 0
     assert ("systemctl", "restart", "NetworkManager") in runner.commands
 
 
@@ -360,8 +360,8 @@ def test_ensure_ap_connection_open_mode_recreates_without_security_keys(tmp_path
         },
     )
 
-    ok = _ensure_ap_connection(ap, runner)
-    assert ok
+    success = _ensure_ap_connection(ap, runner)
+    assert success
     assert ("nmcli", "connection", "delete", ap.con_name) in runner.commands
     assert _nmcli_modify_cmd(ap) in runner.commands
     assert "802-11-wireless-security.key-mgmt" not in _nmcli_modify_cmd(ap)
@@ -385,7 +385,7 @@ def test_run_self_heal_port53_conflict_disables_resolved_stub(tmp_path: Path) ->
     responses[("nmcli", "--wait", "12", "connection", "up", ap.con_name)] = [_ok(""), _ok("")]
     runner = _FakeRunner(responses)
 
-    result = run_self_heal_once(
+    exit_code = run_self_heal_once(
         ap,
         ap.self_heal,
         runner,
@@ -393,5 +393,5 @@ def test_run_self_heal_port53_conflict_disables_resolved_stub(tmp_path: Path) ->
         diagnostics_only=False,
     )
 
-    assert result == 0
+    assert exit_code == 0
     assert ("systemctl", "restart", "systemd-resolved") in runner.commands

--- a/apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py
@@ -12,8 +12,8 @@ from vibesensor.cli.hotspot_self_heal import main
 
 
 def test_hotspot_self_heal_cli_loads_config_and_runs_diagnostics() -> None:
-    cfg = SimpleNamespace(ap=SimpleNamespace(), self_heal=SimpleNamespace())
-    cfg.ap.self_heal = cfg.self_heal
+    config = SimpleNamespace(ap=SimpleNamespace(), self_heal=SimpleNamespace())
+    config.ap.self_heal = config.self_heal
 
     with (
         patch(
@@ -23,7 +23,7 @@ def test_hotspot_self_heal_cli_loads_config_and_runs_diagnostics() -> None:
                 mode="diagnostics",
             ),
         ),
-        patch("vibesensor.cli.hotspot_self_heal.load_config", return_value=cfg) as load_config,
+        patch("vibesensor.cli.hotspot_self_heal.load_config", return_value=config) as load_config,
         patch("vibesensor.cli.hotspot_self_heal.run_self_heal", return_value=0) as run_self_heal,
         patch("logging.basicConfig") as basic_config,
         pytest.raises(SystemExit) as exc_info,
@@ -32,5 +32,5 @@ def test_hotspot_self_heal_cli_loads_config_and_runs_diagnostics() -> None:
 
     assert exc_info.value.code == 0
     load_config.assert_called_once_with(Path("/tmp/test-config.yaml"))
-    run_self_heal.assert_called_once_with(cfg.ap, cfg.ap.self_heal, diagnostics_only=True)
+    run_self_heal.assert_called_once_with(config.ap, config.ap.self_heal, diagnostics_only=True)
     basic_config.assert_called_once()


### PR DESCRIPTION
This PR covers repo review chunk 012 and only the following files: `apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py`, `apps/server/tests/adapters/hotspot/test_hotspot_parsers.py`, `apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py`, and `apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py`.

I reviewed every code file in this chunk individually. The hotspot parser and config CLI tests were already in good shape, so the only behavior-preserving improvements here are small readability cleanups in the self-heal tests. In `test_hotspot_self_heal.py`, a helper that always returns `HealthState` is now annotated as such, and a few generic local names were expanded to `exit_code` and `success` so the assertions read more clearly. In `test_hotspot_self_heal_cli.py`, the temporary `cfg` object was renamed to `config` for the same reason.

Key changed files: `apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py` and `apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py`.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py apps/server/tests/adapters/hotspot/test_hotspot_parsers.py apps/server/tests/adapters/hotspot/test_hotspot_self_heal.py apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py`

Risk is minimal because the diff is test-only and naming/annotation-only. I did not force edits into the other reviewed files when inspection showed no safer maintainability win.
