### PR TITLE
Repo review chunk 116: clarify updater workflow helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/status.py
+++ b/apps/server/vibesensor/use_cases/updates/status.py
@@ -31,6 +31,8 @@ _LOG_TAIL_TRIM_TO = 100
 
 
 def _phase_name(phase: UpdatePhase | str) -> str:
+    """Normalize enum-backed phases to their persisted string representation."""
+
     return phase.value if isinstance(phase, UpdatePhase) else phase
 
 
@@ -54,6 +56,8 @@ class UpdateStatusTracker:
         return self._status
 
     def persist(self) -> None:
+        """Flush the current in-memory status snapshot to the state store."""
+
         self._state_store.save(self._status)
 
     def _touch(self, *, phase_changed: bool = False) -> float:
@@ -101,6 +105,8 @@ class UpdateStatusTracker:
         return redacted
 
     def redacted_args(self, args: list[str], sensitive_keys: set[str]) -> list[str]:
+        """Redact positional values that follow sensitive command-line flags."""
+
         redacted: list[str] = []
         hide_next = False
         for raw_arg in args:
@@ -175,6 +181,8 @@ class UpdateStatusTracker:
         self.persist()
 
     def finish_cleanup(self) -> None:
+        """Finalize status after cleanup, preserving successful end states."""
+
         now = time.time()
         self._status.finished_at = self._status.finished_at or now
         if self._status.state == UpdateState.running:

--- a/apps/server/vibesensor/use_cases/updates/validation.py
+++ b/apps/server/vibesensor/use_cases/updates/validation.py
@@ -15,6 +15,8 @@ MIN_FREE_DISK_BYTES = 200 * 1024 * 1024
 
 
 def _probe_rollback_dir(rollback_dir: Path) -> None:
+    """Verify that the rollback directory exists and accepts a small temp file."""
+
     rollback_dir.mkdir(parents=True, exist_ok=True)
     probe_handle = tempfile.NamedTemporaryFile(
         prefix=".rollback-write-probe-",
@@ -28,6 +30,15 @@ def _probe_rollback_dir(rollback_dir: Path) -> None:
     finally:
         probe_handle.close()
     probe_path.unlink(missing_ok=True)
+
+
+def _disk_check_path(rollback_dir: Path) -> Path:
+    """Choose the filesystem whose free space should gate update work."""
+
+    disk_check_path = rollback_dir.parent
+    if not disk_check_path.exists():
+        return Path("/var/lib") if Path("/var/lib").exists() else Path("/")
+    return disk_check_path
 
 
 async def validate_prerequisites(
@@ -71,9 +82,7 @@ async def validate_prerequisites(
         return False
 
     try:
-        disk_check_path = config.rollback_dir.parent
-        if not disk_check_path.exists():
-            disk_check_path = Path("/var/lib") if Path("/var/lib").exists() else Path("/")
+        disk_check_path = _disk_check_path(config.rollback_dir)
         free_bytes = shutil.disk_usage(disk_check_path).free
         if free_bytes < config.min_free_disk_bytes:
             free_mb = free_bytes // (1024 * 1024)

--- a/apps/server/vibesensor/use_cases/updates/venv_paths.py
+++ b/apps/server/vibesensor/use_cases/updates/venv_paths.py
@@ -14,14 +14,20 @@ __all__ = [
 
 
 def reinstall_venv_python_path(repo: Path) -> Path:
+    """Return the updater reinstall venv's expected Python interpreter path."""
+
     return repo / "apps" / "server" / ".venv" / "bin" / "python3"
 
 
 def reinstall_venv_config_path(repo: Path) -> Path:
+    """Return the updater reinstall venv's ``pyvenv.cfg`` path."""
+
     return repo / "apps" / "server" / ".venv" / "pyvenv.cfg"
 
 
 def is_reinstall_venv_ready(repo: Path) -> bool:
+    """Report whether the reinstall venv looks executable and configured."""
+
     venv_python = reinstall_venv_python_path(repo)
     if not (venv_python.is_file() and os.access(venv_python, os.X_OK)):
         return False
@@ -29,4 +35,6 @@ def is_reinstall_venv_ready(repo: Path) -> bool:
 
 
 def reinstall_python_executable(repo: Path) -> str:
+    """Return the string form expected by subprocess-based installer calls."""
+
     return str(reinstall_venv_python_path(repo))

--- a/apps/server/vibesensor/use_cases/updates/workflow.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow.py
@@ -87,6 +87,8 @@ class UpdateWorkflow:
     # ------------------------------------------------------------------
 
     async def _validate(self, request: UpdateRequest) -> bool:
+        """Run prerequisite validation before any network or install mutation."""
+
         if not await validate_prerequisites(
             commands=self._commands,
             tracker=self._tracker,
@@ -136,6 +138,8 @@ class UpdateWorkflow:
         current_version: str,
         latest_tag: str,
     ) -> None:
+        """Finish successfully when only the ESP firmware refresh still matters."""
+
         self._tracker.log(f"Already up-to-date (version={current_version})")
         await self._firmware_refresher.refresh_esp_firmware(pinned_tag=latest_tag)
         if self._cancelled():
@@ -145,6 +149,8 @@ class UpdateWorkflow:
         )
 
     async def _download_and_install(self, release_check: UpdateReleaseCheck) -> None:
+        """Download, verify, and install a newly discovered server release."""
+
         release = release_check.release
         assert release is not None  # noqa: S101
         self._tracker.transition(UpdatePhase.downloading)
@@ -177,6 +183,8 @@ class UpdateWorkflow:
         await self._finalize()
 
     async def _install(self, wheel_path: Path, version: str) -> bool:
+        """Create rollback state before mutating the live server environment."""
+
         self._tracker.transition(UpdatePhase.installing)
         self._tracker.log("Installing update...")
         if not await self._installer.snapshot_for_rollback():
@@ -189,6 +197,8 @@ class UpdateWorkflow:
         return await self._installer.install_release(wheel_path, version)
 
     async def _finalize(self) -> None:
+        """Restore normal runtime state and schedule the backend restart."""
+
         if not await self._wifi.complete_update_success("Update completed successfully"):
             return
         if await schedule_service_restart(
@@ -210,6 +220,8 @@ class UpdateWorkflow:
     # ------------------------------------------------------------------
 
     def _cancelled(self) -> bool:
+        """Centralize the workflow's cancellation check for phase handlers."""
+
         return self._cancel_requested()
 
 


### PR DESCRIPTION
Chunk 116 reviews the remaining four updater files directly: `apps/server/vibesensor/use_cases/updates/status.py`, `validation.py`, `venv_paths.py`, and `workflow.py`. I read every code file in this chunk before deciding what to change.

This diff remains behavior-preserving and focuses on helper clarity in the updater runtime path. In `status.py`, I documented the small persistence/redaction helpers that control how phases are normalized, arguments are scrubbed, and cleanup completion is persisted. In `validation.py`, I documented the rollback-directory probe and extracted `_disk_check_path()` so the free-space gate uses one named helper instead of inline fallback logic. In `venv_paths.py`, I documented each reinstall-venv helper so its intended contract is obvious at call sites. In `workflow.py`, I added short docstrings to the private phase handlers and the centralized cancellation helper so the update flow is easier to follow when debugging release, install, and restart behavior.

Key files changed:
- `apps/server/vibesensor/use_cases/updates/status.py`
- `apps/server/vibesensor/use_cases/updates/validation.py`
- `apps/server/vibesensor/use_cases/updates/venv_paths.py`
- `apps/server/vibesensor/use_cases/updates/workflow.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates` (`205 passed`)
- `make lint`

Risk is low: there are no contract or control-flow changes, only helper extraction plus documentation around already-covered updater paths.
