### PR TITLE
Repo review chunk 032: clarify config rollback tests

### DIFF
--- a/apps/server/tests/infra/config/test_settings_transaction.py
+++ b/apps/server/tests/infra/config/test_settings_transaction.py
@@ -14,6 +14,14 @@ def _make_state() -> dict[str, int]:
     return {"value": 1}
 
 
+def _apply_state_value(state: dict[str, int], value: int):
+    def _apply(_prev: dict[str, int]) -> bool:
+        state["value"] = value
+        return True
+
+    return _apply
+
+
 class TestUpdateWithRollback:
     """Exercise the generic snapshot→apply→persist→audit→restore flow."""
 
@@ -25,7 +33,7 @@ class TestUpdateWithRollback:
             lock=RLock(),
             persist=lambda: None,
             snapshot=lambda: dict(state),
-            apply=lambda prev: (state.update(value=10), True)[1],
+            apply=_apply_state_value(state, 10),
             restore=lambda prev: state.update(prev),
             audit_log=lambda prev: audit_calls.append(prev),
             result=lambda: state["value"],
@@ -60,7 +68,7 @@ class TestUpdateWithRollback:
                 lock=RLock(),
                 persist=bad_persist,
                 snapshot=lambda: dict(state),
-                apply=lambda prev: (state.update(value=99), True)[1],
+                apply=_apply_state_value(state, 99),
                 restore=lambda prev: state.update(prev),
                 result=lambda: state["value"],
             )


### PR DESCRIPTION
This PR covers **chunk 032** of the full repository review and includes these reviewed code files:

- `apps/server/tests/infra/config/test_sensor_settings.py`
- `apps/server/tests/infra/config/test_settings_audit_logging.py`
- `apps/server/tests/infra/config/test_settings_derivation.py`
- `apps/server/tests/infra/config/test_settings_runtime.py`
- `apps/server/tests/infra/config/test_settings_store.py`
- `apps/server/tests/infra/config/test_settings_transaction.py`

I personally reviewed every code file in this chunk. Most of these config-focused tests were already clear and intentionally narrow, so they were left unchanged after direct inspection. The behavior-preserving cleanup here is in `test_settings_transaction.py`: two tests used tuple-index side effects inside lambdas to mutate state during the transaction helper exercise. This PR replaces that trick with a tiny named helper that makes the state update explicit and easier to read while keeping the same assertions and rollback coverage.

Validation performed locally:

`./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/config/test_sensor_settings.py apps/server/tests/infra/config/test_settings_audit_logging.py apps/server/tests/infra/config/test_settings_derivation.py apps/server/tests/infra/config/test_settings_runtime.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/infra/config/test_settings_transaction.py`

Result: `64 passed`.

Risk is very low because this is test-only readability cleanup with no production behavior changes.
