### PR TITLE
Repo review chunk 018: tighten remaining PDF test typing

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_scenario_output_regression.py
+++ b/apps/server/tests/adapters/pdf/test_report_scenario_output_regression.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from test_support.core import standard_metadata
 from test_support.sample_scenarios import build_speed_sweep_samples, make_sample
 
@@ -32,7 +30,7 @@ class TestMultiSensorLocalization:
     """Multi-sensor runs should retain strongest-location evidence in summary output."""
 
     def test_multi_sensor_run(self) -> None:
-        samples: list[dict[str, Any]] = []
+        samples: list[dict[str, object]] = []
         tire_circumference = 2.036
         for idx in range(30):
             speed = 40.0 + idx * 2.0

--- a/apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py
+++ b/apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 from test_support.core import standard_metadata
 from test_support.sample_scenarios import (
@@ -90,7 +88,7 @@ class TestPhaseSegmentation:
     def test_diagnostic_mask(
         self,
         phases: list[DrivingPhase],
-        kwargs: dict[str, Any],
+        kwargs: dict[str, object],
         expected: list[bool],
     ) -> None:
         assert diagnostic_sample_mask(phases, **kwargs) == expected

--- a/apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py
+++ b/apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.mapping import map_summary, prepare_report_input
@@ -14,7 +12,7 @@ from vibesensor.adapters.pdf.presentation import strength_text
 # Shared top-cause / finding templates
 # ---------------------------------------------------------------------------
 
-_F_ORDER_CAUSE: dict[str, Any] = {
+_F_ORDER_CAUSE: dict[str, object] = {
     "finding_id": "F_ORDER",
     "suspected_source": "wheel/tire",
     "strongest_location": "front-left",

--- a/apps/server/tests/adapters/pdf/test_report_tier_gating.py
+++ b/apps/server/tests/adapters/pdf/test_report_tier_gating.py
@@ -68,8 +68,8 @@ def _make_summary(
     speed_band: str = "60-70 km/h",
     sensor_count: int = 2,
     lang: str = "en",
-    test_plan: list[dict] | None = None,
-) -> dict:
+    test_plan: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
     """Build a minimal summary dict for map_summary() testing."""
     finding = {
         "finding_id": "order_1x_wheel",

--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -26,7 +26,7 @@ from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_fi
 
 def _minimal_summary(**overrides: object) -> dict[str, object]:
     """Build a minimal SummaryData dict with overrides."""
-    base: dict = {
+    base: dict[str, object] = {
         "file_name": "test",
         "run_id": "run-1",
         "rows": 10,

--- a/apps/server/tests/adapters/pdf/test_template_builder.py
+++ b/apps/server/tests/adapters/pdf/test_template_builder.py
@@ -55,7 +55,7 @@ def _make_context(**overrides: object) -> ReportMappingContext:
 
 
 def _make_report(**overrides: object) -> Report:
-    defaults: dict = {
+    defaults: dict[str, object] = {
         "run_id": "run-001",
         "lang": "en",
         "car_name": None,
@@ -66,7 +66,7 @@ def _make_report(**overrides: object) -> Report:
 
 
 def _make_primary(**overrides: object) -> PrimaryCandidateContext:
-    defaults: dict = {
+    defaults: dict[str, object] = {
         "primary_candidate": None,
         "primary_source": "wheel/tire",
         "primary_system": "Wheel/Tire",


### PR DESCRIPTION
This PR covers **chunk 018** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/pdf/test_report_scenario_confidence_regression.py`
- `apps/server/tests/adapters/pdf/test_report_scenario_output_regression.py`
- `apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py`
- `apps/server/tests/adapters/pdf/test_report_sensor_location_stats.py`
- `apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py`
- `apps/server/tests/adapters/pdf/test_report_summary_basics.py`
- `apps/server/tests/adapters/pdf/test_report_tier_gating.py`
- `apps/server/tests/adapters/pdf/test_summary_view.py`
- `apps/server/tests/adapters/pdf/test_template_builder.py`

I personally reviewed every code file in this chunk. The worthwhile behavior-preserving cleanup here was finishing a small typing consistency sweep across the remaining PDF report test helpers: replacing a few leftover `Any`/bare `dict` annotations with the more precise `dict[str, object]` contracts already used elsewhere in this test area. The concrete edits are in `test_report_scenario_output_regression.py`, `test_report_scenario_phase_regression.py`, `test_report_strength_label_peak_amp.py`, `test_report_tier_gating.py`, `test_summary_view.py`, and `test_template_builder.py`; the other three files were reviewed directly and intentionally left unchanged.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_scenario_confidence_regression.py apps/server/tests/adapters/pdf/test_report_scenario_output_regression.py apps/server/tests/adapters/pdf/test_report_scenario_phase_regression.py apps/server/tests/adapters/pdf/test_report_sensor_location_stats.py apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_tier_gating.py apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/adapters/pdf/test_template_builder.py`

Risk is low: these are test-only typing/readability cleanups with no assertion or runtime behavior changes. No additional follow-up is needed inside this chunk.
