### PR TITLE
Repo review chunk 111: clarify peak helper seams

### DIFF
--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/__init__.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/__init__.py
@@ -1,1 +1,5 @@
-"""Peak-analysis internals for the diagnostics pipeline."""
+"""Peak-analysis internals for the diagnostics pipeline.
+
+These helpers stay behind the diagnostics findings flow and support persistent
+peak accumulation, scoring, and report-facing peak tables.
+"""

--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/findings.py
@@ -46,7 +46,7 @@ def prepare_analysis_samples(
     ]
     use_filtered_samples = len(diagnostic_samples) >= _MIN_DIAGNOSTIC_SAMPLES
     analysis_samples = diagnostic_samples if use_filtered_samples else samples
-    if analysis_samples is diagnostic_samples:
+    if use_filtered_samples:
         analysis_phases: Sequence[DrivingPhase] = [
             phase for phase, keep in zip(resolved_phases, diagnostic_mask, strict=True) if keep
         ]
@@ -151,6 +151,7 @@ class PeakFindingAnalyzer:
         *,
         run_noise_baseline_g: float | None,
     ) -> list[PeakBin]:
+        """Project accumulated peak-bin statistics into scored peak bins."""
         bins: list[PeakBin] = []
         for bin_center, amps in stats.bin_amps.items():
             if any(abs(bin_center - of) < self._freq_bin_hz for of in self._order_finding_freqs):
@@ -175,6 +176,7 @@ class PeakFindingAnalyzer:
 
     @staticmethod
     def _select_top_findings(bins: list[PeakBin], *, n_samples: int) -> list[DomainFinding]:
+        """Rank persistent bins ahead of transient bins and export the top findings."""
         del n_samples
         persistent: list[tuple[float, PeakBin]] = []
         transient: list[tuple[float, PeakBin]] = []

--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py
@@ -29,6 +29,7 @@ def _presence_ratio_with_location_rescue(
     total_location_sample_counts: Mapping[str, int],
     loc_counts_for_bin: Mapping[str, int],
 ) -> float:
+    """Rescue sparse global presence when one well-sampled location stays consistent."""
     presence = count / max(1, n_samples)
     settings = PEAK_CONFIDENCE_SETTINGS
     if total_location_sample_counts and loc_counts_for_bin:
@@ -50,6 +51,7 @@ def _compute_peak_confidence(
     has_location_counts: bool,
     peak_strength_db: float,
 ) -> float:
+    """Apply the shared confidence policy for classified peak bins."""
     settings = PEAK_CONFIDENCE_SETTINGS
     snr_score = min(1.0, log1p(raw_snr) / SNR_LOG_DIVISOR)
     spatial_penalty = (

--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/statistics.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/statistics.py
@@ -10,6 +10,7 @@ from vibesensor.vibration_strength import percentile
 
 
 def _safe_percentile(sorted_vals: Sequence[float], q: float, *, default: float = 0.0) -> float:
+    """Return a percentile for sorted input while tolerating empty and singleton cases."""
     if len(sorted_vals) >= 2:
         return float(percentile(list(sorted_vals), q))
     return float(sorted_vals[-1]) if sorted_vals else default


### PR DESCRIPTION
Chunk 111 reviews these nine diagnostics peak files: `apps/server/vibesensor/use_cases/diagnostics/peaks/__init__.py`, `accumulation.py`, `classification.py`, `finding_builder.py`, `findings.py`, `scoring.py`, `settings.py`, `statistics.py`, and `table.py`. I read every code file in that slice directly before deciding what to change.

The resulting diff stays behavior-preserving and focuses on small maintainability seams inside the peaks subpackage. In `findings.py`, I replaced an identity comparison with the already-computed `use_filtered_samples` flag so the filtered-phase path reads directly as intent instead of relying on object identity. I also added short docstrings to the internal bin-scoring and top-selection helpers there. In `scoring.py` and `statistics.py`, I documented the location-rescue, confidence, and safe-percentile helpers so their policy roles are clearer during future diagnostics work. Finally, `peaks/__init__.py` now explains that this package is an internal support layer behind the diagnostics findings flow.

Key files changed:
- `apps/server/vibesensor/use_cases/diagnostics/peaks/__init__.py`
- `apps/server/vibesensor/use_cases/diagnostics/peaks/findings.py`
- `apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py`
- `apps/server/vibesensor/use_cases/diagnostics/peaks/statistics.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/diagnostics/test_peak_classification.py apps/server/tests/use_cases/diagnostics/test_peak_scoring.py apps/server/tests/use_cases/diagnostics/test_finding_objects.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/adapters/pdf/test_report_persistence_classification.py` (`82 passed`)
- `make lint`

Risk is low because the functional logic and thresholds are unchanged; the remaining reviewed peak modules were left alone where no worthwhile behavior-preserving cleanup stood out.
