### PR TITLE
Repo review chunk 139: clarify firmware headers

### DIFF
--- a/firmware/esp/include/vibesensor_contracts.h
+++ b/firmware/esp/include/vibesensor_contracts.h
@@ -1,12 +1,8 @@
 #pragma once
 
-// Canonical source of truth:
-//   libs/shared/contracts/metrics_fields.json
-//   libs/shared/contracts/network_ports.json
-//   libs/shared/contracts/report_fields.json
-//
-// Keep names aligned with shared contracts when firmware embeds field labels
-// in logs/debug output.
+// Keep these firmware-side field labels and port constants aligned with the
+// shared backend/UI contracts whenever names or defaults change. Firmware only
+// embeds them for protocol constants and debug output.
 
 #define VS_FIELD_VIBRATION_STRENGTH_DB "vibration_strength_db"
 #define VS_FIELD_STRENGTH_BUCKET "strength_bucket"

--- a/firmware/esp/include/vibesensor_network.h
+++ b/firmware/esp/include/vibesensor_network.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 
+// Allow per-developer network overrides without editing the committed defaults.
 #if __has_include("vibesensor_network.local.h")
 #include "vibesensor_network.local.h"
 #endif

--- a/firmware/esp/include/vibesensor_network.local.example.h
+++ b/firmware/esp/include/vibesensor_network.local.example.h
@@ -4,5 +4,6 @@
 // Do not commit secrets or private network details.
 
 #define VIBESENSOR_WIFI_SSID "YOUR_WIFI_SSID"
+// Use an empty PSK only for open networks.
 #define VIBESENSOR_WIFI_PSK ""
 #define VIBESENSOR_SERVER_IP_OCTETS 10, 4, 0, 100


### PR DESCRIPTION
## Summary
This is repo review chunk `139` for `firmware/esp/include/vibesensor_contracts.h`, `vibesensor_network.h`, and `vibesensor_network.local.example.h`. I directly reviewed all three header files in the chunk before deciding what to change.

The changes are header-comment cleanups only. In `vibesensor_contracts.h`, the leading note still referenced `libs/shared/contracts/...` paths that no longer exist in this repository. I replaced that stale path list with a concise explanation of the real maintenance rule: these firmware field labels and port constants must stay aligned with the shared backend/UI contracts, and firmware only embeds them for protocol/debug usage.

In `vibesensor_network.h`, I added a small comment above the optional `vibesensor_network.local.h` include to make it obvious that developers can override local network settings without editing the committed defaults. In `vibesensor_network.local.example.h`, I added one clarification that an empty PSK is only appropriate for open networks.

No macros, defaults, include behavior, or runtime values changed. The chunk is limited to making the firmware network/contract headers easier to understand and less misleading.

## Validation
I ran:
- `make lint`
- `cd firmware/esp && pio test -e native`

## Risks / skipped items
No intentional behavior changes. I kept scope to comment and guidance cleanup only.
