### PR TITLE
Repo review chunk 146: share transport packet send

### DIFF
--- a/firmware/esp/src/runtime_transport.cpp
+++ b/firmware/esp/src/runtime_transport.cpp
@@ -11,24 +11,34 @@
 namespace vibesensor::runtime {
 namespace {
 
+bool send_control_packet(TransportState& state,
+                         RuntimeStatus& status,
+                         const uint8_t* packet,
+                         size_t len,
+                         uint8_t error_code) {
+  if (state.control_udp.beginPacket(vibesensor_network::server_ip, kServerControlPort) != 1) {
+    set_last_error(status, error_code);
+    return false;
+  }
+  state.control_udp.write(packet, len);
+  if (state.control_udp.endPacket() != 1) {
+    set_last_error(status, error_code);
+    return false;
+  }
+  return true;
+}
+
 void send_ack(TransportState& state,
               RuntimeStatus& status,
               uint32_t cmd_seq,
               uint8_t ack_status) {
-  uint8_t packet[16];
+  uint8_t packet[vibesensor::kAckBytes];
   size_t len = vibesensor::pack_ack(
       packet, sizeof(packet), state.client_id, cmd_seq, ack_status);
   if (len == 0) {
     return;
   }
-  if (state.control_udp.beginPacket(vibesensor_network::server_ip, kServerControlPort) != 1) {
-    set_last_error(status, 8);
-    return;
-  }
-  state.control_udp.write(packet, len);
-  if (state.control_udp.endPacket() != 1) {
-    set_last_error(status, 8);
-  }
+  send_control_packet(state, status, packet, len, 8);
 }
 
 }  // namespace
@@ -36,7 +46,7 @@ void send_ack(TransportState& state,
 void initialize_transport(TransportState& state) {
   String mac = WiFi.macAddress();
   if (!vibesensor::parse_mac(mac, state.client_id)) {
-    const uint8_t fallback[6] = {0xD0, 0x5A, 0x00, 0x00, 0x00, 0x01};
+    const uint8_t fallback[vibesensor::kClientIdBytes] = {0xD0, 0x5A, 0x00, 0x00, 0x00, 0x01};
     memcpy(state.client_id, fallback, sizeof(state.client_id));
   }
   state.control_port =
@@ -65,17 +75,7 @@ bool send_hello(TransportState& state, RuntimeStatus& status) {
   if (len == 0) {
     return false;
   }
-
-  if (state.control_udp.beginPacket(vibesensor_network::server_ip, kServerControlPort) != 1) {
-    set_last_error(status, 4);
-    return false;
-  }
-  state.control_udp.write(packet, len);
-  if (state.control_udp.endPacket() != 1) {
-    set_last_error(status, 4);
-    return false;
-  }
-  return true;
+  return send_control_packet(state, status, packet, len, 4);
 }
 
 void service_hello(TransportState& state, RuntimeStatus& status) {

--- a/firmware/esp/src/runtime_transport.h
+++ b/firmware/esp/src/runtime_transport.h
@@ -6,13 +6,14 @@
 #include "runtime_led.h"
 #include "runtime_queue.h"
 #include "runtime_status.h"
+#include "vibesensor_proto.h"
 
 namespace vibesensor::runtime {
 
 struct TransportState {
   WiFiUDP data_udp;
   WiFiUDP control_udp;
-  uint8_t client_id[6] = {};
+  uint8_t client_id[vibesensor::kClientIdBytes] = {};
   uint16_t control_port = 0;
   uint32_t last_hello_ms = 0;
   bool handshake_complete = false;


### PR DESCRIPTION
## Summary
This is repo review chunk `146` for `firmware/esp/src/runtime_transport.cpp`, `runtime_transport.h`, `runtime_wifi.cpp`, and `runtime_wifi.h`. I directly reviewed every code file in the chunk before deciding what to change.

The transport side had one clear behavior-preserving cleanup: both HELLO and ACK sending were open-coding the same control-UDP `beginPacket` / `write` / `endPacket` sequence, and the transport state still hard-coded the client-id byte count even though the protocol header already defines it. This PR adds a small local `send_control_packet()` helper in `runtime_transport.cpp`, uses the shared helper from both send paths, switches the ACK buffer sizing over to `vibesensor::kAckBytes`, and uses `vibesensor::kClientIdBytes` for the transport client-id buffer and fallback array sizing.

I also directly reviewed `runtime_wifi.cpp` and `runtime_wifi.h` and left them unchanged. Their AP scan/connect/retry flow and state shape were already straightforward, and further refactoring there would have risked changing hardware-specific behavior for little maintainability gain.

## Validation
I ran:
- `make lint`
- `cd firmware/esp && pio test -e native`

## Risks / skipped items
No intentional behavior changes. The cleanup stays narrowly focused on transport packet sending and shared protocol sizing.
