### PR TITLE
Repo review chunk 128: simplify UI runtime helpers

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -53,6 +53,11 @@ export class UiLiveTransportController {
     }
   }
 
+  private refreshWsChrome(): void {
+    this.renderWsState();
+    this.updateSpectrumOverlay();
+  }
+
   startTransportMode(): void {
     const isDemoMode = new URLSearchParams(window.location.search).has("demo");
     if (isDemoMode) {
@@ -92,8 +97,7 @@ export class UiLiveTransportController {
     } catch (error) {
       this.state.transport.payloadError = error instanceof Error ? error.message : this.payloadErrorMessage();
       this.state.spectrum.hasSpectrumData = false;
-      this.renderWsState();
-      this.updateSpectrumOverlay();
+      this.refreshWsChrome();
       return;
     }
 
@@ -131,8 +135,7 @@ export class UiLiveTransportController {
       },
       onStateChange: (nextState) => {
         this.state.transport.wsState = nextState;
-        this.renderWsState();
-        this.updateSpectrumOverlay();
+        this.refreshWsChrome();
         if (nextState === "connected" || nextState === "no_data") {
           this.sendSelection();
         }

--- a/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
@@ -38,23 +38,24 @@ export function createUiShellNavigationModule(
     }
   }
 
+  function activateMenuButton(button: HTMLElement): void {
+    const viewId = button.dataset.view;
+    if (!viewId) return;
+    setActiveView(viewId);
+  }
+
   function activateMenuTabByIndex(index: number): void {
     if (!els.menuButtons.length) return;
     const safeIndex = ((index % els.menuButtons.length) + els.menuButtons.length)
       % els.menuButtons.length;
     const button = els.menuButtons[safeIndex];
-    const viewId = button.dataset.view;
-    if (!viewId) return;
-    setActiveView(viewId);
+    activateMenuButton(button);
     button.focus();
   }
 
   function bindHandlers(): void {
     els.menuButtons.forEach((button, index) => {
-      const activate = (): void => {
-        const viewId = button.dataset.view;
-        if (viewId) setActiveView(viewId);
-      };
+      const activate = (): void => activateMenuButton(button);
       button.addEventListener("click", activate);
       button.addEventListener("keydown", (event) => {
         if (event.key === "Enter" || event.key === " ") {

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -33,11 +33,27 @@ export function createUiShellPreferencesModule(
     return raw === "mps" ? "mps" : "kmh";
   }
 
+  function syncSelectValue(select: HTMLSelectElement | null, value: string): void {
+    if (select) {
+      select.value = value;
+    }
+  }
+
+  function applyLanguageValue(rawLanguage: string): void {
+    shell.lang = ctx.normalizeLanguage(rawLanguage);
+    syncSelectValue(els.languageSelect, shell.lang);
+  }
+
+  function applySpeedUnitValue(rawUnit: string): void {
+    shell.speedUnit = normalizeSpeedUnit(rawUnit);
+    syncSelectValue(els.speedUnitSelect, shell.speedUnit);
+  }
+
   async function hydratePersistedPreferences(): Promise<void> {
     try {
       const languageResponse = await getSettingsLanguage();
       if (languageResponse?.language) {
-        shell.lang = ctx.normalizeLanguage(languageResponse.language);
+        applyLanguageValue(languageResponse.language);
         ctx.applyLanguage(true);
       }
     } catch (error) {
@@ -46,10 +62,7 @@ export function createUiShellPreferencesModule(
     try {
       const speedUnitResponse = await getSettingsSpeedUnit();
       if (speedUnitResponse?.speed_unit) {
-        shell.speedUnit = normalizeSpeedUnit(speedUnitResponse.speed_unit);
-        if (els.speedUnitSelect) {
-          els.speedUnitSelect.value = shell.speedUnit;
-        }
+        applySpeedUnitValue(speedUnitResponse.speed_unit);
         ctx.renderSpeedReadout();
       }
     } catch (error) {
@@ -62,15 +75,10 @@ export function createUiShellPreferencesModule(
     const nextLang = ctx.normalizeLanguage(lang);
     try {
       const payload = await setSettingsLanguage(nextLang);
-      shell.lang = ctx.normalizeLanguage(payload?.language || nextLang);
-      if (els.languageSelect) {
-        els.languageSelect.value = shell.lang;
-      }
+      applyLanguageValue(payload?.language || nextLang);
       ctx.applyLanguage(true);
     } catch (error) {
-      if (els.languageSelect) {
-        els.languageSelect.value = previousLang;
-      }
+      syncSelectValue(els.languageSelect, previousLang);
       ctx.showError(error instanceof Error ? error.message : ctx.t("settings.save_failed"));
     }
   }
@@ -80,15 +88,10 @@ export function createUiShellPreferencesModule(
     const nextUnit = normalizeSpeedUnit(unit);
     try {
       const payload = await setSettingsSpeedUnit(nextUnit);
-      shell.speedUnit = normalizeSpeedUnit(payload?.speed_unit || nextUnit);
-      if (els.speedUnitSelect) {
-        els.speedUnitSelect.value = shell.speedUnit;
-      }
+      applySpeedUnitValue(payload?.speed_unit || nextUnit);
       ctx.renderSpeedReadout();
     } catch (error) {
-      if (els.speedUnitSelect) {
-        els.speedUnitSelect.value = previousUnit;
-      }
+      syncSelectValue(els.speedUnitSelect, previousUnit);
       ctx.showError(error instanceof Error ? error.message : ctx.t("settings.save_failed"));
     }
   }


### PR DESCRIPTION
## Summary
This is repo review chunk `128` for `apps/ui/src/app/runtime/ui_car_creation_command.ts`, `ui_live_transport_controller.ts`, `ui_recording_history_refresh.ts`, `ui_shell_controller.ts`, `ui_shell_feature_ports.ts`, `ui_shell_language_refresh_module.ts`, `ui_shell_navigation_module.ts`, `ui_shell_notification_module.ts`, `ui_shell_preferences_module.ts`, and `ui_shell_status_module.ts`. I directly reviewed every code file in the chunk before making changes.

The diff remains behavior-preserving and limited to three helper-level cleanups inside the UI runtime layer. In `ui_live_transport_controller.ts`, I extracted `refreshWsChrome()` so payload-error handling and websocket state changes share the same websocket-pill/banner plus overlay refresh path. In `ui_shell_navigation_module.ts`, I added `activateMenuButton()` so click and keyboard-index navigation reuse one menu activation helper instead of repeating the same dataset lookup. In `ui_shell_preferences_module.ts`, I added `syncSelectValue()`, `applyLanguageValue()`, and `applySpeedUnitValue()` so persisted preference hydration and save paths share one normalization/UI-sync rule per preference. The remaining seven files were reviewed directly and left unchanged because their runtime seams were already compact and well covered.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/ui_car_creation_command.spec.ts apps/ui/tests/ui_live_transport_controller.spec.ts apps/ui/tests/ui_recording_history_refresh.spec.ts apps/ui/tests/ui_shell_runtime_modules.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional functional changes. I kept scope to helper extraction only and did not alter websocket semantics, shell contracts, or persisted-preference behavior.
