### PR TITLE
Repo review chunk 108: relax diagnostics sequence contracts

### DIFF
--- a/apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py
@@ -33,6 +33,7 @@ def _locations_connected_throughout_run(
     *,
     lang: str = "en",
 ) -> set[str]:
+    """Return locations that remain present across the full run span."""
     by_location_times: dict[str, set[float]] = defaultdict(set)
     all_times: list[float] = []
 

--- a/apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py
@@ -74,7 +74,7 @@ def build_sensor_bundle(
     return build_sensor_analysis(
         samples=samples,
         language=language,
-        per_sample_phases=per_sample_phases,
+        per_sample_phases=list(per_sample_phases),
     )
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from statistics import median as _median
 
 from vibesensor.domain import LocationIntensitySummary, RunSuitability
@@ -64,10 +65,10 @@ def build_findings_bundle(
 
 
 def build_sensor_bundle(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     language: str,
-    per_sample_phases: list[DrivingPhase],
+    per_sample_phases: Sequence[DrivingPhase],
 ) -> tuple[list[str], set[str], list[LocationIntensitySummary]]:
     """Build location-scoped sensor summaries used by analysis and reports."""
     return build_sensor_analysis(
@@ -79,7 +80,7 @@ def build_sensor_bundle(
 
 def build_run_suitability_bundle(
     context: DiagnosticsContext,
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     prepared: PreparedRunData,
     accel_stats: AccelStatistics,

--- a/apps/server/vibesensor/use_cases/diagnostics/_validation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_validation.py
@@ -8,6 +8,7 @@ from ._types import AnalysisSampleInput, ensure_analysis_sample
 
 
 def _validate_required_strength_metrics(samples: Sequence[AnalysisSampleInput]) -> None:
+    """Require at least one precomputed strength-metric sample in the run input."""
     typed_samples = [ensure_analysis_sample(sample) for sample in samples]
     if not typed_samples:
         return

--- a/apps/server/vibesensor/use_cases/diagnostics/findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/findings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from vibesensor.domain import Finding as DomainFinding
 
 from . import _reference_findings
@@ -25,7 +27,7 @@ __all__ = [
 
 
 def finalize_findings(
-    findings: list[DomainFinding],
+    findings: Sequence[DomainFinding],
 ) -> tuple[DomainFinding, ...]:
     """Partition, rank by confidence, and assign stable ``F###`` IDs.
 

--- a/apps/server/vibesensor/use_cases/diagnostics/location_analysis.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/location_analysis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Collection, Sequence, Set
 from dataclasses import dataclass, replace
 from math import ceil, floor, log1p, pow
 
@@ -51,7 +52,8 @@ class LocationAnalysisResult:
         return self.top_location
 
 
-def _weighted_speed_window_label(speed_weight_pairs: list[tuple[float, float]]) -> str | None:
+def _weighted_speed_window_label(speed_weight_pairs: Sequence[tuple[float, float]]) -> str | None:
+    """Return a human-readable weighted speed window for one location winner."""
     valid = [(speed, weight) for speed, weight in speed_weight_pairs if speed > 0]
     p10 = _weighted_percentile(valid, 0.10)
     p90 = _weighted_percentile(valid, 0.90)
@@ -82,10 +84,10 @@ def _localization_confidence(
 
 def _score_locations_in_bin(
     bin_label: str,
-    rows: list[JsonObject],
+    rows: Sequence[JsonObject],
     *,
     corroboration_amp_multiplier: float,
-    connected_locations: set[str] | None,
+    connected_locations: Set[str] | None,
     suspected_source: str | None,
 ) -> LocationAnalysisResult | None:
     """Score and rank sensor locations within a single speed-bin.
@@ -204,10 +206,10 @@ def _score_locations_in_bin(
 
 
 def summarize_order_match_locations(
-    matches: list[OrderMatchObservation],
+    matches: Sequence[OrderMatchObservation],
     lang: str,
-    relevant_speed_bins: list[str] | tuple[str, ...] | set[str] | None = None,
-    connected_locations: set[str] | None = None,
+    relevant_speed_bins: Collection[str] | None = None,
+    connected_locations: Set[str] | None = None,
     suspected_source: str | None = None,
 ) -> tuple[object, LocationAnalysisResult | None]:
     """Return strongest location summary, optionally restricted to specific speed bins.

--- a/apps/server/vibesensor/use_cases/diagnostics/math_utils.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/math_utils.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from math import isfinite, sqrt
 
 
-def _mean(values: list[float]) -> float:
+def _mean(values: Sequence[float]) -> float:
     """Arithmetic mean returning 0.0 for empty inputs."""
     if not values:
         return 0.0
     return sum(values) / len(values)
 
 
-def _corr_abs(x_vals: list[float], y_vals: list[float]) -> float | None:
+def _corr_abs(x_vals: Sequence[float], y_vals: Sequence[float]) -> float | None:
+    """Absolute Pearson correlation for equal-length numeric sequences."""
     if len(x_vals) != len(y_vals) or len(x_vals) < 3:
         return None
     n = len(x_vals)
@@ -35,7 +37,7 @@ def _corr_abs(x_vals: list[float], y_vals: list[float]) -> float | None:
     return result if isfinite(result) else None
 
 
-def _corr_abs_clamped(x: list[float], y: list[float]) -> float | None:
+def _corr_abs_clamped(x: Sequence[float], y: Sequence[float]) -> float | None:
     """Absolute Pearson correlation, clamped to [0, 1]."""
     raw = _corr_abs(x, y)
     if raw is None:
@@ -44,7 +46,7 @@ def _corr_abs_clamped(x: list[float], y: list[float]) -> float | None:
 
 
 def _weighted_percentile(
-    pairs: list[tuple[float, float]],
+    pairs: Sequence[tuple[float, float]],
     q: float,
 ) -> float | None:
     """Return the *q*-th weighted percentile from *(value, weight)* pairs."""


### PR DESCRIPTION
Chunk 108 reviews these ten diagnostics files: `apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py`, `_summary_result.py`, `_summary_steps.py`, `_types.py`, `_validation.py`, `_view_types.py`, `findings.py`, `location_analysis.py`, `math_utils.py`, and `phase_segmentation.py`. I reviewed every code file in that slice directly before deciding what to change.

The changes stay behavior-preserving and focus on read-only helper contracts. Several pure helpers in the diagnostics summary, findings, localization, and math seams were typed as `list[...]` even though they only iterate over inputs. I widened those signatures to `Sequence[...]` or other read-only collection abstractions so the annotations better match reality without changing runtime behavior. I also added a few short helper docstrings at key boundaries (`_sensor_locations`, `_validation`, `location_analysis`, and `math_utils`) where the code already behaved clearly but the contract was implicit.

Key files changed:
- `apps/server/vibesensor/use_cases/diagnostics/_summary_steps.py`
- `apps/server/vibesensor/use_cases/diagnostics/findings.py`
- `apps/server/vibesensor/use_cases/diagnostics/location_analysis.py`
- `apps/server/vibesensor/use_cases/diagnostics/math_utils.py`
- plus small documentation-only updates in `_sensor_locations.py` and `_validation.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_strength_and_reason_selection_regressions.py apps/server/tests/use_cases/diagnostics/test_run_analysis.py apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py apps/server/tests/adapters/pdf/test_report_analysis_localization_integration.py apps/server/tests/adapters/gps/test_issue_148_speed_window.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py` (`172 passed`)
- `make lint`

Risk is low because the diff only clarifies helper docs and relaxes non-mutating type hints; the remaining reviewed files were left unchanged where no worthwhile safe cleanup was justified.
