### PR TITLE
Repo review chunk 073: inline single-use speed update helper

### DIFF
--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -241,15 +241,6 @@ def create_settings_routes(
 
     # -- speed source ----------------------------------------------------------
 
-    async def _apply_speed_source_update(req: SpeedSourceRequest) -> SpeedSourceResponse:
-        payload = _speed_source_update_payload(req)
-        with domain_errors_to_http(catch_value_error=400):
-            result = await asyncio.to_thread(
-                settings_store.update_speed_source,
-                payload,
-            )
-        return _speed_source_response(result)
-
     @router.get("/api/settings/speed-source", response_model=SpeedSourceResponse)
     async def get_speed_source() -> SpeedSourceResponse:
         """Return the persisted speed-source configuration used for order tracking."""
@@ -262,7 +253,13 @@ def create_settings_routes(
     )
     async def update_speed_source(req: SpeedSourceRequest) -> SpeedSourceResponse:
         """Update the preferred speed source, manual fallback speed, and staleness timeout."""
-        return await _apply_speed_source_update(req)
+        payload = _speed_source_update_payload(req)
+        with domain_errors_to_http(catch_value_error=400):
+            result = await asyncio.to_thread(
+                settings_store.update_speed_source,
+                payload,
+            )
+        return _speed_source_response(result)
 
     @router.get("/api/settings/speed-source/status", response_model=SpeedSourceStatusResponse)
     async def get_speed_source_status() -> SpeedSourceStatusResponse:


### PR DESCRIPTION
Chunk 073 covers four files in `apps/server/vibesensor/adapters/http`: `recording.py`, `settings.py`, `updates.py`, and `websocket.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `settings.py`. The speed-source `PUT /api/settings/speed-source` route delegated immediately to a nested `_apply_speed_source_update()` helper that was only called once and just wrapped a short `asyncio.to_thread(...)` call plus the shared HTTP error translation. This PR inlines that helper back into the route handler so the control flow stays in one place and the module carries one less local abstraction.

The other three files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/http/test_recording_endpoints.py apps/server/tests/adapters/http/test_recording_route_http.py apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/adapters/http/test_update_endpoints.py apps/server/tests/adapters/http/test_request_observability.py apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py` (`79 passed`)
- `make lint`

Risk is low because the diff only removes a single-use local helper while preserving the same payload construction and error handling path.
