### PR TITLE
Repo review chunk 163: tighten test tooling

### DIFF
--- a/tools/tests/_parallel_runner_support.py
+++ b/tools/tests/_parallel_runner_support.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Shared helpers for duration-aware parallel test runner scripts."""
+
 from __future__ import annotations
 
 import json

--- a/tools/tests/benchmark_pipeline.py
+++ b/tools/tests/benchmark_pipeline.py
@@ -87,36 +87,39 @@ def run_benchmark(
 
     # --- Parallel ---
     pool = WorkerPool(max_workers=4, thread_name_prefix="bench-fft")
-    proc_par = _make_processor(pool=pool)
-    for cid, freq in zip(client_ids, freqs, strict=True):
-        _inject_signal(proc_par, cid, freq)
-
-    par_ingest_ms: list[float] = []
-    par_compute_ms: list[float] = []
-    for _round in range(n_rounds):
-        t0 = time.monotonic()
+    try:
+        proc_par = _make_processor(pool=pool)
         for cid, freq in zip(client_ids, freqs, strict=True):
-            for _ in range(n_ingest_per_round):
-                _inject_signal(proc_par, cid, freq)
-        par_ingest_ms.append((time.monotonic() - t0) * 1000)
+            _inject_signal(proc_par, cid, freq)
 
-        t0 = time.monotonic()
-        proc_par.compute_all(client_ids)
-        par_compute_ms.append((time.monotonic() - t0) * 1000)
+        par_ingest_ms: list[float] = []
+        par_compute_ms: list[float] = []
+        for _round in range(n_rounds):
+            t0 = time.monotonic()
+            for cid, freq in zip(client_ids, freqs, strict=True):
+                for _ in range(n_ingest_per_round):
+                    _inject_signal(proc_par, cid, freq)
+            par_ingest_ms.append((time.monotonic() - t0) * 1000)
 
-    pool.shutdown()
+            t0 = time.monotonic()
+            proc_par.compute_all(client_ids)
+            par_compute_ms.append((time.monotonic() - t0) * 1000)
+    finally:
+        pool.shutdown()
 
     # --- Verify output equivalence ---
     # Re-run from fresh processors with identical input
     proc_a = _make_processor(pool=None)
     pool_b = WorkerPool(max_workers=4)
-    proc_b = _make_processor(pool=pool_b)
-    for cid, freq in zip(client_ids, freqs, strict=True):
-        _inject_signal(proc_a, cid, freq)
-        _inject_signal(proc_b, cid, freq)
-    res_a = proc_a.compute_all(client_ids)
-    res_b = proc_b.compute_all(client_ids)
-    pool_b.shutdown()
+    try:
+        proc_b = _make_processor(pool=pool_b)
+        for cid, freq in zip(client_ids, freqs, strict=True):
+            _inject_signal(proc_a, cid, freq)
+            _inject_signal(proc_b, cid, freq)
+        res_a = proc_a.compute_all(client_ids)
+        res_b = proc_b.compute_all(client_ids)
+    finally:
+        pool_b.shutdown()
 
     output_match = True
     for cid in client_ids:

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Run duration-balanced backend test shards with cached timing data."""
+
 from __future__ import annotations
 
 import argparse

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -27,6 +27,20 @@ UI_LOCK_FILE = UI_DIR / "package-lock.json"
 UI_LOCK_HASH_FILE = UI_DIR / ".npm-ci-lock.sha256"
 PRINT_LOCK = threading.Lock()
 RESULT_LOCK = threading.Lock()
+ALL_JOB_NAMES = (
+    "backend-quality",
+    "backend-typecheck",
+    "frontend-typecheck",
+    "ui-smoke",
+    "release-smoke",
+    "firmware-native-tests",
+    "backend-tests-1",
+    "backend-tests-2",
+    "backend-tests-3",
+    "backend-tests-4",
+    "backend-tests-5",
+    "e2e",
+)
 
 
 @dataclass(frozen=True)
@@ -371,20 +385,7 @@ def main() -> int:
     parser.add_argument(
         "--job",
         action="append",
-        choices=[
-            "backend-quality",
-            "backend-typecheck",
-            "frontend-typecheck",
-            "ui-smoke",
-            "release-smoke",
-            "firmware-native-tests",
-            "backend-tests-1",
-            "backend-tests-2",
-            "backend-tests-3",
-            "backend-tests-4",
-            "backend-tests-5",
-            "e2e",
-        ],
+        choices=ALL_JOB_NAMES,
         help="Run only selected job(s). Repeat to run multiple jobs.",
     )
     parser.add_argument(
@@ -403,24 +404,7 @@ def main() -> int:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     all_jobs = _job_steps(python_cmd)
-    selected_jobs = (
-        args.job
-        if args.job
-        else [
-            "backend-quality",
-            "backend-typecheck",
-            "frontend-typecheck",
-            "ui-smoke",
-            "release-smoke",
-            "firmware-native-tests",
-            "backend-tests-1",
-            "backend-tests-2",
-            "backend-tests-3",
-            "backend-tests-4",
-            "backend-tests-5",
-            "e2e",
-        ]
-    )
+    selected_jobs = args.job if args.job else list(ALL_JOB_NAMES)
 
     if _shared_ui_workspace_would_race(
         selected_jobs,

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Run docker-backed e2e shards with cached duration balancing and cleanup hooks."""
+
 from __future__ import annotations
 
 import argparse

--- a/tools/tests/run_release_smoke.py
+++ b/tools/tests/run_release_smoke.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Build release-like artifacts locally and run the packaged smoke validator."""
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
This is repo review chunk `163` for `tools/tests/_parallel_runner_support.py`, `tools/tests/act-event.json`, `tools/tests/benchmark_pipeline.py`, `tools/tests/heuristics_audit.py`, `tools/tests/run_backend_parallel.py`, `tools/tests/run_changed.py`, `tools/tests/run_ci_parallel.py`, `tools/tests/run_ci_with_act.sh`, `tools/tests/run_e2e_parallel.py`, and `tools/tests/run_release_smoke.py`. I directly reviewed every code file in the chunk before deciding what to change.

Most of the slice stayed unchanged after review. The JSON `act` event fixture, the heuristics audit, the changed-file runner, and the `act` wrapper were all reviewed directly and left alone. The edits stay behavior-preserving and focus on maintainability in the shared test tooling: `_parallel_runner_support.py`, `run_backend_parallel.py`, `run_e2e_parallel.py`, and `run_release_smoke.py` now have concise module docstrings; `run_ci_parallel.py` now keeps its full job-name list in one shared constant instead of repeating it for CLI choices and default selection; and `benchmark_pipeline.py` now shuts down both worker pools via `try/finally`, preserving cleanup even if an exception interrupts the benchmark.

## Validation
I ran:
- `make lint`
- `.venv/bin/python tools/tests/benchmark_pipeline.py --help >/dev/null`
- `.venv/bin/python tools/tests/run_backend_parallel.py --help >/dev/null`
- `.venv/bin/python tools/tests/run_ci_parallel.py --help >/dev/null`
- `.venv/bin/python tools/tests/run_e2e_parallel.py --help >/dev/null`
- `.venv/bin/python tools/tests/run_release_smoke.py --help >/dev/null`
- `.venv/bin/python tools/tests/run_changed.py --dry-run >/dev/null`

## Risks / skipped items
No behavior changes intended. The unchanged files in the chunk were reviewed directly and left as-is.
