### PR TITLE
Repo review chunk 097: clarify shared helpers

### DIFF
--- a/apps/server/vibesensor/shared/__init__.py
+++ b/apps/server/vibesensor/shared/__init__.py
@@ -1,4 +1,4 @@
-"""Cross-cutting shared server helpers."""
+"""Cross-cutting shared helpers and protocol-style ports used across the server."""
 
 from vibesensor.shared.ports import (
     ClientTracker,

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -51,6 +51,7 @@ def build_summary_warnings(
 def normalize_run_context_warnings(
     warnings: RunContextWarningsInput,
 ) -> list[RunContextWarning]:
+    """Return normalized warning models from stored domain objects or JSON-shaped payloads."""
     if warnings is None:
         return []
     normalized: list[RunContextWarning] = []

--- a/apps/server/vibesensor/shared/sampling.py
+++ b/apps/server/vibesensor/shared/sampling.py
@@ -32,7 +32,9 @@ def bounded_sample[SampleT](
     """
     if max_items <= 0:
         raise ValueError(f"bounded_sample: max_items must be >= 1, got {max_items}")
-    stride: int = max(1, -(-total_hint // max_items)) if total_hint > max_items else 1
+    stride = 1
+    if total_hint > max_items:
+        stride = max(1, -(-total_hint // max_items))
     kept: list[SampleT] = []
     total = 0
     for sample in samples:


### PR DESCRIPTION
Chunk 097 covers ten shared backend files: `__init__.py`, `_data_files.py`, `exceptions.py`, `json_utils.py`, `locations.py`, `order_bands.py`, `ports.py`, `run_context_warning.py`, `sampling.py`, and `sensor_metadata.py`. I reviewed every code file in this chunk directly before deciding what to change.

The final cleanup is intentionally small and behavior-preserving. In `shared/__init__.py`, I clarified the package overview so it reflects that this module primarily exposes cross-cutting helpers and protocol-style ports. In `sampling.py`, I expanded the initial stride selection in `bounded_sample()` into an explicit branch, which keeps the same ceiling-division behavior while making the down-sampling setup easier to read. In `run_context_warning.py`, I added a docstring to `normalize_run_context_warnings()` so the stored-model / JSON-payload normalization contract is spelled out where callers use it.

Key files changed:
- `apps/server/vibesensor/shared/__init__.py`
- `apps/server/vibesensor/shared/run_context_warning.py`
- `apps/server/vibesensor/shared/sampling.py`

The remaining seven files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/test_run_context_warning.py apps/server/tests/shared/boundaries/test_run_log.py apps/server/tests/integration/test_review_guardrails_core_regressions.py apps/server/tests/integration/test_runtime_quality_pass_regressions.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_audit.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py` (`115 passed`)
- `make lint`

Risk is low because the diff only improves readability and documentation around already-covered shared helper behavior.
