### PR TITLE
fix(ci): preconfigure arm binfmt

### DIFF
--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -44,6 +44,11 @@ jobs:
           cache: pip
           cache-dependency-path: apps/server/pyproject.toml
 
+      - name: Set up arm emulation
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm
+
       - name: Install Pi image build prerequisites
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

This PR fixes the next runner-side blocker in the `Weekly Pi Image` workflow after `#1819`. The package installation step is now correct, but the workflow still fails inside `Build Pi image` because the GitHub runner does not expose working `armhf` emulation to `pi-gen` early enough for its `arch-test` check.

The failing run was `23680477115`. The relevant part of the log was:

- `Registering qemu-arm for binfmt_misc...`
- `Checking native armhf executable support...`
- `armhf: not supported on this machine/kernel`
- `WARNING: Only a native build environment is supported. Checking emulated support...`
- `armhf: not supported on this machine/kernel`
- `No fallback mechanism found. Ensure your OS has binfmt_misc support enabled and configured.`

That tells us the runner had the right binaries installed, but `arch-test` still could not see a usable `binfmt_misc` configuration for `armhf` by the time upstream `pi-gen` evaluated the host.

## Problem being solved

At this stage the workflow no longer fails because of:

- the Python floor mismatch,
- missing `qemu-arm`, or
- incompatible Ubuntu package selection.

The remaining failure is host-side emulation activation.

Upstream `pi-gen` does attempt its own registration, but on the GitHub-hosted Ubuntu runner that has not been sufficient to make `arch-test armhf` succeed in time. The practical fix is to preconfigure ARM binfmt support explicitly at the workflow level before calling into `pi-gen`, so the runner environment already satisfies the prerequisite that `pi-gen` is about to check.

## Implementation approach

I added a standard `docker/setup-qemu-action@v4` step to the weekly workflow, scoped to `platforms: arm`.

This action uses the established `tonistiigi/binfmt` setup path to install and register the necessary QEMU/binfmt support on the runner. That gives us a more reliable runner bootstrap than expecting upstream `pi-gen` to discover and finish host registration on its own in this GitHub Actions environment.

The goal here is not to replace `pi-gen`’s own checks. The goal is to ensure the runner already satisfies them.

## Main code change

### `.github/workflows/weekly-pi-image.yml`

Added:

- `docker/setup-qemu-action@v4`
- `platforms: arm`

The step is placed before the explicit package-install/build sequence so that runner-side emulation support is configured before `./infra/pi-image/pi-gen/build.sh` invokes upstream `pi-gen`.

## Why this is the right fix

The failed run shows that having the QEMU packages installed is not enough by itself on the GitHub runner. The host also needs working binfmt registration that `arch-test` can observe. `docker/setup-qemu-action` is a standard GitHub Actions mechanism for exactly this problem and is a better fit for runner bootstrap than trying to keep layering more shell-side workarounds into our package-install step.

This is also the smallest complete follow-up. It leaves the existing Trixie migration, release rotation behavior, QEMU package selection, and local prereq checks untouched. It only adds the missing runner bootstrap needed to make the actual build path viable in CI.

## Validation performed

I validated this change with:

- direct inspection of failed run `23680477115`,
- targeted diff review of the workflow change, and
- `make lint`

As with the earlier weekly-workflow fixes, the authoritative end-to-end confirmation must come from GitHub Actions because the local environment still does not provide Docker access to the active user.

## Risks and tradeoffs considered

The risk is low. This change only affects the weekly GitHub Actions runner setup for the Pi image job. It does not modify application code, image contents, package metadata, or the release-publication logic.

The only tradeoff is an extra workflow setup step and the small amount of time that comes with it, which is acceptable given that the job cannot proceed successfully without usable ARM emulation on the runner.

## Out of scope

This PR does not change any local image-build commands, the Pi image runtime target, or the rotating weekly release behavior. It strictly fixes the missing runner-side binfmt bootstrap that is currently blocking the weekly workflow from getting past `pi-gen`’s host architecture check.
