### PR TITLE
Repo review chunk 067: simplify journey cleanup loops

### DIFF
--- a/apps/server/tests_e2e/test_e2e_docker_user_journeys.py
+++ b/apps/server/tests_e2e/test_e2e_docker_user_journeys.py
@@ -32,6 +32,16 @@ LOCATION_CODES = (
 )
 
 
+def _delete_resources(base_url: str, path_template: str, identifiers: list[str]) -> None:
+    for identifier in identifiers:
+        api_json(
+            base_url,
+            path_template.format(identifier=identifier),
+            method="DELETE",
+            expected_status=(200, 404),
+        )
+
+
 def _circumference_m(width_mm: float, aspect_pct: float, rim_in: float) -> float:
     # Apply default deflection factor (0.97) to match server-side computation.
     return math.pi * ((rim_in * 25.4 + 2.0 * (width_mm * (aspect_pct / 100.0))) / 1000.0) * 0.97
@@ -267,27 +277,9 @@ def test_e2e_docker_user_journeys(journey_group: str) -> None:
             assert "diagnostic worksheet" not in text_from_en_request
 
     finally:
-        for run_id in list(created_run_ids):
-            api_json(
-                base_url,
-                f"/api/history/{run_id}",
-                method="DELETE",
-                expected_status=(200, 404),
-            )
-        for sensor_mac in seen_sensor_macs:
-            api_json(
-                base_url,
-                f"/api/settings/sensors/{sensor_mac}",
-                method="DELETE",
-                expected_status=(200, 404),
-            )
-        for client_id in seen_client_ids:
-            api_json(
-                base_url,
-                f"/api/clients/{client_id}",
-                method="DELETE",
-                expected_status=(200, 404),
-            )
+        _delete_resources(base_url, "/api/history/{identifier}", list(created_run_ids))
+        _delete_resources(base_url, "/api/settings/sensors/{identifier}", seen_sensor_macs)
+        _delete_resources(base_url, "/api/clients/{identifier}", seen_client_ids)
         api_json(
             base_url,
             "/api/settings/speed-source",


### PR DESCRIPTION
Chunk 067 covers five files in `apps/server/tests_e2e`: `test_e2e_docker_rear_left_wheel_fault.py`, `test_e2e_docker_recording_lifecycle.py`, `test_e2e_docker_run_quality.py`, `test_e2e_docker_runtime_settings.py`, and `test_e2e_docker_user_journeys.py`. I directly reviewed every code file in this chunk before deciding what to change.

The only code change is in `test_e2e_docker_user_journeys.py`. Its `finally` block repeated the same delete-loop shape three times for runs, sensor settings, and clients. This PR extracts a small local `_delete_resources(...)` helper and uses it for those three teardown passes. That keeps the large scenario test focused on the journey assertions instead of burying them under repetitive cleanup mechanics.

The other four E2E files were reviewed and left unchanged.

Validation performed locally:
- `make lint`
- As with chunk 066, attempted Docker-backed E2E validation is environment-blocked here because local Docker commands cannot connect to `/var/run/docker.sock`, so `python3 tools/tests/run_e2e_parallel.py --fast-e2e --shards 1` cannot complete in this environment.

Risk is low because the diff only simplifies repeated teardown code in test cleanup paths.
