### PR TITLE
Repo review chunk 089: document location validator

### DIFF
--- a/apps/server/vibesensor/infra/__init__.py
+++ b/apps/server/vibesensor/infra/__init__.py
@@ -1,1 +1,1 @@
-"""Operational infrastructure packages."""
+"""Operational infrastructure helpers shared by runtime and settings code."""

--- a/apps/server/vibesensor/infra/location_assignment_validator.py
+++ b/apps/server/vibesensor/infra/location_assignment_validator.py
@@ -10,6 +10,8 @@ __all__ = ["AssignedLocation", "LocationAssignmentValidator"]
 
 @dataclass(frozen=True, slots=True)
 class AssignedLocation:
+    """A currently claimed location code owned by a specific runtime/config record."""
+
     owner_id: str
     owner_name: str
     location_code: str
@@ -24,6 +26,8 @@ class LocationAssignmentValidator:
         self._max_utf8_bytes = max_utf8_bytes
 
     def normalize(self, location: str) -> str:
+        """Trim a location string and cap it to the stored UTF-8 byte budget."""
+
         clean = location.strip()
         encoded = clean.encode("utf-8", errors="ignore")
         if len(encoded) <= self._max_utf8_bytes:
@@ -37,6 +41,8 @@ class LocationAssignmentValidator:
         location_code: str,
         assigned_locations: Iterable[AssignedLocation],
     ) -> None:
+        """Raise when *location_code* is already assigned to a different owner."""
+
         if not location_code:
             return
         for assigned in assigned_locations:


### PR DESCRIPTION
Chunk 089 covers the two files in `apps/server/vibesensor/infra`: `__init__.py` and `location_assignment_validator.py`. I directly reviewed both code files before making changes.

This slice was already functionally sound, so the safe behavior-preserving improvement here is documentation. `LocationAssignmentValidator` is shared by both runtime registry code and persisted sensor-settings code, but the file only had a short class docstring. I expanded the module-level and symbol-level documentation so the ownership and behavior are clearer where the validator is defined instead of forcing callers to infer its trimming, byte-budget, and duplicate-assignment rules from implementation details alone.

Key files changed:
- `apps/server/vibesensor/infra/__init__.py`
- `apps/server/vibesensor/infra/location_assignment_validator.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/test_location_assignment_validator.py apps/server/tests/hygiene/test_location_codes_sync.py apps/server/tests/infra/runtime/test_client_metadata.py` (`9 passed`)
- `make lint`

Risk is very low because there is no behavior change. I reviewed the small infra chunk end-to-end and left the underlying validation logic untouched.
