### PR TITLE
Repo review chunk 042: simplify simulator ingestion helpers

### DIFF
--- a/apps/server/tests/integration/test_sim_ingestion.py
+++ b/apps/server/tests/integration/test_sim_ingestion.py
@@ -35,28 +35,41 @@ SIM_DATA_PORT = os.environ.get("VIBESENSOR_TEST_SIM_DATA_PORT", "9000")
 SIM_CONTROL_PORT = os.environ.get("VIBESENSOR_TEST_SIM_CONTROL_PORT", "9001")
 
 
+def _api_response_bytes(
+    path: str,
+    *,
+    timeout: int = 30,
+    method: str = "GET",
+    data: bytes | None = None,
+) -> bytes:
+    """Read raw API response bytes for GET/POST helper wrappers."""
+    request: str | Request
+    if method == "GET" and data is None:
+        request = f"{BASE_URL}{path}"
+    else:
+        request = Request(
+            f"{BASE_URL}{path}",
+            data=data,
+            method=method,
+            headers={"Content-Type": "application/json"},
+        )
+    with urlopen(request, timeout=timeout) as resp:
+        return resp.read()
+
+
 def _api_json(path: str, *, timeout: int = 30) -> dict[str, Any]:
     """Simple HTTP GET returning JSON."""
-    with urlopen(f"{BASE_URL}{path}", timeout=timeout) as resp:
-        return json.loads(resp.read())
+    return json.loads(_api_response_bytes(path, timeout=timeout))
 
 
 def _api_post_json(path: str, *, timeout: int = 30) -> dict[str, Any]:
     """Simple HTTP POST returning JSON."""
-    req = Request(
-        f"{BASE_URL}{path}",
-        data=b"",
-        method="POST",
-        headers={"Content-Type": "application/json"},
-    )
-    with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
+    return json.loads(_api_response_bytes(path, timeout=timeout, method="POST", data=b""))
 
 
 def _api_bytes(path: str, *, timeout: int = 30) -> bytes:
     """Simple HTTP GET returning raw bytes."""
-    with urlopen(f"{BASE_URL}{path}", timeout=timeout) as resp:
-        return resp.read()
+    return _api_response_bytes(path, timeout=timeout)
 
 
 def _history_run_ids() -> set[str]:


### PR DESCRIPTION
## Summary
This is **chunk 042** of the repository review. I directly reviewed every code file in this chunk:

- `apps/server/tests/integration/test_sim_ingestion.py`
- `apps/server/tests/integration/test_single_no_transient.py`
- `apps/server/tests/integration/test_single_transient.py`
- `apps/server/tests/integration/test_weird_sensor_mix.py`

The safe cleanup in this group was in `test_sim_ingestion.py`. That file had three tiny API wrappers (`_api_json`, `_api_post_json`, and `_api_bytes`) that each repeated the same `urlopen(...).read()` plumbing. I extracted a small `_api_response_bytes()` helper and rewired the wrappers through it. The wrappers still preserve the same public behavior for the tests, but the file now has a single source of truth for request construction and response reads.

The other three files were reviewed directly and left unchanged. They are already heavily parameterized and their existing local helpers are doing real work, so additional refactoring in this chunk would have increased churn without improving readability.

## Validation
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_sim_ingestion.py apps/server/tests/integration/test_single_no_transient.py apps/server/tests/integration/test_single_transient.py apps/server/tests/integration/test_weird_sensor_mix.py` (`469 passed, 5 skipped`)
- `make lint`

## Risks / follow-ups
This is intentionally low risk and test-only. The five skipped cases are the environment-gated live-server simulator-ingestion checks; the direct-injection coverage in the same chunk still ran locally and the helper change itself is narrow.
