### PR TITLE
fix(ci): publish weekly image as full release

### DIFF
--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-            --jq '.[] | select(.prerelease and (.tag_name == "weekly-pi-image" or (.tag_name | startswith("pi-image-v")))) | .tag_name' \
+            --jq '.[] | select(.tag_name == "weekly-pi-image" or (.tag_name | startswith("pi-image-v"))) | .tag_name' \
             | while IFS= read -r tag; do
                 if [ -n "${tag}" ]; then
                   gh release delete "${tag}" --yes --cleanup-tag
@@ -134,7 +134,8 @@ jobs:
           tag_name: ${{ steps.metadata.outputs.tag }}
           target_commitish: ${{ github.sha }}
           name: ${{ steps.metadata.outputs.release_name }}
-          prerelease: true
+          prerelease: false
+          make_latest: false
           body: |
             Automated weekly Raspberry Pi image snapshot from `main`.
 
@@ -144,7 +145,7 @@ jobs:
             - Flash the image with Raspberry Pi Imager after downloading the release asset.
 
             This workflow reuses `infra/pi-image/pi-gen/build.sh` so the weekly image follows the same supported image-build path as local builds.
-            Before publishing, it deletes the previous weekly Pi image prerelease so the Releases overview only shows the latest Pi image snapshot.
+            Before publishing, it deletes the previous weekly Pi image release so the Releases overview only shows the latest Pi image snapshot.
           files: |
             ${{ steps.assets.outputs.release_dir }}/*
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary

This PR changes the `Weekly Pi Image` workflow so the rolling `weekly-pi-image` entry is published as a full GitHub release instead of a prerelease, while explicitly keeping it out of the repository’s `Latest` slot.

This is a follow-up to the earlier weekly-image stabilization work. We now have a successful end-to-end weekly image build and publish run (`23684347422`), but the published release metadata did not match the intended product behavior: GitHub showed the weekly Pi image as a prerelease. The user asked for that weekly image entry to be a normal release instead.

There is an important subtlety here: changing from prerelease to full release without any other adjustment would let GitHub treat the weekly image as a candidate for the repository’s “Latest” release badge. That would be undesirable because the repository already has a normal server release line, and the rolling weekly Pi image should not displace the current server release from the `Latest` position.

So this PR does two things together:

- publish the weekly Pi image as a full release
- explicitly mark it as **not latest**

I also manually updated the already-published `weekly-pi-image` release on GitHub to match this behavior immediately, without waiting for the next long-running weekly build.

## Problem being solved

Before this change, the weekly workflow used `softprops/action-gh-release@v2` with:

- `prerelease: true`

and its cleanup step only deleted earlier weekly image releases that were themselves marked prereleases:

- `.prerelease and (.tag_name == "weekly-pi-image" or (.tag_name | startswith("pi-image-v")))`

That was consistent with the earlier implementation, but once the user clarified that the weekly image should be a proper release, those two pieces became stale:

1. the publish step was explicitly creating the wrong release type
2. the cleanup step was implicitly assuming that every rolling weekly image entry would stay a prerelease forever

There was also a documentation mismatch inside the release body text, which said the workflow deletes the previous weekly Pi image “prerelease.” If we changed the release type without updating the cleanup filter and body text, the workflow would be internally inconsistent:

- it would create a full release,
- but cleanup would only target prereleases,
- and the published release copy would still describe the old prerelease behavior.

## Implementation approach

This PR keeps the change intentionally small and limited to the weekly image workflow.

I did **not** rerun the full weekly image workflow as part of this follow-up because the user explicitly asked not to do that right now. The long build path was already validated successfully in the immediately preceding work, and the current task is just a release-metadata correction.

Instead, I validated the workflow file locally, ran the repository lint suite, and then manually patched the currently published `weekly-pi-image` release on GitHub so users immediately see the intended release type.

That gives us:

- immediate correction of the already-published weekly image release
- a workflow definition that will keep future weekly runs aligned with that behavior
- no unnecessary re-execution of the long image build pipeline

## Main code changes

### 1. Publish the weekly image as a full release

In `.github/workflows/weekly-pi-image.yml`, the publish step now uses:

- `prerelease: false`

That changes the rolling `weekly-pi-image` entry from a prerelease to a standard release.

### 2. Keep the weekly image out of the `Latest` slot

The same publish step now also sets:

- `make_latest: false`

This is the important safeguard that prevents the weekly Pi image from taking over the repository’s “Latest” badge when it is published as a normal release. The current server release remains the latest release for the repository, while the weekly image still appears as a standard release entry.

### 3. Make cleanup independent of prerelease state

The cleanup step now deletes prior weekly Pi image releases by tag pattern only:

- `weekly-pi-image`
- tags starting with `pi-image-v`

and no longer filters on `.prerelease`.

That matters because once the weekly image is a full release, the previous cleanup filter would no longer match it. Without this update, future runs could leave stale weekly image releases behind.

### 4. Fix the published release copy

The workflow release body text now says:

- “Before publishing, it deletes the previous weekly Pi image release...”

instead of calling it a prerelease.

This keeps the user-facing release page aligned with the actual workflow behavior.

## Manual change applied to the current release

In addition to the repo change, I manually patched the current GitHub release tagged `weekly-pi-image` so the live release immediately reflects the requested behavior.

The manual update changed the release to:

- `prerelease = false`
- `make_latest = false`

and updated the release body text to replace “previous weekly Pi image prerelease” with “previous weekly Pi image release.”

I then verified the live release state:

- `weekly-pi-image` is now a full release
- it is **not** shown as `Latest`
- `server-v2026.3.28.14` remains the repository’s `Latest` release

## Validation performed

I validated the change without rerunning the long weekly build:

- parsed `.github/workflows/weekly-pi-image.yml` with `.venv/bin/python` + `yaml.safe_load`
- ran `make lint`
- queried the live release via `gh api` / `gh release view`
- checked `gh release list --limit 10` to confirm the weekly release is no longer marked pre-release and that the server release still holds the `Latest` badge

## Risks and tradeoffs

The main risk here would have been changing the weekly image to a full release and accidentally making it the repository’s `Latest` release. That is why `make_latest: false` is part of the same change rather than a separate follow-up.

Another subtle risk would have been leaving the cleanup step tied to prerelease-only filtering. That would have caused drift over time as soon as future weekly runs started producing standard releases.

Both of those cases are addressed in this PR.

## Out of scope

This PR does not rerun the full weekly image workflow. That was intentionally skipped per user request. The underlying image build and publish path was already proven in the prior successful weekly run, and this follow-up is limited to release classification and release-page behavior.
