### PR TITLE
Repo review chunk 100: clarify report payload helpers

### DIFF
--- a/apps/server/vibesensor/shared/boundaries/report_payload_gate.py
+++ b/apps/server/vibesensor/shared/boundaries/report_payload_gate.py
@@ -8,4 +8,5 @@ __all__ = ["has_projectable_report_payload"]
 
 
 def has_projectable_report_payload(payload: Mapping[str, object]) -> bool:
+    """Return whether *payload* has the minimum shape needed for report projection."""
     return isinstance(payload.get("findings"), list) or isinstance(payload.get("top_causes"), list)

--- a/apps/server/vibesensor/shared/boundaries/report_payload_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/report_payload_projection.py
@@ -19,11 +19,13 @@ __all__ = [
 
 
 def summary_metadata(payload: Mapping[str, object]) -> Mapping[str, object]:
+    """Return the summary metadata mapping, or an empty mapping when absent."""
     metadata = payload.get("metadata")
     return metadata if isinstance(metadata, dict) else {}
 
 
 def active_sensor_locations(payload: Mapping[str, object]) -> tuple[str, ...]:
+    """Return active sensor locations, preferring the connected-throughout list."""
     connected = payload.get("sensor_locations_connected_throughout")
     locations = connected if isinstance(connected, list) else []
     active = tuple(str(loc).strip() for loc in locations if str(loc).strip())
@@ -35,6 +37,7 @@ def active_sensor_locations(payload: Mapping[str, object]) -> tuple[str, ...]:
 
 
 def report_duration_s(payload: Mapping[str, object]) -> float | None:
+    """Return a coerced report duration in seconds, or ``None`` for invalid input."""
     duration_s_raw = payload.get("duration_s")
     if duration_s_raw is None:
         return None
@@ -45,6 +48,7 @@ def report_duration_s(payload: Mapping[str, object]) -> float | None:
 
 
 def peak_table_rows(payload: Mapping[str, object]) -> tuple[PeakTableRow, ...]:
+    """Return normalized peak-table rows from the plots payload."""
     plots = payload.get("plots")
     if not isinstance(plots, Mapping):
         return ()
@@ -55,6 +59,7 @@ def peak_table_rows(payload: Mapping[str, object]) -> tuple[PeakTableRow, ...]:
 
 
 def sensor_intensity_payload(payload: Mapping[str, object]) -> tuple[object, ...]:
+    """Return the sensor-intensity payload as an immutable tuple copy."""
     raw_sensor_intensity = payload.get("sensor_intensity_by_location")
     if not isinstance(raw_sensor_intensity, list):
         return ()
@@ -62,6 +67,7 @@ def sensor_intensity_payload(payload: Mapping[str, object]) -> tuple[object, ...
 
 
 def coerce_count(value: object) -> int:
+    """Coerce count-like values to ``int``, defaulting invalid inputs to zero."""
     if value is None:
         return 0
     try:

--- a/apps/server/vibesensor/shared/boundaries/report_renderer_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/report_renderer_payload.py
@@ -36,13 +36,17 @@ class PreparedReportRendererPayload:
 def build_report_renderer_payload(
     payload: Mapping[str, object],
 ) -> PreparedReportRendererPayload:
+    """Return the normalized renderer-edge payload derived from a report summary."""
     metadata = summary_metadata(payload)
     rows = payload.get("rows")
     sample_count = coerce_count(rows)
     sensor_count_raw = payload.get("sensor_count_used")
     sensor_count = coerce_count(sensor_count_raw)
     report_date = payload.get("report_date")
-    report_date_str = str(report_date).strip() or None if isinstance(report_date, str) else None
+    report_date_str = None
+    if isinstance(report_date, str):
+        normalized_report_date = report_date.strip()
+        report_date_str = normalized_report_date or None
     return PreparedReportRendererPayload(
         run_id=str(payload.get("run_id") or "unknown") or "unknown",
         car_name=str(metadata.get("car_name") or "").strip() or None,


### PR DESCRIPTION
Chunk 100 covers ten shared-boundary files: `report_interpretation.py`, `report_payload_gate.py`, `report_payload_projection.py`, `report_renderer_payload.py`, `run_log.py`, `run_suitability.py`, `settings_snapshot_codec.py`, `summary_warning.py`, `test_plan_projection.py`, and `test_run_reconstruction.py`. I reviewed every code file in this chunk directly before deciding what to change.

The final diff stays intentionally behavior-preserving and focused on the lightweight report payload helpers in this slice. In `report_payload_gate.py`, I documented the minimal projection contract for the public gate helper. In `report_payload_projection.py`, I added concise docstrings to the tiny public normalization helpers so their fallback/coercion behavior is visible without re-reading the implementation. In `report_renderer_payload.py`, I added a function docstring and rewrote the `report_date` normalization into an explicit branch, which preserves the exact returned values while making the cleanup path easier to follow.

Key files changed:
- `apps/server/vibesensor/shared/boundaries/report_payload_gate.py`
- `apps/server/vibesensor/shared/boundaries/report_payload_projection.py`
- `apps/server/vibesensor/shared/boundaries/report_renderer_payload.py`

The remaining seven files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/test_report_payload_gate.py apps/server/tests/shared/boundaries/test_report_payload_projection.py apps/server/tests/shared/boundaries/test_report_renderer_payload.py` (`16 passed`)
- `make lint`

Risk is low because the diff only clarifies helper contracts and makes one normalization branch more explicit without changing behavior.
