### PR TITLE
Repo review chunk 103: clarify shared constants exports

### DIFF
--- a/apps/server/vibesensor/shared/constants/dsp.py
+++ b/apps/server/vibesensor/shared/constants/dsp.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 from typing import Final
 
-from vibesensor.vibration_strength import PEAK_BANDWIDTH_HZ as PEAK_BANDWIDTH_HZ
-from vibesensor.vibration_strength import PEAK_SEPARATION_HZ as PEAK_SEPARATION_HZ
+from vibesensor.vibration_strength import PEAK_BANDWIDTH_HZ as _PEAK_BANDWIDTH_HZ
+from vibesensor.vibration_strength import PEAK_SEPARATION_HZ as _PEAK_SEPARATION_HZ
+
+PEAK_BANDWIDTH_HZ: Final[float] = _PEAK_BANDWIDTH_HZ
+"""Bandwidth around each detected strength peak (Hz)."""
+
+PEAK_SEPARATION_HZ: Final[float] = _PEAK_SEPARATION_HZ
+"""Minimum separation between neighbouring detected peaks (Hz)."""
 
 WAVEFORM_DISPLAY_HZ: Final[int] = 120
 """Decimated sample rate sent to the UI waveform chart (Hz)."""

--- a/apps/server/vibesensor/shared/constants/phases.py
+++ b/apps/server/vibesensor/shared/constants/phases.py
@@ -9,3 +9,4 @@ PHASE_I18N_KEYS: Final[dict[str, str]] = {
     "deceleration": "DRIVING_PHASE_DECELERATION",
     "coast_down": "DRIVING_PHASE_COAST_DOWN",
 }
+"""Map persisted driving-phase keys to report/boundary i18n labels."""


### PR DESCRIPTION
Chunk 103 covers eight files in `apps/server/vibesensor/shared/constants`: `__init__.py`, `analysis.py`, `dsp.py`, `github.py`, `phases.py`, `type_checks.py`, `ui.py`, and `units.py`. I reviewed every code file in this chunk directly before choosing a change.

This constants slice was already in good shape, so the final diff stays intentionally small and behavior-preserving. In `dsp.py`, I replaced the odd self-alias imports for `PEAK_BANDWIDTH_HZ` and `PEAK_SEPARATION_HZ` with explicit, documented local re-exports. The values remain identical; the change just makes the module’s public surface easier to read and keeps those constants documented alongside the other DSP settings. In `phases.py`, I added a concise docstring to `PHASE_I18N_KEYS` so the shared boundary/report label mapping is self-explanatory at the definition site.

Key files changed:
- `apps/server/vibesensor/shared/constants/dsp.py`
- `apps/server/vibesensor/shared/constants/phases.py`

The remaining six files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/utils/test_constants_and_helpers.py apps/server/tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py` (`19 passed`)
- `make lint`

Risk is low because the diff only clarifies public constant exports and documentation without changing any constant values or runtime semantics.
