### PR TITLE
Repo review chunk 029: simplify hygiene boundary imports

### DIFF
--- a/apps/server/tests/hygiene/test_domain_test_run_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_test_run_guardrails.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from vibesensor.shared.boundaries.test_run_reconstruction import (
+    test_run_from_summary as reconstruct_test_run_from_summary,
+)
+
 
 def test_test_run_is_frozen_dataclass() -> None:
     """``TestRun`` must be a frozen dataclass."""
@@ -180,8 +184,6 @@ def test_test_run_primary_source_and_location() -> None:
 
 def test_test_run_from_summary_populates_speed_profile() -> None:
     """test_run_from_summary extracts SpeedProfile when speed_stats is present."""
-    from vibesensor.shared.boundaries.test_run_reconstruction import test_run_from_summary
-
     summary = {
         "run_id": "test-123",
         "findings": [],
@@ -192,15 +194,13 @@ def test_test_run_from_summary_populates_speed_profile() -> None:
             "steady_speed": True,
         },
     }
-    result = test_run_from_summary(summary)
+    result = reconstruct_test_run_from_summary(summary)
     assert result.speed_profile is not None, "test_run_from_summary must populate speed_profile"
     assert result.speed_profile.steady_speed
 
 
 def test_test_run_from_summary_populates_suitability() -> None:
     """test_run_from_summary extracts RunSuitability when run_suitability is present."""
-    from vibesensor.shared.boundaries.test_run_reconstruction import test_run_from_summary
-
     summary = {
         "run_id": "test-123",
         "findings": [],
@@ -209,7 +209,7 @@ def test_test_run_from_summary_populates_suitability() -> None:
             {"check_key": "speed", "state": "pass", "explanation": "OK"},
         ],
     }
-    result = test_run_from_summary(summary)
+    result = reconstruct_test_run_from_summary(summary)
     assert result.suitability is not None, "test_run_from_summary must populate suitability"
     assert result.suitability.is_usable
 


### PR DESCRIPTION
This PR covers **chunk 029** of the full repository review and includes these reviewed code files:

- `apps/server/tests/hygiene/test_domain_new_types.py`
- `apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py`
- `apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py`
- `apps/server/tests/hygiene/test_domain_test_run_guardrails.py`
- `apps/server/tests/hygiene/test_frontend_metric_fields_sync.py`
- `apps/server/tests/hygiene/test_history_db_mixins.py`
- `apps/server/tests/hygiene/test_location_codes_sync.py`
- `apps/server/tests/hygiene/test_main_release_workflow.py`
- `apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `apps/server/tests/hygiene/test_pi_gen_artifact_selection.py`

I personally reviewed every code file in this chunk. Most of these hygiene guards were already tight and readable, so they were intentionally left unchanged after direct inspection. The behavior-preserving cleanup here is in `test_domain_test_run_guardrails.py`: two tests repeated the same inline import of the shared `test_run_from_summary` helper. This PR lifts that import to module scope and aliases it so pytest does not try to collect it as a test, which keeps the test body shorter without changing assertions or semantics.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_domain_new_types.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py apps/server/tests/hygiene/test_domain_test_run_guardrails.py apps/server/tests/hygiene/test_frontend_metric_fields_sync.py apps/server/tests/hygiene/test_history_db_mixins.py apps/server/tests/hygiene/test_location_codes_sync.py apps/server/tests/hygiene/test_main_release_workflow.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py apps/server/tests/hygiene/test_pi_gen_artifact_selection.py`

Result: `62 passed`.

Risk is very low because this is test-only import cleanup with an alias chosen specifically to avoid pytest collecting the helper as a test function.
