### PR TITLE
Repo review chunk 015: tighten PDF test helpers

### DIFF
--- a/apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py
+++ b/apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py
@@ -19,7 +19,7 @@ def sample(
     speed_kmh: float | None,
     dominant_freq_hz: float,
     peak_amp_g: float,
-) -> dict:
+) -> dict[str, object]:
     return base_sample(
         idx,
         speed_kmh=speed_kmh,

--- a/apps/server/tests/adapters/pdf/_report_persistence_helpers.py
+++ b/apps/server/tests/adapters/pdf/_report_persistence_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from test_support.report_helpers import analysis_metadata as make_metadata
 from test_support.report_helpers import analysis_sample_with_peaks as sample
 
@@ -18,16 +20,16 @@ def uniform_samples(
     speed: float = 80.0,
     dt: float = 0.5,
     **kwargs: object,
-) -> list[dict]:
+) -> list[dict[str, object]]:
     return [sample(float(i) * dt, speed, [{"hz": freq, "amp": amp}], **kwargs) for i in range(n)]
 
 
 def build_findings(
-    samples: list[dict],
+    samples: list[dict[str, object]],
     *,
     order_finding_freqs: set[float] | None = None,
     per_sample_phases: list[DrivingPhase] | None = None,
-) -> list[dict]:
+) -> list[dict[str, object]]:
     return _build_persistent_peak_findings(
         samples=samples,
         order_finding_freqs=order_finding_freqs or set(),
@@ -36,7 +38,7 @@ def build_findings(
     )
 
 
-def findings_at_freq(findings: tuple | list, *freq_strs: str) -> list:
+def findings_at_freq(findings: Sequence[object], *freq_strs: str) -> list[object]:
     from vibesensor.domain import Finding
 
     def _matches(finding: object) -> bool:
@@ -50,5 +52,5 @@ def findings_at_freq(findings: tuple | list, *freq_strs: str) -> list:
     return [f for f in findings if _matches(f)]
 
 
-def summarize(samples: list[dict], **meta_overrides: object) -> dict:
+def summarize(samples: list[dict[str, object]], **meta_overrides: object) -> dict[str, object]:
     return summarize_run_data(make_metadata(**meta_overrides), samples, lang="en")

--- a/apps/server/tests/adapters/pdf/test_i18n_separation.py
+++ b/apps/server/tests/adapters/pdf/test_i18n_separation.py
@@ -19,6 +19,24 @@ from vibesensor.adapters.pdf.mapping import map_summary, prepare_report_input
 from vibesensor.report_i18n import is_i18n_ref, tr
 from vibesensor.report_i18n import resolve_i18n as resolve_i18n_impl
 
+_TRANSLATED_MARKERS = [
+    # Dutch markers
+    "Onbekend",
+    "Wiel / Band",
+    "Wielorde",
+    "wielorde",
+    "motororde",
+    "aandrijfasorde",
+    "Sensor zonder label",
+    "Snelheidsvariatie",
+    "Sensordekking",
+    # English translated phrases (from report_i18n, not raw codes)
+    "Unlabeled sensor",
+    "wheel order",
+    "engine order",
+    "driveshaft order",
+]
+
 
 def _resolve_i18n(lang: str, value: object) -> str:
     return resolve_i18n_impl(lang, value, tr=lambda key, **kw: tr(lang, key, **kw))
@@ -106,24 +124,6 @@ def _check_no_translated_strings(obj: object, path: str = "") -> list[str]:
 
     Returns a list of paths where localized text was found.
     """
-    # Known translated strings that should NOT appear in analysis output
-    _TRANSLATED_MARKERS = [
-        # Dutch markers
-        "Onbekend",
-        "Wiel / Band",
-        "Wielorde",
-        "wielorde",
-        "motororde",
-        "aandrijfasorde",
-        "Sensor zonder label",
-        "Snelheidsvariatie",
-        "Sensordekking",
-        # English translated phrases (from report_i18n, not raw codes)
-        "Unlabeled sensor",
-        "wheel order",
-        "engine order",
-        "driveshaft order",
-    ]
     violations: list[str] = []
 
     if isinstance(obj, str):


### PR DESCRIPTION
This PR covers repo review chunk 015 and only the following files: `apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py`, `apps/server/tests/adapters/pdf/_report_persistence_helpers.py`, `apps/server/tests/adapters/pdf/test_diagram_layout.py`, `apps/server/tests/adapters/pdf/test_i18n_separation.py`, `apps/server/tests/adapters/pdf/test_report_analysis_findings_integration.py`, `apps/server/tests/adapters/pdf/test_report_analysis_helpers.py`, `apps/server/tests/adapters/pdf/test_report_analysis_localization_integration.py`, `apps/server/tests/adapters/pdf/test_report_analysis_log_integration.py`, `apps/server/tests/adapters/pdf/test_report_analysis_phase_flow.py`, and `apps/server/tests/adapters/pdf/test_report_analysis_separation.py`.

I reviewed every code file in this chunk individually. Most of this PDF adapter test batch was already in good shape, so the changes are deliberately small and behavior-preserving. The updates focus on test-helper clarity: `_report_pdf_test_helpers.py` and `_report_persistence_helpers.py` now use tighter payload/helper annotations, and `test_i18n_separation.py` hoists its translated marker list to module scope so the recursive checker reuses a single constant instead of rebuilding the same list during each walk.

Key changed files: `apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py`, `apps/server/tests/adapters/pdf/_report_persistence_helpers.py`, and `apps/server/tests/adapters/pdf/test_i18n_separation.py`.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/_report_pdf_test_helpers.py apps/server/tests/adapters/pdf/_report_persistence_helpers.py apps/server/tests/adapters/pdf/test_diagram_layout.py apps/server/tests/adapters/pdf/test_i18n_separation.py apps/server/tests/adapters/pdf/test_report_analysis_findings_integration.py apps/server/tests/adapters/pdf/test_report_analysis_helpers.py apps/server/tests/adapters/pdf/test_report_analysis_localization_integration.py apps/server/tests/adapters/pdf/test_report_analysis_log_integration.py apps/server/tests/adapters/pdf/test_report_analysis_phase_flow.py apps/server/tests/adapters/pdf/test_report_analysis_separation.py`

Risk is minimal because the diff is test-only and limited to helper typing plus constant hoisting.
