### PR TITLE
Repo review chunk 027: simplify hygiene test fakes

### DIFF
--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -45,44 +46,28 @@ def install_pi_text() -> str:
 def test_smoke_health_route_registered() -> None:
     state = MagicMock()
     placeholder = MagicMock()
-    state.telemetry = type(
-        "Telemetry",
-        (),
-        {
-            "control_plane": placeholder,
-            "health_state": placeholder,
-            "processing_loop_state": placeholder,
-            "processor": placeholder,
-            "registry": placeholder,
-            "run_recorder": placeholder,
-            "ws_hub": placeholder,
-        },
-    )()
-    state.settings = type(
-        "Settings",
-        (),
-        {
-            "gps_monitor": placeholder,
-            "settings_store": placeholder,
-        },
-    )()
-    state.history = type(
-        "History",
-        (),
-        {
-            "export_service": placeholder,
-            "report_service": placeholder,
-            "run_service": placeholder,
-        },
-    )()
-    state.updates = type(
-        "Updates",
-        (),
-        {
-            "esp_flash_manager": placeholder,
-            "update_manager": placeholder,
-        },
-    )()
+    state.telemetry = SimpleNamespace(
+        control_plane=placeholder,
+        health_state=placeholder,
+        processing_loop_state=placeholder,
+        processor=placeholder,
+        registry=placeholder,
+        run_recorder=placeholder,
+        ws_hub=placeholder,
+    )
+    state.settings = SimpleNamespace(
+        gps_monitor=placeholder,
+        settings_store=placeholder,
+    )
+    state.history = SimpleNamespace(
+        export_service=placeholder,
+        report_service=placeholder,
+        run_service=placeholder,
+    )
+    state.updates = SimpleNamespace(
+        esp_flash_manager=placeholder,
+        update_manager=placeholder,
+    )
     router = create_router(state)
     routes = {r.path: r.methods for r in router.routes if hasattr(r, "methods")}
     assert "/api/health" in routes, "Missing /api/health route"


### PR DESCRIPTION
This PR covers **chunk 027** of the full repository review and includes these reviewed code files:

- `apps/server/tests/hygiene/test_ai_smoke.py`
- `apps/server/tests/hygiene/test_analysis_settings_sync.py`
- `apps/server/tests/hygiene/test_api_model_boundary_parity.py`
- `apps/server/tests/hygiene/test_car_library_artifact_sync.py`
- `apps/server/tests/hygiene/test_ci_command_parity.py`
- `apps/server/tests/hygiene/test_ci_job_parity.py`
- `apps/server/tests/hygiene/test_ci_lite_job_parity.py`
- `apps/server/tests/hygiene/test_ci_parallel_bootstrap.py`
- `apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py`
- `apps/server/tests/hygiene/test_dev_workflow.py`

I personally reviewed every code file in this chunk. Most of these hygiene guards were already clear and intentionally narrow, so they were left unchanged after direct inspection. The one behavior-preserving cleanup here is in `test_ai_smoke.py`: the smoke test that builds a fake app state used four separate ad-hoc `type(..., (), {...})()` attribute bags. This PR replaces those with `types.SimpleNamespace`, which is the standard-library tool for lightweight attribute containers and makes the test setup much easier to read.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py apps/server/tests/hygiene/test_analysis_settings_sync.py apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/hygiene/test_car_library_artifact_sync.py apps/server/tests/hygiene/test_ci_command_parity.py apps/server/tests/hygiene/test_ci_job_parity.py apps/server/tests/hygiene/test_ci_lite_job_parity.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_dependency_reproducibility_hygiene.py apps/server/tests/hygiene/test_dev_workflow.py`

Result: `76 passed`.

Risk is very low because this is test-only setup simplification with no assertion or behavior changes.
