### PR TITLE
Repo review chunk 030: simplify sample-column hygiene helpers

### DIFF
--- a/apps/server/tests/hygiene/test_sample_column_alignment.py
+++ b/apps/server/tests/hygiene/test_sample_column_alignment.py
@@ -54,6 +54,10 @@ def _insert_columns() -> list[str]:
     return list(_V2_COLUMNS)
 
 
+def _core_ddl_columns() -> set[str]:
+    return set(_ddl_columns()) - _DDL_ONLY
+
+
 def _domain_fields() -> list[str]:
     return [f.name for f in dataclasses.fields(SensorFrame)]
 
@@ -62,14 +66,18 @@ def _export_columns() -> list[str]:
     return list(EXPORT_CSV_COLUMNS)
 
 
+def _core_export_columns() -> set[str]:
+    return set(_export_columns()) - _EXPORT_ONLY
+
+
 class TestSampleColumnAlignment:
     def test_insert_columns_match_ddl(self) -> None:
-        ddl = set(_ddl_columns()) - _DDL_ONLY
+        ddl = _core_ddl_columns()
         insert = set(_insert_columns())
         assert ddl == insert, f"DDL↔insert mismatch: {ddl.symmetric_difference(insert)}"
 
     def test_domain_fields_cover_ddl(self) -> None:
-        ddl = set(_ddl_columns()) - _DDL_ONLY
+        ddl = _core_ddl_columns()
         domain = set(_domain_fields())
         missing_from_domain = ddl - domain
         assert not missing_from_domain, (
@@ -77,15 +85,15 @@ class TestSampleColumnAlignment:
         )
 
     def test_export_columns_cover_ddl(self) -> None:
-        ddl = set(_ddl_columns()) - _DDL_ONLY
-        export = set(_export_columns()) - _EXPORT_ONLY
+        ddl = _core_ddl_columns()
+        export = _core_export_columns()
         missing_from_export = ddl - export
         assert not missing_from_export, (
             f"DDL columns missing from EXPORT_CSV_COLUMNS: {missing_from_export}"
         )
 
     def test_no_unexpected_extras_in_domain(self) -> None:
-        ddl = set(_ddl_columns()) - _DDL_ONLY
+        ddl = _core_ddl_columns()
         domain = set(_domain_fields())
         unexpected = domain - ddl
         assert not unexpected, (
@@ -93,8 +101,8 @@ class TestSampleColumnAlignment:
         )
 
     def test_no_unexpected_extras_in_export(self) -> None:
-        ddl = set(_ddl_columns()) - _DDL_ONLY
-        export = set(_export_columns()) - _EXPORT_ONLY
+        ddl = _core_ddl_columns()
+        export = _core_export_columns()
         unexpected = export - ddl
         assert not unexpected, (
             "EXPORT_CSV_COLUMNS has entries not in DDL"


### PR DESCRIPTION
This PR covers **chunk 030** of the full repository review and includes these reviewed code files:

- `apps/server/tests/hygiene/test_run_backend_parallel.py`
- `apps/server/tests/hygiene/test_run_changed.py`
- `apps/server/tests/hygiene/test_run_e2e_parallel.py`
- `apps/server/tests/hygiene/test_sample_column_alignment.py`
- `apps/server/tests/hygiene/test_shared_contracts_smoke.py`
- `apps/server/tests/hygiene/test_strength_peak_parity.py`
- `apps/server/tests/hygiene/test_type_safety_consolidation.py`
- `apps/server/tests/hygiene/test_ui_smoke_contract.py`
- `apps/server/tests/hygiene/test_ui_vite_server_contract.py`

I personally reviewed every code file in this chunk. Most of these hygiene guards were already focused and intentionally narrow, so they were left unchanged after direct inspection. The behavior-preserving cleanup here is in `test_sample_column_alignment.py`: multiple tests recomputed the same normalized DDL/export column sets inline. This PR extracts tiny helpers for the normalized DDL and export column sets, which shortens the individual tests and makes the alignment intent easier to scan without changing any assertions or coverage.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_run_changed.py apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_sample_column_alignment.py apps/server/tests/hygiene/test_shared_contracts_smoke.py apps/server/tests/hygiene/test_strength_peak_parity.py apps/server/tests/hygiene/test_type_safety_consolidation.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/hygiene/test_ui_vite_server_contract.py`

Result: `46 passed`.

Risk is very low because this is test-only helper extraction with no behavioral changes.
