### PR TITLE
Repo review chunk 054: simplify diagnostics helper tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py
@@ -44,8 +44,12 @@ def _context_metadata() -> dict[str, object]:
     }
 
 
+def _context():
+    return build_diagnostics_context(_context_metadata(), file_name="ctx")
+
+
 def test_diagnostics_context_decodes_typed_reference_data() -> None:
-    context = build_diagnostics_context(_context_metadata(), file_name="ctx")
+    context = _context()
 
     assert context.run_id == "ctx-run"
     assert context.raw_sample_rate_hz == 200.0
@@ -58,7 +62,7 @@ def test_diagnostics_context_decodes_typed_reference_data() -> None:
 
 
 def test_effective_order_reference_spec_applies_sample_ratio_overrides() -> None:
-    context = build_diagnostics_context(_context_metadata(), file_name="ctx")
+    context = _context()
     sample = replace(
         make_analysis_sample(
             t_s=0.0,
@@ -78,7 +82,7 @@ def test_effective_order_reference_spec_applies_sample_ratio_overrides() -> None
 
 
 def test_diagnostics_context_rehydrates_boundary_metadata_with_known_and_unknown_fields() -> None:
-    context = build_diagnostics_context(_context_metadata(), file_name="ctx")
+    context = _context()
 
     metadata = context_to_metadata_dict(context)
 

--- a/apps/server/tests/use_cases/diagnostics/test_finding_objects.py
+++ b/apps/server/tests/use_cases/diagnostics/test_finding_objects.py
@@ -12,6 +12,25 @@ from vibesensor.use_cases.diagnostics.findings import PeakFindingAnalyzer, final
 # ===========================================================================
 
 
+def _peak_samples(
+    *,
+    hz: float = 50.0,
+    amp: float = 0.05,
+    vibration_strength_db: float = 25.0,
+    count: int = 30,
+) -> list[dict[str, float | str | list[dict[str, float]]]]:
+    return [
+        {
+            "speed_kmh": 60.0,
+            "t_s": float(i),
+            "top_peaks": [{"hz": hz, "amp": amp}],
+            "vibration_strength_db": vibration_strength_db,
+            "client_name": "sensor_fl",
+        }
+        for i in range(count)
+    ]
+
+
 class TestDomainFindingFromPayload:
     def test_finding_id(self) -> None:
         f = finding_from_payload(make_finding_payload(confidence=0.65))
@@ -111,18 +130,8 @@ class TestPeakFindingAnalyzer:
 
     def test_returns_findings(self) -> None:
         """Smoke test: samples with top peaks produce findings."""
-        samples = [
-            {
-                "speed_kmh": 60.0,
-                "t_s": float(i),
-                "top_peaks": [{"hz": 50.0, "amp": 0.05}],
-                "vibration_strength_db": 25.0,
-                "client_name": "sensor_fl",
-            }
-            for i in range(30)
-        ]
         analyzer = PeakFindingAnalyzer(
-            samples=samples,
+            samples=_peak_samples(),
             order_finding_freqs=set(),
             lang="en",
         )
@@ -134,16 +143,7 @@ class TestPeakFindingAnalyzer:
 
     def test_order_freq_exclusion(self) -> None:
         """Bins overlapping with order frequencies are excluded."""
-        samples = [
-            {
-                "speed_kmh": 60.0,
-                "t_s": float(i),
-                "top_peaks": [{"hz": 50.0, "amp": 0.05}],
-                "vibration_strength_db": 25.0,
-                "client_name": "sensor_fl",
-            }
-            for i in range(30)
-        ]
+        samples = _peak_samples()
         # With 50 Hz in order freqs → should be excluded
         analyzer_excluded = PeakFindingAnalyzer(
             samples=samples,


### PR DESCRIPTION
Chunk 054 covers ten files in `apps/server/tests/use_cases/diagnostics`: `test_diagnosis_robustness_runtime_inputs.py`, `test_diagnostics_context.py`, `test_diagnostics_shared.py`, `test_diagnostics_shared_extended.py`, `test_finding_objects.py`, `test_findings_builder_support.py`, `test_findings_helpers.py`, `test_findings_ranking_and_guardrail_regressions.py`, `test_findings_subpackage.py`, and `test_localization_and_suppression.py`. I directly reviewed every code file in this chunk before making changes.

The behavior-preserving cleanups here are small but worthwhile. In `test_diagnostics_context.py`, the three tests all rebuilt the same diagnostics context from identical metadata, so this PR extracts a local `_context()` helper to keep the tests centered on the specific decode/projection assertions. In `test_finding_objects.py`, the `PeakFindingAnalyzer` tests duplicated the same synthetic peak-sample fixture; this PR extracts `_peak_samples()` so the tests share one scenario definition instead of repeating the list comprehension.

The other eight files were reviewed and left unchanged after direct inspection. They already read clearly enough, or their large scenario matrices and guardrail coverage did not present an equally safe simplification inside this chunk.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py apps/server/tests/use_cases/diagnostics/test_diagnostics_shared.py apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py apps/server/tests/use_cases/diagnostics/test_finding_objects.py apps/server/tests/use_cases/diagnostics/test_findings_builder_support.py apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_findings_ranking_and_guardrail_regressions.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py` (`157 passed`)
- `make lint`

Risk is low because the diff only consolidates repeated test setup and preserves the existing assertions and exercised behavior.
