### PR TITLE
fix(ui): align uncertainty settings row

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -399,7 +399,7 @@
                     <div class="subtle" data-i18n="settings.analysis.group.uncertainty_model_help">Use these only when vehicle data is approximate, modified, or worn. Higher uncertainty makes matching more tolerant, but it can lower specificity and confidence.</div>
                   </div>
                 </details>
-                <div class="settings-subgrid">
+                <div class="settings-subgrid settings-subgrid--aligned-labels">
                   <div class="field"><label for="speedUncertaintyInput" data-i18n="settings.speed_uncertainty">Speed Uncertainty (%)</label><input id="speedUncertaintyInput" type="number" step="0.1" /><div id="speedUncertaintyGuidance" class="subtle settings-field-guidance"></div></div>
                   <div class="field"><label for="tireDiameterUncertaintyInput" data-i18n="settings.tire_diameter_uncertainty">Tire Diameter Uncertainty (%)</label><input id="tireDiameterUncertaintyInput" type="number" step="0.1" /><div id="tireDiameterUncertaintyGuidance" class="subtle settings-field-guidance"></div></div>
                   <div class="field"><label for="finalDriveUncertaintyInput" data-i18n="settings.final_drive_uncertainty">Final Drive Uncertainty (%)</label><input id="finalDriveUncertaintyInput" type="number" step="0.1" /><div id="finalDriveUncertaintyGuidance" class="subtle settings-field-guidance"></div></div>

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -1807,6 +1807,12 @@ td.vib-cell[data-severity="l1"] { background: rgba(37, 99, 235, 0.1); }
 .settings-group { border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); padding: var(--space-3); }
 .settings-group h3 { margin: 0 0 var(--space-2); font-size: 0.84rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pill-muted-text); }
 .settings-subgrid { grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); }
+.settings-subgrid--aligned-labels > .field > label {
+  display: flex;
+  align-items: flex-end;
+  min-block-size: calc(2 * 1.35em);
+  line-height: 1.35;
+}
 .settings-field-guidance { min-height: 2.3em; line-height: 1.45; }
 .settings-actions { display: flex; justify-content: flex-end; gap: var(--space-2); flex-wrap: wrap; }
 .settings-actions .btn,

--- a/apps/ui/tests/smoke.settings-alignment.spec.ts
+++ b/apps/ui/tests/smoke.settings-alignment.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+
+import { fulfillJson, installCommonRoutes, installFakeWebSocket, requestPath } from "./smoke.helpers";
+
+const analysisSettingsPayload = {
+  wheel_bandwidth_pct: 5,
+  driveshaft_bandwidth_pct: 5,
+  engine_bandwidth_pct: 5,
+  min_abs_band_hz: 0.5,
+  max_band_half_width_pct: 6,
+  speed_uncertainty_pct: 3,
+  tire_diameter_uncertainty_pct: 4,
+  final_drive_uncertainty_pct: 1,
+  gear_uncertainty_pct: 2,
+};
+
+test("analysis uncertainty inputs stay aligned when the middle label wraps", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      if (requestPath(route).startsWith("/api/settings/cars")) {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/settings/analysis", async (route) => {
+    await fulfillJson(route, analysisSettingsPayload);
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="analysisTab"]').click();
+
+  const speedLabel = page.locator('label[for="speedUncertaintyInput"]');
+  const tireLabel = page.locator('label[for="tireDiameterUncertaintyInput"]');
+  const finalDriveLabel = page.locator('label[for="finalDriveUncertaintyInput"]');
+  await expect(speedLabel).toBeVisible();
+  await expect(tireLabel).toBeVisible();
+  await expect(finalDriveLabel).toBeVisible();
+
+  const [speedLabelBox, tireLabelBox, speedTop, tireTop, finalDriveTop] = await Promise.all([
+    speedLabel.boundingBox(),
+    tireLabel.boundingBox(),
+    page.locator("#speedUncertaintyInput").evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+    page.locator("#tireDiameterUncertaintyInput").evaluate((el) =>
+      Math.round(el.getBoundingClientRect().top),
+    ),
+    page.locator("#finalDriveUncertaintyInput").evaluate((el) =>
+      Math.round(el.getBoundingClientRect().top),
+    ),
+  ]);
+
+  if (!speedLabelBox || !tireLabelBox) {
+    throw new Error("Expected uncertainty labels to have layout boxes");
+  }
+
+  expect(tireLabelBox.height).toBeGreaterThan(speedLabelBox.height);
+  expect(Math.abs(speedTop - tireTop)).toBeLessThanOrEqual(1);
+  expect(Math.abs(finalDriveTop - tireTop)).toBeLessThanOrEqual(1);
+});


### PR DESCRIPTION
Closes #1814

## Summary

This PR fixes the alignment defect in the `Settings > Analysis` view where the first row of the `Uncertainty Model` card loses its visual rhythm when the middle label wraps. At `1280x800` in Chromium, the `Tire Diameter Uncertainty (%)` label wraps to two lines, which made the middle input sit visibly lower than the `Speed Uncertainty (%)` and `Final Drive Uncertainty (%)` inputs on either side.

The fix is intentionally small and targeted. It does not change any analysis logic, saved settings behavior, or API contracts. It only adjusts the layout contract for the affected settings grid so peer fields reserve consistent label space, then adds a focused Playwright smoke test to keep that alignment stable.

## Problem being solved

Issue `#1814` is a visual alignment bug, not a functional settings bug. The GitHub issue body and evidence pack showed a very specific failure mode:

- page: `Settings > Analysis`
- section: `Uncertainty Model`
- viewport: `1280x800`
- browser: Chromium

The visual defect is that the middle label wraps while the side labels stay on one line. Because each field is rendered as a simple vertical stack (`label -> input -> guidance`), the wrapped middle label consumes more height than its neighbors. That extra label height pushes only the middle input downward, so the three inputs no longer share the same visible top edge.

The result is a row that looks mis-stacked even though the controls are supposed to read as a clean three-field group.

## Implementation approach

I first traced the issue from the GitHub ticket into the actual UI surface:

- the `Uncertainty Model` card markup in `apps/ui/index.html`
- the shared settings grid styles in `apps/ui/src/styles/app.css`

The root cause turned out to be shared layout, not feature logic. The uncertainty fields already live in a common `settings-subgrid`, and each field already uses the generic `.field` stack used throughout the settings UI. That meant the right fix was to adjust the layout behavior only for the affected subgrid, not to add any custom JavaScript or special-case behavior in the analysis settings module.

I explicitly avoided broad changes to every settings field row in the app. The issue is narrow, and the safest maintainable fix is to scope the alignment rule to the uncertainty grid that actually exhibits the wrap-driven defect.

## Main code changes

### 1. Add a dedicated alignment modifier to the affected uncertainty grid

In `apps/ui/index.html`, the `Uncertainty Model` grid now uses:

- `settings-subgrid settings-subgrid--aligned-labels`

This adds a specific layout hook to the problematic grid without changing the structure of the other settings sections.

### 2. Reserve consistent label space for peer fields in that grid

In `apps/ui/src/styles/app.css`, I added a scoped rule for the new modifier:

- labels in that grid become flex containers
- their content is bottom-aligned
- a consistent two-line minimum block size is reserved
- the line height is set explicitly for the reserved label space

That means:

- single-line labels still sit naturally
- wrapped labels can grow as needed
- peer fields reserve enough space that the first-row inputs line up visually instead of drifting vertically when only one label wraps

The important detail here is scope. This does not rewrite the generic `.field` component across the app. It only applies to the uncertainty settings grid that needs the extra label-space contract.

### 3. Add a focused regression test at the issue viewport

I added `apps/ui/tests/smoke.settings-alignment.spec.ts`.

The test uses the existing smoke helpers and the same smoke Playwright project that already runs at `1280x800`. It:

- loads the `Settings > Analysis` tab
- seeds analysis settings data for the uncertainty fields
- confirms the middle tire-diameter label is taller than the speed label (so the wrap condition is actually present)
- asserts that the three first-row uncertainty inputs still share the same top alignment within a tiny tolerance

This is important because a purely visual bug can otherwise reappear quietly during future copy, spacing, or settings-layout changes.

## Validation performed

I validated this change locally with the focused checks that matter for this UI issue:

- `make lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts tests/smoke.settings-alignment.spec.ts tests/smoke.settings.spec.ts --project=laptop-light --workers=1`

The new alignment test initially failed, which was useful: it caught that my first attempt had placed the modifier class on the wrong `settings-subgrid` block (`Order Band Widths` instead of `Uncertainty Model`). After correcting that scoping mistake, the new alignment test passed along with the existing broader analysis/settings smoke suite.

## Broader validation note

Per the repo guidance for frontend changes, I also attempted the broader local Docker-stack validation path. That was blocked by the current environment rather than by the code change:

- this host does not have a working Docker daemon/socket available
- `docker compose` is not installed as a plugin here
- the legacy `docker-compose` client is present, but cannot connect to `/var/run/docker.sock`

Because of that environment constraint, I could not complete the local compose-up + simulator validation step for this issue. I am calling that out explicitly rather than silently skipping it. The focused frontend build and Playwright validation above did complete successfully, and CI will provide the remaining cross-environment coverage on the PR.

## Risks and tradeoffs

The main tradeoff was whether to fix this with a global `.field` rule or a scoped modifier. I chose the scoped modifier because it is safer:

- it addresses the reported defect directly
- it avoids accidental spacing shifts in unrelated settings forms
- it keeps the fix easy to reason about if future UI copy changes again

The label-space rule currently reserves a two-line minimum for that grid. That is the smallest layout contract that resolves the reported wrap scenario without over-designing the entire settings system.

## Out of scope

This PR does not address the separate open UI alignment issue `#1815` about the `Manage Cars` action buttons. That issue remains in the backlog and will be handled only after `#1814` is fully merged or blocked, consistent with the one-issue-at-a-time run rules.
