### PR TITLE
Repo review chunk 043: simplify shared warning tests

### DIFF
--- a/apps/server/tests/shared/test_run_context_warning.py
+++ b/apps/server/tests/shared/test_run_context_warning.py
@@ -9,6 +9,14 @@ from vibesensor.shared.run_context_warning import (
     normalize_run_context_warnings,
 )
 
+_REFERENCE_CONTEXT_WARNING = RunContextWarning(
+    code=WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
+    severity="warn",
+    applies_to="order_analysis",
+    title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+    detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+)
+
 
 def test_build_summary_warnings_returns_app_level_models() -> None:
     warnings = build_summary_warnings(
@@ -16,15 +24,7 @@ def test_build_summary_warnings_returns_app_level_models() -> None:
         reference_complete=False,
     )
 
-    assert warnings == [
-        RunContextWarning(
-            code=WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
-            severity="warn",
-            applies_to="order_analysis",
-            title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
-            detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-        )
-    ]
+    assert warnings == [_REFERENCE_CONTEXT_WARNING]
 
 
 def test_normalize_run_context_warnings_keeps_wire_payload_shape() -> None:
@@ -41,12 +41,4 @@ def test_normalize_run_context_warnings_keeps_wire_payload_shape() -> None:
         ]
     )
 
-    assert warnings == [
-        RunContextWarning(
-            code=WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
-            severity="warn",
-            applies_to="order_analysis",
-            title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
-            detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-        )
-    ]
+    assert warnings == [_REFERENCE_CONTEXT_WARNING]


### PR DESCRIPTION
## Summary
This is **chunk 043** of the repository review. I directly reviewed every code file in this chunk:

- `apps/server/tests/shared/test_run_context_warning.py`
- `apps/server/tests/shared/test_structured_logging.py`

The safe maintainability cleanup in this group was in `test_run_context_warning.py`. Both tests spelled out the same `RunContextWarning(...)` expectation inline. I extracted that repeated expected value into a single module constant and reused it in both assertions. The behavior under test is unchanged, but the file is now easier to read and less brittle if the shared warning contract ever needs an intentional update.

`test_structured_logging.py` was also reviewed directly and left unchanged. Its three focused tests are already short, explicit, and not repeating enough setup to justify extra helpers.

## Validation
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/test_run_context_warning.py apps/server/tests/shared/test_structured_logging.py` (`5 passed`)
- `make lint`

## Risks / follow-ups
This is intentionally low risk and test-only. I skipped any broader helper extraction across the two files because the shared surface here is tiny and more abstraction would be noise rather than a readability win.
