### PR TITLE
Repo review chunk 159: tighten tool helpers

### DIFF
--- a/tools/build_ui_static.py
+++ b/tools/build_ui_static.py
@@ -51,6 +51,18 @@ def _run(command: list[str], cwd: Path) -> None:
     subprocess.run(command, cwd=cwd, check=True)
 
 
+def _git_head_commit(repo_root: Path) -> str:
+    if not (repo_root / ".git").exists():
+        return ""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description="Build and sync the UI static assets into the server package."
@@ -100,16 +112,7 @@ def main(argv: list[str] | None = None) -> None:
         ignore_names={"node_modules", "dist", ".git", ".npm-ci-lock.sha256"},
     )
     static_assets_hash = _hash_tree(static_dir, ignore_names={UI_BUILD_METADATA_FILE})
-    git_commit = (
-        subprocess.run(
-            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
-            check=False,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        if (repo_root / ".git").exists()
-        else ""
-    )
+    git_commit = _git_head_commit(repo_root)
     (static_dir / UI_BUILD_METADATA_FILE).write_text(
         json.dumps(
             {

--- a/tools/watch_pr_checks.py
+++ b/tools/watch_pr_checks.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Poll GitHub PR checks until they are all green or a failure appears."""
+
 from __future__ import annotations
 
 import argparse
@@ -9,6 +11,7 @@ import time
 from datetime import datetime, timezone
 
 SUCCESS_CONCLUSION = "SUCCESS"
+COMPLETED_STATUS = "COMPLETED"
 MERGE_ISSUE_STATES = {"DIRTY", "BEHIND", "BLOCKED", "UNKNOWN"}
 
 
@@ -53,7 +56,7 @@ def _label(check: dict[str, object]) -> str:
 
 def _is_green(check: dict[str, object]) -> bool:
     return (
-        str(check.get("status") or "") == "COMPLETED"
+        str(check.get("status") or "") == COMPLETED_STATUS
         and str(check.get("conclusion") or "") == SUCCESS_CONCLUSION
     )
 
@@ -61,7 +64,7 @@ def _is_green(check: dict[str, object]) -> bool:
 def _is_non_green_terminal(check: dict[str, object]) -> bool:
     status = str(check.get("status") or "")
     conclusion = str(check.get("conclusion") or "")
-    return status == "COMPLETED" and conclusion != SUCCESS_CONCLUSION
+    return status == COMPLETED_STATUS and conclusion != SUCCESS_CONCLUSION
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
This is repo review chunk `159` for `tools/build_ui_static.py` and `tools/watch_pr_checks.py`. I directly reviewed both code files in the chunk before deciding what to change.

The changes are small helper-level cleanups only. In `build_ui_static.py`, the optional git-head lookup used for UI build metadata was inlined inside `main()`, so I pulled it into a small `_git_head_commit()` helper to keep the metadata-writing path more linear. In `watch_pr_checks.py`, I added a short module docstring and replaced the repeated completed-status string with a shared constant reused by the green/non-green helper checks.

## Validation
I ran:
- `make lint`

## Risks / skipped items
No intentional behavior changes. The updates are limited to helper extraction and small readability cleanup in the tooling scripts.
