### PR TITLE
Fix #1784: remove unresolved PDF template placeholders

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -8,8 +8,8 @@
     "nl": "Er wordt geen aandrijflijnprobleem met speling, slingering of balans gevonden."
   },
   "ACTION_DRIVELINE_INSPECTION_WHAT": {
-    "en": "Inspect propshaft runout/balance, center support bearing, CV/guibo joints {driveline_focus}.",
-    "nl": "Controleer cardanas slingering/balans, middenlager, homokineten/flexschijf {driveline_focus}."
+    "en": "Inspect propshaft runout/balance, center support bearing, and CV/guibo joints.",
+    "nl": "Controleer cardanas slingering/balans, middenlager en homokineten/flexschijf."
   },
   "ACTION_DRIVELINE_INSPECTION_WHY": {
     "en": "Driveline-order vibration is commonly caused by shaft imbalance, joint wear, or support bearing issues.",
@@ -92,8 +92,8 @@
     "nl": "Er wordt geen bandtoestandsafwijking gevonden op de gecontroleerde wielen."
   },
   "ACTION_TIRE_CONDITION_WHAT": {
-    "en": "Inspect {wheel_focus} for tire defects: flat spots, belt shift, uneven wear, pressure mismatch.",
-    "nl": "Controleer {wheel_focus} op banddefecten: vlakke plekken, gordelverschuiving, ongelijk slijtagebeeld, drukverschillen."
+    "en": "Inspect the relevant wheel/tire assemblies for tire defects: flat spots, belt shift, uneven wear, and pressure mismatch.",
+    "nl": "Controleer de relevante wiel-/bandsets op banddefecten: vlakke plekken, gordelverschuiving, ongelijk slijtagebeeld en drukverschillen."
   },
   "ACTION_TIRE_CONDITION_WHY": {
     "en": "Tire structural issues often create strong 1x/2x wheel-order vibration.",
@@ -108,12 +108,12 @@
     "nl": "Balans en slingering zijn binnen specificatie op alle gecontroleerde wielen/banden en de klacht blijft ongewijzigd."
   },
   "ACTION_WHEEL_BALANCE_WHAT": {
-    "en": "Inspect and balance {wheel_focus}; measure radial/lateral runout on the wheel and tire{speed_hint}.",
-    "nl": "Controleer en balanceer {wheel_focus}; meet radiale/laterale slingering op wiel en band{speed_hint}."
+    "en": "Inspect and balance the relevant wheel/tire assemblies; measure radial/lateral runout on the wheel and tire.",
+    "nl": "Controleer en balanceer de relevante wiel-/bandsets; meet radiale/laterale slingering op wiel en band."
   },
   "ACTION_WHEEL_BALANCE_WHY": {
-    "en": "{location_hint} wheel-order signatures are most likely caused by imbalance, runout, or tire deformation.",
-    "nl": "{location_hint} wielorde-signaturen worden meestal veroorzaakt door onbalans, slingering of banddeformatie."
+    "en": "Wheel-order signatures are most likely caused by imbalance, runout, or tire deformation.",
+    "nl": "Wielorde-signaturen worden meestal veroorzaakt door onbalans, slingering of banddeformatie."
   },
   "ADDITIONAL_OBSERVATIONS": {
     "en": "Additional Observations",

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -125,6 +125,66 @@ def test_map_summary_uses_domain_action_render_queries_for_next_steps() -> None:
     assert data.next_steps[0].eta == "15-30 min"
 
 
+def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
+    summary = minimal_summary(
+        findings=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.74,
+            }
+        ],
+        top_causes=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.74,
+            }
+        ],
+        test_plan=[
+            {
+                "action_id": "wheel_balance_and_runout",
+                "what": "ACTION_WHEEL_BALANCE_WHAT",
+                "why": "ACTION_WHEEL_BALANCE_WHY",
+                "confirm": "ACTION_WHEEL_BALANCE_CONFIRM",
+                "falsify": "ACTION_WHEEL_BALANCE_FALSIFY",
+                "eta": "20-45 min",
+            },
+            {
+                "action_id": "wheel_tire_condition",
+                "what": "ACTION_TIRE_CONDITION_WHAT",
+                "why": "ACTION_TIRE_CONDITION_WHY",
+                "confirm": "ACTION_TIRE_CONDITION_CONFIRM",
+                "falsify": "ACTION_TIRE_CONDITION_FALSIFY",
+                "eta": "10-20 min",
+            },
+            {
+                "action_id": "driveline_inspection",
+                "what": "ACTION_DRIVELINE_INSPECTION_WHAT",
+                "why": "ACTION_DRIVELINE_INSPECTION_WHY",
+                "confirm": "ACTION_DRIVELINE_INSPECTION_CONFIRM",
+                "falsify": "ACTION_DRIVELINE_INSPECTION_FALSIFY",
+                "eta": "20-35 min",
+            },
+        ],
+    )
+
+    data = map_summary(prepare_report_input(summary))
+    rendered = " ".join(
+        part
+        for step in data.next_steps
+        for part in (step.action, step.why, step.confirm, step.falsify)
+        if part
+    )
+
+    assert "{wheel_focus}" not in rendered
+    assert "{speed_hint}" not in rendered
+    assert "{location_hint}" not in rendered
+    assert "{driveline_focus}" not in rendered
+    assert "{" not in rendered
+    assert "}" not in rendered
+
+
 def test_map_summary_uses_connected_sensors_for_report_evidence() -> None:
     summary = minimal_summary(
         lang="en",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -14,6 +14,7 @@ from reportlab.pdfgen.canvas import Canvas
 from test_support.core import extract_pdf_text
 from test_support.report_helpers import (
     RUN_END,
+    minimal_summary,
     write_jsonl,
 )
 from test_support.report_helpers import (
@@ -179,6 +180,60 @@ def test_report_pdf_header_contains_firmware_version(tmp_path: Path) -> None:
     text_blob = extract_pdf_text(build_report_pdf(map_summary(prepare_report_input(summary))))
     assert "Firmware Version" in text_blob
     assert "esp-fw-1.2.3" in text_blob
+
+
+def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
+    summary = minimal_summary(
+        findings=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.74,
+            }
+        ],
+        top_causes=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.74,
+            }
+        ],
+        test_plan=[
+            {
+                "action_id": "wheel_balance_and_runout",
+                "what": "ACTION_WHEEL_BALANCE_WHAT",
+                "why": "ACTION_WHEEL_BALANCE_WHY",
+                "confirm": "ACTION_WHEEL_BALANCE_CONFIRM",
+                "falsify": "ACTION_WHEEL_BALANCE_FALSIFY",
+                "eta": "20-45 min",
+            },
+            {
+                "action_id": "wheel_tire_condition",
+                "what": "ACTION_TIRE_CONDITION_WHAT",
+                "why": "ACTION_TIRE_CONDITION_WHY",
+                "confirm": "ACTION_TIRE_CONDITION_CONFIRM",
+                "falsify": "ACTION_TIRE_CONDITION_FALSIFY",
+                "eta": "10-20 min",
+            },
+            {
+                "action_id": "driveline_inspection",
+                "what": "ACTION_DRIVELINE_INSPECTION_WHAT",
+                "why": "ACTION_DRIVELINE_INSPECTION_WHY",
+                "confirm": "ACTION_DRIVELINE_INSPECTION_CONFIRM",
+                "falsify": "ACTION_DRIVELINE_INSPECTION_FALSIFY",
+                "eta": "20-35 min",
+            },
+        ],
+    )
+
+    text_blob = extract_pdf_text(build_report_pdf(map_summary(prepare_report_input(summary))))
+
+    assert "{wheel_focus}" not in text_blob
+    assert "{speed_hint}" not in text_blob
+    assert "{location_hint}" not in text_blob
+    assert "{driveline_focus}" not in text_blob
+    assert "Inspect propshaft runout/balance" in text_blob
+    assert "Inspect the relevant wheel/tire assemblies" in text_blob
 
 
 def test_report_pdf_wraps_long_system_card_location() -> None:

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -8,8 +8,8 @@
     "nl": "Er wordt geen aandrijflijnprobleem met speling, slingering of balans gevonden."
   },
   "ACTION_DRIVELINE_INSPECTION_WHAT": {
-    "en": "Inspect propshaft runout/balance, center support bearing, CV/guibo joints {driveline_focus}.",
-    "nl": "Controleer cardanas slingering/balans, middenlager, homokineten/flexschijf {driveline_focus}."
+    "en": "Inspect propshaft runout/balance, center support bearing, and CV/guibo joints.",
+    "nl": "Controleer cardanas slingering/balans, middenlager en homokineten/flexschijf."
   },
   "ACTION_DRIVELINE_INSPECTION_WHY": {
     "en": "Driveline-order vibration is commonly caused by shaft imbalance, joint wear, or support bearing issues.",
@@ -92,8 +92,8 @@
     "nl": "Er wordt geen bandtoestandsafwijking gevonden op de gecontroleerde wielen."
   },
   "ACTION_TIRE_CONDITION_WHAT": {
-    "en": "Inspect {wheel_focus} for tire defects: flat spots, belt shift, uneven wear, pressure mismatch.",
-    "nl": "Controleer {wheel_focus} op banddefecten: vlakke plekken, gordelverschuiving, ongelijk slijtagebeeld, drukverschillen."
+    "en": "Inspect the relevant wheel/tire assemblies for tire defects: flat spots, belt shift, uneven wear, and pressure mismatch.",
+    "nl": "Controleer de relevante wiel-/bandsets op banddefecten: vlakke plekken, gordelverschuiving, ongelijk slijtagebeeld en drukverschillen."
   },
   "ACTION_TIRE_CONDITION_WHY": {
     "en": "Tire structural issues often create strong 1x/2x wheel-order vibration.",
@@ -108,12 +108,12 @@
     "nl": "Balans en slingering zijn binnen specificatie op alle gecontroleerde wielen/banden en de klacht blijft ongewijzigd."
   },
   "ACTION_WHEEL_BALANCE_WHAT": {
-    "en": "Inspect and balance {wheel_focus}; measure radial/lateral runout on the wheel and tire{speed_hint}.",
-    "nl": "Controleer en balanceer {wheel_focus}; meet radiale/laterale slingering op wiel en band{speed_hint}."
+    "en": "Inspect and balance the relevant wheel/tire assemblies; measure radial/lateral runout on the wheel and tire.",
+    "nl": "Controleer en balanceer de relevante wiel-/bandsets; meet radiale/laterale slingering op wiel en band."
   },
   "ACTION_WHEEL_BALANCE_WHY": {
-    "en": "{location_hint} wheel-order signatures are most likely caused by imbalance, runout, or tire deformation.",
-    "nl": "{location_hint} wielorde-signaturen worden meestal veroorzaakt door onbalans, slingering of banddeformatie."
+    "en": "Wheel-order signatures are most likely caused by imbalance, runout, or tire deformation.",
+    "nl": "Wielorde-signaturen worden meestal veroorzaakt door onbalans, slingering of banddeformatie."
   },
   "ADDITIONAL_OBSERVATIONS": {
     "en": "Additional Observations",


### PR DESCRIPTION
## Summary
This PR fixes `#1784` by removing unresolved template tokens from the PDF report’s `Next steps` content and locking that behavior in with focused regressions. The reported problem was not a rendering artifact: literal placeholders such as `{wheel_focus}`, `{speed_hint}`, `{location_hint}`, and `{driveline_focus}` were being written into the generated PDF, which made the report feel like a prototype instead of a finished diagnostic document.

After tracing the issue through the report pipeline, the leak turned out to be narrower than a full templating-system bug. The affected text came from four `Next steps` translations in the report i18n JSON files. Those strings still contained placeholder fragments that were never actually supplied when the PDF builder rendered `RecommendedAction`-based next steps. As a result, the text reached the final PDF unchanged. This PR replaces those unfinished template fragments with finished production copy that remains readable without per-finding interpolation, and it adds regression tests at both the mapped-report and rendered-PDF levels so those brace tokens cannot quietly reappear.

## Problem details
The issue body called out unresolved tokens in the exported PDF’s `Next steps` section. A focused exploration pass confirmed that the specific placeholders were embedded in the action-copy translations for:

- `ACTION_DRIVELINE_INSPECTION_WHAT`
- `ACTION_TIRE_CONDITION_WHAT`
- `ACTION_WHEEL_BALANCE_WHAT`
- `ACTION_WHEEL_BALANCE_WHY`

Those strings lived in both `apps/server/data/report_i18n.json` and the packaged fallback copy at `apps/server/vibesensor/data/report_i18n.json`.

The key observation was that the PDF pipeline is not currently building those actions with per-finding interpolation data for fields like `wheel_focus` or `location_hint`. In other words, the placeholders were not “temporarily missing” because of a recent formatting regression; they were effectively dead template fragments in user-facing strings. That is why the leak was stable and reproducible in the finished report output.

I also checked the suspected header/overview surfaces while scoping the issue. Those turned out not to be the main source for this bug family because the header panel already routes optional values through `_safe()` fallbacks. That made the smallest complete fix more targeted: finish the affected `Next steps` copy instead of broadening the PDF renderer or report data model unnecessarily.

## Implementation approach
I kept this change backend-only and intentionally narrow. Rather than trying to retrofit a new interpolation contract into `RecommendedAction` or expanding the test-plan domain model to carry extra placeholder values, I treated the current behavior as the product contract: these next-step rows are rendered from stable action keys without per-case substitution inputs. Given that constraint, the cleanest solution was to make the translated strings themselves complete and readable without additional formatting data.

This avoids two risks that a larger refactor would have introduced. First, it avoids inventing new adapter/domain coupling just to thread optional display fragments into the PDF path. Second, it avoids silently masking the problem with generic placeholder stripping that could leave awkward grammar in user-facing copy. Instead, the four affected strings now say exactly what the report can reliably say today.

## Main code changes
In `apps/server/data/report_i18n.json`, I rewrote the four affected English and Dutch `Next steps` strings so they no longer depend on unresolved placeholder values. The new wording keeps the same operational meaning while reading as finished production copy:

- driveline inspection text now refers directly to propshaft runout/balance, the center support bearing, and CV/guibo joints
- tire-condition inspection now refers to the relevant wheel/tire assemblies instead of a missing `{wheel_focus}` value
- wheel-balance inspection now refers to the relevant wheel/tire assemblies and removes the missing speed-hint fragment
- wheel-balance rationale now explains wheel-order signatures without the missing location-hint prefix

I made the same edits in `apps/server/vibesensor/data/report_i18n.json` to keep the packaged fallback copy aligned with the source-of-truth data file. That duplication matters in this repo because packaged installations can load the fallback copy even when the development data directory is not the active source.

On the test side, I added a focused mapping regression in `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`. That test builds a report summary with the affected action keys and verifies that the mapped `next_steps` text contains no unresolved placeholder tokens or stray braces.

I also added a rendered-output regression in `apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`. That test builds a real PDF from summary data, extracts the text, and asserts that the known placeholder tokens do not appear in the final document. It also checks for representative expected production text so the test guards against an accidental “remove everything” fallback.

## Validation
Focused validation passed locally with:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_i18n.py`
- `make lint`
- `make typecheck-backend`

I also ran a targeted review pass on the final diff. That review did not find any material correctness, localization, or regression issues.

## Risks, tradeoffs, and scope boundaries
The main tradeoff here is that the affected `Next steps` copy is now intentionally generic where the old placeholder plan appears to have wanted more context-specific phrasing. I think that is the right trade for this issue because the report should never show unfinished template syntax to the user, and the current data path does not actually provide those interpolated values. Finished generic copy is materially better than unstable “smart” copy that leaks implementation tokens.

I deliberately did not expand this PR into a larger redesign of the report action model or `tr()` formatting semantics. There may be future value in carrying richer per-action display context through the report pipeline, but that would be a separate design decision with broader domain-model consequences. For this issue, the smallest complete fix is to make the currently shipped output trustworthy and to add regressions that catch placeholder leakage in both mapped content and the final PDF.

Out of scope for this PR are the remaining PDF audit issues (`#1785` and onward), which focus on broader wording, hierarchy, and layout quality. This change is specifically about eliminating unfinished placeholder syntax from user-visible report output and preventing that regression from returning.
