### PR TITLE
Repo review chunk 122: clarify UI payload helpers

### DIFF
--- a/apps/ui/src/api.ts
+++ b/apps/ui/src/api.ts
@@ -22,6 +22,9 @@ export {
   getEspFlashLogs,
   cancelEspFlash,
   getEspFlashHistory,
+  getUpdateStatus,
+  startUpdate,
+  cancelUpdate,
 } from "./api/settings";
 export { getCarLibraryBrands, getCarLibraryTypes, getCarLibraryModels } from "./api/car_library";
 export {
@@ -34,7 +37,6 @@ export {
 } from "./api/history";
 export { getClientLocations, setClientLocation, identifyClient, removeClient } from "./api/clients";
 export { getLoggingStatus, startLoggingRun, stopLoggingRun } from "./api/logging";
-export { getUpdateStatus, startUpdate, cancelUpdate } from "./api/settings";
 export type {
   HealthStatusPayload,
   UpdateStatusPayload,

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -38,6 +38,14 @@ export type AdaptedPayload = {
   } | null;
 };
 
+function hasCompleteSpectrumData(
+  freq: number[],
+  combined: number[],
+  strengthMetrics: SpectrumClientData["strength_metrics"] | null,
+): strengthMetrics is NonNullable<SpectrumClientData["strength_metrics"]> {
+  return freq.length > 0 && combined.length > 0 && strengthMetrics !== null && freq.length === combined.length;
+}
+
 function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectra"] | null {
   if (!spectra?.clients) return null;
   const sharedFreq = spectra.freq ?? [];
@@ -48,7 +56,7 @@ function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectr
     const freq = rawPerClientFreq.length > 0 ? rawPerClientFreq : sharedFreq;
     const combined = spectrum.combined_spectrum_amp_g ?? [];
     const strengthMetrics = spectrum.strength_metrics ?? null;
-    if (!freq.length || !combined.length || strengthMetrics === null || freq.length !== combined.length) {
+    if (!hasCompleteSpectrumData(freq, combined, strengthMetrics)) {
       continue;
     }
     adaptedClients[clientId] = {


### PR DESCRIPTION
## Summary
This is repo review chunk `122` for the first ten files under `apps/ui/src`: `api.ts`, `config.ts`, `constants.ts`, `format.ts`, `i18n.ts`, `main.ts`, `server_payload.ts`, `spectrum.ts`, `theme.ts`, and `ws.ts`. I directly reviewed every code file in the chunk before making changes.

The diff is behavior-preserving and focused on readability at two well-covered seams. In `api.ts`, I folded the update-related exports into the existing `./api/settings` export block so the public settings/update surface is declared in one place. In `server_payload.ts`, I extracted the inline client-spectrum completeness gate into a named `hasCompleteSpectrumData()` helper, which keeps the skip criteria explicit without altering payload adaptation behavior. The remaining eight files were reviewed directly and left unchanged because their current contracts were already compact, well-factored, and covered by the surrounding UI runtime checks.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/ws_contract.spec.ts apps/ui/tests/demo_mode.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. Docker Compose validation remains unavailable in this environment because there is no Docker daemon socket, so I used the existing Vite/Playwright smoke path instead.
