### PR TITLE
Repo review chunk 107: tighten diagnostics helper contracts

### DIFF
--- a/apps/server/vibesensor/use_cases/diagnostics/_context_projection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_context_projection.py
@@ -68,6 +68,7 @@ def context_to_metadata_dict(context: DiagnosticsContext) -> JsonObject:
 
 
 def context_to_configuration_snapshot(context: DiagnosticsContext) -> ConfigurationSnapshot:
+    """Project diagnostics context into the domain configuration snapshot shape."""
     spec = context.order_reference_spec
     return ConfigurationSnapshot(
         sensor_model=context.sensor_model,
@@ -81,6 +82,7 @@ def context_to_configuration_snapshot(context: DiagnosticsContext) -> Configurat
 
 
 def context_to_car(context: DiagnosticsContext) -> Car | None:
+    """Project the optional car context used by report and finding consumers."""
     spec = context.order_reference_spec
     car_snapshot = context.run_context.car
     if not (context.car_name or context.car_type or context.car_variant or spec is not None):
@@ -96,6 +98,7 @@ def context_to_car(context: DiagnosticsContext) -> Car | None:
 
 
 def context_to_symptom(context: DiagnosticsContext) -> Symptom:
+    """Project diagnostics symptom metadata into the domain symptom object."""
     if not context.symptom_description:
         return Symptom.unspecified()
     return Symptom(

--- a/apps/server/vibesensor/use_cases/diagnostics/_counters.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_counters.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 
-def counter_delta(counter_values: list[float]) -> int:
+
+def counter_delta(counter_values: Sequence[float]) -> int:
     """Compute cumulative positive delta from a list of monotonic counter values."""
     if len(counter_values) < 2:
         return 0

--- a/apps/server/vibesensor/use_cases/diagnostics/_reference_findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_reference_findings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from vibesensor.domain import Finding as DomainFinding
 from vibesensor.domain import FindingKind, VibrationSource
 from vibesensor.shared.constants.analysis import SPEED_COVERAGE_MIN_PCT
@@ -24,6 +26,7 @@ def _reference_missing_finding(
     suspected_source: VibrationSource,
     kind: FindingKind = FindingKind.REFERENCE,
 ) -> DomainFinding:
+    """Build a bare reference-gap finding with the standard diagnostics shape."""
     return DomainFinding(
         finding_id=finding_id,
         suspected_source=suspected_source,
@@ -35,7 +38,7 @@ def _reference_missing_finding(
 def build_reference_findings(
     *,
     context: DiagnosticsContext,
-    samples: list[Sample],
+    samples: Sequence[Sample],
     speed_sufficient: bool,
     tire_circumference_m: float | None,
     raw_sample_rate_hz: float | None,
@@ -82,7 +85,7 @@ def build_reference_findings(
 
 
 def engine_reference_coverage_pct(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     context: DiagnosticsContext,
     tire_circumference_m: float | None,
@@ -97,7 +100,7 @@ def engine_reference_coverage_pct(
 
 
 def has_engine_reference(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     context: DiagnosticsContext,
     tire_circumference_m: float | None,

--- a/apps/server/vibesensor/use_cases/diagnostics/_reference_resolution.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_reference_resolution.py
@@ -10,6 +10,7 @@ from ._types import AnalysisSampleInput, Sample, ensure_analysis_sample
 
 
 def _tire_reference_from_context(context: DiagnosticsContext) -> tuple[float | None, str | None]:
+    """Return the wheel reference circumference and the metadata source name."""
     spec = _order_reference_spec_from_context(context)
     if spec is not None and spec.supports_wheel_reference:
         return spec.tire_circumference_m, "order_reference_spec"
@@ -24,6 +25,7 @@ def _order_reference_spec_from_context(
     context: DiagnosticsContext,
     sample: Sample | None = None,
 ) -> OrderReferenceSpec | None:
+    """Return the effective order-reference spec for one optional sample override."""
     return context.effective_order_reference_spec(sample)
 
 
@@ -32,6 +34,7 @@ def _effective_engine_rpm(
     context: DiagnosticsContext,
     tire_circumference_m: float | None,
 ) -> tuple[float | None, str]:
+    """Resolve measured or inferred engine rpm plus the source label."""
     typed_sample = ensure_analysis_sample(sample)
     measured = typed_sample.engine_rpm
     if measured is not None and measured > 0:

--- a/apps/server/vibesensor/use_cases/diagnostics/_run_loader.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_run_loader.py
@@ -10,6 +10,7 @@ from vibesensor.shared.types.sensor_frame import SensorFrame
 
 
 def _load_run(path: Path) -> tuple[JsonObject, list[SensorFrame], list[str]]:
+    """Load one JSONL run and return metadata, samples, and decode warnings."""
     if not path.exists():
         raise FileNotFoundError(path)
     if path.suffix.lower() != ".jsonl":


### PR DESCRIPTION
Chunk 107 reviews these ten diagnostics files: `apps/server/vibesensor/use_cases/diagnostics/__init__.py`, `_analysis_models.py`, `_context.py`, `_context_decode.py`, `_context_projection.py`, `_counters.py`, `_reference_findings.py`, `_reference_resolution.py`, `_run_loader.py`, and `_sample_metrics.py`. I reviewed every code file in that slice directly before deciding what to change.

The resulting diff stays strictly behavior-preserving and focuses on helper contracts. In `_context_projection.py`, `_reference_resolution.py`, and `_run_loader.py`, I added missing helper docstrings so the boundary between typed diagnostics context, reference resolution, and run loading is easier to understand without chasing callers. In `_counters.py` and `_reference_findings.py`, I widened read-only collection annotations from `list[...]` to `Sequence[...]`, matching the actual implementations because those helpers only iterate over their inputs and never mutate them.

Key files changed:
- `apps/server/vibesensor/use_cases/diagnostics/_context_projection.py`
- `apps/server/vibesensor/use_cases/diagnostics/_counters.py`
- `apps/server/vibesensor/use_cases/diagnostics/_reference_findings.py`
- `apps/server/vibesensor/use_cases/diagnostics/_reference_resolution.py`
- `apps/server/vibesensor/use_cases/diagnostics/_run_loader.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_analysis_architecture.py apps/server/tests/use_cases/diagnostics/test_diagnostics_context.py apps/server/tests/use_cases/diagnostics/test_diagnostics_shared_extended.py apps/server/tests/adapters/pdf/test_report_analysis_helpers.py apps/server/tests/adapters/pdf/test_report_floor_estimation.py apps/server/tests/infra/processing/test_metrics_cache_and_settings_regressions.py` (`112 passed`)
- `make lint`

Risk is low because the changes only clarify helper documentation and relax non-mutating type hints. I intentionally left the other reviewed files unchanged where no worthwhile safe cleanup was justified.
