### PR TITLE
Repo review chunk 057: simplify test plan coverage

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_test_plan.py
+++ b/apps/server/tests/use_cases/diagnostics/test_test_plan.py
@@ -19,6 +19,15 @@ _MINIMAL_META: dict[str, Any] = {
 }
 
 
+def _summary(*, findings_builder) -> dict[str, Any]:
+    return summarize_run_data(
+        _MINIMAL_META,
+        [],
+        lang="en",
+        findings_builder=findings_builder,
+    )
+
+
 def test_summary_test_plan_ignores_payload_actions_and_projects_domain_plan() -> None:
     payload = make_finding_payload(
         suspected_source="wheel/tire",
@@ -40,12 +49,7 @@ def test_summary_test_plan_ignores_payload_actions_and_projects_domain_plan() ->
     def _findings_builder(_: FindingsBuildRequest) -> tuple[Finding, ...]:
         return finalize_findings([finding_from_payload(payload)])
 
-    summary = summarize_run_data(
-        _MINIMAL_META,
-        [],
-        lang="en",
-        findings_builder=_findings_builder,
-    )
+    summary = _summary(findings_builder=_findings_builder)
 
     action_ids = [str(step.get("action_id") or "") for step in summary["test_plan"]]
 
@@ -55,10 +59,7 @@ def test_summary_test_plan_ignores_payload_actions_and_projects_domain_plan() ->
 
 
 def test_summary_test_plan_uses_boundary_step_shape_from_domain_actions() -> None:
-    summary = summarize_run_data(
-        _MINIMAL_META,
-        [],
-        lang="en",
+    summary = _summary(
         findings_builder=lambda _request: finalize_findings(
             [finding_from_payload(make_finding_payload(suspected_source="engine"))]
         ),


### PR DESCRIPTION
Chunk 057 covers eight files in `apps/server/tests/use_cases/diagnostics`: `test_strength_bands_extended.py`, `test_strength_scoring.py`, `test_summary_pure_functions.py`, `test_test_plan.py`, `test_vibration_math_coverage.py`, `test_vibration_strength_absolute_metrics.py`, `test_vibration_strength_boundaries.py`, and `test_vibration_strength_core.py`. I directly reviewed every code file in this chunk before making changes.

The behavior-preserving cleanup here is in `test_test_plan.py`. Both tests exercised the same `summarize_run_data(...)` call shape with the same metadata, empty sample list, and English language, differing only in the injected `findings_builder`. This PR extracts that shared summary invocation into a local `_summary()` helper so each test reads as a contract assertion about test-plan projection rather than about repeated setup plumbing.

The other seven files were reviewed and left unchanged after direct inspection. They were already either compact, well-parameterized, or centered around existing math/helpers where additional refactoring in this chunk would have added churn without a clear maintainability gain.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_summary_pure_functions.py apps/server/tests/use_cases/diagnostics/test_test_plan.py apps/server/tests/use_cases/diagnostics/test_vibration_math_coverage.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py` (`118 passed`)
- `make lint`

Risk is low because the diff only consolidates repeated test setup and preserves the existing assertions and exercised behavior.
