### PR TITLE
Repo review chunk 061: harden updater tests

### DIFF
--- a/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
+++ b/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.runner import CommandRunner
-from vibesensor.use_cases.updates.status import collect_runtime_details
+from vibesensor.use_cases.updates.status import UpdateStateStore, collect_runtime_details
 
 
 def _build_fake_downloaded_wheel(path: Path, *, version: str) -> None:
@@ -146,7 +146,11 @@ def setup_update_env(
         runner.set_response("sudo -n true", 0)
     repo = tmp_path / "repo"
     repo.mkdir()
-    kwargs: dict[str, object] = {"runner": runner, "repo_path": str(repo)}
+    kwargs: dict[str, object] = {
+        "runner": runner,
+        "repo_path": str(repo),
+        "state_store": UpdateStateStore(tmp_path / "update_status.json"),
+    }
     if rollback:
         kwargs["rollback_dir"] = str(tmp_path / "rollback")
     mgr = UpdateManager(**kwargs)

--- a/apps/server/tests/use_cases/updates/test_interrupted_recovery.py
+++ b/apps/server/tests/use_cases/updates/test_interrupted_recovery.py
@@ -20,15 +20,22 @@ def _make_tracker(status: UpdateJobStatus | None = None) -> UpdateStatusTracker:
     )
 
 
+def _running_status(
+    phase: UpdatePhase,
+    *,
+    finished_at: float | None = None,
+) -> UpdateJobStatus:
+    return UpdateJobStatus(
+        state=UpdateState.running,
+        phase=phase,
+        started_at=time.time() - 60,
+        finished_at=finished_at,
+    )
+
+
 class TestNeedsRecovery:
     def test_running_without_finished_at_needs_recovery(self) -> None:
-        tracker = _make_tracker(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.installing,
-                started_at=time.time() - 60,
-            ),
-        )
+        tracker = _make_tracker(_running_status(UpdatePhase.installing))
         recovery = InterruptedUpdateRecovery(tracker=tracker, wifi_factory=lambda: None)
         assert recovery.needs_recovery() is True
 
@@ -39,10 +46,8 @@ class TestNeedsRecovery:
 
     def test_running_with_finished_at_does_not_need_recovery(self) -> None:
         tracker = _make_tracker(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.done,
-                started_at=time.time() - 60,
+            _running_status(
+                UpdatePhase.done,
                 finished_at=time.time() - 30,
             ),
         )
@@ -67,13 +72,7 @@ class TestNeedsRecovery:
 class TestRecover:
     @pytest.mark.asyncio
     async def test_marks_as_failed_and_persists(self) -> None:
-        tracker = _make_tracker(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.downloading,
-                started_at=time.time() - 60,
-            ),
-        )
+        tracker = _make_tracker(_running_status(UpdatePhase.downloading))
         wifi = AsyncMock()
         recovery = InterruptedUpdateRecovery(
             tracker=tracker,
@@ -90,13 +89,7 @@ class TestRecover:
 
     @pytest.mark.asyncio
     async def test_calls_wifi_cleanup(self) -> None:
-        tracker = _make_tracker(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.connecting_wifi,
-                started_at=time.time() - 60,
-            ),
-        )
+        tracker = _make_tracker(_running_status(UpdatePhase.connecting_wifi))
         wifi = AsyncMock()
         recovery = InterruptedUpdateRecovery(
             tracker=tracker,
@@ -112,11 +105,7 @@ class TestRecover:
         state_path = tmp_path / "update_state.json"
         store = UpdateStateStore(path=state_path)
         store.save(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.installing,
-                started_at=time.time() - 60,
-            ),
+            _running_status(UpdatePhase.installing),
         )
         tracker = UpdateStatusTracker(
             state_store=store,

--- a/apps/server/tests/use_cases/updates/test_update_manager_api.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_api.py
@@ -13,10 +13,11 @@ from vibesensor.adapters.http.dependencies import (
     UpdateDeps,
 )
 from vibesensor.use_cases.updates.manager import UpdateManager
+from vibesensor.use_cases.updates.status import UpdateStateStore
 
 
 class TestUpdateApiEndpoints:
-    def test_status_endpoint_exists(self) -> None:
+    def test_status_endpoint_exists(self, tmp_path) -> None:
         from vibesensor.adapters.http import create_router
 
         placeholder = MagicMock()
@@ -40,7 +41,9 @@ class TestUpdateApiEndpoints:
                 export_service=placeholder,
             ),
             updates=UpdateDeps(
-                update_manager=UpdateManager(),
+                update_manager=UpdateManager(
+                    state_store=UpdateStateStore(tmp_path / "update_status.json"),
+                ),
                 esp_flash_manager=MagicMock(),
             ),
         )

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -87,7 +87,14 @@ class TestUpdateManagerAsync:
     async def test_no_sudo_fails_gracefully(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path, sudo_ok=False, rollback=False)
         runner.set_response("sudo -n true", 1, "", "sudo: a password is required")
-        with patch("shutil.which", mock_which):
+        with (
+            patch("shutil.which", mock_which),
+            patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
+            patch(
+                "vibesensor.use_cases.updates.workflow.check_for_update",
+                side_effect=AssertionError("check_for_update should not run without privileges"),
+            ),
+        ):
             await run_update(manager, "TestNet", "pass")
         assert manager.status.state == UpdateState.failed
         assert (

--- a/apps/server/tests/use_cases/updates/test_update_manager_core.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_core.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -10,12 +12,17 @@ from _update_manager_test_helpers import FakeRunner, cancel_task, mock_which
 from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.models import UpdatePhase, UpdateState
+from vibesensor.use_cases.updates.status import UpdateStateStore
 
 
 class TestUpdateManager:
     def make_manager(self, *, runner: FakeRunner | None = None) -> tuple[UpdateManager, FakeRunner]:
         active_runner = runner or FakeRunner()
-        manager = UpdateManager(runner=active_runner, repo_path="/tmp/fakerepo")
+        manager = UpdateManager(
+            runner=active_runner,
+            repo_path="/tmp/fakerepo",
+            state_store=UpdateStateStore(Path(tempfile.mkdtemp()) / "update_status.json"),
+        )
         return manager, active_runner
 
     def test_initial_status_is_idle(self) -> None:
@@ -51,7 +58,7 @@ class TestUpdateManager:
 
         runner.run = slow_run
         runner.set_response("sudo -n true", 0)
-        manager = UpdateManager(runner=runner, repo_path="/tmp/fakerepo")
+        manager, _ = self.make_manager(runner=runner)
 
         with patch("shutil.which", mock_which):
             manager.start("TestNet", "pass123")
@@ -80,7 +87,7 @@ class TestUpdateManager:
 
         runner.run = slow_run
         runner.set_response("sudo -n true", 0)
-        manager = UpdateManager(runner=runner, repo_path="/tmp/fakerepo")
+        manager, _ = self.make_manager(runner=runner)
 
         with patch("shutil.which", mock_which):
             manager.start("TestNet", "pass")
@@ -92,7 +99,7 @@ class TestUpdateManager:
     async def test_status_to_payload_never_leaks_password(self) -> None:
         runner = FakeRunner()
         runner.set_response("sudo -n true", 0)
-        manager = UpdateManager(runner=runner, repo_path="/tmp/fakerepo")
+        manager, _ = self.make_manager(runner=runner)
 
         with patch("shutil.which", mock_which):
             manager.start("TestNet", "supersecret")
@@ -104,7 +111,7 @@ class TestUpdateManager:
     async def test_start_sets_ssid_and_timestamps(self) -> None:
         runner = FakeRunner()
         runner.set_response("sudo -n true", 0)
-        manager = UpdateManager(runner=runner, repo_path="/tmp/fakerepo")
+        manager, _ = self.make_manager(runner=runner)
 
         before = time.time()
         with patch("shutil.which", mock_which):


### PR DESCRIPTION
Chunk 061 covers ten files in `apps/server/tests/use_cases/updates`: `_update_manager_test_helpers.py`, `test_interrupted_recovery.py`, `test_run_release_smoke.py`, `test_update_installer_verification.py`, `test_update_job_executor.py`, `test_update_job_lifecycle.py`, `test_update_manager_api.py`, `test_update_manager_async.py`, `test_update_manager_core.py`, and `test_update_manager_models.py`. I directly reviewed every code file in this chunk before making changes.

The main cleanup is in `test_interrupted_recovery.py`, where repeated “running update started a minute ago” status setup is centralized in `_running_status(...)` so the recovery tests focus on the phase-specific behavior under assertion.

While validating the chunk, two updater tests exposed environment-dependent brittleness in the existing test setup. To keep the behavior under test stable across local runs, this PR also isolates `UpdateManager` state with per-test `UpdateStateStore` instances in the shared test helper, the core manager tests, and the API router smoke test. In `test_update_manager_async.py`, the no-sudo case now explicitly forces the non-root path and asserts that release lookup never runs when privilege validation should fail.

The remaining five files were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/_update_manager_test_helpers.py apps/server/tests/use_cases/updates/test_interrupted_recovery.py apps/server/tests/use_cases/updates/test_run_release_smoke.py apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/test_update_job_executor.py apps/server/tests/use_cases/updates/test_update_job_lifecycle.py apps/server/tests/use_cases/updates/test_update_manager_api.py apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/use_cases/updates/test_update_manager_core.py apps/server/tests/use_cases/updates/test_update_manager_models.py` (`78 passed`)
- `make lint`

Risk is low because the diff only reduces repeated test setup and removes environment leakage from the updater test fixtures.
