### PR TITLE
Repo review chunk 119: clarify updater wifi helpers

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_config.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_config.py
@@ -16,6 +16,8 @@ HOTSPOT_RESTORE_DELAY_S = 2.0
 
 @dataclass(frozen=True, slots=True)
 class UpdateWifiConfig:
+    """Static knobs for the updater's hotspot-to-uplink handoff."""
+
     ap_con_name: str
     wifi_ifname: str
     uplink_connection_name: str
@@ -31,6 +33,8 @@ class UpdateWifiConfig:
 
 
 def build_default_wifi_config(*, ap_con_name: str, wifi_ifname: str) -> UpdateWifiConfig:
+    """Build the default updater Wi-Fi configuration for the active device."""
+
     return UpdateWifiConfig(
         ap_con_name=ap_con_name,
         wifi_ifname=wifi_ifname,

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
@@ -8,6 +8,8 @@ from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 
 class UpdateHotspotRecovery:
+    """Manage the updater's hotspot shutdown and restoration lifecycle."""
+
     __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
@@ -22,6 +24,8 @@ class UpdateHotspotRecovery:
         self._config = config
 
     async def stop_hotspot(self) -> bool:
+        """Stop the hotspot before attempting an uplink connection."""
+
         self._tracker.log("Stopping hotspot...")
         rc, _, _ = await self._commands.run(
             ["nmcli", "connection", "down", self._config.ap_con_name],
@@ -34,6 +38,8 @@ class UpdateHotspotRecovery:
         return True
 
     async def cleanup_uplink(self) -> None:
+        """Tear down any transient updater uplink connection state."""
+
         await self._commands.run(
             ["nmcli", "connection", "down", self._config.uplink_connection_name],
             phase="restore",
@@ -48,6 +54,8 @@ class UpdateHotspotRecovery:
         )
 
     async def restore_hotspot(self) -> bool:
+        """Re-enable the hotspot, retrying within the configured restore budget."""
+
         await self.cleanup_uplink()
         for attempt in range(1, self._config.hotspot_restore_retries + 1):
             rc, _, _ = await self._commands.run(

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py
@@ -43,15 +43,23 @@ class UpdateWifiOrchestrator:
         )
 
     async def stop_hotspot(self) -> bool:
+        """Stop the hotspot before the updater attempts to join an uplink."""
+
         return await self._controller.stop_hotspot()
 
     async def connect_uplink(self, ssid: str, password: str) -> bool:
+        """Create and connect the transient uplink profile for this update run."""
+
         return await self._controller.connect_uplink(ssid, password)
 
     async def restore_hotspot(self) -> bool:
+        """Restore the hotspot after update work completes or is interrupted."""
+
         return await self._controller.restore_hotspot()
 
     async def recover_interrupted_update(self) -> None:
+        """Recover updater Wi-Fi state after a previously interrupted job."""
+
         self._tracker.log("startup_recover: cleaning up uplink connection")
         try:
             await self._controller.cleanup_uplink()
@@ -81,6 +89,8 @@ class UpdateWifiOrchestrator:
             )
 
     async def cleanup_restore_hotspot(self) -> None:
+        """Restore the hotspot during cleanup without letting cancellation interrupt it."""
+
         try:
             restored = await asyncio.shield(self.restore_hotspot())
             if not restored:
@@ -95,9 +105,13 @@ class UpdateWifiOrchestrator:
             LOGGER.warning("Cleanup hotspot restore failed", exc_info=True)
 
     async def collect_cleanup_diagnostics(self) -> list[UpdateIssue]:
+        """Collect any hotspot diagnostics that should be attached to cleanup failures."""
+
         return await asyncio.to_thread(parse_wifi_diagnostics)
 
     async def complete_update_success(self, message: str) -> bool:
+        """Restore the hotspot and then finalize the job as successful."""
+
         self._tracker.transition(UpdatePhase.restoring_hotspot)
         self._tracker.log("Restoring hotspot...")
         restored = await self.restore_hotspot()
@@ -109,6 +123,8 @@ class UpdateWifiOrchestrator:
         return True
 
     async def maybe_restore_hotspot_during_cleanup(self) -> None:
+        """Restore the hotspot if cleanup begins while the updater still owns Wi-Fi state."""
+
         status = self._tracker.status
         if status.state == UpdateState.running or status.phase in _HOTSPOT_RESTORE_PHASES:
             self._tracker.transition(UpdatePhase.restoring_hotspot)

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_readiness.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_readiness.py
@@ -9,6 +9,8 @@ from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 
 class UpdateWifiReadiness:
+    """Wait for the transient uplink connection to become usable for updates."""
+
     __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
@@ -23,6 +25,8 @@ class UpdateWifiReadiness:
         self._config = config
 
     async def bring_uplink_up(self, ssid: str) -> bool:
+        """Bring the prepared uplink connection up, retrying on scan lag."""
+
         rc = 1
         stderr = ""
         for attempt in range(1, self._config.uplink_connect_retries + 1):
@@ -73,6 +77,8 @@ class UpdateWifiReadiness:
         return False
 
     async def wait_for_dns_ready(self) -> bool:
+        """Wait for DNS resolution to succeed before download work begins."""
+
         self._tracker.log(
             "Validating uplink internet/DNS readiness for at least "
             f"{int(self._config.dns_ready_min_wait_s)}s...",

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
@@ -10,6 +10,8 @@ _UNESCAPED_COLON_RE = re.compile(r"(?<!\\):")
 
 
 def ssid_security_modes(scan_output: str, ssid: str) -> set[str]:
+    """Return the advertised security modes for the matching SSID in nmcli output."""
+
     modes: set[str] = set()
     target = ssid.strip()
     if not target:
@@ -31,6 +33,8 @@ def ssid_security_modes(scan_output: str, ssid: str) -> set[str]:
 
 
 class UpdateUplinkProvisioner:
+    """Create and configure the temporary Wi-Fi uplink connection for updates."""
+
     __slots__ = ("_commands", "_config", "_tracker")
 
     def __init__(
@@ -45,6 +49,8 @@ class UpdateUplinkProvisioner:
         self._config = config
 
     async def prepare_uplink_connection(self, ssid: str, password: str) -> bool:
+        """Create the transient uplink profile and apply any required credentials."""
+
         if not password and not await self._validate_open_network(ssid):
             return False
         await self._delete_existing_uplink_connections()
@@ -57,6 +63,8 @@ class UpdateUplinkProvisioner:
         return True
 
     async def _validate_open_network(self, ssid: str) -> bool:
+        """Reject blank-password attempts when the scanned SSID is secured."""
+
         rc, stdout, _ = await self._commands.run(
             [
                 "nmcli",
@@ -88,6 +96,8 @@ class UpdateUplinkProvisioner:
         return False
 
     async def _delete_existing_uplink_connections(self) -> None:
+        """Remove any stale transient uplink profiles before recreating them."""
+
         rc, stdout, _ = await self._commands.run(
             ["nmcli", "-t", "-f", "UUID,NAME", "connection", "show"],
             phase="connecting_wifi",
@@ -110,6 +120,8 @@ class UpdateUplinkProvisioner:
             )
 
     async def _create_uplink_connection(self, ssid: str) -> bool:
+        """Create a new transient uplink profile for the requested SSID."""
+
         rc, _, stderr = await self._commands.run(
             [
                 "nmcli",
@@ -136,6 +148,8 @@ class UpdateUplinkProvisioner:
         return False
 
     async def _configure_uplink_connection(self) -> bool:
+        """Apply the non-secret updater defaults to the uplink profile."""
+
         rc, _, stderr = await self._commands.run(
             [
                 "nmcli",
@@ -160,15 +174,12 @@ class UpdateUplinkProvisioner:
         if rc == 0:
             return True
         self._tracker.fail("connecting_wifi", "Failed to configure uplink", stderr)
-        await self._commands.run(
-            ["nmcli", "connection", "delete", self._config.uplink_connection_name],
-            phase="connecting_wifi",
-            timeout=self._config.nmcli_timeout_s,
-            sudo=True,
-        )
+        await self._delete_uplink_connection()
         return False
 
     async def _apply_wifi_password(self, password: str) -> bool:
+        """Apply WPA-PSK credentials to the transient uplink profile."""
+
         rc, _, stderr = await self._commands.run(
             [
                 "nmcli",
@@ -187,10 +198,15 @@ class UpdateUplinkProvisioner:
         if rc == 0:
             return True
         self._tracker.fail("connecting_wifi", "Failed to set Wi-Fi credentials", stderr)
+        await self._delete_uplink_connection()
+        return False
+
+    async def _delete_uplink_connection(self) -> None:
+        """Delete the transient uplink profile after a partial setup failure."""
+
         await self._commands.run(
             ["nmcli", "connection", "delete", self._config.uplink_connection_name],
             phase="connecting_wifi",
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        return False


### PR DESCRIPTION
## Summary
This is repo review chunk `119` for `apps/server/vibesensor/use_cases/updates/wifi`, covering these eight code files: `__init__.py`, `wifi.py`, `wifi_config.py`, `wifi_diagnostics.py`, `wifi_hotspot_recovery.py`, `wifi_orchestrator.py`, `wifi_readiness.py`, and `wifi_uplink_setup.py`. I directly reviewed every code file in the chunk before making changes.

The diff keeps behavior unchanged and focuses on maintainability. The main improvements are local boundary documentation for the updater Wi-Fi lifecycle and a small duplication cleanup in `wifi_uplink_setup.py`, where the repeated transient-uplink delete path now goes through a single `_delete_uplink_connection()` helper. The key edited files are `wifi_config.py`, `wifi_hotspot_recovery.py`, `wifi_orchestrator.py`, `wifi_readiness.py`, and `wifi_uplink_setup.py`. `__init__.py`, `wifi.py`, and `wifi_diagnostics.py` were reviewed directly and left unchanged.

## Validation
I ran:
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/wifi apps/server/tests/use_cases/updates/test_update_job_lifecycle.py`
- `make lint`
- Native runtime smoke with `./.venv/bin/vibesensor-server --config apps/server/config.dev.yaml`, `./.venv/bin/vibesensor-ws-smoke --uri ws://127.0.0.1:8000/ws --min-clients 1 --timeout 20`, and `./.venv/bin/vibesensor-sim --count 3 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`

## Risks / skipped items
No intentional functional changes. I also attempted the repo’s Docker Compose smoke path, but this environment does not expose a Docker daemon socket, so I used the native server + simulator smoke as the closest available runtime substitute.
