### PR TITLE
Repo review chunk 125: clarify UI app runtime helpers

### DIFF
--- a/apps/ui/src/app/spectrum_animation.ts
+++ b/apps/ui/src/app/spectrum_animation.ts
@@ -7,6 +7,8 @@ export interface SpectrumHeavyFrame {
 }
 
 const FREQ_EPSILON = 1e-6;
+const MAX_INTERIOR_FINGERPRINT_SAMPLES = 4;
+const FINGERPRINT_SAMPLE_SEGMENTS = MAX_INTERIOR_FINGERPRINT_SAMPLES + 1;
 
 /** Compute a lightweight fingerprint (length + sampled values) for a freq array. */
 function freqFingerprint(freq: number[]): string {
@@ -14,8 +16,8 @@ function freqFingerprint(freq: number[]): string {
   if (n === 0) return "0";
   // Sample first, last, and up to 4 evenly-spaced interior points.
   const indices = [0, n - 1];
-  for (let k = 1; k <= 4 && k * (n - 1) / 5 < n; k++) {
-    indices.push(Math.round(k * (n - 1) / 5));
+  for (let k = 1; k <= MAX_INTERIOR_FINGERPRINT_SAMPLES && k * (n - 1) / FINGERPRINT_SAMPLE_SEGMENTS < n; k++) {
+    indices.push(Math.round(k * (n - 1) / FINGERPRINT_SAMPLE_SEGMENTS));
   }
   const parts = [String(n)];
   for (const idx of indices) {

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -74,6 +74,10 @@ export interface LivePayloadUpdateResult {
   hasNewSpectrumFrame: boolean;
 }
 
+function hasRenderableSpectrumData(spectra: { clients: Record<string, SpectrumClientData> }): boolean {
+  return Object.values(spectra.clients).some((clientSpec) => clientSpec.freq.length > 0 && clientSpec.combined.length > 0);
+}
+
 export function applySpectrumTick(
   previousSpectra: { clients: Record<string, SpectrumClientData> },
   previousHasSpectrumData: boolean,
@@ -86,12 +90,9 @@ export function applySpectrumTick(
       hasNewSpectrumFrame: false,
     };
   }
-  const hasSpectrumData = Object.values(incomingSpectra.clients).some(
-    (clientSpec) => clientSpec.freq.length > 0 && clientSpec.combined.length > 0,
-  );
   return {
     spectra: incomingSpectra,
-    hasSpectrumData,
+    hasSpectrumData: hasRenderableSpectrumData(incomingSpectra),
     hasNewSpectrumFrame: true,
   };
 }

--- a/apps/ui/src/app/ui_dom_registry.ts
+++ b/apps/ui/src/app/ui_dom_registry.ts
@@ -127,10 +127,14 @@ function el(id: string): HTMLElement | null {
   return getById<HTMLElement>(id);
 }
 
+function queryAll<T extends Element>(selector: string): T[] {
+  return Array.from(document.querySelectorAll<T>(selector));
+}
+
 export function createUiDomRegistry(): UiDomElements {
   return {
-    menuButtons: Array.from(document.querySelectorAll(".menu-btn")),
-    views: Array.from(document.querySelectorAll(".view")),
+    menuButtons: queryAll<HTMLElement>(".menu-btn"),
+    views: queryAll<HTMLElement>(".view"),
     languageSelect: selectEl("languageSelect"),
     speedUnitSelect: selectEl("speedUnitSelect"),
     speed: el("speed"),
@@ -181,7 +185,7 @@ export function createUiDomRegistry(): UiDomElements {
     wizardCloseBtn: btnEl("wizardCloseBtn"),
     wizardBackBtn: btnEl("wizardBackBtn"),
     wizardSteps: [0, 1, 2, 3, 4].map((index) => el(`wizardStep${index}`)),
-    wizardStepDots: Array.from(document.querySelectorAll<HTMLElement>(".wizard-step-dot")),
+    wizardStepDots: queryAll<HTMLElement>(".wizard-step-dot"),
     wizardBrandList: el("wizardBrandList"),
     wizardTypeList: el("wizardTypeList"),
     wizardModelList: el("wizardModelList"),
@@ -200,13 +204,11 @@ export function createUiDomRegistry(): UiDomElements {
     wizRimInput: inputEl("wizRim"),
     wizFinalDriveInput: inputEl("wizFinalDrive"),
     wizGearRatioInput: inputEl("wizGearRatio"),
-    speedSourceRadios: Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[name="speedSourceRadio"]'),
-    ),
+    speedSourceRadios: queryAll<HTMLInputElement>('input[name="speedSourceRadio"]'),
     manualSpeedInput: inputEl("manualSpeedInput"),
     saveSpeedSourceBtn: btnEl("saveSpeedSourceBtn"),
-    settingsTabs: Array.from(document.querySelectorAll(".settings-tab")),
-    settingsTabPanels: Array.from(document.querySelectorAll(".settings-tab-panel")),
+    settingsTabs: queryAll<HTMLElement>(".settings-tab"),
+    settingsTabPanels: queryAll<HTMLElement>(".settings-tab-panel"),
     updateSsidInput: inputEl("updateSsidInput"),
     updatePasswordInput: inputEl("updatePasswordInput"),
     updateTogglePasswordBtn: btnEl("updateTogglePasswordBtn"),


### PR DESCRIPTION
## Summary
This is repo review chunk `125` for `apps/ui/src/app/app_feature_bundle.ts`, `demo_mode.ts`, `feature_deps_base.ts`, `spectrum_animation.ts`, `start_ui_app.ts`, `ui_app_runtime.ts`, `ui_app_state.ts`, and `ui_dom_registry.ts`. I directly reviewed every code file in the chunk before making changes.

The diff stays behavior-preserving and focused on readability in three foundational helpers. In `spectrum_animation.ts`, I replaced the paired magic numbers in the heavy-frame fingerprint sampler with named constants so the compatibility fast path is easier to audit. In `ui_app_state.ts`, I extracted the inline “does this tick actually contain usable spectrum data?” check into `hasRenderableSpectrumData()`, which keeps the live-state transition more explicit without changing selected-client or spectrum-frame behavior. In `ui_dom_registry.ts`, I added a typed `queryAll()` helper and reused it for the repeated selector-list lookups so the DOM registry keeps one consistent array-query pattern. The remaining five files were reviewed directly and left unchanged because their bootstrap and orchestration code was already compact and easy to follow.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/demo_mode.spec.ts apps/ui/tests/ui_shell_runtime_modules.spec.ts apps/ui/tests/history_feature_modules.spec.ts apps/ui/tests/esp_flash_feature.spec.ts --project=laptop-light --workers=1`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/cycle2_fixes.spec.ts --grep "applySpectrumTick heavy/light handling|spectrum heavy-frame animation compatibility" --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. I kept scope away from broader app startup refactors and only touched helper-level clarity in covered paths.
