### PR TITLE
Repo review chunk 152: document wifi tmpfiles entry

### DIFF
--- a/infra/pi-image/pi-gen/assets/vibesensor-wifi.conf
+++ b/infra/pi-image/pi-gen/assets/vibesensor-wifi.conf
@@ -1,1 +1,2 @@
+# Ensure the Wi-Fi logging directory exists on boot.
 d /var/log/wifi 0755 root root -


### PR DESCRIPTION
## Summary
This is repo review chunk `152` for `infra/pi-image/pi-gen/assets/vibesensor-wifi.conf`. I directly reviewed the file before deciding what to change.

This asset is intentionally tiny, but it was also context-free: the single tmpfiles rule created `/var/log/wifi` without any inline explanation. I added a short comment clarifying that the file exists to ensure the Wi-Fi logging directory is present at boot. That keeps the asset readable during future pi-image maintenance without changing the tmpfiles behavior itself.

## Validation
I ran:
- `make lint`
- `awk 'NR==1,NR==2 { print }' infra/pi-image/pi-gen/assets/vibesensor-wifi.conf >/dev/null`

## Risks / skipped items
No intentional behavior changes. The only edit is a comment above the existing tmpfiles rule.
