### PR TITLE
Repo review chunk 117: clarify firmware flash helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_manager.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_manager.py
@@ -34,12 +34,13 @@ LOGGER = logging.getLogger(__name__)
 _FLASH_HISTORY_LIMIT = 10
 _FLASH_STEP_TIMEOUT_S = 90
 _FLASH_LOG_MAX_LINES: int = 2000
-"""Maximum number of log lines retained for a single flash job."""
 _FLASH_LOG_TRIM_TO: int = 1000
-"""Number of most-recent log lines to keep after the log buffer is trimmed."""
+# Retain a bounded flash log buffer while keeping enough recent context for polling.
 
 
 def _esptool_base_cmd() -> list[str] | None:
+    """Return the preferred esptool invocation, or ``None`` when unavailable."""
+
     esptool = shutil.which("esptool.py")
     if esptool:
         return [esptool]
@@ -82,10 +83,14 @@ class EspFlashManager:
         return self._task
 
     async def list_ports(self) -> list[SerialPortInfoDict]:
+        """List currently detected serial ports in API-response form."""
+
         ports = await self._ports.list_ports()
         return [p.to_dict() for p in ports]
 
     def start(self, *, port: str | None, auto_detect: bool) -> int:
+        """Start a new flash job and return its monotonically increasing job id."""
+
         if self._task is not None and not self._task.done():
             raise UpdateError("Flash already in progress", status="conflict")
         self._job_counter += 1
@@ -104,12 +109,16 @@ class EspFlashManager:
         return self._job_counter
 
     def cancel(self) -> bool:
+        """Request cancellation for the active flash job, if one exists."""
+
         if self._task is None or self._task.done():
             return False
         self._cancel_event.set()
         return True
 
     def logs_since(self, after: int) -> FlashLogResponse:
+        """Return the retained flash log lines strictly after the requested index."""
+
         start = max(0, after)
         return FlashLogResponse(
             from_index=start,
@@ -118,9 +127,13 @@ class EspFlashManager:
         )
 
     def history(self) -> list[EspFlashHistoryEntryDict]:
+        """Return completed flash attempts newest-first for the HTTP API."""
+
         return [entry.to_dict() for entry in self._history]
 
     def _append_log(self, line: str) -> None:
+        """Append one log line while enforcing the bounded in-memory log buffer."""
+
         self._logs.append(line)
         if len(self._logs) > _FLASH_LOG_MAX_LINES:
             del self._logs[:-_FLASH_LOG_TRIM_TO]
@@ -135,6 +148,8 @@ class EspFlashManager:
         cwd: Path,
         timeout_s: float = _FLASH_STEP_TIMEOUT_S,
     ) -> int:
+        """Run one esptool phase, streaming its output into the job log."""
+
         self._status.phase = phase
         self._append_log(f"$ {' '.join(args)}")
         rc = await self._runner.run(
@@ -157,6 +172,8 @@ class EspFlashManager:
         return True
 
     def _finalize(self, *, state: EspFlashState, error: str | None = None) -> None:
+        """Store terminal job state and append a bounded history entry."""
+
         self._status.state = state
         self._status.error = error
         self._status.finished_at = time.time()

--- a/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py
@@ -27,6 +27,8 @@ class SubprocessFlashCommandRunner(FlashCommandRunner):
         cancel_event: asyncio.Event,
         timeout_s: float | None = None,
     ) -> int:
+        """Run one flash subprocess, streaming lines until exit, cancel, or timeout."""
+
         proc = await asyncio.create_subprocess_exec(
             *args,
             cwd=cwd,

--- a/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_types.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_types.py
@@ -144,6 +144,8 @@ class EspFlashStatus:
     log_count: int = 0
 
     def to_dict(self) -> EspFlashStatusDict:
+        """Serialise the live flash-manager status for API responses."""
+
         return EspFlashStatusDict(
             state=self.state.value,
             phase=self.phase,

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py
@@ -30,6 +30,8 @@ class FirmwareRefresher:
         self._timeout_s = timeout_s
 
     async def refresh_esp_firmware(self, pinned_tag: str = "") -> None:
+        """Refresh the firmware cache, falling back to the current cache on failure."""
+
         self._tracker.log("Refreshing ESP firmware cache...")
         venv_python = reinstall_python_executable(self._repo)
         refresh_exe = str(Path(venv_python).with_name("vibesensor-fw-refresh"))

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
@@ -36,6 +36,8 @@ _FW_ASSET_SUFFIX = ".zip"
 
 
 def _coerce_release_asset_payload(raw: JsonObject) -> GitHubReleaseAssetPayload:
+    """Project a raw GitHub asset JSON object into the updater payload shape."""
+
     payload: GitHubReleaseAssetPayload = {}
     name = raw.get("name")
     url = raw.get("url")
@@ -47,6 +49,8 @@ def _coerce_release_asset_payload(raw: JsonObject) -> GitHubReleaseAssetPayload:
 
 
 def _coerce_release_payload(raw: JsonObject) -> GitHubReleasePayload:
+    """Project a raw GitHub release JSON object into the updater payload shape."""
+
     payload: GitHubReleasePayload = {}
     tag_name = raw.get("tag_name")
     if isinstance(tag_name, str):
@@ -166,6 +170,8 @@ class GitHubReleaseFetcher(GitHubAPIClient):
 
     @staticmethod
     def _release_has_firmware_asset(release: GitHubReleasePayload) -> bool:
+        """Return whether the release exposes at least one firmware bundle asset."""
+
         return any(
             is_firmware_asset_name(str(a.get("name", ""))) for a in release.get("assets", [])
         )


### PR DESCRIPTION
Chunk 117 reviews these ten firmware-update files directly: `apps/server/vibesensor/use_cases/updates/firmware/__init__.py`, `esp_flash_manager.py`, `esp_flash_runner.py`, `esp_flash_types.py`, `esp_serial.py`, `firmware_bundle.py`, `firmware_cache.py`, `firmware_refresh.py`, `firmware_release_fetcher.py`, and `firmware_types.py`. I read every code file in this chunk before deciding what to change.

This diff stays behavior-preserving and focuses on the firmware flashing helpers that future debugging usually starts from. In `esp_flash_manager.py`, I removed two standalone string literals that were effectively dead pseudo-comments and replaced them with a real bounded-log comment, then documented the core flash lifecycle helpers (`start`, `cancel`, `logs_since`, `_run_flash_step`, `_finalize`, and related helpers). In `esp_flash_runner.py`, `esp_flash_types.py`, `firmware_refresh.py`, and `firmware_release_fetcher.py`, I added targeted docstrings around subprocess execution, API serialization, cache refresh behavior, and GitHub release payload coercion so the firmware path reads more like a set of explicit contracts.

Key files changed:
- `apps/server/vibesensor/use_cases/updates/firmware/esp_flash_manager.py`
- `apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py`
- `apps/server/vibesensor/use_cases/updates/firmware/esp_flash_types.py`
- `apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py`
- `apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/firmware apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py` (`92 passed`)
- `make lint`

Risk is low: there are no firmware command, cache, or API behavior changes—only dead-comment cleanup plus helper documentation around already-covered flows.
