### PR TITLE
Repo review chunk 045: simplify strength precedence tests

### DIFF
--- a/apps/server/tests/shared/boundaries/test_strength_db_precedence.py
+++ b/apps/server/tests/shared/boundaries/test_strength_db_precedence.py
@@ -45,6 +45,20 @@ def _sensor_intensity(p95: float) -> list[LocationIntensitySummary]:
     return [LocationIntensitySummary(location="front", p95_intensity_db=p95)]
 
 
+def _resolve_strength_db(
+    run: TestRun,
+    *,
+    sensor_intensity: list[LocationIntensitySummary],
+) -> float | None:
+    """Resolve report facts and return only the strength_db under test."""
+    return resolve_primary_report_facts(
+        aggregate=run,
+        origin_location="",
+        sensor_locations_active=["front"],
+        sensor_intensity=sensor_intensity,
+    ).strength_db
+
+
 # ---------------------------------------------------------------------------
 # Precedence tier 1: domain-derived strength takes priority
 # ---------------------------------------------------------------------------
@@ -53,14 +67,7 @@ def _sensor_intensity(p95: float) -> list[LocationIntensitySummary]:
 def test_domain_strength_takes_precedence_over_sensor_fallback() -> None:
     """When domain aggregate provides strength_db, sensor fallback is ignored."""
     run = _make_test_run(strength_db=25.0)
-    facts = resolve_primary_report_facts(
-        aggregate=run,
-        origin_location="",
-        sensor_locations_active=["front"],
-        sensor_intensity=_sensor_intensity(18.0),
-    )
-
-    assert facts.strength_db == 25.0
+    assert _resolve_strength_db(run, sensor_intensity=_sensor_intensity(18.0)) == 25.0
 
 
 # ---------------------------------------------------------------------------
@@ -71,14 +78,7 @@ def test_domain_strength_takes_precedence_over_sensor_fallback() -> None:
 def test_sensor_fallback_used_when_domain_strength_is_none() -> None:
     """When no finding has vibration_strength_db, sensor p95 is the fallback."""
     run = _make_test_run(strength_db=None)
-    facts = resolve_primary_report_facts(
-        aggregate=run,
-        origin_location="",
-        sensor_locations_active=["front"],
-        sensor_intensity=_sensor_intensity(18.0),
-    )
-
-    assert facts.strength_db == 18.0
+    assert _resolve_strength_db(run, sensor_intensity=_sensor_intensity(18.0)) == 18.0
 
 
 # ---------------------------------------------------------------------------
@@ -89,14 +89,7 @@ def test_sensor_fallback_used_when_domain_strength_is_none() -> None:
 def test_strength_db_is_none_when_both_sources_absent() -> None:
     """When neither domain nor sensor provides strength_db, result is None."""
     run = _make_test_run(strength_db=None)
-    facts = resolve_primary_report_facts(
-        aggregate=run,
-        origin_location="",
-        sensor_locations_active=["front"],
-        sensor_intensity=[],
-    )
-
-    assert facts.strength_db is None
+    assert _resolve_strength_db(run, sensor_intensity=[]) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This is **chunk 045** of the repository review. I directly reviewed every code file in this chunk:

- `apps/server/tests/shared/boundaries/test_has_ref_gaps_regression.py`
- `apps/server/tests/shared/boundaries/test_report_facts_projection.py`
- `apps/server/tests/shared/boundaries/test_report_payload_gate.py`
- `apps/server/tests/shared/boundaries/test_report_payload_projection.py`
- `apps/server/tests/shared/boundaries/test_report_renderer_payload.py`
- `apps/server/tests/shared/boundaries/test_run_log.py`
- `apps/server/tests/shared/boundaries/test_run_suitability.py`
- `apps/server/tests/shared/boundaries/test_strength_db_precedence.py`
- `apps/server/tests/shared/boundaries/test_summary_data_quality_serialization.py`
- `apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py`

The safe cleanup in this group was in `test_strength_db_precedence.py`. The three precedence-tier tests all rebuilt the same `resolve_primary_report_facts(...)` call just to assert the resulting `strength_db`. I extracted a small `_resolve_strength_db()` helper so those tests focus only on the precedence condition under review while preserving the exact boundary call path.

The other nine files were reviewed directly and left unchanged. They are already short, boundary-focused, and not repeating enough setup to justify more indirection.

## Validation
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/test_has_ref_gaps_regression.py apps/server/tests/shared/boundaries/test_report_facts_projection.py apps/server/tests/shared/boundaries/test_report_payload_gate.py apps/server/tests/shared/boundaries/test_report_payload_projection.py apps/server/tests/shared/boundaries/test_report_renderer_payload.py apps/server/tests/shared/boundaries/test_run_log.py apps/server/tests/shared/boundaries/test_run_suitability.py apps/server/tests/shared/boundaries/test_strength_db_precedence.py apps/server/tests/shared/boundaries/test_summary_data_quality_serialization.py apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py` (`85 passed`)
- `make lint`

## Risks / follow-ups
This is intentionally low risk and test-only. I skipped broader helper extraction elsewhere in the chunk because the remaining files are already compact and purpose-specific.
