### PR TITLE
Repo review chunk 110: clarify order helper seams

### DIFF
--- a/apps/server/vibesensor/use_cases/diagnostics/orders/__init__.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/__init__.py
@@ -1,1 +1,5 @@
-"""Order-analysis internals for the diagnostics pipeline."""
+"""Order-analysis internals for the diagnostics pipeline.
+
+These modules stay behind the diagnostics package boundary so callers depend on
+the public diagnostics entry points instead of the order-tracking file layout.
+"""

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py
@@ -35,10 +35,11 @@ def assemble_order_finding(
     score: OrderFindingScore,
 ) -> tuple[float, DomainFinding]:
     """Build a single order finding from a scored match result."""
+    order_label = _order_label(hypothesis.order, hypothesis.order_label_base)
     ref_text = ", ".join(sorted(match.ref_sources))
     evidence = i18n_ref(
         "EVIDENCE_ORDER_TRACKED",
-        order_label=_order_label(hypothesis.order, hypothesis.order_label_base),
+        order_label=order_label,
         matched=match.matched,
         possible=match.possible,
         match_rate=context.effective_match_rate,
@@ -59,7 +60,7 @@ def assemble_order_finding(
         finding_key=hypothesis.key,
         suspected_source=hypothesis.suspected_source,
         confidence=score.confidence,
-        order=_order_label(hypothesis.order, hypothesis.order_label_base),
+        order=order_label,
         strongest_location=score.strongest_location or None,
         strongest_speed_band=phase_evidence.strongest_speed_band or None,
         kind=FindingKind.DIAGNOSTIC,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/heuristics.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/heuristics.py
@@ -11,11 +11,6 @@ from vibesensor.use_cases.diagnostics.math_utils import _mean
 from vibesensor.use_cases.diagnostics.orders.settings import ORDER_HEURISTIC_SETTINGS
 
 
-def _normalized_source(finding: DomainFinding) -> str:
-    src: str = finding.source_normalized
-    return src
-
-
 def detect_diffuse_excitation(
     connected_locations: set[str],
     possible_by_location: dict[str, int],
@@ -82,7 +77,7 @@ def suppress_engine_aliases(
         (
             finding.effective_confidence
             for _, finding in findings
-            if _normalized_source(finding) == VibrationSource.WHEEL_TIRE
+            if finding.source_normalized == VibrationSource.WHEEL_TIRE
         ),
         default=0.0,
     )
@@ -90,14 +85,14 @@ def suppress_engine_aliases(
         (
             score
             for score, finding in findings
-            if _normalized_source(finding) == VibrationSource.WHEEL_TIRE
+            if finding.source_normalized == VibrationSource.WHEEL_TIRE
         ),
         default=0.0,
     )
     if best_wheel_conf > 0:
         settings = ORDER_HEURISTIC_SETTINGS
         for index, (ranking_score, finding) in enumerate(findings):
-            if _normalized_source(finding) != VibrationSource.ENGINE:
+            if finding.source_normalized != VibrationSource.ENGINE:
                 continue
             if ranking_score >= best_wheel_ranking:
                 continue

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/physics.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/physics.py
@@ -32,6 +32,7 @@ def _wheel_hz(
     context: DiagnosticsContext | None = None,
     order_reference_spec: OrderReferenceSpec | None = None,
 ) -> float | None:
+    """Return wheel rotational frequency from speed plus optional reference data."""
     typed_sample = ensure_analysis_sample(sample)
     speed_kmh = typed_sample.speed_kmh
     if speed_kmh is None or speed_kmh <= 0:
@@ -51,6 +52,7 @@ def _driveshaft_hz(
     context: DiagnosticsContext,
     tire_circumference_m: float | None,
 ) -> float | None:
+    """Return driveshaft frequency from the best available wheel/final-drive inputs."""
     typed_sample = ensure_analysis_sample(sample)
     speed_kmh = typed_sample.speed_kmh
     spec = _order_reference_spec_from_context(context, typed_sample)
@@ -82,6 +84,7 @@ def _engine_hz(
     context: DiagnosticsContext,
     tire_circumference_m: float | None,
 ) -> tuple[float | None, str]:
+    """Return engine rotational frequency plus the source label used to derive it."""
     rpm, src = _effective_engine_rpm(
         ensure_analysis_sample(sample),
         context,
@@ -166,4 +169,5 @@ _ORDER_HYPOTHESES: tuple[OrderHypothesis, ...] = (
 
 
 def _order_hypotheses() -> tuple[OrderHypothesis, ...]:
+    """Return the static hypothesis catalog used by order-analysis sessions."""
     return _ORDER_HYPOTHESES


### PR DESCRIPTION
Chunk 110 reviews these ten order-analysis files: `apps/server/vibesensor/use_cases/diagnostics/orders/__init__.py`, `finding_builder.py`, `heuristics.py`, `match_rate.py`, `matching.py`, `physics.py`, `pipeline.py`, `scoring.py`, `settings.py`, and `statistics.py`. I reviewed every code file in that slice directly before deciding what to change.

This diff stays behavior-preserving and focuses on readability in the order-tracking seam. In `finding_builder.py`, I removed duplicate `_order_label(...)` calls by computing the label once and reusing it for both evidence text and the final domain finding. In `heuristics.py`, I dropped a trivial `_normalized_source()` wrapper and used `finding.source_normalized` directly, which makes the suppression logic easier to read without changing the rules. In `physics.py`, I added short docstrings to the wheel, driveshaft, engine, and hypothesis-catalog helpers, and in `orders/__init__.py` I expanded the package docstring so maintainers know these modules are intentionally internal behind the diagnostics entry points.

Key files changed:
- `apps/server/vibesensor/use_cases/diagnostics/orders/__init__.py`
- `apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py`
- `apps/server/vibesensor/use_cases/diagnostics/orders/heuristics.py`
- `apps/server/vibesensor/use_cases/diagnostics/orders/physics.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_order_analysis_input_regressions.py apps/server/tests/use_cases/diagnostics/test_compute_effective_match_rate.py apps/server/tests/use_cases/diagnostics/test_order_objects.py apps/server/tests/use_cases/diagnostics/test_order_scoring.py apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py` (`116 passed`)
- `make lint`

Risk is low because the changes only simplify repeated expressions and improve documentation; the remaining reviewed order modules were left unchanged where no worthwhile safe cleanup was justified.
