### PR TITLE
Repo review chunk 040: simplify report pipeline tests

### DIFF
--- a/apps/server/tests/integration/test_report_pipeline.py
+++ b/apps/server/tests/integration/test_report_pipeline.py
@@ -54,6 +54,11 @@ def _extract_pdf_text(pdf_bytes: bytes) -> str:
     return "\n".join(filter(None, (page.extract_text() for page in reader.pages))).lower()
 
 
+def _build_pdf_from_summary(summary: dict[str, Any]) -> bytes:
+    """Render a PDF directly from an analysis summary."""
+    return build_report_pdf(map_summary(prepare_report_input(summary)))
+
+
 # ---------------------------------------------------------------------------
 # Helper: build the full 120s multi-phase scenario
 # ---------------------------------------------------------------------------
@@ -333,9 +338,7 @@ class TestPdfReportValidation:
     def _run_and_generate(self, request: pytest.FixtureRequest) -> None:
         meta, samples = _build_20s_scenario()
         request.cls.summary = run_analysis(samples, metadata=meta)
-        request.cls.pdf_bytes = build_report_pdf(
-            map_summary(prepare_report_input(request.cls.summary))
-        )
+        request.cls.pdf_bytes = _build_pdf_from_summary(request.cls.summary)
         request.cls.pdf_text = _extract_pdf_text(request.cls.pdf_bytes)
         request.cls.top = extract_top(request.cls.summary)
 
@@ -406,7 +409,7 @@ class TestPdfReportValidation:
             rows[1]["p95_intensity_db"] = 37.2
             rows[1]["mean_intensity_db"] = 35.0
 
-        pdf_text = _extract_pdf_text(build_report_pdf(map_summary(prepare_report_input(summary))))
+        pdf_text = _extract_pdf_text(_build_pdf_from_summary(summary))
         assert "diagnosed location source" in pdf_text
         assert "wheel" in pdf_text
         assert "driveline" in pdf_text
@@ -434,7 +437,7 @@ class TestPdfReportValidation:
             }
             for i in range(1, 9)
         ]
-        pdf_bytes = build_report_pdf(map_summary(prepare_report_input(summary)))
+        pdf_bytes = _build_pdf_from_summary(summary)
         reader = PdfReader(io.BytesIO(pdf_bytes))
         pdf_text = _extract_pdf_text(pdf_bytes)
 
@@ -459,7 +462,7 @@ class TestPdfReportValidation:
         # Domain reconstruction reads sensor_model from metadata sub-dict
         if isinstance(summary.get("metadata"), dict):
             summary["metadata"]["sensor_model"] = long_sensor
-        pdf_text = _extract_pdf_text(build_report_pdf(map_summary(prepare_report_input(summary))))
+        pdf_text = _extract_pdf_text(_build_pdf_from_summary(summary))
         assert "tailtoken-runid-12345" in pdf_text
         assert "tailtoken" in pdf_text and "sensormodel-98765" in pdf_text
 
@@ -481,12 +484,8 @@ class TestPdfLanguageParity:
 
         request.cls.summary_en = run_analysis(samples, metadata=meta_en)
         request.cls.summary_nl = run_analysis(samples, metadata=meta_nl)
-        request.cls.pdf_en = build_report_pdf(
-            map_summary(prepare_report_input(request.cls.summary_en))
-        )
-        request.cls.pdf_nl = build_report_pdf(
-            map_summary(prepare_report_input(request.cls.summary_nl))
-        )
+        request.cls.pdf_en = _build_pdf_from_summary(request.cls.summary_en)
+        request.cls.pdf_nl = _build_pdf_from_summary(request.cls.summary_nl)
 
     def test_both_pdfs_are_valid(self) -> None:
         """Both EN and NL PDFs are generated and valid."""


### PR DESCRIPTION
## Summary
This is **chunk 040** of the repository review. I directly reviewed every code file in this chunk:

- `apps/server/tests/integration/test_multi_domain_regressions.py`
- `apps/server/tests/integration/test_multi_no_transient.py`
- `apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py`
- `apps/server/tests/integration/test_multi_system_overlap.py`
- `apps/server/tests/integration/test_multi_transient.py`
- `apps/server/tests/integration/test_real_world_scenarios.py`
- `apps/server/tests/integration/test_refactor_contract_regressions.py`
- `apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py`
- `apps/server/tests/integration/test_report_pipeline.py`
- `apps/server/tests/integration/test_review_guardrails_core_regressions.py`

The worthwhile behavior-preserving cleanup in this group was in `test_report_pipeline.py`. Several tests rebuilt the same summary -> prepared report input -> PDF rendering path inline before asserting on different report behaviors. I extracted a small `_build_pdf_from_summary()` helper and reused it where the same setup was repeated. That keeps the tests focused on the actual PDF/report assertions while preserving the exact render path under test.

No other files in the chunk had a similarly safe maintainability win after direct review, so they were left unchanged.

## Validation
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_multi_domain_regressions.py apps/server/tests/integration/test_multi_no_transient.py apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py apps/server/tests/integration/test_multi_system_overlap.py apps/server/tests/integration/test_multi_transient.py apps/server/tests/integration/test_real_world_scenarios.py apps/server/tests/integration/test_refactor_contract_regressions.py apps/server/tests/integration/test_report_delivery_and_stream_resilience_regressions.py apps/server/tests/integration/test_report_pipeline.py apps/server/tests/integration/test_review_guardrails_core_regressions.py` (`540 passed`)
- `make lint`

## Risks / follow-ups
This is intentionally low risk and test-only. I skipped broader refactors in the surrounding integration files because they would have changed chunk scope without a clear readability payoff.
