### PR TITLE
fix(pi-image): prefer static qemu interpreter

### DIFF
--- a/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
+++ b/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
@@ -27,6 +27,24 @@ patch_export_image_boot_size() {
     "${export_prerun}"
 }
 
+patch_build_docker_qemu_interpreter() {
+  local build_docker="${PI_GEN_DIR}/build-docker.sh"
+  local stock_check='if ! qemu_arm=$(which qemu-arm) ; then'
+  local patched_check='if ! qemu_arm=$(command -v qemu-arm-static 2>/dev/null) && ! qemu_arm=$(command -v qemu-arm 2>/dev/null) ; then'
+
+  if grep -Fq "${patched_check}" "${build_docker}"; then
+    return
+  fi
+  if ! grep -Fq "${stock_check}" "${build_docker}"; then
+    echo "Unexpected build-docker.sh qemu lookup in ${build_docker}"
+    exit 1
+  fi
+
+  sed -i \
+    's/if ! qemu_arm=$(which qemu-arm) ; then/if ! qemu_arm=$(command -v qemu-arm-static 2>\/dev\/null) \&\& ! qemu_arm=$(command -v qemu-arm 2>\/dev\/null) ; then/' \
+    "${build_docker}"
+}
+
 set_base_stage_skip_files() {
   local state="$1"
   local stage=""
@@ -58,6 +76,7 @@ prepare_pi_gen_repo() {
 
   rewrite_pi_gen_mirror_sources
   patch_export_image_boot_size
+  patch_build_docker_qemu_interpreter
 }
 
 configure_incremental_build() {


### PR DESCRIPTION
## Summary

This PR patches the cloned `pi-gen` repository during image-build preparation so its `build-docker.sh` prefers `qemu-arm-static` over `qemu-arm` when choosing the binfmt interpreter to register.

The need for this follow-up came from the latest weekly workflow run, `23680592010`. At that point we had already fixed the outer runner prerequisites:

- the weekly workflow installs compatible QEMU packages,
- the workflow seeds ARM binfmt support before invoking `pi-gen`, and
- the job gets as far as `Build Pi image` consistently.

However, the run still fails with the same inner `pi-gen` architecture-support check:

- `Registering qemu-arm for binfmt_misc...`
- `Checking native armhf executable support...`
- `armhf: not supported on this machine/kernel`
- `WARNING: Only a native build environment is supported. Checking emulated support...`
- `armhf: not supported on this machine/kernel`
- `No fallback mechanism found. Ensure your OS has binfmt_misc support enabled and configured.`

## Problem being solved

By this point, the issue no longer looks like an outer GitHub runner setup problem. The failure is happening in the `pi-gen` container path itself.

The important detail is that upstream `build-docker.sh` currently tries to locate and register `qemu-arm`, while the upstream `pi-gen` Docker image installs `qemu-user-static` in its Dockerfile. That means the containerized build environment is guaranteed to have `qemu-arm-static`, but not necessarily `qemu-arm` at the exact interpreter path that the host-side binfmt registration is attempting to use.

That mismatch creates a plausible and consistent explanation for the observed behavior:

- registration logic runs,
- the build continues into `pi-gen`,
- but `arch-test armhf` still cannot see working emulation inside the containerized build environment.

So this PR fixes the interpreter-path mismatch directly where it originates: the cloned upstream `pi-gen` repo that we already patch during local preparation.

## Implementation approach

I extended our existing `prepare_pi_gen_repo()` compatibility patching flow in `infra/pi-image/pi-gen/lib/pi_gen_repo.sh`.

We already patch the cloned upstream repo for other compatibility/behavior needs, such as mirror rewriting and boot partition sizing. This PR adds one more targeted upstream-compatibility patch:

- locate the current `build-docker.sh` qemu lookup,
- replace it so it prefers `qemu-arm-static`,
- and only fall back to `qemu-arm` if the static binary is not available.

That keeps the adjustment surgical and colocated with the rest of our tracked upstream `pi-gen` patch points.

## Main code change

### `infra/pi-image/pi-gen/lib/pi_gen_repo.sh`

Added `patch_build_docker_qemu_interpreter()` and called it from `prepare_pi_gen_repo()`.

The patch:

- verifies the expected upstream lookup is still present,
- no-ops if the patch has already been applied, and
- rewrites the lookup from `which qemu-arm` to a preference order of:
  1. `qemu-arm-static`
  2. `qemu-arm`

That means the binfmt interpreter path chosen during the `pi-gen` build-docker bootstrap will match the static QEMU binary that is reliably present in the `pi-gen` container image.

## Why this is the right fix

This is a better target than adding still more outer workflow setup because the logs show we are already past the outer prerequisites and into `pi-gen`’s own build bootstrap. The remaining failure repeats after:

- package corrections,
- compatible package selection, and
- explicit runner-side binfmt setup.

At that point the most credible remaining mismatch is inside the upstream `pi-gen` repo itself.

Patching the interpreter selection is also lower-risk than broadening the upstream Docker image dependencies or rewriting larger portions of `build-docker.sh`. We are not changing the overall build strategy or emulation model. We are just telling `pi-gen` to use the static ARM interpreter it already ships first, which better matches the environment it is creating for itself.

## Validation performed

I validated this change with:

- direct inspection of the failing weekly run `23680592010`,
- direct comparison of upstream `build-docker.sh` and the upstream `pi-gen` Dockerfile behavior, which currently points to a likely `qemu-arm` vs `qemu-arm-static` mismatch,
- targeted diff review of the repo-side patch, and
- `make lint`

As with the prior weekly workflow fixes, the final end-to-end verification still depends on GitHub Actions because the current local environment does not provide Docker access to the active user.

## Risks and tradeoffs considered

This patch is intentionally narrow, but it does rely on the current upstream `build-docker.sh` lookup shape being stable enough for our string-based patch. To keep that safe, the helper explicitly checks for the known upstream line and fails fast if the layout changes unexpectedly, rather than silently producing a broken partial edit.

The payoff is that we keep the compatibility logic in one controlled place and avoid drifting farther from upstream than necessary.

## Out of scope

This PR does not change the weekly release retention logic, Python compatibility target, outer workflow package list, or the general Pi image composition. It only patches the cloned upstream `pi-gen` bootstrap so its binfmt interpreter choice matches the static QEMU binary that is already present in its own container environment.
