### PR TITLE
Repo review chunk 066: share sensor cleanup helper

### DIFF
--- a/apps/server/tests_e2e/_docker_edge_helpers.py
+++ b/apps/server/tests_e2e/_docker_edge_helpers.py
@@ -37,6 +37,16 @@ def _cleanup_clients(base_url: str) -> None:
         )
 
 
+def _cleanup_sensor_settings(base_url: str, *mac_addresses: str) -> None:
+    for mac_address in mac_addresses:
+        api_json(
+            base_url,
+            f"/api/settings/sensors/{mac_address}",
+            method="DELETE",
+            expected_status=(200, 404),
+        )
+
+
 def _wait_complete(base_url: str, run_id: str) -> dict:
     return wait_run_status(base_url, run_id, statuses=("complete", "error"), timeout_s=120.0)
 

--- a/apps/server/tests_e2e/test_e2e_docker_client_locations.py
+++ b/apps/server/tests_e2e/test_e2e_docker_client_locations.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests_e2e._docker_edge_helpers import (
     _cleanup_clients,
+    _cleanup_sensor_settings,
     _simulate,
 )
 from tests_e2e.e2e_helpers import (
@@ -68,10 +69,7 @@ def test_client_location_invalid_input_matrix(e2e_env: dict[str, str]) -> None:
             expected_status=409,
         )
     finally:
-        for mac in macs:
-            api_json(
-                base, f"/api/settings/sensors/{mac}", method="DELETE", expected_status=(200, 404)
-            )
+        _cleanup_sensor_settings(base, *macs)
         _cleanup_clients(base)
 
 
@@ -115,8 +113,5 @@ def test_location_reassignment_releases_previous_slot(e2e_env: dict[str, str]) -
         assert sensors[mac_1.replace(":", "")]["location_code"] == "rear_left_wheel"
         assert sensors[mac_2.replace(":", "")]["location_code"] == "front_left_wheel"
     finally:
-        for mac in (mac_1, mac_2):
-            api_json(
-                base, f"/api/settings/sensors/{mac}", method="DELETE", expected_status=(200, 404)
-            )
+        _cleanup_sensor_settings(base, mac_1, mac_2)
         _cleanup_clients(base)


### PR DESCRIPTION
Chunk 066 covers ten files in `apps/server/tests_e2e`: `__init__.py`, `_docker_edge_helpers.py`, `conftest.py`, `e2e_helpers.py`, `test_e2e_docker_client_locations.py`, `test_e2e_docker_crud.py`, `test_e2e_docker_engine_order_fault.py`, `test_e2e_docker_exports.py`, `test_e2e_docker_history_status.py`, and `test_e2e_docker_pdf_accuracy.py`. I directly reviewed every code file in this chunk before making changes.

The behavior-preserving cleanup is a small shared-helper extraction for repeated sensor-setting teardown in the client-location E2E tests. `_docker_edge_helpers.py` now provides `_cleanup_sensor_settings(...)`, and `test_e2e_docker_client_locations.py` uses it in both `finally` blocks instead of repeating the same delete loop inline. This keeps the test bodies focused on the assignment/reassignment behavior under test and leaves cleanup mechanics in the shared helper module already used by these edge-case E2Es.

The remaining eight files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `make lint`
- Attempted `python3 tools/tests/run_e2e_parallel.py --fast-e2e --shards 1`, but local Docker-backed E2E execution was blocked because this environment could not connect to the Docker daemon at `/var/run/docker.sock`.

Risk is low because the diff only consolidates repeated E2E cleanup code.
