### PR TITLE
Repo review chunk 058: simplify history service tests

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -120,6 +120,22 @@ def _projectable_analysis(**overrides: object) -> dict[str, object]:
     return cast(dict[str, object], summary)
 
 
+def _projected_run_service(
+    run: dict[str, Any],
+    *,
+    active_car: CarSnapshot | None = None,
+) -> ProjectedHistoryRunService:
+    service = HistoryRunService(
+        _HistoryDbStub(run=run),
+    )
+    if active_car is None:
+        return ProjectedHistoryRunService(service)
+    return ProjectedHistoryRunService(
+        service,
+        current_car_reader=_SettingsStoreStub(active_car=active_car),
+    )
+
+
 def test_raise_delete_run_error_maps_unknown_reason_to_domain_error() -> None:
     with pytest.raises(AnalysisNotReadyError, match="Cannot delete run at this time"):
         raise_delete_run_error("locked")
@@ -251,24 +267,18 @@ async def test_projected_run_service_adds_current_context_overlay_explicitly() -
             lang="en",
         ),
     )
-    service = ProjectedHistoryRunService(
-        HistoryRunService(
-            _HistoryDbStub(
-                run={
-                    "run_id": "run-1",
-                    "status": "complete",
-                    "metadata": {"language": "en"},
-                    "analysis": persisted_analysis,
-                }
-            ),
-        ),
-        current_car_reader=_SettingsStoreStub(
-            active_car=CarSnapshot(
-                car_id="car-b",
-                name="Daily Car",
-                car_type="wagon",
-                aspects={"tire_width_mm": 225.0},
-            )
+    service = _projected_run_service(
+        {
+            "run_id": "run-1",
+            "status": "complete",
+            "metadata": {"language": "en"},
+            "analysis": persisted_analysis,
+        },
+        active_car=CarSnapshot(
+            car_id="car-b",
+            name="Daily Car",
+            car_type="wagon",
+            aspects={"tire_width_mm": 225.0},
         ),
     )
 
@@ -283,33 +293,29 @@ async def test_projected_run_service_adds_current_context_overlay_explicitly() -
 
 @pytest.mark.asyncio
 async def test_projected_run_service_projects_persisted_summary_through_domain() -> None:
-    service = ProjectedHistoryRunService(
-        HistoryRunService(
-            _HistoryDbStub(
-                run={
-                    "run_id": "run-1",
-                    "status": "complete",
-                    "analysis": _projectable_analysis(
-                        lang="en",
-                        findings=[
-                            {
-                                "finding_id": "F001",
-                                "suspected_source": "wheel/tire",
-                                "strongest_location": "front-left",
-                                "strongest_speed_band": "50-80 km/h",
-                                "confidence": 0.71,
-                                "evidence_metrics": {"vibration_strength_db": 21.0},
-                            },
-                        ],
-                        top_causes=[],
-                        test_plan=[],
-                        run_suitability=[],
-                        most_likely_origin={},
-                        _internal={"secret": True},
-                    ),
-                },
+    service = _projected_run_service(
+        {
+            "run_id": "run-1",
+            "status": "complete",
+            "analysis": _projectable_analysis(
+                lang="en",
+                findings=[
+                    {
+                        "finding_id": "F001",
+                        "suspected_source": "wheel/tire",
+                        "strongest_location": "front-left",
+                        "strongest_speed_band": "50-80 km/h",
+                        "confidence": 0.71,
+                        "evidence_metrics": {"vibration_strength_db": 21.0},
+                    },
+                ],
+                top_causes=[],
+                test_plan=[],
+                run_suitability=[],
+                most_likely_origin={},
+                _internal={"secret": True},
             ),
-        )
+        }
     )
 
     run = await service.get_run("run-1")
@@ -323,28 +329,24 @@ async def test_projected_run_service_projects_persisted_summary_through_domain()
 
 @pytest.mark.asyncio
 async def test_projected_run_service_drops_persisted_origin_without_primary_finding() -> None:
-    service = ProjectedHistoryRunService(
-        HistoryRunService(
-            _HistoryDbStub(
-                run={
-                    "run_id": "run-1",
-                    "status": "complete",
-                    "analysis": _projectable_analysis(
-                        lang="en",
-                        findings=[],
-                        top_causes=[],
-                        test_plan=[],
-                        run_suitability=[],
-                        most_likely_origin={
-                            "location": "rear left",
-                            "suspected_source": "wheel/tire",
-                            "weak_spatial_separation": True,
-                        },
-                        _internal={"secret": True},
-                    ),
+    service = _projected_run_service(
+        {
+            "run_id": "run-1",
+            "status": "complete",
+            "analysis": _projectable_analysis(
+                lang="en",
+                findings=[],
+                top_causes=[],
+                test_plan=[],
+                run_suitability=[],
+                most_likely_origin={
+                    "location": "rear left",
+                    "suspected_source": "wheel/tire",
+                    "weak_spatial_separation": True,
                 },
+                _internal={"secret": True},
             ),
-        )
+        }
     )
 
     run = await service.get_run("run-1")


### PR DESCRIPTION
Chunk 058 covers four files in `apps/server/tests/use_cases/history`: `test_history_async_offloading.py`, `test_history_http_services.py`, `test_history_service_edges.py`, and `test_report_preparation_contract.py`. I directly reviewed every code file in this chunk before deciding what to change.

The behavior-preserving cleanup is in `test_history_http_services.py`. Three projected-history tests were each rebuilding the same `ProjectedHistoryRunService(HistoryRunService(_HistoryDbStub(...)))` stack, with only the persisted run payload and optional active-car overlay changing between cases. This PR extracts that shared setup into a local `_projected_run_service(...)` helper so the tests foreground the projection behavior being asserted rather than repeating constructor nesting.

The other three files were reviewed and left unchanged. `test_history_async_offloading.py` is already compact and purpose-built, `test_history_service_edges.py` already centralizes its run-building helpers well, and `test_report_preparation_contract.py` already uses a focused prepared-input factory with minimal setup noise.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/history/test_history_async_offloading.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_report_preparation_contract.py` (`36 passed`)
- `make lint`

Risk is low because the diff only consolidates repeated test setup and leaves all assertions and exercised code paths unchanged.
