### PR TITLE
Repo review chunk 037: simplify runtime speed-source tests

### DIFF
--- a/apps/server/tests/infra/runtime/test_rotational_speeds.py
+++ b/apps/server/tests/infra/runtime/test_rotational_speeds.py
@@ -2,40 +2,39 @@
 
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.infra.runtime.rotational_speeds import rotational_basis_speed_source
 
 
-def test_rotational_basis_speed_source_prefers_explicit_resolution_source() -> None:
-    assert (
-        rotational_basis_speed_source(
+@pytest.mark.parametrize(
+    ("selected_source", "kwargs", "expected"),
+    [
+        (
             "gps",
-            gps_enabled=True,
-            resolution_source="fallback_manual",
-        )
-        == "fallback_manual"
-    )
-
-
-def test_rotational_basis_speed_source_uses_fallback_flag_without_resolution_source() -> None:
-    assert (
-        rotational_basis_speed_source(
+            {"gps_enabled": True, "resolution_source": "fallback_manual"},
+            "fallback_manual",
+        ),
+        (
             "gps",
-            gps_enabled=True,
-            fallback_active=True,
-        )
-        == "fallback_manual"
-    )
-
-
-def test_rotational_basis_speed_source_handles_disabled_gps() -> None:
-    assert (
-        rotational_basis_speed_source("gps", gps_enabled=False, resolution_source="none")
-        == "unknown"
-    )
-
-
-def test_rotational_basis_speed_source_preserves_manual_selection() -> None:
-    assert (
-        rotational_basis_speed_source("manual", gps_enabled=True, resolution_source="gps")
-        == "manual"
-    )
+            {"gps_enabled": True, "fallback_active": True},
+            "fallback_manual",
+        ),
+        (
+            "gps",
+            {"gps_enabled": False, "resolution_source": "none"},
+            "unknown",
+        ),
+        (
+            "manual",
+            {"gps_enabled": True, "resolution_source": "gps"},
+            "manual",
+        ),
+    ],
+)
+def test_rotational_basis_speed_source_cases(
+    selected_source: str,
+    kwargs: dict[str, object],
+    expected: str,
+) -> None:
+    assert rotational_basis_speed_source(selected_source, **kwargs) == expected


### PR DESCRIPTION
Chunk 037 reviews these runtime test files: `apps/server/tests/infra/runtime/test_registry.py`, `test_registry_diagnostics.py`, `test_registry_location_cap.py`, `test_registry_thread_safety.py`, `test_rotational_speeds.py`, `test_runtime.py`, `test_startup_runner.py`, `test_task_supervisor.py`, and `test_udp_transport_lifecycle.py`.

I reviewed every code file in the chunk directly before making changes. Most of the files were already compact and purpose-built, so they remain unchanged after review. The only code edit is in `apps/server/tests/infra/runtime/test_rotational_speeds.py`, where four single-assert tests covering the same truth table were consolidated into one `pytest.mark.parametrize` case table. This keeps the expected source-selection matrix in one place and makes future additions less repetitive without changing behavior.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts= apps/server/tests/infra/runtime/test_registry.py apps/server/tests/infra/runtime/test_registry_diagnostics.py apps/server/tests/infra/runtime/test_registry_location_cap.py apps/server/tests/infra/runtime/test_registry_thread_safety.py apps/server/tests/infra/runtime/test_rotational_speeds.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/infra/runtime/test_startup_runner.py apps/server/tests/infra/runtime/test_task_supervisor.py apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py` (`69 passed`).

Risk is low because the change is test-only and preserves the same assertions. I did not force churn in the other reviewed files where no worthwhile behavior-preserving cleanup was justified.