### PR TITLE
Fix #1770: stabilize live trace controls during refresh

### DIFF
--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -67,6 +67,13 @@ type SpectrumSeriesEntry = {
   values: number[];
 };
 
+type SpectrumLegendButton = {
+  button: HTMLButtonElement;
+  label: HTMLSpanElement;
+  meta: HTMLSpanElement | null;
+  swatch: HTMLSpanElement | null;
+};
+
 type UiSpectrumControllerDeps = {
   state: AppState;
   els: UiDomElements;
@@ -83,6 +90,10 @@ export class UiSpectrumController {
   private readonly rootStyle: CSSStyleDeclaration;
 
   private readonly spectrumBandPlugin: uPlot.Plugin;
+
+  private legendResetButton: SpectrumLegendButton | null = null;
+
+  private readonly legendSeriesButtons = new Map<string, SpectrumLegendButton>();
 
   private spectrumTweenRaf: number | null = null;
 
@@ -264,65 +275,124 @@ export class UiSpectrumController {
   }
 
   private renderSensorLegend(entries: SpectrumSeriesEntry[]): void {
-    if (!this.els.legend) return;
-    this.els.legend.innerHTML = "";
-    if (!entries.length) return;
+    const legend = this.els.legend;
+    if (!legend) return;
+    if (!entries.length) {
+      this.legendResetButton?.button.remove();
+      for (const parts of this.legendSeriesButtons.values()) {
+        parts.button.remove();
+      }
+      this.legendSeriesButtons.clear();
+      return;
+    }
 
-    const allButton = document.createElement("button");
-    allButton.type = "button";
+    const allButton = this.ensureLegendResetButton();
     const allActive = this.pinnedSeriesId === null;
-    allButton.className = `legend-item legend-item--interactive legend-item--reset${allActive ? " legend-item--active" : ""}`;
-    allButton.setAttribute("aria-pressed", allActive ? "true" : "false");
-    allButton.title = this.t("spectrum.legend.clear_focus");
-    allButton.addEventListener("click", () => {
+    allButton.button.className = `legend-item legend-item--interactive legend-item--reset${allActive ? " legend-item--active" : ""}`;
+    allButton.button.setAttribute("aria-pressed", allActive ? "true" : "false");
+    allButton.button.title = this.t("spectrum.legend.clear_focus");
+    allButton.label.textContent = this.t("spectrum.legend.all_series");
+    this.placeLegendButton(legend, allButton.button, 0);
+
+    const activeIds = new Set<string>();
+    let nextIndex = 1;
+    for (const entry of entries) {
+      activeIds.add(entry.id);
+      const parts = this.ensureLegendSeriesButton(entry.id);
+      const isActive = this.pinnedSeriesId === entry.id;
+      const isMuted = this.pinnedSeriesId !== null && !isActive;
+      parts.button.className = `legend-item legend-item--interactive${isActive ? " legend-item--active" : ""}${isMuted ? " legend-item--muted" : ""}`;
+      parts.button.setAttribute("aria-pressed", isActive ? "true" : "false");
+      parts.button.title = isActive
+        ? this.t("spectrum.legend.clear_focus")
+        : this.t("spectrum.legend.focus_series", { sensor: entry.label });
+      parts.label.textContent = entry.label;
+      parts.swatch?.style.setProperty("--swatch-color", entry.color);
+      const metric = this.state.spectrum.spectra.clients[entry.id]?.strength_metrics?.vibration_strength_db;
+      if (parts.meta) {
+        parts.meta.textContent = typeof metric === "number" && Number.isFinite(metric)
+          ? `${this.formatDb(metric)} dB`
+          : "";
+      }
+      this.placeLegendButton(legend, parts.button, nextIndex);
+      nextIndex += 1;
+    }
+
+    for (const [entryId, parts] of this.legendSeriesButtons) {
+      if (activeIds.has(entryId)) continue;
+      parts.button.remove();
+      this.legendSeriesButtons.delete(entryId);
+    }
+  }
+
+  private ensureLegendResetButton(): SpectrumLegendButton {
+    if (this.legendResetButton) {
+      return this.legendResetButton;
+    }
+    const button = document.createElement("button");
+    button.type = "button";
+    button.addEventListener("click", () => {
       this.pinnedSeriesId = null;
       this.applyLegendSelection();
     });
-    const allLabel = document.createElement("span");
-    allLabel.className = "legend-item__label";
-    allLabel.textContent = this.t("spectrum.legend.all_series");
-    allButton.appendChild(allLabel);
-    this.els.legend.appendChild(allButton);
+    const label = document.createElement("span");
+    label.className = "legend-item__label";
+    button.appendChild(label);
+    this.legendResetButton = {
+      button,
+      label,
+      meta: null,
+      swatch: null,
+    };
+    return this.legendResetButton;
+  }
 
-    for (const entry of entries) {
-      const button = document.createElement("button");
-      button.type = "button";
-      const isActive = this.pinnedSeriesId === entry.id;
-      const isMuted = this.pinnedSeriesId !== null && !isActive;
-      button.className = `legend-item legend-item--interactive${isActive ? " legend-item--active" : ""}${isMuted ? " legend-item--muted" : ""}`;
-      button.setAttribute("aria-pressed", isActive ? "true" : "false");
-      button.title = isActive
-        ? this.t("spectrum.legend.clear_focus")
-        : this.t("spectrum.legend.focus_series", { sensor: entry.label });
-      button.addEventListener("click", () => {
-        this.pinnedSeriesId = isActive ? null : entry.id;
-        this.applyLegendSelection();
-      });
-
-      const swatch = document.createElement("span");
-      swatch.className = "swatch";
-      swatch.style.setProperty("--swatch-color", entry.color);
-
-      const textGroup = document.createElement("span");
-      textGroup.className = "legend-item__text-group";
-
-      const labelSpan = document.createElement("span");
-      labelSpan.className = "legend-item__label";
-      labelSpan.textContent = entry.label;
-
-      const metric = this.state.spectrum.spectra.clients[entry.id]?.strength_metrics?.vibration_strength_db;
-      const metaSpan = document.createElement("span");
-      metaSpan.className = "legend-item__meta";
-      metaSpan.textContent = typeof metric === "number" && Number.isFinite(metric)
-        ? `${this.formatDb(metric)} dB`
-        : "";
-
-      textGroup.appendChild(labelSpan);
-      textGroup.appendChild(metaSpan);
-      button.appendChild(swatch);
-      button.appendChild(textGroup);
-      this.els.legend.appendChild(button);
+  private ensureLegendSeriesButton(entryId: string): SpectrumLegendButton {
+    const existing = this.legendSeriesButtons.get(entryId);
+    if (existing) {
+      return existing;
     }
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.addEventListener("click", () => {
+      this.pinnedSeriesId = this.pinnedSeriesId === entryId ? null : entryId;
+      this.applyLegendSelection();
+    });
+
+    const swatch = document.createElement("span");
+    swatch.className = "swatch";
+
+    const textGroup = document.createElement("span");
+    textGroup.className = "legend-item__text-group";
+
+    const label = document.createElement("span");
+    label.className = "legend-item__label";
+
+    const meta = document.createElement("span");
+    meta.className = "legend-item__meta";
+
+    textGroup.appendChild(label);
+    textGroup.appendChild(meta);
+    button.appendChild(swatch);
+    button.appendChild(textGroup);
+
+    const created = {
+      button,
+      label,
+      meta,
+      swatch,
+    };
+    this.legendSeriesButtons.set(entryId, created);
+    return created;
+  }
+
+  private placeLegendButton(legend: HTMLElement, button: HTMLButtonElement, index: number): void {
+    const currentChild = legend.children[index];
+    if (currentChild === button) {
+      return;
+    }
+    legend.insertBefore(button, currentChild ?? null);
   }
 
   private renderBandLegend(activeBands: ChartBand[] = []): void {

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -6,23 +6,142 @@ import { createAppState } from "../src/app/ui_app_state";
 import type { UiDomElements } from "../src/app/ui_dom_registry";
 import { installWindowGlobal } from "./async_test_helpers";
 
+type ElementStub = HTMLElement & {
+  children: ElementStub[];
+  className: string;
+  textContent: string;
+  hidden: boolean;
+  disabled: boolean;
+  title: string;
+  type: string;
+  style: CSSStyleDeclaration;
+  appendChild(child: ElementStub): ElementStub;
+  insertBefore(child: ElementStub, before: ElementStub | null): ElementStub;
+  remove(): void;
+  addEventListener(type: string, handler: () => void): void;
+  click(): void;
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  innerHTML: string;
+};
+
+type ElementState = {
+  parent: ElementStub | null;
+  children: ElementStub[];
+  attributes: Record<string, string>;
+  styles: Record<string, string>;
+  listeners: Record<string, Array<() => void>>;
+};
+
+function createElementStub(tagName = "div"): ElementStub {
+  const state: ElementState = {
+    parent: null,
+    children: [],
+    attributes: {},
+    styles: {},
+    listeners: {},
+  };
+  const element = {
+    className: "",
+    textContent: "",
+    hidden: false,
+    disabled: false,
+    title: "",
+    type: "",
+    style: {
+      setProperty(name: string, value: string): void {
+        state.styles[name] = value;
+      },
+      getPropertyValue(name: string): string {
+        return state.styles[name] ?? "";
+      },
+    } as unknown as CSSStyleDeclaration,
+    get children(): ElementStub[] {
+      return state.children;
+    },
+    appendChild(child: ElementStub): ElementStub {
+      return this.insertBefore(child, null);
+    },
+    insertBefore(child: ElementStub, before: ElementStub | null): ElementStub {
+      child.remove();
+      childState.get(child)!.parent = element;
+      const index = before ? state.children.indexOf(before) : -1;
+      if (index >= 0) {
+        state.children.splice(index, 0, child);
+      } else {
+        state.children.push(child);
+      }
+      return child;
+    },
+    remove(): void {
+      if (!state.parent) return;
+      const siblings = childState.get(state.parent)!.children;
+      const index = siblings.indexOf(element);
+      if (index >= 0) {
+        siblings.splice(index, 1);
+      }
+      state.parent = null;
+    },
+    addEventListener(type: string, handler: () => void): void {
+      state.listeners[type] ??= [];
+      state.listeners[type].push(handler);
+    },
+    click(): void {
+      for (const handler of state.listeners.click ?? []) {
+        handler();
+      }
+    },
+    getAttribute(name: string): string | null {
+      return state.attributes[name] ?? null;
+    },
+    setAttribute(name: string, value: string): void {
+      state.attributes[name] = value;
+    },
+    get innerHTML(): string {
+      return "";
+    },
+    set innerHTML(value: string) {
+      if (value !== "") {
+        throw new Error("ElementStub only supports clearing innerHTML");
+      }
+      for (const child of [...state.children]) {
+        child.remove();
+      }
+    },
+  } as unknown as ElementStub;
+  childState.set(element, state);
+  void tagName;
+  return element;
+}
+
+const childState = new WeakMap<ElementStub, ElementState>();
+
+function installDocumentStub(): () => void {
+  const originalDocument = globalThis.document;
+  const originalGetComputedStyle = globalThis.getComputedStyle;
+  (globalThis as { document?: Document }).document = {
+    documentElement: {} as HTMLElement,
+    createElement(tagName: string) {
+      return createElementStub(tagName);
+    },
+  } as Document;
+  globalThis.getComputedStyle = (() =>
+    ({
+      getPropertyValue: () => "",
+    }) as CSSStyleDeclaration) as typeof getComputedStyle;
+  return () => {
+    (globalThis as { document?: Document }).document = originalDocument;
+    globalThis.getComputedStyle = originalGetComputedStyle;
+  };
+}
+
 test.describe("UiSpectrumController", () => {
   test.beforeEach(() => {
     installWindowGlobal();
   });
 
   test("reuses the same band plugin across repeated plugin reads", () => {
-    const originalDocument = globalThis.document;
-    const originalGetComputedStyle = globalThis.getComputedStyle;
-
-    (globalThis as { document?: Document }).document = {
-      documentElement: {} as HTMLElement,
-    } as Document;
-    globalThis.getComputedStyle = (() =>
-      ({
-        getPropertyValue: () => "",
-      }) as CSSStyleDeclaration) as typeof getComputedStyle;
-
+    const restoreDocument = installDocumentStub();
     try {
       const controller = new UiSpectrumController({
         state: createAppState(),
@@ -41,8 +160,108 @@ test.describe("UiSpectrumController", () => {
 
       expect(firstPlugin).toBe(secondPlugin);
     } finally {
-      (globalThis as { document?: Document }).document = originalDocument;
-      globalThis.getComputedStyle = originalGetComputedStyle;
+      restoreDocument();
+    }
+  });
+
+  test("reuses legend buttons across live refreshes and click toggles", () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const state = createAppState();
+      state.transport.wsState = "connected";
+      state.spectrum.spectra.clients = {
+        "sensor-a": {
+          freq: [10, 20],
+          combined: [1, 0.8],
+          strength_metrics: {
+            noise_floor_amp_g: 0.1,
+            peak_amp_g: 1,
+            strength_bucket: null,
+            top_peaks: [{
+              amp: 1,
+              hz: 10,
+              strength_bucket: null,
+              vibration_strength_db: 12,
+            }],
+            vibration_strength_db: 12,
+          },
+        },
+        "sensor-b": {
+          freq: [10, 20],
+          combined: [0.6, 0.5],
+          strength_metrics: {
+            noise_floor_amp_g: 0.1,
+            peak_amp_g: 0.6,
+            strength_bucket: null,
+            top_peaks: [{
+              amp: 0.6,
+              hz: 20,
+              strength_bucket: null,
+              vibration_strength_db: 8,
+            }],
+            vibration_strength_db: 8,
+          },
+        },
+      };
+
+      const legend = createElementStub("div");
+      const inspector = createElementStub("div");
+      const bandToggle = createElementStub("button");
+
+      const controller = new UiSpectrumController({
+        state,
+        els: {
+          legend,
+          spectrumInspector: inspector,
+          spectrumBandToggle: bandToggle,
+        } as unknown as UiDomElements,
+        t: (key, vars) => vars?.sensor ? `${key}:${String(vars.sensor)}` : key,
+      });
+
+      const internals = controller as unknown as {
+        currentEntries: Array<{ id: string; label: string; color: string; values: number[] }>;
+        currentFreqAxis: number[];
+        renderSensorLegend(entries: Array<{ id: string; label: string; color: string; values: number[] }>): void;
+      };
+      const entries = [
+        { id: "sensor-a", label: "Front Right Wheel", color: "#ff5500", values: [12, 11] },
+        { id: "sensor-b", label: "Rear Left Wheel", color: "#3366ff", values: [8, 7] },
+      ];
+
+      internals.currentEntries = entries;
+      internals.currentFreqAxis = [10, 20];
+      internals.renderSensorLegend(entries);
+
+      const allButton = legend.children[0];
+      const sensorButton = legend.children[1];
+      const sensorMeta = sensorButton.children[1].children[1];
+      expect(sensorMeta.textContent).toBe("12.0 dB");
+
+      sensorButton.click();
+      expect(legend.children[0]).toBe(allButton);
+      expect(legend.children[1]).toBe(sensorButton);
+      expect(sensorButton.getAttribute("aria-pressed")).toBe("true");
+
+      state.spectrum.spectra.clients["sensor-a"].strength_metrics.vibration_strength_db = 13;
+      state.spectrum.spectra.clients["sensor-a"].strength_metrics.top_peaks[0].vibration_strength_db = 13;
+      const refreshedEntries = [
+        { ...entries[0], values: [13, 12] },
+        entries[1],
+      ];
+      internals.currentEntries = refreshedEntries;
+      internals.renderSensorLegend(refreshedEntries);
+
+      expect(legend.children[0]).toBe(allButton);
+      expect(legend.children[1]).toBe(sensorButton);
+      expect(sensorMeta.textContent).toBe("13.0 dB");
+      expect(sensorButton.getAttribute("aria-pressed")).toBe("true");
+
+      sensorButton.click();
+      expect(legend.children[0]).toBe(allButton);
+      expect(legend.children[1]).toBe(sensorButton);
+      expect(sensorButton.getAttribute("aria-pressed")).toBe("false");
+    } finally {
+      restoreDocument();
     }
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes #1770, a Live-view interaction bug where the per-sensor trace controls around the spectrum plot could feel unreliable while realtime data was flowing. During the audit, the issue showed up as missed clicks: users would try to isolate a sensor trace, but the button-like legend control behaved as if it was being replaced underneath the cursor during refresh.

The fix keeps the existing Live spectrum workflow intact and targets that instability directly. Instead of rebuilding the interactive legend buttons on refresh, the controller now reuses stable DOM elements for the “all traces” reset control and each per-sensor trace button, updating only their text, pressed state, muted state, title text, and metric labels in place. That preserves the user’s hover, focus, and click target while live data keeps updating.

## Problem and root cause

The issue body called out three user-facing symptoms: controls were not reliably clickable, clicks could be interrupted by rerender churn, and hover/focus/active state did not feel stable while the stream updated. Tracing `apps/ui/src/app/runtime/ui_spectrum_controller.ts` showed the problem was controller-side DOM churn, not the chart model itself.

`renderSpectrum()` updates the plot for each incoming live frame and then calls `applyLegendSelection()`. That method re-rendered the sensor legend. The chart plugin hooks also called back into legend rendering during `setData` and `setSeries`. The previous `renderSensorLegend()` implementation started by clearing `legend.innerHTML`, then recreated every button and reattached new click handlers for the reset chip and each sensor chip. In a live-updating chart that means the active DOM nodes can disappear and be replaced during hover or between pointer down and click handling.

That behavior matches the audit report closely: the controls were visually present, but they did not behave like stable controls because they were ephemeral DOM nodes recreated on refresh.

## Implementation approach

I kept the existing chart model, selection model, and legend presentation, and changed only the legend lifecycle. The goal was the smallest complete fix without broadening scope into throttling, chart recreation, or Live-view redesign.

In `apps/ui/src/app/runtime/ui_spectrum_controller.ts`, I introduced a small internal bookkeeping type, `SpectrumLegendButton`, plus two controller fields:

- `legendResetButton` for the persistent “All sensor traces” control
- `legendSeriesButtons`, a `Map<string, SpectrumLegendButton>` keyed by sensor id

With those in place, `renderSensorLegend()` no longer clears the legend container and rebuilds the whole subtree every time. Instead it now:

1. Reuses or creates the reset button once via `ensureLegendResetButton()`.
2. Reuses or creates each sensor button once via `ensureLegendSeriesButton(entryId)`.
3. Updates button classes, `aria-pressed`, title text, sensor label text, swatch color, and vibration-strength text in place.
4. Preserves button order with `placeLegendButton()` using `insertBefore()` only when the node is not already in the correct position.
5. Removes only truly stale sensor buttons whose ids are no longer present in the current entry set.
6. Clears the legend only when there are no entries at all.

I also changed the click handler behavior so it toggles against the controller’s current `pinnedSeriesId` at click time instead of relying on the `isActive` value captured when the button was last rendered. That is an important companion change: once buttons are intentionally reused, their event handlers must reference current state instead of old render-time state.

The chart still updates at the same cadence and keeps the same selection semantics; refresh now mutates existing controls instead of replacing them.

## Tests and regression coverage

I extended `apps/ui/tests/ui_spectrum_controller.spec.ts` with a focused regression that mirrors the failure mode reported in the issue. I kept the same test style and added a lightweight DOM stub harness for the controller APIs used here: `createElement`, `appendChild`, `insertBefore`, event listeners, attributes, and child tracking.

The new regression verifies that:

- the first legend render creates a reset button and sensor button
- clicking a sensor button pins the trace without replacing the button node
- a subsequent refresh render with updated metrics reuses the exact same button instances
- the metric label updates in place
- a second click correctly clears the pin state while keeping the same button objects alive

That test guards the actual root cause here: the legend controls must remain the same DOM nodes across refreshes, not just re-render the same text.

The existing end-user coverage in `apps/ui/tests/smoke.spectrum.spec.ts` stayed in the validation run so the visible spectrum interaction flow remains exercised in the browser.

## Scope boundaries

This PR does not change backend contracts, generated schemas, server behavior, documentation, or the broader spectrum interaction model. The issue was specifically about unstable trace controls, so I kept the fix centered on that surface.

## Validation

I validated the change locally with the same frontend checks used for the previous UI audit issues:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/ui_spectrum_controller.spec.ts tests/smoke.spectrum.spec.ts --workers=1`
- `cd apps/ui && npm run build`
- `make lint`

All of those passed.

During the Playwright smoke run, Vite still emitted the known `ECONNREFUSED 127.0.0.1:8000` proxy noise for backend API routes in this environment. That did not fail the tests and matches the earlier demo-mode smoke behavior for this UI-only work.

I also ran a targeted code-review pass on the diff after validation; it did not identify any material bugs or regressions.

Local Docker verification remains blocked in this environment by the missing Docker compose plugin or daemon socket, which is the same limitation encountered earlier in this run. I am calling that out explicitly rather than pretending it ran.

## Risks, tradeoffs, and edge cases

The main tradeoff here is keeping a small amount of controller-owned DOM bookkeeping instead of relying on full re-render simplicity. In return, the UI now preserves interaction stability, which is the more important property for live controls.

I considered broader alternatives such as throttling legend refresh, changing when `applyLegendSelection()` is called, or restructuring the chart hooks. Those would have increased scope and risked coupling this issue to unrelated chart behavior. Reusing keyed buttons is the narrower fix because it addresses the root cause without changing how often the chart updates.

An edge case worth noting is sensor churn: if a sensor disappears from the live entry set, its stale button is removed explicitly; if the entire entry set becomes empty, the legend is cleared. That keeps the DOM honest while still preserving button identity across the normal realtime-refresh case that caused the audit failure.
