### PR TITLE
Repo review chunk 063: remove stale flash test helper

### DIFF
--- a/apps/server/tests/use_cases/updates/firmware/test_esp_flash_phase_coherence.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_esp_flash_phase_coherence.py
@@ -14,17 +14,10 @@ These tests verify the phase is always coherent after _finalize().
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from vibesensor.use_cases.updates.firmware.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.firmware.esp_flash_types import EspFlashState, EspFlashStatus
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
-
-
-def _make_manager(tmp_path: Path) -> EspFlashManager:
-    """Return an EspFlashManager with minimal construction."""
-    return EspFlashManager()
 
 
 def _manager_with_active_phase(phase: str) -> EspFlashManager:


### PR DESCRIPTION
Chunk 063 covers three files in `apps/server/tests/use_cases/updates/firmware`: `test_esp_flash_manager.py`, `test_esp_flash_phase_coherence.py`, and `test_firmware_cache.py`. I directly reviewed every code file in this chunk before making changes.

The behavior-preserving cleanup is in `test_esp_flash_phase_coherence.py`. That regression file still carried an unused `_make_manager(...)` helper and its associated `Path` import even though all of the live tests use `_manager_with_active_phase(...)` instead. This PR removes the stale helper so the file only exposes the helper that is actually part of the test flow.

The other two files were reviewed and left unchanged. `test_esp_flash_manager.py` already centralizes its fake bundle/cache/runner helpers effectively despite its size, and `test_firmware_cache.py` is already compact and purpose-built around release selection and safe extraction behavior.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_phase_coherence.py apps/server/tests/use_cases/updates/firmware/test_firmware_cache.py` (`39 passed`)
- `make lint`

Risk is low because the diff only removes dead test code and an unused import.
