### PR TITLE
Repo review chunk 062: simplify update state tests

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -63,6 +63,23 @@ def _mock_which(name: str) -> str | None:
     return f"/usr/bin/{name}" if name in ("nmcli", "python3") else None
 
 
+def _running_status(
+    phase: UpdatePhase,
+    *,
+    finished_at: float | None = None,
+    ssid: str = "",
+    log_tail: list[str] | None = None,
+) -> UpdateJobStatus:
+    return UpdateJobStatus(
+        state=UpdateState.running,
+        phase=phase,
+        started_at=time.time() - 60,
+        finished_at=finished_at,
+        ssid=ssid,
+        log_tail=[] if log_tail is None else log_tail,
+    )
+
+
 @pytest.fixture
 def update_env(
     tmp_path: Path,
@@ -253,10 +270,8 @@ class TestStartupRecovery:
         state_path, store, _, make_mgr = update_env
 
         store.save(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.installing,
-                started_at=time.time() - 60,
+            _running_status(
+                UpdatePhase.installing,
                 ssid="CrashNet",
                 log_tail=["some log"],
             ),
@@ -290,10 +305,8 @@ class TestStartupRecovery:
         """A running job WITH finished_at set does not trigger recovery."""
         _, store, _, make_mgr = update_env
         store.save(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.done,
-                started_at=time.time() - 60,
+            _running_status(
+                UpdatePhase.done,
                 finished_at=time.time() - 30,
             ),
         )
@@ -306,13 +319,7 @@ class TestStartupRecovery:
     async def test_recovery_attempts_network_cleanup(self, update_env) -> None:
         """Startup recovery attempts to clean up uplink and restore hotspot."""
         _, store, runner, make_mgr = update_env
-        store.save(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.connecting_wifi,
-                started_at=time.time() - 60,
-            ),
-        )
+        store.save(_running_status(UpdatePhase.connecting_wifi))
         mgr = make_mgr()
 
         await mgr.startup_recover()
@@ -325,13 +332,7 @@ class TestStartupRecovery:
     async def test_recovery_handles_nmcli_failure_gracefully(self, update_env) -> None:
         """If nmcli fails during recovery, it adds issues but doesn't crash."""
         _, store, runner, make_mgr = update_env
-        store.save(
-            UpdateJobStatus(
-                state=UpdateState.running,
-                phase=UpdatePhase.downloading,
-                started_at=time.time() - 60,
-            ),
-        )
+        store.save(_running_status(UpdatePhase.downloading))
         runner.default_response = (1, "", "nmcli not found")
         mgr = make_mgr()
 
@@ -432,7 +433,14 @@ class TestPersistenceDuringLifecycle:
         runner.set_response("sudo -n true", 1, "", "no sudo")
         mgr = make_mgr()
 
-        with patch("shutil.which", _mock_which):
+        with (
+            patch("shutil.which", _mock_which),
+            patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
+            patch(
+                "vibesensor.use_cases.updates.workflow.check_for_update",
+                side_effect=AssertionError("check_for_update should not run without privileges"),
+            ),
+        ):
             mgr.start("TestNet", "")
             task = mgr.job_task
             assert task is not None


### PR DESCRIPTION
Chunk 062 covers four files in `apps/server/tests/use_cases/updates`: `test_update_models_roundtrip.py`, `test_update_state_persistence.py`, `test_update_validation.py`, and `test_validate_update_request.py`. I directly reviewed every code file in this chunk before deciding what to change.

The behavior-preserving cleanup is in `test_update_state_persistence.py`. Several startup-recovery and persistence tests rebuilt the same “running update started a minute ago” status with only the phase, SSID, log tail, or `finished_at` changing. This PR extracts that repeated setup into `_running_status(...)`, making the tests easier to scan while keeping the same persisted-state semantics under test.

While validating locally, one persistence test also showed the same root/non-root sensitivity as the previous updates chunk: in this environment the updater runs as root, so the sudo validation branch must be forced explicitly when a test is asserting the “insufficient privileges” outcome. The affected test now patches `os.geteuid()` and asserts release lookup must not run.

The other three files were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/test_update_models_roundtrip.py apps/server/tests/use_cases/updates/test_update_state_persistence.py apps/server/tests/use_cases/updates/test_update_validation.py apps/server/tests/use_cases/updates/test_validate_update_request.py` (`35 passed`)
- `make lint`

Risk is low because the diff only consolidates repeated test setup and hardens an environment-dependent test path.
