### PR TITLE
Repo review chunk 120: tighten UI script imports

### DIFF
--- a/apps/ui/take-screenshot.mjs
+++ b/apps/ui/take-screenshot.mjs
@@ -7,6 +7,7 @@
 import { chromium } from "@playwright/test";
 import { spawn } from "node:child_process";
 import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const OUTPUT_PATH = process.argv[2] || "/tmp/vibesensor-screenshot.png";
 const SERVER_PORT = 4175;
@@ -36,7 +37,7 @@ async function startServer(cwd) {
 }
 
 async function main() {
-  const cwd = new URL(".", import.meta.url).pathname;
+  const cwd = fileURLToPath(new URL(".", import.meta.url));
   let server;
   let browser;
   try {

--- a/apps/ui/update-snapshots.mjs
+++ b/apps/ui/update-snapshots.mjs
@@ -2,10 +2,11 @@
  * Regenerates Playwright snapshot baselines using the available chromium binary.
  * Run with: node update-snapshots.mjs
  */
-import { chromium } from "playwright-core";
+import { chromium } from "@playwright/test";
 import { spawn } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const CHROME_EXEC = "/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome";
 const SERVER_PORT = 4176;
@@ -49,7 +50,7 @@ function savePng(path, buf) {
 }
 
 async function main() {
-  const cwd = new URL(".", import.meta.url).pathname;
+  const cwd = fileURLToPath(new URL(".", import.meta.url));
   let server;
   let browser;
 


### PR DESCRIPTION
## Summary
This is repo review chunk `120` for the top-level `apps/ui` tooling/config surface. I directly reviewed all ten code files in the chunk: `biome.json`, `dev-docker.sh`, `index.html`, `package-lock.json`, `package.json`, `playwright.config.ts`, `playwright.smoke.config.ts`, `take-screenshot.mjs`, `tsconfig.json`, and `update-snapshots.mjs`.

The changes stay behavior-preserving and focus on maintainability. The only code edits are in `take-screenshot.mjs` and `update-snapshots.mjs`. Both scripts now use `fileURLToPath(new URL('.', import.meta.url))` instead of raw `URL.pathname`, which is safer for filesystem paths. `update-snapshots.mjs` also now imports `chromium` from the declared `@playwright/test` dependency instead of reaching through the transitive `playwright-core` package. The other eight files were reviewed directly and left unchanged because their current contracts already matched the repo’s hygiene guards and smoke configuration expectations.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ui_vite_server_contract.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/hygiene/test_dev_workflow.py`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. Docker Compose validation remains unavailable in this environment because there is no Docker daemon socket, so I used the existing Vite/Playwright smoke path instead.
