### PR TITLE
Repo review chunk 123: clarify WS validation summary

### DIFF
--- a/apps/ui/src/ws_payload_validator.ts
+++ b/apps/ui/src/ws_payload_validator.ts
@@ -9,13 +9,14 @@ const ajv = new Ajv2020({
 });
 
 const liveWsPayloadValidator = ajv.compile(wsPayloadSchema) as ValidateFunction<LiveWsPayload>;
+const MAX_FORMATTED_VALIDATION_ERRORS = 3;
 
-function formatValidationErrors(errors: readonly ErrorObject[] | null | undefined): string {
+function formatValidationErrorSummary(errors: readonly ErrorObject[] | null | undefined): string {
   if (!errors?.length) {
     return "unknown schema violation";
   }
   return errors
-    .slice(0, 3)
+    .slice(0, MAX_FORMATTED_VALIDATION_ERRORS)
     .map((error) => {
       const path = error.instancePath || "/";
       return `${path} ${error.message ?? "is invalid"}`;
@@ -27,5 +28,5 @@ export function validateLiveWsPayload(payload: unknown): LiveWsPayload {
   if (liveWsPayloadValidator(payload)) {
     return payload;
   }
-  throw new Error(`Invalid websocket payload: ${formatValidationErrors(liveWsPayloadValidator.errors)}`);
+  throw new Error(`Invalid websocket payload: ${formatValidationErrorSummary(liveWsPayloadValidator.errors)}`);
 }


### PR DESCRIPTION
## Summary
This is repo review chunk `123` for `apps/ui/src/ws_payload_validator.ts`. I directly reviewed the only code file in the chunk before making changes.

The update is intentionally small and behavior-preserving. The validator already used the generated websocket schema correctly, so I kept the logic intact and focused only on maintainability. I extracted the maximum number of validation errors included in the thrown summary into a named constant and renamed the internal formatter helper to `formatValidationErrorSummary()` so the function name matches what it actually produces. That keeps the truncation policy explicit and removes a magic number from the core validation path without changing payload acceptance, rejection, or error wording structure beyond the internal helper name. No schema contracts, public exports, or runtime control flow were changed.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/ws_contract.spec.ts apps/ui/tests/demo_mode.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. I did not expand scope beyond this file; broader websocket payload behavior remains covered by the existing contract and smoke suites above.
