### PR TITLE
Repo review chunk 053: simplify diagnostics regression tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_compute_effective_match_rate.py
+++ b/apps/server/tests/use_cases/diagnostics/test_compute_effective_match_rate.py
@@ -71,7 +71,6 @@ def test_low_speed_fault_not_rescued_when_highest_bin_poor() -> None:
             ("90-100 km/h", 8, 1),  # noise at highest bin
         ),
     )
-    # Highest bin (90-100) doesn’t qualify → no speed-band rescue
     # Highest bin (90-100) doesn't qualify → no speed-band rescue
     assert band is None
     assert eff == 0.20
@@ -93,7 +92,6 @@ def test_second_highest_bin_not_considered() -> None:
             ("90-100 km/h", 6, 1),  # poor – highest
         ),
     )
-    # Highest bin (90-100) doesn’t qualify → no rescue
     # Highest bin (90-100) doesn't qualify → no rescue
     assert band is None
     assert eff == 0.20
@@ -137,7 +135,6 @@ def test_only_highest_bin_evaluated() -> None:
             ("90-100 km/h", 6, 1),  # noise – highest
         ),
     )
-    # Highest bin (90-100) doesn’t qualify → no rescue
     # Highest bin (90-100) doesn't qualify → no rescue
     assert band is None
     assert eff == 0.20

--- a/apps/server/tests/use_cases/diagnostics/test_confidence_assessment_invariant.py
+++ b/apps/server/tests/use_cases/diagnostics/test_confidence_assessment_invariant.py
@@ -21,22 +21,25 @@ def _assert_all_findings_have_assessment(findings: tuple[Any, ...]) -> None:
     assert not missing, f"Findings without ConfidenceAssessment: {missing}"
 
 
+def _wheel_fault_result(file_name: str):
+    return RunAnalysis(
+        standard_metadata(),
+        fault_phase(
+            speed_kmh=80.0,
+            duration_s=20.0,
+            fault_sensor="front-right",
+            sensors=ALL_SENSORS,
+        ),
+        lang="en",
+        file_name=file_name,
+    ).summarize()
+
+
 class TestLivePipelineConfidenceInvariant:
     """All findings produced by live analysis must carry ConfidenceAssessment."""
 
     def test_wheel_fault_all_findings_assessed(self) -> None:
-        analysis = RunAnalysis(
-            standard_metadata(),
-            fault_phase(
-                speed_kmh=80.0,
-                duration_s=20.0,
-                fault_sensor="front-right",
-                sensors=ALL_SENSORS,
-            ),
-            lang="en",
-            file_name="invariant-wheel",
-        )
-        result = analysis.summarize()
+        result = _wheel_fault_result("invariant-wheel")
         test_run = result.test_run
 
         assert test_run is not None
@@ -44,18 +47,7 @@ class TestLivePipelineConfidenceInvariant:
         _assert_all_findings_have_assessment(test_run.findings)
 
     def test_top_causes_subset_of_enriched_findings(self) -> None:
-        analysis = RunAnalysis(
-            standard_metadata(),
-            fault_phase(
-                speed_kmh=80.0,
-                duration_s=20.0,
-                fault_sensor="front-right",
-                sensors=ALL_SENSORS,
-            ),
-            lang="en",
-            file_name="invariant-subset",
-        )
-        result = analysis.summarize()
+        result = _wheel_fault_result("invariant-subset")
         test_run = result.test_run
 
         assert test_run is not None
@@ -70,18 +62,7 @@ class TestBoundaryDecoderConfidenceInvariant:
     """Findings decoded from historical summary payloads get synthesized assessment."""
 
     def test_decoded_findings_all_assessed(self) -> None:
-        analysis = RunAnalysis(
-            standard_metadata(),
-            fault_phase(
-                speed_kmh=80.0,
-                duration_s=20.0,
-                fault_sensor="front-right",
-                sensors=ALL_SENSORS,
-            ),
-            lang="en",
-            file_name="invariant-decode",
-        )
-        result = analysis.summarize()
+        result = _wheel_fault_result("invariant-decode")
         summary = analysis_result_to_summary(result)
 
         # Decode through the boundary (simulates historical data load)
@@ -91,18 +72,7 @@ class TestBoundaryDecoderConfidenceInvariant:
         _assert_all_findings_have_assessment(decoded_run.findings)
 
     def test_decoded_top_causes_assessed(self) -> None:
-        analysis = RunAnalysis(
-            standard_metadata(),
-            fault_phase(
-                speed_kmh=80.0,
-                duration_s=20.0,
-                fault_sensor="front-right",
-                sensors=ALL_SENSORS,
-            ),
-            lang="en",
-            file_name="invariant-decode-tc",
-        )
-        result = analysis.summarize()
+        result = _wheel_fault_result("invariant-decode-tc")
         summary = analysis_result_to_summary(result)
 
         decoded_run = _decode_test_run(summary)

--- a/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_faults.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_faults.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 from typing import Any
 
-import pytest
 from test_support import (
     ALL_SENSORS,
     assert_summary_sections,
@@ -17,10 +16,6 @@ from vibesensor.adapters.analysis_summary import summarize_run_data
 
 
 class TestDualFaultTwoCorners:
-    @pytest.mark.xfail(
-        reason="Pipeline collapses same-order dual faults into single finding (GH-292)",
-        strict=False,
-    )
     def test_dual_fault_front_right_and_rear_left(self) -> None:
         samples: list[dict[str, Any]] = []
         whz = wheel_hz(80.0)


### PR DESCRIPTION
Chunk 053 covers ten files in `apps/server/tests/use_cases/diagnostics`: `test_analysis_units_db_only.py`, `test_common_vibration_causes.py`, `test_compute_effective_match_rate.py`, `test_confidence_assessment_invariant.py`, `test_confidence_scoring_regressions.py`, `test_confidence_threshold_boundaries.py`, `test_contradictory_phase_signals.py`, `test_coverage_gap_audit_top10.py`, `test_diagnosis_robustness_faults.py`, and `test_diagnosis_robustness_report_pdf.py`. I directly reviewed every code file in this chunk before changing anything.

This PR keeps the changes behavior-preserving and test-focused. In `test_confidence_assessment_invariant.py`, the four invariant tests all rebuilt the same wheel-fault `RunAnalysis(...)` scenario, so I extracted a small `_wheel_fault_result()` helper to remove repeated setup and keep each assertion focused on the invariant being checked. In `test_compute_effective_match_rate.py`, I removed duplicated explanatory comments so the rescue-path expectations are clearer. In `test_diagnosis_robustness_faults.py`, a long-standing `xfail` was consistently passing, so I removed the stale marker and the now-unused `pytest` import; that improves signal without changing product behavior.

The other seven files were reviewed and left unchanged after direct inspection.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_analysis_units_db_only.py apps/server/tests/use_cases/diagnostics/test_common_vibration_causes.py apps/server/tests/use_cases/diagnostics/test_compute_effective_match_rate.py apps/server/tests/use_cases/diagnostics/test_confidence_assessment_invariant.py apps/server/tests/use_cases/diagnostics/test_confidence_scoring_regressions.py apps/server/tests/use_cases/diagnostics/test_confidence_threshold_boundaries.py apps/server/tests/use_cases/diagnostics/test_contradictory_phase_signals.py apps/server/tests/use_cases/diagnostics/test_coverage_gap_audit_top10.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_faults.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_report_pdf.py` (`446 passed`)
- `make lint`

Risk is low because the diff only simplifies test structure and updates an obsolete passing expectation.
