### PR TITLE
Repo review chunk 153: share pi-gen shell helpers

### DIFF
--- a/infra/pi-image/pi-gen/lib/artifacts.sh
+++ b/infra/pi-image/pi-gen/lib/artifacts.sh
@@ -1,26 +1,27 @@
-choose_final_artifact() {
+latest_artifact_matching() {
   local base_dir="$1"
+  shift
   local candidate=""
+  local pattern=""
 
-  candidate="$(find "${base_dir}" -maxdepth 1 -type f -name "image_*${IMG_SUFFIX}*.img" | sort -r | head -n 1 || true)"
-  if [ -n "${candidate}" ]; then
-    printf '%s\n' "${candidate}"
-    return 0
-  fi
-
-  candidate="$(find "${base_dir}" -maxdepth 1 -type f -name "image_*${IMG_SUFFIX}*.img.xz" | sort -r | head -n 1 || true)"
-  if [ -n "${candidate}" ]; then
-    printf '%s\n' "${candidate}"
-    return 0
-  fi
-
-  candidate="$(find "${base_dir}" -maxdepth 1 -type f -name "image_*${IMG_SUFFIX}*.zip" | sort -r | head -n 1 || true)"
-  if [ -n "${candidate}" ]; then
-    printf '%s\n' "${candidate}"
-    return 0
-  fi
+  for pattern in "$@"; do
+    candidate="$(find "${base_dir}" -maxdepth 1 -type f -name "${pattern}" | sort -r | head -n 1 || true)"
+    if [ -n "${candidate}" ]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
 
   return 1
+}
+
+choose_final_artifact() {
+  local base_dir="$1"
+  latest_artifact_matching \
+    "${base_dir}" \
+    "image_*${IMG_SUFFIX}*.img" \
+    "image_*${IMG_SUFFIX}*.img.xz" \
+    "image_*${IMG_SUFFIX}*.zip"
 }
 
 prune_old_artifacts() {

--- a/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
+++ b/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
@@ -27,6 +27,26 @@ patch_export_image_boot_size() {
     "${export_prerun}"
 }
 
+set_base_stage_skip_files() {
+  local state="$1"
+  local stage=""
+
+  for stage in 0 1 2; do
+    case "${state}" in
+      present)
+        touch "${PI_GEN_DIR}/stage${stage}/SKIP"
+        ;;
+      absent)
+        rm -f "${PI_GEN_DIR}/stage${stage}/SKIP"
+        ;;
+      *)
+        echo "Unsupported SKIP marker state: ${state}"
+        exit 1
+        ;;
+    esac
+  done
+}
+
 prepare_pi_gen_repo() {
   if [ ! -d "${PI_GEN_DIR}/.git" ]; then
     git clone --depth 1 --branch "${PI_GEN_REF}" https://github.com/RPi-Distro/pi-gen.git "${PI_GEN_DIR}"
@@ -51,13 +71,11 @@ configure_incremental_build() {
       echo "CLEAN=1: removing previous pigen_work container"
       docker rm -v pigen_work >/dev/null
     fi
-    rm -f "${PI_GEN_DIR}/stage0/SKIP" "${PI_GEN_DIR}/stage1/SKIP" "${PI_GEN_DIR}/stage2/SKIP"
+    set_base_stage_skip_files absent
     echo "Full build: rebuilding all stages"
   else
     echo "Incremental build: skipping stage0/1/2 (set CLEAN=1 to rebuild from scratch)"
-    touch "${PI_GEN_DIR}/stage0/SKIP"
-    touch "${PI_GEN_DIR}/stage1/SKIP"
-    touch "${PI_GEN_DIR}/stage2/SKIP"
+    set_base_stage_skip_files present
   fi
 }
 


### PR DESCRIPTION
## Summary
This is repo review chunk `153` for `infra/pi-image/pi-gen/lib/app_artifacts.sh`, `artifacts.sh`, `common.sh`, `image_validation.sh`, `mirror.sh`, `pi_gen_repo.sh`, `prereqs.sh`, and `stage_assembly.sh`. I directly reviewed every code file in the chunk before deciding what to change.

The changes stay focused on small shell deduping in the two spots that clearly repeated the same local patterns. In `artifacts.sh`, final-artifact selection repeated the same “find the newest matching file and return if present” flow for each supported extension, so I extracted that into a small helper and reused it from `choose_final_artifact()`. In `pi_gen_repo.sh`, incremental-build setup repeated the same `stage0`/`stage1`/`stage2` SKIP marker touch/remove logic, so I pulled that into a small helper and reused it in `configure_incremental_build()`.

I also directly reviewed the other six pi-gen library files and left them unchanged.

## Validation
I ran:
- `make lint`
- `bash -n infra/pi-image/pi-gen/build.sh infra/pi-image/pi-gen/validate-image.sh infra/pi-image/pi-gen/lib/*.sh`

## Risks / skipped items
No intentional behavior changes. This PR stays limited to repeated shell-flow cleanup inside the pi-image helper libraries.
