### PR TITLE
Repo review chunk 070: remove obsolete transport markers

### DIFF
--- a/apps/server/vibesensor/adapters/gps/gps_transport.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport.py
@@ -176,45 +176,6 @@ class GPSTransportState:
             lifecycle_changes=lifecycle_changes or None,
         )
 
-    def _mark_connected(self) -> None:
-        self._replace_captured_state(
-            transport_changes={"connection_state": "connected"},
-            lifecycle_changes={
-                "last_error": None,
-                "current_reconnect_delay": _GPS_RECONNECT_DELAY_S,
-            },
-        )
-
-    def _mark_stream_disconnected(self) -> None:
-        self._replace_transport(
-            connection_state="disconnected",
-            speed_snapshot=(None, None),
-            last_fix_mode=None,
-            last_epx_m=None,
-            last_epy_m=None,
-            last_epv_m=None,
-            zero_speed_streak=0,
-            device_info=None,
-        )
-
-    def _mark_connection_error(self, exc: BaseException, reconnect_delay: float) -> None:
-        self._replace_captured_state(
-            transport_changes={
-                "connection_state": "disconnected",
-                "speed_snapshot": (None, None),
-                "last_fix_mode": None,
-                "last_epx_m": None,
-                "last_epy_m": None,
-                "last_epv_m": None,
-                "zero_speed_streak": 0,
-                "device_info": None,
-            },
-            lifecycle_changes={
-                "last_error": str(exc) or type(exc).__name__,
-                "current_reconnect_delay": reconnect_delay,
-            },
-        )
-
     def set_enabled(self, enabled: bool) -> None:
         snapshot = self._state.transport
         if not enabled:


### PR DESCRIPTION
Chunk 070 covers eight files in `apps/server/vibesensor/adapters/gps`: `__init__.py`, `gps_speed.py`, `gps_transport.py`, `gpsd_message_handler.py`, `speed_resolution.py`, `speed_status.py`, `speed_validation.py`, and `transport_lifecycle.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `gps_transport.py`. That module still contained three private `_mark_*` helpers for connected/disconnected/error transitions even though the transport loop now routes those lifecycle mutations through `TransportLifecycle` plus `_apply_transition_changes(...)`. The helpers were no longer referenced anywhere, so this PR removes them as dead code.

The other seven GPS adapter files were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/gps` (`191 passed`)
- `make lint`

Risk is low because the diff only removes unreferenced private helpers and leaves the active lifecycle path unchanged.
