### PR TITLE
fix(pi-image): avoid python crypt in validation

### DIFF
--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -113,6 +113,10 @@ _BUILD_WRAPPER_CHECKS: list[tuple[str, str]] = [
         "Validation failed: sshd first-boot readiness test failed",
         "build wrapper must validate sshd first-boot readiness",
     ),
+    (
+        "Validation failed: first user password hash does not match VS_FIRST_USER_PASS",
+        "build wrapper must validate the configured first user password hash",
+    ),
 ]
 
 

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -355,13 +355,11 @@ echo "SSHD_FIRST_BOOT_READINESS_OK"
     exit 1
   fi
 
-  if ! python3 - "${VS_FIRST_USER_PASS}" "${SHADOW_HASH}" <<'PY'
-import crypt
-import sys
-plain = sys.argv[1]
-shadow_hash = sys.argv[2]
-sys.exit(0 if crypt.crypt(plain, shadow_hash) == shadow_hash else 1)
-PY
+  require_cmd perl
+  if ! perl -e '
+my ($plain, $shadow_hash) = @ARGV;
+exit(crypt($plain, $shadow_hash) eq $shadow_hash ? 0 : 1);
+' "${VS_FIRST_USER_PASS}" "${SHADOW_HASH}"
   then
     echo "Validation failed: first user password hash does not match VS_FIRST_USER_PASS"
     exit 1


### PR DESCRIPTION
## Summary

This PR fixes the next `Weekly Pi Image` blocker exposed after `#1827`. The prior sequence of weekly-image fixes already got the workflow dramatically farther than where it started:

- stage0 bootstrap now succeeds
- the VibeSensor stage package installs succeed
- the image build completes successfully
- the updater module-path validation failure is fixed by `#1826`
- the over-strict SSH host-key enablement assertion is fixed by `#1827`

The latest rerun after `#1827` was `23683661316`. That run again completed the full image build and advanced deeper into post-build validation. The failure was no longer about updater imports and no longer about `regenerate_ssh_host_keys.service`. Instead, the validator itself crashed while checking that the configured first user password hash matched `VS_FIRST_USER_PASS`:

- `Build finished`
- rootfs validation progressed through the earlier checks
- then raised `ModuleNotFoundError: No module named 'crypt'`
- and reported `Validation failed: first user password hash does not match VS_FIRST_USER_PASS`

That means the current bug is in the validator’s host-side implementation, not in the generated image contents.

## Problem being solved

`infra/pi-image/pi-gen/lib/image_validation.sh` verifies that the generated shadow entry for the default first user corresponds to the configured plaintext password. That is a good check and should remain in place.

However, the validator implemented that comparison using Python’s `crypt` module:

```sh
python3 - ...
import crypt
...
```

That stopped working once we aligned the weekly-image workflow with newer Python. The `crypt` module has been removed from modern Python, so the validation code now fails before it can even compare the password hash. In other words, the check is conceptually valid but implemented using a runtime dependency that no longer exists in the environment we intentionally moved to.

So the correct fix is not to weaken or delete the password validation. The correct fix is to keep validating the password hash, but use a stable toolchain surface that still exposes `crypt(3)` behavior.

## Implementation approach

This PR keeps the password-hash validation behavior intact and swaps out only the implementation detail that became incompatible with the Python version in the workflow.

I chose Perl for the hash verification step because:

- it is already present in the GitHub-hosted Linux environment we use for the image build
- its `crypt()` support is backed by the system libc / libcrypt behavior rather than the removed Python stdlib wrapper
- it lets us validate the exact same shadow hash formats without changing the generated image or the password policy
- it keeps the fix extremely small and localized to the validator

I also added a hygiene smoke assertion so this password-validation path is explicitly covered in repository checks instead of being an untested tail branch inside the image validator.

## Main code changes

### 1. Replace the removed Python `crypt` dependency in `image_validation.sh`

In `infra/pi-image/pi-gen/lib/image_validation.sh`, the old inline Python snippet has been replaced with a Perl-based comparison:

- call `require_cmd perl`
- run a tiny `perl -e` snippet
- compare `crypt($plain, $shadow_hash)` to the stored shadow hash

The failure message remains the same:

- `Validation failed: first user password hash does not match VS_FIRST_USER_PASS`

That preserves the validator’s behavior and error contract while removing the dependency on a deleted Python module.

### 2. Add hygiene coverage for the password-hash validation path

In `apps/server/tests/hygiene/test_ai_smoke.py`, I added a build-wrapper smoke assertion for:

- `Validation failed: first user password hash does not match VS_FIRST_USER_PASS`

This fits the existing style of the file, which already checks for other important image-validation requirements by asserting that key guard strings remain present in the shared pi-gen source text.

That does not fully unit test the Perl snippet, but it does ensure the password-hash validation branch remains part of the wrapper/validator contract and does not quietly disappear during future refactors.

## Why this is the right fix

I considered three possible responses to the failure:

1. remove the password-hash validation entirely
2. try to keep using Python and vendor or install a replacement crypt implementation
3. keep the validation and move it to a tool that still exposes `crypt()` reliably

Option 3 is the best fit.

Removing the check would throw away a useful validation step at the exact moment the pipeline is getting close to green. Adding an extra Python dependency just for one comparison would be unnecessary complexity in a build path that has already required a lot of stabilization work. Using Perl keeps the implementation tiny, host-local, and compatible with the system hashing support already used by shadow passwords.

This is also consistent with the larger weekly-image repair strategy so far: fix each real blocker at the narrowest correct layer rather than adding broad workarounds.

## Validation performed

I ran the local checks relevant to this change:

- `bash -n infra/pi-image/pi-gen/lib/image_validation.sh`
- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_ai_smoke.py`
- `make lint`

All of them passed.

As with the rest of the weekly-image work, GitHub Actions remains the authoritative end-to-end test for the actual image build and publish flow because the Docker-backed Pi image build is not available in this environment.

## Risks and tradeoffs

This introduces a direct dependency on `perl` in the validation script, but that is a practical host-side dependency rather than a target-image dependency. The script now explicitly checks for it with `require_cmd perl`, so if a future build environment genuinely lacks Perl, the failure mode will be clear instead of surfacing as a Python traceback from a removed module.

The generated image itself is unchanged by this PR. Only the validator logic changes.

## Next step

Once this PR is green, the next move is to merge it, rerun `Weekly Pi Image` on `main`, and watch whether the workflow finally escapes `Build Pi image` and enters:

- `Collect weekly release assets`
- `Upload weekly image workflow artifact`
- `Delete previous weekly Pi image releases`
- `Publish weekly Pi image release`

If it does, that will be the first end-to-end proof that both the image build and the single rolling weekly release behavior are working as intended.
