### PR TITLE
fix(ci): use compatible qemu packages

### DIFF
--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y qemu-user-binfmt qemu-user-static rsync xz-utils
+          sudo apt-get install -y qemu-user qemu-user-static rsync xz-utils
 
       - name: Build Pi image
         shell: bash

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [apps/server/README.md](apps/server/README.md) for configuration and uplink-
 Build on a Linux machine with Docker:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y docker.io qemu-user-binfmt qemu-user-static rsync xz-utils
+sudo apt-get update && sudo apt-get install -y docker.io qemu-user qemu-user-static rsync xz-utils
 ./infra/pi-image/pi-gen/build.sh
 ```
 

--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -9,7 +9,7 @@ with no manual setup.
 - Linux build machine (or WSL2)
 - Docker
 - git, rsync
-- `qemu-user-binfmt` (provides host `qemu-arm` for current upstream `pi-gen`)
+- `qemu-user` (provides host `qemu-arm` for current upstream `pi-gen`)
 - `qemu-user-static` (used by VibeSensor's post-build image validator)
 - ~20 minutes build time (depends on cache and network)
 - For best x86/WSL performance, keep the repo on the Linux filesystem (for example `/home/...`), not on a Windows-mounted path.
@@ -18,8 +18,11 @@ On Debian/Ubuntu hosts you can install the image-build prerequisites with:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y docker.io git qemu-user-binfmt qemu-user-static rsync xz-utils
+sudo apt-get install -y docker.io git qemu-user qemu-user-static rsync xz-utils
 ```
+
+On Ubuntu runners, `qemu-user-binfmt` conflicts with `qemu-user-static`, so use
+`qemu-user` to provide `qemu-arm` instead.
 
 ## Build
 


### PR DESCRIPTION
## Summary

This PR fixes the next post-merge failure in the `Weekly Pi Image` workflow after `#1818`. The previous follow-up correctly identified that the upstream `pi-gen` build now needs host `qemu-arm` in addition to the `qemu-arm-static` binary used by VibeSensor’s validator. However, the first live run after that change failed even earlier during package installation on the GitHub runner because the chosen Ubuntu package combination was invalid.

The failed workflow run was `23680384517`. The `Install Pi image build prerequisites` step failed with:

- `qemu-user-binfmt : Conflicts: qemu-user-static`
- `qemu-user-static : Conflicts: qemu-user-binfmt`
- `E: Unable to correct problems, you have held broken packages.`

So the remaining problem is not the emulator requirement itself. The problem is that Ubuntu 24.04’s package set does not allow installing `qemu-user-binfmt` and `qemu-user-static` together, even though our build path needs the capabilities that were intended to come from both.

## Problem being solved

At this point the weekly workflow had already moved through three distinct failure modes:

1. the original Python runtime mismatch between the Pi image and the backend package metadata,
2. the missing upstream `pi-gen` host emulator binary (`qemu-arm`), and then
3. the GitHub runner package conflict created by trying to satisfy that requirement with `qemu-user-binfmt` plus `qemu-user-static`.

This PR fixes the third one.

The target state is straightforward:

- upstream `pi-gen` must be able to find host `qemu-arm`, and
- VibeSensor’s validator must still have `qemu-arm-static` available.

On Ubuntu runners, the compatible package pair that provides those binaries is:

- `qemu-user`
- `qemu-user-static`

That pair gives us the two binaries we actually need without triggering the package conflict that blocked the last run.

## Implementation approach

I kept this change narrowly focused on package selection and documentation.

The workflow now installs `qemu-user` instead of `qemu-user-binfmt`, while continuing to install `qemu-user-static`. That preserves the intended functionality from `#1818` but adapts it to the actual package relationships on the GitHub-hosted Ubuntu runner.

I also updated the Pi-image documentation and the top-level Raspberry Pi image instructions so they no longer recommend the conflicting package combination. The docs now describe `qemu-user` as the source of host `qemu-arm`, and explicitly note that Ubuntu runners cannot combine `qemu-user-binfmt` with `qemu-user-static`.

## Main changes

### `.github/workflows/weekly-pi-image.yml`

The `Install Pi image build prerequisites` step now installs:

- `qemu-user`
- `qemu-user-static`
- `rsync`
- `xz-utils`

This is the actual workflow fix.

### `infra/pi-image/pi-gen/README.md`

The Pi-image build readme now:

- lists `qemu-user` rather than `qemu-user-binfmt` as the host package that provides `qemu-arm`,
- keeps `qemu-user-static` called out for the validator path, and
- documents the Ubuntu conflict so local builders do not repeat the same failed package combination.

### `README.md`

The top-level “Prebuilt image” instructions now use the same working package set so the highest-visibility quickstart path matches the workflow that actually runs in CI.

## Why this is the right fix

This is the smallest complete correction because it leaves the underlying emulator requirements intact and only changes how the host environment satisfies them. We already know from the failed run log that the runner rejected the prior package combination before the image build even began. So the right move is not to change the image pipeline again, but to choose the package pair that provides the required binaries without conflicting.

This also keeps the local prereq changes from `#1818` meaningful. Our build path still expects both `qemu-arm` and `qemu-arm-static`; this PR simply aligns the documented and automated installation method with the reality of the runner’s package manager.

## Validation performed

I validated this change with:

- direct inspection of the failed workflow log for run `23680384517`,
- local package metadata inspection to confirm the relevant package relationships,
- targeted diff review of the touched files, and
- `make lint`

The key package fact verified during investigation is that `qemu-user-binfmt` conflicts with `qemu-user-static`, while `qemu-user` is the package that supplies `qemu-arm` without introducing that conflict.

I am still relying on GitHub Actions for authoritative end-to-end weekly image confirmation because the current local environment does not provide Docker access to the active user.

## Risks and tradeoffs considered

This change is low risk. It does not alter the app, the Pi image contents, the release cleanup logic, or the Trixie migration. It only corrects the host package installation strategy for the runner and the matching docs.

The only meaningful tradeoff is that the docs now need one extra bit of platform nuance: upstream `pi-gen` may mention `qemu-user-binfmt`, but on Ubuntu the compatible pair for our workflow is `qemu-user` plus `qemu-user-static`. That nuance is worth documenting because it prevents a reproducible setup failure.

## Out of scope

This PR does not change runtime behavior on the device, alter validation rules, or revisit the weekly release rotation logic. It only fixes the runner package conflict that is currently blocking the weekly Pi image workflow from reaching the actual build again.
