### PR TITLE
Repo review chunk 082: drop dead websocket flag write

### DIFF
--- a/apps/server/vibesensor/adapters/websocket/connection_tracker.py
+++ b/apps/server/vibesensor/adapters/websocket/connection_tracker.py
@@ -59,9 +59,7 @@ class ConnectionTracker:
     async def remove(self, websocket: WebSocket) -> None:
         """Deregister *websocket* from the tracker."""
         async with self._lock:
-            conn = self._connections.pop(id(websocket), None)
-            if conn is not None:
-                conn.closing = True
+            self._connections.pop(id(websocket), None)
 
     async def update_selected_client(self, websocket: WebSocket, client_id: str | None) -> None:
         """Update the client-filter for an existing connection."""


### PR DESCRIPTION
Chunk 082 covers the six files in `apps/server/vibesensor/adapters/websocket`: `__init__.py`, `broadcast_runner.py`, `connection_tracker.py`, `hub.py`, `payload_orchestrator.py`, and `tick_controller.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `connection_tracker.py`. The `remove()` method popped the connection from the internal registry and then immediately set `conn.closing = True` on the detached object. Because that connection record had already been removed from the tracker, the post-pop mutation no longer influenced tracker behavior or future snapshots. This PR removes that dead state write and leaves the actual deregistration semantics unchanged.

The other five WebSocket adapter files in the chunk were reviewed and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/websocket/test_connection_tracker.py apps/server/tests/adapters/websocket/test_ws_hub.py apps/server/tests/adapters/websocket/test_payload_orchestrator.py apps/server/tests/adapters/websocket/test_tick_controller.py` (`60 passed`)
- `make lint`

Risk is low because the diff removes an unobservable mutation after the connection has already been removed from the tracker.
