### PR TITLE
Repo review chunk 137: simplify WS contract tests

### DIFF
--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -34,6 +34,10 @@ const basePayload = {
   speed_mps: 10,
 };
 
+function expectInvalidPayload(payload: unknown): void {
+  expect(() => adaptServerPayload(payload)).toThrow(/Invalid websocket payload/);
+}
+
 function requireSpectra(adapted: ReturnType<typeof adaptServerPayload>) {
   expect(adapted.spectra).not.toBeNull();
   if (!adapted.spectra) throw new Error("Expected adapted spectra");
@@ -52,7 +56,7 @@ test.describe("schema_version handling", () => {
 
   test("rejects payload without schema_version", () => {
     const { schema_version: _, ...noVersion } = basePayload;
-    expect(() => adaptServerPayload(noVersion)).toThrow(/Invalid websocket payload/);
+    expectInvalidPayload(noVersion);
   });
 
   test("accepts unknown schema_version (logs warning, does not throw)", () => {
@@ -64,29 +68,25 @@ test.describe("schema_version handling", () => {
   });
 
   test("rejects invalid field types via AJV validation", () => {
-    expect(() =>
-      adaptServerPayload({
-        ...basePayload,
-        speed_mps: "10",
-      }),
-    ).toThrow(/Invalid websocket payload/);
+    expectInvalidPayload({
+      ...basePayload,
+      speed_mps: "10",
+    });
   });
 
   test("rejects partial strength_metrics instead of defaulting missing fields", () => {
-    expect(() =>
-      adaptServerPayload({
-        ...basePayload,
-        spectra: {
-          freq: [10, 20, 30],
-          clients: {
-            sensor1: {
-              combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-              strength_metrics: { vibration_strength_db: 12 },
-            },
+    expectInvalidPayload({
+      ...basePayload,
+      spectra: {
+        freq: [10, 20, 30],
+        clients: {
+          sensor1: {
+            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
+            strength_metrics: { vibration_strength_db: 12 },
           },
         },
-      }),
-    ).toThrow(/Invalid websocket payload/);
+      },
+    });
   });
 
   test("EXPECTED_SCHEMA_VERSION is string '1'", () => {
@@ -179,20 +179,18 @@ test.describe("shared freq optimization", () => {
   });
 
   test("rejects malformed per-client freq elements instead of skipping the client", () => {
-    expect(() =>
-      adaptServerPayload({
-        ...basePayload,
-        spectra: {
-          clients: {
-            sensor1: {
-              freq: [10, "bad", 30],
-              combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-              strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
-            },
+    expectInvalidPayload({
+      ...basePayload,
+      spectra: {
+        clients: {
+          sensor1: {
+            freq: [10, "bad", 30],
+            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
+            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
           },
         },
-      }),
-    ).toThrow(/Invalid websocket payload/);
+      },
+    });
   });
 
   test("skips client when freq and amplitude bin counts differ", () => {
@@ -238,28 +236,26 @@ test.describe("shared freq optimization", () => {
   });
 
   test("rejects malformed strength metric peaks instead of dropping them", () => {
-    expect(() =>
-      adaptServerPayload({
-        ...basePayload,
-        spectra: {
-          freq: [10, 20, 30],
-          clients: {
-            sensor1: {
-              combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-              strength_metrics: {
-                vibration_strength_db: 12,
-                peak_amp_g: 0.2,
-                noise_floor_amp_g: 0.01,
-                strength_bucket: null,
-                top_peaks: [
-                  { hz: 10, amp: 0.1, vibration_strength_db: 12, strength_bucket: "l2" },
-                  { hz: 20, amp: 0.2 },
-                ],
-              },
+    expectInvalidPayload({
+      ...basePayload,
+      spectra: {
+        freq: [10, 20, 30],
+        clients: {
+          sensor1: {
+            combined_spectrum_amp_g: [0.01, 0.02, 0.03],
+            strength_metrics: {
+              vibration_strength_db: 12,
+              peak_amp_g: 0.2,
+              noise_floor_amp_g: 0.01,
+              strength_bucket: null,
+              top_peaks: [
+                { hz: 10, amp: 0.1, vibration_strength_db: 12, strength_bucket: "l2" },
+                { hz: 20, amp: 0.2 },
+              ],
             },
           },
         },
-      }),
-    ).toThrow(/Invalid websocket payload/);
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
This is repo review chunk `137` for `apps/ui/tests/visual.spec.ts` and `apps/ui/tests/ws_contract.spec.ts`. I directly reviewed both code files in the chunk before deciding what to change.

The only code change is in `ws_contract.spec.ts`. That file repeated the same `expect(() => adaptServerPayload(...)).toThrow(/Invalid websocket payload/)` shape across several schema-validation cases. I extracted a small local `expectInvalidPayload()` helper and reused it for the invalid-schema and invalid-value scenarios so the regression file keeps one failure-expectation path without changing any coverage or semantics.

`visual.spec.ts` was also reviewed directly and left unchanged. During a broader local validation attempt that included both files, the visual test hit existing committed snapshot mismatches across the laptop/tablet light/dark baselines. Because resolving that drift would require deliberate snapshot re-baselining in excluded PNG artifacts rather than a safe code-only cleanup, I kept this chunk scoped to the WS contract test refactor and recorded the snapshot issue in the tracker.

## Validation
I ran:
- `npm --prefix apps/ui run lint`
- `npm --prefix apps/ui run typecheck`
- `npm --prefix apps/ui run build`
- `npx --prefix apps/ui playwright test --config=apps/ui/playwright.config.ts apps/ui/tests/ws_contract.spec.ts --project=laptop-light --workers=1`
- `npm --prefix apps/ui run test:smoke`

## Risks / skipped items
No intentional behavior changes. Skipped snapshot updates for `visual.spec.ts` because the current baseline drift needs an intentional re-baseline, not a speculative cleanup change.
