### PR TITLE
Repo review chunk 127: simplify UI settings helpers

### DIFF
--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -44,13 +44,17 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
     return ctx.getSpeedUnit() === "mps" ? t("speed.unit.mps") : t("speed.unit.kmh");
   }
 
+  function formatSpeedValue(speedKmh: number | null, unitLabel: string): string | null {
+    const speed = speedKmhInSelectedUnit(speedKmh);
+    return speed != null ? `${fmt(speed, 1)} ${unitLabel}` : null;
+  }
+
   function renderGpsStatus(status: SpeedSourceStatusPayload): void {
     const unitLabel = selectedSpeedUnitLabel();
     if (els.headerGpsStatus) {
       const stateLabel = connectionStateLabel(status.connection_state);
-      const speed = speedKmhInSelectedUnit(status.effective_speed_kmh);
-      const speedText = speed != null ? ` ${fmt(speed, 1)} ${unitLabel}` : "";
-      els.headerGpsStatus.textContent = `GPS ${stateLabel}${speedText}`;
+      const speedText = formatSpeedValue(status.effective_speed_kmh, unitLabel);
+      els.headerGpsStatus.textContent = `GPS ${stateLabel}${speedText ? ` ${speedText}` : ""}`;
       const variant = status.connection_state === "connected"
         ? "ok"
         : (status.connection_state === "stale" ? "warn" : "muted");
@@ -69,14 +73,10 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
         : t("settings.speed.last_update_never");
     }
     if (els.gpsStatusRawSpeed) {
-      const rawSpeed = speedKmhInSelectedUnit(status.raw_speed_kmh);
-      els.gpsStatusRawSpeed.textContent = rawSpeed != null ? `${fmt(rawSpeed, 1)} ${unitLabel}` : "--";
+      els.gpsStatusRawSpeed.textContent = formatSpeedValue(status.raw_speed_kmh, unitLabel) ?? "--";
     }
     if (els.gpsStatusEffectiveSpeed) {
-      const effectiveSpeed = speedKmhInSelectedUnit(status.effective_speed_kmh);
-      els.gpsStatusEffectiveSpeed.textContent = effectiveSpeed != null
-        ? `${fmt(effectiveSpeed, 1)} ${unitLabel}`
-        : "--";
+      els.gpsStatusEffectiveSpeed.textContent = formatSpeedValue(status.effective_speed_kmh, unitLabel) ?? "--";
     }
     if (els.gpsStatusLastError) {
       els.gpsStatusLastError.textContent = status.last_error ?? "--";

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -26,6 +26,15 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     return SPEED_SOURCE_KINDS.some((kind) => kind === value);
   }
 
+  function parseManualSpeedKph(rawValue: number): number | null {
+    return Number.isFinite(rawValue) && rawValue > 0 && rawValue <= 500 ? rawValue : null;
+  }
+
+  function applyStaleTimeoutFromInput(payload: SpeedSourceRequest): void {
+    const staleVal = Number(els.staleTimeoutInput?.value);
+    if (staleVal >= 3 && staleVal <= 120) payload.stale_timeout_s = staleVal;
+  }
+
   function syncSpeedSourceInputs(): void {
     els.speedSourceRadios.forEach((radio) => {
       radio.checked = radio.value === settings.speedSource;
@@ -71,24 +80,20 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     els.speedSourceRadios.forEach((radio) => {
       if (radio.checked && isSpeedSourceKind(radio.value)) src = radio.value;
     });
-    const manual = Number(els.manualSpeedInput?.value);
     const payload: SpeedSourceRequest = {
       speed_source: src,
-      manual_speed_kph: Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null,
+      manual_speed_kph: parseManualSpeedKph(Number(els.manualSpeedInput?.value)),
     };
-    const staleVal = Number(els.staleTimeoutInput?.value);
-    if (staleVal >= 3 && staleVal <= 120) payload.stale_timeout_s = staleVal;
+    applyStaleTimeoutFromInput(payload);
     void syncSpeedSourceToServer(payload);
   }
 
   function saveHeaderManualSpeedFromInput(): void {
-    const manual = Number(els.headerManualSpeedInput?.value);
     const payload: SpeedSourceRequest = {
       speed_source: "manual",
-      manual_speed_kph: Number.isFinite(manual) && manual > 0 && manual <= 500 ? manual : null,
+      manual_speed_kph: parseManualSpeedKph(Number(els.headerManualSpeedInput?.value)),
     };
-    const staleVal = Number(els.staleTimeoutInput?.value);
-    if (staleVal >= 3 && staleVal <= 120) payload.stale_timeout_s = staleVal;
+    applyStaleTimeoutFromInput(payload);
     void syncSpeedSourceToServer(payload);
   }
 

--- a/apps/ui/src/app/features/settings_tabs_controller.ts
+++ b/apps/ui/src/app/features/settings_tabs_controller.ts
@@ -14,19 +14,22 @@ function setActiveSettingsTab(els: UiDomElements, tabId: string): void {
   });
 }
 
+function activateSettingsTabButton(els: UiDomElements, tab: HTMLElement): void {
+  const tabId = tab.getAttribute("data-settings-tab");
+  if (tabId) setActiveSettingsTab(els, tabId);
+}
+
 export function bindSettingsTabs(els: UiDomElements): void {
   const activateTabByIndex = (index: number): void => {
     if (!els.settingsTabs.length) return;
     const safeIndex = ((index % els.settingsTabs.length) + els.settingsTabs.length) % els.settingsTabs.length;
     const button = els.settingsTabs[safeIndex];
-    const tabId = button.getAttribute("data-settings-tab");
-    if (tabId) setActiveSettingsTab(els, tabId);
+    activateSettingsTabButton(els, button);
     button.focus();
   };
   els.settingsTabs.forEach((tab, idx) => {
     tab.addEventListener("click", () => {
-      const tabId = tab.getAttribute("data-settings-tab");
-      if (tabId) setActiveSettingsTab(els, tabId);
+      activateSettingsTabButton(els, tab);
     });
     tab.addEventListener("keydown", (event) => {
       if (event.key === "Enter" || event.key === " ") {


### PR DESCRIPTION
## Summary
This is repo review chunk `127` for `apps/ui/src/app/features/settings_feature.ts`, `settings_gps_status_module.ts`, `settings_speed_source_module.ts`, `settings_tabs_controller.ts`, and `update_feature.ts`. I directly reviewed every code file in the chunk before making changes.

The diff stays behavior-preserving and limited to three helper-level cleanups inside the settings/update layer. In `settings_speed_source_module.ts`, I extracted `parseManualSpeedKph()` and `applyStaleTimeoutFromInput()` so both save paths share one manual-speed validation rule and one stale-timeout extraction path instead of duplicating the same guards. In `settings_gps_status_module.ts`, I added `formatSpeedValue()` so header/raw/effective GPS speed rendering all use the same selected-unit formatting logic. In `settings_tabs_controller.ts`, I added `activateSettingsTabButton()` so click and index-based keyboard navigation share one tab-activation helper. The remaining two files were reviewed directly and left unchanged because their orchestration and polling flows were already compact and well covered.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/esp_flash_feature.spec.ts apps/ui/tests/cycle2_fixes.spec.ts --grep "manual speed validation logic|createUpdateFeature polling" --project=laptop-light --workers=1`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/ui_shell_runtime_modules.spec.ts --grep "renders speed override and car-selection warning" --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. I kept scope to shared helper extraction only and did not alter settings contracts, validation limits, tab behavior, or update polling behavior.
