### PR TITLE
[codex] Fix feed freshness cadence handling

### DIFF
--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -278,11 +278,23 @@ def test_build_ws_payload_returns_required_keys() -> None:
 
 
 def test_build_ws_payload_light_tick_omits_only_spectra() -> None:
-    state = _make_state(clients=_TWO_CLIENTS, ws_include_heavy=False)
+    state = _make_state(
+        clients=[
+            {
+                "id": "aaaaaaaaaaaa",
+                "name": "front-left",
+                "sample_rate_hz": 400,
+                "frame_samples": 200,
+            },
+        ],
+        ws_include_heavy=False,
+    )
     payload = state.ws_broadcast.build_payload(selected_client="aaaaaaaaaaaa")
 
     assert "spectra" not in payload
     assert payload["selected_client_id"] == "aaaaaaaaaaaa"
+    assert payload["clients"][0]["frame_samples"] == 200
+    assert "latest_metrics" not in payload["clients"][0]
 
 
 def test_build_ws_payload_auto_selects_first_client() -> None:

--- a/apps/server/tests/integration/test_refactor_contract_regressions.py
+++ b/apps/server/tests/integration/test_refactor_contract_regressions.py
@@ -295,6 +295,20 @@ class TestClientApiRow:
         )
         assert set(rows[0].keys()) == set(helper_row.keys())
 
+    def test_lightweight_row_keeps_frame_samples_without_metrics(self) -> None:
+        row = build_client_api_row(
+            ClientSnapshot(
+                client_id="aabbccddeeff",
+                name="sensor",
+                connected=True,
+                sample_rate_hz=400,
+                frame_samples=200,
+            ),
+            include_metrics=False,
+        )
+        assert row["frame_samples"] == 200
+        assert "latest_metrics" not in row
+
 
 # ---------------------------------------------------------------------------
 # Fix 8: Version comparison warning

--- a/apps/server/vibesensor/infra/runtime/client_snapshot.py
+++ b/apps/server/vibesensor/infra/runtime/client_snapshot.py
@@ -53,9 +53,9 @@ def build_client_api_row(
         "last_seen_age_ms": snapshot.last_seen_age_ms,
         "frames_total": snapshot.frames_total,
         "dropped_frames": snapshot.dropped_frames,
+        "frame_samples": snapshot.frame_samples,
     }
     if include_metrics:
-        row["frame_samples"] = snapshot.frame_samples
         row["latest_metrics"] = (
             snapshot.latest_metrics if snapshot.latest_metrics is not None else ClientMetrics()
         )

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -79,8 +79,10 @@ class ClientApiRow(TypedDict, total=True):
     last_seen_age_ms: int | None
     frames_total: int
     dropped_frames: int
-    # API-only fields — omitted in lightweight WebSocket snapshots:
+    # Light enough for both HTTP and WebSocket snapshots, but still optional for
+    # compatibility with older payload producers.
     frame_samples: NotRequired[int]
+    # API-only fields — omitted in lightweight WebSocket snapshots:
     latest_metrics: NotRequired[ClientMetrics]
     reset_count: NotRequired[int]
     last_reset_time: NotRequired[float | None]

--- a/apps/ui/src/app/features/data_freshness.ts
+++ b/apps/ui/src/app/features/data_freshness.ts
@@ -1,0 +1,58 @@
+export interface FreshnessClient {
+  sample_rate_hz?: number | null;
+  frame_samples?: number | null;
+}
+
+const LEGACY_FRESH_THRESHOLD_MS = 250;
+const LEGACY_DELAYED_THRESHOLD_MS = 1000;
+const FRESH_CADENCE_MULTIPLIER = 1.25;
+const DELAYED_CADENCE_MULTIPLIER = 2.5;
+
+export function deriveDataFreshnessThresholds(
+  clients: readonly FreshnessClient[],
+): { freshMs: number; delayedMs: number } {
+  let slowestCadenceMs = 0;
+  for (const client of clients) {
+    const sampleRateHz = Number(client.sample_rate_hz);
+    const frameSamples = Number(client.frame_samples);
+    if (
+      !Number.isFinite(sampleRateHz) ||
+      !Number.isFinite(frameSamples) ||
+      sampleRateHz <= 0 ||
+      frameSamples <= 0
+    ) {
+      continue;
+    }
+    slowestCadenceMs = Math.max(slowestCadenceMs, (frameSamples * 1000) / sampleRateHz);
+  }
+  if (slowestCadenceMs <= 0) {
+    return {
+      freshMs: LEGACY_FRESH_THRESHOLD_MS,
+      delayedMs: LEGACY_DELAYED_THRESHOLD_MS,
+    };
+  }
+  return {
+    freshMs: Math.max(
+      LEGACY_FRESH_THRESHOLD_MS,
+      Math.ceil(slowestCadenceMs * FRESH_CADENCE_MULTIPLIER),
+    ),
+    delayedMs: Math.max(
+      LEGACY_DELAYED_THRESHOLD_MS,
+      Math.ceil(slowestCadenceMs * DELAYED_CADENCE_MULTIPLIER),
+    ),
+  };
+}
+
+export function classifyDataFreshness(
+  ageMs: number,
+  clients: readonly FreshnessClient[],
+): "fresh" | "delayed" | "stale" {
+  const { freshMs, delayedMs } = deriveDataFreshnessThresholds(clients);
+  if (ageMs <= freshMs) {
+    return "fresh";
+  }
+  if (ageMs <= delayedMs) {
+    return "delayed";
+  }
+  return "stale";
+}

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -21,6 +21,7 @@ import {
   renderRealtimeSensorTable,
 } from "../views/realtime_sensor_table_view";
 import { createPollingController } from "./polling_controller";
+import { classifyDataFreshness } from "./data_freshness";
 
 export interface RealtimeFeatureDeps extends FeatureDepsBase {
   realtime: RealtimeState;
@@ -163,7 +164,8 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
   }
 
   function dataFreshnessText(): string {
-    const ages = connectedClients()
+    const connected = connectedClients();
+    const ages = connected
       .map((client) => client.last_seen_age_ms)
       .filter((age): age is number => typeof age === "number" && Number.isFinite(age));
     if (!ages.length) {
@@ -171,10 +173,11 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     }
     const ageMs = Math.max(...ages.map((age) => Math.max(0, age)));
     const ageText = t("status.age_ms_ago", { value: formatInt(ageMs) });
-    if (ageMs <= 250) {
+    const freshness = classifyDataFreshness(ageMs, connected);
+    if (freshness === "fresh") {
       return t("dashboard.data_freshness_fresh", { age: ageText });
     }
-    if (ageMs <= 1000) {
+    if (freshness === "delayed") {
       return t("dashboard.data_freshness_delayed", { age: ageText });
     }
     return t("dashboard.data_freshness_stale", { age: ageText });

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -19,6 +19,7 @@ export type AdaptedClient = Pick<
   | "last_seen_age_ms"
   | "dropped_frames"
   | "frames_total"
+  | "frame_samples"
   | "sample_rate_hz"
   | "firmware_version"
 >;

--- a/apps/ui/tests/realtime_feature_freshness.spec.ts
+++ b/apps/ui/tests/realtime_feature_freshness.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  classifyDataFreshness,
+  deriveDataFreshnessThresholds,
+} from "../src/app/features/data_freshness";
+
+function makeClient(overrides: Partial<{ sample_rate_hz: number; frame_samples: number }> = {}) {
+  return {
+    sample_rate_hz: 800,
+    frame_samples: 200,
+    ...overrides,
+  };
+}
+
+test.describe("realtime freshness thresholds", () => {
+  test("falls back to legacy thresholds when cadence metadata is missing", () => {
+    expect(deriveDataFreshnessThresholds([makeClient({ frame_samples: 0 })])).toEqual({
+      freshMs: 250,
+      delayedMs: 1000,
+    });
+  });
+
+  test("treats a healthy 400 Hz / 200-sample sensor as fresh across one frame cadence", () => {
+    const clients = [makeClient({ sample_rate_hz: 400, frame_samples: 200 })];
+
+    expect(deriveDataFreshnessThresholds(clients)).toEqual({
+      freshMs: 625,
+      delayedMs: 1250,
+    });
+    expect(classifyDataFreshness(503, clients)).toBe("fresh");
+    expect(classifyDataFreshness(900, clients)).toBe("delayed");
+    expect(classifyDataFreshness(1300, clients)).toBe("stale");
+  });
+});


### PR DESCRIPTION
## What changed
- made the dashboard classify feed freshness from live sensor cadence instead of fixed 250 ms / 1000 ms thresholds
- carried `frame_samples` through the UI payload model and into the realtime freshness calculation
- kept `frame_samples` in lightweight WebSocket client rows so live updates have the cadence metadata the UI needs
- added backend and UI regressions for the lightweight WS payload and the 400 Hz / 200-sample freshness case

## Why it changed
A newly flashed sensor was streaming 200-sample frames at 400 Hz, which means healthy frames arrive about every 500 ms. The dashboard was still using a hardcoded 250 ms `fresh` threshold, so it kept flipping between fresh and delayed even when the feed was healthy.

## Impact
- the live feed freshness card now stays `Fresh` for healthy 400 Hz / 200-sample sensors
- lightweight WS payloads still avoid heavy metrics, but they now retain the frame cadence metadata the UI relies on

## Root cause
This was a two-part mismatch:
1. the UI used fixed freshness thresholds that assumed much faster frame cadence
2. the backend omitted `frame_samples` from lightweight WebSocket snapshots, so the UI could not derive the real cadence during live updates

## Validation
- `pytest -q apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/integration/test_refactor_contract_regressions.py`
- `cd apps/ui && npx -y node@22 ../../tools/config/sync_shared_contracts_to_ui.mjs --check`
- `cd apps/ui && npx -y node@22 ./node_modules/typescript/bin/tsc --noEmit`
- `cd apps/ui && npx -y node@22 ./node_modules/@playwright/test/cli.js test tests/realtime_feature_freshness.spec.ts tests/ui_live_payload_application.spec.ts --config <temp config>`
- live verification on the Pi at `http://10.4.0.1`: WS payload included `frame_samples: 200` and the `Feed freshness` label stayed `Fresh` across 20 samples up to 466 ms age
