### PR TITLE
Repo review chunk 068: hoist source i18n key map

### DIFF
--- a/apps/server/vibesensor/report_i18n.py
+++ b/apps/server/vibesensor/report_i18n.py
@@ -16,6 +16,16 @@ from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
 from vibesensor.shared.types.json_types import JsonValue
 
 _DATA_FILE = resolve_static_data_file("report_i18n.json")
+_SOURCE_I18N_KEYS: dict[VibrationSource, str] = {
+    VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
+    VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
+    VibrationSource.ENGINE: "SOURCE_ENGINE",
+    VibrationSource.BODY_RESONANCE: "SOURCE_BODY_RESONANCE",
+    VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
+    VibrationSource.BASELINE_NOISE: "SOURCE_BASELINE_NOISE",
+    VibrationSource.UNKNOWN_RESONANCE: "SOURCE_UNKNOWN_RESONANCE",
+    VibrationSource.UNKNOWN: "UNKNOWN",
+}
 
 
 @lru_cache(maxsize=1)
@@ -62,16 +72,6 @@ def is_i18n_ref(value: object) -> bool:
 def human_source(source: object, *, tr: Callable[[str], str]) -> str:
     """Resolve a source code to its user-facing label."""
     raw = str(source or "").strip().lower()
-    mapping: dict[VibrationSource, str] = {
-        VibrationSource.WHEEL_TIRE: tr("SOURCE_WHEEL_TIRE"),
-        VibrationSource.DRIVELINE: tr("SOURCE_DRIVELINE"),
-        VibrationSource.ENGINE: tr("SOURCE_ENGINE"),
-        VibrationSource.BODY_RESONANCE: tr("SOURCE_BODY_RESONANCE"),
-        VibrationSource.TRANSIENT_IMPACT: tr("SOURCE_TRANSIENT_IMPACT"),
-        VibrationSource.BASELINE_NOISE: tr("SOURCE_BASELINE_NOISE"),
-        VibrationSource.UNKNOWN_RESONANCE: tr("SOURCE_UNKNOWN_RESONANCE"),
-        VibrationSource.UNKNOWN: tr("UNKNOWN"),
-    }
     try:
         key = VibrationSource(raw)
     except ValueError:
@@ -80,7 +80,7 @@ def human_source(source: object, *, tr: Callable[[str], str]) -> str:
             raw,
         )
         return raw.replace("_", " ").title() if raw else tr("UNKNOWN")
-    return mapping.get(key, tr("UNKNOWN"))
+    return tr(_SOURCE_I18N_KEYS.get(key, "UNKNOWN"))
 
 
 def resolve_i18n(


### PR DESCRIPTION
Chunk 068 covers five files in `apps/server/vibesensor`: `__init__.py`, `_version.py`, `report_i18n.py`, `strength_bands.py`, and `vibration_strength.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `report_i18n.py`. `human_source()` was rebuilding the same `VibrationSource` → translation-key mapping every time it resolved a source label. This PR hoists that mapping to module scope as `_SOURCE_I18N_KEYS` and keeps `human_source()` focused on two steps: parse the incoming source value and translate the corresponding key. The fallback behavior for unknown values is unchanged.

The other four files were reviewed and left unchanged. `strength_bands.py` and `vibration_strength.py` are already concise and central to the repo’s shared vibration-math contract, so I avoided unnecessary churn there.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_i18n_separation.py apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/use_cases/diagnostics/test_vibration_math_coverage.py` (`86 passed`)
- `make lint`

Risk is low because the diff only hoists constant mapping data without changing translation behavior.
