### PR TITLE
Repo review chunk 155: clarify pi-gen stage order

### DIFF
--- a/infra/pi-image/pi-gen/templates/pi-gen-config.template
+++ b/infra/pi-image/pi-gen/templates/pi-gen-config.template
@@ -8,4 +8,5 @@ DISABLE_FIRST_BOOT_USER_RENAME=1
 WPA_COUNTRY='__VS_WPA_COUNTRY__'
 ENABLE_SSH=1
 PUBKEY_ONLY_SSH=0
+# Run the custom VibeSensor stage after the stock base stages have completed.
 STAGE_LIST="stage0 stage1 stage2 stage-vibesensor"


### PR DESCRIPTION
## Summary
This is repo review chunk `155` for `infra/pi-image/pi-gen/templates/pi-gen-config.template`. I directly reviewed the file before deciding what to change.

The pi-gen template already had the correct stage list, but it did not explain why the custom `stage-vibesensor` stage appears after the stock `stage0`/`stage1`/`stage2` sequence. I added a short inline comment clarifying that the custom VibeSensor stage intentionally runs after the base stages complete. That gives future maintainers the missing context without changing any template values or image-build behavior.

## Validation
I ran:
- `make lint`
- `grep -n '^STAGE_LIST=' infra/pi-image/pi-gen/templates/pi-gen-config.template >/dev/null`

## Risks / skipped items
No intentional behavior changes. The only edit is an explanatory comment in the template file.
