### PR TITLE
Repo review chunk 020: tighten history-db test typing

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -40,7 +40,7 @@ def _analysis(run_id: str, **overrides: object) -> AnalysisSummary:
     return cast(AnalysisSummary, payload)
 
 
-def _sensor_frame_dict(i: int, *, run_id: str = "run-v2") -> dict:
+def _sensor_frame_dict(i: int, *, run_id: str = "run-v2") -> dict[str, object]:
     return {
         "record_type": "sample",
         "schema_version": "v2-jsonl",

--- a/apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from vibesensor.adapters.gps.gps_speed import SpeedResolution
 from vibesensor.shared.types.payload_types import ClientMetrics
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 from vibesensor.use_cases.run.logger import _MAX_HISTORY_CREATE_RETRIES
@@ -78,9 +79,7 @@ class _FakeGPSMonitor:
     effective_speed_mps = None
     override_speed_mps = None
 
-    def resolve_speed(self):
-        from vibesensor.adapters.gps.gps_speed import SpeedResolution
-
+    def resolve_speed(self) -> SpeedResolution:
         return SpeedResolution(speed_mps=None, fallback_active=False, source="none")
 
 
@@ -96,10 +95,10 @@ class _FakeProcessor:
     ) -> None:
         return None
 
-    def latest_sample_xyz(self, client_id: str):
+    def latest_sample_xyz(self, client_id: str) -> tuple[float, float, float]:
         return (0.01, 0.02, 0.03)
 
-    def latest_sample_rate_hz(self, client_id: str):
+    def latest_sample_rate_hz(self, client_id: str) -> int:
         return 800
 
     def compute_metrics(self, client_id: str, sample_rate_hz: int | None = None) -> ClientMetrics:
@@ -131,7 +130,7 @@ def _make_logger(history_db, _tmp_path: Path) -> RunRecorder:
     )
 
 
-def _start_and_snapshot(logger: RunRecorder):
+def _start_and_snapshot(logger: RunRecorder) -> tuple[str, str, float]:
     """Start logging and return (run_id, start_utc, start_mono)."""
     logger.start_recording()
     snap = logger._session_snapshot()


### PR DESCRIPTION
This PR covers **chunk 020** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py`
- `apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py`
- `apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py`
- `apps/server/tests/adapters/persistence/history_db/test_schema_migration.py`

I personally reviewed every code file in this chunk. The worthwhile behavior-preserving cleanup here was tightening a couple of remaining test-helper annotations in the history-db area: one sample-row fixture helper still returned a bare `dict`, and the write-error fakes had a few missing return annotations even though they expose stable shapes to the recorder code under test. The concrete edits are in `test_history_db_structured_storage.py` and `test_history_write_errors.py`; the other six files were reviewed directly and intentionally left unchanged.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py apps/server/tests/adapters/persistence/history_db/test_history_write_errors.py apps/server/tests/adapters/persistence/history_db/test_sample_row_decoding.py apps/server/tests/adapters/persistence/history_db/test_schema_migration.py`

Risk is low: these are test-only typing/readability cleanups with no assertion or runtime behavior changes. No additional follow-up is needed inside this chunk.
