### PR TITLE
Repo review chunk 090: share settings audit logging

### DIFF
--- a/apps/server/vibesensor/infra/config/car_settings.py
+++ b/apps/server/vibesensor/infra/config/car_settings.py
@@ -10,7 +10,7 @@ from typing import Protocol, TypeVar
 
 from vibesensor.domain import Car, CarSnapshot
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
-from vibesensor.shared.structured_logging import log_extra
+from vibesensor.infra.config.settings_transaction import log_settings_change
 from vibesensor.shared.types.car_config import (
     CarConfigUpdatePayload,
     CarsSnapshot,
@@ -57,25 +57,6 @@ def _car_payload(car: Car | None) -> dict[str, object] | None:
     if car is None:
         return None
     return dict(car_to_persistence_dict(car))
-
-
-def _log_car_settings_change(
-    *,
-    action: str,
-    before: object,
-    after: object,
-    **fields: object,
-) -> None:
-    LOGGER.info(
-        "settings_change",
-        extra=log_extra(
-            event="settings_change",
-            settings_action=action,
-            before=before,
-            after=after,
-            **fields,
-        ),
-    )
 
 
 class CarSettingsService:
@@ -148,7 +129,8 @@ class CarSettingsService:
             snapshot=lambda: self._state.active_car_id,
             apply=_apply,
             restore=lambda previous: setattr(self._state, "active_car_id", previous),
-            audit_log=lambda previous: _log_car_settings_change(
+            audit_log=lambda previous: log_settings_change(
+                LOGGER,
                 action="set_active_car",
                 before=previous,
                 after=self._state.active_car_id,
@@ -172,7 +154,8 @@ class CarSettingsService:
             snapshot=lambda: list(self._state.cars),
             apply=_apply,
             restore=lambda previous: setattr(self._state, "cars", previous),
-            audit_log=lambda _previous: _log_car_settings_change(
+            audit_log=lambda _previous: log_settings_change(
+                LOGGER,
                 action="add_car",
                 before=None,
                 after=_car_payload(self._find_car(created_car_id)),
@@ -224,7 +207,8 @@ class CarSettingsService:
             snapshot=lambda: list(self._state.cars),
             apply=_apply,
             restore=lambda previous: setattr(self._state, "cars", previous),
-            audit_log=lambda previous: _log_car_settings_change(
+            audit_log=lambda previous: log_settings_change(
+                LOGGER,
                 action="update_car",
                 before=_car_payload(next((car for car in previous if car.id == car_id), None)),
                 after=_car_payload(self._find_car(car_id)),
@@ -261,7 +245,8 @@ class CarSettingsService:
             snapshot=lambda: list(self._state.cars),
             apply=_apply,
             restore=lambda previous: setattr(self._state, "cars", previous),
-            audit_log=lambda previous: _log_car_settings_change(
+            audit_log=lambda previous: log_settings_change(
+                LOGGER,
                 action="update_active_car_aspects",
                 before=next(
                     (dict(car.aspects) for car in previous if car.id == self._state.active_car_id),
@@ -293,7 +278,8 @@ class CarSettingsService:
             snapshot=lambda: (list(self._state.cars), self._state.active_car_id),
             apply=_apply,
             restore=_restore,
-            audit_log=lambda previous: _log_car_settings_change(
+            audit_log=lambda previous: log_settings_change(
+                LOGGER,
                 action="delete_car",
                 before=_car_payload(next((car for car in previous[0] if car.id == car_id), None)),
                 after=None,

--- a/apps/server/vibesensor/infra/config/sensor_settings.py
+++ b/apps/server/vibesensor/infra/config/sensor_settings.py
@@ -8,11 +8,11 @@ from threading import RLock
 
 from vibesensor.domain import Sensor, SensorPlacement, normalize_sensor_id
 from vibesensor.infra.config.car_settings import _clamp_str, _UpdateWithRollback
+from vibesensor.infra.config.settings_transaction import log_settings_change
 from vibesensor.infra.location_assignment_validator import (
     AssignedLocation,
     LocationAssignmentValidator,
 )
-from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.types.sensor_config import (
     SensorConfig,
     SensorConfigUpdatePayload,
@@ -28,25 +28,6 @@ class SensorSettingsState:
     """Mutable sensor-settings state owned by ``SettingsStore``."""
 
     sensors: dict[str, SensorConfig] = field(default_factory=dict)
-
-
-def _log_sensor_settings_change(
-    *,
-    action: str,
-    before: object,
-    after: object,
-    **fields: object,
-) -> None:
-    LOGGER.info(
-        "settings_change",
-        extra=log_extra(
-            event="settings_change",
-            settings_action=action,
-            before=before,
-            after=after,
-            **fields,
-        ),
-    )
 
 
 class SensorSettingsService:
@@ -125,7 +106,8 @@ class SensorSettingsService:
             snapshot=self.sensor_configs_snapshot_unlocked,
             apply=_apply,
             restore=lambda previous: setattr(self._state, "sensors", previous),
-            audit_log=lambda previous: _log_sensor_settings_change(
+            audit_log=lambda previous: log_settings_change(
+                LOGGER,
                 action="set_sensor",
                 before=(
                     previous_sensor.to_dict()
@@ -151,7 +133,8 @@ class SensorSettingsService:
             snapshot=self.sensor_configs_snapshot_unlocked,
             apply=_apply,
             restore=lambda previous: setattr(self._state, "sensors", previous),
-            audit_log=lambda previous: _log_sensor_settings_change(
+            audit_log=lambda previous: log_settings_change(
+                LOGGER,
                 action="remove_sensor",
                 before=(
                     previous_sensor.to_dict()

--- a/apps/server/vibesensor/infra/config/settings_transaction.py
+++ b/apps/server/vibesensor/infra/config/settings_transaction.py
@@ -7,9 +7,33 @@ sequencing used by all settings update paths.
 from __future__ import annotations
 
 from collections.abc import Callable
+from logging import Logger
 from threading import RLock
 
 from vibesensor.shared.exceptions import PersistenceError
+from vibesensor.shared.structured_logging import log_extra
+
+
+def log_settings_change(
+    logger: Logger,
+    *,
+    action: str,
+    before: object,
+    after: object,
+    **fields: object,
+) -> None:
+    """Emit a structured settings-change audit record for the supplied logger."""
+
+    logger.info(
+        "settings_change",
+        extra=log_extra(
+            event="settings_change",
+            settings_action=action,
+            before=before,
+            after=after,
+            **fields,
+        ),
+    )
 
 
 def update_with_rollback[SnapshotT, ResultT](


### PR DESCRIPTION
Chunk 090 covers the seven files in `apps/server/vibesensor/infra/config`: `__init__.py`, `car_settings.py`, `sensor_settings.py`, `settings_derivation.py`, `settings_runtime.py`, `settings_store.py`, and `settings_transaction.py`. I directly reviewed every code file in this chunk before changing anything.

The useful behavior-preserving cleanup here was duplication reduction in the settings collaborators. `CarSettingsService` and `SensorSettingsService` each carried a local copy of the same structured `settings_change` audit logger shape. I moved that shared audit-record emission into `settings_transaction.py` and updated both collaborators to use the single helper. `SettingsStore` stayed on its current local helper because the repository’s static guard explicitly requires a narrow `update_with_rollback` import shape there.

Key files changed:
- `apps/server/vibesensor/infra/config/car_settings.py`
- `apps/server/vibesensor/infra/config/sensor_settings.py`
- `apps/server/vibesensor/infra/config/settings_transaction.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/config/test_settings_runtime.py apps/server/tests/infra/config/test_settings_audit_logging.py apps/server/tests/infra/config/test_settings_derivation.py apps/server/tests/infra/config/test_sensor_settings.py apps/server/tests/infra/config/test_settings_store.py apps/server/tests/infra/config/test_settings_transaction.py` (`64 passed`)
- `make lint`

Risk is low because the refactor preserves the existing log payload shape and only removes duplicate helper code inside the config layer.
