### PR TITLE
Repo review chunk 104: clarify shared type contracts

### DIFF
--- a/apps/server/vibesensor/shared/types/car_config.py
+++ b/apps/server/vibesensor/shared/types/car_config.py
@@ -24,6 +24,8 @@ __all__ = [
 
 
 class CarConfigUpdatePayload(TypedDict, total=False):
+    """Partial update payload for mutating one stored car configuration."""
+
     id: str
     name: str
     type: str
@@ -32,6 +34,8 @@ class CarConfigUpdatePayload(TypedDict, total=False):
 
 
 class CarConfigPayload(TypedDict):
+    """Canonical persisted/shared payload for one car configuration profile."""
+
     id: str
     name: str
     type: str

--- a/apps/server/vibesensor/shared/types/history_records.py
+++ b/apps/server/vibesensor/shared/types/history_records.py
@@ -29,6 +29,7 @@ class HistoryRunListEntry:
     error_message: str | None = None
 
     def to_json_object(self) -> JsonObject:
+        """Serialize the list-entry record into a JSON-safe persistence payload."""
         payload: JsonObject = {
             "run_id": self.run_id,
             "status": self.status.value,
@@ -61,6 +62,7 @@ class StoredHistoryRun:
     analysis_completed_at: str | None = None
 
     def to_json_object(self) -> JsonObject:
+        """Serialize the full stored-run record into a JSON-safe payload."""
         payload: JsonObject = {
             "run_id": self.run_id,
             "status": self.status.value,
@@ -94,6 +96,7 @@ class AnalyzingRunHealth:
     analyzing_oldest_started_at: str | None = None
 
     def to_json_object(self) -> JsonObject:
+        """Serialize the analyzer-health snapshot into a JSON-safe payload."""
         payload: JsonObject = {
             "analyzing_run_count": self.analyzing_run_count,
             "analyzing_oldest_age_s": self.analyzing_oldest_age_s,


### PR DESCRIPTION
Chunk 104 covers ten files under `apps/server/vibesensor/shared/types`: `__init__.py`, `analysis_views.py`, `car_config.py`, `data_quality_contracts.py`, `finding_payload_parts.py`, `health_snapshot.py`, `history_analysis_contracts.py`, `history_records.py`, `json_types.py`, and `payload_types.py`. I reviewed every code file in this chunk directly before choosing what to change.

The final diff stays behavior-preserving and focuses on the contract files that still needed a bit more definition-site clarity. In `car_config.py`, I added concise docstrings to the update and persisted car payload TypedDicts so their roles are obvious where they are declared. In `history_records.py`, I added docstrings to the public `to_json_object()` methods on the typed history dataclasses, documenting the JSON-safe payload they produce for persistence and transport.

Key files changed:
- `apps/server/vibesensor/shared/types/car_config.py`
- `apps/server/vibesensor/shared/types/history_records.py`

The remaining eight files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/types/test_analysis_view_types.py apps/server/tests/shared/types/test_domain_models.py apps/server/tests/shared/types/test_finding_payload_parts.py apps/server/tests/adapters/websocket/test_ws_models.py apps/server/tests/hygiene/test_api_model_boundary_parity.py apps/server/tests/hygiene/test_domain_new_types.py` (`129 passed`)
- `make lint`

Risk is low because the diff only documents existing shared contract types and serialization helpers without changing any field shapes or runtime behavior.
