### PR TITLE
Fix #1791: rebalance PDF evidence page 2

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -24,6 +24,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     PAGE_H,
     PAGE_W,
     build_page1_layout,
+    build_page2_layout,
     observed_signature_row_count,
 )
 
@@ -292,6 +293,21 @@ def test_build_page1_layout_prioritizes_observed_signature_panel() -> None:
     )
     assert layout.observed.h > layout.header.h
     assert layout.systems.h < 50 * mm
+
+
+def test_build_page2_layout_expands_evidence_space_and_keeps_continuation_room() -> None:
+    layout = build_page2_layout(
+        width=PAGE_W - 2 * MARGIN,
+        page_top=PAGE_H - MARGIN,
+        has_transient_findings=True,
+        has_next_steps_continued=True,
+    )
+    assert layout.pattern_panel.h > 125 * mm
+    assert layout.peaks_panel.h >= 58 * mm
+    assert layout.observations_panel is not None
+    assert layout.observations_panel.h < 24 * mm
+    assert layout.continued_next_steps is not None
+    assert layout.continued_next_steps.h > 16 * mm
 
 
 def test_observed_signature_row_count_reserves_optional_reason_and_tier_a_warning() -> None:

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_evidence.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_evidence.py
@@ -96,7 +96,7 @@ def _draw_pattern_evidence(
             ev.certainty_reason,
             size=FS_SMALL,
             color=SUB_CLR,
-            max_lines=2,
+            max_lines=3,
         )
     ry -= 2.0 * mm
 
@@ -113,7 +113,7 @@ def _draw_pattern_evidence(
             ev.warning,
             size=FS_SMALL,
             color=WARN_CLR,
-            max_lines=3,
+            max_lines=4,
         )
         ry -= 1.5 * mm
 
@@ -124,6 +124,7 @@ def _draw_pattern_evidence(
         w - 8 * mm,
         tr("INTERPRETATION"),
         _safe(ev.interpretation, na),
+        max_lines=5,
     )
     _draw_section_block(
         c,
@@ -133,4 +134,5 @@ def _draw_pattern_evidence(
         tr("WHY_PARTS_LISTED"),
         _safe(ev.why_parts_text, na),
         title_gap=3.0 * mm,
+        max_lines=5,
     )

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -228,7 +228,7 @@ def build_page2_layout(
 
     left_w = width * EVIDENCE_CAR_PANEL_WIDTH_RATIO
     right_w = width - left_w - GAP
-    main_h = 118 * mm
+    main_h = 132 * mm
     left_y = y_cursor - main_h
     car_panel = PanelLayout(MARGIN, left_y, left_w, main_h)
     inner_pad = 5 * mm
@@ -241,14 +241,14 @@ def build_page2_layout(
     )
     pattern_panel = PanelLayout(MARGIN + left_w + GAP, left_y, right_w, main_h)
 
-    table_h = 53 * mm
+    table_h = 58 * mm
     table_y = left_y - GAP - table_h
     peaks_panel = PanelLayout(MARGIN, table_y, width, table_h)
 
     observations_panel = None
     obs_y_anchor = table_y
     if has_transient_findings:
-        obs_h = 24 * mm
+        obs_h = 22 * mm
         obs_y = table_y - GAP - obs_h
         observations_panel = PanelLayout(MARGIN, obs_y, width, obs_h)
         obs_y_anchor = obs_y


### PR DESCRIPTION
## Summary

This PR fixes issue #1791, `[PDF Audit] Rebalance page 2 to use space more effectively`, by rebalancing the existing page-2 PDF layout so the evidence page feels deliberately composed instead of loosely filled. Before this change, page 2 already contained the right ingredients — the car hotspot visual, the evidence summary, the peaks table, optional transient observations, and optional continued next steps — but the fixed layout reserved more unused space than necessary while the right-hand explanation blocks stayed artificially short. The result was a page that could feel sparse overall even though the densest evidence content was still compressed into a few capped text blocks.

The fix stays layout-first and data-model-neutral. I did not change how evidence is mapped, scored, or ranked. Instead, I rebalanced the existing panel heights in `build_page2_layout()` and allowed the page-2 evidence text blocks to use more of that reclaimed space. This gives page 2 a fuller, more intentional composition without changing the report’s two-page structure.

## Problem being solved

The issue described a page-2 composition mismatch: there is enough evidence on the page to justify a stronger layout, but the page did not feel like it was using the available space intentionally. In practice, the page was split into large fixed sections, yet the right-side `Pattern evidence` panel capped some of its most explanatory text at conservative line counts. That meant the page showed visible slack while still forcing interpretation-heavy content to stay short.

Focused exploration showed that this was primarily a layout-allocation problem in `apps/server/vibesensor/adapters/pdf/pdf_style.py::build_page2_layout()` and a renderer-cap problem in `apps/server/vibesensor/adapters/pdf/panels/_panel_evidence.py::_draw_pattern_evidence()`. The page-2 composition already had fixed sections for:

- the title bar
- the main evidence row (car visual + pattern evidence)
- the diagnostic peaks table
- the optional additional-observations panel
- the optional continued next-steps panel

Because those sections are all laid out from explicit fixed heights, the page’s overall feel is governed less by content generation and more by how that vertical budget is divided. That made this issue a good fit for a pure renderer/layout rebalance rather than a report-content redesign.

## Implementation approach

I used a small, behavior-safe rebalance that spends more of page 2 on the main evidence row and the peaks section while slightly trimming a lower-value secondary panel.

First, `build_page2_layout()` now allocates more height to the main row that contains the car visual and the pattern evidence panel. That gives the page’s most important explanatory region more presence and makes the evidence page feel less top-light.

Second, the peaks table receives a little more height as well. This helps the more technical diagnostics section feel less compressed beneath the expanded evidence row and makes the top-to-bottom reading flow more even.

Third, the optional `Additional observations` panel gives back a small amount of height. That section is intentionally sparse by design — it only renders a short capped list of transient findings — so it was the safest place to trim space without reducing the value of the page.

Finally, the right-side pattern-evidence renderer now uses the expanded vertical room instead of leaving it idle. The certainty-reason block, warning block, interpretation block, and why-parts block all get slightly more line budget. This directly addresses the issue’s complaint that page 2 can feel sparse while explanation-rich content remains compressed.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/pdf_style.py`, `build_page2_layout()` now reserves:

- `132 mm` for the main evidence row instead of `118 mm`
- `58 mm` for the peaks panel instead of `53 mm`
- `22 mm` for the optional observations panel instead of `24 mm`

These are deliberate, modest shifts rather than a full redesign. They let page 2 consume more of the available page height while still preserving room for the conditional continued-next-steps panel that can appear when page 1 overflows.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_evidence.py`, `_draw_pattern_evidence()` now allows more of the existing report evidence copy to show:

- `certainty_reason` grows from 2 lines to 3
- the warning detail grows from 3 lines to 4
- the `Interpretation` block grows from the default 4 lines to 5
- the `Why parts listed` block grows from the default 4 lines to 5

I intentionally did not add new copy, reorder the section, or create new page-2 subpanels. The goal was to make the current explanation content feel less cramped while the page itself becomes less under-filled.

On the regression side, I extended `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py` with a focused page-2 layout assertion. The new test verifies both sides of the contract for this issue family: the evidence panels are now materially larger, and page 2 still preserves enough room for the continued-next-steps panel when transient observations are also present.

## Validation performed

I validated this change with a focused slice that covered both the page-2 layout changes and the most important coupled overflow guardrail introduced during issue `#1788`:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/integration/test_report_pipeline.py -k 'long_next_steps_without_ellipsis or not long_next_steps_without_ellipsis'`
- `make lint`
- `make typecheck-backend`

That focused suite passed with `89 passed`, and both lint and backend typecheck were green afterward.

I also ran a targeted review pass against the final diff to look specifically for hidden page-2 overflow risks, continued-next-steps starvation, and layout mismatches between the new constants and the regression test expectations. No materially important issues were found in that review.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that this PR improves composition by reallocating space within the existing page-2 structure rather than redesigning page 2 from scratch. I did not reorder the panels, merge the car visual with the evidence panel, or create new full-width narrative sections. Those changes might be valid future design discussions, but they were not necessary to satisfy the issue’s request for a more intentional page layout.

I also kept the fix strictly within the renderer and layout layer. I did not change the evidence payload, add new report fields, or modify the logic that decides what appears on page 2. That keeps the blast radius small and makes the change easy to reason about: same page-2 content, better use of the page.

Overall, this PR makes page 2 feel more deliberate by letting the main evidence row and the technical evidence section claim more of the space they already deserve, while preserving the two-page contract and the conditional overflow behavior that recent PDF issues already tightened.
