### PR TITLE
Repo review chunk 118: clarify release helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
@@ -27,11 +27,8 @@ LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_ROLLBACK_DIR = "/var/lib/vibesensor/rollback"
 
-# Shared download constants used by both server and firmware fetchers.
 DOWNLOAD_CHUNK_BYTES = 1024 * 1024  # 1 MB per read()
-"""Chunk size for streaming downloads.  Shared between
-:class:`ServerReleaseFetcher` and
-:class:`~vibesensor.use_cases.updates.firmware.firmware_release_fetcher.GitHubReleaseFetcher`."""
+# Shared chunk size for both server and firmware GitHub asset downloads.
 
 _HASH_CHUNK_BYTES = 65536  # 64 KB per hash update
 
@@ -65,6 +62,8 @@ class ReleaseInfo:
     published_at: str = ""
 
     def to_dict(self) -> dict[str, str]:
+        """Serialise discovered release metadata for status or debug output."""
+
         return {
             "tag": self.tag,
             "version": self.version,
@@ -84,6 +83,8 @@ class GitHubReleaseAsset:
 
     @classmethod
     def from_api_payload(cls, raw: object) -> GitHubReleaseAsset | None:
+        """Decode one GitHub asset payload into the typed helper model."""
+
         if not is_json_object(raw):
             return None
         name = raw.get("name")
@@ -105,6 +106,8 @@ class GitHubRelease:
 
     @classmethod
     def from_api_payload(cls, raw: object) -> GitHubRelease | None:
+        """Decode one GitHub release payload into the typed helper model."""
+
         if not is_json_object(raw):
             return None
         tag_name = raw.get("tag_name")
@@ -188,6 +191,8 @@ class ServerReleaseFetcher(GitHubAPIClient):
     _MAX_DOWNLOAD_MB = _MAX_DOWNLOAD_BYTES // (1024 * 1024)
 
     def _download_asset(self, url: str, dest: Path) -> None:
+        """Stream a release asset to disk with an upper size bound."""
+
         validate_https_url(url, context="release")
         headers = self._api_headers()
         headers["Accept"] = "application/octet-stream"

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -19,6 +19,8 @@ from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_vali
 
 
 def _sha256_file(path: Path) -> str:
+    """Hash a file as lowercase SHA-256 for release validation checks."""
+
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
@@ -162,6 +164,8 @@ def validate_release_wheel_metadata(
     *,
     expected_version: str,
 ) -> list[str]:
+    """Return metadata validation errors for a built server release wheel."""
+
     return wheel_metadata_validation_errors(
         wheel_path,
         expected_name="vibesensor",
@@ -170,6 +174,8 @@ def validate_release_wheel_metadata(
 
 
 def _read_http(url: str) -> tuple[int, str, str]:
+    """Fetch a URL and return status, content type, and decoded body text."""
+
     request = urllib.request.Request(url, headers={"Connection": "close"})
     with urllib.request.urlopen(request, timeout=3.0) as response:
         body = response.read().decode("utf-8", errors="replace")
@@ -178,6 +184,8 @@ def _read_http(url: str) -> tuple[int, str, str]:
 
 
 def _terminate_process(process: subprocess.Popen[str]) -> None:
+    """Terminate a spawned smoke-test process, escalating to kill if needed."""
+
     if process.poll() is not None:
         return
     process.terminate()
@@ -208,6 +216,8 @@ _SMOKE_SERVER_BOOTSTRAP = "\n".join(
 
 
 def packaged_static_index_path() -> Path:
+    """Resolve the packaged UI index.html path from the installed app module."""
+
     import importlib
 
     app_module = importlib.import_module("vibesensor.app")

--- a/apps/server/vibesensor/use_cases/updates/releases/releases.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/releases.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class UpdateReleaseCheck:
+    """Outcome of checking for a newer server release during updater execution."""
+
     release: ReleaseInfo | None
     latest_tag: str = ""
     failed: bool = False


### PR DESCRIPTION
Chunk 118 reviews the four release-helper files directly: `apps/server/vibesensor/use_cases/updates/releases/__init__.py`, `release_fetcher.py`, `release_validation.py`, and `releases.py`. I read every code file in this chunk before deciding what to change.

This diff remains behavior-preserving and focuses on the updater’s release-discovery seams. In `release_fetcher.py`, I removed a standalone string literal that was acting as a pseudo-comment for the shared download chunk size, replaced it with a real comment, and documented the typed payload decoders plus the streaming asset download helper. In `release_validation.py`, I added short docstrings around the local SHA-256 helper, wheel-metadata validation wrapper, HTTP probe helper, smoke-process terminator, and packaged-static path resolver so the release-smoke tooling reads more like an explicit contract. In `releases.py`, I documented `UpdateReleaseCheck` to make the async check/download flow easier to follow from the updater workflow.

Key files changed:
- `apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py`
- `apps/server/vibesensor/use_cases/updates/releases/release_validation.py`
- `apps/server/vibesensor/use_cases/updates/releases/releases.py`

Validation performed locally:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/releases apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/integration/test_refactor_contract_regressions.py` (`71 passed`)
- `make lint`

Risk is low: no release lookup, download, or smoke-validation behavior changed—just dead-comment cleanup plus helper documentation around already-covered paths.
