### PR TITLE
Repo review chunk 151: share pi-gen mode checks

### DIFF
--- a/infra/pi-image/pi-gen/.gitignore
+++ b/infra/pi-image/pi-gen/.gitignore
@@ -1,3 +1,4 @@
 .cache/
+# Keep the placeholder so the output directory exists in fresh clones.
 out/*
 !out/.gitkeep

--- a/infra/pi-image/pi-gen/build.sh
+++ b/infra/pi-image/pi-gen/build.sh
@@ -11,24 +11,32 @@ source "${SCRIPT_DIR}/lib/pi_gen_repo.sh"
 source "${SCRIPT_DIR}/lib/stage_assembly.sh"
 source "${SCRIPT_DIR}/lib/artifacts.sh"
 
+builds_app_artifacts() {
+  [[ "${BUILD_MODE}" == "app" || "${BUILD_MODE}" == "all" ]]
+}
+
+builds_image_artifacts() {
+  [[ "${BUILD_MODE}" == "image" || "${BUILD_MODE}" == "all" ]]
+}
+
 init_pi_gen_env
 validate_build_mode
 ensure_output_dirs
 apply_fast_mode
 validate_first_user_credentials
 
-if [[ "${BUILD_MODE}" == "app" || "${BUILD_MODE}" == "all" ]]; then
+if builds_app_artifacts; then
   require_app_prereqs
 fi
 
-if [[ "${BUILD_MODE}" == "image" || "${BUILD_MODE}" == "all" ]]; then
+if builds_image_artifacts; then
   require_image_prereqs
   ensure_docker_available
   RASPBIAN_MIRROR="$(select_raspbian_mirror)"
   echo "Using Raspbian mirror: ${RASPBIAN_MIRROR}"
 fi
 
-if [[ "${BUILD_MODE}" == "app" || "${BUILD_MODE}" == "all" ]]; then
+if builds_app_artifacts; then
   build_app_artifacts
 fi
 


### PR DESCRIPTION
## Summary
This is repo review chunk `151` for `infra/pi-image/pi-gen/.gitignore`, `build.sh`, and `validate-image.sh`. I directly reviewed every code file in the chunk before deciding what to change.

The main cleanup is in `build.sh`, which repeated the same `BUILD_MODE` checks in multiple places for app-artifact work versus image-build work. I introduced two small local helpers, `builds_app_artifacts()` and `builds_image_artifacts()`, and reused them for the prerequisite and build gates. That keeps the script’s control flow the same while making the mode-driven behavior easier to read at a glance.

I also added a short note in `.gitignore` to explain why `out/.gitkeep` remains tracked even though the rest of `out/` is ignored. I directly reviewed `validate-image.sh` and left it unchanged because it is already a thin, readable entrypoint over the shared validation helpers.

## Validation
I ran:
- `make lint`
- `bash -n infra/pi-image/pi-gen/build.sh infra/pi-image/pi-gen/validate-image.sh`

## Risks / skipped items
No intentional behavior changes. The shell refactor stays local to repeated build-mode predicates, and the validation entrypoint was intentionally left untouched.
