### PR TITLE
Repo review chunk 021: tighten simulator test typing

### DIFF
--- a/apps/server/tests/adapters/simulator/test_server_http.py
+++ b/apps/server/tests/adapters/simulator/test_server_http.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 from urllib.request import Request
 
 from vibesensor.adapters.simulator.server_http import set_server_speed_override_kmh
 
 
 class _FakeResponse:
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: dict[str, object]) -> None:
         self._payload = payload
 
     def __enter__(self) -> _FakeResponse:
@@ -24,7 +23,7 @@ class _FakeResponse:
 
 
 def test_set_server_speed_override_uses_http_api_snake_case(monkeypatch) -> None:
-    captured: dict[str, Any] = {}
+    captured: dict[str, object] = {}
 
     def fake_urlopen(req: Request, timeout: float) -> _FakeResponse:
         captured["url"] = req.full_url


### PR DESCRIPTION
This PR covers **chunk 021** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/simulator/test_server_http.py`
- `apps/server/tests/adapters/simulator/test_sim_client.py`
- `apps/server/tests/adapters/simulator/test_sim_scene.py`

I personally reviewed every code file in this chunk. The only worthwhile behavior-preserving cleanup was in `test_server_http.py`, where the fake response payload and captured request dictionary still used `Any` even though the test only stores concrete JSON-like values. Tightening those to `dict[str, object]` makes the helper contract clearer without affecting request construction, assertions, or runtime behavior. The other two simulator test files were also reviewed directly and intentionally left unchanged because they were already compact and readable.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/simulator/test_server_http.py apps/server/tests/adapters/simulator/test_sim_client.py apps/server/tests/adapters/simulator/test_sim_scene.py`

Result: `4 passed`.

Risk is minimal because this is a test-only type-contract cleanup with no semantic changes. I did not change simulator behavior, HTTP request fields, numeric expectations, or scene-generation assertions. No additional follow-up is needed for this chunk.
