### PR TITLE
Repo review chunk 052: simplify diagnostics golden tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py
@@ -142,8 +142,8 @@ def _short_run_samples() -> list[dict[str, Any]]:
     return samples
 
 
-def test_characterization_wheel_fault_summary_contract() -> None:
-    analysis = RunAnalysis(
+def _wheel_fault_analysis(file_name: str) -> RunAnalysis:
+    return RunAnalysis(
         standard_metadata(),
         fault_phase(
             speed_kmh=80.0,
@@ -152,8 +152,12 @@ def test_characterization_wheel_fault_summary_contract() -> None:
             sensors=ALL_SENSORS,
         ),
         lang="en",
-        file_name="characterization-wheel",
+        file_name=file_name,
     )
+
+
+def test_characterization_wheel_fault_summary_contract() -> None:
+    analysis = _wheel_fault_analysis("characterization-wheel")
     result = analysis.summarize()
     summary = analysis_result_to_summary(result)
 
@@ -179,17 +183,7 @@ def test_characterization_wheel_fault_summary_contract() -> None:
 
 
 def test_characterization_live_analysis_surfaces_domain_plan_ordering() -> None:
-    analysis = RunAnalysis(
-        standard_metadata(),
-        fault_phase(
-            speed_kmh=80.0,
-            duration_s=20.0,
-            fault_sensor="front-right",
-            sensors=ALL_SENSORS,
-        ),
-        lang="en",
-        file_name="characterization-wheel-planning",
-    )
+    analysis = _wheel_fault_analysis("characterization-wheel-planning")
 
     result = analysis.summarize()
     summary = analysis_result_to_summary(result)
@@ -209,17 +203,7 @@ def test_characterization_live_analysis_surfaces_domain_plan_ordering() -> None:
 
 
 def test_characterization_wheel_fault_persist_reload_round_trip(tmp_path: Path) -> None:
-    analysis = RunAnalysis(
-        standard_metadata(),
-        fault_phase(
-            speed_kmh=80.0,
-            duration_s=20.0,
-            fault_sensor="front-right",
-            sensors=ALL_SENSORS,
-        ),
-        lang="en",
-        file_name="characterization-wheel-roundtrip",
-    )
+    analysis = _wheel_fault_analysis("characterization-wheel-roundtrip")
 
     round_trip_summary = _persist_and_reload_summary(
         tmp_path,


### PR DESCRIPTION
Chunk 052 covers ten files in `apps/server/tests/use_cases/diagnostics`: `test_analysis_architecture.py`, `test_analysis_golden_output.py`, `test_analysis_helpers_gaps.py`, `test_analysis_persistence.py`, `test_analysis_pipeline_audit.py`, `test_analysis_pipeline_guard_regressions.py`, `test_analysis_pipeline_integration_regressions.py`, `test_analysis_sample.py`, `test_analysis_settings.py`, and `test_analysis_settings_source_of_truth.py`. I directly reviewed every code file in this chunk before making changes.

The worthwhile behavior-preserving cleanup here was in `test_analysis_golden_output.py`. The first three characterization tests all built the same wheel-fault `RunAnalysis(...)` setup and only varied the `file_name`. This PR extracts that repeated setup into a small local `_wheel_fault_analysis()` helper so the tests stay focused on their summary, planning, and persistence assertions instead of re-declaring identical fixtures.

The other nine files were reviewed and left unchanged. They already provide focused coverage for diagnostics architecture guardrails, persistence behavior, pipeline regressions, sample normalization, and settings contracts without an equally safe cleanup candidate.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_analysis_architecture.py apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py apps/server/tests/use_cases/diagnostics/test_analysis_helpers_gaps.py apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_guard_regressions.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py apps/server/tests/use_cases/diagnostics/test_analysis_sample.py apps/server/tests/use_cases/diagnostics/test_analysis_settings.py apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py` (`116 passed`)
- `make lint`

Risk is low because the diff is limited to test structure and preserves the existing assertions and exercised diagnostics behaviors.
