### PR TITLE
Repo review chunk 065: share wifi log dir helper

### DIFF
--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_diagnostics.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_diagnostics.py
@@ -5,35 +5,37 @@ from pathlib import Path
 from vibesensor.use_cases.updates.wifi.wifi_diagnostics import parse_wifi_diagnostics
 
 
+def _wifi_log_dir(tmp_path: Path) -> Path:
+    log_dir = tmp_path / "wifi"
+    log_dir.mkdir()
+    return log_dir
+
+
 class TestParseWifiDiagnostics:
     def test_no_log_dir(self, tmp_path) -> None:
         assert parse_wifi_diagnostics(str(tmp_path / "nonexistent")) == []
 
     def test_summary_failure(self, tmp_path) -> None:
-        log_dir = tmp_path / "wifi"
-        log_dir.mkdir()
+        log_dir = _wifi_log_dir(tmp_path)
         (log_dir / "summary.txt").write_text("status=FAILED\nrc=22\n")
         issues = parse_wifi_diagnostics(str(log_dir))
         assert any("failure" in issue.message.lower() for issue in issues)
 
     def test_summary_timeout_case_insensitive(self, tmp_path) -> None:
-        log_dir = tmp_path / "wifi"
-        log_dir.mkdir()
+        log_dir = _wifi_log_dir(tmp_path)
         (log_dir / "summary.txt").write_text("status=timeout\n")
         issues = parse_wifi_diagnostics(str(log_dir))
         assert any("timeout" in (issue.detail or "").lower() for issue in issues)
 
     def test_summary_password_not_leaked(self, tmp_path) -> None:
-        log_dir = tmp_path / "wifi"
-        log_dir.mkdir()
+        log_dir = _wifi_log_dir(tmp_path)
         (log_dir / "summary.txt").write_text("status=FAILED psk=hunter2\n")
         issues = parse_wifi_diagnostics(str(log_dir))
         for issue in issues:
             assert "hunter2" not in (issue.detail or "")
 
     def test_hotspot_log_errors(self, tmp_path) -> None:
-        log_dir = tmp_path / "wifi"
-        log_dir.mkdir()
+        log_dir = _wifi_log_dir(tmp_path)
         (log_dir / "hotspot.log").write_text(
             "2024-01-01 INFO normaline\n2024-01-01 ERROR something failed\n2024-01-01 INFO ok\n",
         )


### PR DESCRIPTION
Chunk 065 covers five files in `apps/server/tests/use_cases/updates/wifi`: `test_hotspot_recovery.py`, `test_wifi_diagnostics.py`, `test_wifi_orchestrator.py`, `test_wifi_readiness.py`, and `test_wifi_uplink_setup.py`. I directly reviewed every code file in this chunk before deciding on changes.

The code change is a small cleanup in `test_wifi_diagnostics.py`. Several tests were rebuilding the same `tmp_path / "wifi"` directory fixture inline before writing summary or hotspot log files. This PR extracts that repeated setup into `_wifi_log_dir(...)`, which keeps the individual test bodies focused on the specific file content and assertion they care about.

The other four files were reviewed and left unchanged. They already use focused local builders for their fakes and state setup, and I did not see a behavior-preserving cleanup that would improve them meaningfully without adding churn.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py apps/server/tests/use_cases/updates/wifi/test_wifi_diagnostics.py apps/server/tests/use_cases/updates/wifi/test_wifi_orchestrator.py apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py` (`24 passed`)
- `make lint`

Risk is low because the change only deduplicates repeated test fixture setup.
