### PR TITLE
Repo review chunk 023: tighten websocket test typing

### DIFF
--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
@@ -21,7 +20,7 @@ def _make_ws() -> AsyncMock:
     return ws
 
 
-def _sent_json(ws: AsyncMock) -> Any:
+def _sent_json(ws: AsyncMock) -> dict[str, object]:
     """Return the parsed JSON sent via ``ws.send_text``."""
     return json.loads(ws.send_text.call_args[0][0])
 
@@ -466,7 +465,7 @@ class TestSanitizeForJson:
         assert had is False
 
     @pytest.mark.parametrize("empty", [{}, []], ids=["dict", "list"])
-    def test_empty_structures(self, empty: Any) -> None:
+    def test_empty_structures(self, empty: object) -> None:
         cleaned, had = sanitize_for_json(empty)
         assert cleaned == empty
         assert had is False

--- a/apps/server/tests/adapters/websocket/test_ws_models.py
+++ b/apps/server/tests/adapters/websocket/test_ws_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -12,6 +12,9 @@ from vibesensor.cli.ws_schema_export import export_schema
 from vibesensor.infra.processing import ClientBuffer, SignalProcessor
 from vibesensor.shared.types.payload_types import SCHEMA_VERSION
 from vibesensor.vibration_strength import empty_vibration_strength_metrics
+
+if TYPE_CHECKING:
+    from vibesensor.app.runtime_state import RuntimeState
 
 # ---------------------------------------------------------------------------
 # Schema export check
@@ -32,7 +35,7 @@ def test_schema_export_check_passes() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_state(**kwargs: Any) -> Any:
+def _make_state(**kwargs: object) -> RuntimeState:
     """Build a RuntimeState with stubs (reuse the helpers from test_build_ws_payload)."""
     # Import the factory from the existing test module.
     from test_build_ws_payload import _make_state as _factory
@@ -60,8 +63,8 @@ class TestMultiSpectrumFreqDedup:
 
     @staticmethod
     def _make_processor_with_clients(
-        client_data: dict[str, dict[str, Any]],
-    ) -> Any:
+        client_data: dict[str, dict[str, list[float]]],
+    ) -> SignalProcessor:
         """Create a SignalProcessor and inject fake spectrum data."""
         proc = SignalProcessor(
             sample_rate_hz=800,

--- a/apps/server/tests/adapters/websocket/test_ws_schema_export.py
+++ b/apps/server/tests/adapters/websocket/test_ws_schema_export.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 from _paths import REPO_ROOT
@@ -26,7 +26,7 @@ def schema_text() -> str:
 
 
 @pytest.fixture(scope="module")
-def schema_dict(schema_text: str) -> dict[str, Any]:
+def schema_dict(schema_text: str) -> dict[str, object]:
     """Cached parsed schema dict."""
     return json.loads(schema_text)
 
@@ -36,7 +36,7 @@ def schema_dict(schema_text: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def test_export_schema_returns_valid_json(schema_dict: dict[str, Any]) -> None:
+def test_export_schema_returns_valid_json(schema_dict: dict[str, object]) -> None:
     """export_schema() must return a valid JSON string."""
     assert isinstance(schema_dict, dict)
     assert "properties" in schema_dict or "$defs" in schema_dict
@@ -77,14 +77,14 @@ def test_export_schema_matches_committed_schema(schema_text: str) -> None:
     )
 
 
-def test_export_schema_has_schema_version(schema_dict: dict[str, Any]) -> None:
+def test_export_schema_has_schema_version(schema_dict: dict[str, object]) -> None:
     """The schema must include the schema_version field."""
     props = schema_dict.get("properties", {})
     assert "schema_version" in props, "schema_version must be a top-level property"
 
 
 def test_export_schema_requires_always_present_top_level_fields(
-    schema_dict: dict[str, Any],
+    schema_dict: dict[str, object],
 ) -> None:
     """Always-emitted WS payload fields must be required in the schema."""
     required = set(schema_dict.get("required", []))


### PR DESCRIPTION
This PR covers **chunk 023** of the full repository review and includes these reviewed code files:

- `apps/server/tests/adapters/websocket/test_build_ws_payload.py`
- `apps/server/tests/adapters/websocket/test_connection_tracker.py`
- `apps/server/tests/adapters/websocket/test_payload_orchestrator.py`
- `apps/server/tests/adapters/websocket/test_tick_controller.py`
- `apps/server/tests/adapters/websocket/test_ws_hub.py`
- `apps/server/tests/adapters/websocket/test_ws_models.py`
- `apps/server/tests/adapters/websocket/test_ws_schema_export.py`

I personally reviewed every code file in this chunk. The diff stays strictly behavior-preserving and test-only: it tightens a few remaining JSON/payload helper contracts so these websocket tests model the concrete shapes they already use. In practice that means `_sent_json()` in `test_ws_hub.py` now returns a JSON-object payload instead of `Any`, the schema-export test module uses `dict[str, object]` for parsed schema fixtures, and `test_ws_models.py` narrows its helper return types to the concrete `RuntimeState` and `SignalProcessor` shapes already produced. The other websocket test files were reviewed directly and left unchanged because they were already clear and compact.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_connection_tracker.py apps/server/tests/adapters/websocket/test_payload_orchestrator.py apps/server/tests/adapters/websocket/test_tick_controller.py apps/server/tests/adapters/websocket/test_ws_hub.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/adapters/websocket/test_ws_schema_export.py`

Result: `82 passed`.

Risk is low because these are test-only type/readability cleanups with no websocket runtime behavior changes.
