### PR TITLE
Repo review chunk 014: simplify HTTP route tests

### DIFF
--- a/apps/server/tests/adapters/http/test_request_observability.py
+++ b/apps/server/tests/adapters/http/test_request_observability.py
@@ -14,6 +14,10 @@ from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.shared.structured_logging import REQUEST_ID_HEADER
 
 
+def _log_record(caplog: pytest.LogCaptureFixture, message: str):
+    return next(rec for rec in caplog.records if rec.message == message)
+
+
 def test_request_logging_middleware_sets_response_header_and_logs_request(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -29,7 +33,7 @@ def test_request_logging_middleware_sets_response_header_and_logs_request(
             response = client.get("/ping")
 
     assert response.status_code == 200
-    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    request_log = _log_record(caplog, "http_request")
     assert response.headers[REQUEST_ID_HEADER] == request_log.request_id
     assert request_log.method == "GET"
     assert request_log.path == "/ping"
@@ -52,7 +56,7 @@ def test_request_id_flows_into_settings_audit_logs(caplog: pytest.LogCaptureFixt
     assert response.status_code == 200
     assert response.headers[REQUEST_ID_HEADER] == "client-req-42"
 
-    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    request_log = _log_record(caplog, "http_request")
     audit_log = next(
         rec
         for rec in caplog.records
@@ -79,7 +83,7 @@ def test_unhandled_errors_still_echo_request_id(caplog: pytest.LogCaptureFixture
 
     assert response.status_code == 500
     assert response.headers[REQUEST_ID_HEADER] == "failing-request"
-    failure_log = next(rec for rec in caplog.records if rec.message == "http_request_failed")
+    failure_log = _log_record(caplog, "http_request_failed")
     assert failure_log.request_id == "failing-request"
 
 
@@ -97,7 +101,7 @@ def test_http_exception_keeps_status_code_and_request_id(caplog: pytest.LogCaptu
 
     assert response.status_code == 418
     assert response.headers[REQUEST_ID_HEADER] == "teapot-request"
-    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    request_log = _log_record(caplog, "http_request")
     assert request_log.request_id == "teapot-request"
     assert request_log.status_code == 418
     assert all(rec.message != "http_request_failed" for rec in caplog.records)
@@ -126,7 +130,7 @@ def test_request_validation_error_keeps_status_code_and_request_id(
 
     assert response.status_code == 422
     assert response.headers[REQUEST_ID_HEADER] == "validation-request"
-    request_log = next(rec for rec in caplog.records if rec.message == "http_request")
+    request_log = _log_record(caplog, "http_request")
     assert request_log.request_id == "validation-request"
     assert request_log.status_code == 422
     assert all(rec.message != "http_request_failed" for rec in caplog.records)

--- a/apps/server/tests/adapters/http/test_settings_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_endpoints.py
@@ -82,24 +82,21 @@ def _settings_router(fake_state):
 class TestNormalizeMacOr400:
     """normalize_mac_or_400 raises HTTP 400 for invalid MAC path parameters."""
 
-    @pytest.mark.asyncio
-    async def test_empty_mac_raises_400(self, _settings_router) -> None:
+    def test_empty_mac_raises_400(self) -> None:
         from vibesensor.adapters.http._helpers import normalize_mac_or_400
 
         with pytest.raises(HTTPException) as exc_info:
             normalize_mac_or_400("")
         assert exc_info.value.status_code == 400
 
-    @pytest.mark.asyncio
-    async def test_oversized_mac_raises_400(self, _settings_router) -> None:
+    def test_oversized_mac_raises_400(self) -> None:
         from vibesensor.adapters.http._helpers import normalize_mac_or_400
 
         with pytest.raises(HTTPException) as exc_info:
             normalize_mac_or_400("A" * 65)
         assert exc_info.value.status_code == 400
 
-    @pytest.mark.asyncio
-    async def test_invalid_mac_format_raises_400(self, _settings_router) -> None:
+    def test_invalid_mac_format_raises_400(self) -> None:
         from vibesensor.adapters.http._helpers import normalize_mac_or_400
 
         with pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
This PR covers repo review chunk 014 and only the following files: `apps/server/tests/adapters/http/test_recording_endpoints.py`, `apps/server/tests/adapters/http/test_recording_route_http.py`, `apps/server/tests/adapters/http/test_request_observability.py`, `apps/server/tests/adapters/http/test_route_registration.py`, `apps/server/tests/adapters/http/test_settings_endpoints.py`, and `apps/server/tests/adapters/http/test_update_endpoints.py`.

I reviewed every code file in this chunk individually. Most of these HTTP endpoint tests were already clear, so the changes stay small and behavior-preserving. In `test_request_observability.py`, repeated caplog lookups now go through a shared `_log_record()` helper, which keeps the request-id assertions easier to scan. In `test_settings_endpoints.py`, the `normalize_mac_or_400` tests now reflect what they really are: synchronous helper checks, without unnecessary async markers or an unused router fixture dependency.

Key changed files: `apps/server/tests/adapters/http/test_request_observability.py` and `apps/server/tests/adapters/http/test_settings_endpoints.py`.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/test_recording_endpoints.py apps/server/tests/adapters/http/test_recording_route_http.py apps/server/tests/adapters/http/test_request_observability.py apps/server/tests/adapters/http/test_route_registration.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/adapters/http/test_update_endpoints.py`

Risk is minimal because the diff is test-only and limited to helper/marker simplification.
