### PR TITLE
Repo review chunk 076: inline report context helper

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -68,7 +68,25 @@ class ReportMappingContext:
         return False
 
 
-def _build_report_mapping_context(validated: ValidatedPreparedReportInput) -> ReportMappingContext:
+def observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
+    """Build the observed-signature block for the report template."""
+    return PatternEvidence(
+        primary_system=primary.primary_system,
+        strongest_location=primary.primary_location,
+        speed_band=primary.primary_speed,
+        strength_label=primary.strength_text,
+        strength_peak_db=primary.strength_db,
+        certainty_label=primary.certainty_label_text,
+        certainty_pct=primary.certainty_pct,
+        certainty_reason=primary.certainty_reason,
+    )
+
+
+def prepare_report_mapping_context(
+    prepared: PreparedReportInput | ValidatedPreparedReportInput,
+) -> ReportMappingContext:
+    """Build the adapter-owned report mapping context from the validated handoff."""
+    validated = validate_prepared_report_input(prepared)
     report_facts = validated.report_facts
     report_date = validated.renderer_payload.report_date or utc_now_iso()
     date_str = str(report_date)[:19].replace("T", " ") + " UTC"
@@ -89,25 +107,3 @@ def _build_report_mapping_context(validated: ValidatedPreparedReportInput) -> Re
         firmware_version=report_facts.firmware_version,
         domain_aggregate=validated.domain_test_run,
     )
-
-
-def observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
-    """Build the observed-signature block for the report template."""
-    return PatternEvidence(
-        primary_system=primary.primary_system,
-        strongest_location=primary.primary_location,
-        speed_band=primary.primary_speed,
-        strength_label=primary.strength_text,
-        strength_peak_db=primary.strength_db,
-        certainty_label=primary.certainty_label_text,
-        certainty_pct=primary.certainty_pct,
-        certainty_reason=primary.certainty_reason,
-    )
-
-
-def prepare_report_mapping_context(
-    prepared: PreparedReportInput | ValidatedPreparedReportInput,
-) -> ReportMappingContext:
-    """Build the adapter-owned report mapping context from the validated handoff."""
-    validated = validate_prepared_report_input(prepared)
-    return _build_report_mapping_context(validated)


### PR DESCRIPTION
Chunk 076 covers the next ten top-level files in `apps/server/vibesensor/adapters/pdf`: `pdf_page2.py`, `pdf_style.py`, `pdf_text.py`, `peak_table.py`, `presentation.py`, `report_context.py`, `report_data.py`, `report_sections.py`, `report_types.py`, and `template_builder.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `report_context.py`. The public `prepare_report_mapping_context()` function validated its input and then immediately delegated to a private `_build_report_mapping_context()` helper that was only called once. This PR inlines that one-off helper back into the public function so the validation and context construction stay together in a single, easy-to-follow flow.

The other nine files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_template_builder.py apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/use_cases/history/test_report_preparation_contract.py` (`103 passed`)
- `make lint`

Risk is low because the diff removes a single-use private helper while preserving the same validated inputs and returned context fields.
