### PR TITLE
fix(ui): align manage cars actions

### DIFF
--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -1945,7 +1945,7 @@ td.vib-cell[data-severity="l1"] { background: rgba(37, 99, 235, 0.1); }
 .car-list-table .car-active-pill { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; }
 .car-active-pill.active { background: var(--pill-ok-bg); color: var(--pill-ok-text); }
 .car-active-pill.inactive { background: var(--pill-muted-bg); color: var(--pill-muted-text); }
-.car-list-actions { display: flex; gap: var(--space-1); flex-wrap: wrap; }
+.car-list-actions { display: flex; gap: var(--space-1); flex-wrap: wrap; justify-content: flex-end; }
 .car-list-actions .btn { padding: 4px 12px; font-size: 0.82rem; }
 
 /* Add car wizard */

--- a/apps/ui/tests/smoke.settings-alignment.spec.ts
+++ b/apps/ui/tests/smoke.settings-alignment.spec.ts
@@ -63,3 +63,49 @@ test("analysis uncertainty inputs stay aligned when the middle label wraps", asy
   expect(Math.abs(speedTop - tireTop)).toBeLessThanOrEqual(1);
   expect(Math.abs(finalDriveTop - tireTop)).toBeLessThanOrEqual(1);
 });
+
+test("manage cars delete button stays in the same visible column across rows", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      if (requestPath(route).startsWith("/api/settings/cars")) {
+        await fulfillJson(route, {
+          cars: [
+            { id: "car-1", name: "Active Car", type: "sedan", aspects: {} },
+            { id: "car-2", name: "Inactive Car", type: "suv", aspects: {} },
+          ],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+
+  const activeRow = page.locator('#carListBody tr[data-car-id="car-1"]');
+  const inactiveRow = page.locator('#carListBody tr[data-car-id="car-2"]');
+  const activeDeleteButton = activeRow.locator(".car-delete-btn");
+  const inactiveDeleteButton = inactiveRow.locator(".car-delete-btn");
+
+  await expect(activeDeleteButton).toBeVisible();
+  await expect(inactiveDeleteButton).toBeVisible();
+  await expect(activeRow.locator(".car-activate-btn")).toHaveCount(0);
+  await expect(inactiveRow.locator(".car-activate-btn")).toHaveCount(1);
+
+  const [activeDeleteRight, inactiveDeleteRight] = await Promise.all([
+    activeDeleteButton.evaluate((el) => {
+      const { right } = el.getBoundingClientRect();
+      return Math.round(right);
+    }),
+    inactiveDeleteButton.evaluate((el) => {
+      const { right } = el.getBoundingClientRect();
+      return Math.round(right);
+    }),
+  ]);
+
+  expect(Math.abs(activeDeleteRight - inactiveDeleteRight)).toBeLessThanOrEqual(1);
+});


### PR DESCRIPTION
Closes #1815

## Summary

This PR fixes the visual alignment defect in the `Settings > Car` view where the `Delete` action shifts columns between car rows. In the current table, inactive rows render `Activate` followed by `Delete`, so the delete button appears in the right action slot. The active row omits `Activate`, leaving `Delete` as the only button in the cell, and that causes it to sit in the left slot instead. The result is a table whose action column no longer reads as a stable repeated pattern.

The fix is intentionally small. It keeps the existing car-list markup and action behavior intact, and it only adjusts the action-cell layout contract so the shared button row is anchored to the right edge. I also added a focused Playwright regression that exercises the exact audit scenario from the issue and verifies that the delete buttons keep the same visible column across active and inactive rows.

## Problem being solved

Issue `#1815` came from the screenshot-based UI alignment audit and is strictly about visible layout consistency, not about action semantics. The GitHub issue body and evidence pack captured a specific, reproducible defect:

- page: `Settings > Car`
- section: `Manage Cars` table
- viewport: `1280x800`
- browser: Chromium

What looks wrong in the issue screenshots is not that any action is missing or mislabeled. It is that the action column stops behaving like a repeated table pattern. One row places `Delete` where the right-hand action belongs, while the active row places `Delete` where the left-hand action belongs. That makes the delete affordance jump horizontally from row to row, which is especially noticeable because the table otherwise has consistent columns and repeated structure.

Done” for this issue therefore means the delete action should occupy a consistent visible column across rows, and the action area should keep a stable right edge whether or not the row has an `Activate` button.

## Root cause and implementation approach

I traced the defect into the actual car-list rendering and styling rather than treating it as a generic table-spacing problem.

The relevant markup lives in `apps/ui/src/app/views/settings_car_list_view.ts`. Each row renders its actions like this:

- inactive row: `Activate` + `Delete`
- active row: only `Delete`

That behavior is intentional. The active car should not offer an `Activate` action for itself. The bug comes from how those actions are laid out, not from which buttons exist.

The relevant CSS lives in `apps/ui/src/styles/app.css`. The action cell uses a shared `.car-list-actions` flex container with a gap and wrapping, but no explicit horizontal alignment. With default flex behavior, a row that contains only `Delete` starts at the left edge of the action cell. A row that contains both `Activate` and `Delete` naturally places `Delete` to the right of `Activate`. That is why the delete button appears to drift between columns even though the underlying table structure is unchanged.

I chose the narrowest maintainable fix surface: keep the existing markup exactly as-is and right-align the `.car-list-actions` container with `justify-content: flex-end;`.

That approach has a few advantages:

- it preserves the current semantics of active vs inactive rows
- it avoids adding fake placeholders, hidden buttons, or row-specific markup branches
- it addresses the visual issue directly at the layout layer where it originates
- it keeps the change tightly scoped to the car-list action cell instead of broadening the behavior of other button rows across the app

## Main code changes

### 1. Right-align the Manage Cars action row

In `apps/ui/src/styles/app.css`, `.car-list-actions` now includes `justify-content: flex-end;`.

This keeps the action group anchored to the right edge of the cell in all cases:

- inactive rows still render `Activate` followed by `Delete`
- active rows still render only `Delete`
- the delete button now lands in the same visible right-hand slot across both cases

No markup changes were needed, and no button order or behavior changed.

### 2. Add a focused alignment regression

I extended `apps/ui/tests/smoke.settings-alignment.spec.ts` with a second alignment test targeted at the issue conditions.

The new test:

- sets the viewport to `1280x800`
- seeds one active car row and one inactive car row through the existing settings route helpers
- opens `Settings > Car`
- confirms the active row has no `Activate` button while the inactive row does
- measures the right edge of each row’s `Delete` button
- asserts those right edges match within a 1px tolerance

That test captures the actual visual contract from the issue rather than just checking that buttons exist. It also fits naturally in the existing `smoke.settings-alignment.spec.ts` file, which already covers other screenshot-audit alignment regressions.

## Validation performed

I validated the change locally with the relevant repository checks for this UI issue:

- `make lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts tests/smoke.settings-alignment.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`

These all passed.

The targeted Playwright run is important here because it covers both the new alignment assertion and the existing car-settings behavior tests. That gives confidence that the CSS adjustment fixes the visual defect without disturbing the car-tab guidance and selection behavior already covered in `smoke.cars.spec.ts`.

## Broader validation note

As with the previous UI issue, I also kept the broader frontend validation requirement in mind. In this environment, the local Docker-stack path remains blocked because the host does not currently expose a working Docker daemon/socket. I am explicitly documenting that rather than silently skipping it.

So for this PR:

- targeted local lint/typecheck/build/Playwright validation completed successfully
- broader local compose-up + simulator validation remains environment-blocked
- PR CI will provide the remaining cross-environment coverage

## Risks and tradeoffs

The main decision here was whether to solve the issue with layout CSS or with additional row-specific markup. I chose the CSS route because it is simpler and more maintainable.

Adding placeholders or hidden inactive controls would make the DOM harder to reason about and would encode a layout concern into the markup. By contrast, `justify-content: flex-end;` expresses the real design intent directly: the action group should be right-aligned regardless of how many actions are present in a given row.

The blast radius is low because `.car-list-actions` is a specific class for this table’s action cells. The change does not touch generic button styles, shared table layout rules, or other action rows elsewhere in the UI.

## Out of scope

This PR does not change any car activation or deletion behavior, and it does not alter the broader settings layout beyond the action-column alignment reported in `#1815`.

If this merges green, it should also complete the currently known open GitHub issue backlog for this run.
