### PR TITLE
Repo review chunk 086: reuse car tire helper

### DIFF
--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -201,25 +201,19 @@ class Car:
 
     @property
     def tire_width_mm(self) -> float | None:
-        spec = self.order_reference_spec
-        if spec is not None:
-            return spec.tire_spec.width_mm
-        return None
+        spec = self.tire_spec
+        return spec.width_mm if spec is not None else None
 
     @property
     def tire_aspect_pct(self) -> float | None:
-        spec = self.order_reference_spec
-        if spec is not None:
-            return spec.tire_spec.aspect_pct
-        return None
+        spec = self.tire_spec
+        return spec.aspect_pct if spec is not None else None
 
     @property
     def rim_in(self) -> float | None:
         """Rim diameter in inches (aspects key ``rim_in``)."""
-        spec = self.order_reference_spec
-        if spec is not None:
-            return spec.tire_spec.rim_in
-        return None
+        spec = self.tire_spec
+        return spec.rim_in if spec is not None else None
 
     @property
     def tire_circumference_m(self) -> float | None:


### PR DESCRIPTION
Chunk 086 covers the first ten files in `apps/server/vibesensor/domain`: `__init__.py`, `_numeric.py`, `_snapshot_parse.py`, `analysis_settings.py`, `car.py`, `confidence_assessment.py`, `diagnostic_case.py`, `driving_phase_summary.py`, `driving_segment.py`, and `finding.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `car.py`. The `Car.tire_width_mm`, `Car.tire_aspect_pct`, and `Car.rim_in` properties were each re-walking `order_reference_spec` and reaching through to the embedded tire object even though `Car` already exposes a dedicated `tire_spec` helper for that purpose. This PR makes those three accessors reuse `self.tire_spec` instead, which trims duplication and keeps tire-geometry reads routed through the existing single helper.

The other nine domain files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/domain/test_snapshots.py apps/server/tests/domain/test_confidence_and_planning_value_objects.py apps/server/tests/domain/test_car_domain.py apps/server/tests/domain/test_core.py apps/server/tests/domain/test_domain_objects.py apps/server/tests/domain/test_planning_domain_only.py` (`177 passed`)
- `make lint`

Risk is low because the diff only reuses an existing property and does not change the returned tire geometry values.
