### PR TITLE
Repo review chunk 134: simplify swatch styles

### DIFF
--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -463,8 +463,10 @@ input:focus-visible,
 .legend { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-4); margin-top: var(--space-3); font-size: 0.85rem; }
 .legend.band-legend { margin-top: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--border); }
 .legend-item { display: inline-flex; align-items: center; gap: var(--space-1); }
-.swatch { width: 12px; height: 12px; border-radius: 3px; }
 .swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
   background: var(--swatch-color, currentColor);
   border: 1px solid rgba(20, 32, 51, 0.2);
 }


### PR DESCRIPTION
## Summary
This is repo review chunk `134` for `apps/ui/src/styles/app.css`. I directly reviewed the stylesheet file before deciding what to change.

The diff is intentionally tiny and behavior-preserving. In the legend styling area, `.swatch` was defined in two adjacent base rules even though both blocks were part of the same shared selector contract and there was no cascade or override reason to keep them separate. I collapsed those adjacent declarations into a single `.swatch` rule so the shared legend-chip styling is easier to scan and maintain in one place. No selector names changed, no values changed, and no responsive or dark-mode overrides were touched.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional behavior changes. I kept scope to a local stylesheet simplification and avoided any layout, spacing, or color changes.
