### PR TITLE
Repo review chunk 059: simplify run helper tests

### DIFF
--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -14,6 +14,7 @@ from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot
 from vibesensor.shared.types.history_records import AnalyzingRunHealth
 from vibesensor.use_cases.run import _recorder_runtime
 from vibesensor.use_cases.run._recorder_types import _build_run_metadata_record
+from vibesensor.use_cases.run.lifecycle_state import ActiveRunSnapshot
 from vibesensor.use_cases.run.post_analysis import PostAnalysisHealthSnapshot
 
 
@@ -22,6 +23,13 @@ class _NullDB:
 
     def analyzing_run_health(self):
         return AnalyzingRunHealth(analyzing_run_count=0, analyzing_oldest_age_s=None)
+
+
+def _started_snapshot(logger) -> ActiveRunSnapshot:
+    logger.start_recording()
+    snapshot = logger._session_snapshot()
+    assert snapshot is not None
+    return snapshot
 
 
 def test_build_sample_records_uses_only_active_clients(make_logger) -> None:
@@ -123,9 +131,7 @@ def test_append_records_ignores_stale_recent_metrics_without_new_frames(
 ) -> None:
     logger = make_logger(history_db=fake_history_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -151,9 +157,7 @@ def test_append_records_ignores_stale_recent_metrics_without_new_frames(
 def test_history_run_created_on_first_sample_append(make_logger, fake_history_db) -> None:
     logger = make_logger(history_db=fake_history_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -223,9 +227,7 @@ def test_finalize_preserves_run_metadata_from_recording_start(
 ) -> None:
     logger = make_logger(settings_store=mutable_fake_settings, history_db=fake_history_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -249,9 +251,7 @@ def test_append_records_surfaces_create_run_failure_in_status(
 ) -> None:
     logger = make_logger(history_db=failing_create_run_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -270,9 +270,7 @@ def test_append_records_clears_write_error_after_successful_retry(
 ) -> None:
     logger = make_logger(history_db=failing_append_once_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -293,9 +291,7 @@ def test_append_records_reports_timeout_when_no_data_for_threshold(
 ) -> None:
     logger = make_logger(registry=no_active_registry)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -317,9 +313,7 @@ def test_append_records_does_not_timeout_on_brief_gap(
 ) -> None:
     logger = make_logger(registry=no_active_registry)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -368,9 +362,7 @@ def test_stop_recording_does_not_block_on_post_analysis(
     )
     logger = make_logger(history_db=history_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -409,9 +401,7 @@ def test_post_analysis_failure_sets_persistent_error_status(
     )
     logger = make_logger(history_db=history_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -535,9 +525,7 @@ def test_post_analysis_uses_run_language_from_metadata(
     history_db = HistoryDB(tmp_path / "history.db")
     logger = make_logger(history_db=history_db, language_provider=lambda: "nl")
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -625,9 +613,7 @@ def test_db_persists_when_jsonl_disabled(make_logger, tmp_path: Path) -> None:
     history_db = HistoryDB(tmp_path / "history.db")
     logger = make_logger(history_db=history_db, persist_history_db=True)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s
@@ -653,9 +639,7 @@ def test_post_analysis_caps_sample_count_and_stores_sampling_metadata(
     history_db = HistoryDB(tmp_path / "history.db")
     logger = make_logger(history_db=history_db)
 
-    logger.start_recording()
-    snapshot = logger._session_snapshot()
-    assert snapshot is not None
+    snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
     start_time_utc = snapshot.start_time_utc
     start_mono = snapshot.start_mono_s


### PR DESCRIPTION
Chunk 059 covers ten files in `apps/server/tests/use_cases/run`: `conftest.py`, `test_lifecycle_state.py`, `test_metrics_log_helpers.py`, `test_metrics_logger_lifecycle.py`, `test_pipeline_resilience.py`, `test_post_analysis_executor.py`, `test_post_analysis_loader.py`, `test_post_analysis_summary.py`, `test_post_analysis_worker.py`, and `test_recorder_runtime.py`. I directly reviewed every code file in this chunk before deciding what to change.

The behavior-preserving cleanup is in `test_metrics_log_helpers.py`. A long stretch of tests repeated the same run setup ceremony: start recording, fetch the active session snapshot, assert it exists, and then unpack the same run identifiers and timestamps before exercising append, finalize, or post-analysis behavior. This PR extracts that repeated setup into a local `_started_snapshot(...)` helper so those tests focus on the individual persistence and runtime assertions instead of the same snapshot plumbing.

The other nine files were reviewed and left unchanged. They were already either compact, clearly segmented by responsibility, or built around small local helpers where more refactoring would have added churn without a clear readability win.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/run/conftest.py apps/server/tests/use_cases/run/test_lifecycle_state.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/use_cases/run/test_pipeline_resilience.py apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_post_analysis_loader.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/use_cases/run/test_recorder_runtime.py` (`97 passed`)
- `make lint`

Risk is low because the diff only consolidates repeated test setup and preserves the same assertions and exercised code paths.
