### PR TITLE
Fix #1792: clarify PDF hotspot evidence card

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -463,6 +463,14 @@
     "en": "Evidence snapshot",
     "nl": "Bewijssamenvatting"
   },
+  "HOTSPOT_MARKER_SIZE_HINT": {
+    "en": "Larger markers indicate stronger local intensity.",
+    "nl": "Grotere markeringen duiden op sterkere lokale intensiteit."
+  },
+  "HOTSPOT_SUMMARY": {
+    "en": "Hotspot summary",
+    "nl": "Hotspotsamenvatting"
+  },
   "FALSIFY": {
     "en": "Falsify",
     "nl": "Weerleg"

--- a/apps/server/tests/adapters/pdf/test_report_i18n.py
+++ b/apps/server/tests/adapters/pdf/test_report_i18n.py
@@ -163,6 +163,8 @@ def test_dutch_translations_complete() -> None:
     assert "aandrijflijnprobleem" in _nl("ACTION_DRIVELINE_INSPECTION_FALSIFY")
     assert "ordefout" in _nl("FREQUENCY_TRACKS_ENGINE_ORDER_USING_REF_LABEL_BEST")
     assert "ordefout" in _nl("FREQUENCY_TRACKS_WHEEL_ORDER_USING_VEHICLE_SPEED_AND")
+    assert "hotspotsamenvatting" in _nl("HOTSPOT_SUMMARY").lower()
+    assert "lokale intensiteit" in _nl("HOTSPOT_MARKER_SIZE_HINT").lower()
     assert "bedrijfsomstandigheid" in _nl(
         "PEAK_FREQUENCY_SHIFTS_RANDOMLY_WITH_NO_REPEATABLE_OPERATING",
     )

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -72,6 +72,52 @@ def test_marker_colors_follow_diagnostic_highlight_and_use_single_color_markers(
     assert marker_by_name["engine bay"].stroke == marker_by_name["engine bay"].fill
 
 
+def test_marker_radius_grows_with_local_intensity_for_active_locations() -> None:
+    location_points = {
+        "front-left wheel": (40.0, 180.0),
+        "front-right wheel": (160.0, 180.0),
+        "rear-left wheel": (40.0, 80.0),
+    }
+    markers, _, _ = build_sensor_render_plan(
+        location_points=location_points,
+        drawing_width=220.0,
+        drawing_height=252.0,
+        connected_locations=set(location_points.keys()),
+        amp_by_location={
+            "front-left wheel": 12.0,
+            "front-right wheel": 22.0,
+            "rear-left wheel": 32.0,
+        },
+        highlight={},
+        colors=REPORT_COLORS,
+    )
+    marker_by_name = {marker.name: marker for marker in markers}
+
+    assert marker_by_name["front-left wheel"].radius < marker_by_name["front-right wheel"].radius
+    assert marker_by_name["front-right wheel"].radius < marker_by_name["rear-left wheel"].radius
+
+
+def test_highlighted_location_without_intensity_keeps_diagnostic_color() -> None:
+    location_points = {
+        "front-left wheel": (40.0, 180.0),
+        "front-right wheel": (160.0, 180.0),
+    }
+    markers, _, _ = build_sensor_render_plan(
+        location_points=location_points,
+        drawing_width=220.0,
+        drawing_height=252.0,
+        connected_locations=set(location_points.keys()),
+        amp_by_location={"front-right wheel": 22.0},
+        highlight={"front-left wheel": REPORT_COLORS["danger"]},
+        colors=REPORT_COLORS,
+    )
+    marker_by_name = {marker.name: marker for marker in markers}
+
+    assert marker_by_name["front-left wheel"].state == "connected-inactive"
+    assert marker_by_name["front-left wheel"].fill == REPORT_COLORS["danger"]
+    assert marker_by_name["front-left wheel"].stroke == REPORT_COLORS["danger"]
+
+
 def test_label_placement_stays_in_bounds_and_avoids_overlap_for_dense_layout() -> None:
     location_points = {
         "front-left wheel": (36.0, 198.0),
@@ -241,6 +287,48 @@ def test_render_plan_prefers_diagnosed_location_when_intensity_hotspot_differs()
     marker_by_name = {marker.name: marker for marker in markers}
     assert marker_by_name["front-left wheel"].fill == REPORT_COLORS["text_secondary"]
     assert marker_by_name["rear-left wheel"].fill == REPORT_COLORS["danger"]
+
+
+def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> None:
+    from io import BytesIO
+
+    from pypdf import PdfReader
+    from test_support.report_helpers import minimal_summary
+
+    from vibesensor.adapters.pdf.mapping import map_summary, prepare_report_input
+    from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+
+    summary = minimal_summary(
+        lang="en",
+        findings=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.82,
+                "strongest_location": "front-left wheel",
+            }
+        ],
+        top_causes=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.82,
+                "strongest_location": "front-left wheel",
+            }
+        ],
+        sensor_locations=["front-left wheel", "front-right wheel"],
+        sensor_intensity_by_location=[
+            LocationIntensitySummary(location="front-left wheel", p95_intensity_db=32.0),
+            LocationIntensitySummary(location="front-right wheel", p95_intensity_db=18.0),
+        ],
+        samples=[],
+    )
+
+    pdf = build_report_pdf(map_summary(prepare_report_input(summary)))
+    text = " ".join((PdfReader(BytesIO(pdf)).pages[1].extract_text() or "").split()).lower()
+
+    assert "hotspot summary:" in text
+    assert "larger markers indicate stronger local intensity." in text
 
 
 def test_choose_label_plan_raises_value_error_when_no_candidates(

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -203,6 +203,17 @@ def build_sensor_render_plan(
     active_count = sum(1 for value in states.values() if value == "connected-active")
     single_sensor = active_count == 1 and (min_amp is None or min_amp == max_amp)
 
+    def active_radius(name: str, *, highlighted: bool) -> float:
+        if min_amp is None or max_amp is None or min_amp == max_amp:
+            return 6.2 if highlighted else 5.0
+        amp = amp_by_location.get(name)
+        if amp is None:
+            return 6.2 if highlighted else 5.0
+        normalized = (amp - min_amp) / (max_amp - min_amp)
+        if highlighted:
+            return 5.8 + (normalized * 0.6)
+        return 4.4 + normalized
+
     markers: list[MarkerRenderPlan] = []
     occupied_boxes: list[tuple[float, float, float, float]] = []
     for name, (px, py) in location_points.items():
@@ -210,13 +221,13 @@ def build_sensor_render_plan(
         if state == "connected-active":
             if name in highlight:
                 fill = highlight[name]
-                radius = 6.2
+                radius = active_radius(name, highlighted=True)
             else:
                 fill = colors["text_secondary"]
-                radius = 5.0
+                radius = active_radius(name, highlighted=False)
             stroke_width = 0.8
         elif state == "connected-inactive":
-            fill = colors["surface_alt"]
+            fill = highlight.get(name, colors["surface_alt"])
             radius = 4.8
             stroke_width = 0.8
         else:

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_diagram.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_diagram.py
@@ -13,12 +13,35 @@ from vibesensor.adapters.pdf.pdf_style import BMW_LENGTH_MM as _BMW_LENGTH_MM
 from vibesensor.adapters.pdf.pdf_style import BMW_WIDTH_MM as _BMW_WIDTH_MM
 from vibesensor.adapters.pdf.pdf_style import (
     CAR_PANEL_TITLE_RESERVE,
+    FS_SMALL,
     MARGIN,
     PAGE_H,
+    PANEL_HEADER_H,
+    SUB_CLR,
+    TEXT_CLR,
     build_page2_layout,
 )
+from vibesensor.adapters.pdf.pdf_text import _draw_text
 from vibesensor.adapters.pdf.report_data import FindingPresentation, ReportTemplateData
 from vibesensor.domain import LocationHotspotRow
+
+
+def _hotspot_strength_text(data: ReportTemplateData, *, fallback: str) -> str:
+    peak_db = data.pattern_evidence.strength_peak_db
+    if peak_db is not None:
+        return f"{peak_db:.0f} dB"
+    if data.pattern_evidence.strength_label:
+        return data.pattern_evidence.strength_label
+    return fallback
+
+
+def _hotspot_summary_text(
+    data: ReportTemplateData, *, fallback: str, tr_fn: Callable[..., str]
+) -> str:
+    location = data.pattern_evidence.strongest_location or fallback
+    strength = _hotspot_strength_text(data, fallback=fallback)
+    certainty = data.pattern_evidence.certainty_label or fallback
+    return f"{tr_fn('HOTSPOT_SUMMARY')}: {location} | {strength} | {certainty}"
 
 
 def fit_rect_preserve_aspect(
@@ -84,6 +107,31 @@ def _draw_car_visual_panel(
     content_width: float,
 ) -> None:
     _draw_panel(c, x, y, w, h, tr_fn("EVIDENCE_AND_HOTSPOTS"))
+    caption_x = x + 4 * mm
+    caption_top = y + h - PANEL_HEADER_H - 1.5 * mm
+    caption_w = w - 8 * mm
+    caption_reserve = 11 * mm
+    not_available = tr_fn("NOT_AVAILABLE")
+    caption_bottom = _draw_text(
+        c,
+        caption_x,
+        caption_top,
+        caption_w,
+        _hotspot_summary_text(data, fallback=not_available, tr_fn=tr_fn),
+        size=FS_SMALL,
+        color=TEXT_CLR,
+        max_lines=2,
+    )
+    _draw_text(
+        c,
+        caption_x,
+        caption_bottom - 0.4 * mm,
+        caption_w,
+        tr_fn("HOTSPOT_MARKER_SIZE_HINT"),
+        size=FS_SMALL,
+        color=SUB_CLR,
+        max_lines=2,
+    )
     layout = build_page2_layout(
         width=content_width,
         page_top=PAGE_H - MARGIN,
@@ -95,6 +143,8 @@ def _draw_car_visual_panel(
     box_y = car_layout.box_y if x == MARGIN else y + 5 * mm
     box_w = car_layout.box_w if x == MARGIN else w - 10 * mm
     box_h = car_layout.box_h if x == MARGIN else h - CAR_PANEL_TITLE_RESERVE
+    box_y += caption_reserve
+    box_h -= caption_reserve
 
     src_w = _BMW_WIDTH_MM
     src_h = _BMW_LENGTH_MM

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -463,6 +463,14 @@
     "en": "Evidence snapshot",
     "nl": "Bewijssamenvatting"
   },
+  "HOTSPOT_MARKER_SIZE_HINT": {
+    "en": "Larger markers indicate stronger local intensity.",
+    "nl": "Grotere markeringen duiden op sterkere lokale intensiteit."
+  },
+  "HOTSPOT_SUMMARY": {
+    "en": "Hotspot summary",
+    "nl": "Hotspotsamenvatting"
+  },
   "FALSIFY": {
     "en": "Falsify",
     "nl": "Weerleg"


### PR DESCRIPTION
## Summary

This PR fixes issue #1792, `[PDF Audit] Make the hotspot card explain intensity and confidence more clearly`, by making the page-2 hotspot card explain what the car diagram is showing instead of relying on the reader to infer it from colored markers alone. Before this change, the report already had the right raw inputs for the hotspot panel: the strongest location, the overall signal strength, the current certainty label, the highlighted suspected source, and per-location intensity data. The gap was presentation. The diagram showed markers, but it did not tell a non-analyst reader what those marker sizes and emphasis meant, so the card could feel decorative rather than explanatory.

The fix stays renderer-only and preserves the existing report data model. Instead, I used the existing report inputs to make the panel communicate where the current hotspot is, how strong it is, and how certain the overall diagnosis is. I also made marker size reflect local intensity so the visual encoding matches the explanatory text.

## Problem being solved

The issue described a hotspot card that contained evidence but did not explain itself clearly enough. In practice, page 2 already includes a car diagram with active markers and diagnostic highlight colors, but a reader who is not deeply familiar with the report design has to guess what the map is intended to convey. The strongest area is not summarized in text, the certainty context is not surfaced alongside the diagram, and marker size did not reflect local intensity even though that intensity data was already available to the renderer.

Focused exploration showed that this was not a missing-data problem. The relevant inputs were already present in the page-2 renderer path:

- `sensor_intensity_by_location` for local intensity evidence
- `pattern_evidence.strongest_location` for the main hotspot location
- `pattern_evidence.strength_peak_db` and `strength_label` for signal strength
- `pattern_evidence.certainty_label` for confidence framing
- highlighted top-cause locations for diagnostic emphasis

That made this issue a good fit for a renderer-first fix. The main task was to make the existing hotspot evidence legible inside the card itself.

## Implementation approach

I used a two-part clarity improvement.

First, the card now includes a compact textual summary above the diagram. That summary explicitly names the strongest hotspot location, the available strength value, and the certainty label in one short line. Right below it, a second line explains the marker-size encoding in plain language: larger markers indicate stronger local intensity. 
Second, the diagram itself now reflects intensity more honestly. Connected active markers are no longer effectively fixed-size dots. Their radii now scale from the existing per-location intensity values, so a stronger local hotspot produces a larger marker. That means the visual encoding and the new caption reinforce each other instead of communicating different levels of detail.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/diagram_layout.py`, `build_sensor_render_plan()` now derives connected-active marker radii from the existing local intensity range. When a report has multiple active locations with different local amplitudes, the marker size now grows with that intensity instead of staying almost constant. Single-sensor cases and equal-intensity cases still fall back to the prior highlighted vs non-highlighted sizing so the diagram remains stable when there is no meaningful local range to visualize.

I also fixed an important coupled edge case in the same planner. If a diagnosed location is highlighted by the findings but happens to lack local intensity data, it can still be connected. Previously, that location would fall into the `connected-inactive` style and lose its diagnostic highlight color entirely. The render plan now preserves the diagnostic highlight color in that case, which keeps the visual story consistent even when local intensity data is incomplete.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_diagram.py`, `_draw_car_visual_panel()` now renders two lines of explanation above the car diagram:

- a `Hotspot summary` line with location, strength, and certainty
- a short marker-size hint explaining that larger markers indicate stronger local intensity

To make room for that copy without distorting the vehicle drawing, the panel reserves a small caption area above the diagram and then fits the car visual into the remaining space while preserving aspect ratio.

In both report i18n catalogs:

- `apps/server/data/report_i18n.json`
- `apps/server/vibesensor/data/report_i18n.json`

I added `HOTSPOT_SUMMARY` and `HOTSPOT_MARKER_SIZE_HINT` so the new explanatory copy is localized alongside the rest of the report UI.

On the regression side, `apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py` now covers three important contracts:

- active marker radii increase with stronger local intensity
- highlighted locations without local intensity still keep their diagnostic color
- the composed PDF text for page 2 contains the new hotspot summary and marker-size hint

I also updated `apps/server/tests/adapters/pdf/test_report_i18n.py` to assert the Dutch translations for the two new report strings.

## Validation performed

I validated the change with a focused backend slice that covered both the hotspot-specific behavior and the nearby PDF layout guardrails that could have been affected by reserving caption space above the car diagram:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_i18n.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/integration/test_report_pipeline.py -k 'long_next_steps_without_ellipsis or not long_next_steps_without_ellipsis'`
- `make lint`
- `make typecheck-backend`

That validation passed cleanly with `74 passed`, followed by green lint and backend typecheck.

I also ran a targeted review pass against the final diff looking specifically for marker-state regressions, misleading intensity encoding, caption-space overflow, and any case where the new renderer text might contradict the highlighted diagnosis. That review found one real coupled issue: highlighted locations without local intensity data could lose their diagnostic color. I fixed that in the branch and re-ran the focused validation slice.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that the PR improves clarity by enriching the existing hotspot card rather than redesigning page 2 or replacing the car visual with a more explicit evidence table. I intentionally kept the fix small and renderer-local because the underlying data pipeline was already sufficient.

I also did not add raw per-marker dB labels directly onto the map. That would have created a much higher collision risk in the existing diagram layout and would have pushed the panel toward analyst-oriented clutter. The chosen approach keeps the diagram readable while still giving the reader one clear summary and one clear explanation of the marker-size encoding.

Finally, I retried the repo’s required local Docker verification after the backend change, but this environment still cannot run that path because `docker compose` is unavailable here. The application-level change itself is otherwise locally validated through the focused PDF test slice, lint, and backend typecheck.
