### PR TITLE
Repo review chunk 064: simplify release validation test

### DIFF
--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -10,6 +10,7 @@ import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import yaml
 from _paths import SERVER_ROOT
 
@@ -276,9 +277,5 @@ def test_validate_packaged_static_assets_requires_index(monkeypatch) -> None:
         lambda self: False if self == static_dir / "index.html" else original_is_file(self),
     )
 
-    try:
+    with pytest.raises(RuntimeError, match="Missing packaged UI asset"):
         validate_packaged_static_assets()
-    except RuntimeError as exc:
-        assert "Missing packaged UI asset" in str(exc)
-    else:
-        raise AssertionError("Expected missing packaged UI asset failure")


### PR DESCRIPTION
Chunk 064 covers both files in `apps/server/tests/use_cases/updates/releases`: `test_release_fetcher.py` and `test_release_validation.py`. I directly reviewed every code file in this chunk before deciding what to change.

The only code change is in `test_release_validation.py`. One test still used a manual `try/except/else` pattern to assert that `validate_packaged_static_assets()` raises when the packaged `index.html` asset is missing. That pattern worked, but it was more verbose than the surrounding suite and hid the intent slightly. This PR converts the assertion to `pytest.raises(...)`, which is the standard test idiom already used throughout the repository for exception expectations.

`test_release_fetcher.py` was reviewed and left unchanged. It is already small, cohesive, and clear around release payload decoding, version selection, asset downloading, and API header behavior.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/releases/test_release_fetcher.py apps/server/tests/use_cases/updates/releases/test_release_validation.py` (`29 passed`)
- `make lint`

Risk is low because the change only simplifies an exception assertion in test code without altering runtime behavior.
