### PR TITLE
Repo review chunk 078: inline TypedDict config loop

### DIFF
--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from pydantic import ConfigDict, TypeAdapter, ValidationError
 
@@ -69,17 +69,13 @@ class CarLibraryEntry(TypedDict):
     variants: list[CarLibraryVariant]
 
 
-def _configure_pydantic_schema(typed_dict: Any) -> None:
-    typed_dict.__pydantic_config__ = _STRICT_TYPEDDICT_CONFIG
-
-
 for _typed_dict in (
     CarLibraryGearbox,
     CarLibraryTireOption,
     CarLibraryVariant,
     CarLibraryEntry,
 ):
-    _configure_pydantic_schema(_typed_dict)
+    cast(Any, _typed_dict).__pydantic_config__ = _STRICT_TYPEDDICT_CONFIG
 
 _CAR_LIBRARY_ADAPTER = TypeAdapter(list[CarLibraryEntry])
 


### PR DESCRIPTION
Chunk 078 covers `apps/server/vibesensor/adapters/persistence/__init__.py` and `apps/server/vibesensor/adapters/persistence/car_library.py`. I directly reviewed both code files in this chunk before making changes.

The only code change is in `car_library.py`. The module defines four TypedDict contracts and then applies the same strict Pydantic config to each of them. That work previously went through a single-use `_configure_pydantic_schema()` helper whose only job was to assign `__pydantic_config__`. This PR removes the one-off wrapper and performs that assignment inline in the existing loop with the same strict config value.

`__init__.py` was reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_variants.py apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py apps/server/tests/adapters/persistence/test_car_library_routes.py apps/server/tests/hygiene/test_car_library_artifact_sync.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py apps/server/tests/integration/test_review_guardrails_core_regressions.py apps/server/tests/integration/test_review_guardrails_extended_regressions.py` (`147 passed`)
- `make typecheck-backend`
- `make lint`

Risk is low because the diff preserves the same config assignment and validated load/query behavior.
