### PR TITLE
fix(pi-image): prefer stable raspbian mirrors

### DIFF
--- a/infra/pi-image/pi-gen/lib/common.sh
+++ b/infra/pi-image/pi-gen/lib/common.sh
@@ -27,12 +27,16 @@ init_pi_gen_env() {
   CLEAN="${CLEAN:-0}"
   RASPBIAN_MIRROR="${RASPBIAN_MIRROR:-}"
   RASPBIAN_MIRROR_FALLBACKS=(
-    "https://archive.raspbian.org/raspbian/"
     "http://raspbian.raspberrypi.com/raspbian/"
     "http://mirror.init7.net/raspbian/raspbian/"
     "http://mirrors.ustc.edu.cn/raspbian/raspbian/"
     "http://ftp.halifax.rwth-aachen.de/raspbian/raspbian/"
     "http://mirror.ox.ac.uk/sites/archive.raspbian.org/archive/raspbian/"
+    # The HTTPS archive endpoint is a useful fallback, but recent GitHub-hosted
+    # runner builds have intermittently hit TLS EOFs while fetching large
+    # package sets from it. Prefer the standard HTTP mirrors first and keep the
+    # archive endpoint as the last resort.
+    "https://archive.raspbian.org/raspbian/"
   )
 
   if [ "${USE_QEMU:-0}" = "1" ]; then


### PR DESCRIPTION
## Summary

This PR fixes the next `Weekly Pi Image` failure that appeared after the earlier bootstrap-keyring repair and the subsequent `stage-vibesensor` package-index/package-name fix. The latest weekly rerun (`23681682513`) no longer failed in stage0 and no longer failed in `stage-vibesensor/00-packages`; it progressed much farther into the image build and then failed during archive downloads from `https://archive.raspbian.org/raspbian/` with repeated TLS EOF errors.

The key point is that the workflow has now advanced through three layers of previously-blocking problems:

- stage0 signature verification is fixed,
- `stage-vibesensor` package resolution is fixed,
- and the next blocker is now a later network fetch failure from the specific mirror we currently prefer first.

That means the current problem is no longer package metadata or bootstrap trust. It is a mirror-selection reliability problem during larger package fetches.

## Problem being solved

The failing run reached deep into the package-install path and then reported:

- `OpenSSL error: error:0A000126:SSL routines::unexpected eof while reading`
- `E: Failed to fetch https://archive.raspbian.org/.../libdebuginfod1t64_0.192-4+rpi1_armhf.deb`
- `E: Failed to fetch https://archive.raspbian.org/.../python3-smbus2_0.4.3-1_armhf.deb`
- `E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`

Those errors happened while the build was using `https://archive.raspbian.org/raspbian/` as its selected Raspbian mirror. That mirror is currently first in our fallback list, so any time it responds successfully to the availability probe it becomes the mirror used for the entire build.

In other words, the workflow was doing exactly what our current configuration told it to do. The problem is that this specific HTTPS endpoint appears to be less reliable than the standard HTTP Raspbian mirrors for large GitHub-hosted runner builds, even though it answers the initial release-probe request successfully.

## Implementation approach

This PR keeps the fix intentionally small and low-risk.

I am **not** changing the keyring repair from `#1823`, because that solved the old `Invalid Release signature` blocker.

I am **not** changing the `stage-vibesensor` APT refresh or `dnsmasq-base` package fix from `#1824`, because that solved the next package-resolution blocker.

Instead, this PR addresses only the new mirror reliability issue by changing the preferred mirror order. The idea is simple:

- prefer the standard HTTP Raspbian mirrors first,
- keep the HTTPS archive endpoint available as a fallback,
- and avoid making it the default mirror when a more stable option is available.

That approach preserves the existing mirror-probing logic and keeps the fix narrowly focused on the newly observed failure mode.

## Main code change

### Reorder `RASPBIAN_MIRROR_FALLBACKS`

`infra/pi-image/pi-gen/lib/common.sh` previously started `RASPBIAN_MIRROR_FALLBACKS` with:

- `https://archive.raspbian.org/raspbian/`

followed by the standard HTTP mirrors.

This PR moves the HTTPS archive endpoint to the end of the fallback list and leaves the standard HTTP mirrors first:

- `http://raspbian.raspberrypi.com/raspbian/`
- `http://mirror.init7.net/raspbian/raspbian/`
- `http://mirrors.ustc.edu.cn/raspbian/raspbian/`
- `http://ftp.halifax.rwth-aachen.de/raspbian/raspbian/`
- `http://mirror.ox.ac.uk/sites/archive.raspbian.org/archive/raspbian/`
- `https://archive.raspbian.org/raspbian/` (last-resort fallback)

I also added an inline comment documenting why the HTTPS archive endpoint is no longer first: GitHub-hosted runner builds have been hitting intermittent TLS EOFs while fetching larger package sets from that endpoint.

This is a pragmatic reliability change, not a trust-model change. APT signature verification still protects package integrity; the transport preference is simply moving back toward the mirrors that appear more stable in this workflow.

## Why this is the right size of fix

It would be easy to overreact here by adding a larger retry framework, custom apt transport knobs, or a more invasive mirror abstraction. I did not do that for three reasons.

First, the failure is already specific enough to justify a targeted mirror-order change.

Second, the repo already has mirror probing and fallback behavior, so the cleanest solution is to tune that existing mechanism rather than bolt on new complexity.

Third, we are still iterating through real failures surfaced by the workflow itself. Small, reviewable, single-purpose fixes have been the safest way to make progress without obscuring which change actually solved which blocker.


One subtle detail worth calling out is that the earlier `#1822` HTTPS preference was a reasonable debugging step when the build was still failing in stage0 and we had not yet proven whether transport or trust material was to blame. Now that the vendored bootstrap keyring has removed the signature-verification blocker, that earlier mirror preference has effectively outlived its usefulness. Reordering the list is therefore also a cleanup step: it aligns the configured default mirror order with the workflow behavior that the last two reruns have demonstrated is actually more reliable.

## Validation

I ran the local checks that are meaningful for this small config-layer change:

- `bash -n infra/pi-image/pi-gen/lib/common.sh`
- `make lint`

As with the earlier weekly-image fixes, local end-to-end image generation is not available in this environment because Docker-backed Pi image builds cannot be run by the current user. So GitHub Actions remains the authoritative integration test for this workflow.

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that this change prefers HTTP mirrors before the HTTPS archive endpoint. That is acceptable here because package integrity is still enforced by APT’s repository signatures; we are not weakening trust verification, only changing which reachable mirror gets used first.

I considered adding retries or `--fix-missing` behavior instead, but that would treat the symptom after the less-reliable endpoint had already been selected. Reordering the fallback list is simpler and better aligned with the observed failure.

I also kept `https://archive.raspbian.org/raspbian/` in the list instead of removing it outright. It remains useful as a last-resort fallback if the standard mirrors are unavailable.

## Out of scope / next step

This PR does not change the previously merged keyring or stage-package fixes. Once CI is green, the next step is to merge it, rerun `Weekly Pi Image` on `main`, and see whether the build finally reaches the release-asset collection, upload, old-release deletion, and publish steps that have never been reached successfully yet.
