### PR TITLE
Repo review chunk 105: document persisted type helpers

### DIFF
--- a/apps/server/vibesensor/shared/types/persisted_analysis.py
+++ b/apps/server/vibesensor/shared/types/persisted_analysis.py
@@ -20,10 +20,12 @@ class PersistedAnalysis(Mapping[str, object]):
 
     @classmethod
     def from_json_object(cls, payload: JsonObject) -> PersistedAnalysis:
+        """Build a persisted-analysis wrapper from an in-memory JSON payload."""
         return cls(_payload=deepcopy(payload))
 
     @classmethod
     def from_storage_json_object(cls, payload: JsonObject) -> PersistedAnalysis:
+        """Build from storage JSON, validating and stripping the schema-version field."""
         normalized = deepcopy(payload)
         raw_version = normalized.pop(_STORAGE_SCHEMA_VERSION_KEY, 0)
         if raw_version not in (0, PERSISTED_ANALYSIS_SCHEMA_VERSION):
@@ -31,9 +33,11 @@ class PersistedAnalysis(Mapping[str, object]):
         return cls(_payload=normalized)
 
     def to_json_object(self) -> JsonObject:
+        """Return a deep-copied JSON payload for in-memory consumers."""
         return deepcopy(self._payload)
 
     def to_storage_json_object(self) -> JsonObject:
+        """Return a storage payload with the persisted-analysis schema version attached."""
         payload = self.to_json_object()
         payload[_STORAGE_SCHEMA_VERSION_KEY] = PERSISTED_ANALYSIS_SCHEMA_VERSION
         return payload
@@ -49,6 +53,7 @@ class PersistedAnalysis(Mapping[str, object]):
 
     @property
     def language(self) -> str:
+        """Return the persisted language code, or an empty string when absent."""
         value = self._payload.get("lang")
         return value if isinstance(value, str) else ""
 

--- a/apps/server/vibesensor/shared/types/run_schema.py
+++ b/apps/server/vibesensor/shared/types/run_schema.py
@@ -95,6 +95,7 @@ class RunMetadata:
         end_time_utc: str | None = None,
         incomplete_for_order_analysis: bool = False,
     ) -> RunMetadata:
+        """Construct canonical run metadata for a newly recorded run."""
         return cls(
             record_type=RUN_METADATA_TYPE,
             schema_version=RUN_SCHEMA_VERSION,
@@ -115,6 +116,7 @@ class RunMetadata:
 
     @classmethod
     def from_dict(cls, data: Mapping[str, object]) -> RunMetadata:
+        """Normalize a raw persisted metadata mapping into the typed dataclass."""
         from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
 
         run_id = str(data.get("run_id", ""))
@@ -145,6 +147,7 @@ class RunMetadata:
 
     @property
     def language(self) -> str | None:
+        """Return the normalized persisted language code from metadata extras."""
         value = self.extras.get("language")
         if isinstance(value, str):
             normalized = value.strip().lower()
@@ -152,6 +155,7 @@ class RunMetadata:
         return None
 
     def to_dict(self) -> JsonObject:
+        """Serialize typed run metadata back to the canonical JSONL header shape."""
         payload: JsonObject = {
             "record_type": self.record_type,
             "schema_version": self.schema_version,


### PR DESCRIPTION
Chunk 105 covers seven files under `apps/server/vibesensor/shared/types`: `persisted_analysis.py`, `run_schema.py`, `sensor_config.py`, `sensor_frame.py`, `settings_snapshot.py`, `settings_types.py`, and `speed_source_config.py`. I reviewed every code file in this chunk directly before choosing what to change.

The final diff stays behavior-preserving and targets the two dataclass-style APIs in this slice that still lacked a bit of definition-site clarity. In `persisted_analysis.py`, I added concise docstrings to the factory/serialization methods and the `language` property so the distinction between in-memory JSON, storage JSON, and normalized access is explicit. In `run_schema.py`, I added matching docstrings to the `RunMetadata` constructor, raw-dict decoder, `language` property, and serializer so callers can understand the typed JSONL-header lifecycle without reading each implementation.

Key files changed:
- `apps/server/vibesensor/shared/types/persisted_analysis.py`
- `apps/server/vibesensor/shared/types/run_schema.py`

The remaining five files in the chunk were reviewed directly and left unchanged.

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/shared/types/test_domain_models.py apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py` (`83 passed`)
- `make lint`

Risk is low because the diff only documents existing typed constructors/serializers and does not alter any persisted payload shape or runtime behavior.
