### PR TITLE
Fix firmware constexpr compatibility in release builds

### DIFF
--- a/firmware/esp/lib/reliability/reliability.h
+++ b/firmware/esp/lib/reliability/reliability.h
@@ -14,13 +14,9 @@ constexpr uint32_t kRetryJitterDivisor = 4U;
 constexpr uint16_t clamp_sample_rate(uint16_t configured_hz,
                                      uint16_t min_hz,
                                      uint16_t max_hz) {
-  if (configured_hz < min_hz) {
-    return min_hz;
-  }
-  if (configured_hz > max_hz) {
-    return max_hz;
-  }
-  return configured_hz;
+  return configured_hz < min_hz
+             ? min_hz
+             : (configured_hz > max_hz ? max_hz : configured_hz);
 }
 
 inline uint16_t clamp_frame_samples(uint16_t configured_samples,

--- a/firmware/esp/platformio.ini
+++ b/firmware/esp/platformio.ini
@@ -34,6 +34,7 @@ platform = native
 test_framework = unity
 test_build_src = no
 build_flags =
+  -std=gnu++11
   -I test/native_support
   -I include
   -I lib/vibesensor_proto


### PR DESCRIPTION
## Summary

This PR fixes the current `Main Release` workflow failures on `main` by restoring firmware compatibility with the ESP32 release toolchain and tightening the host-side firmware test environment so the same class of regression gets caught before release.

The release workflow was failing consistently in the `Build firmware` step even though the regular `CI` workflow on `main` was green. The failing runs were all stopping at the same compile error inside `firmware/esp/lib/reliability/reliability.h`, where `clamp_sample_rate(...)` was declared `constexpr` but implemented with a statement-bodied function that the Arduino/ESP32 compiler in the release environment would not accept as a constant expression.

The fix is intentionally small: rewrite the helper into a C++11-compatible single-return `constexpr` expression, and make the native PlatformIO test environment compile with the same `gnu++11` standard so future regressions of this exact kind fail in earlier validation instead of slipping through to release.

## Problem being solved

The regression was not in the release workflow logic itself. The workflow correctly reached the firmware build, installed PlatformIO, selected the firmware directory, and invoked `pio run`. The failure happened when the firmware sources were compiled under the toolchain used by `espressif32@6.13.0` with Arduino 2.0.17.

The failing helper looked logically correct, and it compiled in the existing native host-side test setup, but it relied on relaxed `constexpr` rules that are available in newer C++ modes and not in the stricter mode effectively used by the release firmware build. Because `runtime_config.h` uses `clamp_sample_rate(...)` to initialize a `constexpr` configuration value, the compiler rejected it as not being a valid constant expression and the whole firmware build stopped before packaging, screenshots, release creation, or wiki publishing could even begin.

That mismatch between host-side test compilation and the release firmware compiler is the real issue this PR addresses.

## Implementation approach

The implementation follows the smallest safe path to restore release behavior while also covering the gap that let the regression escape.

First, `firmware/esp/lib/reliability/reliability.h` now expresses `clamp_sample_rate(...)` as a single return statement using nested ternaries. This preserves the exact runtime behavior of the helper — values below the minimum clamp upward, values above the maximum clamp downward, and in-range values pass through unchanged — but does so in a form that is valid under older `constexpr` restrictions.

Second, `firmware/esp/platformio.ini` updates the `native` test environment to compile with `-std=gnu++11`. That keeps the host-side reliability tests aligned with the effective language level that matters for the actual firmware build path. The goal is not to make native testing artificially older across the whole project; it is to ensure that a `constexpr` helper which must be valid for the firmware target is exercised under the same standard expectations during local and CI-native validation.

## Main code changes by area

In `firmware/esp/lib/reliability/reliability.h`, the only behavioral helper touched is `clamp_sample_rate(...)`. The logic did not change, only the expression form. That matters because this helper feeds `kSampleRateHz` in `src/runtime_config.h`, so any change here has firmware-wide impact. Keeping the same clamp semantics was important.

In `firmware/esp/platformio.ini`, the `native` environment now explicitly adds `-std=gnu++11` in `build_flags`. This makes the native `test_reliability_logic` target a more faithful guard for compile-time firmware helpers that need to survive the ESP32 release toolchain.

No workflow YAML changes were needed for this fix. The release workflow failure was a code/toolchain compatibility regression, not a release-pipeline orchestration bug.

## Validation performed

I validated the fix locally against the same surfaces implicated by the release failures.

Firmware-focused validation:

- `cd firmware/esp && pio test -e native -f test_reliability_logic`
- `cd firmware/esp && pio run`

The first command verifies the reliability helpers in the host-side PlatformIO test environment, now with the stricter standard setting. The second command verifies the actual target firmware build path that was failing in `Main Release`.

Repository validation:

- `make lint`

I also inspected the failing GitHub Actions runs directly and confirmed that the broken step was consistently `Build firmware`, with the compiler error pointing at `clamp_sample_rate(...)` being rejected as a `constexpr` body for constant-expression use. That gave a tight feedback loop from failure reproduction to patch to local confirmation.

## Risks, tradeoffs, and edge cases considered

The main risk with compile-time helper changes is accidentally altering firmware configuration behavior while trying to satisfy the compiler. This PR avoids that by keeping the clamp semantics identical and changing only the syntactic form of the return logic.

Another possible reaction would have been to relax the use site so the sample rate was no longer computed as a `constexpr`. I deliberately did not take that route because the compile-time configuration in `runtime_config.h` is useful and intentional. The better fix is to keep the helper valid for that use rather than weakening the configuration model.

There is also a tradeoff in pinning the native test environment more explicitly to `gnu++11`: it narrows the host-side language mode. In this case that is desirable, because the host-side test exists to protect firmware helpers, and the real firmware target is the compatibility constraint that matters. If native tests rely on newer language features in the future, that tension would need reevaluation, but for the current reliability test surface this stricter alignment is a net positive.

## Out of scope

This PR does not broaden CI to add a full firmware target build into the standard `CI` workflow. That could be a worthwhile future improvement, but it would be a larger runtime/cost tradeoff than necessary for this immediate repair. The current goal is to unblock the broken release path quickly and safely.

After merge, the important verification step is the one the user asked for: watch the next `Main Release` run on `main` and confirm that the firmware build — and therefore the rest of the release pipeline — now completes successfully.
