### PR TITLE
Repo review chunk 109: relax diagnostics plot contracts

### DIFF
--- a/apps/server/vibesensor/use_cases/diagnostics/plots.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/plots.py
@@ -55,13 +55,13 @@ from vibesensor.vibration_strength import percentile
 
 def build_plot_series(
     *,
-    samples: list[Sample],
-    speed_breakdown: list[SpeedBreakdownRowData],
-    phase_speed_breakdown: list[PhaseSpeedBreakdownRowData],
+    samples: Sequence[Sample],
+    speed_breakdown: Sequence[SpeedBreakdownRowData],
+    phase_speed_breakdown: Sequence[PhaseSpeedBreakdownRowData],
     findings: Sequence[DomainFinding],
     steady_speed: bool,
-    per_sample_phases: list[DrivingPhase],
-    phase_segments: list[PhaseSegment],
+    per_sample_phases: Sequence[DrivingPhase],
+    phase_segments: Sequence[PhaseSegment],
     raw_sample_rate_hz: float | None,
 ) -> PlotSeriesBundle:
     """Build reusable time/speed/finding series for the plot payload."""
@@ -160,7 +160,7 @@ def _finding_series_label(finding: DomainFinding) -> str:
 def build_steady_speed_distribution(
     *,
     steady_speed: bool,
-    vib_mag_points: list[tuple[float, float, str]],
+    vib_mag_points: Sequence[tuple[float, float, str]],
 ) -> dict[str, float] | None:
     """Build steady-speed percentile distribution when appropriate."""
     if not (steady_speed and vib_mag_points):
@@ -177,7 +177,7 @@ def build_steady_speed_distribution(
 
 
 def build_amp_vs_phase(
-    phase_speed_breakdown: list[PhaseSpeedBreakdownRowData],
+    phase_speed_breakdown: Sequence[PhaseSpeedBreakdownRowData],
 ) -> list[AmpVsPhaseRowData]:
     """Shape the phase-grouped vibration rows for plotting."""
     amp_vs_phase: list[AmpVsPhaseRowData] = []
@@ -197,7 +197,7 @@ def build_amp_vs_phase(
 
 
 def serialize_phase_context(
-    phase_segments: list[PhaseSegment],
+    phase_segments: Sequence[PhaseSegment],
 ) -> tuple[list[PhaseSegmentPlotData], list[PhaseBoundaryData]]:
     """Serialize phase segments for plot consumers."""
     phase_segments_out: list[PhaseSegmentPlotData] = []
@@ -229,14 +229,14 @@ def serialize_phase_context(
 def _plot_data(
     *,
     samples: Sequence[AnalysisSampleInput],
-    speed_breakdown: list[SpeedBreakdownRowData],
-    phase_speed_breakdown: list[PhaseSpeedBreakdownRowData],
+    speed_breakdown: Sequence[SpeedBreakdownRowData],
+    phase_speed_breakdown: Sequence[PhaseSpeedBreakdownRowData],
     findings: Sequence[DomainFinding],
     raw_sample_rate_hz: float | None,
     steady_speed: bool,
     run_noise_baseline_g: float | None = None,
-    per_sample_phases: list[DrivingPhase] | None = None,
-    phase_segments: list[PhaseSegment] | None = None,
+    per_sample_phases: Sequence[DrivingPhase] | None = None,
+    phase_segments: Sequence[PhaseSegment] | None = None,
 ) -> PlotDataResultData:
     typed_samples = ensure_analysis_samples(samples)
     if run_noise_baseline_g is None:

--- a/apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py
@@ -53,7 +53,7 @@ from vibesensor.use_cases.diagnostics.statistics import (
 
 
 def build_phase_timeline(
-    phase_segments: list[PhaseSegment],
+    phase_segments: Sequence[PhaseSegment],
     findings: Sequence[DomainFinding],
     *,
     min_confidence: float,
@@ -80,8 +80,9 @@ def build_phase_timeline(
 
 
 def build_domain_driving_segments(
-    phase_segments: list[PhaseSegment],
+    phase_segments: Sequence[PhaseSegment],
 ) -> tuple[DomainDrivingSegment, ...]:
+    """Project diagnostics phase segments into the domain driving-segment shape."""
     return tuple(
         DomainDrivingSegment(
             phase=segment.phase,
@@ -109,7 +110,7 @@ def build_sensor_analysis(
     *,
     samples: Sequence[AnalysisSampleInput],
     language: str,
-    per_sample_phases: list[DrivingPhase],
+    per_sample_phases: Sequence[DrivingPhase],
 ) -> tuple[list[str], set[str], list[LocationIntensitySummary]]:
     """Build sensor location lists and intensity rows from analysed samples."""
     typed_samples = ensure_analysis_samples(samples)
@@ -213,8 +214,8 @@ def prepare_run_data(
     )
 
 
-def build_phase_summary(phase_segments: list[PhaseSegment]) -> DrivingPhaseSummary:
+def build_phase_summary(phase_segments: Sequence[PhaseSegment]) -> DrivingPhaseSummary:
     """Small wrapper to keep phase-summary imports localized."""
     from vibesensor.use_cases.diagnostics.phase_segmentation import phase_summary
 
-    return phase_summary(phase_segments)
+    return phase_summary(list(phase_segments))

--- a/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
@@ -33,7 +33,7 @@ from vibesensor.use_cases.diagnostics.speed_profile_helpers import _phase_to_str
 from vibesensor.vibration_strength import percentile
 
 
-def _counter_delta(counter_values: list[tuple[float | None, float]]) -> int:
+def _counter_delta(counter_values: Sequence[tuple[float | None, float]]) -> int:
     """Sort timestamped counter pairs and delegate to shared helper."""
     min_counter_pairs = 2
     if len(counter_values) < min_counter_pairs:
@@ -53,7 +53,7 @@ _EMPTY_BUCKET_COUNTS: dict[str, int] = {f"l{idx}": 0 for idx in range(6)}
 
 def _phase_speed_breakdown(
     samples: Sequence[AnalysisSampleInput],
-    per_sample_phases: list[DrivingPhase],
+    per_sample_phases: Sequence[DrivingPhase],
 ) -> list[PhaseSpeedBreakdownRowData]:
     """Group vibration statistics by driving phase (temporal context)."""
     typed_samples = ensure_analysis_samples(samples)
@@ -129,11 +129,11 @@ def _speed_breakdown(samples: Sequence[AnalysisSampleInput]) -> list[SpeedBreakd
 
 def _sensor_intensity_by_location(
     samples: Sequence[AnalysisSampleInput],
-    include_locations: set[str] | None = None,
+    include_locations: Sequence[str] | set[str] | None = None,
     *,
     lang: str = "en",
-    connected_locations: set[str] | None = None,
-    per_sample_phases: list[DrivingPhase] | None = None,
+    connected_locations: Sequence[str] | set[str] | None = None,
+    per_sample_phases: Sequence[DrivingPhase] | None = None,
 ) -> list[LocationIntensitySummary]:
     """Compute per-location vibration intensity statistics."""
     typed_samples = ensure_analysis_samples(samples)

--- a/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
@@ -106,7 +106,7 @@ def scan_peak_samples(samples: Sequence[AnalysisSampleInput]) -> PeakSampleScan:
     )
 
 
-def safe_percentile(sorted_vals: list[float], q: float, *, default: float = 0.0) -> float:
+def safe_percentile(sorted_vals: Sequence[float], q: float, *, default: float = 0.0) -> float:
     """Return ``percentile(sorted_vals, q)`` when possible, else a safe fallback."""
     if len(sorted_vals) >= 2:
         return float(percentile(sorted_vals, q))
@@ -119,7 +119,7 @@ def safe_percentile(sorted_vals: list[float], q: float, *, default: float = 0.0)
 
 
 def aggregate_fft_spectrum(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     freq_bin_hz: float = 2.0,
     aggregation: str = "persistence",
@@ -157,7 +157,7 @@ def aggregate_fft_spectrum(
 
 
 def aggregate_fft_spectrum_raw(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     freq_bin_hz: float = 2.0,
     run_noise_baseline_g: float | None = None,
@@ -179,7 +179,7 @@ def aggregate_fft_spectrum_raw(
 
 
 def spectrogram_from_peaks(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     aggregation: Literal["persistence", "max"] = "persistence",
     run_noise_baseline_g: float | None = None,
@@ -314,7 +314,7 @@ def spectrogram_from_peaks(
 
 
 def spectrogram_from_peaks_raw(
-    samples: list[Sample],
+    samples: Sequence[Sample],
     *,
     run_noise_baseline_g: float | None = None,
     peak_scan: PeakSampleScan | None = None,

--- a/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spectrogram.py
@@ -109,7 +109,7 @@ def scan_peak_samples(samples: Sequence[AnalysisSampleInput]) -> PeakSampleScan:
 def safe_percentile(sorted_vals: Sequence[float], q: float, *, default: float = 0.0) -> float:
     """Return ``percentile(sorted_vals, q)`` when possible, else a safe fallback."""
     if len(sorted_vals) >= 2:
-        return float(percentile(sorted_vals, q))
+        return float(percentile(list(sorted_vals), q))
     return sorted_vals[-1] if sorted_vals else default
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py
@@ -51,7 +51,7 @@ def _speed_stats(speed_values: Sequence[float]) -> SpeedProfileSummary:
         return SpeedProfileSummary()
     vmin = min(speed_values)
     vmax = max(speed_values)
-    vmean, var = _mean_variance(speed_values)
+    vmean, var = _mean_variance(list(speed_values))
     stddev = sqrt(var) if var is not None else 0.0
     vrange = max(0.0, vmax - vmin)
     return SpeedProfileSummary(

--- a/apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py
@@ -23,8 +23,8 @@ from vibesensor.use_cases.diagnostics.math_utils import _weighted_percentile
 
 
 def _amplitude_weighted_speed_window(
-    speeds: list[float],
-    amplitudes: list[float],
+    speeds: Sequence[float],
+    amplitudes: Sequence[float],
 ) -> tuple[float | None, float | None]:
     """Return the dominant amplitude-weighted speed bin window."""
     bin_weight: dict[str, float] = defaultdict(float)
@@ -46,7 +46,7 @@ def _amplitude_weighted_speed_window(
     return (low_kmh, low_kmh + float(SPEED_BIN_WIDTH_KMH))
 
 
-def _speed_stats(speed_values: list[float]) -> SpeedProfileSummary:
+def _speed_stats(speed_values: Sequence[float]) -> SpeedProfileSummary:
     if not speed_values:
         return SpeedProfileSummary()
     vmin = min(speed_values)
@@ -107,10 +107,10 @@ def _phase_to_str(phase: object) -> str | None:
 
 
 def _speed_profile_from_points(
-    points: list[tuple[float, float]],
+    points: Sequence[tuple[float, float]],
     *,
-    allowed_speed_bins: list[str] | tuple[str, ...] | set[str] | None = None,
-    phase_weights: list[float] | None = None,
+    allowed_speed_bins: Sequence[str] | set[str] | None = None,
+    phase_weights: Sequence[float] | None = None,
 ) -> tuple[float | None, tuple[float, float] | None, str | None]:
     allowed = set(allowed_speed_bins) if allowed_speed_bins is not None else None
 

--- a/apps/server/vibesensor/use_cases/diagnostics/top_cause_selection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/top_cause_selection.py
@@ -10,6 +10,7 @@ Core selection and ranking logic operates on domain ``Finding`` objects.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import replace as _dc_replace
 
 from vibesensor.domain import Finding, Signature, VibrationSource
@@ -20,7 +21,7 @@ from vibesensor.domain import Finding, Signature, VibrationSource
 
 
 def group_findings_by_source(
-    findings: tuple[Finding, ...],
+    findings: Sequence[Finding],
 ) -> list[tuple[float, Finding]]:
     """Group findings by source and return ranked representatives.
 
@@ -73,7 +74,7 @@ def group_findings_by_source(
 
 
 def select_top_causes(
-    findings: tuple[Finding, ...],
+    findings: Sequence[Finding],
     *,
     drop_off_points: float = 15.0,
     max_causes: int = 3,
@@ -86,7 +87,7 @@ def select_top_causes(
     if not surfaceable:
         return ()
 
-    grouped = group_findings_by_source(tuple(surfaceable))
+    grouped = group_findings_by_source(surfaceable)
     best_score_pct = grouped[0][0] * 100.0
     threshold_pct = best_score_pct - drop_off_points
 


### PR DESCRIPTION
Chunk 109 reviews these eight diagnostics files: `apps/server/vibesensor/use_cases/diagnostics/plots.py`, `run_data_preparation.py`, `signal_aggregation.py`, `spectrogram.py`, `speed_profile_helpers.py`, `statistics.py`, `summary_builder.py`, and `top_cause_selection.py`. I reviewed every code file in that slice directly before deciding what to change.

The resulting diff is behavior-preserving and focuses on pure helper contracts. Several plot-building, run-preparation, spectrogram, speed-profile, and top-cause helpers only iterate over their inputs but still required concrete mutable `list[...]` or `tuple[...]` types. I widened those read-only annotations to `Sequence[...]` (or equivalent collection shapes) so the type surface better reflects how the code actually behaves. I also added one small docstring to `build_domain_driving_segments()` to make that domain-projection boundary explicit.

Key files changed:
- `apps/server/vibesensor/use_cases/diagnostics/plots.py`
- `apps/server/vibesensor/use_cases/diagnostics/run_data_preparation.py`
- `apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py`
- `apps/server/vibesensor/use_cases/diagnostics/spectrogram.py`
- `apps/server/vibesensor/use_cases/diagnostics/speed_profile_helpers.py`
- `apps/server/vibesensor/use_cases/diagnostics/top_cause_selection.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_plot_data_phase_context.py apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_run_analysis.py apps/server/tests/use_cases/diagnostics/test_summary_pure_functions.py` (`63 passed`)
- `make lint`

Risk is low because the diff only relaxes read-only type contracts and adds a clarifying docstring. `statistics.py` and `summary_builder.py` were reviewed directly and left unchanged because no worthwhile safe cleanup was justified there.
