### PR TITLE
Repo review chunk 050: simplify scenario helpers

### DIFF
--- a/apps/server/tests/test_support/scenario_ground_truth.py
+++ b/apps/server/tests/test_support/scenario_ground_truth.py
@@ -18,6 +18,10 @@ from vibesensor.adapters.analysis_summary import summarize_run_data
 ALL_SENSORS = ["front-left", "front-right", "rear-left", "rear-right"]
 
 
+def _sample_count(duration_s: float, dt_s: float) -> int:
+    return max(1, int(duration_s / dt_s))
+
+
 def idle_phase(
     *,
     duration_s: float,
@@ -29,7 +33,7 @@ def idle_phase(
     """Generate idle/stationary samples with only noise peaks."""
     return make_idle_samples(
         sensors=sensors,
-        n_samples=max(1, int(duration_s / dt_s)),
+        n_samples=_sample_count(duration_s, dt_s),
         dt_s=dt_s,
         start_t_s=start_t_s,
         noise_amp=noise_amp,
@@ -50,7 +54,7 @@ def road_noise_phase(
     return make_noise_samples(
         sensors=sensors,
         speed_kmh=speed_kmh,
-        n_samples=max(1, int(duration_s / dt_s)),
+        n_samples=_sample_count(duration_s, dt_s),
         dt_s=dt_s,
         start_t_s=start_t_s,
         noise_amp=noise_amp,
@@ -71,7 +75,7 @@ def ramp_phase(
     road_vib_db: float = 10.0,
 ) -> list[dict[str, Any]]:
     """Generate speed ramp phase with road-only noise."""
-    total_samples = n_steps * max(1, int(step_duration_s / dt_s))
+    total_samples = n_steps * _sample_count(step_duration_s, dt_s)
     return make_ramp_samples(
         sensors=sensors,
         speed_start=speed_start,
@@ -104,7 +108,7 @@ def fault_phase(
         fault_sensor=fault_sensor,
         sensors=sensors,
         speed_kmh=speed_kmh,
-        n_samples=max(1, int(duration_s / dt_s)),
+        n_samples=_sample_count(duration_s, dt_s),
         dt_s=dt_s,
         start_t_s=start_t_s,
         fault_amp=fault_amp,


### PR DESCRIPTION
Chunk 050 covers one file: `apps/server/tests/test_support/scenario_ground_truth.py`. I directly reviewed that code file before making changes.

The cleanup here is narrowly behavior-preserving. The helper module had the same duration-to-sample-count calculation repeated across `idle_phase()`, `road_noise_phase()`, `ramp_phase()`, and `fault_phase()`. This PR extracts that into a single local `_sample_count()` helper and routes the four phase builders through it. That keeps the phase helpers aligned, removes repetition, and makes the common “at least one sample” rule easier to reason about in one place.

No semantics are intended to change. The phase builders still generate the same sample counts for the same `duration_s` and `dt_s` inputs, and the summary-building flow remains untouched.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/integration/test_scenario_ground_truth_front_axle.py apps/server/tests/integration/test_scenario_ground_truth_invariants.py apps/server/tests/integration/test_scenario_ground_truth_nuisance.py apps/server/tests/integration/test_scenario_ground_truth_rear_axle.py apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py apps/server/tests/use_cases/diagnostics/test_confidence_assessment_invariant.py` (`46 passed`)
- `make lint`

Risk is low because the diff is limited to shared test-support code and is covered by the scenario-ground-truth and diagnostics consumer suites above.
