### PR TITLE
Repo review chunk 017: tighten PDF layout and audit helper typing

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -20,7 +20,13 @@ from vibesensor.adapters.pdf.panels._panel_diagram import (
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 
 
-def _sample(idx: int, *, speed_kmh: float, dominant_freq_hz: float, peak_amp_g: float) -> dict:
+def _sample(
+    idx: int,
+    *,
+    speed_kmh: float,
+    dominant_freq_hz: float,
+    peak_amp_g: float,
+) -> dict[str, object]:
     return _base_sample(
         idx,
         speed_kmh=speed_kmh,
@@ -31,7 +37,7 @@ def _sample(idx: int, *, speed_kmh: float, dominant_freq_hz: float, peak_amp_g: 
 
 def test_report_pdf_no_car_metadata(tmp_path: Path) -> None:
     run_path = tmp_path / "no_car.jsonl"
-    records: list[dict] = [_run_metadata()]
+    records: list[dict[str, object]] = [_run_metadata()]
     for idx in range(15):
         records.append(_sample(idx, speed_kmh=50.0 + idx, dominant_freq_hz=14.0, peak_amp_g=0.08))
     records.append(RUN_END)
@@ -47,7 +53,7 @@ def test_report_pdf_no_car_metadata(tmp_path: Path) -> None:
 
 def test_report_pdf_two_pages(tmp_path: Path) -> None:
     run_path = tmp_path / "two_pages.jsonl"
-    records: list[dict] = [_run_metadata(tire_circumference_m=2.2)]
+    records: list[dict[str, object]] = [_run_metadata(tire_circumference_m=2.2)]
     for idx in range(30):
         speed = 40 + idx
         wheel_hz = (speed * (1000.0 / 3600.0)) / 2.2

--- a/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
@@ -13,9 +13,12 @@ from vibesensor.report_i18n import tr
 # ---------------------------------------------------------------------------
 
 
-def _make_minimal_summary(*, overrides: dict | None = None) -> dict:
+def _make_minimal_summary(
+    *,
+    overrides: dict[str, object] | None = None,
+) -> dict[str, object]:
     """Return a minimal summary dict that ``map_summary`` can process."""
-    base: dict = {
+    base: dict[str, object] = {
         "lang": "en",
         "report_date": "2025-01-01T00:00:00",
         "metadata": {"car_name": "Test Car"},
@@ -56,7 +59,7 @@ def _make_peaks_table_row(
     p95_vs_run_noise_ratio: float = 5.0,
     spatial_uniformity: float | None = None,
     speed_uniformity: float | None = None,
-) -> dict:
+) -> dict[str, object]:
     """Build a single peaks-table row dict as produced by diagnostics peak-table builders."""
     if strength_db is None:
         strength_db = p95_intensity_db  # mirrors the current (buggy) behavior


### PR DESCRIPTION
This PR covers **chunk 017** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
- `apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py`
- `apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py`
- `apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`
- `apps/server/tests/adapters/pdf/test_report_persistence_classification.py`
- `apps/server/tests/adapters/pdf/test_report_persistence_findings.py`
- `apps/server/tests/adapters/pdf/test_report_persistence_summary.py`
- `apps/server/tests/adapters/pdf/test_report_pipeline_audit.py`
- `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
- `apps/server/tests/adapters/pdf/test_report_scenario_classification_regression.py`

I personally reviewed every code file in this chunk. The worthwhile behavior-preserving cleanup here was tightening a few remaining bare `dict` helper annotations in the PDF layout and report-pipeline audit tests. The concrete edits are in `test_report_new_modules_pdf_layout.py` and `test_report_pipeline_audit.py`; the other eight files were reviewed directly and intentionally left unchanged because their current helper structure and assertions were already clear.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_persistence_classification.py apps/server/tests/adapters/pdf/test_report_persistence_findings.py apps/server/tests/adapters/pdf/test_report_persistence_summary.py apps/server/tests/adapters/pdf/test_report_pipeline_audit.py apps/server/tests/adapters/pdf/test_report_rendering_regressions.py apps/server/tests/adapters/pdf/test_report_scenario_classification_regression.py`

Risk is low: these are test-only typing/readability improvements with no assertion or production-path behavior changes. No additional follow-up is needed inside this chunk.
