### PR TITLE
Repo review chunk 016: tighten PDF report test payload typing

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_content_coverage.py
+++ b/apps/server/tests/adapters/pdf/test_report_content_coverage.py
@@ -33,7 +33,13 @@ _I18N_JSON = SERVER_ROOT / "data" / "report_i18n.json"
 # -- Fixtures reused from test_reports.py pattern ----------------------------
 
 
-def _sample(idx: int, *, speed_kmh: float, dominant_freq_hz: float, peak_amp_g: float) -> dict:
+def _sample(
+    idx: int,
+    *,
+    speed_kmh: float,
+    dominant_freq_hz: float,
+    peak_amp_g: float,
+) -> dict[str, object]:
     return _base_sample(
         idx,
         speed_kmh=speed_kmh,
@@ -45,7 +51,7 @@ def _sample(idx: int, *, speed_kmh: float, dominant_freq_hz: float, peak_amp_g: 
 
 def _make_run_jsonl(tmp_path: Path, *, tire_circumference_m: float = 2.20) -> Path:
     run_path = tmp_path / "run_content.jsonl"
-    records: list[dict] = [_run_metadata(tire_circumference_m=tire_circumference_m)]
+    records: list[dict[str, object]] = [_run_metadata(tire_circumference_m=tire_circumference_m)]
     for idx in range(30):
         speed = 40 + idx
         wheel_hz = (speed * KMH_TO_MPS) / tire_circumference_m

--- a/apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py
+++ b/apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py
@@ -4,7 +4,7 @@ from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.mapping import map_summary, prepare_report_input
 
-_ORDER_TOP_CAUSE: dict = {
+_ORDER_TOP_CAUSE: dict[str, object] = {
     "finding_id": "F_ORDER",
     "suspected_source": "wheel/tire",
     "strongest_location": "front-left",
@@ -13,14 +13,18 @@ _ORDER_TOP_CAUSE: dict = {
     "signatures_observed": ["1x wheel order"],
 }
 
-_BASE_ORDER_FINDING: dict = {
+_BASE_ORDER_FINDING: dict[str, object] = {
     "finding_id": "F_ORDER",
     "amplitude_metric": {"value": 0.015, "units": "g"},
     "evidence_metrics": {"vibration_strength_db": 23.4},
 }
 
 
-def _summary_with_top_order(finding: dict, *, sensor_rows: list[dict] | None = None) -> dict:
+def _summary_with_top_order(
+    finding: dict[str, object],
+    *,
+    sensor_rows: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
     return minimal_summary(
         top_causes=[_ORDER_TOP_CAUSE],
         findings=[finding],

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -20,7 +20,13 @@ from vibesensor.use_cases.diagnostics.summary_builder import (
 )
 
 
-def _sample(idx: int, *, speed_kmh: float, dominant_freq_hz: float, peak_amp_g: float) -> dict:
+def _sample(
+    idx: int,
+    *,
+    speed_kmh: float,
+    dominant_freq_hz: float,
+    peak_amp_g: float,
+) -> dict[str, object]:
     return _base_sample(
         idx,
         speed_kmh=speed_kmh,
@@ -52,7 +58,7 @@ def _origin_explanation(origin: VibrationOrigin) -> object:
 
 def test_map_summary_basic(tmp_path: Path) -> None:
     run_path = tmp_path / "map_summary.jsonl"
-    records: list[dict] = [_run_metadata(tire_circumference_m=2.2)]
+    records: list[dict[str, object]] = [_run_metadata(tire_circumference_m=2.2)]
     for idx in range(20):
         speed = 50 + idx
         wheel_hz = (speed * (1000.0 / 3600.0)) / 2.2


### PR DESCRIPTION
This PR covers **chunk 016** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/pdf/test_report_cli.py`
- `apps/server/tests/adapters/pdf/test_report_content_coverage.py`
- `apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py`
- `apps/server/tests/adapters/pdf/test_report_floor_estimation.py`
- `apps/server/tests/adapters/pdf/test_report_i18n.py`
- `apps/server/tests/adapters/pdf/test_report_mapping_context.py`
- `apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py`
- `apps/server/tests/adapters/pdf/test_report_metrics_consistency.py`
- `apps/server/tests/adapters/pdf/test_report_new_modules_labels.py`
- `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`

I personally reviewed every code file in this chunk. The only worthwhile behavior-preserving cleanup here was tightening a few remaining bare `dict` helper annotations in the PDF report tests so the synthetic payload contracts are clearer and more consistent with the surrounding typed helpers. The concrete edits are in `test_report_content_coverage.py`, `test_report_data_strength_db_source.py`, and `test_report_new_modules_mapping.py`; the other seven files were reviewed and intentionally left unchanged.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_cli.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py apps/server/tests/adapters/pdf/test_report_floor_estimation.py apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_report_metrics_consistency.py apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`

Risk is low: this is test-only typing/readability cleanup with no assertion or runtime behavior changes. No additional follow-up is needed inside this chunk.
