### PR TITLE
fix(ci): use supported gh api release calls

### DIFF
--- a/apps/server/tests/hygiene/test_publish_github_release.py
+++ b/apps/server/tests/hygiene/test_publish_github_release.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tests._paths import REPO_ROOT
+
+_PUBLISH_RELEASE = REPO_ROOT / "tools" / "publish_github_release.py"
+
+
+def _load_publish_github_release_module():
+    spec = importlib.util.spec_from_file_location(
+        "publish_github_release_local_for_tests",
+        _PUBLISH_RELEASE,
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_PUBLISH_RELEASE}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_existing_release_id_uses_repo_endpoint_without_repo_flag(monkeypatch) -> None:
+    module = _load_publish_github_release_module()
+    commands: list[list[str]] = []
+
+    def _fake_run(command: list[str], *, check: bool = True, capture_output: bool = False):
+        commands.append(list(command))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"id": 123}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    assert module._existing_release_id("owner/repo", "server-v2026.3.28") == 123
+    assert commands == [["gh", "api", "repos/owner/repo/releases/tags/server-v2026.3.28"]]
+
+
+def test_main_creates_release_without_repo_flag_and_uploads_with_repo_flag(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_publish_github_release_module()
+    commands: list[list[str]] = []
+    notes_file = tmp_path / "notes.md"
+    notes_file.write_text("release notes\n", encoding="utf-8")
+    asset_file = tmp_path / "artifact.zip"
+    asset_file.write_text("artifact", encoding="utf-8")
+
+    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag: None)
+
+    def _fake_run(command: list[str], *, check: bool = True, capture_output: bool = False):
+        commands.append(list(command))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    module.main(
+        [
+            "--repo",
+            "owner/repo",
+            "--tag",
+            "server-v2026.3.28",
+            "--target",
+            "abc123",
+            "--title",
+            "Release 2026.3.28",
+            "--notes-file",
+            str(notes_file),
+            "--asset",
+            str(asset_file),
+        ]
+    )
+
+    create_command, upload_command = commands
+    assert create_command[:2] == ["gh", "api"]
+    assert "-R" not in create_command
+    assert "repos/owner/repo/releases" in create_command
+    assert "--method" in create_command
+    assert create_command[create_command.index("--method") + 1] == "POST"
+
+    assert upload_command[:3] == ["gh", "release", "upload"]
+    assert upload_command[-2:] == ["-R", "owner/repo"]
+    assert str(asset_file) in upload_command
+
+
+def test_main_updates_existing_release_without_repo_flag(monkeypatch, tmp_path: Path) -> None:
+    module = _load_publish_github_release_module()
+    commands: list[list[str]] = []
+    notes_file = tmp_path / "notes.md"
+    notes_file.write_text("release notes\n", encoding="utf-8")
+    asset_file = tmp_path / "artifact.zip"
+    asset_file.write_text("artifact", encoding="utf-8")
+
+    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag: 77)
+
+    def _fake_run(command: list[str], *, check: bool = True, capture_output: bool = False):
+        commands.append(list(command))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    module.main(
+        [
+            "--repo",
+            "owner/repo",
+            "--tag",
+            "server-v2026.3.28",
+            "--target",
+            "abc123",
+            "--title",
+            "Release 2026.3.28",
+            "--notes-file",
+            str(notes_file),
+            "--asset",
+            str(asset_file),
+        ]
+    )
+
+    update_command, upload_command = commands
+    assert update_command[:2] == ["gh", "api"]
+    assert "-R" not in update_command
+    assert "repos/owner/repo/releases/77" in update_command
+    assert "--method" in update_command
+    assert update_command[update_command.index("--method") + 1] == "PATCH"
+
+    assert upload_command[:3] == ["gh", "release", "upload"]
+    assert upload_command[-2:] == ["-R", "owner/repo"]

--- a/tools/publish_github_release.py
+++ b/tools/publish_github_release.py
@@ -22,14 +22,16 @@ def _run(
     )
 
 
+def _repo_api_endpoint(repo: str, path: str) -> str:
+    return f"repos/{repo}/{path.lstrip('/')}"
+
+
 def _existing_release_id(repo: str, tag: str) -> int | None:
     result = _run(
         [
             "gh",
             "api",
-            "-R",
-            repo,
-            f"repos/{repo}/releases/tags/{tag}",
+            _repo_api_endpoint(repo, f"releases/tags/{tag}"),
         ],
         check=False,
         capture_output=True,
@@ -114,13 +116,11 @@ def main(argv: list[str] | None = None) -> None:
                 [
                     "gh",
                     "api",
-                    "-R",
-                    args.repo,
                     "--method",
                     "POST",
                     "-H",
                     "Accept: application/vnd.github+json",
-                    f"repos/{args.repo}/releases",
+                    _repo_api_endpoint(args.repo, "releases"),
                     "--input",
                     payload_file,
                 ]
@@ -130,13 +130,11 @@ def main(argv: list[str] | None = None) -> None:
                 [
                     "gh",
                     "api",
-                    "-R",
-                    args.repo,
                     "--method",
                     "PATCH",
                     "-H",
                     "Accept: application/vnd.github+json",
-                    f"repos/{args.repo}/releases/{release_id}",
+                    _repo_api_endpoint(args.repo, f"releases/{release_id}"),
                     "--input",
                     payload_file,
                 ]


### PR DESCRIPTION
## Summary

This PR fixes the current `Main Release` workflow failure on `main` by correcting how `tools/publish_github_release.py` calls the GitHub CLI. The recent release-publisher refactor introduced direct `gh api` usage, but it carried over the `-R` repository flag from `gh release` commands. On the GitHub-hosted runner version in use here, `gh api` does not accept `-R`, so the workflow fails in the `Create combined release` step before the release can be created or updated.

The fix keeps the new Python release-publisher helper in place and patches it at the root cause. The script now uses repository-scoped REST endpoints directly for all `gh api` calls and keeps `-R` only on `gh release upload`, where that flag is supported. I also added focused regression tests that load the tool script directly and verify the create, update, and upload command paths.

## Problem being solved

The breakage is not a flaky Actions problem or an upstream GitHub release outage. It is a deterministic command-construction bug.

I confirmed that by checking the two latest failing `Main Release` runs on live GitHub:

- run `23688000296`
- run `23688247491`

Both failed in the same job and the same step:

- job: `release`
- step: `Create combined release`

The failed logs showed the workflow successfully building the UI, server wheel, firmware artifacts, flash manifest, release bundle, and wiki screenshots. The failure happened only when the new helper script attempted to create or update the GitHub release. The runner error was consistent in both runs:

- `unknown shorthand flag: 'R' in -R`
- followed by a Python `CalledProcessError` from `tools/publish_github_release.py`

That made the root cause very clear: the newly added script was invoking `gh api -R ...`, but the installed GH CLI only supports `-R` for some subcommands such as `gh release`, not for `gh api`.

## Implementation approach

I kept the recent architectural direction rather than reverting back to the old action-based release creation path. The repository already introduced `tools/publish_github_release.py` so release publication logic could be expressed directly and reused across workflows. That direction is still reasonable; the bug was in the exact CLI invocation, not in the overall design.

So the goal here was to deliver the smallest complete fix that restores `Main Release` behavior while preserving the new helper’s purpose.

The chosen approach was:

1. leave the workflow shape unchanged
2. keep `tools/publish_github_release.py` as the release publisher
3. remove unsupported `-R` usage from all `gh api` calls
4. keep `-R` on `gh release upload`, where it is valid and still useful
5. add focused tests around the helper so this specific CLI mismatch cannot silently return

This avoids a broader workflow rewrite and makes the command compatibility contract explicit in test coverage.

## Main code changes

### 1. Fix repository endpoint handling in `tools/publish_github_release.py`

The script now uses a small `_repo_api_endpoint()` helper to construct GitHub REST endpoints in the form:

- `repos/OWNER/REPO/releases`
- `repos/OWNER/REPO/releases/tags/TAG`
- `repos/OWNER/REPO/releases/ID`

That helper is then used in all `gh api` calls.

Concretely, the following paths were corrected:

- `_existing_release_id()`
- the `POST` path for creating a release
- the `PATCH` path for updating an existing release

Before this change, each of those commands passed `-R <repo>` into `gh api`, which caused the live workflow failure.

After this change, the repository is expressed only through the REST endpoint for `gh api`, which is the supported syntax for this CLI behavior.

### 2. Preserve supported `gh release upload` behavior

The script still uses `gh release upload ... -R <repo>` for asset upload. That is intentional.

The bug was not that all GH CLI commands reject `-R`; the problem was that `gh api` rejects it in this runner environment. Keeping `-R` on `gh release upload` preserves the existing upload behavior while fixing only the unsupported subcommand usage.

### 3. Add focused regression coverage for the helper script

I added `apps/server/tests/hygiene/test_publish_github_release.py`.

This test module follows the repo’s existing pattern for testing standalone tool scripts by loading them directly with `importlib.util.spec_from_file_location`. It then stubs the script’s `_run()` helper and verifies actual command construction behavior.

The new tests cover three key cases:

- lookup of an existing release by tag
- create path when no existing release is found
- update path when an existing release id is found

The assertions specifically verify that:

- `gh api` commands do **not** contain `-R`
- `gh api` commands do target the correct `repos/{repo}/...` endpoints
- `gh release upload` still uses `-R`, since that path remains valid

That gives us a direct regression net around the exact failure mode seen in the live `Main Release` logs.

## Validation performed

I validated the fix with the relevant local checks for this workflow/tooling change.

Repository-wide lint/static validation:

- `make lint`

Focused test validation with the repository venv interpreter:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_publish_github_release.py apps/server/tests/hygiene/test_main_release_workflow.py apps/server/tests/use_cases/updates/test_run_release_smoke.py`

That focused pytest slice passed cleanly.

One local environment note: invoking plain `pytest` first failed because this host’s default pytest configuration expects xdist-style addopts that are not available in the bare system interpreter. Running the same targeted suite via `.venv/bin/python` with `-o addopts=''` matched the repo runtime and validated the changed surfaces successfully.

## Risks and tradeoffs

The main tradeoff was whether to revert the new publisher approach entirely or to repair it. I chose repair because the new helper is already wired into the workflows and is also reused by the weekly Pi image release path.

Fixing the command construction is lower risk than reverting workflow behavior again, and it helps both release surfaces stay on the same supported helper.

The blast radius is intentionally small:

- one release helper script changed
- one focused hygiene test module was added
- no application runtime behavior changed
- no release artifact format changed
- no workflow sequencing changed

## Out of scope

This PR does not change release naming, changelog generation, asset selection, or wiki screenshot publication behavior. It only restores compatibility between the release helper and the GH CLI used in CI.

Once this PR is green and merged, the `Main Release` workflow should be able to create/update releases again instead of failing at the final publish step.
