### PR TITLE
Repo review chunk 071: clarify hotspot self-heal flow

### DIFF
--- a/apps/server/vibesensor/adapters/hotspot/self_heal.py
+++ b/apps/server/vibesensor/adapters/hotspot/self_heal.py
@@ -1,7 +1,7 @@
 """Wi-Fi hotspot self-heal manager.
 
-Monitors hotspot connectivity and automatically recovers from failures
-by restarting ``hostapd``/``dnsmasq`` when the hotspot becomes unreachable.
+Monitors hotspot connectivity and attempts recovery with NetworkManager-driven
+repairs plus related hotspot diagnostics when the AP becomes degraded.
 """
 
 from __future__ import annotations
@@ -121,7 +121,7 @@ def run_self_heal_once(
     state_store: HealStateStore,
     diagnostics_only: bool = False,
 ) -> int:
-    """Run one self-heal cycle; return an exit code (0 = ok, 1 = healed, 2 = failed)."""
+    """Run one self-heal cycle; return 0 when healthy/recovered, else 2."""
     if diagnostics_only:
         _emit_diagnostics(ap, self_heal.diagnostics_lookback_minutes, runner, LOGGER)
         return 0
@@ -136,11 +136,11 @@ def run_self_heal_once(
 
     actions = apply_heals(ap, self_heal, health, runner, state_store)
 
-    healed = collect_health(ap, self_heal, runner)
-    status = "healed" if healed.ok else "failed"
+    post_heal_health = collect_health(ap, self_heal, runner)
+    status = "healed" if post_heal_health.ok else "failed"
 
     for action in actions:
-        action.helped = healed.ok
+        action.helped = post_heal_health.ok
         LOGGER.warning(
             "hotspot heal attempt=%s detected=%s action=%s helped=%s",
             action.name,
@@ -149,8 +149,8 @@ def run_self_heal_once(
             "yes" if action.helped else "no",
         )
 
-    _log_summary(status, ap, healed)
-    if not healed.ok:
+    _log_summary(status, ap, post_heal_health)
+    if not post_heal_health.ok:
         _emit_diagnostics(ap, self_heal.diagnostics_lookback_minutes, runner, LOGGER)
         return 2
     return 0


### PR DESCRIPTION
Chunk 071 covers the five files in `apps/server/vibesensor/adapters/hotspot`: `__init__.py`, `health_probe.py`, `parsers.py`, `remediation.py`, and `self_heal.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `self_heal.py`, and it is intentionally behavior-preserving. The module docstring still described `hostapd`/`dnsmasq` restarts even though the implementation now performs NetworkManager-driven hotspot recovery plus diagnostics. The `run_self_heal_once()` docstring also claimed a `1 = healed` exit code, but the implementation actually returns `0` when the hotspot is already healthy or successfully recovered, and `2` when it remains degraded. I updated those docs to match the real behavior and renamed the local post-remediation health snapshot from `healed` to `post_heal_health` so the control flow reads more clearly.

The other four hotspot adapter files were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/hotspot` (`51 passed`)
- `make lint`

Risk is very low because the diff is limited to documentation clarity and a local variable rename.
