### PR TITLE
Repo review chunk 083: refresh app module docs

### DIFF
--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -1,8 +1,8 @@
 """FastAPI application factory and CLI entry point.
 
-Service construction lives in ``runtime/builders.py``.  Runtime coordination
-lives in the ``runtime/`` package.  This module creates the FastAPI app,
-wires the lifespan, and serves static assets.
+Service construction lives in ``container.py`` and runtime state lives in
+``runtime_state.py``. This module creates the FastAPI app, wires the lifespan,
+and serves static assets.
 """
 
 from __future__ import annotations

--- a/apps/server/vibesensor/app/config_loader.py
+++ b/apps/server/vibesensor/app/config_loader.py
@@ -82,7 +82,7 @@ def _read_config_file(path: Path) -> JsonObject:
 def load_config(config_path: Path | None = None) -> AppConfig:
     """Load, validate, and return the application configuration.
 
-     Reads *config_path* (or the default ``config.yaml`` next to this module),
+    Reads *config_path* (or the default ``config.yaml`` next to this module),
     applies precedence ``DEFAULT_CONFIG -> YAML override file -> typed
     validation/clamping``, and returns a fully validated ``AppConfig``.
     """


### PR DESCRIPTION
Chunk 083 covers the nine files in `apps/server/vibesensor/app`: `__init__.py`, `bootstrap.py`, `config_defaults.py`, `config_loader.py`, `config_paths.py`, `config_schema.py`, `container.py`, `runtime_state.py`, and `settings.py`. I directly reviewed every code file in this chunk before making changes.

The reviewed code in this slice was already structurally sound, so the only edits are behavior-preserving maintenance cleanups in the touched app entrypoint/config modules:

- `bootstrap.py`: refresh the module docstring so it points at the current composition modules (`container.py` and `runtime_state.py`) instead of the old `runtime/builders.py` path.
- `config_loader.py`: fix the `load_config()` docstring indentation so the rendered documentation matches the real loading flow.

The other seven app files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/app/test_import_purity.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_app_lifecycle.py apps/server/tests/app/test_config.py apps/server/tests/app/test_config_extended.py apps/server/tests/app/test_config_validation.py apps/server/tests/app/test_container.py` (`103 passed`)
- `make lint`

Risk is effectively nil because the diff only updates stale/internal documentation in reviewed files and does not alter runtime logic.
