### PR TITLE
Repo review chunk 156: document export trim step

### DIFF
--- a/infra/pi-image/pi-gen/templates/export-image/04-vibesensor-trim/00-run.sh
+++ b/infra/pi-image/pi-gen/templates/export-image/04-vibesensor-trim/00-run.sh
@@ -2,5 +2,6 @@
 
 on_chroot << 'CHROOT_EOF'
 set -e
+# Trim cached apt metadata from the exported image to keep artifacts smaller.
 rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /var/cache/apt/archives/partial/*
 CHROOT_EOF


### PR DESCRIPTION
## Summary
This is repo review chunk `156` for `infra/pi-image/pi-gen/templates/export-image/04-vibesensor-trim/00-run.sh`. I directly reviewed the file before deciding what to change.

This hook is intentionally tiny, but the single chroot command was context-free: it removed apt cache content without saying why. I added a short inline comment clarifying that the step trims cached apt metadata from the exported image to keep the final artifacts smaller. The shell logic itself is unchanged.

## Validation
I ran:
- `make lint`
- `bash -n infra/pi-image/pi-gen/templates/export-image/04-vibesensor-trim/00-run.sh`

## Risks / skipped items
No intentional behavior changes. The only edit is an explanatory comment in the export-image trim hook.
