### PR TITLE
Repo review chunk 113: clarify run helper seams

### DIFF
--- a/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_runtime.py
@@ -52,6 +52,7 @@ def active_frames_total(registry: ClientTracker) -> int:
 
 
 def _is_tick_error_message(message: str | None) -> bool:
+    """Return whether a write error came from the periodic runtime tick path."""
     return message == _DB_TIMEOUT_ERROR or bool(
         message and message.startswith(_TICK_FAILURE_PREFIX),
     )
@@ -62,6 +63,7 @@ def _flush_active_run_tick(
     *,
     logger: logging.Logger,
 ) -> tuple[str | None, bool]:
+    """Flush one active-run tick without holding the recorder lock during I/O-heavy work."""
     with recorder._lock:
         snapshot = recorder._lifecycle.snapshot()
         if snapshot is None:

--- a/apps/server/vibesensor/use_cases/run/lifecycle_state.py
+++ b/apps/server/vibesensor/use_cases/run/lifecycle_state.py
@@ -106,11 +106,7 @@ class RunLifecycleState:
                 return None
         elif current_total <= self.start_frames_total:
             return None
-        return ActiveRunSnapshot(
-            run_id=run_id,
-            start_time_utc=self.start_time_utc,
-            start_mono_s=self.start_mono_s,
-        )
+        return self.snapshot()
 
     def should_drop_prebuilt_rows(
         self,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -38,6 +38,8 @@ class PostAnalysisRunner(Protocol):
 
 
 class PostAnalysisLoader(Protocol):
+    """Injected boundary for loading metadata and samples for a completed run."""
+
     def __call__(
         self,
         *,
@@ -96,6 +98,7 @@ PostAnalysisAttemptResult = PostAnalysisExecutionResult | PostAnalysisExecutionR
 
 
 def is_retryable_post_analysis_error(exc: Exception) -> bool:
+    """Return whether a post-analysis exception should be retried before storing failure."""
     return isinstance(exc, (sqlite3.Error, OSError, MemoryError))
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_loader.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import ceil
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -39,9 +40,10 @@ PostAnalysisLoadResult = (
 
 
 def _sample_stride(total_sample_count: int) -> int:
+    """Return the minimum stride that keeps bounded post-analysis under the sample cap."""
     if total_sample_count <= _MAX_POST_ANALYSIS_SAMPLES:
         return 1
-    return -(-total_sample_count // _MAX_POST_ANALYSIS_SAMPLES)
+    return ceil(total_sample_count / _MAX_POST_ANALYSIS_SAMPLES)
 
 
 def load_post_analysis_run(

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -101,6 +101,7 @@ def build_post_analysis_summary(
 
 
 def _post_analysis_sample_rate_hz(metadata: RunMetadata) -> int | None:
+    """Resolve the sample rate used for duration checks from canonical or extra metadata."""
     raw_sample_rate_hz = metadata.raw_sample_rate_hz
     if raw_sample_rate_hz is not None and raw_sample_rate_hz > 0:
         return raw_sample_rate_hz


### PR DESCRIPTION
Chunk 113 reviews these ten run-layer files: `apps/server/vibesensor/use_cases/run/__init__.py`, `_recorder_runtime.py`, `_recorder_types.py`, `lifecycle_state.py`, `logger.py`, `persistence_writer.py`, `post_analysis.py`, `post_analysis_executor.py`, `post_analysis_loader.py`, and `post_analysis_summary.py`. I read every code file in that slice directly before deciding what to change.

This diff stays behavior-preserving and focuses on small helper-level clarity improvements. In `lifecycle_state.py`, `pending_flush_snapshot()` now reuses `snapshot()` once its extra flush guards pass instead of rebuilding the same `ActiveRunSnapshot` inline. In `post_analysis_loader.py`, I replaced the ceiling-division trick with `math.ceil(...)`, which is easier to read while preserving the exact stride calculation. I also added short docstrings to a few private/internal helpers and protocol seams in `_recorder_runtime.py`, `post_analysis_executor.py`, and `post_analysis_summary.py` so their intent is clearer during future maintenance.

Key files changed:
- `apps/server/vibesensor/use_cases/run/lifecycle_state.py`
- `apps/server/vibesensor/use_cases/run/_recorder_runtime.py`
- `apps/server/vibesensor/use_cases/run/post_analysis_loader.py`
- `apps/server/vibesensor/use_cases/run/post_analysis_executor.py`
- `apps/server/vibesensor/use_cases/run/post_analysis_summary.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/run/test_lifecycle_state.py apps/server/tests/use_cases/run/test_post_analysis_loader.py apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_recorder_runtime.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py` (`50 passed`)
- `make lint`

Risk is low because the logic, thresholds, and control flow remain unchanged; the remaining reviewed run modules were left alone where no safe maintainability win stood out.
