### PR TITLE
Repo review chunk 114: clarify remaining run helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/run/run_context.py
+++ b/apps/server/vibesensor/use_cases/run/run_context.py
@@ -118,9 +118,9 @@ def _build_car_settings_changed_warning(
 
 def _normalized_aspects(snapshot: CarSnapshot) -> tuple[tuple[str, float], ...]:
     normalized = [
-        (key, float(value))
+        (key, numeric_value)
         for key, value in snapshot.aspects.items()
-        if isinstance(key, str) and _as_float(value) is not None
+        if isinstance(key, str) and (numeric_value := _as_float(value)) is not None
     ]
     return tuple(sorted(normalized))
 

--- a/apps/server/vibesensor/use_cases/run/sample_flush.py
+++ b/apps/server/vibesensor/use_cases/run/sample_flush.py
@@ -60,6 +60,7 @@ class SampleFlushOrchestrator:
         self._timestamp_utc = timestamp_utc
 
     def _refresh_recent_client_metrics(self) -> None:
+        """Refresh metrics only for clients that still have recent live samples."""
         active_client_ids = self._registry.active_client_ids()
         recent_client_ids = sorted(
             set(

--- a/apps/server/vibesensor/use_cases/run/status_reporting.py
+++ b/apps/server/vibesensor/use_cases/run/status_reporting.py
@@ -38,6 +38,7 @@ def build_run_recorder_status(
     persistence: RunPersistenceWriter,
     post_analysis: PostAnalysisWorker,
 ) -> RunRecorderStatusSnapshot:
+    """Build the compact status snapshot exposed by recorder-facing APIs."""
     post_snapshot = post_analysis.snapshot()
     persist = persistence.status_snapshot()
     return RunRecorderStatusSnapshot(
@@ -59,6 +60,7 @@ def build_run_recorder_health_snapshot(
     post_analysis: PostAnalysisWorker,
     logger: logging.Logger,
 ) -> RunRecorderHealthSnapshot:
+    """Build the richer health snapshot used by diagnostics and monitoring surfaces."""
     snapshot = post_analysis.snapshot()
     analysis_elapsed_s = None
     if snapshot.active_started_at is not None:


### PR DESCRIPTION
Chunk 114 reviews the remaining four run-helper files: `apps/server/vibesensor/use_cases/run/run_context.py`, `sample_builder.py`, `sample_flush.py`, and `status_reporting.py`. I read every code file in that slice directly before deciding what to change.

This diff stays behavior-preserving and focuses on the smallest maintainability seams left in the run package. In `run_context.py`, `_normalized_aspects()` no longer calls both `_as_float(...)` and `float(...)` for the same accepted value; it now reuses the normalized numeric result directly, which avoids duplicate conversion while preserving the exact comparison behavior. In `sample_flush.py`, I added a short docstring to the recent-client refresh helper so its scope is explicit when reading the stop/flush path. In `status_reporting.py`, I documented the compact status builder and the richer health-snapshot builder so their different audiences are easier to recognize during maintenance.

Key files changed:
- `apps/server/vibesensor/use_cases/run/run_context.py`
- `apps/server/vibesensor/use_cases/run/sample_flush.py`
- `apps/server/vibesensor/use_cases/run/status_reporting.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/run/test_run_context.py apps/server/tests/use_cases/run/test_run_context_temporal_isolation.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_recorder_runtime.py` (`37 passed`)
- `make lint`

Risk is low because the functional control flow is unchanged; `sample_builder.py` was reviewed directly and left untouched because it was already clear and cohesive.
