### PR TITLE
Repo review chunk 135: share UI test helpers

### DIFF
--- a/apps/ui/tests/api_http.spec.ts
+++ b/apps/ui/tests/api_http.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { apiJson } from "../src/api/http";
+import { installWindowGlobal } from "./async_test_helpers";
 
 test.describe("apiJson", () => {
   test.beforeEach(() => {
-    (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
-      typeof globalThis;
+    installWindowGlobal();
   });
 
   test("timeout aborts with and without provided AbortSignal", async () => {

--- a/apps/ui/tests/async_test_helpers.ts
+++ b/apps/ui/tests/async_test_helpers.ts
@@ -16,6 +16,19 @@ export function createDeferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
+export function installWindowGlobal(): void {
+  (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
+    typeof globalThis;
+}
+
+export function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
 export function installTimerHarness(): TimerHarness {
   const originalSetTimeout = globalThis.setTimeout;
   const originalClearTimeout = globalThis.clearTimeout;

--- a/apps/ui/tests/cycle2_fixes.spec.ts
+++ b/apps/ui/tests/cycle2_fixes.spec.ts
@@ -15,6 +15,7 @@ import { expect, test } from "@playwright/test";
 import { adaptServerPayload } from "../src/server_payload";
 import { applySpectrumTick } from "../src/app/ui_app_state";
 import { areHeavyFramesCompatible, interpolateHeavyFrame } from "../src/app/spectrum_animation";
+import { EXPECTED_SCHEMA_VERSION, type LiveWsPayload } from "../src/contracts/ws_payload_types";
 
 function makeStrengthMetrics(vibrationStrengthDb: number) {
   return {
@@ -36,10 +37,17 @@ function requireSpectra(adapted: ReturnType<typeof adaptServerPayload>) {
 // 1. adaptServerPayload – spectra null yields null, not stale data
 // ---------------------------------------------------------------------------
 test.describe("adaptServerPayload spectra handling", () => {
-  const basePayload: Record<string, unknown> = {
+  const basePayload = {
+    schema_version: EXPECTED_SCHEMA_VERSION,
+    server_time: "2026-01-01T00:00:00Z",
     clients: [],
     speed_mps: 10,
-  };
+    selected_client_id: null,
+    rotational_speeds: null,
+  } satisfies Pick<
+    LiveWsPayload,
+    "schema_version" | "server_time" | "clients" | "speed_mps" | "selected_client_id" | "rotational_speeds"
+  >;
 
   test("returns null spectra when payload has no spectra field", () => {
     const adapted = adaptServerPayload({ ...basePayload });

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -2,11 +2,11 @@ import { expect, test } from "@playwright/test";
 
 import { runDemoMode } from "../src/app/demo_mode";
 import { adaptServerPayload } from "../src/server_payload";
+import { installWindowGlobal } from "./async_test_helpers";
 
 test.describe("runDemoMode", () => {
   test.beforeEach(() => {
-    (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
-      typeof globalThis;
+    installWindowGlobal();
   });
 
   test("emits a schema-valid websocket payload", () => {

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -3,21 +3,16 @@ import { expect, test } from "@playwright/test";
 import { createEspFlashFeature } from "../src/app/features/esp_flash_feature";
 import { createUpdateFeature } from "../src/app/features/update_feature";
 import type { UiDomElements } from "../src/app/ui_dom_registry";
-import { createDeferred, flushAsyncWork, installTimerHarness } from "./async_test_helpers";
+import {
+  createDeferred,
+  flushAsyncWork,
+  installTimerHarness,
+  installWindowGlobal,
+  jsonResponse,
+} from "./async_test_helpers";
 import type { TimerHarness } from "./async_test_helpers";
 
 type ClickListener = (() => void) | null;
-
-function jsonResponse(body: unknown): Response {
-  const payload = JSON.stringify(body);
-  return {
-    ok: true,
-    status: 200,
-    statusText: "OK",
-    headers: new Headers({ "content-type": "application/json" }),
-    text: async () => payload,
-  } as unknown as Response;
-}
 
 function pendingPollDelays(timers: TimerHarness): number[] {
   return timers.pendingDelays().filter((delay) => delay !== 10_000);
@@ -219,12 +214,11 @@ function createUpdateDeps() {
   };
 }
 
-test.describe("createEspFlashFeature polling", () => {
-  test.beforeEach(() => {
-    (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
-      typeof globalThis;
-  });
+test.beforeEach(() => {
+  installWindowGlobal();
+});
 
+test.describe("createEspFlashFeature polling", () => {
   test("start replaces the previous poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
     const restoreFetch = installFetchMock(async (url, method) => {
@@ -331,11 +325,6 @@ test.describe("createEspFlashFeature polling", () => {
 });
 
 test.describe("createUpdateFeature polling", () => {
-  test.beforeEach(() => {
-    (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
-      typeof globalThis;
-  });
-
   test("start replaces the previous update poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
     const restoreFetch = installFetchMock(async (url, method) => {

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -8,6 +8,7 @@ import {
 import { createHistoryListModule } from "../src/app/features/history_list_module";
 import { createAppState, type RunDetail } from "../src/app/ui_app_state";
 import type { UiDomElements } from "../src/app/ui_dom_registry";
+import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
 
 type ButtonStub = HTMLButtonElement & {
   disabled: boolean;
@@ -58,14 +59,6 @@ function createHistoryElements(): {
   };
 }
 
-function jsonResponse(body: unknown, init?: ResponseInit): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "content-type": "application/json" },
-    ...init,
-  });
-}
-
 function historyInsightsPayload(runId: string, sensorCountUsed: number) {
   return {
     run_id: runId,
@@ -107,8 +100,7 @@ function ensureRunDetail(state: ReturnType<typeof createAppState>, runId: string
 }
 
 test.beforeEach(() => {
-  (globalThis as { window?: Window & typeof globalThis }).window = globalThis as unknown as Window &
-    typeof globalThis;
+  installWindowGlobal();
 });
 
 test("history list module refreshes runs and renders table state", async () => {


### PR DESCRIPTION
## Summary
This is repo review chunk `135` for `apps/ui/tests/api_http.spec.ts`, `async_test_helpers.ts`, `car_wizard_view.spec.ts`, `cycle2_fixes.spec.ts`, `demo_mode.spec.ts`, `esp_flash_feature.spec.ts`, `history_feature_modules.spec.ts`, `polling_controller.spec.ts`, `smoke.bootstrap.spec.ts`, and `smoke.cars.spec.ts`. I directly reviewed every test file in the chunk before deciding what to change.

The main cleanup is shared test infrastructure reuse. `api_http.spec.ts`, `demo_mode.spec.ts`, `esp_flash_feature.spec.ts`, and `history_feature_modules.spec.ts` repeated the same `window` bootstrap, and the last two also carried local JSON response helpers. I moved those patterns into the existing `async_test_helpers.ts` module via `installWindowGlobal()` and `jsonResponse()` and updated the affected specs to reuse them. While validating the whole chunk, `cycle2_fixes.spec.ts` exposed stale `adaptServerPayload()` fixtures that no longer matched the required WS contract fields. I refreshed that base fixture to import `EXPECTED_SCHEMA_VERSION`/`LiveWsPayload` and include the now-required payload keys so the regression tests track the real contract again. The remaining four files were reviewed directly and left unchanged.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/api_http.spec.ts apps/ui/tests/car_wizard_view.spec.ts apps/ui/tests/cycle2_fixes.spec.ts apps/ui/tests/demo_mode.spec.ts apps/ui/tests/esp_flash_feature.spec.ts apps/ui/tests/history_feature_modules.spec.ts apps/ui/tests/polling_controller.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional behavior changes. I kept scope to test-helper reuse plus fixture alignment with the already-live WS contract.
