### PR TITLE
Repo review chunk 098: document shared helpers

### DIFF
--- a/apps/server/vibesensor/shared/statistics_utils.py
+++ b/apps/server/vibesensor/shared/statistics_utils.py
@@ -9,6 +9,7 @@ from vibesensor.vibration_strength import percentile
 
 
 def _percent_missing(samples: list[JsonObject], key: str) -> float:
+    """Return the percentage of samples whose *key* is missing or blank."""
     if not samples:
         return 100.0
     missing = sum(1 for sample in samples if sample.get(key) in (None, ""))
@@ -16,6 +17,7 @@ def _percent_missing(samples: list[JsonObject], key: str) -> float:
 
 
 def _mean_variance(values: list[float]) -> tuple[float | None, float | None]:
+    """Return the mean and sample variance for *values*."""
     if not values:
         return None, None
     count = len(values)
@@ -37,6 +39,7 @@ class _OutlierSummary(TypedDict):
 
 
 def _outlier_summary(values: list[float]) -> _OutlierSummary:
+    """Summarize Tukey-IQR outlier bounds and counts for *values*."""
     if not values:
         return {
             "count": 0,

--- a/apps/server/vibesensor/shared/structured_logging.py
+++ b/apps/server/vibesensor/shared/structured_logging.py
@@ -1,3 +1,5 @@
+"""Structured logging helpers for request-scoped JSON log output."""
+
 from __future__ import annotations
 
 import json
@@ -16,10 +18,12 @@ _STANDARD_LOG_RECORD_FIELDS = frozenset(logging.makeLogRecord({}).__dict__) | {"
 
 
 def current_request_id() -> str | None:
+    """Return the currently bound request identifier, if any."""
     return _REQUEST_ID.get()
 
 
 def normalize_request_id(raw_value: str | None) -> str:
+    """Sanitize a request-id header value or generate a new opaque fallback."""
     if raw_value is None:
         return uuid4().hex
     candidate = "".join(ch for ch in raw_value.strip() if ch in _ALLOWED_REQUEST_ID_CHARS)[:64]
@@ -27,15 +31,18 @@ def normalize_request_id(raw_value: str | None) -> str:
 
 
 def bind_request_id(raw_value: str | None) -> tuple[str, Token[str | None]]:
+    """Normalize and bind a request id to the current context."""
     request_id = normalize_request_id(raw_value)
     return request_id, _REQUEST_ID.set(request_id)
 
 
 def reset_request_id(token: Token[str | None]) -> None:
+    """Restore the previous request-id context using *token*."""
     _REQUEST_ID.reset(token)
 
 
 def log_extra(**fields: object) -> dict[str, object]:
+    """Build ``logging`` extra fields, automatically attaching the bound request id."""
     extra = dict(fields)
     request_id = current_request_id()
     if request_id is not None:
@@ -55,6 +62,7 @@ def _json_compatible(value: object) -> JsonValue:
 
 class StructuredLogFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
+        """Serialize *record* as a stable JSON object with extra fields preserved."""
         payload: dict[str, JsonValue] = {
             "timestamp": self.formatTime(record, self.datefmt),
             "level": record.levelname,


### PR DESCRIPTION
Chunk 098 covers five shared helper files: `sensor_units.py`, `statistics_utils.py`, `strength_fields.py`, `structured_logging.py`, and `time_utils.py`. I reviewed every code file in this chunk directly before deciding what to change.

The final diff stays intentionally non-functional. `structured_logging.py` exposes the request-id binding and JSON log formatting helpers that are used across the app, but the module and its public helper functions had no docstrings. I added concise docstrings so the request-scoped logging contract is visible at the call site. In `statistics_utils.py`, I added small helper docstrings for `_percent_missing()`, `_mean_variance()`, and `_outlier_summary()` so the reporting/statistics helpers are easier to understand without re-deriving the math from the implementation.

Key files changed:
- `apps/server/vibesensor/shared/structured_logging.py`
- `apps/server/vibesensor/shared/statistics_utils.py`

The remaining three files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/test_structured_logging.py apps/server/tests/adapters/pdf/test_report_analysis_helpers.py` (`72 passed`)
- `make lint`

Risk is low because the diff only adds documentation around already-covered helpers and does not alter any runtime logic or payload formatting.
