### PR TITLE
Repo review chunk 039: simplify report contract tests

### DIFF
--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -63,6 +63,16 @@ def _make_steady_speed_fault_dataset() -> tuple[dict, list[dict]]:
     return meta, samples
 
 
+def _report_data_from_samples(
+    meta: dict,
+    samples: list[dict],
+    *,
+    lang: str,
+) -> ReportTemplateData:
+    summary = summarize_run_data(meta, samples, lang=lang)
+    return map_summary(prepare_report_input(summary))
+
+
 # ------------------------------------------------------------------
 # Tests
 # ------------------------------------------------------------------
@@ -71,9 +81,7 @@ def _make_steady_speed_fault_dataset() -> tuple[dict, list[dict]]:
 def test_analysis_output_accepted_by_report_mapper():
     """summarize_run_data() output must prepare and map cleanly."""
     meta, samples = _make_small_dataset()
-    summary = summarize_run_data(meta, samples, lang="en")
-
-    report_data = map_summary(prepare_report_input(summary))
+    report_data = _report_data_from_samples(meta, samples, lang="en")
 
     assert isinstance(report_data, ReportTemplateData)
 
@@ -81,8 +89,7 @@ def test_analysis_output_accepted_by_report_mapper():
 def test_report_data_has_populated_fields():
     """Key report fields must be non-empty after mapping real analysis output."""
     meta, samples = _make_small_dataset()
-    summary = summarize_run_data(meta, samples, lang="en")
-    report_data = map_summary(prepare_report_input(summary))
+    report_data = _report_data_from_samples(meta, samples, lang="en")
 
     # Structural: the report must have a title and language
     assert report_data.title
@@ -100,9 +107,7 @@ def test_analysis_without_fault_maps_cleanly():
     """A run with only road-noise (no fault) must still map without errors."""
     meta = standard_metadata(language="en")
     samples = make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=30, speed_kmh=60.0)
-    summary = summarize_run_data(meta, samples, lang="en")
-
-    report_data = map_summary(prepare_report_input(summary))
+    report_data = _report_data_from_samples(meta, samples, lang="en")
 
     assert isinstance(report_data, ReportTemplateData)
     assert report_data.lang == "en"
@@ -112,9 +117,7 @@ def test_multilingual_mapping():
     """Analysis + report mapping must work for non-English languages."""
     meta = standard_metadata(language="nl")
     samples = make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=20, speed_kmh=60.0)
-    summary = summarize_run_data(meta, samples, lang="nl")
-
-    report_data = map_summary(prepare_report_input(summary))
+    report_data = _report_data_from_samples(meta, samples, lang="nl")
 
     assert isinstance(report_data, ReportTemplateData)
     assert report_data.lang == "nl"


### PR DESCRIPTION
Chunk 039 reviews these integration test files: `apps/server/tests/integration/test_api_history_processing_regressions.py`, `test_concurrency_generation_guard_regressions.py`, `test_contract_analysis_persistence_http.py`, `test_contract_analysis_report.py`, `test_contract_persistence_analysis.py`, `test_coverage_gap_audit_round2.py`, `test_decode_project_roundtrip.py`, `test_exception_discipline.py`, `test_io_and_time_guard_regressions.py`, and `test_messy_real_world.py`.

I reviewed every code file in the chunk directly. Most of the integration modules were already purposeful and sectioned well enough to leave unchanged after review. The only code edit is in `apps/server/tests/integration/test_contract_analysis_report.py`, where several tests repeated the same summarize → prepare-report-input → map-summary sequence before asserting different report-contract facts. I extracted `_report_data_from_samples()` so those tests stay focused on the contract behavior they validate instead of repeating the same setup plumbing.

Validation performed:
`./.venv/bin/python -m pytest -q -o addopts= apps/server/tests/integration/test_api_history_processing_regressions.py apps/server/tests/integration/test_concurrency_generation_guard_regressions.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_contract_persistence_analysis.py apps/server/tests/integration/test_coverage_gap_audit_round2.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/integration/test_exception_discipline.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_messy_real_world.py` (`233 passed`), plus `make lint`.

Risk is low because the change is test-only and preserves the same assertions. I intentionally skipped churn in the other reviewed files where no worthwhile behavior-preserving cleanup was justified.