### PR TITLE
Repo review chunk 088: use test run plan factory

### DIFF
--- a/apps/server/vibesensor/domain/test_run.py
+++ b/apps/server/vibesensor/domain/test_run.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from vibesensor.domain.driving_segment import DrivingSegment
 from vibesensor.domain.finding import Finding, VibrationSource
@@ -24,7 +24,7 @@ class TestRun:
     top_causes: tuple[Finding, ...] = ()
     speed_profile: SpeedProfile | None = None
     suitability: RunSuitability | None = None
-    test_plan: TestPlan = TestPlan()
+    test_plan: TestPlan = field(default_factory=TestPlan)
 
     def __post_init__(self) -> None:
         if not self.top_causes:


### PR DESCRIPTION
Chunk 088 covers the remaining ten files in `apps/server/vibesensor/domain`: `run_suitability.py`, `sensor.py`, `speed_profile.py`, `speed_profile_summary.py`, `speed_source.py`, `strength_metrics.py`, `test_plan.py`, `test_run.py`, `tire_spec.py`, and `vibration_origin.py`. I directly reviewed every code file in this chunk before making changes.

The only code change is in `test_run.py`. `TestRun` used an already-instantiated `TestPlan()` object as its field default. That default is immutable today, so runtime behavior was already stable, but switching it to `field(default_factory=TestPlan)` removes the shared-default-object smell and keeps the aggregate consistent with the adjacent domain-value-object cleanup work.

The other nine domain files in this chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/domain/test_speed_profile_and_run_suitability.py apps/server/tests/domain/test_strength_metrics.py apps/server/tests/domain/test_planning_domain_only.py apps/server/tests/domain/test_configuration_and_sensor_value_objects.py apps/server/tests/domain/test_test_run_value_objects.py apps/server/tests/domain/test_confidence_and_planning_value_objects.py apps/server/tests/domain/test_core.py` (`172 passed`)
- `make lint`

Risk is low because the diff preserves the exact same default value semantics and only changes how the immutable default is constructed.
