### PR TITLE
Repo review chunk 072: trim redundant HTTP error branches

### DIFF
--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -13,8 +13,6 @@ from vibesensor.domain import normalize_sensor_id
 from vibesensor.shared.exceptions import (
     AnalysisNotReadyError,
     ConfigurationError,
-    DataCorruptError,
-    ProcessingError,
     ProtocolError,
     RunNotFoundError,
     UpdateError,
@@ -69,10 +67,6 @@ def domain_errors_to_http(
     except UpdateError as exc:
         status_code = 409 if exc.status == "conflict" else 500
         raise HTTPException(status_code=status_code, detail=str(exc)) from exc
-    except DataCorruptError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-    except ProcessingError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
     except VibeSensorError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except ValueError as exc:


### PR DESCRIPTION
Chunk 072 covers ten files in `apps/server/vibesensor/adapters/http`: `__init__.py`, `_helpers.py`, `analysis_settings_request_codec.py`, `car_library.py`, `clients.py`, `debug.py`, `dependencies.py`, `health.py`, `history.py`, and `middleware.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `_helpers.py`. The `domain_errors_to_http()` context manager had explicit `DataCorruptError` and `ProcessingError` branches that both returned the same HTTP 500 response already provided by the later `VibeSensorError` fallback. Since both exceptions inherit from `VibeSensorError`, those branches were redundant dead code, so this PR removes the duplicate imports and handlers without changing the HTTP contract.

The other nine HTTP adapter files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http apps/server/tests/adapters/persistence/test_car_library_routes.py` (`145 passed`)
- `make lint`

Risk is low because the diff only removes unreachable duplicate exception mapping branches while preserving the existing status-code behavior through the shared fallback handler.
