### PR TITLE
Repo review chunk 145: share runtime axis count

### DIFF
--- a/firmware/esp/src/runtime_config.h
+++ b/firmware/esp/src/runtime_config.h
@@ -51,6 +51,7 @@ constexpr uint16_t kFrameSamples = (kConfiguredFrameSamples == 0)
 constexpr uint16_t kServerDataPort = static_cast<uint16_t>(VIBESENSOR_SERVER_DATA_PORT);
 constexpr uint16_t kServerControlPort = static_cast<uint16_t>(VIBESENSOR_SERVER_CONTROL_PORT);
 constexpr uint16_t kControlPortBase = static_cast<uint16_t>(VIBESENSOR_CONTROL_PORT_BASE);
+constexpr size_t kAxesPerSample = 3;
 
 #ifndef VIBESENSOR_FRAME_QUEUE_LEN_TARGET
 #define VIBESENSOR_FRAME_QUEUE_LEN_TARGET 128

--- a/firmware/esp/src/runtime_queue.cpp
+++ b/firmware/esp/src/runtime_queue.cpp
@@ -38,7 +38,7 @@ void enqueue_frame(FrameQueueState& state,
   frame.last_tx_ms = 0;
   memcpy(frame.xyz,
          state.build_xyz,
-         static_cast<size_t>(state.build_count) * 3 * sizeof(int16_t));
+         static_cast<size_t>(state.build_count) * kAxesPerSample * sizeof(int16_t));
 
   state.head = (state.head + 1) % state.capacity;
   state.size++;
@@ -86,7 +86,7 @@ void append_sample(FrameQueueState& state,
     state.build_t0_us = sample_due_us;
   }
 
-  const size_t idx = static_cast<size_t>(state.build_count) * 3;
+  const size_t idx = static_cast<size_t>(state.build_count) * kAxesPerSample;
   state.build_xyz[idx + 0] = x;
   state.build_xyz[idx + 1] = y;
   state.build_xyz[idx + 2] = z;

--- a/firmware/esp/src/runtime_queue.h
+++ b/firmware/esp/src/runtime_queue.h
@@ -11,7 +11,7 @@ struct DataFrame {
   uint32_t seq = 0;
   uint64_t t0_us = 0;
   uint16_t sample_count = 0;
-  int16_t xyz[static_cast<size_t>(kFrameSamples) * 3] = {};
+  int16_t xyz[static_cast<size_t>(kFrameSamples) * kAxesPerSample] = {};
   bool transmitted = false;
   uint32_t last_tx_ms = 0;
 };
@@ -22,7 +22,7 @@ struct FrameQueueState {
   size_t head = 0;
   size_t tail = 0;
   size_t size = 0;
-  int16_t build_xyz[static_cast<size_t>(kFrameSamples) * 3] = {};
+  int16_t build_xyz[static_cast<size_t>(kFrameSamples) * kAxesPerSample] = {};
   uint16_t build_count = 0;
   uint64_t build_t0_us = 0;
   uint32_t next_seq = 0;

--- a/firmware/esp/src/runtime_sampling.cpp
+++ b/firmware/esp/src/runtime_sampling.cpp
@@ -73,8 +73,8 @@ bool next_sensor_sample(SamplingState& state,
       for (size_t i = 0;
            i < read_count && state.sensor_prefetch_count < kSensorPrefetchSamples;
            ++i) {
-        const size_t src = i * 3;
-        const size_t dst = state.sensor_prefetch_head * 3;
+        const size_t src = i * kAxesPerSample;
+        const size_t dst = state.sensor_prefetch_head * kAxesPerSample;
         state.sensor_prefetch_xyz[dst + 0] = state.sensor_batch_xyz[src + 0];
         state.sensor_prefetch_xyz[dst + 1] = state.sensor_batch_xyz[src + 1];
         state.sensor_prefetch_xyz[dst + 2] = state.sensor_batch_xyz[src + 2];
@@ -87,7 +87,7 @@ bool next_sensor_sample(SamplingState& state,
   if (state.sensor_prefetch_count == 0) {
     return false;
   }
-  const size_t offset = state.sensor_prefetch_tail * 3;
+  const size_t offset = state.sensor_prefetch_tail * kAxesPerSample;
   *x = state.sensor_prefetch_xyz[offset + 0];
   *y = state.sensor_prefetch_xyz[offset + 1];
   *z = state.sensor_prefetch_xyz[offset + 2];

--- a/firmware/esp/src/runtime_sampling.h
+++ b/firmware/esp/src/runtime_sampling.h
@@ -16,8 +16,8 @@ struct SamplingState {
   TwoWire& i2c;
   ADXL345 adxl;
   bool sensor_ok = false;
-  int16_t sensor_batch_xyz[kSensorReadBatchSamples * 3] = {};
-  int16_t sensor_prefetch_xyz[kSensorPrefetchSamples * 3] = {};
+  int16_t sensor_batch_xyz[kSensorReadBatchSamples * kAxesPerSample] = {};
+  int16_t sensor_prefetch_xyz[kSensorPrefetchSamples * kAxesPerSample] = {};
   size_t sensor_prefetch_head = 0;
   size_t sensor_prefetch_tail = 0;
   size_t sensor_prefetch_count = 0;


### PR DESCRIPTION
## Summary
This is repo review chunk `145` for `firmware/esp/src/main.cpp`, `runtime_config.h`, `runtime_led.cpp`, `runtime_led.h`, `runtime_queue.cpp`, `runtime_queue.h`, `runtime_sampling.cpp`, `runtime_sampling.h`, `runtime_status.cpp`, and `runtime_status.h`. I directly reviewed every file in the chunk before deciding what to change.

The only code change is shared axis-count cleanup across the queue/sampling path. `runtime_queue.*` and `runtime_sampling.*` still hard-coded the XYZ component count as raw `3` multipliers in frame buffers, build buffers, batch buffers, prefetch buffers, and offset calculations. I added a single `kAxesPerSample` constant to `runtime_config.h` and rewired those queue/sampling declarations and index calculations to reuse it.

That keeps one definition for the runtime’s sample shape instead of repeating the same literal across multiple files. The remaining five files in the chunk (`main.cpp`, `runtime_led.*`, and `runtime_status.*`) were reviewed directly and left unchanged.

## Validation
I ran:
- `make lint`
- `cd firmware/esp && pio test -e native`

## Risks / skipped items
No intentional behavior changes. I kept the refactor limited to deduplicating the XYZ axis count across the runtime queue/sampling path.
