### PR TITLE
Repo review chunk 092: simplify snapshot window

### DIFF
--- a/apps/server/vibesensor/infra/processing/ring_buffer_ingest.py
+++ b/apps/server/vibesensor/infra/processing/ring_buffer_ingest.py
@@ -38,6 +38,8 @@ def _advance_sensor_clock(
     *,
     t0_us: int | None,
 ) -> None:
+    """Advance the buffer's sensor-clock anchors after a successful ingest."""
+
     if t0_us is not None and t0_us > 0:
         next_t0_us = int(t0_us)
         if next_t0_us > buf.last_t0_us:

--- a/apps/server/vibesensor/infra/processing/snapshot_builder.py
+++ b/apps/server/vibesensor/infra/processing/snapshot_builder.py
@@ -47,7 +47,7 @@ def compute_snapshot_window(
 ) -> SnapshotWindow:
     """Compute the time-window size and FFT-block strategy for a compute snapshot."""
     desired_samples = int(max(1.0, float(sample_rate_hz) * float(waveform_seconds)))
-    n_time = min(count, capacity, max(1, desired_samples))
+    n_time = min(count, capacity, desired_samples)
     needs_separate_fft_block = count >= fft_n and n_time < fft_n
     return SnapshotWindow(
         n_time=n_time,


### PR DESCRIPTION
Chunk 092 covers the remaining three files in `apps/server/vibesensor/infra/processing`: `ring_buffer_ingest.py`, `snapshot_builder.py`, and `time_align.py`. I directly reviewed every code file in this chunk before making changes.

The best safe cleanup here was a small simplification in the snapshot helper plus a documentation clarification in the ingest helper. `compute_snapshot_window()` already guaranteed `desired_samples >= 1`, so the later `max(1, desired_samples)` was redundant. I removed that extra guard so the helper expresses the real invariant directly. In `ring_buffer_ingest.py`, I also documented `_advance_sensor_clock()` so the timestamp/samples-since-`t0_us` bookkeeping is easier to understand where it lives.

`time_align.py` was reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/processing/test_ring_buffer_ingest.py apps/server/tests/infra/processing/test_snapshot_builder.py apps/server/tests/infra/processing/test_processing_time_align.py apps/server/tests/infra/processing/test_time_align_edge_cases.py apps/server/tests/infra/processing/test_time_alignment.py` (`65 passed`)
- `make lint`

Risk is low because the code change only removes a provably redundant bound after the existing invariant has already been established, and the rest of the diff is documentation-only.
