### PR TITLE
Repo review chunk 106: clarify use_cases package docs

### DIFF
--- a/apps/server/vibesensor/use_cases/__init__.py
+++ b/apps/server/vibesensor/use_cases/__init__.py
@@ -1,1 +1,4 @@
-"""Application use-case orchestration packages."""
+"""Application use-case orchestration packages.
+
+Concrete history, diagnostics, run, and update workflows live in subpackages.
+"""


### PR DESCRIPTION
Chunk 106 covers a single file: `apps/server/vibesensor/use_cases/__init__.py`. I reviewed that code file directly before deciding what to change.

This package file contains no executable logic; it exists to describe the orchestration layer boundary. The resulting diff is therefore intentionally minimal and behavior-preserving. I expanded the package docstring so it no longer stops at a generic label and instead tells maintainers what actually lives under `use_cases`: the concrete history, diagnostics, run, and update workflow subpackages. That makes the package boundary a little clearer for humans and for future refactors without changing any import surface or runtime semantics.

Key file changed:
- `apps/server/vibesensor/use_cases/__init__.py`

Validation performed locally:
- `./.venv/bin/python - <<'PY' ... import vibesensor.use_cases ... PY` import smoke against the repo venv
- `make lint`

Risk is very low because the change only adjusts a package-level docstring. No exports, symbols, or behavior changed.

There were no skipped in-scope logic changes here because the file does not contain behavior beyond package metadata.
