### PR TITLE
Repo review chunk 013: simplify HTTP adapter tests

### DIFF
--- a/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
@@ -23,6 +23,10 @@ from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.adapters.http import create_router
 
 
+def _pdf_text(body: bytes) -> str:
+    return "\n".join(page.extract_text() or "" for page in PdfReader(BytesIO(body)).pages).lower()
+
+
 @pytest.mark.asyncio
 async def test_history_insights_returns_persisted_analysis() -> None:
     router, _ = make_router_and_state(language="en")
@@ -60,10 +64,8 @@ async def test_report_pdf_respects_lang_query_with_persisted_report_template_dat
     assert nl.body.startswith(b"%PDF")
     assert en.body.startswith(b"%PDF")
 
-    nl_reader = PdfReader(BytesIO(nl.body))
-    en_reader = PdfReader(BytesIO(en.body))
-    nl_text = "\n".join(page.extract_text() or "" for page in nl_reader.pages).lower()
-    text_from_en_request = "\n".join(page.extract_text() or "" for page in en_reader.pages).lower()
+    nl_text = _pdf_text(nl.body)
+    text_from_en_request = _pdf_text(en.body)
     assert "diagnostisch werkformulier" in nl_text
     assert "diagnostisch werkformulier" in text_from_en_request
     assert "diagnostic worksheet" not in text_from_en_request
@@ -98,12 +100,8 @@ async def test_report_pdf_lang_override_when_template_data_persisted() -> None:
 
     assert nl.body.startswith(b"%PDF")
     assert en.body.startswith(b"%PDF")
-    nl_text = "\n".join(
-        (page.extract_text() or "") for page in PdfReader(BytesIO(nl.body)).pages
-    ).lower()
-    text_from_en_request = "\n".join(
-        (page.extract_text() or "") for page in PdfReader(BytesIO(en.body)).pages
-    ).lower()
+    nl_text = _pdf_text(nl.body)
+    text_from_en_request = _pdf_text(en.body)
     assert "diagnostisch werkformulier" in nl_text
     assert "diagnostisch werkformulier" in text_from_en_request
     assert "diagnostic worksheet" not in text_from_en_request

--- a/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
+++ b/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
@@ -79,19 +79,18 @@ def _settings_test_client() -> tuple[TestClient, MagicMock]:
 
 
 @pytest.mark.parametrize(
-    ("method", "path", "service_attr"),
+    ("method", "path"),
     [
-        ("GET", "/api/history/bad%20id", "get_run"),
-        ("GET", "/api/history/bad%20id/insights", "get_insights"),
-        ("DELETE", "/api/history/bad%20id", "delete_run"),
-        ("GET", "/api/history/bad%20id/report.pdf", "build_pdf"),
-        ("GET", "/api/history/bad%20id/export", "build_export"),
+        ("GET", "/api/history/bad%20id"),
+        ("GET", "/api/history/bad%20id/insights"),
+        ("DELETE", "/api/history/bad%20id"),
+        ("GET", "/api/history/bad%20id/report.pdf"),
+        ("GET", "/api/history/bad%20id/export"),
     ],
 )
 def test_history_routes_reject_invalid_run_ids_before_reaching_services(
     method: str,
     path: str,
-    service_attr: str,
 ) -> None:
     client, run_service, report_service, export_service = _history_test_client()
 


### PR DESCRIPTION
This PR covers repo review chunk 013 and only the following files: `apps/server/tests/adapters/http/_history_endpoint_helpers.py`, `apps/server/tests/adapters/http/test_analysis_settings_request_codec.py`, `apps/server/tests/adapters/http/test_api_history_export_endpoints.py`, `apps/server/tests/adapters/http/test_api_history_report_endpoints.py`, `apps/server/tests/adapters/http/test_api_history_route_state.py`, `apps/server/tests/adapters/http/test_api_path_identifier_validation.py`, `apps/server/tests/adapters/http/test_api_ws_health_and_clients.py`, `apps/server/tests/adapters/http/test_health_endpoint.py`, `apps/server/tests/adapters/http/test_helpers_exception_handling.py`, and `apps/server/tests/adapters/http/test_http_api_schema_export.py`.

I reviewed every code file in this chunk individually. Most of the HTTP adapter tests were already clear and well factored, so the changes here stay deliberately small and behavior-preserving. In `test_api_history_report_endpoints.py`, two tests were repeating the same PDF text extraction and normalization logic; this now lives in a shared `_pdf_text()` helper. In `test_api_path_identifier_validation.py`, the invalid run-id matrix no longer carries an unused parametrized field, which makes the table easier to read without changing coverage.

Key changed files: `apps/server/tests/adapters/http/test_api_history_report_endpoints.py` and `apps/server/tests/adapters/http/test_api_path_identifier_validation.py`.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/_history_endpoint_helpers.py apps/server/tests/adapters/http/test_analysis_settings_request_codec.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/adapters/http/test_api_ws_health_and_clients.py apps/server/tests/adapters/http/test_health_endpoint.py apps/server/tests/adapters/http/test_helpers_exception_handling.py apps/server/tests/adapters/http/test_http_api_schema_export.py`

Risk is minimal because the diff is test-only and helper/table simplification only.
