### PR TITLE
fix(pi-image): align ssh host-key validation

### DIFF
--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -336,11 +336,8 @@ echo "SSHD_FIRST_BOOT_READINESS_OK"
     exit 1
   fi
 
-  if [ ! -L "${ROOT_MNT}/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service" ]; then
-    echo "Validation failed: regenerate_ssh_host_keys.service is not enabled"
-    exit 1
-  fi
-
+  # The supported contract is ssh.service enablement plus the drop-in below.
+  # Trixie no longer guarantees a standalone regenerate_ssh_host_keys symlink.
   if [ ! -f "${ROOT_MNT}/etc/systemd/system/ssh.service.d/10-vibesensor-hostkeys.conf" ]; then
     echo "Validation failed: missing ssh host-key bootstrap drop-in"
     exit 1


### PR DESCRIPTION
## Summary

This PR fixes the next `Weekly Pi Image` blocker uncovered after `#1826`. The previous run (`23682122396`) failed because the validator still imported the old updater module path. PR `#1826` corrected the updater console-script targets and the validator import, and that change worked: the next weekly rerun (`23682948899`) completed the full image build again, got past the old `firmware_cache` `ModuleNotFoundError`, and then failed later in rootfs validation with a new, narrower SSH assertion:

- `Build finished`
- image artifact created successfully
- rootfs validation advanced beyond the updater import smoke
- failure became `Validation failed: regenerate_ssh_host_keys.service is not enabled`

That is good progress. It shows the updater import-path bug was genuinely fixed and the pipeline is now failing later on a separate validation assumption.

## Problem being solved

The repository’s stated SSH first-boot contract is not “the image must enable a specific `regenerate_ssh_host_keys.service` symlink.” The supported contract is more behavioral and is already documented in the Pi image README:

- `openssh-server` is present
- `ssh.service` is enabled
- host keys are intentionally absent from the baked image
- a systemd drop-in generates host keys before `sshd` starts so each device gets unique keys on first boot

That is also what the image customization code implements in `infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template`:

- it writes `99-vibesensor-password-auth.conf`
- it writes `etc/systemd/system/ssh.service.d/10-vibesensor-hostkeys.conf`
- the drop-in includes `ExecStartPre=/bin/sh -c 'if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then /usr/bin/ssh-keygen -A; fi'`

So the actual runtime guarantee is that `ssh.service` can come up on first boot even when host keys are absent. The validator already exercises that directly a few lines earlier by removing host keys in the mounted rootfs, running `ssh-keygen -A` when none are present, and checking `sshd -t` in the ARM chroot smoke block.

The failure came from an additional validator assumption that the standalone `regenerate_ssh_host_keys.service` symlink must also be enabled under `multi-user.target.wants`. That assumption is stronger than the documented contract and stronger than what the current image customization actually requires.

## Implementation approach

This PR intentionally does not add more first-boot SSH wiring to the image. The image already has the supported mechanism:

- `ssh.service` enabled
- SSH password-auth drop-in present
- host-key bootstrap drop-in present
- first-boot `sshd` readiness smoke already passing under the validator’s ARM chroot

Because that behavior is already in place, the smallest correct fix is to remove the over-strict validation check rather than teach the image to satisfy an unnecessary additional symlink expectation.

That keeps the validation aligned with the contract we actually depend on and avoids adding extra systemd coupling just to placate a stale assertion.

## Main code change

### `infra/pi-image/pi-gen/lib/image_validation.sh`

I removed the block that failed the build when `multi-user.target.wants/regenerate_ssh_host_keys.service` was not a symlink inside the target rootfs.

In its place, I left a short explanatory comment documenting the supported contract:

- `ssh.service` must be enabled
- the `10-vibesensor-hostkeys.conf` drop-in must exist
- the drop-in remains the supported first-boot host-key generation mechanism
- Trixie should not be assumed to provide a standalone enabled `regenerate_ssh_host_keys` symlink as part of that contract

The validator still keeps the important SSH checks:

- `ssh.service` enablement
- `ssh.service` not masked
- presence of the host-key bootstrap drop-in
- verification that the drop-in actually contains `ssh-keygen -A`
- active first-boot SSH readiness smoke inside the ARM chroot

So this change is not loosening SSH validation broadly. It is removing one assertion that no longer represents the supported behavior, while preserving the behavior-based checks that matter for recovery-oriented first boot.

## Why this is the right fix

I considered two possible approaches:

1. keep the validator as-is and modify the image build to explicitly enable `regenerate_ssh_host_keys.service`
2. align the validator with the image’s actual supported behavior and documented contract

Option 2 is the better fit for this codebase.

The repository already documents the drop-in approach rather than a separate required enabled service. The template already provisions the drop-in. The validator already performs an SSH readiness smoke test that is more meaningful than checking one extra symlink. Requiring the additional symlink would make the image more coupled to distro-specific systemd packaging details without improving the actual SSH recovery guarantee we care about.

In short: the failing assertion was checking packaging shape rather than the supported behavior. This PR moves it back to behavior.

## Validation performed

I ran the local checks relevant to this change:

- `bash -n infra/pi-image/pi-gen/lib/image_validation.sh`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py`
- `make lint`

These all passed.

As with the previous weekly-image fixes, the full Docker-backed Pi image build is not available in this environment, so GitHub Actions remains the authoritative integration test for the end-to-end workflow.

## Risks and tradeoffs

This does relax one specific validation assertion, but only because it was not the behavior we actually guarantee or document. The important SSH safety properties remain checked.

If a future distro image changes SSH packaging again, we should continue preferring behavior-based validation like the existing `sshd` readiness smoke over assumptions about auxiliary unit symlinks. That makes the Pi image validation more resilient across packaging changes while still protecting the actual first-boot recovery path.

## Next step

Once this PR is green, the next step is to merge it and rerun `Weekly Pi Image` on `main` again. If this was the last validator mismatch, the workflow should finally proceed beyond `Build Pi image` into:

- `Collect weekly release assets`
- `Upload weekly image workflow artifact`
- `Delete previous weekly Pi image releases`
- `Publish weekly Pi image release`

That will be the first true end-to-end confirmation that both the image build and the single-rolling-release behavior are working together.
