### PR TITLE
Repo review chunk 048: simplify shared utils tests

### DIFF
--- a/apps/server/tests/shared/utils/test_constants_and_helpers.py
+++ b/apps/server/tests/shared/utils/test_constants_and_helpers.py
@@ -36,28 +36,15 @@ def test_peak_constants_positive() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _spec_with_circumference(circ_m: float) -> OrderReferenceSpec:
-    """Build a minimal OrderReferenceSpec whose tire has the given circumference.
-
-    Uses a TireSpec with dimensions reverse-engineered to approximate the
-    requested circumference.  For test convenience only.
-    """
-    from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
-
-    return OrderReferenceSpec.from_settings(
-        {**AnalysisSettingsSnapshot.DEFAULTS, "tire_circumference_m": circ_m},
-    )
-
-
-def _make_spec(circ_m: float) -> OrderReferenceSpec:
-    """Build a spec using defaults — circumference comes from real tire dims."""
+def _make_spec() -> OrderReferenceSpec:
+    """Build a spec using default analysis settings."""
     from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 
     return OrderReferenceSpec.from_settings(AnalysisSettingsSnapshot.DEFAULTS)
 
 
 def test_wheel_hz_from_speed_kmh_basic() -> None:
-    spec = _make_spec(2.0)
+    spec = _make_spec()
     circ = spec.tire_circumference_m
     result = spec.wheel_hz_from_speed_kmh(100.0)
     assert result is not None
@@ -79,7 +66,7 @@ def test_wheel_hz_from_speed_kmh_basic() -> None:
     ],
 )
 def test_wheel_hz_returns_none_for_invalid_input(speed: float, func: str) -> None:
-    spec = _make_spec(2.0)
+    spec = _make_spec()
     if func == "kmh":
         assert spec.wheel_hz_from_speed_kmh(speed) is None
     else:
@@ -87,7 +74,7 @@ def test_wheel_hz_returns_none_for_invalid_input(speed: float, func: str) -> Non
 
 
 def test_wheel_hz_from_speed_mps_basic() -> None:
-    spec = _make_spec(2.0)
+    spec = _make_spec()
     circ = spec.tire_circumference_m
     result = spec.wheel_hz(27.78)
     assert result is not None
@@ -96,7 +83,7 @@ def test_wheel_hz_from_speed_mps_basic() -> None:
 
 def test_wheel_hz_mps_kmh_consistency() -> None:
     """Both wheel_hz helpers must agree for the same physical speed."""
-    spec = _make_spec(2.1)
+    spec = _make_spec()
     speed_kmh = 90.0
     speed_mps = speed_kmh * KMH_TO_MPS
     from_kmh = spec.wheel_hz_from_speed_kmh(speed_kmh)
@@ -112,7 +99,7 @@ def test_wheel_hz_mps_kmh_consistency() -> None:
 
 
 def test_engine_rpm_basic() -> None:
-    spec = _make_spec(2.0)
+    spec = _make_spec()
     wh = spec.wheel_hz(10.0 * spec.tire_circumference_m)
     assert wh is not None
     rpm = spec.engine_rpm_from_wheel_hz(wh)


### PR DESCRIPTION
Chunk 048 covers two files in `apps/server/tests/shared/utils`: `test_constants_and_helpers.py` and `test_json_utils.py`. I directly reviewed both code files in this chunk before making changes.

The only worthwhile behavior-preserving cleanup was in `test_constants_and_helpers.py`. That module had an unused `_spec_with_circumference()` helper plus a `_make_spec(circ_m)` helper that accepted a circumference argument it never used. This PR removes the dead helper, simplifies `_make_spec()` to a parameterless helper that reflects its real behavior, and updates the call sites accordingly. The result is a smaller, clearer test module with no misleading setup API.

`test_json_utils.py` was also reviewed directly and left unchanged. It already has focused coverage for sanitization, NumPy normalization, JSON round-tripping, and payload projection without obvious duplication or dead scaffolding to remove safely.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/utils/test_constants_and_helpers.py apps/server/tests/shared/utils/test_json_utils.py` (`45 passed`)
- `make lint`

Risk is low because the diff is limited to test helpers and keeps the underlying assertions and exercised behaviors intact.
