### PR TITLE
Fix #1774: fix History expand-details helper overflow

### DIFF
--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -1177,21 +1177,26 @@ input:focus-visible,
 }
 .history-row__detail-affordance {
   display: flex;
+  min-width: 0;
 }
 .history-row__toggle {
-  display: inline-grid;
+  display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
+  align-items: start;
   gap: 0.6rem;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   background: var(--surface);
   color: var(--text);
+  width: min(100%, 17rem);
+  max-width: 100%;
+  min-width: 0;
   padding: 0.45rem 0.75rem;
   font: inherit;
   font-size: 0.82rem;
   font-weight: 600;
   text-align: left;
+  white-space: normal;
   cursor: pointer;
   transition: border-color 140ms ease, color 140ms ease, background 140ms ease;
 }
@@ -1217,11 +1222,14 @@ input:focus-visible,
 .history-row__toggle-title {
   font-size: 0.82rem;
   font-weight: 700;
+  overflow-wrap: anywhere;
 }
 .history-row__toggle-hint {
   color: var(--muted);
   font-size: 0.76rem;
   font-weight: 500;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 .history-row__toggle-icon {
   width: 0;

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -125,6 +125,18 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
   await page.locator("#tab-history").click();
   const toggle = page.locator('[data-run-toggle="details"][data-run="run-001"]');
   await expect(toggle).toContainText("View diagnosis and heatmap");
+  const overflowMetrics = await toggle.evaluate((button) => {
+    const hint = button.querySelector<HTMLElement>(".history-row__toggle-hint");
+    return {
+      buttonClientWidth: button.clientWidth,
+      buttonScrollWidth: button.scrollWidth,
+      hintClientWidth: hint?.clientWidth ?? 0,
+      hintScrollWidth: hint?.scrollWidth ?? 0,
+    };
+  });
+  const overflowTolerancePx = 2;
+  expect(overflowMetrics.buttonScrollWidth).toBeLessThanOrEqual(overflowMetrics.buttonClientWidth + overflowTolerancePx);
+  expect(overflowMetrics.hintScrollWidth).toBeLessThanOrEqual(overflowMetrics.hintClientWidth + overflowTolerancePx);
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-expanded", "true");


### PR DESCRIPTION
## Summary
This PR fixes the small but visible layout defect called out in issue #1774, where the helper copy inside the History row `Expand details` control could look cramped or slightly broken in the default desktop layout. The control itself was already the right interaction: it exposed the primary action clearly and matched the simplified History details work from the previous issue. The problem was presentation. The secondary line of copy beneath the main label did not have a stable, readable fit inside the control, which made the component look less intentional than the surrounding UI.

The chosen fix keeps the control, keeps the wording, and keeps the interaction model exactly as-is. Instead of changing markup or copy, it tightens the layout rules around the existing button so the text wraps predictably and remains visually contained. I also added a focused smoke assertion that measures the rendered widths of the toggle and helper text directly, so the specific overflow regression from the audit is now covered by automation.

## Problem being solved
The collaborative UI audit screenshot for the History page highlighted a minor issue with outsized polish impact. In the `Expand details` affordance, the helper line beneath the main label did not fit cleanly within the button. It was readable, but the fit was cramped enough to make the control look unstable and unfinished. Because this control sits inside a dense, repeated table row pattern, even a small misfit becomes noticeable when users scan the History page repeatedly.

This issue was intentionally narrow. The goal was not to redesign the History row, not to shorten the copy, and not to move the action elsewhere. It was simply to make the existing control feel deliberate at the default desktop layout used during the audit.

## Implementation approach
I treated this as a layout-containment problem rather than a content problem. The existing structure already had the right semantics: a button with a title line, a helper line, and an icon. The real problem was that the button was being laid out as an auto-sized `inline-grid` inside a flex wrapper, which meant the helper line could end up squeezed into an awkward width. That produced the “slightly broken” look described in the issue even though the component still technically fit on screen.

Instead of introducing new wrappers or changing the control markup, I adjusted the layout rules at the two relevant levels:

1. The outer affordance wrapper now explicitly allows shrinking with `min-width: 0`, which avoids a common flexbox trap where nested content resists narrowing correctly.
2. The button itself now uses a block `grid` layout with an intentional width cap, normal wrapping, and safer overflow handling for both the title and helper text.

That combination keeps the component flexible inside the row while also giving the copy a stable readable shape.

## Main code changes
In `apps/ui/src/styles/app.css`, the History row affordance now opts into safer shrinking and more predictable wrapping. The main changes are:

- `.history-row__detail-affordance` now sets `min-width: 0` so the flex child can actually shrink within the row instead of forcing awkward text behavior.
- `.history-row__toggle` now uses `display: grid` instead of `inline-grid`, switches alignment to `start`, and gets `width: min(100%, 17rem)` with `max-width: 100%` and `min-width: 0`. This gives the control a stable target width without breaking narrow layouts.
- The button also now allows `white-space: normal`, which makes wrapped copy intentional instead of accidental.
- `.history-row__toggle-title` and `.history-row__toggle-hint` both now use `overflow-wrap: anywhere` so either line can wrap cleanly even when localized strings or constrained widths create awkward breakpoints.
- `.history-row__toggle-hint` also gets a slightly better `line-height`, which improves readability once wrapping is allowed.

These are all presentation-only changes. They do not alter the markup, expand/collapse behavior, accessible state, or the simplified diagnosis-first History details content shipped in the preceding issue.

In `apps/ui/tests/smoke.history.spec.ts`, I extended the existing History smoke coverage around the details toggle. After confirming the button contains the expected helper text, the test now measures both the toggle element and the helper text node and asserts that neither overflows its available width. I kept a small two-pixel tolerance to avoid false failures from subpixel rendering differences across browsers and CI environments.

## Contracts, docs, and behavior surface
There are no API, schema, or contract changes in this PR. There are also no translation changes and no documentation changes, because the user-facing wording and behavior remain the same. This is a targeted presentation fix plus regression coverage.

That narrow scope is intentional. The audit feedback was specifically about how the helper text fit within the control, so the fix stays tightly aligned with that acceptance criterion rather than using the issue as an excuse to rework the broader History row.

## Validation performed
I validated the change with the normal frontend-focused checks for this surface:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts --workers=1`
- `cd apps/ui && npm run build`
- `cd /workspace/VibeSensor && make lint`

After a targeted review pass suggested that a one-pixel overflow tolerance could be slightly too strict for subpixel rounding in some environments, I widened the smoke assertion tolerance to two pixels and reran:

- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts --workers=1`

All of those checks passed locally.

## Risks, tradeoffs, and edge cases considered
The main tradeoff here is between giving the control a stable readable width and keeping it responsive inside a dense row layout. I intentionally used `width: min(100%, 17rem)` rather than a hard width so the control still yields gracefully on narrower layouts while avoiding the cramped auto-sized presentation seen in the audit screenshot.

I also chose to keep the existing copy instead of shortening it. Shortening the text could have masked the layout problem without actually making the component more robust. By fixing the wrapping behavior directly, the control remains resilient if the wording changes slightly later or if localized strings are longer.

The overflow assertions in the smoke test measure real rendered dimensions rather than relying on snapshots alone. That gives stronger protection against this specific regression, but DOM measurements can be sensitive to tiny browser rounding differences. The explicit two-pixel tolerance is there to balance signal and stability.

## Out of scope
This PR does not change the History details interaction, the button label text, the diagnosis/heatmap content, or the broader History row layout. Those areas were either already addressed in earlier issues or were not part of the acceptance criteria here. The goal of this PR is simply to make the existing control look intentional and polished at the audited default desktop layout.
