### PR TITLE
Repo review chunk 087: use run capture factories

### DIFF
--- a/apps/server/vibesensor/domain/run_capture.py
+++ b/apps/server/vibesensor/domain/run_capture.py
@@ -148,8 +148,8 @@ class RunSetup:
     """
 
     sensors: tuple[Sensor, ...] = ()
-    speed_source: SpeedSource = SpeedSource()
-    configuration_snapshot: ConfigurationSnapshot = ConfigurationSnapshot()
+    speed_source: SpeedSource = field(default_factory=SpeedSource)
+    configuration_snapshot: ConfigurationSnapshot = field(default_factory=ConfigurationSnapshot)
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +173,7 @@ class RunCapture:
     """
 
     run_id: str
-    setup: RunSetup = RunSetup()
+    setup: RunSetup = field(default_factory=RunSetup)
     analysis_settings: tuple[tuple[str, int | float | bool | str], ...] = ()
     measurements: tuple[Measurement, ...] = ()
     sample_count: int = 0


### PR DESCRIPTION
Chunk 087 covers the next ten files in `apps/server/vibesensor/domain`: `finding_evidence.py`, `finding_types.py`, `location_hotspot.py`, `order_match.py`, `order_reference.py`, `run.py`, `run_capture.py`, `run_context.py`, `run_metadata.py`, and `run_status.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `run_capture.py`. `RunSetup` and `RunCapture` were using already-instantiated dataclass values as field defaults (`SpeedSource()`, `ConfigurationSnapshot()`, and `RunSetup()`). Those defaults are currently immutable, so behavior was already stable, but switching them to `field(default_factory=...)` removes the shared-default-object smell and matches the surrounding domain snapshot/value-object style more clearly.

The other nine domain files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/domain/test_run_capture.py apps/server/tests/domain/test_run_setup.py apps/server/tests/domain/test_snapshots.py apps/server/tests/domain/test_test_run_value_objects.py apps/server/tests/domain/test_finding_origin_value_objects.py apps/server/tests/domain/test_core.py` (`166 passed`)
- `make lint`

Risk is low because the diff preserves the same default values and only changes how those immutable defaults are constructed.
