### PR TITLE
Fix #1790: tighten PDF hypothesis cards

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
+++ b/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
@@ -15,6 +15,7 @@ from pypdf import PdfReader
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.adapters.pdf.report_data import (
+    PartSuggestion,
     PatternEvidence,
     ReportTemplateData,
     SystemFindingCard,
@@ -183,3 +184,46 @@ def test_report_keeps_strongest_sensor_on_page_one_when_no_system_cards() -> Non
 
     assert "Strongest sensor: Rear Right" in observed_single_line
     assert "Confidence is too low to attribute vibration to specific systems." in text
+
+
+def test_report_cards_switch_to_check_first_summary_when_parts_exist() -> None:
+    """Actionable cards should spend space on pattern + first checks, not duplicate location."""
+    data = ReportTemplateData(
+        title="VibeSensor Diagnostic Report",
+        observed=PatternEvidence(
+            primary_system="Wheel / Tire",
+            strongest_location="Front Left",
+            certainty_label="High",
+        ),
+        system_cards=[
+            SystemFindingCard(
+                system_name="Wheel / Tire",
+                strongest_location="Front Left",
+                pattern_summary="1x wheel order",
+                parts=[
+                    PartSuggestion(name="Wheel bearing assembly"),
+                    PartSuggestion(name="Tire belt package"),
+                ],
+            ),
+        ],
+        pattern_evidence=PatternEvidence(
+            matched_systems=["Wheel / Tire"],
+            strongest_location="Front Left",
+        ),
+        lang="en",
+        certainty_tier_key="C",
+    )
+    pdf_bytes = build_report_pdf(data)
+    reader = PdfReader(BytesIO(pdf_bytes))
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    observed_start = text.find("Observed Signature")
+    systems_start = text.find("Systems with findings")
+    next_steps_start = text.find("Next steps")
+    observed_section = text[observed_start:systems_start]
+    systems_section = text[systems_start : next_steps_start if next_steps_start >= 0 else None]
+    systems_single_line = " ".join(systems_section.split())
+
+    assert "Strongest sensor: Front Left" not in observed_section
+    assert "Strongest sensor: Front Left" not in systems_section
+    assert "Pattern: 1x wheel order" in systems_single_line
+    assert "What to check first: Wheel bearing assembly, Tire belt package" in systems_single_line

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -291,7 +291,7 @@ def test_build_page1_layout_prioritizes_observed_signature_panel() -> None:
         observed_rows=5,
     )
     assert layout.observed.h > layout.header.h
-    assert layout.systems.h < 58 * mm
+    assert layout.systems.h < 50 * mm
 
 
 def test_observed_signature_row_count_reserves_optional_reason_and_tier_a_warning() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -9,6 +9,7 @@ from _report_pdf_test_helpers import (
     extract_media_box,
     sample,
 )
+from pypdf import PdfReader
 from reportlab.pdfgen.canvas import Canvas
 from test_support.core import extract_pdf_text
 from test_support.report_helpers import (
@@ -230,7 +231,7 @@ def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
     assert "Inspect the relevant wheel/tire assemblies" in text_blob
 
 
-def test_report_pdf_wraps_long_system_card_location() -> None:
+def test_report_pdf_compacts_actionable_system_cards() -> None:
     long_location = (
         "front-left wheel hub housing extended mount with additional bracket and balancing weight"
     )
@@ -247,7 +248,12 @@ def test_report_pdf_wraps_long_system_card_location() -> None:
     canvas = Canvas(buf)
     _draw_system_card(canvas, 40, 120, 160, 130, card, tr=lambda key: key)
     canvas.save()
-    assert long_location.encode("latin-1", errors="ignore") not in buf.getvalue()
+    text = " ".join((PdfReader(BytesIO(buf.getvalue())).pages[0].extract_text() or "").split())
+
+    assert "PATTERN_SUMMARY: 1.02 wheel order harmonic with sideband modulation" in text
+    assert "WHAT_TO_CHECK_FIRST: Front-left wheel bearing assembly with extended descriptor" in text
+    assert "STRONGEST_SENSOR" not in text
+    assert long_location not in text
 
 
 def test_car_diagram_wheel_labels_stay_within_bounds_without_overlap() -> None:

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
@@ -26,6 +26,11 @@ from vibesensor.adapters.pdf.pdf_text import _draw_text
 from vibesensor.adapters.pdf.report_data import ReportTemplateData, SystemFindingCard
 
 
+def _compact_part_names(card: SystemFindingCard, fallback: str) -> str:
+    names = [part.name.strip() for part in card.parts if part.name.strip()]
+    return ", ".join(names[:3]) if names else fallback
+
+
 def _draw_systems_panel(
     c: Canvas,
     data: ReportTemplateData,
@@ -83,6 +88,7 @@ def _draw_system_card(
 ) -> None:
     """Render a single system-finding card."""
     na = tr("NOT_AVAILABLE")
+    content_w = w - 6 * mm
 
     tone_bg = REPORT_COLORS.get(f"card_{card.tone}_bg", REPORT_COLORS["card_neutral_bg"])
     tone_border = REPORT_COLORS.get(
@@ -99,52 +105,54 @@ def _draw_system_card(
         c,
         cx,
         cy,
-        w - 6 * mm,
+        content_w,
         card.system_name,
         font=FONT_B,
         size=FS_CARD_TITLE,
         color=TEXT_CLR,
         max_lines=2,
     )
+
+    if card.parts:
+        pattern_bottom = _draw_text(
+            c,
+            cx,
+            title_bottom - 1.2 * mm,
+            content_w,
+            f"{tr('PATTERN_SUMMARY')}: {_safe(card.pattern_summary, na)}",
+            size=FS_BODY,
+            color=SUB_CLR,
+            max_lines=2,
+        )
+        _draw_text(
+            c,
+            cx,
+            pattern_bottom - 1.0 * mm,
+            content_w,
+            f"{tr('WHAT_TO_CHECK_FIRST')}: {_compact_part_names(card, na)}",
+            size=FS_BODY,
+            color=TEXT_CLR,
+            max_lines=2,
+        )
+        return
+
     strongest_bottom = _draw_text(
         c,
         cx,
         title_bottom - 1.2 * mm,
-        w - 6 * mm,
+        content_w,
         f"{tr('STRONGEST_SENSOR')}: {_safe(card.strongest_location, na)}",
         size=FS_BODY,
         color=SUB_CLR,
         max_lines=2,
     )
-    pattern_bottom = _draw_text(
+    _draw_text(
         c,
         cx,
         strongest_bottom - 1.0 * mm,
-        w - 6 * mm,
-        _safe(card.pattern_summary, na),
+        content_w,
+        f"{tr('PATTERN_SUMMARY')}: {_safe(card.pattern_summary, na)}",
         size=FS_BODY,
         color=SUB_CLR,
         max_lines=2,
     )
-
-    if card.parts:
-        parts_y = pattern_bottom - 1.0 * mm
-        c.setFillColor(_hex(TEXT_CLR))
-        c.setFont(FONT_B, FS_BODY)
-        c.drawString(cx, parts_y, tr("COMMON_PARTS"))
-
-        py = parts_y - 3.6 * mm
-        for part in card.parts[:3]:
-            if py <= y + 3 * mm:
-                break
-            py = _draw_text(
-                c,
-                cx,
-                py,
-                w - 6 * mm,
-                f"• {part.name}",
-                size=FS_BODY,
-                color=TEXT_CLR,
-                max_lines=2,
-            )
-            py -= 0.8 * mm

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -192,7 +192,7 @@ def build_page1_layout(
     observed_h = max(44 * mm, PANEL_HEADER_H + obs_content_h + 8 * mm)
     observed = PanelLayout(MARGIN, header.y - GAP - observed_h, width, observed_h)
 
-    systems_h = 52 * mm
+    systems_h = 46 * mm
     systems = PanelLayout(MARGIN, observed.y - GAP - systems_h, width, systems_h)
 
     y_cursor = systems.y - GAP if y_after_systems_source is None else y_after_systems_source


### PR DESCRIPTION
## Summary

This PR fixes issue #1790, `[PDF Audit] Shrink or enrich the hypothesis cards so they justify their footprint`, by making the page-1 `Systems with findings` panel both smaller and more useful. Before this change, the panel reserved a fairly large fixed slice of page 1, but each card mostly stacked a system name, strongest-sensor location, pattern text, and then a small parts list. That meant the cards occupied a lot of visual space while still feeling low-density, especially because some of that information duplicated context already present elsewhere on the report.

The final implementation takes the smaller, behavior-safe hybrid approach. Rather than redesigning the report model or removing the panel entirely, it keeps the existing mapped `SystemFindingCard` inputs and makes two targeted adjustments: the systems panel itself is more compact, and cards that already have actionable repair-part guidance now spend their limited space on more valuable `Pattern` plus `What to check first` content instead of repeating strongest-sensor detail. Cards without parts still keep the strongest-sensor line so the medium-confidence / hypothesis case does not become too sparse.

## Problem being solved

The issue called out a clear page-1 efficiency problem: the two hypothesis/system cards were using a large footprint without giving enough differentiated value back to the reader. In practice, the cards were easy to read individually, but not especially rewarding for the amount of space they consumed. They also leaned on a content mix that was not equally valuable across tiers. For example, Tier C cards already had actionable part suggestions, but that stronger action-oriented content had to share the card with strongest-sensor text that was not the most useful fact to emphasize in the same space.

Focused exploration showed that this was a page-1 layout and rendering problem rather than a mapping or scoring problem. The relevant surfaces are `apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py`, which draws the cards, and `apps/server/vibesensor/adapters/pdf/pdf_style.py`, which reserves a fixed `systems_h` height for that panel. The underlying report mapper already supplied the key fields needed to improve the cards: `system_name`, `strongest_location`, `pattern_summary`, and `parts`. That meant the smallest complete fix was to make the page-1 renderer spend the existing card budget more intentionally instead of broadening the data model.

## Implementation approach

I chose a hybrid shrink-and-enrich approach.

The first half of the fix shrinks the systems panel itself. `build_page1_layout()` previously reserved 52 mm for `Systems with findings` regardless of how dense or useful that block felt. This PR reduces that fixed reservation to 46 mm.

The second half of the fix makes richer cards justify their remaining footprint. When a card has actionable parts, it now shows:

- the system title
- a compact `Pattern` line
- a compact `What to check first` summary built from the existing parts list

That change makes the card more useful for workshop-style scanning: the reader gets the pattern that triggered the suspicion and the first concrete things worth checking, instead of spending the same vertical space repeating strongest-sensor context.

Importantly, this logic is conditional. When a card has no parts, the renderer keeps the older strongest-sensor context and pattern summary. That preserves enough differentiated content for Tier B / no-parts cards, where removing location would have risked making the cards too empty.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py`, `_draw_system_card()` now branches on whether `card.parts` is populated.

For cards with parts, the renderer no longer draws the `Strongest sensor` line. Instead, it draws a `PATTERN_SUMMARY` line using the existing mapped `pattern_summary`, followed by a `WHAT_TO_CHECK_FIRST` line built from a compact summary of the existing part names. I added a tiny local helper to join up to three non-empty part names into a single summary string so the card can stay dense and readable without introducing new report data types.

For cards without parts, the renderer continues to show the strongest-sensor line and the pattern summary. That keeps the no-parts path informative and avoids over-optimizing only for Tier C cards.

In `apps/server/vibesensor/adapters/pdf/pdf_style.py`, `build_page1_layout()` now reserves 46 mm instead of 52 mm for the systems panel. This is the structural half of the issue fix: the panel now earns less space by default, and the richer cards make better use of the space they still retain.

On the regression side, I updated three focused test surfaces.

In `apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`, the old narrow-card location wrapping test now asserts the new compact actionable-card contract directly. The direct renderer test verifies that a parts-backed card renders `PATTERN_SUMMARY` plus `WHAT_TO_CHECK_FIRST`, omits the duplicated strongest-sensor line, and does not leak the old long location string into the compact card body.

In `apps/server/tests/adapters/pdf/test_report_analysis_separation.py`, I added a full-report page-1 regression that verifies the richer card path in the actual composed PDF. That test locks in the behavior that a parts-backed card shows `Pattern` plus `What to check first` in the `Systems with findings` section while strongest-sensor text stays out of that section.

In `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`, I tightened the page-1 layout guardrail so the systems panel must now stay under 50 mm. That gives the issue a direct regression surface for the smaller panel footprint instead of only relying on indirect visual behavior.

## Validation performed

I validated the change with the focused PDF slice most directly coupled to this panel and layout:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_analysis_separation.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_tier_gating.py apps/server/tests/adapters/pdf/test_report_summary_basics.py`
- `make lint`
- `make typecheck-backend`

That focused suite passed with `77 passed`, and both lint and backend typecheck were green afterward.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is intentional: the richer actionable-card path compresses the part list into a single `What to check first` summary instead of rendering a separate bold `Common parts` heading followed by multiple bullets. That is a deliberate density tradeoff to make page 1 more useful at a glance. The full parts list still comes from the same mapped inputs; the page-1 card just spends its space more selectively.

I also intentionally kept this fix renderer-first. I did not change how `SystemFindingCard` objects are built, how findings are ranked, or how Tier B and Tier C are computed. I did not broaden this into a larger redesign of page 1, a new evidence model, or a reordering of page-2 content.

Overall, this change keeps the existing report structure intact while making the page-1 hypothesis/system cards feel denser, more comparable, and more worth the space they occupy. It also gives page 1 a bit more breathing room at the same time, which matches both directions proposed in the issue without requiring a larger redesign.
