### PR TITLE
Fix #1793: simplify PDF lower evidence wording

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -116,8 +116,8 @@
     "nl": "Wielorde-signaturen worden meestal veroorzaakt door onbalans, slingering of banddeformatie."
   },
   "ADDITIONAL_OBSERVATIONS": {
-    "en": "Additional Observations",
-    "nl": "Aanvullende observaties"
+    "en": "Supporting Observations",
+    "nl": "Ondersteunende observaties"
   },
   "ADD_TEMPORARY_DAMPING_MASS_AND_REPEAT_THE_RUN": {
     "en": "Add temporary damping mass and repeat the run.",
@@ -360,8 +360,8 @@
     "nl": "gedetecteerd op een gemonitorde locatie"
   },
   "DIAGNOSTIC_PEAKS": {
-    "en": "Diagnostic Peaks",
-    "nl": "Diagnostische pieken"
+    "en": "Supporting Measurements",
+    "nl": "Ondersteunende meetwaarden"
   },
   "DIAGNOSTIC_WORKSHEET": {
     "en": "VibeSensor Diagnostic Report",
@@ -1550,5 +1550,29 @@
   "WORKSHOP_SUMMARY": {
     "en": "Workshop Summary",
     "nl": "Werkplaatsoverzicht"
+  },
+  "MEANING": {
+    "en": "Meaning",
+    "nl": "Betekenis"
+  },
+  "PEAK_ROW_BRIEF_EVENT": {
+    "en": "Brief event",
+    "nl": "Korte gebeurtenis"
+  },
+  "PEAK_ROW_NEAR_NOISE_FLOOR": {
+    "en": "Near noise floor",
+    "nl": "Dicht bij ruisvloer"
+  },
+  "PEAK_ROW_OCCASIONAL": {
+    "en": "Occasional",
+    "nl": "Af en toe"
+  },
+  "PEAK_ROW_REPEATED_PATTERN": {
+    "en": "Repeated pattern",
+    "nl": "Herhaald patroon"
+  },
+  "PEAK_ROW_SEEN_MORE_THAN_ONCE": {
+    "en": "Seen more than once",
+    "nl": "Meer dan een keer gezien"
   }
 }

--- a/apps/server/tests/adapters/pdf/test_report_content_coverage.py
+++ b/apps/server/tests/adapters/pdf/test_report_content_coverage.py
@@ -369,3 +369,4 @@ def test_pdf_additional_observations_heading_for_transient_findings() -> None:
     text = extract_pdf_text(pdf)
     i18n = json.loads(_I18N_JSON.read_text(encoding="utf-8"))
     assert i18n["ADDITIONAL_OBSERVATIONS"]["en"] in text
+    assert "(22%)" not in text

--- a/apps/server/tests/adapters/pdf/test_report_i18n.py
+++ b/apps/server/tests/adapters/pdf/test_report_i18n.py
@@ -165,6 +165,11 @@ def test_dutch_translations_complete() -> None:
     assert "ordefout" in _nl("FREQUENCY_TRACKS_WHEEL_ORDER_USING_VEHICLE_SPEED_AND")
     assert "hotspotsamenvatting" in _nl("HOTSPOT_SUMMARY").lower()
     assert "lokale intensiteit" in _nl("HOTSPOT_MARKER_SIZE_HINT").lower()
+    assert "ondersteunende meetwaarden" in _nl("DIAGNOSTIC_PEAKS").lower()
+    assert "ondersteunende observaties" in _nl("ADDITIONAL_OBSERVATIONS").lower()
+    assert _nl("MEANING") == "Betekenis"
+    assert "herhaald patroon" in _nl("PEAK_ROW_REPEATED_PATTERN").lower()
+    assert "ruisvloer" in _nl("PEAK_ROW_NEAR_NOISE_FLOOR").lower()
     assert "bedrijfsomstandigheid" in _nl(
         "PEAK_FREQUENCY_SHIFTS_RANDOMLY_WITH_NO_REPEATABLE_OPERATING",
     )

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
@@ -77,6 +77,54 @@ def test_peak_classification_text_uses_translations() -> None:
     assert translated == "Persistent"
 
 
+def test_build_peak_row_transient_meaning_uses_brief_event_label() -> None:
+    row = build_peak_row(
+        {
+            "rank": 1,
+            "frequency_hz": 95.0,
+            "order_label": "",
+            "p95_intensity_db": 18.0,
+            "strength_db": 18.0,
+            "presence_ratio": 0.2,
+            "peak_classification": "transient",
+            "typical_speed_band": "any",
+        },
+        lang="en",
+        tr=lambda key, **_kw: {
+            "CLASSIFICATION_TRANSIENT": "Intermittent",
+            "PEAK_ROW_BRIEF_EVENT": "Brief event",
+            "SOURCE_TRANSIENT_IMPACT": "Transient impact",
+            "UNKNOWN": "Unknown",
+        }[key],
+    )
+    assert row.relevance == "Brief event"
+
+
+def test_build_peak_row_high_presence_transient_uses_repeatability_label() -> None:
+    row = build_peak_row(
+        {
+            "rank": 1,
+            "frequency_hz": 95.0,
+            "order_label": "",
+            "p95_intensity_db": 18.0,
+            "strength_db": 18.0,
+            "presence_ratio": 0.8,
+            "peak_classification": "transient",
+            "typical_speed_band": "any",
+        },
+        lang="en",
+        tr=lambda key, **_kw: {
+            "CLASSIFICATION_TRANSIENT": "Intermittent",
+            "PEAK_ROW_BRIEF_EVENT": "Brief event",
+            "PEAK_ROW_REPEATED_PATTERN": "Repeated pattern",
+            "PEAK_ROW_SEEN_MORE_THAN_ONCE": "Seen more than once",
+            "SOURCE_TRANSIENT_IMPACT": "Transient impact",
+            "UNKNOWN": "Unknown",
+        }[key],
+    )
+    assert row.relevance == "Repeated pattern"
+
+
 def test_extracted_pdf_builders_are_importable() -> None:
     assert not hasattr(peak_table, "build_peak_rows_from_plots")
     assert "build_peak_rows_from_plots" not in peak_table.__all__

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -370,8 +370,8 @@ def test_map_summary_peak_rows_use_persistence_metrics() -> None:
     row = data.peak_rows[0]
     assert row.peak_db == "18.4"
     assert row.strength_db == "18.4"
-    assert "patterned" in row.relevance
-    assert "85%" in row.relevance
+    assert row.relevance == "Repeated pattern"
+    assert "%" not in row.relevance
 
 
 def test_map_summary_peak_rows_render_baseline_noise_label() -> None:
@@ -396,7 +396,7 @@ def test_map_summary_peak_rows_render_baseline_noise_label() -> None:
     )
     data = map_summary(prepare_report_input(summary))
     assert data.peak_rows
-    assert "noise floor" in data.peak_rows[0].relevance
+    assert data.peak_rows[0].relevance == "Near noise floor"
 
 
 def test_map_summary_data_trust_keeps_warning_detail() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
@@ -170,7 +170,7 @@ def test_report_pdf_ocr_text_fidelity_all_pages(tmp_path: Path) -> None:
         "VibeSensor Diagnostic Report",
         "Evidence and Hotspots",
         "Pattern Evidence",
-        "Diagnostic Peaks",
+        "Supporting Measurements",
         "Diagnosed location source",
         "Wheel/Tire",
         "Driveline",

--- a/apps/server/tests/adapters/pdf/test_report_summary_basics.py
+++ b/apps/server/tests/adapters/pdf/test_report_summary_basics.py
@@ -57,7 +57,7 @@ def test_complete_run_has_speed_bins_findings_and_plots(tmp_path: Path) -> None:
         "Systems with findings",
         "Next steps",
         "Evidence",
-        "Diagnostic Peaks",
+        "Supporting Measurements",
     ):
         assert_pdf_contains(pdf, text)
     assert b"Spectrogram" not in pdf

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py
@@ -38,6 +38,5 @@ def _draw_additional_observations(
             order_label = f"{finding.frequency_hz:.1f} Hz"
         if not order_label:
             order_label = tr("SOURCE_TRANSIENT_IMPACT")
-        confidence = finding.effective_confidence
-        c.drawString(x_pad, y_cursor, f"• {order_label} ({confidence * 100.0:.0f}%)")
+        c.drawString(x_pad, y_cursor, f"• {order_label}")
         y_cursor -= step

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_peaks.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_peaks.py
@@ -42,7 +42,7 @@ def _draw_peaks_table(
     ]
     used = sum(col_w for _, col_w in col_defs)
     notes_w = max(20 * mm, w - used)
-    col_defs.append((tr("RELEVANCE"), notes_w))
+    col_defs.append((tr("MEANING"), notes_w))
 
     row_h = 6.2 * mm
     y = y_top

--- a/apps/server/vibesensor/adapters/pdf/peak_table.py
+++ b/apps/server/vibesensor/adapters/pdf/peak_table.py
@@ -44,8 +44,6 @@ def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> P
     strength_db_val = _as_float(row.get("strength_db"))
     strength_db = f"{strength_db_val:.1f}" if strength_db_val is not None else "—"
     speed = str(row.get("typical_speed_band") or "—")
-    presence = _as_float(row.get("presence_ratio")) or 0.0
-    score = _as_float(row.get("persistence_score")) or 0.0
     return PeakRow(
         rank=rank,
         system=peak_row_system_label(row, tr=tr),
@@ -54,7 +52,7 @@ def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> P
         peak_db=peak_db,
         strength_db=strength_db,
         speed_band=speed,
-        relevance=f"{classification} · {presence:.0%} {tr('PRESENCE')} · {tr('SCORE')} {score:.2f}",
+        relevance=_peak_row_meaning(row, tr=tr),
     )
 
 
@@ -71,3 +69,17 @@ def peak_row_system_label(row: PeakTableRow, *, tr: Callable[..., str]) -> str:
     if i18n_key:
         return str(tr(i18n_key))
     return "—"
+
+
+def _peak_row_meaning(row: PeakTableRow, *, tr: Callable[..., str]) -> str:
+    classification = str(row.get("peak_classification") or "").strip().lower()
+    presence = _as_float(row.get("presence_ratio")) or 0.0
+    if classification == "baseline_noise":
+        return str(tr("PEAK_ROW_NEAR_NOISE_FLOOR"))
+    if classification == "transient" and presence < 0.35:
+        return str(tr("PEAK_ROW_BRIEF_EVENT"))
+    if presence >= 0.7:
+        return str(tr("PEAK_ROW_REPEATED_PATTERN"))
+    if presence >= 0.35:
+        return str(tr("PEAK_ROW_SEEN_MORE_THAN_ONCE"))
+    return str(tr("PEAK_ROW_OCCASIONAL"))

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -116,8 +116,8 @@
     "nl": "Wielorde-signaturen worden meestal veroorzaakt door onbalans, slingering of banddeformatie."
   },
   "ADDITIONAL_OBSERVATIONS": {
-    "en": "Additional Observations",
-    "nl": "Aanvullende observaties"
+    "en": "Supporting Observations",
+    "nl": "Ondersteunende observaties"
   },
   "ADD_TEMPORARY_DAMPING_MASS_AND_REPEAT_THE_RUN": {
     "en": "Add temporary damping mass and repeat the run.",
@@ -360,8 +360,8 @@
     "nl": "gedetecteerd op een gemonitorde locatie"
   },
   "DIAGNOSTIC_PEAKS": {
-    "en": "Diagnostic Peaks",
-    "nl": "Diagnostische pieken"
+    "en": "Supporting Measurements",
+    "nl": "Ondersteunende meetwaarden"
   },
   "DIAGNOSTIC_WORKSHEET": {
     "en": "VibeSensor Diagnostic Report",
@@ -1550,5 +1550,29 @@
   "WORKSHOP_SUMMARY": {
     "en": "Workshop Summary",
     "nl": "Werkplaatsoverzicht"
+  },
+  "MEANING": {
+    "en": "Meaning",
+    "nl": "Betekenis"
+  },
+  "PEAK_ROW_BRIEF_EVENT": {
+    "en": "Brief event",
+    "nl": "Korte gebeurtenis"
+  },
+  "PEAK_ROW_NEAR_NOISE_FLOOR": {
+    "en": "Near noise floor",
+    "nl": "Dicht bij ruisvloer"
+  },
+  "PEAK_ROW_OCCASIONAL": {
+    "en": "Occasional",
+    "nl": "Af en toe"
+  },
+  "PEAK_ROW_REPEATED_PATTERN": {
+    "en": "Repeated pattern",
+    "nl": "Herhaald patroon"
+  },
+  "PEAK_ROW_SEEN_MORE_THAN_ONCE": {
+    "en": "Seen more than once",
+    "nl": "Meer dan een keer gezien"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #1793, `[PDF Audit] Simplify the lower evidence section for non-analyst readers`, by making the bottom section of PDF page 2 read like supporting detail instead of analyst-only output. Before this change, the lower evidence area combined a `Diagnostic Peaks` table and an `Additional Observations` card that were technically useful but cognitively heavy for a general workshop reader. The peaks table surfaced a raw `presence / score` relevance string, and transient observations rendered as short labels with raw confidence percentages. Together, those panels asked the reader to interpret low-level evidence instead of quickly understanding what the section was for.

The fix stays within the renderer and report-copy layer. I did not change the underlying diagnostic calculations, ranking pipeline, or report contracts. Instead, I reframed the lower page-2 evidence area as supporting detail, translated the most analyst-facing text into short plain-language meanings, and removed raw transient confidence percentages that did not help a non-specialist reader make a decision.

## Problem being solved

The issue called out two specific page-2 surfaces: the `Diagnostic Peaks` panel and the related `Additional Observations` card. In the current report, those sections are accurate but they read like direct analysis output rather than report-friendly decision support. That is especially visible in the peaks table’s last column, which currently mixes classification, presence percentage, and persistence score into a dense string such as `Patterned … 85% presence … score …`. Likewise, the observations card exposes raw confidence percentages for transient findings without clarifying that these are secondary, lower-priority signals.

Focused exploration showed that the problem was not missing data. The page-2 renderers already had enough information to communicate the same evidence more clearly. The relevant behavior lives in:

- `apps/server/vibesensor/adapters/pdf/panels/_panel_peaks.py`
- `apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py`
- `apps/server/vibesensor/adapters/pdf/peak_table.py`
- `apps/server/vibesensor/adapters/pdf/pdf_page2.py`

That made this a good fit for a renderer-first fix. The acceptance criteria did not require a new evidence model; they required the section to be easier to understand and to feel like useful supporting context instead of dumped analysis output.

## Implementation approach

I used a demotion-and-translation approach.

First, I reframed both lower panels so their titles communicate that they are supporting context, not the main answer. `Diagnostic Peaks` now renders as `Supporting Measurements`, and `Additional Observations` now renders as `Supporting Observations`. That immediately changes how a reader interprets the bottom section: it is still available, but it is no longer presented as the primary narrative of the report.

Second, I simplified the final peaks-table column. Instead of showing raw `Presence` and `Score` metrics, the renderer now shows a short `Meaning` label for each row. Those meanings are derived from the same existing peak classification and presence inputs, but the output is now plain-language shorthand such as `Repeated pattern`, `Seen more than once`, `Brief event`, `Occasional`, or `Near noise floor`.

Third, I simplified the observations card by removing transient confidence percentages from the bullet lines. That keeps the supporting observations visible without asking the reader to over-interpret precise percentages for signals that are already being presented as secondary context.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/peak_table.py`, `build_peak_row()` now delegates the last-column wording to a new `_peak_row_meaning()` helper. The helper stays deliberately small and uses only the inputs that already exist in the peak row payload:

- `peak_classification`
- `presence_ratio`

The behavior is intentionally plain-language and decision-oriented. `baseline_noise` rows become `Near noise floor`. Low-presence transient rows become `Brief event`. Rows with higher presence become `Repeated pattern` or `Seen more than once`, while the remainder fall back to `Occasional`.

A targeted review pass surfaced one real coupled edge case here: a peak can be classified as transient because it is bursty even when it appears through much of the run. Labeling that as `Brief event` would be misleading. I fixed that by only using the `Brief event` label for transient peaks when presence is actually low; high-presence transient rows now correctly map to the repeatability-based meanings.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_peaks.py`, the last column header now uses `Meaning` instead of `Relevance`. This makes the table easier to scan for a non-analyst reader and aligns the header with the simplified row wording.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py`, the transient bullet lines no longer append raw confidence percentages. The panel now surfaces only the brief order/frequency label for each supporting observation.

In both report i18n catalogs:

- `apps/server/data/report_i18n.json`
- `apps/server/vibesensor/data/report_i18n.json`

I updated the lower-panel titles and added the new `Meaning` and peak-row wording keys. This keeps the change localized to report-facing copy without introducing hard-coded renderer strings.

On the regression side, I updated focused PDF tests so the new contract is explicit. The branch now covers:

- peak-row mapping to the new plain-language meanings
- the high-presence transient edge case found during review
- removal of raw transient confidence percentages from rendered PDF text
- updated page-2 title expectations in both the normal summary smoke and the OCR fidelity coverage
- Dutch translation coverage for the new labels

## Validation performed

I validated the change with a focused backend slice aimed at the lower-evidence surface area and its nearby copy/rendering coverage:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/adapters/pdf/test_report_summary_basics.py apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py apps/server/tests/adapters/pdf/test_report_i18n.py`
- `make lint`
- `make typecheck-backend`

That focused suite passed cleanly with `95 passed`, followed by green lint and backend typecheck.

I also ran a targeted review pass over the finished diff to look specifically for misleading wording, hidden layout regressions, and any mismatch between the simplified labels and the real peak classification logic. That review found the transient/high-presence wording issue described above, I fixed it in the branch, and then I reran the full focused validation slice.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that this PR simplifies the lower evidence section by reframing it, not by removing it. The numeric measurements are still present because they can still be useful for advanced review. The goal was to make their role clearer and to make the quick takeaway understandable without specialist knowledge.

I also intentionally did not redesign the table layout, drop columns, or change how page 2 allocates vertical space. The issue was primarily about readability and framing, not about missing evidence or a broken layout. Keeping the fix in the renderer and i18n layer keeps the blast radius small and preserves the existing analysis pipeline.

Finally, I retried the repo’s required local Docker verification after this backend change, but this environment remains blocked: the available Docker installation rejects `docker compose build --pull` and does not expose a working `docker compose` subcommand for stack startup. The report change itself is otherwise locally validated through the focused PDF suite, lint, and backend typecheck.
