### PR TITLE
Repo review chunk 022: tighten UDP test helper typing

### DIFF
--- a/apps/server/tests/adapters/udp/conftest.py
+++ b/apps/server/tests/adapters/udp/conftest.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 
 import pytest
+
+from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
 
 
 class FakeTransport:
@@ -28,10 +31,10 @@ def fake_transport() -> FakeTransport:
 
 
 @pytest.fixture
-def drain_queue():
+def drain_queue() -> Callable[[DataDatagramProtocol], Awaitable[None]]:
     """Return an async callable that drains a DataDatagramProtocol queue."""
 
-    async def _drain(proto, *, timeout: float = 2.0) -> None:
+    async def _drain(proto: DataDatagramProtocol, *, timeout: float = 2.0) -> None:
         consumer = asyncio.create_task(proto.process_queue())
         await asyncio.wait_for(proto._queue.join(), timeout=timeout)
         consumer.cancel()

--- a/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
+++ b/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -33,8 +34,8 @@ def _make_processor(**kwargs) -> SignalProcessor:
 
 def test_flush_client_buffer_resets_count_and_write_idx() -> None:
     proc = _make_processor()
-    _rng = np.random.default_rng(42)
-    samples = _rng.standard_normal((500, 3)).astype(np.float32)
+    rng = np.random.default_rng(42)
+    samples = rng.standard_normal((500, 3)).astype(np.float32)
     proc.ingest("c1", samples, sample_rate_hz=800)
 
     buf = proc._store.buffers["c1"]
@@ -65,8 +66,8 @@ def test_fft_waits_for_new_samples_after_flush() -> None:
     proc = _make_processor(fft_n=fft_n)
 
     # Ingest enough for FFT
-    _rng = np.random.default_rng(42)
-    samples = _rng.standard_normal((fft_n, 3)).astype(np.float32)
+    rng = np.random.default_rng(42)
+    samples = rng.standard_normal((fft_n, 3)).astype(np.float32)
     proc.ingest("c1", samples, sample_rate_hz=800)
     metrics = proc.compute_metrics("c1", sample_rate_hz=800)
     # Should have spectrum data
@@ -140,7 +141,7 @@ def _data_msg(seq: int, t0_us: int) -> DataMessage:
 
 
 @pytest.fixture
-def registry_ctx(tmp_path):
+def registry_ctx(tmp_path: Path) -> ClientRegistry:
     """Registry pre-registered with a single client."""
     db = HistoryDB(tmp_path / "history.db")
     registry = ClientRegistry(db=db)
@@ -172,10 +173,10 @@ def test_registry_update_from_data_returns_true_on_reset(registry_ctx) -> None:
 
 
 def test_registry_update_from_data_returns_false_on_normal_seq(registry_ctx) -> None:
-    r1 = registry_ctx.update_from_data(_data_msg(100, 100_000), _ADDR, now=2.0)
-    r2 = registry_ctx.update_from_data(_data_msg(101, 200_000), _ADDR, now=3.0)
-    assert r1.reset_detected is False
-    assert r2.reset_detected is False
+    first_result = registry_ctx.update_from_data(_data_msg(100, 100_000), _ADDR, now=2.0)
+    second_result = registry_ctx.update_from_data(_data_msg(101, 200_000), _ADDR, now=3.0)
+    assert first_result.reset_detected is False
+    assert second_result.reset_detected is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -102,7 +102,7 @@ def test_control_datagram_operational_error_is_logged_and_counted(
     protocol = ControlDatagramProtocol(registry)
     packet = pack_ack(bytes.fromhex(client_hex), cmd_seq=7, status=0)
 
-    def raise_oserror(ack, now_ts):
+    def raise_oserror(_ack: object, _now_ts: float) -> None:
         raise OSError("socket boom")
 
     monkeypatch.setattr(registry, "update_from_ack", raise_oserror)


### PR DESCRIPTION
This PR covers **chunk 022** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/udp/conftest.py`
- `apps/server/tests/adapters/udp/test_protocol.py`
- `apps/server/tests/adapters/udp/test_protocol_validator.py`
- `apps/server/tests/adapters/udp/test_protocol_version_mismatch.py`
- `apps/server/tests/adapters/udp/test_reset_buffer_flush.py`
- `apps/server/tests/adapters/udp/test_udp_control_tx.py`
- `apps/server/tests/adapters/udp/test_udp_data_rx.py`
- `apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`

I personally reviewed every code file in this chunk. The behavior-preserving cleanup here stays strictly in test helpers and fixtures: the shared `drain_queue` fixture now has explicit protocol/callable typing, the reset-buffer test module now annotates its registry fixture and uses clearer local names for the two sequential update results, and the operational-error seam in `test_udp_control_tx.py` now has explicit callback argument types. The remaining UDP test files were reviewed directly and intentionally left unchanged because they were already compact and readable.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/udp/conftest.py apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_protocol_validator.py apps/server/tests/adapters/udp/test_protocol_version_mismatch.py apps/server/tests/adapters/udp/test_reset_buffer_flush.py apps/server/tests/adapters/udp/test_udp_control_tx.py apps/server/tests/adapters/udp/test_udp_data_rx.py apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`

Result: `101 passed`.

Risk is low because this is test-only contract and readability cleanup with no packet-format, protocol, or runtime behavior changes.
