### PR TITLE
Repo review chunk 046: simplify summary warning tests

### DIFF
--- a/apps/server/tests/shared/boundaries/test_summary_warning.py
+++ b/apps/server/tests/shared/boundaries/test_summary_warning.py
@@ -6,80 +6,50 @@ from vibesensor.shared.boundaries.summary_warning import (
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
 
+_WARNING_MODEL = RunContextWarning(
+    code="reference_context_incomplete",
+    severity="warn",
+    applies_to="order_analysis",
+    title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+    detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+)
+
+_WARNING_PAYLOAD = {
+    "code": "reference_context_incomplete",
+    "severity": "warn",
+    "applies_to": "order_analysis",
+    "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
+    "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
+}
+
+_LOCALIZED_WARNING_NL = {
+    "code": "reference_context_incomplete",
+    "severity": "warn",
+    "applies_to": "order_analysis",
+    "title": "De referentiecontext voor ordeanalyse was onvolledig voor deze run",
+    "detail": (
+        "Voor deze run ontbreekt een deel van de wiel-/motorreferentie die "
+        "nodig is voor betrouwbare ordeanalyse. Ordegebaseerde bevindingen "
+        "kunnen nog steeds worden getoond, maar behandel ze als voorlopig "
+        "totdat de run met volledige voertuigreferentiegegevens wordt "
+        "herhaald."
+    ),
+}
+
 
 def test_summary_warning_payloads_keep_existing_wire_shape() -> None:
-    warnings = [
-        RunContextWarning(
-            code="reference_context_incomplete",
-            severity="warn",
-            applies_to="order_analysis",
-            title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
-            detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-        )
-    ]
+    warnings = [_WARNING_MODEL]
 
-    assert summary_warning_payloads(warnings) == [
-        {
-            "code": "reference_context_incomplete",
-            "severity": "warn",
-            "applies_to": "order_analysis",
-            "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
-            "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-        }
-    ]
+    assert summary_warning_payloads(warnings) == [_WARNING_PAYLOAD]
 
 
 def test_localize_warning_list_resolves_run_context_warning_models() -> None:
-    warnings = [
-        RunContextWarning(
-            code="reference_context_incomplete",
-            severity="warn",
-            applies_to="order_analysis",
-            title={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
-            detail={"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-        )
-    ]
+    warnings = [_WARNING_MODEL]
 
-    assert localize_warning_list(warnings, lang="nl") == [
-        {
-            "code": "reference_context_incomplete",
-            "severity": "warn",
-            "applies_to": "order_analysis",
-            "title": "De referentiecontext voor ordeanalyse was onvolledig voor deze run",
-            "detail": (
-                "Voor deze run ontbreekt een deel van de wiel-/motorreferentie die "
-                "nodig is voor betrouwbare ordeanalyse. Ordegebaseerde bevindingen "
-                "kunnen nog steeds worden getoond, maar behandel ze als voorlopig "
-                "totdat de run met volledige voertuigreferentiegegevens wordt "
-                "herhaald."
-            ),
-        }
-    ]
+    assert localize_warning_list(warnings, lang="nl") == [_LOCALIZED_WARNING_NL]
 
 
 def test_localize_warning_list_resolves_persisted_warning_payloads() -> None:
-    warnings = [
-        {
-            "code": "reference_context_incomplete",
-            "severity": "warn",
-            "applies_to": "order_analysis",
-            "title": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE"},
-            "detail": {"_i18n_key": "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_DETAIL"},
-        }
-    ]
+    warnings = [_WARNING_PAYLOAD]
 
-    assert localize_warning_list(warnings, lang="nl") == [
-        {
-            "code": "reference_context_incomplete",
-            "severity": "warn",
-            "applies_to": "order_analysis",
-            "title": "De referentiecontext voor ordeanalyse was onvolledig voor deze run",
-            "detail": (
-                "Voor deze run ontbreekt een deel van de wiel-/motorreferentie die "
-                "nodig is voor betrouwbare ordeanalyse. Ordegebaseerde bevindingen "
-                "kunnen nog steeds worden getoond, maar behandel ze als voorlopig "
-                "totdat de run met volledige voertuigreferentiegegevens wordt "
-                "herhaald."
-            ),
-        }
-    ]
+    assert localize_warning_list(warnings, lang="nl") == [_LOCALIZED_WARNING_NL]


### PR DESCRIPTION
## Summary
This is **chunk 046** of the repository review. I directly reviewed every code file in this chunk:

- `apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py`
- `apps/server/tests/shared/boundaries/test_summary_warning.py`

The safe cleanup in this group was in `test_summary_warning.py`. The file repeated the same warning model, wire payload, and Dutch-localized payload literals across all three tests. I extracted those repeated values into module-level constants and reused them in each assertion. The behavior under test is unchanged, but the file is now much easier to scan and less brittle if the shared warning contract ever needs an intentional update.

`test_summary_serialization_public_api.py` was reviewed directly and left unchanged. It is already a single focused contract test with no meaningful duplication to remove.

## Validation
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py apps/server/tests/shared/boundaries/test_summary_warning.py` (`4 passed`)
- `make lint`

## Risks / follow-ups
This is intentionally low risk and test-only. I skipped any extra abstraction in the neighboring public-entrypoint test because it is already minimal and explicit.
