### PR TITLE
Repo review chunk 136: tighten UI smoke tests

### DIFF
--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -21,7 +21,24 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
     },
   });
   await page.route("**/api/history/**/insights**", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ run_id: "run-001", status: "complete", start_time_utc: "2026-01-01T00:00:00Z", duration_s: 12.3, sensor_count_used: 1, sensor_intensity_by_location: [{ location: "Front Left Wheel", p50_intensity_db: 10, p95_intensity_db: 20, max_intensity_db: 30, dropped_frames_delta: 0, queue_overflow_drops_delta: 0, sample_count: 15 }] }) });
+    await fulfillJson(route, {
+      run_id: "run-001",
+      status: "complete",
+      start_time_utc: "2026-01-01T00:00:00Z",
+      duration_s: 12.3,
+      sensor_count_used: 1,
+      sensor_intensity_by_location: [
+        {
+          location: "Front Left Wheel",
+          p50_intensity_db: 10,
+          p95_intensity_db: 20,
+          max_intensity_db: 30,
+          dropped_frames_delta: 0,
+          queue_overflow_drops_delta: 0,
+          sample_count: 15,
+        },
+      ],
+    });
   });
   await installFakeWebSocket(page);
   await page.goto("/");
@@ -33,6 +50,8 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
 
 test("history PDF download revokes object URL with safe delay", async ({ page }) => {
   let reportPdfCalls = 0;
+  const revokeCallCount = () =>
+    page.evaluate(() => (window as typeof window & { __revokeCallCount?: number }).__revokeCallCount ?? 0);
   await installCommonRoutes(page, { runs: [{ run_id: "run-001", start_time_utc: "2026-01-01T00:00:00Z", sample_count: 42 }] });
   await page.route("**/api/history/**/report.pdf**", async (route) => {
     reportPdfCalls += 1;
@@ -52,7 +71,7 @@ test("history PDF download revokes object URL with safe delay", async ({ page })
   await page.locator('[data-run-action="download-pdf"][data-run="run-001"]').click();
   await expect.poll(() => reportPdfCalls).toBe(1);
   await page.waitForTimeout(200);
-  await expect(page.evaluate(() => (window as typeof window & { __revokeCallCount?: number }).__revokeCallCount ?? 0)).resolves.toBe(0);
+  expect(await revokeCallCount()).toBe(0);
   await page.waitForTimeout(1000);
-  await expect(page.evaluate(() => (window as typeof window & { __revokeCallCount?: number }).__revokeCallCount ?? 0)).resolves.toBe(1);
+  expect(await revokeCallCount()).toBe(1);
 });

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -225,6 +225,23 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
+function requestUrl(input: string | URL | RequestInfo): string {
+  return String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
+}
+
+async function withMockFetch(
+  mockFetch: typeof fetch,
+  run: () => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mockFetch;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 function testTranslation(key: string, vars?: Record<string, unknown>): string {
   return vars ? `${key}:${JSON.stringify(vars)}` : key;
 }
@@ -300,19 +317,7 @@ test.describe("createUiShellPreferencesModule", () => {
   test("hydrates persisted language and speed unit without shell navigation", async () => {
     const state = createAppState();
     const { els, speedUnitSelect } = createShellDeps();
-    const originalFetch = globalThis.fetch;
     const requests: string[] = [];
-    globalThis.fetch = (async (input: string | URL | RequestInfo) => {
-      const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
-      requests.push(url);
-      if (url.endsWith("/api/settings/language")) {
-        return jsonResponse({ language: "nl" });
-      }
-      if (url.endsWith("/api/settings/speed-unit")) {
-        return jsonResponse({ speed_unit: "mps" });
-      }
-      throw new Error(`Unexpected request: ${url}`);
-    }) as typeof fetch;
 
     const applyLanguageCalls: boolean[] = [];
     let renderSpeedReadoutCalls = 0;
@@ -330,11 +335,19 @@ test.describe("createUiShellPreferencesModule", () => {
       showError: () => {},
     });
 
-    try {
+    await withMockFetch((async (input: string | URL | RequestInfo) => {
+      const url = requestUrl(input);
+      requests.push(url);
+      if (url.endsWith("/api/settings/language")) {
+        return jsonResponse({ language: "nl" });
+      }
+      if (url.endsWith("/api/settings/speed-unit")) {
+        return jsonResponse({ speed_unit: "mps" });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }) as typeof fetch, async () => {
       await module.hydratePersistedPreferences();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
 
     expect(requests).toEqual(["/api/settings/language", "/api/settings/speed-unit"]);
     expect(state.shell.lang).toBe("nl");
@@ -347,17 +360,7 @@ test.describe("createUiShellPreferencesModule", () => {
   test("bindHandlers persists speed unit changes independently from navigation", async () => {
     const state = createAppState();
     const { els, speedUnitSelect } = createShellDeps();
-    const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; method: string; body: string }> = [];
-    globalThis.fetch = (async (input: string | URL | RequestInfo, init?: RequestInit) => {
-      const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
-      requests.push({
-        url,
-        method: init?.method ?? "GET",
-        body: String(init?.body ?? ""),
-      });
-      return jsonResponse({ speed_unit: "mps" });
-    }) as typeof fetch;
 
     let renderSpeedReadoutCalls = 0;
     const module = createUiShellPreferencesModule({
@@ -372,14 +375,19 @@ test.describe("createUiShellPreferencesModule", () => {
       showError: () => {},
     });
 
-    try {
+    await withMockFetch((async (input: string | URL | RequestInfo, init?: RequestInit) => {
+      requests.push({
+        url: requestUrl(input),
+        method: init?.method ?? "GET",
+        body: String(init?.body ?? ""),
+      });
+      return jsonResponse({ speed_unit: "mps" });
+    }) as typeof fetch, async () => {
       module.bindHandlers();
       speedUnitSelect.triggerChange("mps");
       await expect.poll(() => state.shell.speedUnit).toBe("mps");
       await expect.poll(() => renderSpeedReadoutCalls).toBe(1);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
 
     expect(requests).toEqual([
       {
@@ -395,11 +403,7 @@ test.describe("createUiShellPreferencesModule", () => {
   test("save failure restores the previous value and reports via showError", async () => {
     const state = createAppState();
     const { els, speedUnitSelect } = createShellDeps();
-    const originalFetch = globalThis.fetch;
     const errors: string[] = [];
-    globalThis.fetch = (async () => {
-      throw new Error("save failed");
-    }) as typeof fetch;
 
     const module = createUiShellPreferencesModule({
       shell: state.shell,
@@ -413,13 +417,13 @@ test.describe("createUiShellPreferencesModule", () => {
       },
     });
 
-    try {
+    await withMockFetch((async () => {
+      throw new Error("save failed");
+    }) as typeof fetch, async () => {
       module.bindHandlers();
       speedUnitSelect.triggerChange("mps");
       await expect.poll(() => errors).toEqual(["save failed"]);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    });
 
     expect(state.shell.speedUnit).toBe("kmh");
     expect(speedUnitSelect.value).toBe("kmh");


### PR DESCRIPTION
## Summary
This is repo review chunk `136` for `apps/ui/tests/smoke.esp-flash.spec.ts`, `smoke.helpers.ts`, `smoke.history.spec.ts`, `smoke.settings.spec.ts`, `ui_car_creation_command.spec.ts`, `ui_live_payload_application.spec.ts`, `ui_live_transport_controller.spec.ts`, `ui_recording_history_refresh.spec.ts`, `ui_shell_runtime_modules.spec.ts`, and `ui_startup_coordinator.spec.ts`. I directly reviewed every code file in the chunk before deciding what to change.

The changes stay strictly structural. In `smoke.history.spec.ts`, the history insights route was manually constructing a JSON `route.fulfill()` response even though the chunk already uses the shared `fulfillJson()` helper. I switched that route to the shared helper and replaced the duplicated PDF revoke-count `page.evaluate()` expression with one local helper function so the assertion path is easier to follow. In `ui_shell_runtime_modules.spec.ts`, the preference-module tests repeated the same fetch install/restore pattern and URL coercion logic across multiple cases. I extracted local `requestUrl()` and `withMockFetch()` helpers so those cases share one fetch-mocking path while preserving the existing assertions and `jsonResponse()` helper. The other eight files were reviewed directly and left unchanged.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/smoke.esp-flash.spec.ts apps/ui/tests/smoke.history.spec.ts apps/ui/tests/smoke.settings.spec.ts apps/ui/tests/ui_car_creation_command.spec.ts apps/ui/tests/ui_live_payload_application.spec.ts apps/ui/tests/ui_live_transport_controller.spec.ts apps/ui/tests/ui_recording_history_refresh.spec.ts apps/ui/tests/ui_shell_runtime_modules.spec.ts apps/ui/tests/ui_startup_coordinator.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional behavior changes. I kept scope to helper reuse and boilerplate removal inside existing tests.
