### PR TITLE
Repo review chunk 121: simplify Vite config ports

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -3,6 +3,9 @@ import { defineConfig, loadEnv } from "vite";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, ".", "");
   const backendOrigin = env.VITE_BACKEND_ORIGIN || "http://127.0.0.1:8000";
+  const host = "0.0.0.0";
+  const previewPort = 4173;
+  const devPort = 5173;
 
   return {
     build: {
@@ -13,13 +16,13 @@ export default defineConfig(({ mode }) => {
     // Our smoke tests and preview helpers target fixed URLs, so fail fast on
     // port conflicts instead of silently hopping to the next available port.
     preview: {
-      host: "0.0.0.0",
-      port: 4173,
+      host,
+      port: previewPort,
       strictPort: true,
     },
     server: {
-      host: "0.0.0.0",
-      port: 5173,
+      host,
+      port: devPort,
       strictPort: true,
       proxy: {
         "/api": backendOrigin,


### PR DESCRIPTION
## Summary
This is repo review chunk `121`, covering the single code file `apps/ui/vite.config.ts`. I directly reviewed the file before making changes.

The change is behavior-preserving and keeps the existing Vite contract intact. The config already had the right settings for fixed preview/dev ports, strict port failures, and proxying `/api`, `/static`, and `/ws` to the backend. The only improvement here is to replace the repeated host and port literals with named `host`, `previewPort`, and `devPort` constants. That keeps the fixed-port contract defined in one place without changing any effective values or proxy behavior.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ui_vite_server_contract.py`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. Docker Compose validation remains unavailable in this environment because there is no Docker daemon socket, so I used the existing Vite/Playwright smoke path instead.
