### PR TITLE
Repo review chunk 101: clarify origin boundary normalization

### DIFF
--- a/apps/server/vibesensor/shared/boundaries/vibration_origin.py
+++ b/apps/server/vibesensor/shared/boundaries/vibration_origin.py
@@ -17,7 +17,7 @@ from vibesensor.shared.types.history_analysis_contracts import (
 from vibesensor.shared.types.json_types import JsonValue
 
 
-def location_hotspot_from_payload(payload: dict[str, object]) -> LocationHotspot:
+def location_hotspot_from_payload(payload: Mapping[str, object]) -> LocationHotspot:
     """Decode a persisted or transported hotspot payload into a domain object."""
     alts = payload.get("alternative_locations") or payload.get("ambiguous_locations") or []
     if not isinstance(alts, (list, tuple)):
@@ -52,6 +52,7 @@ def _source_from_payload(
     *,
     fallback: VibrationSource | None = None,
 ) -> VibrationSource:
+    """Resolve a suspected source, preferring the provided fallback when present."""
     if fallback is not None:
         return fallback
     raw_source = str(payload.get("suspected_source") or "").strip().lower()
@@ -78,12 +79,17 @@ def vibration_origin_from_payload(
     resolved_speed_band = speed_band
     if resolved_speed_band is None:
         raw_speed_band = payload.get("strongest_speed_band") or payload.get("speed_band")
-        resolved_speed_band = (
-            str(raw_speed_band).strip() or None if raw_speed_band is not None else None
-        )
+        if raw_speed_band is not None:
+            normalized_speed_band = str(raw_speed_band).strip()
+            resolved_speed_band = normalized_speed_band or None
 
     resolved_reason = payload.get("evidence_summary")
     reason = str(resolved_reason).strip() if isinstance(resolved_reason, str) else ""
+    raw_dominant_phase = payload.get("dominant_phase")
+    dominant_phase = None
+    if raw_dominant_phase is not None:
+        normalized_dominant_phase = str(raw_dominant_phase).strip()
+        dominant_phase = normalized_dominant_phase or None
 
     return VibrationOrigin.from_analysis_inputs(
         suspected_source=_source_from_payload(payload, fallback=suspected_source),
@@ -94,7 +100,7 @@ def vibration_origin_from_payload(
             else _as_float(payload.get("dominance_ratio"))
         ),
         speed_band=resolved_speed_band,
-        dominant_phase=str(payload.get("dominant_phase") or "").strip() or None,
+        dominant_phase=dominant_phase,
         reason=reason,
     )
 


### PR DESCRIPTION
Chunk 101 covers a single shared-boundary file: `apps/server/vibesensor/shared/boundaries/vibration_origin.py`. I reviewed that file directly, along with the surrounding origin/value-object/report-mapping tests that exercise its decoding and projection paths.

The diff stays behavior-preserving and intentionally small. I widened `location_hotspot_from_payload()` to accept a generic `Mapping` instead of a concrete `dict`, which matches how the rest of this boundary module is typed and reflects how the helper is actually used. I also added a short private-helper docstring and expanded the compact inline normalization for `speed_band` and `dominant_phase` into explicit branches inside `vibration_origin_from_payload()`. The returned values remain the same; the goal is simply to make the boundary coercion path easier to read and safer to modify later.

Key file changed:
- `apps/server/vibesensor/shared/boundaries/vibration_origin.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/test_decoder_numeric_coercion.py apps/server/tests/shared/boundaries/test_finding_roundtrip.py apps/server/tests/domain/test_finding_origin_value_objects.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/shared/boundaries/test_finding_payload_projection.py` (`93 passed`)
- `make lint`

Risk is low because the change only clarifies type expectations and rewrites normalization branches without changing the origin payload contract.
