### PR TITLE
Repo review chunk 077: simplify panel card count

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
@@ -34,7 +34,7 @@ def _draw_systems_panel(
     y_cursor: float,
 ) -> float:
     cards = data.system_cards[:2]
-    n_cards = len(cards) if cards else 0
+    n_cards = len(cards)
     layout = build_page1_layout(
         width=width,
         page_top=PAGE_H - MARGIN,


### PR DESCRIPTION
Chunk 077 covers the nine files in `apps/server/vibesensor/adapters/pdf/panels`: `__init__.py`, `_panel_diagram.py`, `_panel_evidence.py`, `_panel_header.py`, `_panel_observations.py`, `_panel_peaks.py`, `_panel_systems.py`, `_panel_title_bar.py`, and `_panel_trust_steps.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `_panel_systems.py`. The panel renderer sliced the system cards list and then computed `n_cards = len(cards) if cards else 0`, but `len(cards)` already returns `0` for the empty case. This PR removes that redundant conditional and keeps the card-count logic direct.

The other eight panel-renderer files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_rendering_regressions.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py` (`57 passed`)
- `make lint`

Risk is very low because the diff only removes a redundant empty-list conditional around `len(cards)`.
