### PR TITLE
Repo review chunk 130: reuse view target helper

### DIFF
--- a/apps/ui/src/app/views/dom_helpers.ts
+++ b/apps/ui/src/app/views/dom_helpers.ts
@@ -5,6 +5,16 @@ export function renderTableEmptyRow(
   return `<tr><td colspan="${colspan}">${textHtml}</td></tr>`;
 }
 
+export function closestFromTarget<T extends Element>(
+  target: EventTarget | null,
+  selector: string,
+): T | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  return target.closest<T>(selector);
+}
+
 export function renderStatusGridRow(
   labelHtml: string,
   valueHtml: string,

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -7,7 +7,7 @@ import type {
 import { HISTORY_HEATMAP_POSITIONS } from "../../config";
 import type { RunDetail } from "../ui_app_state";
 import { heatColor, normalizeUnit } from "../features/heat_utils";
-import { renderTableEmptyRow } from "./dom_helpers";
+import { closestFromTarget, renderTableEmptyRow } from "./dom_helpers";
 
 type LocationIntensityRow = HistoryInsightsPayload["sensor_intensity_by_location"][number];
 
@@ -301,10 +301,7 @@ export function renderHistoryTable(
 export function getHistoryTableAction(
   target: EventTarget | null,
 ): HistoryTableAction | null {
-  if (!(target instanceof Element)) {
-    return null;
-  }
-  const actionElement = target.closest<HTMLElement>("[data-run-action]");
+  const actionElement = closestFromTarget<HTMLElement>(target, "[data-run-action]");
   if (!actionElement) {
     return null;
   }
@@ -315,8 +312,6 @@ export function getHistoryTableAction(
 }
 
 export function getHistoryTableRowRunId(target: EventTarget | null): string | null {
-  if (!(target instanceof Element)) {
-    return null;
-  }
-  return target.closest<HTMLElement>('tr[data-run-row="1"]')?.getAttribute("data-run") ?? null;
+  return closestFromTarget<HTMLElement>(target, 'tr[data-run-row="1"]')
+    ?.getAttribute("data-run") ?? null;
 }

--- a/apps/ui/src/app/views/realtime_sensor_table_view.ts
+++ b/apps/ui/src/app/views/realtime_sensor_table_view.ts
@@ -1,6 +1,6 @@
 import type { LocationOption } from "../../api/types";
 import type { AdaptedClient } from "../../server_payload";
-import { renderTableEmptyRow } from "./dom_helpers";
+import { closestFromTarget, renderTableEmptyRow } from "./dom_helpers";
 
 export interface RealtimeSensorTableViewParams {
   clients: AdaptedClient[];
@@ -62,10 +62,7 @@ export function renderRealtimeSensorTable(
 export function getRealtimeSensorTableClickAction(
   target: EventTarget | null,
 ): RealtimeSensorTableClickAction | null {
-  if (!(target instanceof Element)) {
-    return null;
-  }
-  const button = target.closest<HTMLButtonElement>(".row-identify, .row-remove");
+  const button = closestFromTarget<HTMLButtonElement>(target, ".row-identify, .row-remove");
   if (!button) {
     return null;
   }

--- a/apps/ui/src/app/views/settings_car_list_view.ts
+++ b/apps/ui/src/app/views/settings_car_list_view.ts
@@ -1,5 +1,5 @@
 import type { CarRecord } from "../../api/types";
-import { renderTableEmptyRow } from "./dom_helpers";
+import { closestFromTarget, renderTableEmptyRow } from "./dom_helpers";
 
 export interface SettingsCarListViewParams {
   cars: CarRecord[];
@@ -42,10 +42,7 @@ export function renderSettingsCarList(
 export function getSettingsCarListAction(
   target: EventTarget | null,
 ): SettingsCarListAction | null {
-  if (!(target instanceof Element)) {
-    return null;
-  }
-  const button = target.closest<HTMLButtonElement>(".car-activate-btn, .car-delete-btn");
+  const button = closestFromTarget<HTMLButtonElement>(target, ".car-activate-btn, .car-delete-btn");
   if (!button) {
     return null;
   }


### PR DESCRIPTION
## Summary
This is repo review chunk `130` for `apps/ui/src/app/views/car_wizard_view.ts`, `dom_helpers.ts`, `history_table_view.ts`, `realtime_sensor_table_view.ts`, `settings_car_list_view.ts`, and `update_status_view.ts`. I directly reviewed every code file in the chunk before deciding what to change.

The diff stays behavior-preserving and focused on a small duplication cleanup across the table-style view helpers. `history_table_view.ts`, `realtime_sensor_table_view.ts`, and `settings_car_list_view.ts` each repeated the same `EventTarget` narrowing plus `closest()` lookup before resolving row actions. I added a shared `closestFromTarget()` helper in `dom_helpers.ts` and reused it in those three views so the DOM-target traversal logic now lives in one place while selectors, returned action shapes, and button semantics remain unchanged. The other two files in the chunk stayed untouched after direct review: `car_wizard_view.ts` was already compact and covered by focused helper tests, and `update_status_view.ts` already had a clear small-renderer structure without duplicated event-target logic worth extracting in this pass.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/car_wizard_view.spec.ts apps/ui/tests/history_feature_modules.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional behavior changes. I kept scope to shared DOM lookup reuse only and did not alter markup, action names, history rendering, or update-status content.
