### PR TITLE
Repo review chunk 143: clarify reliability helpers

### DIFF
--- a/firmware/esp/lib/reliability/reliability.h
+++ b/firmware/esp/lib/reliability/reliability.h
@@ -5,17 +5,30 @@
 
 namespace vibesensor::reliability {
 
+constexpr size_t kBytesPerXyzSample = 6U;
+constexpr uint8_t kMaxUint8Value = 0xFF;
+constexpr uint16_t kMaxUint16Value = 0xFFFF;
+constexpr uint8_t kRetryBackoffShiftCap = 6;
+constexpr uint32_t kRetryJitterDivisor = 4U;
+
 constexpr uint16_t clamp_sample_rate(uint16_t configured_hz,
                                      uint16_t min_hz,
                                      uint16_t max_hz) {
-  return configured_hz < min_hz ? min_hz : (configured_hz > max_hz ? max_hz : configured_hz);
+  if (configured_hz < min_hz) {
+    return min_hz;
+  }
+  if (configured_hz > max_hz) {
+    return max_hz;
+  }
+  return configured_hz;
 }
 
 inline uint16_t clamp_frame_samples(uint16_t configured_samples,
                                     size_t max_datagram_bytes,
                                     size_t data_header_bytes) {
-  const size_t max_by_datagram = (max_datagram_bytes - data_header_bytes) / 6U;
-  const uint16_t hi = static_cast<uint16_t>(max_by_datagram > 0xFFFF ? 0xFFFF : max_by_datagram);
+  const size_t max_by_datagram = (max_datagram_bytes - data_header_bytes) / kBytesPerXyzSample;
+  const uint16_t hi =
+      static_cast<uint16_t>(max_by_datagram > kMaxUint16Value ? kMaxUint16Value : max_by_datagram);
   if (configured_samples == 0) {
     return 1;
   }
@@ -23,19 +36,20 @@ inline uint16_t clamp_frame_samples(uint16_t configured_samples,
 }
 
 inline uint8_t saturating_inc_u8(uint8_t value) {
-  return value == 0xFF ? value : static_cast<uint8_t>(value + 1);
+  return value == kMaxUint8Value ? value : static_cast<uint8_t>(value + 1);
 }
 
 inline uint32_t compute_retry_delay_ms(uint32_t base_ms,
                                        uint32_t max_ms,
                                        uint8_t failure_count,
                                        uint32_t random_value) {
-  const uint8_t shift = failure_count < 6 ? failure_count : 6;
+  const uint8_t shift =
+      failure_count < kRetryBackoffShiftCap ? failure_count : kRetryBackoffShiftCap;
   uint32_t delay_ms = base_ms << shift;
   if (delay_ms > max_ms) {
     delay_ms = max_ms;
   }
-  const uint32_t jitter_span = delay_ms / 4U;
+  const uint32_t jitter_span = delay_ms / kRetryJitterDivisor;
   if (jitter_span == 0) {
     return delay_ms;
   }


### PR DESCRIPTION
## Summary
This is repo review chunk `143` for `firmware/esp/lib/reliability/reliability.h`. I directly reviewed the file before deciding what to change.

The cleanup is entirely internal to the header’s helper logic. The file still embedded a few unit/limit values as raw literals: bytes per XYZ sample, the `uint8_t` saturation limit, the retry backoff shift cap, and the retry jitter divisor. It also expressed `clamp_sample_rate()` as a nested ternary, which made the simple bound checks harder to scan.

I introduced named constants for those helper values and rewrote `clamp_sample_rate()` as straight guard clauses. I also reused the new constants in `clamp_frame_samples()`, `saturating_inc_u8()`, and `compute_retry_delay_ms()`. No algorithms, thresholds, or return values changed; the header just reads more directly now.

## Validation
I ran:
- `make lint`
- `cd firmware/esp && pio test -e native`

## Risks / skipped items
No intentional behavior changes. I kept the refactor limited to naming and readability inside the existing helper implementations.
