### PR TITLE
Repo review chunk 160: tighten config generators

### DIFF
--- a/tools/config/generate_contract_reference_doc.py
+++ b/tools/config/generate_contract_reference_doc.py
@@ -1,3 +1,5 @@
+"""Generate the checked-in contract reference markdown from backend sources."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -5,12 +7,12 @@ from pathlib import Path
 from vibesensor.cli.contract_reference_doc import render_contract_reference_markdown
 
 ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_PATH = ROOT / "docs" / "protocol.md"
 
 
 def main() -> None:
-    out_path = ROOT / "docs" / "protocol.md"
-    out_path.write_text(render_contract_reference_markdown(), encoding="utf-8")
-    print(f"Wrote {out_path.relative_to(ROOT)}")
+    OUTPUT_PATH.write_text(render_contract_reference_markdown(), encoding="utf-8")
+    print(f"Wrote {OUTPUT_PATH.relative_to(ROOT)}")
 
 
 if __name__ == "__main__":

--- a/tools/config/generate_ui_shared_constants.py
+++ b/tools/config/generate_ui_shared_constants.py
@@ -1,14 +1,23 @@
+"""Generate frontend constants from shared backend literal definitions."""
+
 from __future__ import annotations
 
 import ast
 import json
 import sys
 from pathlib import Path
+from typing import TypeGuard
 
 ROOT = Path(__file__).resolve().parents[2]
 SHARED_ROOT = ROOT / "apps" / "server" / "vibesensor" / "shared"
 LOCATIONS_PATH = SHARED_ROOT / "locations.py"
 STRENGTH_FIELDS_PATH = SHARED_ROOT / "strength_fields.py"
+
+
+def _is_string_dict(value: object) -> TypeGuard[dict[str, str]]:
+    return isinstance(value, dict) and all(
+        isinstance(key, str) and isinstance(item, str) for key, item in value.items()
+    )
 
 
 def _load_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]:
@@ -31,10 +40,7 @@ def _load_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]
         if value_node is None:
             continue
         value = ast.literal_eval(value_node)
-        if not isinstance(value, dict) or not all(
-            isinstance(key, str) and isinstance(item, str)
-            for key, item in value.items()
-        ):
+        if not _is_string_dict(value):
             msg = f"{module_path}::{constant_name} must be a dict[str, str] literal"
             raise ValueError(msg)
         return dict(value)

--- a/tools/config/sync_shared_contracts_to_ui.mjs
+++ b/tools/config/sync_shared_contracts_to_ui.mjs
@@ -9,6 +9,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const root = resolve(__dirname, '../..');
 const requireFromUi = createRequire(resolve(root, 'apps/ui/package.json'));
+const openapiCliPath = requireFromUi.resolve('openapi-typescript/bin/cli.js');
+const generatorScript = 'tools/config/sync_shared_contracts_to_ui.mjs';
 const httpSchemaSrc = resolve(root, 'apps/ui/src/contracts/http_api_schema.json');
 const httpTypesDst = resolve(root, 'apps/ui/src/generated/http_api_contracts.ts');
 const constantsGeneratorSrc = resolve(root, 'tools/config/generate_ui_shared_constants.py');
@@ -16,6 +18,13 @@ const constantsDst = resolve(root, 'apps/ui/src/constants.ts');
 const wsSchemaSrc = resolve(root, 'apps/ui/src/contracts/ws_payload_schema.json');
 const wsSchemaTsDst = resolve(root, 'apps/ui/src/contracts/ws_payload_schema.generated.ts');
 const wsTypesDst = resolve(root, 'apps/ui/src/contracts/ws_payload_types.ts');
+
+function generatedHeader(sourcePath) {
+	return (
+		`// Generated from ${sourcePath}\n`
+		+ `// Do not edit manually; run ${generatorScript}\n\n`
+	);
+}
 
 function writeGenerated(filePath, content, checkMode) {
 	mkdirSync(dirname(filePath), { recursive: true });
@@ -29,19 +38,19 @@ function writeGenerated(filePath, content, checkMode) {
 	writeFileSync(filePath, content, 'utf8');
 }
 
-async function generateHttpTypes() {
-	const openapiCliPath = requireFromUi.resolve('openapi-typescript/bin/cli.js');
-	const result = spawnSync(process.execPath, [openapiCliPath, httpSchemaSrc], {
+function runOpenApiGenerator(schemaPath, failureMessage) {
+	const result = spawnSync(process.execPath, [openapiCliPath, schemaPath], {
 		encoding: 'utf8',
 	});
 	if (result.status !== 0) {
-		throw new Error(result.stderr || result.stdout || 'openapi-typescript generation failed');
+		throw new Error(result.stderr || result.stdout || failureMessage);
 	}
-	return (
-		'// Generated from apps/ui/src/contracts/http_api_schema.json\n'
-		+ '// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs\n\n'
-		+ result.stdout
-	);
+	return result.stdout;
+}
+
+async function generateHttpTypes() {
+	return generatedHeader('apps/ui/src/contracts/http_api_schema.json')
+		+ runOpenApiGenerator(httpSchemaSrc, 'openapi-typescript generation failed');
 }
 
 function rewriteSchemaRefs(value) {
@@ -107,17 +116,15 @@ async function generateWsTypes() {
 	const tempDir = mkdtempSync(resolve(tmpdir(), 'vibesensor-ws-openapi-'));
 	const tempSchemaPath = resolve(tempDir, 'ws_openapi.json');
 	writeFileSync(tempSchemaPath, `${JSON.stringify(wrapped, null, 2)}\n`, 'utf8');
-	const result = spawnSync(process.execPath, [openapiCliPath, tempSchemaPath], {
-		encoding: 'utf8',
-	});
-	rmSync(tempDir, { recursive: true, force: true });
-	if (result.status !== 0) {
-		throw new Error(result.stderr || result.stdout || 'WS type generation failed');
+	let result;
+	try {
+		result = runOpenApiGenerator(tempSchemaPath, 'WS type generation failed');
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
 	}
 	return (
-		'// Generated from apps/ui/src/contracts/ws_payload_schema.json\n'
-		+ '// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs\n\n'
-		+ result.stdout
+		generatedHeader('apps/ui/src/contracts/ws_payload_schema.json')
+		+ result
 		+ wsAliasBlock(String(schemaVersion))
 	);
 }
@@ -125,8 +132,7 @@ async function generateWsTypes() {
 function generateWsSchemaModule() {
 	const wsSchema = JSON.parse(readFileSync(wsSchemaSrc, 'utf8'));
 	return (
-		'// Generated from apps/ui/src/contracts/ws_payload_schema.json\n'
-		+ '// Do not edit manually; run tools/config/sync_shared_contracts_to_ui.mjs\n\n'
+		generatedHeader('apps/ui/src/contracts/ws_payload_schema.json')
 		+ 'export const wsPayloadSchema = '
 		+ `${JSON.stringify(wsSchema, null, 2)}`
 		+ ' as const;\n\n'


### PR DESCRIPTION
## Summary
This is repo review chunk `160` for `tools/config/generate_contract_reference_doc.py`, `tools/config/generate_ui_shared_constants.py`, and `tools/config/sync_shared_contracts_to_ui.mjs`. I directly reviewed each code file in the chunk before deciding what to change.

The updates stay strictly behavior-preserving and focus on maintainability inside the config/codegen tooling. In `generate_contract_reference_doc.py`, I added a short module docstring and promoted the checked-in output path to a named constant so the script’s intent is visible at a glance. In `generate_ui_shared_constants.py`, I added a small `dict[str, str]` type guard to keep the AST literal-validation path easier to read. In `sync_shared_contracts_to_ui.mjs`, I extracted shared helpers for generated-file headers and `openapi-typescript` invocation, while preserving the existing temporary-directory cleanup behavior for the WebSocket schema flow.

## Validation
I ran:
- `make lint`
- `.venv/bin/python tools/config/generate_ui_shared_constants.py >/dev/null`
- `node tools/config/sync_shared_contracts_to_ui.mjs --check >/dev/null`
- `.venv/bin/python tools/config/generate_contract_reference_doc.py >/dev/null`
- `git diff --exit-code -- docs/protocol.md apps/ui/src/generated/http_api_contracts.ts apps/ui/src/contracts/ws_payload_types.ts apps/ui/src/contracts/ws_payload_schema.generated.ts apps/ui/src/constants.ts`

## Risks / skipped items
No behavior changes intended; the chunk is limited to helper extraction, naming, and documentation-level cleanup.
