### PR TITLE
fix(pi-image): refresh stage package indexes

### DIFF
--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -47,7 +47,7 @@ run_as_root apt-get install -y \
   python3-pip \
   libopenblas0-pthread \
   network-manager \
-  dnsmasq \
+  dnsmasq-base \
   rfkill \
   iw \
   gpsd \

--- a/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
+++ b/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
@@ -1,9 +1,9 @@
 rewrite_pi_gen_mirror_sources() {
-  while IFS= read -r mirror_file; do
+  while IFS= read -r -d '' mirror_file; do
     sed -i \
       -E "s#http://raspbian\\.raspberrypi\\.com/raspbian/#${RASPBIAN_MIRROR}#g" \
       "${mirror_file}"
-  done < <(rg -l "http://raspbian\\.raspberrypi\\.com/raspbian/" "${PI_GEN_DIR}")
+  done < <(grep -rlZ "http://raspbian\\.raspberrypi\\.com/raspbian/" "${PI_GEN_DIR}" || true)
 }
 
 patch_export_image_boot_size() {

--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages
@@ -1,5 +1,5 @@
 network-manager
-dnsmasq
+dnsmasq-base
 rfkill
 iw
 gpsd

--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template
@@ -13,3 +13,10 @@ if [ -d "${APT_SOURCES_DIR}" ]; then
   find "${APT_SOURCES_DIR}" -type f \( -name '*.list' -o -name '*.sources' \) -print0 \
     | xargs -0 -r sed -i 's#http://raspbian.raspberrypi.com/raspbian/#__RASPBIAN_MIRROR__#g'
 fi
+
+# stage2 may leave package lists cleaned after its last install step, but
+# stage-vibesensor adds new runtime packages in 00-packages. Refresh apt here
+# so those installs resolve against the current rewritten mirrors.
+on_chroot <<'CHROOT_EOF'
+apt-get update
+CHROOT_EOF


### PR DESCRIPTION
## Summary

This PR fixes the next `Weekly Pi Image` blocker that appeared immediately after the armhf stage-0 bootstrap keyring repair. After `#1823`, the weekly workflow no longer failed in `debootstrap` with `Invalid Release signature`; instead, it advanced all the way through stage0, stage1, stage2, and then failed in `stage-vibesensor/00-vibesensor/00-packages` during the final VibeSensor-specific runtime package install.

The new failing run was `23681149070`, and the error moved to a very different point in the build:

- `stage0` completed,
- `00-configure-apt` completed,
- stage2 cloud-init packages completed,
- `stage-vibesensor/prerun.sh` completed,
- then `stage-vibesensor/00-vibesensor/00-packages` failed with package-resolution errors.

The important detail is that this is no longer the old signature-verification problem. The build now progresses roughly twenty-plus minutes further than before, so the bootstrap keyring fix is doing real work. This PR addresses the next concrete compatibility issue surfaced by that deeper run.

## Problem being solved

The failing package step reported four notable issues:

- `dnsmasq` had no installation candidate and APT explicitly reported that `dnsmasq-base` replaces it,
- `gpsd` could not be located,
- `libopenblas0-pthread` had no installation candidate,
- `libopenjp2-7` had no installation candidate.

At the same time, the run log also showed a separate warning from our repo-preparation layer:

- `infra/pi-image/pi-gen/lib/pi_gen_repo.sh: line 1: rg: command not found`

That `rg` warning was not the direct cause of the final package failure, but it showed that one part of the image-prep logic had been silently depending on a tool the weekly runner does not install. Since the current issue is specifically about getting the weekly image build green, I fixed that hidden dependency while repairing the stage package flow.

## Implementation approach

I intentionally kept this PR small and limited it to the new failure surface exposed by the last successful merge.

The working theory here is:

1. `stage-vibesensor` is installing packages later than the upstream stages, after prior stage activity may leave package lists stale or cleaned.
2. `dnsmasq` is no longer the correct package contract for this image path; the executable package now advertised by APT is `dnsmasq-base`.
3. The mirror-rewrite helper should not depend on `rg` when the weekly runner never installed it.

Rather than broadly rewriting package ownership or reworking the whole image pipeline again, this PR makes the smallest complete changes needed to test that theory in GitHub Actions:

- refresh APT indexes right before `stage-vibesensor` installs its package list,
- use `dnsmasq-base` wherever this image/manual-install path previously requested `dnsmasq`,
- and replace the `rg`-based mirror rewrite with a `grep`-based implementation that works on the runner we actually use.

## Main code changes

### 1. Refresh APT indexes in `stage-vibesensor` prerun

`infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template` now runs `apt-get update` in chroot after it retargets any stale Raspbian mirror URLs.

That timing matters. `stage-vibesensor` installs VibeSensor-specific runtime packages later than the upstream base stages, and it was previously assuming the inherited package lists were still sufficient for fresh package resolution. The latest workflow run showed that assumption is not reliable enough for these final package installs. Refreshing APT here gives the `00-packages` step a current index at the exact point it needs one.

I kept this in `prerun.sh` rather than restructuring the stage layout because `prerun.sh` already runs before `00-vibesensor/00-packages`, which makes it the lowest-risk place to refresh the package metadata without renaming substages or adding more template plumbing.

### 2. Switch from `dnsmasq` to `dnsmasq-base`

The build log explicitly said:

> `Package dnsmasq is not available ... However the following packages replace it: dnsmasq-base`

So this PR updates both package-install surfaces to request the replacement package instead of the obsolete/transitional name:

- `infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages`
- `apps/server/scripts/install_pi.sh`

That keeps the prebuilt Pi image path and the manual-on-device install path aligned. It also matches how VibeSensor actually uses the dependency: we need the `dnsmasq` executable for NetworkManager hotspot DNS/DHCP behavior, not a standalone long-lived `dnsmasq` system daemon package contract.

### 3. Remove the hidden `rg` dependency from mirror rewriting

`infra/pi-image/pi-gen/lib/pi_gen_repo.sh` previously used `rg -l` to find upstream files containing the default Raspbian mirror URL. The weekly runner does not install `rg`, so the helper emitted a shell error during the image build.

This PR replaces that usage with `grep -rlZ`, which is available in the image-build environment already. That keeps the mirror rewrite behavior intact while removing a silent toolchain mismatch from the workflow.

## Validation

I ran the local checks that are meaningful in this environment:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py`
- `bash -n apps/server/scripts/install_pi.sh infra/pi-image/pi-gen/lib/pi_gen_repo.sh`
- `make lint`

Local Docker-backed end-to-end Pi image builds are still not available here, so GitHub Actions remains the authoritative validator for this path. That is consistent with the prior weekly-image fixes in this series.

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that this PR deliberately does **not** rename `gpsd`, `libopenblas0-pthread`, or `libopenjp2-7` yet. I investigated those package names far enough to know that blindly renaming them would be speculative: pool artifacts exist for them, but the weekly failure alone does not yet prove the correct replacement name. The safer next step is to first remove the stale-index problem and the clearly obsolete `dnsmasq` contract, then let CI tell us whether those remaining package errors were secondary effects or true additional package-name changes.

That keeps this change reviewable and minimizes churn in the image/install scripts.

## Out of scope / next step

This PR does not change the already-shipped weekly release rotation behavior. Once CI is green, the next action is to merge this PR, rerun `Weekly Pi Image` on `main`, and see whether the build gets past `stage-vibesensor/00-packages` into the artifact-collection and publish steps. If it still fails, the remaining package names will be the next concrete, much narrower follow-up.
