### PR TITLE
Repo review chunk 158: share wheel build args

### DIFF
--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template
@@ -25,6 +25,11 @@ PIP_TMP_CACHE=/tmp/vibesensor-pip-cache
 WHEELHOUSE=/tmp/vibesensor-wheelhouse
 PREBUILT_WHEEL="/opt/vibesensor-artifacts/wheels/__APP_WHEEL_FILE__"
 BUILD_DEPS=(python3-dev)
+PIP_WHEEL_ARGS=(
+  --wheel-dir "${WHEELHOUSE}"
+  --prefer-binary
+  --cache-dir "${PIP_TMP_CACHE}"
+)
 
 if [ ! -f "${PREBUILT_WHEEL}" ]; then
   echo "ERROR: missing prebuilt app wheel at ${PREBUILT_WHEEL}"
@@ -41,13 +46,9 @@ mkdir -p "${WHEELHOUSE}"
 mkdir -p "${PIP_TMP_CACHE}"
 python3 -m venv /tmp/vibesensor-wheel-build
 /tmp/vibesensor-wheel-build/bin/pip install --upgrade pip --quiet
-/tmp/vibesensor-wheel-build/bin/pip wheel --wheel-dir "${WHEELHOUSE}" \
-  --prefer-binary \
-  --cache-dir "${PIP_TMP_CACHE}" \
+/tmp/vibesensor-wheel-build/bin/pip wheel "${PIP_WHEEL_ARGS[@]}" \
   "${PREBUILT_WHEEL}[esp]"
-/tmp/vibesensor-wheel-build/bin/pip wheel --wheel-dir "${WHEELHOUSE}" \
-  --prefer-binary \
-  --cache-dir "${PIP_TMP_CACHE}" \
+/tmp/vibesensor-wheel-build/bin/pip wheel "${PIP_WHEEL_ARGS[@]}" \
   "setuptools>=68" \
   "wheel>=0.38"
 rm -rf /tmp/vibesensor-wheel-build


### PR DESCRIPTION
## Summary
This is repo review chunk `158` for `infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages` and `00-run.sh.template`. I directly reviewed both code files in the chunk before deciding what to change.

The only code change is in `00-run.sh.template`, where the chroot-side wheel-build step repeated the same wheelhouse/cache argument set across two `pip wheel` commands. I pulled those shared arguments into a small `PIP_WHEEL_ARGS` array and reused it for both invocations. That keeps the wheel-build behavior identical while making the stage template a little easier to scan and update.

I also directly reviewed `00-packages` and left it unchanged. The package list is already short, explicit, and aligned with the image-validation and runtime expectations elsewhere in the pi-image flow.

## Validation
I ran:
- `make lint`
- `bash -n infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template`

## Risks / skipped items
No intentional behavior changes. This is a small shell-maintainability cleanup inside the stage run template only.
