### PR TITLE
Repo review chunk 157: name stage apt dir

### DIFF
--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+APT_SOURCES_DIR="${ROOTFS_DIR}/etc/apt"
+
 # Always start stage-vibesensor from a clean copy of stage2's rootfs so that
 # incremental builds (with stage0/1/2 skipped) still produce a correct image.
 rm -rf "${ROOTFS_DIR}"
@@ -7,7 +9,7 @@ copy_previous
 
 # Retarget stale apt source entries in reused rootfs snapshots when upstream
 # mirrors are unavailable.
-if [ -d "${ROOTFS_DIR}/etc/apt" ]; then
-  find "${ROOTFS_DIR}/etc/apt" -type f \( -name '*.list' -o -name '*.sources' \) -print0 \
+if [ -d "${APT_SOURCES_DIR}" ]; then
+  find "${APT_SOURCES_DIR}" -type f \( -name '*.list' -o -name '*.sources' \) -print0 \
     | xargs -0 -r sed -i 's#http://raspbian.raspberrypi.com/raspbian/#__RASPBIAN_MIRROR__#g'
 fi


### PR DESCRIPTION
## Summary
This is repo review chunk `157` for `infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template`. I directly reviewed the file before deciding what to change.

The template was already well-commented, but the apt-source retargeting block still repeated the full rootfs apt directory path inline. I introduced a small local `APT_SOURCES_DIR` variable and reused it in the directory existence guard and the `find` command. That keeps the stage path naming a little clearer without changing the template behavior.

## Validation
I ran:
- `make lint`
- `bash -n infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template`

## Risks / skipped items
No intentional behavior changes. This is a tiny readability cleanup inside the stage prerun template only.
