### PR TITLE
Repo review chunk 084: make WS schema IO explicit

### DIFF
--- a/apps/server/vibesensor/cli/ws_schema_export.py
+++ b/apps/server/vibesensor/cli/ws_schema_export.py
@@ -33,7 +33,7 @@ def export_schema(out_path: Path | None = None) -> str:
     text = json.dumps(schema, indent=2, sort_keys=True) + "\n"
     if out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(text)
+        out_path.write_text(text, encoding="utf-8")
     return text
 
 
@@ -49,7 +49,7 @@ def main() -> None:
         if not args.out.exists():
             print(f"FAIL: {args.out} does not exist. Run without --check first.", file=sys.stderr)
             raise SystemExit(1)
-        committed = args.out.read_text()
+        committed = args.out.read_text(encoding="utf-8")
         if committed != generated:
             print(
                 f"FAIL: {args.out} is out of date.\n"


### PR DESCRIPTION
Chunk 084 covers the nine files in `apps/server/vibesensor/cli`: `__init__.py`, `contract_reference_doc.py`, `hotspot_config.py`, `hotspot_self_heal.py`, `http_api_schema_export.py`, `preflight.py`, `report.py`, `server.py`, and `ws_schema_export.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `ws_schema_export.py`. The matching HTTP schema exporter already performs file reads/writes with explicit UTF-8 encoding, while the WebSocket schema exporter relied on platform-default text encoding for both writing the generated contract file and reading the committed file in `--check` mode. This PR makes those file operations explicitly UTF-8 as well, which keeps the two contract export CLIs aligned and avoids depending on ambient locale defaults.

The other eight CLI files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/websocket/test_ws_schema_export.py apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/app/test_preflight_cli.py apps/server/tests/adapters/hotspot/test_hotspot_self_heal_cli.py apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py` (`24 passed`)
- `make lint`

Risk is low because the diff only makes existing text I/O explicit; generated schema content and CLI flow stay the same.
