### PR TITLE
Fix active-car bootstrap desync in settings UI

### DIFF
--- a/apps/ui/src/app/car_selection_state.ts
+++ b/apps/ui/src/app/car_selection_state.ts
@@ -1,0 +1,39 @@
+import type { CarRecord } from "../api/types";
+import type { SettingsState } from "./ui_app_state";
+
+export interface CarSelectionStateSource {
+  cars: SettingsState["cars"];
+  activeCarId: SettingsState["activeCarId"];
+  carsLoaded: SettingsState["carsLoaded"];
+}
+
+export type CarSelectionState =
+  | { kind: "loading" }
+  | { kind: "no_cars" }
+  | { kind: "no_active_car" }
+  | { kind: "active"; car: CarRecord };
+
+export function resolveActiveCar(settings: CarSelectionStateSource): CarRecord | null {
+  if (!settings.activeCarId) {
+    return null;
+  }
+  return settings.cars.find((car) => car.id === settings.activeCarId) ?? null;
+}
+
+export function deriveCarSelectionState(settings: CarSelectionStateSource): CarSelectionState {
+  if (!settings.carsLoaded) {
+    return { kind: "loading" };
+  }
+  if (!settings.cars.length) {
+    return { kind: "no_cars" };
+  }
+  const activeCar = resolveActiveCar(settings);
+  if (activeCar) {
+    return { kind: "active", car: activeCar };
+  }
+  return { kind: "no_active_car" };
+}
+
+export function hasResolvedActiveCar(settings: CarSelectionStateSource): boolean {
+  return deriveCarSelectionState(settings).kind === "active";
+}

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,4 +1,9 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
+import {
+  deriveCarSelectionState,
+  hasResolvedActiveCar,
+  resolveActiveCar,
+} from "../car_selection_state";
 import type { SettingsState } from "../ui_app_state";
 import type { CarsPayload } from "../../api/types";
 import {
@@ -59,16 +64,17 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   }
 
   function hasValidActiveCar(): boolean {
-    return Boolean(settings.activeCarId && settings.cars.some((car) => car.id === settings.activeCarId));
+    return hasResolvedActiveCar(settings);
   }
 
   function syncCarDependentUiState(): void {
-    const hasActiveCar = hasValidActiveCar();
+    const carSelectionState = deriveCarSelectionState(settings);
+    const hasActiveCar = carSelectionState.kind === "active";
     if (els.saveAnalysisBtn) {
       els.saveAnalysisBtn.disabled = !hasActiveCar;
     }
     if (els.analysisNoCarMessage) {
-      els.analysisNoCarMessage.hidden = hasActiveCar;
+      els.analysisNoCarMessage.hidden = hasActiveCar || carSelectionState.kind === "loading";
     }
     ctx.onCarSelectionStateChange();
   }
@@ -103,9 +109,11 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     fmt,
     renderSpeedReadout: ctx.renderSpeedReadout,
   });
+  syncCarDependentUiState();
 
   function syncCarsPayload(payload: CarsPayload): void {
     settings.cars = payload.cars;
+    settings.carsLoaded = true;
     const requestedActiveCarId = payload.active_car_id;
     const hasRequestedActive = requestedActiveCarId
       ? settings.cars.some((car) => car.id === requestedActiveCarId)
@@ -164,7 +172,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
   }
 
   function syncActiveCarToInputs(): void {
-    const car = settings.cars.find((entry) => entry.id === settings.activeCarId);
+    const car = resolveActiveCar(settings);
     if (!car) {
       syncCarDependentUiState();
       return;

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -1,4 +1,5 @@
 import { fmt } from "../../format";
+import { deriveCarSelectionState } from "../car_selection_state";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { RealtimeState, SettingsState, ShellState, TransportState } from "../ui_app_state";
 
@@ -105,10 +106,8 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
   function renderCarSelectionWarning(): void {
     const banner = els.carSelectionBanner;
     if (!banner) return;
-    const hasValidActiveCar = Boolean(
-      settings.activeCarId && settings.cars.some((car) => car.id === settings.activeCarId),
-    );
-    if (hasValidActiveCar) {
+    const carSelectionState = deriveCarSelectionState(settings);
+    if (carSelectionState.kind === "loading" || carSelectionState.kind === "active") {
       banner.hidden = true;
       banner.textContent = "";
       return;

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -152,6 +152,7 @@ export interface HistoryState {
 export interface SettingsState {
   vehicleSettings: VehicleSettings;
   cars: CarRecord[];
+  carsLoaded: boolean;
   activeCarId: string | null;
   speedSource: SpeedSourceKind;
   manualSpeedKph: number | null;
@@ -231,6 +232,7 @@ export function createAppState(): AppState {
         tire_deflection_factor: 0.97,
       },
       cars: [],
+      carsLoaded: false,
       activeCarId: null,
       speedSource: "gps",
       manualSpeedKph: null,

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -46,6 +46,85 @@ test("hides header warning when a valid selected car exists", async ({ page }) =
   await expect(page.locator("#carSelectionBanner")).toBeHidden();
 });
 
+test("keeps warning UI hidden until active car bootstrap resolves and then marks the car active", async ({ page }) => {
+  let releaseCars: (() => void) | null = null;
+  const waitForCars = new Promise<void>((resolve) => {
+    releaseCars = resolve;
+  });
+  const analysisPayload = {
+    tire_width_mm: 285,
+    tire_aspect_pct: 30,
+    rim_in: 21,
+    final_drive_ratio: 3.08,
+    current_gear_ratio: 0.64,
+    wheel_bandwidth_pct: 7.5,
+    driveshaft_bandwidth_pct: 8.5,
+    engine_bandwidth_pct: 9.5,
+    speed_uncertainty_pct: 3,
+    tire_diameter_uncertainty_pct: 4,
+    final_drive_uncertainty_pct: 2,
+    gear_uncertainty_pct: 5,
+    min_abs_band_hz: 0.7,
+    max_band_half_width_pct: 12,
+    tire_deflection_factor: 0.97,
+  };
+
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      const path = requestPath(route);
+      if (path === "/api/settings/cars") {
+        await waitForCars;
+        await fulfillJson(route, {
+          cars: [{
+            id: "car-1",
+            name: "Audit Demo Car",
+            type: "sedan",
+            aspects: {
+              tire_width_mm: 285,
+              tire_aspect_pct: 30,
+              rim_in: 21,
+              final_drive_ratio: 3.08,
+              current_gear_ratio: 0.64,
+            },
+          }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      if (path === "/api/settings/analysis") {
+        await fulfillJson(route, analysisPayload);
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await expect(page.locator("#carSelectionBanner")).toBeHidden();
+
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="analysisTab"]').click();
+
+  await expect(page.locator("#wheelBandwidthInput")).toHaveValue("7.5");
+  await expect(page.locator("#saveAnalysisBtn")).toBeDisabled();
+  await expect(page.locator("#analysisNoCarMessage")).toBeHidden();
+  await expect(page.locator("#carSelectionBanner")).toBeHidden();
+
+  if (!releaseCars) {
+    throw new Error("cars bootstrap gate was not initialized");
+  }
+  releaseCars();
+
+  await expect(page.locator("#saveAnalysisBtn")).toBeEnabled();
+  await expect(page.locator("#carSelectionBanner")).toBeHidden();
+  await expect(page.locator("#analysisNoCarMessage")).toBeHidden();
+
+  await page.locator('[data-settings-tab="carTab"]').click();
+  const activeRow = page.locator('#carListBody tr[data-car-id="car-1"]');
+  await expect(activeRow).toContainText("Audit Demo Car");
+  await expect(activeRow.locator(".car-active-pill")).toHaveClass(/active/);
+});
+
 test("shows warning for invalid persisted selection and after deleting selected car", async ({ page }) => {
   let firstCarsGet = true;
   await installCommonRoutes(page, {

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -477,12 +477,13 @@ test.describe("createUiShellStatusModule", () => {
     expect(appShellWrap.classList.contains("wrap--stale")).toBe(true);
   });
 
-  test("renders speed override and car-selection warning", () => {
+  test("renders speed override and car-selection warning after car bootstrap resolves", () => {
     const state = createAppState();
     state.realtime.speedMps = 12;
     state.settings.speedSource = "manual";
     state.settings.manualSpeedKph = 43.2;
     state.shell.speedUnit = "kmh";
+    state.settings.carsLoaded = true;
     state.settings.cars = [];
     state.settings.activeCarId = null;
     const { els, speed, carSelectionBanner } = createShellDeps();


### PR DESCRIPTION
## Summary
Closes #1730.

This change fixes a UI integrity problem around active-car state during startup and settings hydration. The issue was not that the backend had lost track of the active car. The backend could already return a valid `active_car_id`, a populated car list, and populated analysis settings. The problem was that the frontend treated the pre-load bootstrap state as if it were a confirmed “no car selected” state. That let the shell banner and settings UI make a negative claim before the car list request had actually resolved. In practice, that produced a contradictory experience: analysis inputs could already be populated while the global warning still suggested the setup was incomplete. That contradiction is especially damaging here because vehicle selection is foundational to how the rest of the product is interpreted.

## Implementation approach
I kept the fix intentionally small and localized, but made the state derivation explicit so the shell banner and settings analysis UI stop inventing their own answers. Instead of checking `activeCarId` and `cars` ad hoc in multiple places, the UI now derives car-selection status from one shared helper that distinguishes four states: `loading`, `no_cars`, `no_active_car`, and `active`.

The key design decision was to treat “cars have not finished loading yet” as its own state instead of collapsing it into “no car selected.” That matches the issue’s requested direction without introducing a larger state machine or changing unrelated flows. It also avoids over-correcting the UI by keeping the existing behavior for the real no-car cases once bootstrap has resolved.

## Main code changes
### Shared car-selection derivation
I added `apps/ui/src/app/car_selection_state.ts` as the single frontend source of truth for this question. It exposes three narrow helpers:

- `resolveActiveCar()` to find the actual active `CarRecord`
- `deriveCarSelectionState()` to return the loading/no-cars/no-active/active state
- `hasResolvedActiveCar()` for callers that only need the boolean outcome

This keeps the logic small, testable, and reusable without spreading another mini-state model across multiple modules.

### Settings bootstrap and analysis gating
In `apps/ui/src/app/ui_app_state.ts`, `SettingsState` now tracks `carsLoaded`, which starts as `false`. That lets the UI distinguish unresolved bootstrap from a genuine empty selection.

In `apps/ui/src/app/features/settings_feature.ts`, the settings feature now consumes the shared state helper instead of re-deriving active-car validity inline. The feature also initializes its car-dependent controls immediately from that state, rather than waiting for the first car payload. That matters because the issue showed a startup race where analysis settings could already be visible while car state had not finished reconciling.

Concretely:

- the analysis save button is disabled until a real active car has been resolved
- the analysis no-car empty state stays hidden while car bootstrap is still loading
- `syncCarsPayload()` marks `carsLoaded = true` when the cars request resolves
- `syncActiveCarToInputs()` now resolves the active car through the shared helper instead of doing another local lookup

This keeps the analysis panel in a non-contradictory state during the slow-start path that triggered the audit finding.

### Shell banner behavior
In `apps/ui/src/app/runtime/ui_shell_status_module.ts`, the global no-car banner now uses the same derived state. The banner is hidden both when an active car is resolved and while car bootstrap is still loading. It only becomes visible once the UI knows that the cars request has resolved and the result is genuinely either “noor “cars exist but none is active.” cars

That directly addresses the trust problem from the issue: the UI no longer tells the user “no car selected” before it has enough information to make that claim.

## Test coverage
I added a focused smoke regression in `apps/ui/tests/smoke.cars.spec.ts` that exercises the exact issue shape from the audit rather than a simplified happy path. The test intentionally holds `/api/settings/cars` open while allowing `/api/settings/analysis` to resolve immediately with populated values. During that window, it verifies that:

- the global no-car banner stays hidden
- the analysis no-car message stays hidden
- the analysis save button remains safely disabled while car bootstrap is unresolved

After the cars request is released, the same test verifies that the active car row is marked active and the analysis save button becomes enabled. That covers the specific “analysis is already populated while car state is still reconciling” scenario that made the product feel non-deterministic.

I also updated the adjacent runtime-module test in `apps/ui/tests/ui_shell_runtime_modules.spec.ts` so its expectation matches the new loading-aware model. That test previously assumed the unresolved bootstrap state should already render the warning, which is the behavior this fix intentionally removes.

## Contracts, schema, docs, and compatibility
There are no API contract, schema, or documentation changes in this PR. The server payloads remain unchanged. This is purely a frontend state-derivation fix.

I also did not add any backward-compatibility shim or fallback branch. The existing UI already had the necessary data; it just needed to stop misclassifying the bootstrap phase. The change preserves the real no-car warning behavior after load resolution, including the invalid-selection path covered by existing smoke tests.

## Validation
I ran the following local checks on this branch:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.cars.spec.ts --config=playwright.smoke.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --config=playwright.smoke.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`

Results:

- typecheck passed
- build passed
- all targeted smoke and runtime-module tests passed
- lint completed with one pre-existing unrelated warning in `src/app/features/cars_feature.ts` (`useOptionalChain`), which I did not modify because it is outside the issue scope

I also attempted the repo-level Docker compose runtime check requested by the repository instructions. That verification could not run in this environment because `docker-compose` failed while fetching the server API version from the Unix socket, which indicates the local Docker daemon is unavailable here. I am calling that out explicitly rather than pretending the stack verification ran.

## Risks and tradeoffs
The main tradeoff is that this uses a lightweight `carsLoaded` flag instead of a larger explicit reducer or startup FSM. I chose that because it fully addresses the observed contradiction with minimal surface area and no contract changes. If the UI later needs richer car-bootstrap transitions, the new shared helper is a clean place to evolve them.

The existing silent error handling around `loadCarsFromServer()` is unchanged in this PR. That is deliberate scope control: this issue was about false contradictory UI during successful-but-still-loading startup, not about redesigning settings error reporting. Even with that unchanged behavior, the new loading-aware state removes the false warning path that triggered the audit finding.
