### PR TITLE
Repo review chunk 126: simplify UI feature helpers

### DIFF
--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -28,6 +28,10 @@ const STATE_TO_VARIANT: Readonly<Record<string, string>> = {
   failed: "bad",
 };
 
+function safeEspFlashState(state: string | null | undefined): string {
+  return state || "idle";
+}
+
 export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature {
   const { els, t, escapeHtml } = ctx;
   let nextLogIndex = 0;
@@ -50,7 +54,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
   function renderStatus(status: EspFlashStatusPayload): void {
     if (els.espFlashStatusBanner) {
       // Defensively fallback to "idle" when state is missing from API response
-      const safeState: string = status.state || "idle";
+      const safeState = safeEspFlashState(status.state);
       const stateLabel = t(`settings.esp_flash.state.${safeState}`);
       const extra = status.error ? ` — ${status.error}` : "";
       els.espFlashStatusBanner.textContent = `${stateLabel}${extra}`;
@@ -94,7 +98,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
     }
     const rows = attempts.map((attempt) => {
       // Defensively fallback to "idle" when state is missing from API response
-      const safeState: string = attempt.state || "idle";
+      const safeState = safeEspFlashState(attempt.state);
       const stateLabel = t(`settings.esp_flash.state.${safeState}`);
       const port = attempt.selected_port || t("settings.esp_flash.auto_detect");
       return `<li><strong>${escapeHtml(stateLabel)}</strong> — ${escapeHtml(port)}</li>`;

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -67,6 +67,11 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     return codes.map((code) => ({ code, label: locationLabel(code) }));
   }
 
+  function applyLocationCodes(codes: string[]): void {
+    realtime.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
+    realtime.locationOptions = buildLocationOptions(realtime.locationCodes);
+  }
+
   function locationCodeForClient(client: AdaptedClient): string {
     const explicitCode = String(client.location_code || "").trim();
     if (explicitCode && realtime.locationCodes.includes(explicitCode)) return explicitCode;
@@ -189,11 +194,9 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       const codes = Array.isArray(payload.locations)
         ? payload.locations.map((row) => row.code).filter((code): code is string => typeof code === "string")
         : [];
-      realtime.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
-      realtime.locationOptions = buildLocationOptions(realtime.locationCodes);
+      applyLocationCodes(codes);
     } catch (_err) {
-      realtime.locationCodes = defaultLocationCodes.slice();
-      realtime.locationOptions = buildLocationOptions(realtime.locationCodes);
+      applyLocationCodes([]);
     }
     maybeRenderSensorsSettingsList(true);
   }

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -39,16 +39,20 @@ export interface SettingsAnalysisModule {
 export function createSettingsAnalysisModule(ctx: SettingsAnalysisModuleDeps): SettingsAnalysisModule {
   const { settings, els, t } = ctx;
 
+  function syncNumericInputValue(input: HTMLInputElement | null, value: number): void {
+    if (input) input.value = String(value);
+  }
+
   function syncSettingsInputs(): void {
-    if (els.wheelBandwidthInput) els.wheelBandwidthInput.value = String(settings.vehicleSettings.wheel_bandwidth_pct);
-    if (els.driveshaftBandwidthInput) els.driveshaftBandwidthInput.value = String(settings.vehicleSettings.driveshaft_bandwidth_pct);
-    if (els.engineBandwidthInput) els.engineBandwidthInput.value = String(settings.vehicleSettings.engine_bandwidth_pct);
-    if (els.speedUncertaintyInput) els.speedUncertaintyInput.value = String(settings.vehicleSettings.speed_uncertainty_pct);
-    if (els.tireDiameterUncertaintyInput) els.tireDiameterUncertaintyInput.value = String(settings.vehicleSettings.tire_diameter_uncertainty_pct);
-    if (els.finalDriveUncertaintyInput) els.finalDriveUncertaintyInput.value = String(settings.vehicleSettings.final_drive_uncertainty_pct);
-    if (els.gearUncertaintyInput) els.gearUncertaintyInput.value = String(settings.vehicleSettings.gear_uncertainty_pct);
-    if (els.minAbsBandHzInput) els.minAbsBandHzInput.value = String(settings.vehicleSettings.min_abs_band_hz);
-    if (els.maxBandHalfWidthInput) els.maxBandHalfWidthInput.value = String(settings.vehicleSettings.max_band_half_width_pct);
+    syncNumericInputValue(els.wheelBandwidthInput, settings.vehicleSettings.wheel_bandwidth_pct);
+    syncNumericInputValue(els.driveshaftBandwidthInput, settings.vehicleSettings.driveshaft_bandwidth_pct);
+    syncNumericInputValue(els.engineBandwidthInput, settings.vehicleSettings.engine_bandwidth_pct);
+    syncNumericInputValue(els.speedUncertaintyInput, settings.vehicleSettings.speed_uncertainty_pct);
+    syncNumericInputValue(els.tireDiameterUncertaintyInput, settings.vehicleSettings.tire_diameter_uncertainty_pct);
+    syncNumericInputValue(els.finalDriveUncertaintyInput, settings.vehicleSettings.final_drive_uncertainty_pct);
+    syncNumericInputValue(els.gearUncertaintyInput, settings.vehicleSettings.gear_uncertainty_pct);
+    syncNumericInputValue(els.minAbsBandHzInput, settings.vehicleSettings.min_abs_band_hz);
+    syncNumericInputValue(els.maxBandHalfWidthInput, settings.vehicleSettings.max_band_half_width_pct);
   }
 
   function applyAnalysisSettingsPayload(serverSettings: AnalysisSettingsPayload): void {


### PR DESCRIPTION
## Summary
This is repo review chunk `126` for `apps/ui/src/app/features/cars_feature.ts`, `esp_flash_feature.ts`, `heat_utils.ts`, `history_detail_module.ts`, `history_download_delete_module.ts`, `history_feature.ts`, `history_list_module.ts`, `polling_controller.ts`, `realtime_feature.ts`, and `settings_analysis_module.ts`. I directly reviewed every code file in the chunk before making changes.

The diff remains behavior-preserving and limited to three helper-level cleanups inside the feature layer. In `esp_flash_feature.ts`, I extracted the repeated missing-state fallback into `safeEspFlashState()` so banner and history rendering share one rule for absent ESP flash state values. In `realtime_feature.ts`, I extracted the duplicated “apply returned location codes or fall back to defaults, then rebuild options” logic into `applyLocationCodes()` so the realtime location refresh path keeps one explicit fallback contract. In `settings_analysis_module.ts`, I added `syncNumericInputValue()` to remove the repeated null-check-and-stringify pattern from the analysis settings input sync path. The remaining seven files were reviewed directly and left unchanged because their orchestration, polling, and history flows were already concise and well covered.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/polling_controller.spec.ts apps/ui/tests/esp_flash_feature.spec.ts apps/ui/tests/history_feature_modules.spec.ts apps/ui/tests/ui_startup_coordinator.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. I kept scope to helper extraction only and did not alter feature contracts, event wiring, or polling behavior.
