### PR TITLE
Repo review chunk 091: clean processing docs

### DIFF
--- a/apps/server/vibesensor/infra/processing/__init__.py
+++ b/apps/server/vibesensor/infra/processing/__init__.py
@@ -9,7 +9,8 @@ This package contains the core vibration signal processing pipeline:
 - :mod:`~vibesensor.infra.processing.compute` — FFT cache/window ownership plus metric
   computation from immutable snapshots.
 - :mod:`~vibesensor.infra.processing.snapshot_builder` — compute-snapshot caching and
-  window-size helpers. — pure FFT / spectral-analysis functions.
+  window-size helpers.
+- :mod:`~vibesensor.infra.processing.fft` — pure FFT / spectral-analysis functions.
 - :mod:`~vibesensor.infra.processing.payload` — payload builders for spectrum,
   debug-spectrum, intake-stats, and time-alignment views.
 - :mod:`~vibesensor.infra.processing.time_align` — multi-sensor time-alignment utilities.

--- a/apps/server/vibesensor/infra/processing/payload.py
+++ b/apps/server/vibesensor/infra/processing/payload.py
@@ -43,11 +43,6 @@ if TYPE_CHECKING:
 
 _EMPTY_F32: np.ndarray = np.array([], dtype=np.float32)
 
-EMPTY_SPECTRUM_PAYLOAD: SpectrumSeriesPayload = {
-    "combined_spectrum_amp_g": [],
-    "strength_metrics": empty_vibration_strength_metrics(),
-}
-
 
 def _empty_spectrum_payload() -> SpectrumSeriesPayload:
     return {


### PR DESCRIPTION
Chunk 091 covers the first ten files in `apps/server/vibesensor/infra/processing`: `__init__.py`, `buffer_capacity.py`, `buffer_store.py`, `buffers.py`, `compute.py`, `debug_queries.py`, `fft.py`, `models.py`, `payload.py`, and `processor.py`. I directly reviewed every code file in this chunk before making changes.

The code was already in strong shape, so the changes here stay intentionally small and behavior-preserving. I fixed the package docstring in `__init__.py`, which had accidentally mashed the `snapshot_builder` and `fft` bullets together, and I removed a dead `EMPTY_SPECTRUM_PAYLOAD` constant from `payload.py`. The live code already uses `_empty_spectrum_payload()` everywhere, so the constant was just unused maintenance noise.

Key files changed:
- `apps/server/vibesensor/infra/processing/__init__.py`
- `apps/server/vibesensor/infra/processing/payload.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/processing/test_buffer_capacity.py apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py apps/server/tests/infra/processing/test_buffers_repr_and_fastpath.py apps/server/tests/infra/processing/test_compute_filtering.py apps/server/tests/infra/processing/test_debug_queries.py apps/server/tests/infra/processing/test_payload_builders.py apps/server/tests/infra/processing/test_processing_buffers.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/infra/processing/test_processing.py` (`93 passed`)
- `make lint`

Risk is very low because the diff only removes dead code and repairs package documentation.
