### PR TITLE
Repo review chunk 075: remove dead PDF assignment

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -91,7 +91,6 @@ def build_pattern_evidence(
     # Domain-first: use aggregate effective top causes for matched systems
     aggregate = context.domain_aggregate
     assert aggregate is not None
-    domain_primary = None
     effective = aggregate.effective_top_causes()
     domain_primary = effective[0] if effective else aggregate.primary_finding
     systems_raw = [human_source(str(f.suspected_source), tr=tr) for f in effective[:3]]


### PR DESCRIPTION
Chunk 075 covers the first ten real top-level files in `apps/server/vibesensor/adapters/pdf`: `__init__.py`, `_candidate_resolver.py`, `_card_builder.py`, `diagram_layout.py`, `mapping.py`, `pattern_parts.py`, `pdf_diagram_render.py`, `pdf_drawing.py`, `pdf_engine.py`, and `pdf_page1.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `mapping.py`. Inside `build_pattern_evidence()`, the local `domain_primary` variable was initialized to `None` and then immediately overwritten on the next line with either the first effective top cause or `aggregate.primary_finding`. That initial assignment was dead code, so this PR removes it.

The other nine PDF adapter files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/use_cases/history/test_report_preparation_contract.py` (`130 passed`)
- `make lint`

Risk is very low because the diff removes an unused assignment only.
