### PR TITLE
Repo review chunk 115: clarify updater helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/artifact_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/artifact_validation.py
@@ -39,6 +39,7 @@ class WheelMetadata:
 
 
 def _metadata_message_from_archive(wheel_zip: zipfile.ZipFile) -> Message:
+    """Return the parsed ``METADATA`` message stored inside a wheel archive."""
     metadata_name = next(
         (name for name in wheel_zip.namelist() if name.endswith(".dist-info/METADATA")),
         "",
@@ -53,6 +54,7 @@ def _metadata_message_from_archive(wheel_zip: zipfile.ZipFile) -> Message:
 
 
 def _parse_metadata_message(message: Message) -> WheelMetadata:
+    """Project the raw metadata message into the small updater-facing model."""
     return WheelMetadata(
         name=(message.get("Name") or "").strip(),
         version=(message.get("Version") or "").strip(),
@@ -77,6 +79,7 @@ def wheel_metadata_validation_errors(
     expected_name: str | None = None,
     expected_version: str | None = None,
 ) -> list[str]:
+    """Return human-readable wheel metadata problems for validation/reporting."""
     try:
         metadata = read_wheel_metadata(wheel_path)
     except (OSError, ValueError, zipfile.BadZipFile) as exc:
@@ -193,6 +196,7 @@ class WheelArtifactValidator:
         fatal: bool,
         expected_sha256: str | None = None,
     ) -> bool:
+        """Validate a wheel file and report any failure through the tracker."""
         if not wheel_path.is_file():
             self._report_failure(
                 phase=phase,
@@ -273,6 +277,7 @@ class WheelArtifactValidator:
 
 
 def sha256_file(path: Path) -> str:
+    """Hash a file as lowercase SHA-256 without loading it fully into memory."""
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):

--- a/apps/server/vibesensor/use_cases/updates/installer.py
+++ b/apps/server/vibesensor/use_cases/updates/installer.py
@@ -62,6 +62,12 @@ _TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
 )
 
 
+def _rollback_wheel_version(wheel_path: Path) -> str:
+    """Extract the version token from a rollback wheel filename when present."""
+    wheel_parts = wheel_path.stem.split("-")
+    return wheel_parts[1] if len(wheel_parts) >= 2 else ""
+
+
 class UpdateInstaller:
     """Owns install, rollback snapshot orchestration, and rollback execution."""
 
@@ -409,18 +415,14 @@ class UpdateInstaller:
             for fallback_wheel in rollback_wheels:
                 if fallback_wheel.name == metadata.wheel_name:
                     continue
-                wheel_parts = fallback_wheel.stem.split("-")
-                fallback_version = wheel_parts[1] if len(wheel_parts) >= 2 else ""
-                candidates.append((fallback_wheel, fallback_version, None))
+                candidates.append((fallback_wheel, _rollback_wheel_version(fallback_wheel), None))
         else:
             self._tracker.log(
                 "Rollback metadata missing; falling back to newest "
                 "rollback wheel without checksum pin",
             )
             for fallback_wheel in rollback_wheels:
-                wheel_parts = fallback_wheel.stem.split("-")
-                fallback_version = wheel_parts[1] if len(wheel_parts) >= 2 else ""
-                candidates.append((fallback_wheel, fallback_version, None))
+                candidates.append((fallback_wheel, _rollback_wheel_version(fallback_wheel), None))
 
         for idx, (candidate_wheel, candidate_version, candidate_sha256) in enumerate(candidates):
             if not candidate_wheel.is_file():

--- a/apps/server/vibesensor/use_cases/updates/job_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/job_executor.py
@@ -28,6 +28,7 @@ class UpdateJobExecutor:
         return self._task
 
     def cancel_requested(self) -> bool:
+        """Return whether cancellation has been requested for the active job."""
         return self._cancel_event.is_set()
 
     def start(
@@ -36,6 +37,7 @@ class UpdateJobExecutor:
         *,
         before_start: BeforeStartCallback | None = None,
     ) -> None:
+        """Start a new update task after running any synchronous pre-start hook."""
         if self._task is not None and not self._task.done():
             raise UpdateError("Update already in progress", status="conflict")
         self._cancel_event.clear()
@@ -47,6 +49,7 @@ class UpdateJobExecutor:
         )
 
     def cancel(self) -> bool:
+        """Request cancellation for the active task and signal the cancel event."""
         if self._task is None or self._task.done():
             return False
         self._cancel_event.set()
@@ -64,6 +67,7 @@ class UpdateJobExecutor:
         cleanup: CleanupCallback,
         on_cancelled_cleanup_error: VoidCallback,
     ) -> None:
+        """Run the workflow with timeout/cancel handling and guaranteed cleanup."""
         cancelled = False
         try:
             await asyncio.wait_for(workflow_factory(), timeout=timeout_s)

--- a/apps/server/vibesensor/use_cases/updates/models.py
+++ b/apps/server/vibesensor/use_cases/updates/models.py
@@ -18,11 +18,15 @@ _PASSWORD_MAX_LEN = 128
 
 @dataclass(frozen=True, slots=True)
 class UpdateValidationConfig:
+    """Runtime prerequisites needed before an update job can proceed."""
+
     rollback_dir: Path
     min_free_disk_bytes: int
 
 
 def _coerce_update_state(value: object) -> UpdateState:
+    """Best-effort decode of persisted state values, defaulting to idle."""
+
     if not isinstance(value, str):
         return UpdateState.idle
     try:
@@ -32,6 +36,8 @@ def _coerce_update_state(value: object) -> UpdateState:
 
 
 def _coerce_update_phase(value: object) -> UpdatePhase:
+    """Best-effort decode of persisted phase values, defaulting to idle."""
+
     if not isinstance(value, str):
         return UpdatePhase.idle
     try:
@@ -131,6 +137,8 @@ class UpdateJobStatusPayload(TypedDict):
 
 
 def _coerce_bool(value: object) -> bool:
+    """Decode loosely typed persisted booleans used by status payloads."""
+
     if isinstance(value, bool):
         return value
     if isinstance(value, (int, float)):

--- a/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
@@ -33,9 +33,13 @@ class RollbackSnapshotStore:
         self._tracker = tracker
 
     def _metadata_path(self) -> Path:
+        """Return the canonical JSON metadata path for rollback snapshot state."""
+
         return self._rollback_dir / _ROLLBACK_METADATA_FILE
 
     def write_metadata(self, metadata: RollbackSnapshotMetadata) -> None:
+        """Atomically persist rollback metadata alongside stored wheels."""
+
         self._rollback_dir.mkdir(parents=True, exist_ok=True)
         payload = (
             json.dumps(
@@ -65,6 +69,8 @@ class RollbackSnapshotStore:
             temp_path.unlink(missing_ok=True)
 
     def rollback_wheels(self) -> list[Path]:
+        """Return rollback wheels newest-first by modification time."""
+
         return sorted(
             self._rollback_dir.glob("vibesensor-*.whl"),
             key=lambda path: path.stat().st_mtime,
@@ -72,6 +78,8 @@ class RollbackSnapshotStore:
         )
 
     def prune_wheels(self, *, keep_name: str) -> None:
+        """Keep the current rollback wheel plus the newest fallback candidate."""
+
         wheels = self.rollback_wheels()
         keep_names = {keep_name}
         for old_wheel in wheels:
@@ -85,6 +93,8 @@ class RollbackSnapshotStore:
                 old_wheel.unlink(missing_ok=True)
 
     def load_metadata(self) -> RollbackSnapshotMetadata | None:
+        """Load rollback metadata, reporting unreadable or incomplete state."""
+
         metadata_path = self._metadata_path()
         if not metadata_path.is_file():
             return None


### PR DESCRIPTION
Chunk 115 reviews these ten updater files directly: `apps/server/vibesensor/use_cases/updates/__init__.py`, `artifact_validation.py`, `installer.py`, `job_executor.py`, `job_lifecycle.py`, `manager.py`, `models.py`, `recovery.py`, `rollback_snapshot.py`, and `runner.py`. I inspected every code file in this chunk before deciding what to change.

The resulting diff stays behavior-preserving and focuses on maintainer clarity. In `artifact_validation.py`, I documented the wheel-metadata parsing, validation, and checksum helpers so the updater’s wheel checks are easier to follow. In `installer.py`, I extracted a tiny `_rollback_wheel_version()` helper to remove repeated filename parsing in rollback candidate assembly. In `job_executor.py`, I documented the public lifecycle methods so the cancellation and cleanup contract is explicit. In `models.py` and `rollback_snapshot.py`, I added short docstrings around coercion, validation-config, and rollback-storage helpers that are otherwise easy to misread when debugging persisted updater state.

Key files changed:
- `apps/server/vibesensor/use_cases/updates/artifact_validation.py`
- `apps/server/vibesensor/use_cases/updates/installer.py`
- `apps/server/vibesensor/use_cases/updates/job_executor.py`
- `apps/server/vibesensor/use_cases/updates/models.py`
- `apps/server/vibesensor/use_cases/updates/rollback_snapshot.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/test_update_job_executor.py apps/server/tests/use_cases/updates/test_validate_update_request.py apps/server/tests/use_cases/updates/test_update_state_persistence.py apps/server/tests/use_cases/updates/test_interrupted_recovery.py` (`56 passed`)
- `make lint`

Risk is low: no updater control flow or external contract changed, and the remaining reviewed files were left untouched because they were already cohesive.
