### PR TITLE
Fix #1787: reduce duplicate PDF finding facts

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
+++ b/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
@@ -142,11 +142,44 @@ def test_report_output_matches_template_data() -> None:
             strongest_location="Front Left",
         ),
         lang="en",
+        certainty_tier_key="C",
     )
     pdf_bytes = build_report_pdf(data)
     reader = PdfReader(BytesIO(pdf_bytes))
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    observed_start = text.find("Observed Signature")
+    systems_start = text.find("Systems with findings")
+    next_steps_start = text.find("Next steps")
+    observed_section = text[observed_start:systems_start]
+    systems_section = text[systems_start : next_steps_start if next_steps_start >= 0 else None]
 
     assert "Wheel / Tire" in text
     assert "Front Left" in text
+    assert "Strongest sensor" not in observed_section
+    assert "Strongest sensor: Front Left" in systems_section
     assert "VibeSensor Diagnostic Report" in text
+
+
+def test_report_keeps_strongest_sensor_on_page_one_when_no_system_cards() -> None:
+    """Low-confidence/no-card reports should keep strongest-location context on page 1."""
+    data = ReportTemplateData(
+        title="VibeSensor Diagnostic Report",
+        observed=PatternEvidence(
+            primary_system="Unknown",
+            strongest_location="Rear Right",
+            certainty_label="Low",
+        ),
+        pattern_evidence=PatternEvidence(strongest_location="Rear Right"),
+        lang="en",
+        certainty_tier_key="A",
+    )
+    pdf_bytes = build_report_pdf(data)
+    reader = PdfReader(BytesIO(pdf_bytes))
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    observed_start = text.find("Observed Signature")
+    systems_start = text.find("Systems with findings")
+    observed_section = text[observed_start:systems_start]
+    observed_single_line = " ".join(observed_section.split())
+
+    assert "Strongest sensor: Rear Right" in observed_single_line
+    assert "Confidence is too low to attribute vibration to specific systems." in text

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -19,7 +19,13 @@ from vibesensor.adapters.pdf.panels._panel_diagram import (
     fit_rect_preserve_aspect,
 )
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.adapters.pdf.pdf_style import MARGIN, PAGE_H, PAGE_W, build_page1_layout
+from vibesensor.adapters.pdf.pdf_style import (
+    MARGIN,
+    PAGE_H,
+    PAGE_W,
+    build_page1_layout,
+    observed_signature_row_count,
+)
 
 
 def _sample(
@@ -136,3 +142,30 @@ def test_build_page1_layout_prioritizes_observed_signature_panel() -> None:
     )
     assert layout.observed.h > layout.header.h
     assert layout.systems.h < 58 * mm
+
+
+def test_observed_signature_row_count_reserves_optional_reason_and_tier_a_warning() -> None:
+    assert (
+        observed_signature_row_count(
+            certainty_tier_key="C",
+            system_card_count=1,
+            has_certainty_reason=False,
+        )
+        == 4
+    )
+    assert (
+        observed_signature_row_count(
+            certainty_tier_key="C",
+            system_card_count=1,
+            has_certainty_reason=True,
+        )
+        == 5
+    )
+    assert (
+        observed_signature_row_count(
+            certainty_tier_key="A",
+            system_card_count=0,
+            has_certainty_reason=False,
+        )
+        == 6
+    )

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_header.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_header.py
@@ -32,6 +32,8 @@ from vibesensor.adapters.pdf.pdf_style import (
     TEXT_CLR,
     HeaderColumnsLayout,
     build_page1_layout,
+    observed_signature_row_count,
+    show_observed_signature_location,
 )
 from vibesensor.adapters.pdf.pdf_text import (
     _draw_kv,
@@ -163,11 +165,16 @@ def _draw_header_panel(
     page_top: float,
     na: str,
 ) -> float:
+    obs_rows = observed_signature_row_count(
+        certainty_tier_key=data.certainty_tier_key,
+        system_card_count=len(data.system_cards),
+        has_certainty_reason=bool(data.observed.certainty_reason),
+    )
     header_columns = build_page1_layout(
         width=width,
         page_top=page_top,
         header_content_height=0.0,
-        observed_rows=5,
+        observed_rows=obs_rows,
     ).header_columns
     left_rows, right_rows, left_col_w, right_col_w, meta_right = _build_header_rows(
         c,
@@ -186,7 +193,7 @@ def _draw_header_panel(
         width=width,
         page_top=page_top,
         header_content_height=max(left_h, right_h),
-        observed_rows=5 + (1 if data.observed.certainty_reason else 0),
+        observed_rows=obs_rows,
     )
     _draw_panel(c, layout.header.x, layout.header.y, layout.header.w, layout.header.h, fill=SOFT_BG)
 
@@ -220,7 +227,15 @@ def _draw_observed_signature_panel(
     y_cursor: float,
     na: str,
 ) -> float:
-    obs_rows = 5 + (1 if data.observed.certainty_reason else 0)
+    show_strongest_sensor = show_observed_signature_location(
+        certainty_tier_key=data.certainty_tier_key,
+        system_card_count=len(data.system_cards),
+    )
+    obs_rows = observed_signature_row_count(
+        certainty_tier_key=data.certainty_tier_key,
+        system_card_count=len(data.system_cards),
+        has_certainty_reason=bool(data.observed.certainty_reason),
+    )
     layout = build_page1_layout(
         width=width,
         page_top=PAGE_H - MARGIN,
@@ -256,15 +271,16 @@ def _draw_observed_signature_panel(
         value_w=width - 8 * mm - OBSERVED_LABEL_W,
     )
     oy -= 1.0 * mm
-    _draw_kv(
-        c,
-        ox,
-        oy,
-        tr("STRONGEST_SENSOR"),
-        _safe(data.observed.strongest_location, na),
-        label_w=OBSERVED_LABEL_W,
-    )
-    oy -= obs_step
+    if show_strongest_sensor:
+        _draw_kv(
+            c,
+            ox,
+            oy,
+            tr("STRONGEST_SENSOR"),
+            _safe(data.observed.strongest_location, na),
+            label_w=OBSERVED_LABEL_W,
+        )
+        oy -= obs_step
     _draw_kv(c, ox, oy, tr("CERTAINTY_LABEL_FULL"), cert_val, label_w=OBSERVED_LABEL_W)
     oy -= obs_step
     _draw_kv(

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
@@ -20,6 +20,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     SUB_CLR,
     TEXT_CLR,
     build_page1_layout,
+    observed_signature_row_count,
 )
 from vibesensor.adapters.pdf.pdf_text import _draw_text
 from vibesensor.adapters.pdf.report_data import ReportTemplateData, SystemFindingCard
@@ -39,7 +40,11 @@ def _draw_systems_panel(
         width=width,
         page_top=PAGE_H - MARGIN,
         header_content_height=0.0,
-        observed_rows=5 + (1 if data.observed.certainty_reason else 0),
+        observed_rows=observed_signature_row_count(
+            certainty_tier_key=data.certainty_tier_key,
+            system_card_count=len(data.system_cards),
+            has_certainty_reason=bool(data.observed.certainty_reason),
+        ),
     )
     cards_h = layout.systems.h
     cards_y = y_cursor - cards_h

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py
@@ -25,6 +25,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     TEXT_CLR,
     build_page1_layout,
     build_page2_layout,
+    observed_signature_row_count,
 )
 from vibesensor.adapters.pdf.pdf_text import _draw_kv, _draw_text, _wrap_lines
 from vibesensor.adapters.pdf.report_data import NextStep, ReportTemplateData
@@ -147,7 +148,11 @@ def _draw_bottom_row_panels(
         width=width,
         page_top=PAGE_H - MARGIN,
         header_content_height=0.0,
-        observed_rows=5 + (1 if data.observed.certainty_reason else 0),
+        observed_rows=observed_signature_row_count(
+            certainty_tier_key=data.certainty_tier_key,
+            system_card_count=len(data.system_cards),
+            has_certainty_reason=bool(data.observed.certainty_reason),
+        ),
         y_after_systems_source=y_cursor,
     )
     next_panel = layout.bottom.next_steps

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -151,6 +151,30 @@ def build_header_columns_layout(*, width: float) -> HeaderColumnsLayout:
     )
 
 
+def show_observed_signature_location(*, certainty_tier_key: str, system_card_count: int) -> bool:
+    """Keep strongest-sensor context on page 1 when the systems panel cannot show cards."""
+    return certainty_tier_key == "A" or system_card_count == 0
+
+
+def observed_signature_row_count(
+    *,
+    certainty_tier_key: str,
+    system_card_count: int,
+    has_certainty_reason: bool,
+) -> int:
+    return (
+        4
+        + int(
+            show_observed_signature_location(
+                certainty_tier_key=certainty_tier_key,
+                system_card_count=system_card_count,
+            )
+        )
+        + int(has_certainty_reason)
+        + int(certainty_tier_key == "A")
+    )
+
+
 def build_page1_layout(
     *,
     width: float,


### PR DESCRIPTION
## Summary
This PR fixes `#1787` by reducing duplicated facts between the page-1 `Observed Signature` panel and the `Systems with findings` cards in the PDF report. Before this change, the report repeated the strongest sensor location in both places, which made page 1 feel longer and busier without adding much meaning. The fix keeps the summary panel focused on the global pattern answer and leaves location-specific evidence on the differentiated system cards, while still preserving page-1 clarity for low-confidence reports that do not render system cards at all.

## Problem and scope
The issue was not about missing analysis or incorrect diagnosis. The report already knew the primary system, the strongest location, the confidence level, and the relevant system hypotheses. The problem was that page 1 repeated some of those facts in adjacent sections without changing their job.

In particular, `Observed Signature` showed the strongest sensor location, and then each system card in `Systems with findings` showed its own strongest location again. That reduced the contrast between the two sections:

- `Observed Signature` is supposed to act as the compact answer
- `Systems with findings` is supposed to explain the candidate systems and why they are plausible

When both sections restated the same location fact, page 1 read as more verbose than it needed to, and the system cards spent space repeating metadata instead of feeling like differentiated hypothesis cards.

I kept the scope narrow. This PR does not redesign the PDF or change diagnosis logic. It only tightens the responsibility split between two page-1 sections.

## Implementation approach
I chose the smallest complete fix that reduced duplication without accidentally hiding useful information in edge cases.

The main rule is now:

- when system cards are present, `Observed Signature` does not repeat the strongest sensor location
- when no system cards are shown, page 1 keeps that strongest-sensor detail in `Observed Signature` so the summary page still contains actionable location context

That second rule matters for Tier A / low-confidence reports. In those cases, the systems panel intentionally shows a low-confidence message instead of differentiated cards. If I had removed the strongest sensor location unconditionally, page 1 would have lost that diagnostic clue and users would have needed to rely on later sections for information they previously got at a glance. So the fix had to be conditional, not absolute.

To keep that behavior maintainable, I did not scatter the condition across multiple layout callers. Instead, I introduced shared helpers in `apps/server/vibesensor/adapters/pdf/pdf_style.py` so the rendering rule and the observed-signature row-count math stay centralized and consistent.

## Main code changes by area
In `apps/server/vibesensor/adapters/pdf/panels/_panel_header.py`, I updated `_draw_observed_signature_panel()` so it conditionally renders the `Strongest sensor` line. The panel now stays focused on:

- primary system
- `What to check first`
- certainty
- speed band
- strength

The strongest-sensor line is only added there when the systems panel will not render differentiated cards, which preserves page-1 usefulness for Tier A / no-card outputs.

In the same file, `_draw_header_panel()` now uses the shared observed-signature row-count helper instead of hard-coded assumptions. That keeps the vertical layout in sync with the real number of rows the summary block may render.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py`, I left the per-card strongest-location rendering in place, because that is exactly where the fact becomes useful: attached to a specific system hypothesis. The systems panel now also uses the same shared row-count helper when computing page-1 layout, so it stays aligned with the summary panel’s conditional content.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py`, I updated the bottom-row layout call to use the same helper as well. That prevents panel-height drift when the observed-signature section has optional content such as the strongest-sensor line, a certainty reason, or the Tier A warning.

In `apps/server/vibesensor/adapters/pdf/pdf_style.py`, I added two small shared helpers:

- one that decides whether `Observed Signature` should keep strongest-location context on page 1
- one that computes the observed-signature row count for layout sizing

Those helpers intentionally capture both the no-card/Tier A behavior and the optional-row cases so the panel content and layout stay coupled in one place instead of being re-derived by each caller.

## Tests and validation
I updated focused PDF tests rather than broadening the change surface.

In `apps/server/tests/adapters/pdf/test_report_analysis_separation.py`, I expanded the rendering assertions in two directions:

- one regression now verifies that when a differentiated system card exists, `Observed Signature` does not contain `Strongest sensor` while the systems section does
- a second regression verifies that when the report is Tier A / no-card, page 1 still contains `Strongest sensor` in the `Observed Signature` section

That combination locks in the intended responsibility split instead of only checking raw text presence somewhere in the document.

In `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`, I added a small regression for the shared row-count helper so optional certainty-reason space and the Tier A warning row cannot silently drift out of sync with page-1 height calculations.

I also reran the directly related smoke/content suites so the fix was validated in context, not just through the new assertions.

Local validation passed with:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_analysis_separation.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
- `make lint`
- `make typecheck-backend`

During review, two coupled issues surfaced and were fixed before packaging:

- Tier A / no-card reports needed to keep strongest-location context on page 1
- the shared row-count helper also needed to reserve space for the Tier A warning row

So the final diff already includes both corrections.

## Contracts, docs, and i18n
There are no schema or payload contract changes in this PR. The report data model is unchanged, and no i18n keys were added or removed. The existing `STRONGEST_SENSOR` label remains in use; this change only narrows where it appears on page 1.

I also did not need to update user-facing documentation because this is a PDF presentation refinement.

## Risks, tradeoffs, and out-of-scope notes
The main tradeoff is that this PR improves clarity by reducing repetition, not by redesigning the full systems panel. The cards still show the same core fields as before; they just become more distinct because the summary panel no longer competes with them for the same location fact.

Another deliberate choice was to preserve strongest-location context on page 1 for Tier A outputs. That slightly weakens the “never repeat location in Observed Signature” rule, but it is the right exception because the systems panel does not provide differentiated cards in that mode. The rule is therefore “no duplication when cards exist,” not “hide the field under all circumstances.”

Out of scope here are broader page-1 layout changes such as redesigning the card bodies, changing next-step density, or moving evidence hierarchy between pages. Those remain separate PDF-audit issues.
