### PR TITLE
fix(ci): install pi-gen binfmt prerequisite

### DIFF
--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y qemu-user-static rsync xz-utils
+          sudo apt-get install -y qemu-user-binfmt qemu-user-static rsync xz-utils
 
       - name: Build Pi image
         shell: bash

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ See [apps/server/README.md](apps/server/README.md) for configuration and uplink-
 Build on a Linux machine with Docker:
 
 ```bash
+sudo apt-get update && sudo apt-get install -y docker.io qemu-user-binfmt qemu-user-static rsync xz-utils
 ./infra/pi-image/pi-gen/build.sh
 ```
 

--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -9,8 +9,17 @@ with no manual setup.
 - Linux build machine (or WSL2)
 - Docker
 - git, rsync
+- `qemu-user-binfmt` (provides host `qemu-arm` for current upstream `pi-gen`)
+- `qemu-user-static` (used by VibeSensor's post-build image validator)
 - ~20 minutes build time (depends on cache and network)
 - For best x86/WSL performance, keep the repo on the Linux filesystem (for example `/home/...`), not on a Windows-mounted path.
+
+On Debian/Ubuntu hosts you can install the image-build prerequisites with:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y docker.io git qemu-user-binfmt qemu-user-static rsync xz-utils
+```
 
 ## Build
 

--- a/infra/pi-image/pi-gen/lib/prereqs.sh
+++ b/infra/pi-image/pi-gen/lib/prereqs.sh
@@ -39,6 +39,7 @@ require_image_prereqs() {
   require_cmd mount
   require_cmd umount
   require_cmd awk
+  require_cmd qemu-arm
   require_cmd qemu-arm-static
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the remaining post-merge failure in the `Weekly Pi Image` workflow after `#1817` landed. The previous fix correctly resolved the Python runtime mismatch between the Pi image and the backend package metadata, but the first live run on merged `main` still failed in the `Build Pi image` step because the GitHub runner was missing a newer upstream `pi-gen` host prerequisite.

The failed workflow run was `23680269285`. Its `Build Pi image` log showed the relevant final lines:

- `qemu-arm not found (please install qemu-user-binfmt)`
- `Process completed with exit code 1`

That message is coming from the current upstream `pi-gen` `master` branch’s `build-docker.sh`. Once we moved the image pipeline to the current upstream branch in order to build a Trixie-based 32-bit image, we also inherited that script’s newer host-side emulator requirement. Our workflow still installed `qemu-user-static`, which is sufficient for VibeSensor’s own post-build validator, but not for upstream `pi-gen`’s host-side `qemu-arm`/`binfmt_misc` check.

## Problem being solved

The weekly workflow was failing after the Trixie migration for a more specific reason than before:

1. `#1817` fixed the image runtime compatibility problem by aligning the image target and Python floor.
2. The next live workflow run reached the actual `pi-gen` build.
3. Upstream `pi-gen master` then stopped the build because the host environment did not have `qemu-arm` installed via `qemu-user-binfmt`.

In other words, the original failure was solved, but that exposed the next real prerequisite gap in the current `pi-gen` toolchain contract. The goal of this PR is to satisfy that contract in CI, make the same dependency visible earlier in local builds, and document it so local image builders do not hit the same surprise failure later.

## Implementation approach

I kept this follow-up intentionally narrow.

The workflow now installs `qemu-user-binfmt` in addition to `qemu-user-static`. That matches the upstream `pi-gen` dependency model and gives the runner the `qemu-arm` binary that `build-docker.sh` explicitly checks for before launching the privileged build container.

I also updated our own `infra/pi-image/pi-gen/lib/prereqs.sh` host-side build prerequisites to require `qemu-arm` for image builds. This is important because it moves a confusing downstream failure into a clear, immediate local prerequisite error. Instead of making it through VibeSensor’s wrapper only to fail deep inside upstream `pi-gen`, local users will now get a fast, actionable host-dependency message before the build begins.

Finally, I updated the directly related build docs so the documented local environment matches the actual working host dependency set for the Trixie/master-based image pipeline.

## Main code changes by area

### `.github/workflows/weekly-pi-image.yml`

The `Install Pi image build prerequisites` step now installs:

- `qemu-user-binfmt`
- `qemu-user-static`
- `rsync`
- `xz-utils`

The important change is `qemu-user-binfmt`. That package provides the host `qemu-arm` binary expected by upstream `pi-gen`’s `build-docker.sh` prereq check.

### `infra/pi-image/pi-gen/lib/prereqs.sh`

`require_image_prereqs()` now requires both:

- `qemu-arm`
- `qemu-arm-static`

This reflects the current split responsibilities in our image pipeline:

- `qemu-arm` is needed by upstream `pi-gen` when running the Docker-based image build.
- `qemu-arm-static` is still used by VibeSensor’s own post-build validation flow.

That means our host-side prereq checks now match the complete build path instead of only the validation half.

### `infra/pi-image/pi-gen/README.md`

I updated the Pi-image readme to explicitly list both emulator-related host packages and added a concrete Debian/Ubuntu install command. This prevents the documentation from drifting behind the toolchain and makes local setup more copy/paste friendly.

### `README.md`

I updated the top-level prebuilt-image instructions to include the same host package install step before invoking `./infra/pi-image/pi-gen/build.sh`. That keeps the most likely user entrypoint aligned with the real dependency set.

## Why this is the right fix

This issue is a host-environment dependency mismatch, not an application bug and not another image-runtime compatibility problem. Because the failure originates from the upstream `pi-gen` runner’s prereq checks, the correct fix is to satisfy those checks and document the requirement, not to weaken or work around the upstream behavior.

Adding `qemu-user-binfmt` is the smallest complete CI fix. Adding `qemu-arm` to our own prereq check is the smallest complete local-developer fix. Together they cover both supported execution paths without changing the image contents or the application behavior on the Pi.

## Validation performed

I validated this follow-up locally with:

- `make lint`
- a targeted diff review of the four touched files
- direct inspection of the failed GitHub Actions run log for `23680269285`
- direct verification against the current upstream `pi-gen master` `build-docker.sh`, which explicitly checks for `qemu-arm` and instructs users to install `qemu-user-binfmt`

I did not claim a full successful image build locally because this environment still does not provide Docker access to the active user, so the authoritative end-to-end confirmation for this change must come from GitHub Actions.

## Risks and tradeoffs considered

The change is low risk because it only broadens the host dependency install and prerequisite checks; it does not modify the image assembly logic, application packaging, or release-publish logic. The main tradeoff is slightly stricter local prerequisites for image builders, but that is intentional and preferable to a later, harder-to-diagnose failure inside upstream `pi-gen`.

## Out of scope

This PR does not change the previously merged Trixie migration, the weekly release rotation behavior, or the application’s runtime behavior on the device. It only fixes the newly exposed `qemu-user-binfmt` host dependency gap so the weekly Pi image workflow can proceed past the current `Build Pi image` failure.
