### PR TITLE
fix(pi-image): prefer HTTPS Raspbian mirror

### DIFF
--- a/infra/pi-image/pi-gen/lib/common.sh
+++ b/infra/pi-image/pi-gen/lib/common.sh
@@ -27,6 +27,7 @@ init_pi_gen_env() {
   CLEAN="${CLEAN:-0}"
   RASPBIAN_MIRROR="${RASPBIAN_MIRROR:-}"
   RASPBIAN_MIRROR_FALLBACKS=(
+    "https://archive.raspbian.org/raspbian/"
     "http://raspbian.raspberrypi.com/raspbian/"
     "http://mirror.init7.net/raspbian/raspbian/"
     "http://mirrors.ustc.edu.cn/raspbian/raspbian/"


### PR DESCRIPTION
## Summary

This PR updates the Pi image build to prefer the HTTPS `archive.raspbian.org` mirror before the legacy HTTP Raspbian mirror list.

The motivation is the latest weekly build failure after the emulation issues were resolved. The newest run got through:

- runner QEMU setup,
- package installation,
- inner `arch-test` emulation checks, and
- into `stage0` debootstrap itself.

The new failure happened at the repository bootstrap step:

- `I: Retrieving InRelease`
- `I: Checking Release signature`
- `E: Invalid Release signature`

So at this point the blocker is no longer QEMU or package setup. It is the stage-0 repository bootstrap path for the Raspbian `trixie` archive.

## Problem being solved

The Raspbian `trixie` metadata is signed by the expected Raspbian signing key, and upstream `pi-gen` is already using the appropriate bootstrap keyring for that path. That makes a transport-layer integrity problem more likely than a missing key problem, especially because our current mirror fallbacks still prefer plain HTTP endpoints.

For a repository whose authenticity is enforced by signed metadata, HTTP can still be workable in theory, but in practice it leaves room for transparent proxying or response mangling that shows up exactly as an `Invalid Release signature` error at debootstrap time. Since `archive.raspbian.org` exposes the same repository over HTTPS, the safer and more deterministic default is to try that signed transport path first.

## Implementation approach

I kept the change intentionally small.

The Pi-image build already supports mirror fallback selection through `RASPBIAN_MIRROR_FALLBACKS`. Rather than changing the mirror-selection model or adding any special-case workflow-only override, this PR simply prepends the HTTPS archive endpoint:

- `https://archive.raspbian.org/raspbian/`

ahead of the older HTTP fallback list.

That means both CI and local image builds benefit from the same safer default, while still retaining the existing HTTP mirrors as fallbacks if the preferred endpoint is unreachable.

## Main code change

### `infra/pi-image/pi-gen/lib/common.sh`

In `init_pi_gen_env()`, the `RASPBIAN_MIRROR_FALLBACKS` list now starts with:

- `https://archive.raspbian.org/raspbian/`

before the previous HTTP candidates.

No other build logic changed.

## Why this is the right fix

This is the smallest complete response to the latest observed failure.

We already proved that:

- emulation setup can succeed,
- the build can enter `stage0`, and
- the failure happens specifically during release-signature verification.

At that point, preferring the HTTPS mirror is the most conservative fix that improves transport integrity without weakening GPG verification, skipping signature checks, or rewriting the overall bootstrap flow.

It also preserves the existing fallback behavior, so we are not hardcoding the build to a single endpoint with no recovery path.

## Validation performed

I validated this change with:

- direct inspection of the latest failing weekly build log, which now fails at `E: Invalid Release signature`,
- direct inspection of the live Raspbian `trixie` `InRelease`, which shows expected signed metadata, and
- `make lint`

As with the other weekly image fixes, final confirmation still depends on GitHub Actions because the local environment here does not provide Docker access for end-to-end image builds.

## Risks and tradeoffs considered

The risk is low because this only changes the order of preferred bootstrap mirrors. The existing HTTP mirrors remain available as fallbacks, so the change is resilient rather than brittle.

The main tradeoff is slightly more opinionated mirror preference, but that is justified because HTTPS is the safer default when we are already seeing signature validation failures during bootstrap.

## Out of scope

This PR does not change the image runtime target, QEMU setup, weekly release rotation, or stage composition. It only changes the default Raspbian mirror preference so stage-0 bootstrap tries the HTTPS archive endpoint before the older HTTP mirror list.
