### PR TITLE
Repo review chunk 129: simplify spectrum controller state

### DIFF
--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -63,22 +63,16 @@ function convertToDbInPlace(values: number[]): void {
   }
 }
 
-const bandKeyColors: Record<string, string> = {
-  wheel_1x: orderBandFills.wheel1,
-  wheel_2x: orderBandFills.wheel2,
-  driveshaft_1x: orderBandFills.driveshaft1,
-  engine_1x: orderBandFills.engine1,
-  engine_2x: orderBandFills.engine2,
-  driveshaft_engine_1x: orderBandFills.driveshaftEngine1,
-};
-
-const bandKeyLabels: Record<string, string> = {
-  wheel_1x: "bands.wheel_1x",
-  wheel_2x: "bands.wheel_2x",
-  driveshaft_1x: "bands.driveshaft_1x",
-  engine_1x: "bands.engine_1x",
-  engine_2x: "bands.engine_2x",
-  driveshaft_engine_1x: "bands.driveshaft_engine_1x",
+const bandKeyPresentation: Record<string, { color: string; labelKey: string }> = {
+  wheel_1x: { color: orderBandFills.wheel1, labelKey: "bands.wheel_1x" },
+  wheel_2x: { color: orderBandFills.wheel2, labelKey: "bands.wheel_2x" },
+  driveshaft_1x: { color: orderBandFills.driveshaft1, labelKey: "bands.driveshaft_1x" },
+  engine_1x: { color: orderBandFills.engine1, labelKey: "bands.engine_1x" },
+  engine_2x: { color: orderBandFills.engine2, labelKey: "bands.engine_2x" },
+  driveshaft_engine_1x: {
+    color: orderBandFills.driveshaftEngine1,
+    labelKey: "bands.driveshaft_engine_1x",
+  },
 };
 
 type SpectrumSeriesEntry = {
@@ -112,34 +106,33 @@ export class UiSpectrumController {
   }
 
   updateSpectrumOverlay(): void {
-    if (!this.els.spectrumOverlay) return;
+    const message = this.spectrumOverlayMessage();
+    this.setSpectrumOverlay(message);
+  }
+
+  private spectrumOverlayMessage(): string | null {
     if (this.state.transport.payloadError) {
-      this.els.spectrumOverlay.hidden = false;
-      this.els.spectrumOverlay.textContent = this.state.transport.payloadError;
-      return;
+      return this.state.transport.payloadError;
     }
     if (!this.state.transport.hasReceivedPayload && this.state.transport.wsState === "connecting") {
-      this.els.spectrumOverlay.hidden = false;
-      this.els.spectrumOverlay.textContent = this.t("spectrum.loading");
-      return;
+      return this.t("spectrum.loading");
     }
     if (this.state.transport.wsState === "connecting" || this.state.transport.wsState === "reconnecting") {
-      this.els.spectrumOverlay.hidden = false;
-      this.els.spectrumOverlay.textContent = this.t("ws.connecting");
-      return;
+      return this.t("ws.connecting");
     }
     if (this.state.transport.wsState === "stale") {
-      this.els.spectrumOverlay.hidden = false;
-      this.els.spectrumOverlay.textContent = this.t("spectrum.stale");
-      return;
+      return this.t("spectrum.stale");
     }
     if (!this.state.spectrum.hasSpectrumData) {
-      this.els.spectrumOverlay.hidden = false;
-      this.els.spectrumOverlay.textContent = this.t("spectrum.empty");
-      return;
+      return this.t("spectrum.empty");
     }
-    this.els.spectrumOverlay.hidden = true;
-    this.els.spectrumOverlay.textContent = "";
+    return null;
+  }
+
+  private setSpectrumOverlay(message: string | null): void {
+    if (!this.els.spectrumOverlay) return;
+    this.els.spectrumOverlay.hidden = message === null;
+    this.els.spectrumOverlay.textContent = message ?? "";
   }
 
   renderSpectrum(): void {
@@ -292,13 +285,12 @@ export class UiSpectrumController {
       const center = Number(band.center_hz);
       const tolerance = Number(band.tolerance);
       if (!Number.isFinite(center) || center <= 0 || !Number.isFinite(tolerance)) continue;
-      const color = bandKeyColors[band.key] || orderBandFills.wheel1;
-      const labelKey = bandKeyLabels[band.key] || band.key;
+      const presentation = bandKeyPresentation[band.key];
       out.push({
-        label: this.t(labelKey),
+        label: this.t(presentation?.labelKey ?? band.key),
         min_hz: Math.max(0, center * (1 - tolerance)),
         max_hz: center * (1 + tolerance),
-        color,
+        color: presentation?.color ?? orderBandFills.wheel1,
       });
     }
     return out.length ? out : null;


### PR DESCRIPTION
## Summary
This is repo review chunk `129` for `apps/ui/src/app/runtime/ui_spectrum_controller.ts` and `apps/ui/src/app/runtime/ui_startup_coordinator.ts`. I directly reviewed both code files in the chunk before deciding what to change.

The resulting diff is intentionally behavior-preserving and limited to `ui_spectrum_controller.ts`. That file kept its band presentation metadata split across two parallel maps and repeated the same overlay DOM writes in each transport-state branch. I consolidated the band metadata into a single `bandKeyPresentation` map so label keys and colors now live together, reducing the chance of those tables drifting apart during future edits. I also extracted `spectrumOverlayMessage()` and `setSpectrumOverlay()` so the controller computes overlay state in one place and applies it in one place without changing transport precedence, copy text, or spectrum rendering flow. `ui_startup_coordinator.ts` was reviewed directly and left unchanged because its startup ordering, async warning isolation, and background/polling boundaries were already compact and well covered by focused tests.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/ui_startup_coordinator.spec.ts apps/ui/tests/ui_shell_runtime_modules.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional behavior changes. I avoided altering chart math, tweening, startup sequencing, or transport semantics.
