### PR TITLE
fix(updates): refresh firmware cache import paths

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -47,9 +47,9 @@ vibesensor-hotspot-config = "vibesensor.cli.hotspot_config:main"
 vibesensor-sim = "vibesensor.adapters.simulator.sim_sender:main"
 vibesensor-ws-smoke = "vibesensor.adapters.simulator.ws_smoke:main"
 vibesensor-config-preflight = "vibesensor.cli.preflight:main"
-vibesensor-fw-refresh = "vibesensor.use_cases.updates.firmware_cache:refresh_cache_cli"
-vibesensor-fw-info = "vibesensor.use_cases.updates.firmware_cache:cache_info_cli"
-vibesensor-release-fetch = "vibesensor.use_cases.updates.release_fetcher:fetch_latest_wheel_cli"
+vibesensor-fw-refresh = "vibesensor.use_cases.updates.firmware.firmware_cache:refresh_cache_cli"
+vibesensor-fw-info = "vibesensor.use_cases.updates.firmware.firmware_cache:cache_info_cli"
+vibesensor-release-fetch = "vibesensor.use_cases.updates.releases.release_fetcher:fetch_latest_wheel_cli"
 
 [tool.setuptools.dynamic]
 version = {attr = "vibesensor._version.__version__"}

--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -202,6 +202,15 @@ def test_smoke_server_pyproject_includes_esptool_for_esp_flash() -> None:
         "Server must expose firmware cache refresh CLI entry point"
     )
     assert "vibesensor-fw-info" in text, "Server must expose firmware cache info CLI entry point"
+    assert "vibesensor.use_cases.updates.firmware.firmware_cache:refresh_cache_cli" in text, (
+        "Firmware cache refresh CLI entry point must target the firmware package module"
+    )
+    assert "vibesensor.use_cases.updates.firmware.firmware_cache:cache_info_cli" in text, (
+        "Firmware cache info CLI entry point must target the firmware package module"
+    )
+    assert "vibesensor.use_cases.updates.releases.release_fetcher:fetch_latest_wheel_cli" in text, (
+        "Server release fetch CLI entry point must target the releases package module"
+    )
 
 
 @pytest.mark.smoke

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -188,7 +188,7 @@ validate_image_artifact() {
   }
 
   if ! run_qemu_chroot /opt/VibeSensor/apps/server/.venv/bin/python -c '
-import vibesensor.use_cases.updates.firmware_cache
+import vibesensor.use_cases.updates.firmware.firmware_cache
 print("FIRMWARE_CACHE_MODULE_OK")
 '; then
     echo "Validation failed: firmware_cache module not importable in target rootfs"


### PR DESCRIPTION
## Summary

This PR fixes the latest `Weekly Pi Image` failure after the bootstrap-keyring, stage-package, and mirror-order fixes. The most recent weekly run (`23682122396`) finally completed the full image build, exported the image artifact, and copied the deploy outputs successfully. The failure no longer occurred during `debootstrap`, no longer occurred during `stage-vibesensor/00-packages`, and no longer occurred while fetching packages from the preferred Raspbian mirror.

Instead, the run now fails in the post-build validation step with a stale Python import path:

- the image build finishes,
- the exported `.zip` image artifact exists,
- the validator mounts the rootfs and starts its import checks,
- then it raises `ModuleNotFoundError: No module named 'vibesensor.use_cases.updates.firmware_cache'`.

That means the remaining blocker is no longer an external image-build/environment issue. It is a repo-owned packaging/validation bug caused by updater module paths moving during the updater-package refactor while some consumers still point at the old locations.

## Problem being solved

The run log showed three especially useful signals:

1. `Build finished`
2. the deploy directory contained `image_2026-03-28-vibesensor-rpi3a-plus-trixie-lite-vibesensor-lite.zip`
3. validation then failed with:
   - `ModuleNotFoundError: No module named 'vibesensor.use_cases.updates.firmware_cache'`
   - `Validation failed: firmware_cache module not importable in target rootfs`

When I traced those strings in the repository, I found that the old updater module path still exists in two important places:

- `apps/server/pyproject.toml` console-script entry points
- `infra/pi-image/pi-gen/lib/image_validation.sh`

While inspecting the entry points, I also found that `vibesensor-release-fetch` still points at the pre-refactor path `vibesensor.use_cases.updates.release_fetcher`, even though the code now lives under `vibesensor.use_cases.updates.releases.release_fetcher`.

So the current issue is broader than a single validator typo. The packaging surface itself was partly left behind when the updater modules were split into the `firmware/` and `releases/` subpackages.

## Implementation approach

This PR keeps the fix tightly scoped to the stale import-path surface that the latest weekly run exposed.

I am not touching the image-build mechanics again here. The previous sequence of fixes already proved that the build can now:

- bootstrap successfully,
- install the stage-specific packages,
- get through the mirror/download path,
- and export the image artifact.

The correct next step is therefore to update the broken references so the built image validates against the *current* updater package layout rather than a removed module layout.

I also added a smoke assertion so this exact class of regression becomes much harder to reintroduce the next time the updater package is reorganized.

## Main code changes

### 1. Refresh updater CLI entry points in `pyproject.toml`

`apps/server/pyproject.toml` now points the console scripts at the live refactored module locations:

- `vibesensor-fw-refresh` → `vibesensor.use_cases.updates.firmware.firmware_cache:refresh_cache_cli`
- `vibesensor-fw-info` → `vibesensor.use_cases.updates.firmware.firmware_cache:cache_info_cli`
- `vibesensor-release-fetch` → `vibesensor.use_cases.updates.releases.release_fetcher:fetch_latest_wheel_cli`

This is the real product-facing fix. Those entry points are how the image build and runtime tooling invoke the updater helpers, so leaving them on dead module paths means the generated environment can ship broken CLIs even if the underlying package code is present.

### 2. Update the Pi image validator import check

`infra/pi-image/pi-gen/lib/image_validation.sh` now imports the firmware cache module from its refactored location under `vibesensor.use_cases.updates.firmware.firmware_cache`.

That brings the validator in line with the current package structure and with the updated console-script entry points. It also means the validator is once again testing the thing we actually ship, instead of failing on a deleted compatibility path.

### 3. Add a targeted smoke guard for packaging drift

`apps/server/tests/hygiene/test_ai_smoke.py` now checks that `pyproject.toml` contains the current updater entry-point targets, not just the CLI names.

Previously the smoke test only asserted that strings like `vibesensor-fw-refresh` and `vibesensor-fw-info` existed somewhere in the file. That was too weak to catch a refactor that preserved the command names but left them wired to dead modules. The new assertions close that gap for both firmware-cache CLIs and the server release-fetch CLI.

## Why this fix matters

This is the first weekly-image failure in the current sequence that is clearly a pure repository regression rather than a build-environment or upstream dependency problem. That makes it especially worth fixing precisely.

If we had only patched the validator import and ignored `pyproject.toml`, the weekly image might have passed validation while still shipping broken updater console scripts. That would have been a false success. Conversely, if we had only updated the entry points and not the validator, the image would still fail in CI even though the runtime was healthier.

Updating both surfaces together is the smallest change that is actually complete.

## Validation

I ran the local checks that matter for this packaging/validator fix:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py`
- `bash -n infra/pi-image/pi-gen/lib/image_validation.sh`
- `make lint`

As before, the weekly GitHub Actions workflow remains the authoritative end-to-end validator for the full Pi image path because this environment cannot run the Docker-backed image build locally.

## Risks, tradeoffs, and edge cases considered

This PR does not add backward-compatibility shims for the old module paths. That is intentional and consistent with the repo’s current no-compatibility guidance for this package family. The updater code already lives in the nested `firmware/` and `releases/` modules, so the safest fix is to update callers and packaging metadata directly.

I also considered whether the `ModuleNotFoundError` could be a symptom of something wrong with the built wheel contents rather than the import path itself. The repository search made that much less likely: the old paths were still hardcoded in the exact packaging and validation surfaces involved in the failure, which is the simplest and strongest explanation.

## Out of scope / next step

This PR does not change the earlier image-build fixes that got us to this point. Once CI is green, the next action is to merge it, rerun `Weekly Pi Image` on `main`, and see whether the workflow finally clears validation and reaches the asset upload, old-release deletion, and GitHub Release publication steps.
