### PR TITLE
Repo review chunk 079: share startup quick check logic

### DIFF
--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -14,7 +14,10 @@ from typing import Any
 from vibesensor.adapters.persistence.history_db._client_names_repository import (
     ClientNameRepository,
 )
-from vibesensor.adapters.persistence.history_db._engine import SQLiteHistoryEngine
+from vibesensor.adapters.persistence.history_db._engine import (
+    SQLiteHistoryEngine,
+    run_startup_quick_check,
+)
 from vibesensor.adapters.persistence.history_db._run_repository import RunHistoryRepository
 from vibesensor.adapters.persistence.history_db._settings_repository import (
     SettingsSnapshotRepository,
@@ -203,22 +206,8 @@ class HistoryDB:
         self._engine._migrate_v10_to_v11_persisted_analysis_version()
 
     def _run_startup_quick_check(self) -> None:
-        try:
-            with self._cursor(commit=False) as cur:
-                cur.execute("PRAGMA quick_check")
-                problems = [str(row[0]) for row in cur.fetchall() if str(row[0]) != "ok"]
-        except sqlite3.Error:
-            LOGGER.critical(
-                "History DB quick_check failed during startup for %s",
-                self.db_path,
-                exc_info=True,
-            )
-            raise
-        if problems:
-            details = "; ".join(problems)
-            self._mark_corrupted(details)
-            LOGGER.critical(
-                "History DB quick_check reported corruption for %s: %s",
-                self.db_path,
-                details,
-            )
+        run_startup_quick_check(
+            cursor_provider=self._cursor,
+            db_path=self.db_path,
+            mark_corrupted=self._mark_corrupted,
+        )

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -8,7 +8,7 @@ import shutil
 import sqlite3
 import tempfile
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from threading import RLock
 
@@ -27,6 +27,33 @@ _SETTINGS_SNAPSHOT_MIGRATION_SOURCE_VERSION = 9
 _PERSISTED_ANALYSIS_SCHEMA_MIGRATION_SOURCE_VERSION = 10
 
 __all__ = ["SQLiteHistoryEngine"]
+
+
+def run_startup_quick_check(
+    *,
+    cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+    db_path: Path,
+    mark_corrupted: Callable[[str], None],
+) -> None:
+    try:
+        with cursor_provider(commit=False) as cur:
+            cur.execute("PRAGMA quick_check")
+            problems = [str(row[0]) for row in cur.fetchall() if str(row[0]) != "ok"]
+    except sqlite3.Error:
+        LOGGER.critical(
+            "History DB quick_check failed during startup for %s",
+            db_path,
+            exc_info=True,
+        )
+        raise
+    if problems:
+        details = "; ".join(problems)
+        mark_corrupted(details)
+        LOGGER.critical(
+            "History DB quick_check reported corruption for %s: %s",
+            db_path,
+            details,
+        )
 
 
 class SQLiteHistoryEngine:
@@ -375,22 +402,8 @@ class SQLiteHistoryEngine:
             cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
     def _run_startup_quick_check(self) -> None:
-        try:
-            with self._cursor(commit=False) as cur:
-                cur.execute("PRAGMA quick_check")
-                problems = [str(row[0]) for row in cur.fetchall() if str(row[0]) != "ok"]
-        except sqlite3.Error:
-            LOGGER.critical(
-                "History DB quick_check failed during startup for %s",
-                self.db_path,
-                exc_info=True,
-            )
-            raise
-        if problems:
-            details = "; ".join(problems)
-            self._mark_corrupted(details)
-            LOGGER.critical(
-                "History DB quick_check reported corruption for %s: %s",
-                self.db_path,
-                details,
-            )
+        run_startup_quick_check(
+            cursor_provider=self._cursor,
+            db_path=self.db_path,
+            mark_corrupted=self._mark_corrupted,
+        )


### PR DESCRIPTION
Chunk 079 covers the ten files in `apps/server/vibesensor/adapters/persistence/history_db`: `__init__.py`, `_client_names_repository.py`, `_engine.py`, `_queries.py`, `_run_lifecycle.py`, `_run_repository.py`, `_sample_io.py`, `_samples.py`, `_schema.py`, and `_settings_repository.py`. I directly reviewed every code file in this chunk before making changes.

The change is a small duplication cleanup across the compatibility facade and the shared engine. Both `HistoryDB._run_startup_quick_check()` and `SQLiteHistoryEngine._run_startup_quick_check()` contained the same quick-check implementation. This PR extracts that logic into one shared helper in `_engine.py`, then has both call sites use it. The `HistoryDB` facade still routes the helper through its own `_cursor` and `_mark_corrupted` methods, which preserves the compatibility seam used by focused tests and any remaining legacy call sites.

The other eight `history_db` files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/persistence/history_db apps/server/tests/hygiene/test_history_db_mixins.py apps/server/tests/hygiene/test_sample_column_alignment.py apps/server/tests/use_cases/history apps/server/tests/integration/test_review_guardrails_core_regressions.py apps/server/tests/integration/test_review_guardrails_extended_regressions.py` (`182 passed`)
- `make lint`

Risk is low because the diff centralizes identical logic while preserving both public behavior and the existing test seam.
