### PR TITLE
Repo review chunk 055: simplify order input regression tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py
@@ -22,6 +22,17 @@ from vibesensor.use_cases.diagnostics.orders.physics import _driveshaft_hz, _ord
 # ------------------------------------------------------------------
 
 
+def _guarded_float(value: object) -> float:
+    try:
+        return float(value or 0.0)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _context(overrides: dict | None = None):
+    return build_diagnostics_context(overrides or {}, file_name="test")
+
+
 class TestPdfBuilderConfidenceGuard:
     """float() on confidence should not crash on non-numeric values."""
 
@@ -34,12 +45,7 @@ class TestPdfBuilderConfidenceGuard:
         ],
     )
     def test_confidence_guard(self, raw_value: object, expected: object) -> None:
-        finding = {"confidence": raw_value}
-        try:
-            confidence = float(finding.get("confidence") or 0.0)
-        except (ValueError, TypeError):
-            confidence = 0.0
-        assert confidence == expected
+        assert _guarded_float(raw_value) == expected
 
 
 # ------------------------------------------------------------------
@@ -56,12 +62,7 @@ class TestSummaryFrequencyGuard:
             float(row.get("frequency_hz") or 0.0)
 
     def test_none_frequency(self) -> None:
-        row = {"frequency_hz": None}
-        try:
-            freq = float(row.get("frequency_hz") or 0.0)
-        except (ValueError, TypeError):
-            freq = 0.0
-        assert freq == 0.0
+        assert _guarded_float(None) == 0.0
 
 
 # ------------------------------------------------------------------
@@ -118,11 +119,11 @@ class TestDriveshaftHz:
         overrides: dict,
         tire_m: float | None,
     ) -> None:
-        context = build_diagnostics_context(overrides, file_name="test")
+        context = _context(overrides)
         assert _driveshaft_hz(sample, context, tire_circumference_m=tire_m) is None
 
     def test_valid_inputs(self) -> None:
-        context = build_diagnostics_context({}, file_name="test")
+        context = _context()
         result = _driveshaft_hz(
             {"speed_kmh": 72.0, "final_drive_ratio": 3.5},
             context,
@@ -148,7 +149,7 @@ class TestDriveshaftHz:
             lambda data: _FakeSpec(),
         )
 
-        context = build_diagnostics_context({}, file_name="test")
+        context = _context()
         result = _driveshaft_hz({"speed_kmh": 72.0}, context, tire_circumference_m=None)
 
         assert result == pytest.approx(44.5)


### PR DESCRIPTION
Chunk 055 covers ten files in `apps/server/tests/use_cases/diagnostics`: `test_localization_assessment.py`, `test_locations.py`, `test_negative_false_positives.py`, `test_noise_floor_consistency.py`, `test_order_analysis_input_regressions.py`, `test_order_assessment.py`, `test_order_objects.py`, `test_order_scoring.py`, `test_peak_classification.py`, and `test_peak_scoring.py`. I directly reviewed every code file in this chunk before making changes.

The behavior-preserving cleanup here is in `test_order_analysis_input_regressions.py`. That file repeated two small patterns: the same guarded `float(...)` fallback used by multiple regression checks, and the same `build_diagnostics_context(..., file_name="test")` setup used by several driveshaft-reference tests. This PR extracts those into `_guarded_float()` and `_context()` helpers so the individual tests stay focused on the specific regression contract they are asserting instead of re-declaring the same defensive plumbing.

The other nine files were reviewed and left unchanged after direct inspection. They were already either compact, well-factored around existing helpers, or intentionally large scenario matrices where additional refactoring in this chunk would widen the diff without a clear maintainability payoff.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_localization_assessment.py apps/server/tests/use_cases/diagnostics/test_locations.py apps/server/tests/use_cases/diagnostics/test_negative_false_positives.py apps/server/tests/use_cases/diagnostics/test_noise_floor_consistency.py apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py apps/server/tests/use_cases/diagnostics/test_order_assessment.py apps/server/tests/use_cases/diagnostics/test_order_objects.py apps/server/tests/use_cases/diagnostics/test_order_scoring.py apps/server/tests/use_cases/diagnostics/test_peak_classification.py apps/server/tests/use_cases/diagnostics/test_peak_scoring.py` (`441 passed`)
- `make lint`

Risk is low because the diff only consolidates repeated test-only setup and leaves the exercised behavior unchanged.
