### PR TITLE
Repo review chunk 093: clean runtime package docs

### DIFF
--- a/apps/server/vibesensor/infra/runtime/__init__.py
+++ b/apps/server/vibesensor/infra/runtime/__init__.py
@@ -2,9 +2,14 @@
 
 Submodules
 ----------
-- ``builders``: focused service builders
 - ``client_metadata``: persisted/user-assigned client metadata helpers
+- ``client_liveness_policy``: live/stale retention rules for tracked clients
+- ``client_snapshot_assembler``: locked client-snapshot assembly from registry state
+- ``client_snapshot_projection``: pure projection of registry records into API snapshots
 - ``background_task_coordinator``: lifecycle-owned task tracking + cancellation
+- ``dedup_window``: sliding DATA-sequence dedup tracking
+- ``health_snapshot``: runtime health snapshot assembly for HTTP/read-side consumers
+- ``health_state``: mutable startup and background-task health state
 - ``registry_updates``: DATA-message dedup/reset bookkeeping
 - ``processing_loop``: ProcessingLoop (async tick loop + failure tracking)
 - ``task_supervisor``: TaskSupervisor (managed restart policy + backoff)

--- a/apps/server/vibesensor/infra/runtime/background_task_coordinator.py
+++ b/apps/server/vibesensor/infra/runtime/background_task_coordinator.py
@@ -44,8 +44,7 @@ class BackgroundTaskCoordinator:
     ) -> asyncio.Task[object]:
         task = asyncio.create_task(coroutine, name=name)
         self._monitor_task(task)
-        self._tasks.append(task)
-        return task
+        return self.add(task)
 
     def retain_pending(self) -> list[asyncio.Task[object]]:
         self._tasks = [task for task in self._tasks if not task.done()]


### PR DESCRIPTION
Chunk 093 covers the first ten files in `apps/server/vibesensor/infra/runtime`: `__init__.py`, `background_task_coordinator.py`, `client_liveness_policy.py`, `client_metadata.py`, `client_snapshot.py`, `client_snapshot_assembler.py`, `client_snapshot_projection.py`, `dedup_window.py`, `health_snapshot.py`, and `health_state.py`. I directly reviewed every code file in this chunk before making changes.

This slice was already structurally sound, so the cleanup stays intentionally small and behavior-preserving. In `background_task_coordinator.py`, `start()` duplicated the task-append path that already exists in `add()`. I switched it to reuse `add()` so there is one append path to maintain. In `infra/runtime/__init__.py`, I also refreshed the package docstring: it still referenced a nonexistent `builders` module and did not list the newer liveness, snapshot, dedup, and health helpers that now make up this runtime slice.

Key files changed:
- `apps/server/vibesensor/infra/runtime/background_task_coordinator.py`
- `apps/server/vibesensor/infra/runtime/__init__.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/runtime/test_background_task_coordinator.py apps/server/tests/infra/runtime/test_client_liveness_policy.py apps/server/tests/infra/runtime/test_client_metadata.py apps/server/tests/infra/runtime/test_client_snapshot_assembler.py apps/server/tests/infra/runtime/test_client_snapshot_projection.py apps/server/tests/infra/runtime/test_dedup_window.py apps/server/tests/adapters/http/test_health_endpoint.py apps/server/tests/use_cases/test_system_health.py` (`51 passed`)
- `make lint`

Risk is low because the code change only removes internal duplication and the rest of the diff is documentation-only.
