### PR TITLE
Repo review chunk 102: document summary serialization helpers

### DIFF
--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_findings.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_findings.py
@@ -14,6 +14,7 @@ from vibesensor.shared.types.json_types import is_json_object
 
 
 def serialize_findings(findings: tuple[DomainFinding, ...]) -> list[FindingPayload]:
+    """Project domain findings into persisted summary payload dictionaries."""
     return [finding_payload_from_domain(finding) for finding in findings]
 
 

--- a/apps/server/vibesensor/shared/boundaries/summary_serialization/_plots.py
+++ b/apps/server/vibesensor/shared/boundaries/summary_serialization/_plots.py
@@ -231,6 +231,7 @@ def serialize_phase_segments(
 def serialize_speed_breakdown(
     rows: Sequence[SpeedBreakdownRowLike],
 ) -> list[SpeedBreakdownRow]:
+    """Project speed-breakdown rows into their persisted summary payload shape."""
     payload_rows: list[SpeedBreakdownRow] = []
     for row in rows:
         payload: SpeedBreakdownRow = {
@@ -246,6 +247,7 @@ def serialize_speed_breakdown(
 def serialize_phase_speed_breakdown(
     rows: Sequence[PhaseSpeedBreakdownRowLike],
 ) -> list[PhaseSpeedBreakdownRow]:
+    """Project per-phase speed breakdown rows into persisted summary payloads."""
     payload_rows: list[PhaseSpeedBreakdownRow] = []
     for row in rows:
         payload: PhaseSpeedBreakdownRow = {
@@ -263,6 +265,7 @@ def serialize_phase_speed_breakdown(
 def serialize_peak_table(
     rows: Sequence[PeakTableRowLike],
 ) -> list[PeakTableRow]:
+    """Project peak-table rows into persisted summary payload dictionaries."""
     payload_rows: list[PeakTableRow] = []
     for row in rows:
         payload: PeakTableRow = {
@@ -289,6 +292,7 @@ def serialize_peak_table(
 
 
 def serialize_spectrogram(result: SpectrogramResultLike) -> SpectrogramResult:
+    """Project a spectrogram result into a JSON-safe persisted payload."""
     payload: SpectrogramResult = {
         "x_axis": result.x_axis,
         "x_label_key": result.x_label_key,
@@ -305,6 +309,7 @@ def serialize_spectrogram(result: SpectrogramResultLike) -> SpectrogramResult:
 
 
 def serialize_plot_data(plot_data: PlotDataResultLike) -> PlotDataResult:
+    """Project composite plot data into the persisted summary payload shape."""
     amp_vs_phase: list[AmpVsPhaseRow] = []
     for phase_row in plot_data.amp_vs_phase:
         phase_payload: AmpVsPhaseRow = {


### PR DESCRIPTION
Chunk 102 covers the six-file `shared/boundaries/summary_serialization` package: `__init__.py`, `_data_quality.py`, `_findings.py`, `_location_intensity.py`, `_plots.py`, and `_summary.py`. I reviewed every code file in this chunk directly before deciding what to change.

This slice was already structurally sound, so the final diff stays intentionally small and behavior-preserving. In `_findings.py`, I documented the public `serialize_findings()` helper that projects domain findings into persisted summary payloads. In `_plots.py`, I added concise docstrings to the exported serialization helpers for speed breakdowns, peak tables, spectrograms, and composite plot payloads. Those helpers form part of the summary-serialization public surface, and the new docstrings make their boundary role clear without changing any serialization behavior.

Key files changed:
- `apps/server/vibesensor/shared/boundaries/summary_serialization/_findings.py`
- `apps/server/vibesensor/shared/boundaries/summary_serialization/_plots.py`

The remaining four files in the package were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/test_summary_data_quality_serialization.py apps/server/tests/shared/boundaries/test_summary_serialization_public_api.py apps/server/tests/shared/boundaries/test_summary_location_intensity_serialization.py apps/server/tests/adapters/pdf/test_report_persistence_findings.py apps/server/tests/hygiene/test_domain_summary_boundary_guardrails.py` (`37 passed`)
- `make lint`

Risk is low because the diff only documents existing helper contracts and does not alter payload assembly or serialization semantics.
