### PR TITLE
Repo review chunk 080: share wheel-slot helpers

### DIFF
--- a/apps/server/vibesensor/adapters/simulator/commands.py
+++ b/apps/server/vibesensor/adapters/simulator/commands.py
@@ -5,12 +5,7 @@ import shlex
 from collections.abc import Sequence
 from typing import Protocol
 
-_WHEEL_ALIASES: dict[str, str] = {
-    "fl": "front-left",
-    "fr": "front-right",
-    "rl": "rear-left",
-    "rr": "rear-right",
-}
+from vibesensor.adapters.simulator.sim_scene import _cross_corner_coupling, _normalize_wheel_slot
 
 _DEFAULT_PROFILE_ORDER: tuple[str, ...] = (
     "engine_idle",
@@ -38,40 +33,6 @@ class SimClientLike(Protocol):
     def pulse(self, strength: float) -> None: ...
 
     def summary(self) -> str: ...
-
-
-def _normalize_wheel_slot(name: str) -> str | None:
-    normalized = name.strip().lower().replace("_", "-").replace(" ", "-")
-    if normalized in _WHEEL_ALIASES:
-        return _WHEEL_ALIASES[normalized]
-    axle = "front" if "front" in normalized else "rear" if "rear" in normalized else None
-    side = "left" if "left" in normalized else "right" if "right" in normalized else None
-    if axle and side:
-        return f"{axle}-{side}"
-    return None
-
-
-def _cross_corner_coupling(fault_wheel: str, sensor_name: str) -> float:
-    """Return deterministic single-wheel coupling for non-fault corners.
-
-    Values are chosen to keep transfer-path realism:
-    - same-side front↔rear coupling strongest,
-    - same-axle opposite side moderate,
-    - diagonal weakest but still clearly above floor.
-    """
-    fault = _normalize_wheel_slot(fault_wheel)
-    sensor = _normalize_wheel_slot(sensor_name)
-    if fault is None or sensor is None:
-        return 0.34
-    if fault == sensor:
-        return 1.0
-    fault_axle, fault_side = fault.split("-", maxsplit=1)
-    sensor_axle, sensor_side = sensor.split("-", maxsplit=1)
-    if fault_side == sensor_side and fault_axle != sensor_axle:
-        return 0.52
-    if fault_axle == sensor_axle and fault_side != sensor_side:
-        return 0.48
-    return 0.40
 
 
 def choose_default_profile(index: int) -> str:

--- a/apps/server/vibesensor/adapters/simulator/sim_scene.py
+++ b/apps/server/vibesensor/adapters/simulator/sim_scene.py
@@ -16,37 +16,37 @@ _WHEEL_SLOT_ALIASES: dict[str, str] = {
 }
 
 
+def _normalize_wheel_slot(name: str) -> str | None:
+    normalized = name.strip().lower().replace("_", "-").replace(" ", "-")
+    if normalized in _WHEEL_SLOT_ALIASES:
+        return _WHEEL_SLOT_ALIASES[normalized]
+    axle = "front" if "front" in normalized else "rear" if "rear" in normalized else None
+    side = "left" if "left" in normalized else "right" if "right" in normalized else None
+    if axle and side:
+        return f"{axle}-{side}"
+    return None
+
+
+def _cross_corner_coupling(source_name: str, sink_name: str) -> float:
+    source = _normalize_wheel_slot(source_name)
+    sink = _normalize_wheel_slot(sink_name)
+    if source is None or sink is None:
+        return 0.34
+    if source == sink:
+        return 1.0
+    source_axle, source_side = source.split("-", maxsplit=1)
+    sink_axle, sink_side = sink.split("-", maxsplit=1)
+    if source_side == sink_side and source_axle != sink_axle:
+        return 0.52
+    if source_axle == sink_axle and source_side != sink_side:
+        return 0.48
+    return 0.40
+
+
 class RoadSceneController:
     def __init__(self, clients: list[SimClient]):
         self.clients = clients
         self.rng = random.Random(2026)
-
-    @staticmethod
-    def _normalize_wheel_slot(name: str) -> str | None:
-        normalized = name.strip().lower().replace("_", "-").replace(" ", "-")
-        if normalized in _WHEEL_SLOT_ALIASES:
-            return _WHEEL_SLOT_ALIASES[normalized]
-        axle = "front" if "front" in normalized else "rear" if "rear" in normalized else None
-        side = "left" if "left" in normalized else "right" if "right" in normalized else None
-        if axle and side:
-            return f"{axle}-{side}"
-        return None
-
-    @classmethod
-    def _cross_corner_coupling(cls, source_name: str, sink_name: str) -> float:
-        source = cls._normalize_wheel_slot(source_name)
-        sink = cls._normalize_wheel_slot(sink_name)
-        if source is None or sink is None:
-            return 0.34
-        if source == sink:
-            return 1.0
-        source_axle, source_side = source.split("-", maxsplit=1)
-        sink_axle, sink_side = sink.split("-", maxsplit=1)
-        if source_side == sink_side and source_axle != sink_axle:
-            return 0.52
-        if source_axle == sink_axle and source_side != sink_side:
-            return 0.48
-        return 0.40
 
     @staticmethod
     def _baseline_profile(name: str) -> str:
@@ -70,7 +70,7 @@ class RoadSceneController:
         active_name = self.clients[active_idx].name
         for i, client in enumerate(self.clients):
             client.scene_mode = "single"
-            coupling = self._cross_corner_coupling(active_name, client.name)
+            coupling = _cross_corner_coupling(active_name, client.name)
             if i == active_idx:
                 client.profile_name = "wheel_mild_imbalance"
                 client.scene_gain = self.rng.uniform(0.78, 1.05)
@@ -121,7 +121,7 @@ class RoadSceneController:
             client.scene_mode = "highway100-sync"
             client.profile_name = (
                 "wheel_mild_imbalance"
-                if self._normalize_wheel_slot(client.name) is not None
+                if _normalize_wheel_slot(client.name) is not None
                 else "rear_body"
             )
             client.scene_gain = self.rng.uniform(0.54, 0.78)


### PR DESCRIPTION
Chunk 080 covers the nine files in `apps/server/vibesensor/adapters/simulator`: `__init__.py`, `commands.py`, `profiles.py`, `server_http.py`, `sim_client.py`, `sim_runtime.py`, `sim_scene.py`, `sim_sender.py`, and `ws_smoke.py`. I directly reviewed every code file in this chunk before making changes.

The change removes duplicated wheel-slot helper logic. Both `commands.py` and `sim_scene.py` had their own copies of wheel-slot normalization and cross-corner coupling calculations for mild single-wheel scenarios. This PR keeps one shared implementation in `sim_scene.py` and has `commands.py` reuse it, so the simulator’s scenario helpers and scene controller stay aligned without maintaining duplicate logic.

The other seven simulator files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/simulator/test_sim_scene.py apps/server/tests/integration/test_scenario_ground_truth_invariants.py` (`16 passed`)
- `make lint`

Risk is low because the diff only centralizes identical helper behavior already exercised by the simulator scenario tests.
