### PR TITLE
[codex] fix ota updater and hotspot diagnostics

### DIFF
--- a/apps/server/scripts/hotspot_nmcli.sh
+++ b/apps/server/scripts/hotspot_nmcli.sh
@@ -16,6 +16,8 @@ run_as_root() {
 LOG_DIR=/var/log/wifi
 install -d -m 0755 "${LOG_DIR}"
 LOG_FILE="${LOG_DIR}/hotspot.log"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 touch "${LOG_FILE}"
 
@@ -117,10 +119,35 @@ ${final_status}
 EOF
 }
 
-trap 'rc=$?; failed_line=${BASH_LINENO[0]:-0}; failed_cmd=${BASH_COMMAND:-unknown}; echo "ERROR rc=${rc} line=${failed_line} cmd=${failed_cmd}"; dump_all error; write_summary FAILED "${rc}"; exit "${rc}"' ERR
+resolve_hotspot_config_cli() {
+  local configured_cli="${VIBESENSOR_HOTSPOT_CONFIG_CLI:-}"
+  local bundled_cli="${SERVER_DIR}/.venv/bin/vibesensor-hotspot-config"
+
+  if [ -n "${configured_cli}" ] && [ -x "${configured_cli}" ]; then
+    printf '%s\n' "${configured_cli}"
+    return 0
+  fi
+  if [ -x "${bundled_cli}" ]; then
+    printf '%s\n' "${bundled_cli}"
+    return 0
+  fi
+  if command -v vibesensor-hotspot-config >/dev/null 2>&1; then
+    command -v vibesensor-hotspot-config
+    return 0
+  fi
+  return 1
+}
+
+trap 'rc=$?; failed_line=${BASH_LINENO[0]:-0}; failed_cmd=${BASH_COMMAND:-unknown}; echo "ERROR rc=${rc} line=${failed_line} cmd=${failed_cmd}" >&2; dump_all error; write_summary FAILED "${rc}"; exit "${rc}"' ERR
 trap 'rc=$?; echo "EXIT rc=${rc}"' EXIT
 
-eval "$(vibesensor-hotspot-config "${CONFIG_PATH}")"
+if ! HOTSPOT_CONFIG_CLI="$(resolve_hotspot_config_cli)"; then
+  echo "Could not find vibesensor-hotspot-config. Expected ${SERVER_DIR}/.venv/bin/vibesensor-hotspot-config or a PATH entry." >&2
+  exit 127
+fi
+
+HOTSPOT_CONFIG_EXPORTS="$("${HOTSPOT_CONFIG_CLI}" "${CONFIG_PATH}")"
+eval "${HOTSPOT_CONFIG_EXPORTS}"
 
 CONFIGURED_IFNAME="${IFNAME}"
 DETECTED_IFNAME=""

--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -90,6 +90,25 @@ def test_smoke_hotspot_script_has_no_runtime_apt_get(hotspot_script_text: str) -
     )
 
 
+@pytest.mark.smoke
+def test_smoke_hotspot_script_prefers_repo_venv_hotspot_config_cli(
+    hotspot_script_text: str,
+) -> None:
+    assert ".venv/bin/vibesensor-hotspot-config" in hotspot_script_text, (
+        "hotspot script must resolve hotspot config from the bundled server venv"
+    )
+    assert 'HOTSPOT_CONFIG_EXPORTS="$("${HOTSPOT_CONFIG_CLI}" "${CONFIG_PATH}")"' in (
+        hotspot_script_text
+    ), "hotspot script must capture config CLI output before eval"
+
+
+@pytest.mark.smoke
+def test_smoke_hotspot_script_err_trap_logs_to_stderr(hotspot_script_text: str) -> None:
+    assert 'echo "ERROR rc=${rc} line=${failed_line} cmd=${failed_cmd}" >&2' in (
+        hotspot_script_text
+    ), "ERR trap output must go to stderr so eval command substitutions stay clean"
+
+
 # ---------------------------------------------------------------------------
 # Build wrapper (parametrized for per-check failure isolation)
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
+++ b/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
@@ -143,7 +143,7 @@ def setup_update_env(
 ) -> tuple[UpdateManager, FakeRunner, Path]:
     runner = FakeRunner()
     if sudo_ok:
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
     repo = tmp_path / "repo"
     repo.mkdir()
     kwargs: dict[str, object] = {

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -160,6 +160,19 @@ async def test_snapshot_for_rollback_builds_local_wheel_before_package_index_dow
 
 
 @pytest.mark.asyncio
+async def test_snapshot_for_rollback_accepts_normalized_dev_versions(tmp_path: Path) -> None:
+    installer, commands, _tracker = _make_installer(tmp_path)
+    commands.local_wheel_version = "0.0.0.dev0"
+
+    with patch("vibesensor.__version__", "0.0.0-dev"):
+        assert await installer.snapshot_for_rollback() is True
+
+    calls = [" ".join(call[0]) for call in commands.calls]
+    assert any("pip wheel" in call for call in calls)
+    assert not any("pip download" in call for call in calls)
+
+
+@pytest.mark.asyncio
 async def test_snapshot_for_rollback_falls_back_to_package_index_download(
     tmp_path: Path,
 ) -> None:

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -86,7 +86,7 @@ class TestUpdateManagerAsync:
 
     async def test_no_sudo_fails_gracefully(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path, sudo_ok=False, rollback=False)
-        runner.set_response("sudo -n true", 1, "", "sudo: a password is required")
+        runner.set_response("python3 -c pass", 1, "", "sudo: a password is required")
         with (
             patch("shutil.which", mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),

--- a/apps/server/tests/use_cases/updates/test_update_manager_core.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_core.py
@@ -57,7 +57,7 @@ class TestUpdateManager:
             return await original_run(args, timeout=timeout, env=env)
 
         runner.run = slow_run
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
         with patch("shutil.which", mock_which):
@@ -86,7 +86,7 @@ class TestUpdateManager:
             return await original_run(args, timeout=timeout, env=env)
 
         runner.run = slow_run
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
         with patch("shutil.which", mock_which):
@@ -98,7 +98,7 @@ class TestUpdateManager:
     @pytest.mark.asyncio
     async def test_status_to_payload_never_leaks_password(self) -> None:
         runner = FakeRunner()
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
         with patch("shutil.which", mock_which):
@@ -110,7 +110,7 @@ class TestUpdateManager:
     @pytest.mark.asyncio
     async def test_start_sets_ssid_and_timestamps(self) -> None:
         runner = FakeRunner()
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
         before = time.time()

--- a/apps/server/tests/use_cases/updates/test_update_manager_models.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_models.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+
+import vibesensor.use_cases.updates.runner as update_runner
 from vibesensor.use_cases.updates.models import (
     UpdateIssue,
     UpdateJobStatus,
@@ -89,3 +92,41 @@ class TestSanitizeLogLine:
     def test_normal_line_unchanged(self) -> None:
         line = "Hotspot restored on attempt 1"
         assert sanitize_log_line(line) == line
+
+
+class TestSudoWrapperDiscovery:
+    def test_sudo_prefix_uses_explicit_wrapper_override(self, monkeypatch, tmp_path) -> None:
+        wrapper = tmp_path / "custom-wrapper.sh"
+        wrapper.write_text("#!/usr/bin/env bash\n")
+        wrapper.chmod(0o755)
+
+        monkeypatch.setattr(update_runner.os, "geteuid", lambda: 1000)
+        monkeypatch.setenv("VIBESENSOR_UPDATE_SUDO_WRAPPER", os.fspath(wrapper))
+        monkeypatch.delenv("VIBESENSOR_REPO_PATH", raising=False)
+        monkeypatch.setattr(update_runner, "_DEFAULT_INSTALL_REPO", tmp_path / "missing-install")
+        monkeypatch.setattr(
+            update_runner,
+            "_SOURCE_TREE_WRAPPER_SCRIPT",
+            tmp_path / "missing-source-wrapper.sh",
+        )
+
+        assert update_runner._sudo_prefix() == ["sudo", "-n", os.fspath(wrapper)]
+
+    def test_sudo_prefix_uses_packaged_install_layout(self, monkeypatch, tmp_path) -> None:
+        repo_root = tmp_path / "repo"
+        wrapper = repo_root / "apps" / "server" / "scripts" / "vibesensor_update_sudo.sh"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/usr/bin/env bash\n")
+        wrapper.chmod(0o755)
+
+        monkeypatch.setattr(update_runner.os, "geteuid", lambda: 1000)
+        monkeypatch.delenv("VIBESENSOR_UPDATE_SUDO_WRAPPER", raising=False)
+        monkeypatch.delenv("VIBESENSOR_REPO_PATH", raising=False)
+        monkeypatch.setattr(update_runner, "_DEFAULT_INSTALL_REPO", repo_root)
+        monkeypatch.setattr(
+            update_runner,
+            "_SOURCE_TREE_WRAPPER_SCRIPT",
+            tmp_path / "missing-source-wrapper.sh",
+        )
+
+        assert update_runner._sudo_prefix() == ["sudo", "-n", os.fspath(wrapper)]

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -242,7 +242,7 @@ class TestNoSecretsInPersistedFile:
     async def test_password_not_in_persisted_json(self, update_env) -> None:
         """Wi-Fi password must never appear in the persisted status file."""
         state_path, _, runner, make_mgr = update_env
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
         mgr = make_mgr()
 
         secret_password = "SuperSecret!WiFi#Password42"
@@ -411,7 +411,7 @@ class TestPersistenceDuringLifecycle:
     async def test_state_persisted_on_start(self, update_env) -> None:
         """Calling start() persists the initial running status."""
         _, store, runner, make_mgr = update_env
-        runner.set_response("sudo -n true", 0)
+        runner.set_response("python3 -c pass", 0)
         runner.set_response("nmcli", 1, "", "not available")
         mgr = make_mgr()
 
@@ -430,7 +430,7 @@ class TestPersistenceDuringLifecycle:
     async def test_state_persisted_after_job_ends(self, update_env) -> None:
         """After the update job finishes, the final state is persisted."""
         _, store, runner, make_mgr = update_env
-        runner.set_response("sudo -n true", 1, "", "no sudo")
+        runner.set_response("python3 -c pass", 1, "", "no sudo")
         mgr = make_mgr()
 
         with (

--- a/apps/server/vibesensor/use_cases/updates/artifact_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/artifact_validation.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.updates.status import UpdateStatusTracker
@@ -73,6 +74,15 @@ def read_wheel_metadata(wheel_path: Path) -> WheelMetadata:
         return _parse_metadata_message(_metadata_message_from_archive(wheel_zip))
 
 
+def _versions_match(actual_version: str, expected_version: str) -> bool:
+    """Compare versions with PEP 440 normalization when possible."""
+
+    try:
+        return Version(actual_version) == Version(expected_version)
+    except InvalidVersion:
+        return actual_version == expected_version
+
+
 def wheel_metadata_validation_errors(
     wheel_path: Path,
     *,
@@ -94,7 +104,7 @@ def wheel_metadata_validation_errors(
         )
     if not metadata.version:
         errors.append("wheel metadata is missing Version")
-    elif expected_version and metadata.version != expected_version:
+    elif expected_version and not _versions_match(metadata.version, expected_version):
         errors.append(
             "wheel metadata Version "
             f"{metadata.version!r} does not match expected {expected_version!r}",

--- a/apps/server/vibesensor/use_cases/updates/runner.py
+++ b/apps/server/vibesensor/use_cases/updates/runner.py
@@ -15,25 +15,57 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-__all__ = ["CommandRunner", "UpdateCommandExecutor", "sanitize_log_line"]
+__all__ = [
+    "CommandRunner",
+    "UpdateCommandExecutor",
+    "build_privilege_probe_args",
+    "sanitize_log_line",
+]
 
 # ---------------------------------------------------------------------------
 # sudo wrapper helpers
 # ---------------------------------------------------------------------------
 
-_WRAPPER_SCRIPT = (
+_SOURCE_TREE_WRAPPER_SCRIPT = (
     Path(__file__).resolve().parent.parent.parent / "scripts" / "vibesensor_update_sudo.sh"
 )
+_DEFAULT_INSTALL_REPO = Path("/opt/VibeSensor")
+
+
+def _sudo_wrapper_path() -> Path | None:
+    """Return the first installed wrapper path that exists on disk."""
+
+    configured_wrapper = os.environ.get("VIBESENSOR_UPDATE_SUDO_WRAPPER", "").strip()
+    configured_repo = os.environ.get("VIBESENSOR_REPO_PATH", "").strip()
+    candidate_paths = [
+        Path(configured_wrapper) if configured_wrapper else None,
+        (
+            Path(configured_repo) / "apps" / "server" / "scripts" / "vibesensor_update_sudo.sh"
+            if configured_repo
+            else None
+        ),
+        _DEFAULT_INSTALL_REPO / "apps" / "server" / "scripts" / "vibesensor_update_sudo.sh",
+        _SOURCE_TREE_WRAPPER_SCRIPT,
+    ]
+    for candidate in candidate_paths:
+        if candidate is not None and candidate.is_file():
+            return candidate
+    return None
 
 
 def _sudo_prefix() -> list[str]:
     """Return the sudo prefix for privileged commands."""
     if os.geteuid() == 0:
         return []
-    wrapper = _WRAPPER_SCRIPT
-    if wrapper.is_file():
-        return ["sudo", str(wrapper)]
-    return ["sudo"]
+    wrapper = _sudo_wrapper_path()
+    if wrapper is not None:
+        return ["sudo", "-n", str(wrapper)]
+    return ["sudo", "-n"]
+
+
+def build_privilege_probe_args() -> list[str]:
+    """Return a harmless command that exercises the updater's sudo path."""
+    return ["python3", "-c", "pass"]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/vibesensor/use_cases/updates/validation.py
+++ b/apps/server/vibesensor/use_cases/updates/validation.py
@@ -8,7 +8,10 @@ import tempfile
 from pathlib import Path
 
 from vibesensor.use_cases.updates.models import UpdateValidationConfig
-from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.runner import (
+    UpdateCommandExecutor,
+    build_privilege_probe_args,
+)
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 MIN_FREE_DISK_BYTES = 200 * 1024 * 1024
@@ -57,17 +60,17 @@ async def validate_prerequisites(
 
     if os.geteuid() != 0:
         rc, _, _ = await commands.run(
-            ["sudo", "-n", "true"],
+            build_privilege_probe_args(),
             phase="validating",
             timeout=5,
-            sudo=False,
+            sudo=True,
         )
         if rc != 0:
             tracker.fail(
                 "validating",
                 "Insufficient privileges",
-                "Cannot run sudo non-interactively. In dev/Docker "
-                "environments, hotspot management is not available.",
+                "Cannot run updater privileged commands non-interactively. "
+                "In dev/Docker environments, hotspot management is not available.",
             )
             return False
 


### PR DESCRIPTION
## What changed

- fixed updater privilege probing to use the same restricted sudo wrapper path as the real OTA workflow, including packaged Pi installs
- normalized rollback wheel version comparison so dev builds like `0.0.0-dev` and wheel metadata `0.0.0.dev0` no longer block snapshot creation
- hardened `hotspot_nmcli.sh` to resolve `vibesensor-hotspot-config` from the bundled venv, capture its output before `eval`, and keep ERR-trap output on stderr
- added regression coverage for packaged sudo wrapper discovery, normalized dev rollback versions, and hotspot script launcher assumptions

## Why

The Pi update flow was failing before or during install for three independent reasons:

1. the validation step checked plain `sudo -n true`, but the image only grants non-interactive sudo through the restricted updater wrapper
2. packaged installs could not discover that wrapper because the code only looked in the source-tree layout
3. rollback snapshot validation rejected locally built dev wheels because setuptools normalizes `0.0.0-dev` to `0.0.0.dev0`

Separately, hotspot diagnostics were attaching noisy false failures because `hotspot_nmcli.sh` relied on `PATH` for `vibesensor-hotspot-config`, and an ERR trap inside command substitution could leak `ERROR ...` back into `eval`.

## Impact

- OTA updates on the Pi now complete successfully with the restricted sudo setup shipped in the image
- rollback snapshots work for dev-versioned builds instead of aborting the install
- hotspot diagnostics stop producing the bogus `ERROR: command not found` warning path when the bundled CLI is present

## Validation

- `bash -n apps/server/scripts/hotspot_nmcli.sh`
- `pytest -q apps/server/tests/adapters/hotspot/test_hotspot_config_cli.py apps/server/tests/hygiene/test_ai_smoke.py`
- `pytest -q apps/server/tests/use_cases/updates`
- exercised the full OTA update flow live on the Pi at `10.4.0.1`; update reached `state=success`, restored the hotspot, and reported runtime version `2026.3.28.17`
