### PR TITLE
Fix #1794: align PDF palette and typography with website

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_style_tokens.py
+++ b/apps/server/tests/adapters/pdf/test_report_style_tokens.py
@@ -1,0 +1,28 @@
+"""Focused PDF style-token regressions for report chrome branding."""
+
+from __future__ import annotations
+
+from vibesensor.adapters.pdf.pdf_style import (
+    FS_CARD_TITLE,
+    FS_H2,
+    FS_TITLE,
+    R_CARD,
+    REPORT_COLORS,
+)
+
+
+def test_pdf_theme_tokens_align_with_website_palette() -> None:
+    assert REPORT_COLORS["brand"] == "#7c3aed"
+    assert REPORT_COLORS["brand_surface"] == "#ede9fe"
+    assert REPORT_COLORS["warning"] == "#b7791f"
+    assert REPORT_COLORS["ink"] == "#1a1c24"
+    assert REPORT_COLORS["text_primary"] == "#1a1c24"
+    assert REPORT_COLORS["ink"] == REPORT_COLORS["text_primary"]
+    assert REPORT_COLORS["surface"] == "#f8f9fb"
+
+
+def test_pdf_typography_and_radius_shift_toward_website_chrome() -> None:
+    assert FS_TITLE == 13
+    assert FS_H2 == 10
+    assert FS_CARD_TITLE == 9.0
+    assert R_CARD == 8

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_header.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_header.py
@@ -28,8 +28,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     OBSERVED_LABEL_W,
     PAGE_H,
     PANEL_HEADER_H,
-    SOFT_BG,
-    TEXT_CLR,
+    REPORT_COLORS,
     HeaderColumnsLayout,
     build_page1_layout,
     observed_signature_row_count,
@@ -195,9 +194,16 @@ def _draw_header_panel(
         header_content_height=max(left_h, right_h),
         observed_rows=obs_rows,
     )
-    _draw_panel(c, layout.header.x, layout.header.y, layout.header.w, layout.header.h, fill=SOFT_BG)
+    _draw_panel(
+        c,
+        layout.header.x,
+        layout.header.y,
+        layout.header.w,
+        layout.header.h,
+        fill=REPORT_COLORS["brand_surface"],
+    )
 
-    c.setFillColor(_hex(TEXT_CLR))
+    c.setFillColor(_hex(REPORT_COLORS["brand"]))
     c.setFont(FONT_B, FS_TITLE)
     c.drawString(
         MARGIN + 4 * mm,

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
@@ -16,6 +16,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     MARGIN,
     PAGE_H,
     PANEL_HEADER_H,
+    R_CARD,
     REPORT_COLORS,
     SUB_CLR,
     TEXT_CLR,
@@ -97,7 +98,7 @@ def _draw_system_card(
     )
     c.setFillColor(_hex(tone_bg))
     c.setStrokeColor(_hex(tone_border))
-    c.roundRect(x, y, w, h, 4, stroke=1, fill=1)
+    c.roundRect(x, y, w, h, R_CARD, stroke=1, fill=1)
 
     cx = x + 3 * mm
     cy = y + h - 4 * mm

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_title_bar.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_title_bar.py
@@ -8,10 +8,10 @@ from reportlab.pdfgen.canvas import Canvas
 from vibesensor.adapters.pdf.pdf_drawing import _draw_panel, _hex
 from vibesensor.adapters.pdf.pdf_style import (
     FONT_B,
+    FS_TITLE,
     GAP,
     MARGIN,
-    SOFT_BG,
-    TEXT_CLR,
+    REPORT_COLORS,
     build_page2_layout,
 )
 
@@ -29,9 +29,9 @@ def _draw_title_bar(c: Canvas, *, title: str, width: float, page_top: float) -> 
         layout.title_bar.y,
         layout.title_bar.w,
         layout.title_bar.h,
-        fill=SOFT_BG,
+        fill=REPORT_COLORS["brand_surface"],
     )
-    c.setFillColor(_hex(TEXT_CLR))
-    c.setFont(FONT_B, 11)
+    c.setFillColor(_hex(REPORT_COLORS["brand"]))
+    c.setFont(FONT_B, FS_TITLE)
     c.drawString(MARGIN + 4 * mm, layout.title_bar.y + 3.5 * mm, title)
     return float(layout.title_bar.y - GAP)

--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -19,12 +19,14 @@ BMW_LENGTH_MM = 5007.0
 BMW_WIDTH_MM = 1894.0
 
 REPORT_COLORS = {
+    "brand": "#7c3aed",
+    "brand_surface": "#ede9fe",
     "ink": "#1a1c24",
     "border": "#c4c7d0",
     "surface": "#f8f9fb",
     "surface_alt": "#f1f2f6",
     "success": "#0f9d58",
-    "warning": "#b35d00",
+    "warning": "#b7791f",
     "danger": "#c5221f",
     "axis": "#7b8da0",
     "table_row_border": "#dcdfe6",
@@ -64,13 +66,13 @@ WARN_CLR = REPORT_COLORS["warning"]
 
 FONT = "Helvetica"
 FONT_B = "Helvetica-Bold"
-FS_TITLE = 12
-FS_H2 = 9
+FS_TITLE = 13
+FS_H2 = 10
 FS_BODY = 7
 FS_SMALL = 6
-FS_CARD_TITLE = 8.0
+FS_CARD_TITLE = 9.0
 
-R_CARD = 6
+R_CARD = 8
 GAP = 4 * mm
 OBSERVED_LABEL_W = 28 * mm
 DATA_TRUST_WIDTH_RATIO = 0.32


### PR DESCRIPTION
## Summary
This PR fixes #1794 by bringing the PDF report’s visual language closer to the website without turning the export into a screen-only design. The issue was not that the report lacked structure; the layout already worked. The problem was that the current PDF chrome still read as a generic document instead of feeling like a polished continuation of the product UI. In practice that gap showed up in three places: the report did not reuse the website’s brand accent, the heading hierarchy was flatter than the web experience, and the card/chrome treatment still felt slightly sharper and more utilitarian than the current app.

The implementation deliberately stays small and printable-safe. Rather than recoloring every panel or introducing a more aggressive redesign, it aligns the shared PDF theme tokens and the most visible chrome surfaces. That keeps the report readable on paper, avoids churn across analytical panels, and still makes the export feel related to the website at a glance.

## Problem being solved
Issue #1794 calls out a product-experience mismatch more than a functional bug. The website and the PDF are part of the same workflow, but the report was still using a more neutral visual treatment that did not clearly inherit the application’s current brand language. The result was a report that worked, but felt detached.

The issue specifically asked for closer alignment in typography hierarchy, accent colors, border/card language, and spacing rhythm while keeping the result PDF-appropriate. That framing mattered, because there were multiple possible ways to respond. A broad redesign of every panel would have been risky and unnecessary. The smaller and safer path was to identify the shared theme tokens that most influence first impression and apply them to the report chrome rather than to the report’s full analytical content.

## Chosen implementation approach
I first compared the frontend style authority in `apps/ui/src/styles/app.css` with the backend PDF style authority in `apps/server/vibesensor/adapters/pdf/pdf_style.py`. The website already exposes the visual cues the issue cares about: the primary purple accent (`#7c3aed`), the primary container tint (`#ede9fe`), the current warning tone (`#b7791f`), a softer surface/border language, and a clearer title hierarchy.

From there I kept the change set intentionally narrow:

- add the website-aligned brand tokens to the shared PDF palette
- strengthen heading hierarchy rather than changing body typography
- apply the new brand tint only to the most visible report chrome
- soften shared card corners slightly to better match the site’s card language
- keep analytical panel backgrounds and body text treatment largely unchanged for readability and print safety

That approach preserves the existing report structure and data presentation while making the overall report feel more recognizably “VibeSensor”.

## Main code changes by area
### Shared PDF theme tokens
In `apps/server/vibesensor/adapters/pdf/pdf_style.py`, I added two new shared palette entries:

- `REPORT_COLORS["brand"] = "#7c3aed"`
- `REPORT_COLORS["brand_surface"] = "#ede9fe"`

I also aligned the warning token from the older brown-orange value to the current website warning color `#b7791f`.

On typography, I strengthened the shared title constants while leaving body sizes alone:

- `FS_TITLE` from `12` to `13`
- `FS_H2` from `9` to `10`
- `FS_CARD_TITLE` from `8.0` to `9.0`

On card shape, I softened `R_CARD` from `6` to `8` so shared card chrome reads a bit closer to the website’s rounded surfaces without materially changing layout math.

### Page-one and page-two chrome alignment
In `apps/server/vibesensor/adapters/pdf/panels/_panel_header.py`, the page-one header panel now uses the new `brand_surface` tint instead of the generic soft background, and the report title text uses the shared brand purple. This is the first visual surface a reader sees, so it carries most of the branding shift.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_title_bar.py`, I made the same change for the page-two title bar: brand-surface background, brand-colored title text, and reuse of the shared `FS_TITLE` constant instead of an inline size. That keeps the cross-page chrome visually consistent and ties the two pages together more cleanly.

### Card-language refinement
In `apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py`, the system finding cards now reuse the shared `R_CARD` constant instead of their previous hard-coded corner radius. This is a small change, but it matters because those cards occupy a large visual footprint on page one. Using the shared radius helps the report feel like it follows one design system instead of mixing slightly different card languages.

## Tests and validation
I added a focused regression in `apps/server/tests/adapters/pdf/test_report_style_tokens.py`. The new test suite locks in the key choices from this issue rather than leaving them implicit:

- brand purple token
- brand-surface tint token
- warning token
- text token consistency (`ink` and `text_primary`)
- title hierarchy constants
- shared card radius

I then ran the focused PDF validation slice that best matches the blast radius of the change:

- `./.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/adapters/pdf/test_report_style_tokens.py apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_summary_basics.py`
- `make lint`
- `make typecheck-backend`

After a review pass, I tightened the new token regression slightly so it also protects the still-used `ink` token alongside `text_primary`, then reran the focused style-token pytest file successfully.

## Risks, tradeoffs, and out-of-scope items
The biggest tradeoff here is intentional restraint. This PR does not try to make every PDF panel use purple accents or to fully replicate the web UI inside a print document. That would create more layout risk, reduce neutrality in analytical content, and make the PDF harder to scan or print cleanly. Instead, the branding shift is concentrated in the shared theme and top-level chrome.

I also kept Helvetica in place. The issue mentioned typography alignment, but the safest interpretation for a generated PDF is hierarchy alignment rather than swapping to a less predictable font stack. Stronger headings give the report a closer visual relationship to the website without introducing font-embedding or metric surprises.

There is also no screenshot-diff harness for this issue. The validation here is a combination of focused token regression coverage, existing PDF layout/rendering/OCR tests, and a targeted code review for readability and layout safety. If later product review wants the branding shift to go further, the natural follow-up would be selective additional chrome/card treatment rather than a broad layout rewrite.

## Environment note
I also retried the required Docker-stack verification. In this environment, `docker compose` is unavailable, `docker compose up -d` is parsed as plain Docker CLI usage for the same reason, and the installed legacy `docker-compose` executable fails immediately because it cannot connect to a Docker daemon socket. That means the Docker verification remains environment-blocked here rather than blocked by this code change.
