### PR TITLE
Repo review chunk 147: document native shims

### DIFF
--- a/firmware/esp/test/native_support/Arduino.h
+++ b/firmware/esp/test/native_support/Arduino.h
@@ -5,3 +5,4 @@
 #include <string>
 
 using String = std::string;
+// Native tests only need Arduino's String name, not the full framework API.

--- a/firmware/esp/test/native_support/esp_heap_caps.h
+++ b/firmware/esp/test/native_support/esp_heap_caps.h
@@ -6,6 +6,7 @@
 
 constexpr uint32_t MALLOC_CAP_8BIT = 0;
 
+// Native tests only need a host-backed stand-in for ESP-IDF's heap-cap API.
 inline void* heap_caps_malloc(size_t size, uint32_t) {
   return std::malloc(size);
 }


### PR DESCRIPTION
## Summary
This is repo review chunk `147` for `firmware/esp/test/native_support/Arduino.h`, `esp_heap_caps.h`, and `generated_protocol_contract_fixtures.h`. I directly reviewed every code file in the chunk before deciding what to change.

This slice is mostly native-test scaffolding, so I kept the change set very small. The two handwritten shim headers were intentionally minimal but undocumented: `Arduino.h` only aliases Arduino's `String` type for host-side compilation, and `esp_heap_caps.h` only provides a host-backed stand-in for ESP-IDF's heap-cap allocator symbol. I added short comments to make that role explicit, which should make these files read less like incomplete production headers and more like the focused native-test shims they are.

I also directly reviewed `generated_protocol_contract_fixtures.h` and left it unchanged. It already documents the generator and check command, and local hand edits there would only introduce drift from the source script.

## Validation
I ran:
- `make lint`
- `cd firmware/esp && pio test -e native`

## Risks / skipped items
No intentional behavior changes. The only edits are comments in the handwritten native-test support headers; the generated fixture header was intentionally left untouched.
