### PR TITLE
Repo review chunk 124: tighten UI API typings

### DIFF
--- a/apps/ui/src/api/car_library.ts
+++ b/apps/ui/src/api/car_library.ts
@@ -1,14 +1,14 @@
 import { apiJson } from "./http";
-import type { CarLibraryModel } from "./types";
+import type { CarLibraryBrandsPayload, CarLibraryModelsPayload, CarLibraryTypesPayload } from "./types";
 
-export async function getCarLibraryBrands(): Promise<{ brands: string[] }> {
+export async function getCarLibraryBrands(): Promise<CarLibraryBrandsPayload> {
   return apiJson("/api/car-library/brands");
 }
 
-export async function getCarLibraryTypes(brand: string): Promise<{ types: string[] }> {
+export async function getCarLibraryTypes(brand: string): Promise<CarLibraryTypesPayload> {
   return apiJson(`/api/car-library/types?brand=${encodeURIComponent(brand)}`);
 }
 
-export async function getCarLibraryModels(brand: string, type: string): Promise<{ models: CarLibraryModel[] }> {
+export async function getCarLibraryModels(brand: string, type: string): Promise<CarLibraryModelsPayload> {
   return apiJson(`/api/car-library/models?brand=${encodeURIComponent(brand)}&type=${encodeURIComponent(type)}`);
 }

--- a/apps/ui/src/api/clients.ts
+++ b/apps/ui/src/api/clients.ts
@@ -1,6 +1,8 @@
 import { apiJson } from "./http";
 import type { ClientLocationsResponse } from "./types";
 
+const JSON_HEADERS: HeadersInit = { "Content-Type": "application/json" };
+
 export async function getClientLocations(): Promise<ClientLocationsResponse> {
   return apiJson("/api/client-locations");
 }
@@ -8,7 +10,7 @@ export async function getClientLocations(): Promise<ClientLocationsResponse> {
 export async function setClientLocation(clientId: string, locationCode: string): Promise<void> {
   await apiJson(`/api/clients/${encodeURIComponent(clientId)}/location`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: JSON_HEADERS,
     body: JSON.stringify({ location_code: locationCode }),
   });
 }
@@ -16,7 +18,7 @@ export async function setClientLocation(clientId: string, locationCode: string):
 export async function identifyClient(clientId: string, durationMs = 1500): Promise<void> {
   await apiJson(`/api/clients/${encodeURIComponent(clientId)}/identify`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: JSON_HEADERS,
     body: JSON.stringify({ duration_ms: durationMs }),
   });
 }

--- a/apps/ui/src/api/http.ts
+++ b/apps/ui/src/api/http.ts
@@ -1,14 +1,14 @@
 const DEFAULT_TIMEOUT_MS = 10000;
-const _NOOP = () => {};
-const _WHITESPACE_RE = /\s+/g;
+const NOOP = () => {};
+const WHITESPACE_RE = /\s+/g;
 
 function composeSignal(
   timeoutSignal: AbortSignal,
   externalSignal?: AbortSignal,
 ): { signal: AbortSignal; cleanup: () => void } {
-  if (!externalSignal) return { signal: timeoutSignal, cleanup: _NOOP };
+  if (!externalSignal) return { signal: timeoutSignal, cleanup: NOOP };
   if ("any" in AbortSignal) {
-    return { signal: AbortSignal.any([timeoutSignal, externalSignal]), cleanup: _NOOP };
+    return { signal: AbortSignal.any([timeoutSignal, externalSignal]), cleanup: NOOP };
   }
 
   const controller = new AbortController();
@@ -28,7 +28,7 @@ function composeSignal(
 }
 
 function formatBodySnippet(text: string): string {
-  const compact = text.trim().replace(_WHITESPACE_RE, " ");
+  const compact = text.trim().replace(WHITESPACE_RE, " ");
   return compact.slice(0, 160);
 }
 
@@ -41,9 +41,8 @@ export async function apiJsonResponse<T = unknown>(
   path: string,
   init?: RequestInit,
 ): Promise<ApiJsonResponse<T>> {
-  const timeoutMs = DEFAULT_TIMEOUT_MS;
   const timeoutController = new AbortController();
-  const timeoutId = window.setTimeout(() => timeoutController.abort(), timeoutMs);
+  const timeoutId = window.setTimeout(() => timeoutController.abort(), DEFAULT_TIMEOUT_MS);
   const { signal, cleanup } = composeSignal(timeoutController.signal, init?.signal ?? undefined);
   const response = await fetch(path, { ...init, signal }).finally(() => {
     window.clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
This is repo review chunk `124` for `apps/ui/src/api/car_library.ts`, `clients.ts`, `history.ts`, `http.ts`, `logging.ts`, `settings.ts`, and `types.ts`. I directly reviewed every code file in the chunk before making changes.

The diff is behavior-preserving and limited to three maintainability cleanups in the API wrapper layer. In `car_library.ts`, I replaced ad-hoc inline response shapes with the existing generated `CarLibrary*Payload` aliases so these helpers stay anchored to the shared contract surface instead of duplicating schema structure locally. In `clients.ts`, I extracted a module-local `JSON_HEADERS` constant so the two JSON POST helpers reuse one header definition rather than repeating the same literal. In `http.ts`, I removed a redundant local timeout alias and renamed the private module constants to clearer names without changing timeout, fetch, or error behavior. The remaining four files were reviewed directly and left unchanged because their endpoint wrappers and type aliases were already concise and appropriately scoped.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/api_http.spec.ts apps/ui/tests/ui_car_creation_command.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. I kept the scope to maintainability only and did not refactor endpoint shapes, transport behavior, or runtime error handling.
