### PR TITLE
Fix resolved speed-source UI sync

### DIFF
--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -107,6 +107,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     settings,
     getSpeedUnit: ctx.getSpeedUnit,
     fmt,
+    syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
     renderSpeedReadout: ctx.renderSpeedReadout,
   });
   syncCarDependentUiState();

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -19,6 +19,7 @@ export interface SettingsGpsStatusModuleDeps extends FeatureDepsBase {
   settings: SettingsState;
   getSpeedUnit: () => string;
   fmt: (n: number, digits?: number) => string;
+  syncSpeedSourceSelectionUi: () => void;
   renderSpeedReadout: () => void;
 }
 
@@ -53,7 +54,9 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
     const unitLabel = selectedSpeedUnitLabel();
     if (els.headerGpsStatus) {
       const stateLabel = connectionStateLabel(status.connection_state);
-      const speedText = formatSpeedValue(status.effective_speed_kmh, unitLabel);
+      const speedText = status.speed_source === "gps"
+        ? formatSpeedValue(status.effective_speed_kmh, unitLabel)
+        : null;
       els.headerGpsStatus.textContent = `GPS ${stateLabel}${speedText ? ` ${speedText}` : ""}`;
       const variant = status.connection_state === "connected"
         ? "ok"
@@ -92,14 +95,10 @@ export function createSettingsGpsStatusModule(ctx: SettingsGpsStatusModuleDeps):
   const polling = createPollingController({
     poll: async () => {
       const status = await getSpeedSourceStatus();
-      settings.gpsFallbackActive = status.fallback_active
-        || (
-          settings.speedSource !== "manual"
-          && typeof settings.manualSpeedKph === "number"
-          && settings.manualSpeedKph > 0
-          && status.connection_state !== "connected"
-        );
+      settings.gpsFallbackActive = status.fallback_active;
+      settings.resolvedSpeedSource = status.speed_source;
       renderGpsStatus(status);
+      ctx.syncSpeedSourceSelectionUi();
       ctx.renderSpeedReadout();
       return status.connection_state === "connected"
         ? GPS_POLL_FAST_MS

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -1,6 +1,7 @@
 import type { SpeedSourceKind, SpeedSourcePayload, SpeedSourceRequest } from "../../api/types";
 import { getSettingsSpeedSource, updateSettingsSpeedSource } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
+import { deriveDisplayedSpeedSourceMode } from "../speed_source_state";
 import type { SettingsState } from "../ui_app_state";
 
 const SPEED_SOURCE_KINDS = ["gps", "manual", "obd2"] as const satisfies readonly SpeedSourceKind[];
@@ -13,6 +14,7 @@ export interface SettingsSpeedSourceModuleDeps extends FeatureDepsBase {
 
 export interface SettingsSpeedSourceModule {
   bindHandlers(): void;
+  syncSpeedSourceSelectionUi(): void;
   syncSpeedSourceInputs(): void;
   loadSpeedSourceFromServer(): Promise<void>;
   saveSpeedSourceFromInputs(): void;
@@ -35,24 +37,30 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     if (staleVal >= 3 && staleVal <= 120) payload.stale_timeout_s = staleVal;
   }
 
-  function syncSpeedSourceInputs(): void {
+  function syncSpeedSourceSelectionUi(): void {
+    const displayedMode = deriveDisplayedSpeedSourceMode(settings);
     els.speedSourceRadios.forEach((radio) => {
-      radio.checked = radio.value === settings.speedSource;
+      radio.checked = radio.value === displayedMode;
     });
+    if (els.headerManualOverrideGroup) {
+      els.headerManualOverrideGroup.hidden = displayedMode !== "manual";
+    }
+  }
+
+  function syncSpeedSourceInputs(): void {
+    syncSpeedSourceSelectionUi();
     if (els.manualSpeedInput) {
       els.manualSpeedInput.value = settings.manualSpeedKph != null ? String(settings.manualSpeedKph) : "";
     }
     if (els.headerManualSpeedInput) {
       els.headerManualSpeedInput.value = settings.manualSpeedKph != null ? String(settings.manualSpeedKph) : "";
     }
-    if (els.headerManualOverrideGroup) {
-      els.headerManualOverrideGroup.hidden = settings.speedSource !== "manual";
-    }
   }
 
   function applySpeedSourcePayload(payload: SpeedSourcePayload): void {
     settings.speedSource = payload.speed_source;
     settings.manualSpeedKph = payload.manual_speed_kph;
+    settings.resolvedSpeedSource = null;
     if (els.staleTimeoutInput) els.staleTimeoutInput.value = String(payload.stale_timeout_s);
     syncSpeedSourceInputs();
     ctx.renderSpeedReadout();
@@ -109,6 +117,7 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
 
   return {
     bindHandlers,
+    syncSpeedSourceSelectionUi,
     syncSpeedSourceInputs,
     loadSpeedSourceFromServer,
     saveSpeedSourceFromInputs,

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -1,5 +1,6 @@
 import { fmt } from "../../format";
 import { deriveCarSelectionState } from "../car_selection_state";
+import { isManualEffectiveSpeedSource } from "../speed_source_state";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { RealtimeState, SettingsState, ShellState, TransportState } from "../ui_app_state";
 
@@ -57,12 +58,10 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
     const unitLabel = selectedSpeedUnitLabel();
     if (typeof realtime.speedMps === "number" && Number.isFinite(realtime.speedMps)) {
       const value = speedValueInSelectedUnit(realtime.speedMps);
-      const isManualSource = settings.speedSource === "manual"
-        && typeof settings.manualSpeedKph === "number"
-        && settings.manualSpeedKph > 0;
-      const isFallbackOverride = settings.gpsFallbackActive
-        || realtime.rotationalSpeeds?.basis_speed_source === "fallback_manual";
-      const isOverride = isManualSource || isFallbackOverride;
+      const isOverride = isManualEffectiveSpeedSource(
+        settings,
+        realtime.rotationalSpeeds?.basis_speed_source ?? null,
+      );
       els.speed.textContent = ctx.t(isOverride ? "speed.override" : "speed.gps", {
         value: fmt(value, 1),
         unit: unitLabel,

--- a/apps/ui/src/app/speed_source_state.ts
+++ b/apps/ui/src/app/speed_source_state.ts
@@ -1,0 +1,42 @@
+import type { SettingsState } from "./ui_app_state";
+
+export interface SpeedSourceStateSource {
+  speedSource: SettingsState["speedSource"];
+  manualSpeedKph: SettingsState["manualSpeedKph"];
+  resolvedSpeedSource: SettingsState["resolvedSpeedSource"];
+}
+
+export type DisplayedSpeedSourceMode = "gps" | "manual";
+
+export function isManualLikeSpeedSource(source: string | null | undefined): boolean {
+  return source === "manual" || source === "fallback_manual";
+}
+
+export function deriveDisplayedSpeedSourceMode(
+  settings: SpeedSourceStateSource,
+): DisplayedSpeedSourceMode {
+  if (isManualLikeSpeedSource(settings.resolvedSpeedSource) || settings.speedSource === "manual") {
+    return "manual";
+  }
+  return "gps";
+}
+
+export function resolveEffectiveSpeedSource(
+  settings: SpeedSourceStateSource,
+  runtimeSpeedSource?: string | null,
+): string | null {
+  if (settings.resolvedSpeedSource) {
+    return settings.resolvedSpeedSource;
+  }
+  if (runtimeSpeedSource) {
+    return runtimeSpeedSource;
+  }
+  return settings.speedSource;
+}
+
+export function isManualEffectiveSpeedSource(
+  settings: SpeedSourceStateSource,
+  runtimeSpeedSource?: string | null,
+): boolean {
+  return isManualLikeSpeedSource(resolveEffectiveSpeedSource(settings, runtimeSpeedSource));
+}

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -10,6 +10,7 @@ import type {
   LocationOption,
   LoggingStatusPayload,
   SpeedSourceKind,
+  SpeedSourceStatusPayload,
 } from "../api/types";
 
 export interface VehicleSettings {
@@ -156,6 +157,7 @@ export interface SettingsState {
   activeCarId: string | null;
   speedSource: SpeedSourceKind;
   manualSpeedKph: number | null;
+  resolvedSpeedSource: SpeedSourceStatusPayload["speed_source"] | null;
   gpsFallbackActive: boolean;
 }
 
@@ -236,6 +238,7 @@ export function createAppState(): AppState {
       activeCarId: null,
       speedSource: "gps",
       manualSpeedKph: null,
+      resolvedSpeedSource: null,
       gpsFallbackActive: false,
     },
     spectrum: {

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -182,7 +182,7 @@
   "status.stopped": "Stopped",
   "status.unavailable": "Unavailable",
   "speed.gps": "Speed: {value} {unit} (GPS)",
-  "speed.override": "Speed: {value} {unit} (Override)",
+  "speed.override": "Speed: {value} {unit} (Manual)",
   "speed.none": "Speed: -- {unit}",
   "speed.unit": "Unit",
   "speed.unit.kmh": "km/h",

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -150,6 +150,7 @@ export function gpsStatus(overrides: Partial<Record<string, unknown>>) {
     last_error: null,
     reconnect_delay_s: 1,
     fallback_active: false,
+    speed_source: "gps",
     stale_timeout_s: 5,
 
     ...overrides,

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -69,6 +69,47 @@ test("manual speed save uses settings endpoint only (no speed-override call)", a
   await expect.poll(() => speedOverrideCalls).toBe(0);
 });
 
+test("resolved fallback manual state stays coherent across header, form, and GPS status", async ({ page }) => {
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/speed-source": {
+        speed_source: "gps",
+        manual_speed_kph: 80,
+        stale_timeout_s: 5,
+      },
+      "GET /api/settings/speed-source/status": gpsStatus({
+        gps_enabled: false,
+        connection_state: "disabled",
+        raw_speed_kmh: null,
+        effective_speed_kmh: 80,
+        fallback_active: true,
+        speed_source: "fallback_manual",
+      }),
+    }),
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      speed_mps: 80 / 3.6,
+      clients: [],
+      spectra: { clients: {} },
+    },
+  });
+  await page.goto("/");
+  await expect(page.locator("#speed")).toContainText("80.0 km/h");
+  await expect(page.locator("#speed")).toContainText("Manual");
+
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await expect(page.locator("#gpsStatusState")).toHaveText("Disabled");
+  await expect(page.locator("#gpsStatusEffectiveSpeed")).toHaveText("80.0 km/h");
+  await expect(page.locator("#gpsStatusFallback")).toHaveText("Yes");
+  await expect(page.locator('input[name="speedSourceRadio"][value="manual"]')).toBeChecked();
+  await expect(page.locator('input[name="speedSourceRadio"][value="gps"]')).not.toBeChecked();
+  await expect(page.locator("#manualSpeedInput")).toHaveValue("80");
+  await expect(page.locator("#headerManualOverrideGroup")).toBeVisible();
+});
+
 test("analysis bandwidth and uncertainty settings persist through API round-trip", async ({ page }) => {
   let persistedAnalysisSettings: Record<string, number> = {};
   let analysisPutCalls = 0;

--- a/apps/ui/tests/speed_source_state.spec.ts
+++ b/apps/ui/tests/speed_source_state.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  deriveDisplayedSpeedSourceMode,
+  isManualEffectiveSpeedSource,
+  resolveEffectiveSpeedSource,
+} from "../src/app/speed_source_state";
+
+test.describe("speed source state helpers", () => {
+  test("prefers the resolved fallback-manual source over gps configuration", () => {
+    const settings = {
+      speedSource: "gps" as const,
+      manualSpeedKph: 80,
+      resolvedSpeedSource: "fallback_manual" as const,
+    };
+
+    expect(deriveDisplayedSpeedSourceMode(settings)).toBe("manual");
+    expect(resolveEffectiveSpeedSource(settings)).toBe("fallback_manual");
+    expect(isManualEffectiveSpeedSource(settings)).toBe(true);
+  });
+
+  test("keeps gps selected when gps is the resolved effective source", () => {
+    const settings = {
+      speedSource: "gps" as const,
+      manualSpeedKph: 80,
+      resolvedSpeedSource: "gps" as const,
+    };
+
+    expect(deriveDisplayedSpeedSourceMode(settings)).toBe("gps");
+    expect(resolveEffectiveSpeedSource(settings)).toBe("gps");
+    expect(isManualEffectiveSpeedSource(settings)).toBe(false);
+  });
+
+  test("shows manual before live status arrives when manual is configured", () => {
+    const settings = {
+      speedSource: "manual" as const,
+      manualSpeedKph: 45,
+      resolvedSpeedSource: null,
+    };
+
+    expect(deriveDisplayedSpeedSourceMode(settings)).toBe("manual");
+    expect(resolveEffectiveSpeedSource(settings)).toBe("manual");
+    expect(isManualEffectiveSpeedSource(settings)).toBe(true);
+  });
+
+  test("keeps gps selected for unavailable gps state without inventing manual mode", () => {
+    const settings = {
+      speedSource: "gps" as const,
+      manualSpeedKph: null,
+      resolvedSpeedSource: "none" as const,
+    };
+
+    expect(deriveDisplayedSpeedSourceMode(settings)).toBe("gps");
+    expect(resolveEffectiveSpeedSource(settings)).toBe("none");
+    expect(isManualEffectiveSpeedSource(settings)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #1731.

This PR fixes a frontend state-desynchronization problem around speed source. The backend already had enough information to explain the real operating mode: the persisted speed-source configuration endpoint exposed the configured source and manual speed, while the live status endpoint exposed the resolved source actually driving calculations (`gps`, `manual`, `fallback_manual`, or `none`). The problem was that the UI did not treat those inputs as one coherent model. Instead, the header speed label, the speed-source form controls, and the GPS status surface each inferred state from overlapping but incomplete pieces of data. That made it possible for the page to communicate multiple different stories at once about whether speed was coming from GPS or a manual value.

The audit scenario from the issue is a good example. The live system could correctly keep an 80 km/h effective speed through a manual fallback path while GPS was disabled, but the frontend still implied GPS in the header, left the form controls ambiguous, and exposed status details that the user had to reconcile manually. The real problem was not bad math or missing backend data. It was fragmented UI state derivation.

## Implementation approach
I fixed this by making the frontend consume the resolved live speed source deliberately instead of guessing. The smallest maintainable path was to introduce a shared speed-source helper and extend the UI settings state with the last resolved source from `/api/settings/speed-source/status`. That lets the frontend distinguish between the configured source and the resolved source instead of collapsing them into heuristics.

I kept the fix scoped to the existing frontend contract. There are no backend changes and no API shape changes. The work is entirely about using the data the server already provides, then making the header readout, the speed-source selection UI, and the GPS status presentation all render from the same understanding.

## Main code changes
### Shared speed-source derivation
I added `apps/ui/src/app/speed_source_state.ts` as the shared frontend derivation layer for this problem. It exposes a few narrow helpers:

- a displayed speed-source mode for the radio selection/header manual controls
- a resolved effective speed source that prefers the live status value when available
- a manual-effective check used by the header speed readout

This gives the UI one place to define how `manual`, `fallback_manual`, `gps`, and unresolved state should be interpreted.

### Settings state now remembers the resolved source
In `apps/ui/src/app/ui_app_state.ts`, `SettingsState` now stores `resolvedSpeedSource`, which starts as `null` and is updated by the GPS/speed-status polling module. This is the missing link that lets different UI surfaces stay in sync without re-deriving fallback state independently.

### Speed-source form selection now follows the resolved mode
In `apps/ui/src/app/features/settings_speed_source_module.ts`, the module now separates “selection UI sync” from “full input sync.” That matters because the GPS polling loop needs to keep the selected mode and header manual controls synchronized with the resolved live source, but it must not overwrite any in-progress unsaved manual input edits on every poll cycle.

Concretely:

- the module now derives a display mode (`gps` or `manual`) from the shared helper
- the radio selection and header manual override visibility use that display mode
- full input value syncing still happens when persisted config is loaded or saved
- applying a newly saved configuration clears the previously resolved live source so stale resolved state does not briefly override the freshly saved selection before the next status poll arrives

That last point prevents a subtle post-save flicker where the UI could otherwise keep showing the previous live state until polling caught up.

### GPS status polling now updates shared resolved state
In `apps/ui/src/app/features/settings_gps_status_module.ts`, the polling path now writes `status.speed_source` into UI state and relies directly on `status.fallback_active` instead of a frontend heuristic. This is important because the live status endpoint is already the source of truth for the active effective mode. The old code was trying to infer fallback state by combining configured source, manual speed presence, and connection status, which is exactly the kind of partial inference that caused the issue.

I also tightened the small header GPS-status pill so it only appends an effective speed value when GPS is actually the resolved source. That prevents the pill from visually attributing fallback/manual speed to GPS when GPS is disabled or unavailable.

### Header speed readout now uses resolved live source
In `apps/ui/src/app/runtime/ui_shell_status_module.ts`, the main speed label now uses the shared helper instead of mixing configured manual mode with `gpsFallbackActive` heuristics. The header still consumes the live numeric speed from the realtime payload, but the source label is now based on the resolved source when available, with the runtime rotational basis only used as a narrow fallback before the live status poll has populated state.

This keeps the high-visibility header aligned with the actual effective source used for calculations.

### User-facing copy
I updated the English `speed.override` string from “Override” to “Manual” so the header language matches the issue’s requested behavior and is clearer to a user who needs to know what is actually driving the run. The Dutch catalog already used the manual wording, so no Dutch copy change was needed.

## Regression coverage
I added two layers of regression coverage.

First, `apps/ui/tests/smoke.settings.spec.ts` now includes the exact audit-style scenario: the persisted configuration is GPS with a manual fallback value, the live status reports `fallback_manual`, GPS is disabled, and the effective speed remains 80 km/h. The test verifies that:

- the main header speed says manual
- the GPS status panel reports disabled GPS and an effective 80 km/h speed
- fallback is explicitly active
- the speed-source form shows manual selected with `80` populated
- the header manual control group is visible

Second, `apps/ui/tests/speed_source_state.spec.ts` adds focused transition tests for the helper itself across GPS, manual, fallback-manual, and unavailable states. That covers the acceptance criterion calling for regression protection on transitions, not just one end-to-end screenshot path.

I also kept the broader adjacent suites green so the change does not regress the existing settings or shell behavior.

## Contracts, docs, and compatibility
There are no backend contract changes, schema changes, or documentation updates in this PR. The work consumes the existing `SpeedSourceStatusResponse.speed_source` field that was already available. This is a frontend behavior fix, not a protocol change.

## Validation
I ran the following local checks on this branch:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts tests/smoke.cars.spec.ts --config=playwright.smoke.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/speed_source_state.spec.ts --workers=1`

Results:

- typecheck passed
- build passed
- all targeted smoke, runtime-module, and helper-transition tests passed
- lint completed with the same pre-existing unrelated warning in `src/app/features/cars_feature.ts` (`useOptionalChain`), which remains outside this issue’s scope

I also attempted the repository-level Docker compose runtime verification again, but the environment still does not have a reachable Docker daemon. `docker-compose` fails while fetching the server API version from the Unix socket, so I am explicitly calling out that gap rather than claiming the compose/simulator check succeeded.

## Risks and tradeoffs
The main tradeoff is that the frontend now explicitly distinguishes configured and resolved speed source, which adds a small amount of state (`resolvedSpeedSource`) and one shared helper file. I think that is the right level of complexity: it is enough to remove the contradictory UI behavior without introducing a large reducer or redesigning the speed settings page wholesale.

I intentionally did not try to broaden this into a larger rethink of unsupported source modes like OBD2 in the current UI controls. This PR stays focused on the GPS/manual/fallback/unavailable paths that the issue called out and that the audit reproduced. If the UI later grows a dedicated OBD2 flow, the new shared speed-source helper is the natural place to extend the display logic.
