### PR TITLE
Repo review chunk 112: clarify history report helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/history/report_cache.py
+++ b/apps/server/vibesensor/use_cases/history/report_cache.py
@@ -25,6 +25,7 @@ class HistoryReportPdfCache:
         self._locks: dict[ReportPdfCacheKey, asyncio.Lock] = {}
 
     def get(self, cache_key: ReportPdfCacheKey) -> bytes | None:
+        """Return a cached PDF and refresh its LRU position."""
         cached_pdf = self._entries.get(cache_key)
         if cached_pdf is None:
             return None
@@ -38,6 +39,7 @@ class HistoryReportPdfCache:
         *,
         run_id: str,
     ) -> bytes:
+        """Reuse or build a cached PDF while serializing concurrent builds per key."""
         build_lock = self._locks.setdefault(cache_key, asyncio.Lock())
         async with build_lock:
             cached_pdf = self.get(cache_key)
@@ -56,6 +58,7 @@ class HistoryReportPdfCache:
             return pdf
 
     def _put(self, cache_key: ReportPdfCacheKey, pdf: bytes) -> None:
+        """Insert a PDF into the LRU cache and prune related coordination state."""
         self._entries[cache_key] = pdf
         self._entries.move_to_end(cache_key)
         while len(self._entries) > REPORT_PDF_CACHE_MAX_ENTRIES:
@@ -64,6 +67,7 @@ class HistoryReportPdfCache:
         self._prune_stale_locks()
 
     def _prune_stale_locks(self) -> None:
+        """Drop unlocked coordination locks whose cache entries were already evicted."""
         if len(self._locks) > REPORT_PDF_CACHE_MAX_ENTRIES * 2:
             stale_keys = [
                 key

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -61,17 +61,18 @@ class HistoryReportRequestLoader:
             raise AnalysisNotReadyError("No analysis available for this run")
 
         requested_lang = self._analysis_language(run, requested_lang)
+        report_language = self._report_pdf_cache_lang(run, requested_lang)
         raw_warnings = analysis.get("warnings")
         warnings = raw_warnings if is_json_array(raw_warnings) else None
         cache_key = self._report_pdf_cache_key(
             run,
             run_id,
-            self._report_pdf_cache_lang(run, requested_lang),
+            report_language,
         )
         return HistoryReportRequest(
             cache_key=cache_key,
             filename=f"{safe_filename(run_id)}_report.pdf",
-            language=self._report_pdf_cache_lang(run, requested_lang),
+            language=report_language,
             analysis=analysis,
             warnings=warnings,
         )

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 
 
 def _default_report_filename(payload: Mapping[str, object]) -> str:
+    """Derive the default PDF filename from stable report-identifying payload fields."""
     run_id = str(payload.get("run_id") or payload.get("file_name") or "report")
     return f"{safe_filename(run_id)}_report.pdf"
 
@@ -151,6 +152,7 @@ def validate_prepared_report_input(
 
 
 def _reconstruct_report_test_run(payload: Mapping[str, object]) -> TestRun | None:
+    """Rebuild the report domain aggregate only when the payload is projectable."""
     if not has_projectable_report_payload(payload):
         return None
     return test_run_from_summary(payload)
@@ -162,6 +164,7 @@ def _prepare_report_facts(
     test_run: TestRun,
     warnings: RunContextWarningsInput = None,
 ) -> PreparedReportFacts:
+    """Resolve the semantic report facts shared by downstream PDF mapping."""
     metadata = summary_metadata(payload)
     sensor_locations_active = active_sensor_locations(payload)
     origin = resolve_report_origin(test_run)
@@ -212,6 +215,7 @@ def _build_prepared_report_input(
     cache_key: ReportPdfCacheKey | None,
     warnings: RunContextWarningsInput = None,
 ) -> PreparedReportInput:
+    """Assemble the canonical history-side report handoff for PDF rendering."""
     domain_test_run = _reconstruct_report_test_run(payload)
     prepared_language = str(normalize_lang(language or payload.get("lang")))
     renderer_payload = build_report_renderer_payload(payload)


### PR DESCRIPTION
Chunk 112 reviews these eight history-service files: `apps/server/vibesensor/use_cases/history/__init__.py`, `exports.py`, `helpers.py`, `report_cache.py`, `report_loader.py`, `report_preparation.py`, `reports.py`, and `runs.py`. I read every code file in that slice directly before deciding what to change.

This diff stays behavior-preserving and focuses on small readability improvements in the persisted-report path. In `report_loader.py`, I removed a duplicate call to `_report_pdf_cache_lang(...)` by resolving the report language once and reusing it for both the cache key and the outward request object. That keeps the language resolution path explicit without changing the chosen locale. In `report_cache.py`, I added short docstrings to the cache access/build/prune helpers so the LRU plus per-key lock coordination is easier to follow. In `report_preparation.py`, I documented the internal filename, reconstruction, fact-building, and handoff assembly helpers for the same reason.

Key files changed:
- `apps/server/vibesensor/use_cases/history/report_cache.py`
- `apps/server/vibesensor/use_cases/history/report_loader.py`
- `apps/server/vibesensor/use_cases/history/report_preparation.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/use_cases/history/test_history_async_offloading.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py` (`40 passed`)
- `make lint`

Risk is low because the runtime behavior is unchanged; the remaining reviewed history modules were left untouched where no safe maintainability win stood out.
