### PR TITLE
Repo review chunk 138: clarify ESP config comments

### DIFF
--- a/firmware/esp/.gitignore
+++ b/firmware/esp/.gitignore
@@ -1,4 +1,6 @@
 .pio
 .vscode/*
 !.vscode/extensions.json
+
+# Keep per-developer network overrides out of source control.
 include/vibesensor_network.local.h

--- a/firmware/esp/platformio.ini
+++ b/firmware/esp/platformio.ini
@@ -37,6 +37,7 @@ build_flags =
   -I test/native_support
   -I include
   -I lib/vibesensor_proto
+; Native tests run against host-side seams, so hardware-only firmware libraries stay excluded here.
 lib_ignore =
   adxl345
   vibesensor_proto


### PR DESCRIPTION
## Summary
This is repo review chunk `138` for `firmware/esp/.gitignore` and `firmware/esp/platformio.ini`. I directly reviewed both code/config files in the chunk before deciding what to change.

The changes are comment-only and strictly behavior-preserving. In `firmware/esp/.gitignore`, the repo already ignored `include/vibesensor_network.local.h`, but there was no local explanation for why that header must stay untracked. I added a short note clarifying that it holds per-developer network overrides and should remain out of source control.

In `firmware/esp/platformio.ini`, the native test environment already excluded several hardware-specific libraries under `lib_ignore`, but the reason was implicit. I added a brief comment explaining that the native environment exercises host-side seams rather than real hardware integrations, so those hardware-only firmware libraries stay excluded there.

No config values, environment names, library lists, or build behavior changed. The chunk is limited to making the firmware development/test intent easier to understand for future maintainers.

## Validation
I ran:
- `make lint`
- `cd firmware/esp && pio test -e native`

## Risks / skipped items
No intentional behavior changes. I kept this chunk to documentation-in-config improvements only.
