### PR TITLE
Repo review chunk 096: tighten worker pool stats

### DIFF
--- a/apps/server/vibesensor/infra/workers/__init__.py
+++ b/apps/server/vibesensor/infra/workers/__init__.py
@@ -1,1 +1,1 @@
-"""Worker-pool infrastructure."""
+"""Bounded worker-pool helpers for CPU-heavy background tasks."""

--- a/apps/server/vibesensor/infra/workers/worker_pool.py
+++ b/apps/server/vibesensor/infra/workers/worker_pool.py
@@ -316,19 +316,17 @@ class WorkerPool:
         for a free outstanding-task slot.
         """
         with self._condition:
-            avg_run = (
-                round(self._total_run_s / self._total_tasks, 6) if self._total_tasks > 0 else 0.0
-            )
-            avg_submit_wait = (
-                round(self._total_submit_wait_s / self._total_tasks, 6)
-                if self._total_tasks > 0
-                else 0.0
-            )
+            total_tasks = self._total_tasks
+            avg_run = 0.0
+            avg_submit_wait = 0.0
+            if total_tasks > 0:
+                avg_run = round(self._total_run_s / total_tasks, 6)
+                avg_submit_wait = round(self._total_submit_wait_s / total_tasks, 6)
             return {
                 "max_workers": self._max_workers,
                 "max_queue_size": self._max_queue_size,
                 "max_pending_tasks": self._max_pending_tasks,
-                "total_tasks": self._total_tasks,
+                "total_tasks": total_tasks,
                 "pending_tasks": self._pending_tasks,
                 "queued_tasks": self._queued_tasks,
                 "running_tasks": self._running_tasks,


### PR DESCRIPTION
Chunk 096 covers two worker-infrastructure files: `apps/server/vibesensor/infra/workers/__init__.py` and `apps/server/vibesensor/infra/workers/worker_pool.py`. I reviewed both code files directly, then ran the focused worker and integration coverage that exercises submit timing, alive/shutdown enforcement, max-worker clamping, and bounded batching behavior.

The changes here are intentionally behavior-preserving and small. In `worker_pool.py`, `stats()` was checking `self._total_tasks` multiple times while computing averages. I normalized that into one local `total_tasks` snapshot and a single guarded branch for `avg_run_s` / `avg_submit_wait_s`, which keeps the same returned values while making the method easier to read. In `__init__.py`, I tightened the package docstring so it actually describes the bounded worker-pool helpers this package exposes.

Key files changed:
- `apps/server/vibesensor/infra/workers/__init__.py`
- `apps/server/vibesensor/infra/workers/worker_pool.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/infra/workers/test_worker_pool.py apps/server/tests/integration/test_review_guardrails_core_regressions.py::TestWorkerPoolSubmitTiming apps/server/tests/integration/test_review_guardrails_extended_regressions.py::TestWorkerPoolAliveProtection apps/server/tests/integration/test_coverage_gap_audit_round2.py::TestWorkerPoolExtended` (`26 passed`)
- `make lint`

Risk is low because the diff preserves worker-pool behavior and only clarifies metrics assembly and package documentation.
