### PR TITLE
Repo review chunk 028: parameterize hygiene exception checks

### DIFF
--- a/apps/server/tests/hygiene/test_domain_exceptions.py
+++ b/apps/server/tests/hygiene/test_domain_exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.shared.exceptions import (
     AnalysisNotReadyError,
     ConfigurationError,
@@ -30,34 +32,34 @@ def test_base_exception_is_exception() -> None:
     assert issubclass(VibeSensorError, Exception)
 
 
-def test_domain_errors_catchable_by_base() -> None:
+@pytest.mark.parametrize("exc_cls", _ALL_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_domain_errors_catchable_by_base(exc_cls: type[VibeSensorError]) -> None:
     """All domain exceptions should be catchable with VibeSensorError."""
-    for exc_cls in _ALL_DOMAIN_EXCEPTIONS:
-        try:
-            raise exc_cls("test")
-        except VibeSensorError:
-            pass  # expected
-        else:
-            raise AssertionError(f"{exc_cls.__name__} not catchable as VibeSensorError")
+    try:
+        raise exc_cls("test")
+    except VibeSensorError:
+        pass  # expected
+    else:
+        raise AssertionError(f"{exc_cls.__name__} not catchable as VibeSensorError")
 
 
-def test_all_domain_exceptions_single_base() -> None:
+@pytest.mark.parametrize("exc_cls", _ALL_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_all_domain_exceptions_single_base(exc_cls: type[VibeSensorError]) -> None:
     """Every domain exception inherits exclusively from VibeSensorError."""
     assert VibeSensorError.__bases__ == (Exception,)
-    for exc_cls in _ALL_DOMAIN_EXCEPTIONS:
-        assert exc_cls.__bases__ == (VibeSensorError,), (
-            f"{exc_cls.__name__}.__bases__ = {exc_cls.__bases__}, expected (VibeSensorError,)"
-        )
+    assert exc_cls.__bases__ == (VibeSensorError,), (
+        f"{exc_cls.__name__}.__bases__ = {exc_cls.__bases__}, expected (VibeSensorError,)"
+    )
 
 
-def test_no_stdlib_exception_inheritance() -> None:
+@pytest.mark.parametrize("exc_cls", _ALL_DOMAIN_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_no_stdlib_exception_inheritance(exc_cls: type[VibeSensorError]) -> None:
     """No domain exception is a subclass of ValueError, RuntimeError, or LookupError."""
     stdlib_bases = (ValueError, RuntimeError, LookupError)
-    for exc_cls in _ALL_DOMAIN_EXCEPTIONS:
-        for stdlib in stdlib_bases:
-            assert not issubclass(exc_cls, stdlib), (
-                f"{exc_cls.__name__} should not be a subclass of {stdlib.__name__}"
-            )
+    for stdlib in stdlib_bases:
+        assert not issubclass(exc_cls, stdlib), (
+            f"{exc_cls.__name__} should not be a subclass of {stdlib.__name__}"
+        )
 
 
 def test_configuration_error_caught_by_vibesensor_error() -> None:


### PR DESCRIPTION
This PR covers **chunk 028** of the full repository review and includes these reviewed code files:

- `apps/server/tests/hygiene/test_diagnostic_case_boundary_roles.py`
- `apps/server/tests/hygiene/test_docker_ci_hygiene.py`
- `apps/server/tests/hygiene/test_domain_boundary_parity.py`
- `apps/server/tests/hygiene/test_domain_exceptions.py`
- `apps/server/tests/hygiene/test_domain_exports_guardrails.py`
- `apps/server/tests/hygiene/test_domain_finding_guardrails.py`
- `apps/server/tests/hygiene/test_domain_graph_and_lifecycle_guardrails.py`
- `apps/server/tests/hygiene/test_domain_migration_guardrails.py`
- `apps/server/tests/hygiene/test_domain_model_completeness.py`
- `apps/server/tests/hygiene/test_domain_model_guardrails.py`

I personally reviewed every code file in this chunk. Most of these hygiene guards were already sharp and intentionally narrow, so they were left unchanged after direct inspection. The behavior-preserving cleanup here is in `test_domain_exceptions.py`: several tests manually looped over the same domain exception tuple, which made failures less granular. This PR parameterizes those checks with `pytest.mark.parametrize`, so any future regression points directly at the specific exception class that broke while preserving the same assertions and coverage.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_diagnostic_case_boundary_roles.py apps/server/tests/hygiene/test_docker_ci_hygiene.py apps/server/tests/hygiene/test_domain_boundary_parity.py apps/server/tests/hygiene/test_domain_exceptions.py apps/server/tests/hygiene/test_domain_exports_guardrails.py apps/server/tests/hygiene/test_domain_finding_guardrails.py apps/server/tests/hygiene/test_domain_graph_and_lifecycle_guardrails.py apps/server/tests/hygiene/test_domain_migration_guardrails.py apps/server/tests/hygiene/test_domain_model_completeness.py apps/server/tests/hygiene/test_domain_model_guardrails.py`

Result: `168 passed`.

Risk is very low because this is test-only parameterization for better failure isolation; no production logic or expected behavior changed.
