### PR TITLE
Fix #1795: re-fix clipped History helper text

### DIFF
--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -1191,7 +1191,9 @@ input:focus-visible,
   width: min(100%, 17rem);
   max-width: 100%;
   min-width: 0;
-  padding: 0.45rem 0.75rem;
+  min-height: 38px;
+  height: auto;
+  padding: 0.45rem 0.75rem 0.5rem;
   font: inherit;
   font-size: 0.82rem;
   font-weight: 600;

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -126,17 +126,26 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
   const toggle = page.locator('[data-run-toggle="details"][data-run="run-001"]');
   await expect(toggle).toContainText("View diagnosis and heatmap");
   const overflowMetrics = await toggle.evaluate((button) => {
+    const title = button.querySelector<HTMLElement>(".history-row__toggle-title");
     const hint = button.querySelector<HTMLElement>(".history-row__toggle-hint");
+    const buttonRect = button.getBoundingClientRect();
     return {
       buttonClientWidth: button.clientWidth,
       buttonScrollWidth: button.scrollWidth,
+      buttonClientHeight: button.clientHeight,
+      buttonScrollHeight: button.scrollHeight,
       hintClientWidth: hint?.clientWidth ?? 0,
       hintScrollWidth: hint?.scrollWidth ?? 0,
+      hintBottomGap: hint ? buttonRect.bottom - hint.getBoundingClientRect().bottom : 0,
+      titleTopGap: title ? title.getBoundingClientRect().top - buttonRect.top : 0,
     };
   });
   const overflowTolerancePx = 2;
   expect(overflowMetrics.buttonScrollWidth).toBeLessThanOrEqual(overflowMetrics.buttonClientWidth + overflowTolerancePx);
   expect(overflowMetrics.hintScrollWidth).toBeLessThanOrEqual(overflowMetrics.hintClientWidth + overflowTolerancePx);
+  expect(overflowMetrics.buttonScrollHeight).toBeLessThanOrEqual(overflowMetrics.buttonClientHeight + 1);
+  expect(overflowMetrics.hintBottomGap).toBeGreaterThanOrEqual(2);
+  expect(overflowMetrics.titleTopGap).toBeGreaterThanOrEqual(2);
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-expanded", "true");


### PR DESCRIPTION
## Summary
This PR fixes issue #1795, a follow-up regression report against the History-row toggle work shipped in #1774. The earlier change solved the obvious width and wrapping problem in the `Expand details` helper text, but the latest screenshots attached to #1795 showed that the control was still not visually correct in the real desktop History table. On laptop layouts the helper line sat too low inside the button, the descenders at the bottoms of letters were clipped, and the control looked slightly misaligned relative to adjacent row content. The prior fix improved wrapping without fully ensuring that the two-line button could actually grow to fit its content.

The goal of this PR is to finish that fix without redesigning the History affordance. The wording stays the same, the behavior stays the same, the layout stays the same, and the change is deliberately scoped to the real root cause: a control-specific conflict with a global fixed-height button rule.

## Problem being solved
Issue #1795 was worth prioritizing immediately after #1775 because it is an explicit re-fix request against a surface that had just shipped. I re-read the issue, inspected the current History toggle markup and CSS, and reproduced the problem locally in the real History row state instead of assuming the previous smoke assertion still targeted the true failure mode.

That investigation changed the diagnosis. The bug was no longer horizontal overflow. A temporary local Playwright geometry probe showed that on the failing laptop layout the toggle had roughly `buttonClientHeight=36`, `buttonScrollHeight=41`, and a negative bottom gap for the helper line. That confirmed the rendered content was taller than the available button box, so the issue was vertical clipping. The helper text was technically present and wrapped, but the button itself did not have enough height for both lines plus padding.

The root cause was a global styling rule in `apps/ui/src/styles/app.css`:

- `select, input, button, .btn { height: 38px; }`

That default is fine for normal one-line controls, but it still applied to the two-line History toggle. After #1774, the toggle could wrap more safely, yet it was still being forced into a fixed-height button on desktop pointers. That is why the text looked better in width terms but still clipped vertically in the real UI.

## Implementation approach
The fix stays local to the History row toggle rather than weakening the global control baseline for the rest of the app. The updated `.history-row__toggle` styling now does three things:

1. Sets `min-height: 38px` so the control still respects the standard button baseline when its content is short.
2. Sets `height: auto` so the button can grow when the two-line title/helper stack needs more room.
3. Slightly increases the bottom padding so the helper line no longer rides too close to the lower edge of the control.

This is safer than removing the shared button height rule globally. The problem here was specific: one button intentionally contains two stacked text lines. Giving that single control an explicit escape hatch solves the bug without broader layout churn.

## Main code changes by area
In `apps/ui/src/styles/app.css`, the History toggle keeps the width and wrapping behavior from #1774, but now overrides the height constraint that was still causing clipping. The control can expand vertically when needed while still preserving the familiar desktop baseline for normal cases.

In `apps/ui/tests/smoke.history.spec.ts`, the existing regression coverage was extended so the test now protects the real failure mode rather than only the first one we noticed. The earlier smoke assertions already measured button and helper widths to make sure the text did not overflow horizontally. This PR keeps those checks and adds vertical-fit assertions:

- `buttonScrollHeight` must fit inside `buttonClientHeight` within a tiny tolerance.
- The helper line must keep positive bottom spacing inside the button.
- The title must keep positive top spacing inside the button.

These assertions matter because #1774 passed the width-focused test while the control could still look broken in practice. The updated smoke now validates the overall geometry of the two-line control, which should make this class of regression much harder to miss.

## Schema, contract, config, or documentation changes
There are no backend, schema, API, config, or documentation changes in this PR. The issue is entirely in the frontend presentation layer and is fixed with a CSS override plus stronger browser-level regression coverage.

## Validation and tests performed
I kept validation focused but complete for the changed surface:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts --workers=1`
- `cd apps/ui && npm run build`
- `cd /workspace/VibeSensor && make lint`

Before the final smoke update, I also used a temporary non-committed Playwright geometry probe during investigation to confirm the root cause and the effect of the fix. That probe showed the failing state at approximately `36/41px` for client/scroll height with a negative helper bottom gap, and then showed the fixed state at `49/49px` with a clearly positive bottom gap. The temporary probe file was removed immediately after use and is not part of this PR.

I also ran a targeted review pass on the final two-file diff after local validation, and it did not find any material bugs or missing edge-case coverage.

## Risks, tradeoffs, and edge cases considered
The main tradeoff in this fix is choosing a local override instead of broadening the default behavior for all buttons. I believe that is the correct tradeoff here. A global change from fixed-height buttons to auto-height buttons would have much larger visual blast radius and could subtly alter alignment across multiple screens. This PR avoids that by targeting only the known multiline control.

The smoke test tolerances are intentionally modest. Width checks still allow a small 2px tolerance to avoid subpixel rounding flakes across browsers, while the vertical checks use geometry conditions that should remain stable even if font rendering differs slightly. The assertions are strict enough to catch clipping, but not so strict that harmless rendering differences should create noise.

## Follow-ups and out-of-scope items
This PR does not redesign the History row toggle copy, change the button structure, or alter the global button-height policy across the rest of the application. If future issues show that other multiline controls are fighting the same shared height rule, that should be handled as a separate UI consistency task. For this issue, the narrowest complete fix is to let the existing History toggle size itself correctly and lock that behavior in with a geometry-based smoke regression.
