### PR TITLE
Repo review chunk 049: simplify test support helpers

### DIFF
--- a/apps/server/tests/test_support/fault_scenarios.py
+++ b/apps/server/tests/test_support/fault_scenarios.py
@@ -227,6 +227,24 @@ def make_profile_fault_samples(
     )
 
 
+def _apply_gain_mismatch(
+    base: list[dict[str, Any]],
+    *,
+    fault_sensor: str,
+    gain_factor: float,
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for sample in base:
+        if sample["client_name"] == fault_sensor:
+            sample = {**sample}
+            sample["top_peaks"] = [
+                {"hz": peak["hz"], "amp": peak["amp"] * gain_factor} for peak in sample["top_peaks"]
+            ]
+            sample["vibration_strength_db"] = sample["vibration_strength_db"] + 3.0
+        result.append(sample)
+    return result
+
+
 def make_gain_mismatch_samples(
     *,
     fault_sensor: str,
@@ -254,16 +272,7 @@ def make_gain_mismatch_samples(
         fault_vib_db=fault_vib_db,
         noise_vib_db=noise_vib_db,
     )
-    result: list[dict[str, Any]] = []
-    for sample in base:
-        if sample["client_name"] == fault_sensor:
-            sample = {**sample}
-            sample["top_peaks"] = [
-                {"hz": peak["hz"], "amp": peak["amp"] * gain_factor} for peak in sample["top_peaks"]
-            ]
-            sample["vibration_strength_db"] = sample["vibration_strength_db"] + 3.0
-        result.append(sample)
-    return result
+    return _apply_gain_mismatch(base, fault_sensor=fault_sensor, gain_factor=gain_factor)
 
 
 def make_engine_order_samples(
@@ -442,16 +451,7 @@ def make_profile_gain_mismatch_samples(
         fault_vib_db=fault_vib_db,
         noise_vib_db=noise_vib_db,
     )
-    result: list[dict[str, Any]] = []
-    for sample in base:
-        if sample["client_name"] == fault_sensor:
-            sample = {**sample}
-            sample["top_peaks"] = [
-                {"hz": peak["hz"], "amp": peak["amp"] * gain_factor} for peak in sample["top_peaks"]
-            ]
-            sample["vibration_strength_db"] = sample["vibration_strength_db"] + 3.0
-        result.append(sample)
-    return result
+    return _apply_gain_mismatch(base, fault_sensor=fault_sensor, gain_factor=gain_factor)
 
 
 def build_fault_samples_at_speed(


### PR DESCRIPTION
Chunk 049 covers ten files in `apps/server/tests/test_support`: `__init__.py`, `analysis.py`, `assertions.py`, `core.py`, `fault_scenarios.py`, `findings.py`, `gps.py`, `persisted_analysis.py`, `report_helpers.py`, and `sample_scenarios.py`. I directly reviewed every code file in this chunk before making changes.

The worthwhile behavior-preserving cleanup here was in `fault_scenarios.py`. Both `make_gain_mismatch_samples()` and `make_profile_gain_mismatch_samples()` had the same post-processing loop that copies the fault sensor’s samples, scales each peak amplitude by the gain factor, and bumps the reported vibration strength. This PR extracts that transformation into a shared `_apply_gain_mismatch()` helper so the profile-aware and non-profile paths stay in sync without duplicated logic.

The other nine helper files were reviewed and left unchanged. They already serve as focused shared fixtures, builders, and assertions for the server test suite, and I did not find a similarly safe simplification that would improve them without changing behavior.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_messy_real_world.py` (`134 passed`)
- `make lint`

Risk is low because the diff is limited to shared test-support code and preserves the existing gain-mismatch behavior through the same consumer regression coverage.
