### PR TITLE
fix(ui): redesign history preview heatmap

### DIFF
--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -83,6 +83,13 @@ function metricFromLocationStat(row: LocationIntensityRow): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
+function humanizeHeatmapLocationKey(key: string): string {
+  return key
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 function renderPreviewHeatmap(
   summary: HistoryInsightsPayload,
   params: Pick<HistoryTableViewParams, "escapeHtml" | "fmt" | "t">,
@@ -90,37 +97,80 @@ function renderPreviewHeatmap(
   const { escapeHtml, fmt, t } = params;
   const statsRows = sensorIntensityRows(summary);
   const metricByLocation: Record<string, number> = {};
+  const labelByLocation: Record<string, string> = {};
   for (const row of statsRows) {
     const key = normalizeLogLocationKey(row.location);
     const metric = metricFromLocationStat(row);
+    const label = String(row.location ?? "").trim();
     if (key && typeof metric === "number" && Number.isFinite(metric)) {
       metricByLocation[key] = metric;
+    }
+    if (key && label) {
+      labelByLocation[key] = label;
     }
   }
   const values = Object.values(metricByLocation).filter((value) => typeof value === "number");
   const min = values.length ? Math.min(...values) : null;
   const max = values.length ? Math.max(...values) : null;
   const knownPositionKeys = new Set<string>(HISTORY_HEATMAP_POSITIONS.map((point) => point.key));
-  const unmappedLocationKeys = Object.keys(metricByLocation).filter((key) => !knownPositionKeys.has(key));
-  const dots = HISTORY_HEATMAP_POSITIONS
+  const strongestValue = values.length ? Math.max(...values) : null;
+  const zones = HISTORY_HEATMAP_POSITIONS
     .map((point) => {
       const value = metricByLocation[point.key];
+      const label = labelByLocation[point.key] || humanizeHeatmapLocationKey(point.key);
       const hasValue = typeof value === "number" && Number.isFinite(value);
-      if (!hasValue || min === null || max === null) return "";
+      if (!hasValue || min === null || max === null) {
+        return `
+          <div
+            class="history-heatmap__zone history-heatmap__zone--empty"
+            data-location-key="${escapeHtml(point.key)}"
+            style="grid-area:${point.area}"
+            title="${escapeHtml(label)}"
+          >
+            <div class="history-heatmap__zone-label">${escapeHtml(label)}</div>
+            <div class="history-heatmap__zone-value history-heatmap__zone-value--empty">${escapeHtml(t("report.missing"))}</div>
+            <div class="history-heatmap__zone-meter" aria-hidden="true"></div>
+          </div>
+        `;
+      }
       const norm = normalizeUnit(value, min, max);
       const fill = heatColor(norm);
       const valueLabel = `${fmt(value, 1)} dB`;
-      return `<div class="mini-car-dot" style="top:${point.top}%;left:${point.left}%;background:${fill}" title="${escapeHtml(point.key)}: ${escapeHtml(valueLabel)}"></div>`;
+      const isStrongest = strongestValue !== null && value === strongestValue;
+      return `
+        <div
+          class="history-heatmap__zone${isStrongest ? " history-heatmap__zone--strongest" : ""}"
+          data-location-key="${escapeHtml(point.key)}"
+          style="grid-area:${point.area};--history-heatmap-accent:${fill};--history-heatmap-fill:${Math.round(norm * 100)}%;"
+          title="${escapeHtml(label)}: ${escapeHtml(valueLabel)}"
+        >
+          <div class="history-heatmap__zone-label">${escapeHtml(label)}</div>
+          <div class="history-heatmap__zone-value">${escapeHtml(valueLabel)}</div>
+          <div class="history-heatmap__zone-meter" aria-hidden="true">
+            <span class="history-heatmap__zone-meter-fill"></span>
+          </div>
+        </div>
+      `;
     })
     .join("");
-  const unmappedSummary = unmappedLocationKeys.length
-    ? `<div class="subtle">${escapeHtml(unmappedLocationKeys.join(", "))}</div>`
+  const unmappedSummary = Object.keys(metricByLocation)
+    .filter((key) => !knownPositionKeys.has(key))
+    .map((key) => {
+      const label = labelByLocation[key] || humanizeHeatmapLocationKey(key);
+      const value = metricByLocation[key];
+      return `<div class="history-heatmap__extra-chip">${escapeHtml(label)} · ${escapeHtml(`${fmt(value, 1)} dB`)}</div>`;
+    })
+    .join("");
+  const extrasMarkup = unmappedSummary
+    ? `<div class="history-heatmap__extras">${unmappedSummary}</div>`
     : "";
   return `
-      <div class="mini-car-wrap">
-        <div class="mini-car-title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
-        <div class="mini-car">${dots}</div>
-        ${unmappedSummary}
+      <div class="history-heatmap">
+        <div class="history-heatmap__header">
+          <div class="history-heatmap__title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+        </div>
+        <div class="history-heatmap__grid">${zones}</div>
+        ${extrasMarkup}
       </div>
     `;
 }
@@ -156,16 +206,6 @@ function findingSignatureText(
   }
   const text = String(raw ?? "").trim();
   return text || "--";
-}
-
-function shouldShowNextStep(finding: FindingPayload | null): boolean {
-  if (!finding) {
-    return false;
-  }
-  if (findingTone(finding) === "success") {
-    return true;
-  }
-  return typeof finding.confidence === "number" && Number.isFinite(finding.confidence) && finding.confidence >= 0.85;
 }
 
 function findingLocationText(
@@ -294,9 +334,6 @@ function renderInsightsOverview(
   const signature = findingSignatureText(primary, params);
   const confidence = confidenceText(primary, params);
   const tone = findingTone(primary);
-  const nextStep = shouldShowNextStep(primary) && location !== t("report.missing")
-    ? t("history.findings_next_step", { location })
-    : "";
   return `
       <div class="history-findings-overview">
         <div class="history-findings-overview__header">
@@ -325,9 +362,6 @@ function renderInsightsOverview(
               <strong>${escapeHtml(signature)}</strong>
             </div>
           </div>
-          ${nextStep
-    ? `<div class="history-diagnosis-card__next-step"><span class="history-diagnosis-card__next-step-label">${escapeHtml(t("history.findings_next_step_label"))}</span><strong>${escapeHtml(nextStep)}</strong></div>`
-    : ""}
         </div>
       </div>
     `;
@@ -404,15 +438,19 @@ function renderRunDetailsRow(
   let heatmapMarkup = "";
   if (detail.previewLoading) {
     heatmapMarkup = `
-      <div class="mini-car-wrap">
-        <div class="mini-car-title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+      <div class="history-heatmap">
+        <div class="history-heatmap__header">
+          <div class="history-heatmap__title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+        </div>
         <p class="subtle">${escapeHtml(t("history.loading_preview"))}</p>
       </div>
     `;
   } else if (detail.previewError) {
     heatmapMarkup = `
-      <div class="mini-car-wrap">
-        <div class="mini-car-title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+      <div class="history-heatmap">
+        <div class="history-heatmap__header">
+          <div class="history-heatmap__title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+        </div>
         <p class="history-inline-error">${escapeHtml(detail.previewError)}</p>
       </div>
     `;
@@ -420,8 +458,10 @@ function renderRunDetailsRow(
     heatmapMarkup = renderPreviewHeatmap(summary, params);
   } else {
     heatmapMarkup = `
-      <div class="mini-car-wrap">
-        <div class="mini-car-title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+      <div class="history-heatmap">
+        <div class="history-heatmap__header">
+          <div class="history-heatmap__title">${escapeHtml(t("history.preview_heatmap_title"))}</div>
+        </div>
         <p class="subtle">${escapeHtml(t("history.preview_unavailable"))}</p>
       </div>
     `;

--- a/apps/ui/src/config.ts
+++ b/apps/ui/src/config.ts
@@ -12,12 +12,12 @@ export const SPECTRUM_MIN_RENDER_AMP_G = 1e-6;
 export const SPECTRUM_TWEEN_DURATION_MS = 180;
 
 export const HISTORY_HEATMAP_POSITIONS = [
-  { key: "front-left wheel", top: 23, left: 20 },
-  { key: "front-right wheel", top: 23, left: 80 },
-  { key: "rear-left wheel", top: 76, left: 20 },
-  { key: "rear-right wheel", top: 76, left: 80 },
-  { key: "engine bay", top: 30, left: 50 },
-  { key: "driveshaft tunnel", top: 51, left: 50 },
-  { key: "driver seat", top: 43, left: 40 },
-  { key: "trunk", top: 86, left: 50 },
+  { key: "front-left wheel", area: "front-left" },
+  { key: "front-right wheel", area: "front-right" },
+  { key: "rear-left wheel", area: "rear-left" },
+  { key: "rear-right wheel", area: "rear-right" },
+  { key: "engine bay", area: "engine" },
+  { key: "driveshaft tunnel", area: "driveshaft" },
+  { key: "driver seat", area: "driver" },
+  { key: "trunk", area: "trunk" },
 ] as const;

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -130,8 +130,6 @@
   "history.findings_speed_band": "Speed band",
   "history.findings_confidence": "Confidence",
   "history.findings_signature": "Signature",
-  "history.findings_next_step_label": "Inspect first",
-  "history.findings_next_step": "{location}",
   "history.summary_created": "Created",
   "history.summary_updated": "Updated",
   "history.summary_size": "Duration",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -130,8 +130,6 @@
   "history.findings_speed_band": "Snelheidsband",
   "history.findings_confidence": "Betrouwbaarheid",
   "history.findings_signature": "Signatuur",
-  "history.findings_next_step_label": "Controleer eerst",
-  "history.findings_next_step": "{location}",
   "history.summary_created": "Aangemaakt",
   "history.summary_updated": "Bijgewerkt",
   "history.summary_size": "Duur",

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -1384,33 +1384,112 @@ input:focus-visible,
 .history-evidence-panel {
   min-width: 0;
 }
-.mini-car-wrap { min-width: 0; display: grid; gap: var(--space-2); }
-.mini-car-title {
-  margin-bottom: var(--space-2);
+.history-heatmap {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+.history-heatmap__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.history-heatmap__title {
   font-weight: 600;
   color: var(--muted);
   font-size: 0.82rem;
 }
-.mini-car {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 1 / 1.7;
+.history-heatmap__grid {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-areas:
+    "front-left engine front-right"
+    "driver driveshaft ."
+    "rear-left trunk rear-right";
+}
+.history-heatmap__zone {
+  --history-heatmap-accent: var(--border);
+  --history-heatmap-fill: 0%;
+  display: grid;
+  gap: 0.55rem;
+  align-content: start;
+  min-height: 5.75rem;
+  padding: var(--space-2);
   border: 1px solid var(--border);
-  border-radius: 80px 80px 48px 48px;
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.history-heatmap__zone::before {
+  content: "";
+  display: block;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: var(--history-heatmap-accent);
+}
+.history-heatmap__zone--empty {
   background: var(--surface-2);
-  max-width: 260px;
-  margin: 0 auto;
+  border-style: dashed;
 }
-.mini-car-dot {
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.65);
+.history-heatmap__zone--empty::before {
+  background: var(--border);
+  opacity: 0.7;
 }
-.mini-car-dot--muted { opacity: 0.45; }
+.history-heatmap__zone--strongest {
+  box-shadow:
+    0 0 0 1px var(--history-heatmap-accent),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.history-heatmap__zone-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  line-height: 1.3;
+}
+.history-heatmap__zone-value {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.history-heatmap__zone-value--empty {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+.history-heatmap__zone-meter {
+  height: 0.4rem;
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.history-heatmap__zone-meter-fill {
+  display: block;
+  height: 100%;
+  width: var(--history-heatmap-fill);
+  border-radius: inherit;
+  background: var(--history-heatmap-accent);
+}
+.history-heatmap__extras {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.history-heatmap__extra-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-2);
+  font-size: 0.78rem;
+  color: var(--muted);
+}
 .history-preview-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
 .history-preview-table th,
 .history-preview-table td {
@@ -1530,21 +1609,6 @@ input:focus-visible,
 .history-diagnosis-card__confidence--warn {
   background: #fff3cd;
   color: #8a6d1d;
-}
-.history-diagnosis-card__next-step {
-  display: grid;
-  gap: 0.25rem;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--surface-2);
-}
-.history-diagnosis-card__next-step-label {
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--muted);
 }
 .history-findings-overview__explanation {
   margin: 0;
@@ -1707,8 +1771,13 @@ input:focus-visible,
   .history-results-layout {
     grid-template-columns: 1fr;
   }
-  .mini-car {
-    max-width: 220px;
+  .history-heatmap__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "front-left front-right"
+      "engine driver"
+      "driveshaft trunk"
+      "rear-left rear-right";
   }
 }
 
@@ -2403,11 +2472,6 @@ input[aria-invalid="true"] {
 
   .swatch {
     border-color: rgba(255, 255, 255, 0.15);
-  }
-
-  .mini-car-dot {
-    border-color: rgba(255, 255, 255, 0.2);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
   }
 
   .live-sensor-card__status-dot {

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -353,14 +353,16 @@ test("history list rendering promotes loaded findings ahead of supporting statis
 
   expect(historyTableBody.innerHTML).toContain("history.details_title");
   expect(historyTableBody.innerHTML).toContain("history.primary_diagnosis");
-  expect(historyTableBody.innerHTML).toContain("history.findings_next_step_label");
   expect(historyTableBody.innerHTML).toContain("history-evidence-column");
+  expect(historyTableBody.innerHTML).toContain('data-location-key="front-right wheel"');
+  expect(historyTableBody.innerHTML).toContain("32.0 dB");
   expect(historyTableBody.innerHTML).toContain("Front-right wheel imbalance");
   expect(historyTableBody.innerHTML).toContain("history.findings_signature");
   expect(historyTableBody.innerHTML).not.toContain("history.secondary_candidates_title");
   expect(historyTableBody.innerHTML).not.toContain("history.findings_loaded");
   expect(historyTableBody.innerHTML).not.toContain("Secondary driveline contribution");
   expect(historyTableBody.innerHTML).not.toContain("history.preview_stats_title");
+  expect(historyTableBody.innerHTML).not.toContain("history.findings_next_step_label");
 });
 
 test("history feature preloads collapsed row context for completed runs", async () => {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -151,7 +151,11 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
   await expect(toggle).toHaveAttribute("aria-expanded", "true");
   await expect(page.locator(".history-details-row")).toBeVisible();
   await expect(page.locator(".history-details-header")).toContainText("Diagnostic panel");
-  await expect(page.locator(".mini-car-dot")).toHaveAttribute("title", /20.0 dB$/);
+  const frontLeftZone = page.locator('.history-heatmap__zone[data-location-key="front-left wheel"]');
+  await expect(frontLeftZone).toContainText("Front Left Wheel");
+  await expect(frontLeftZone).toContainText("20.0 dB");
+  await expect(page.locator(".history-heatmap__zone-meter-fill")).toHaveCount(1);
+  await expect(page.locator(".mini-car-dot")).toHaveCount(0);
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
   await expect(page.locator(".history-details-row")).toHaveCount(0);
@@ -264,7 +268,8 @@ test("history loaded insights promote the result summary above supporting eviden
   await expect(page.locator(".history-details-header")).toContainText("Diagnostic panel");
   await expect(page.locator(".history-diagnosis-card")).toContainText("Front-right wheel imbalance");
   await expect(page.locator(".history-diagnosis-card")).toContainText("1x wheel");
-  await expect(page.locator(".history-diagnosis-card")).toContainText("Inspect first");
+  await expect(page.locator(".history-diagnosis-card")).not.toContainText("Inspect first");
+  await expect(page.locator('.history-heatmap__zone[data-location-key="front-right wheel"]')).toContainText("32.0 dB");
   await expect(page.locator(".history-secondary-findings")).toHaveCount(0);
   await expect(page.locator(".history-finding-card--secondary")).toHaveCount(0);
   await expect(page.locator(".history-evidence-column .history-preview-stats")).toHaveCount(0);


### PR DESCRIPTION
## Summary

Fixes #1839 by replacing the history detail view’s sparse placeholder-style preview heatmap with a denser, labeled intensity layout and by removing the separate `Inspect first` row from the diagnosis card.

## Problem

The current history diagnosis experience is doing two things that make the expanded run view read worse than it should.

First, the preview heatmap is technically correct but visually weak. It renders a large gray mini-car silhouette with small absolute-positioned dots, which means most of the panel is empty space. When only one or two locations have data, the result looks unfinished rather than informative. The dots also hide the actual location names and dB values behind hover-only affordances.

Second, the diagnosis card includes a dedicated `Inspect first` row. In the reviewed layout this row did not add meaningful context beyond the already-visible strongest location and instead pulled focus away from the rest of the diagnosis summary. The issue asked for that row to be removed entirely.

The scope here is intentionally narrow: improve the history preview inside the existing diagnosis view and remove the extra next-step row, without redesigning unrelated parts of history, findings loading, or report generation.

## Implementation approach

I kept the existing data source and interpretation logic intact. The history detail view already receives `sensor_intensity_by_location` summary rows and already derives preview values from the dB-oriented fields. Rather than changing payload contracts or introducing a new preview model, this change only reworks how that summary is presented.

The key design choice was to move from a passive silhouette-with-dots model to an explicit location grid. That preserves the issue’s “heatmap preview” idea, but makes every known location visible, keeps the strongest measured zones easy to spot, and exposes intensity values directly in the UI.

## Main code changes

### 1. Reworked the history preview renderer

`apps/ui/src/app/views/history_table_view.ts` is the main logic change.

The preview renderer now builds a labeled grid of heatmap zones from the existing `sensor_intensity_by_location` data. For each known location, it normalizes the location key, keeps the strongest available dB-based metric, preserves the original payload label when available, and renders a visible zone card instead of a tiny positioned dot.

Known locations now show a clear label plus a dB value. Empty known locations remain present as muted placeholders so the layout still communicates spatial context even when the run only has data for one sensor. If a payload includes locations outside the known heatmap layout, those fall back to compact chips below the grid instead of being discarded.

The same renderer also highlights the strongest populated zone, which makes the panel easier to scan without changing any of the underlying diagnosis ranking logic.

I also updated the preview’s loading, error, and unavailable states so they use the same new wrapper structure rather than the removed mini-car markup.

### 2. Removed the diagnosis card’s “Inspect first” row

Still in `history_table_view.ts`, the diagnosis summary no longer computes or renders the extra next-step block. The strongest location already appears in the diagnosis chips, so keeping a second dedicated row for the same concept added noise without new value. Removing it simplifies the card and matches the issue’s requested outcome directly.

Because that UI block is gone, the now-unused locale keys were removed from both `apps/ui/src/i18n/catalogs/en.json` and `nl.json`, keeping the translation files aligned with the live code instead of leaving dead strings behind.

### 3. Replaced the old mini-car styling with a responsive zone-grid layout

`apps/ui/src/styles/app.css` now defines the preview as a grid of intensity cards instead of a tall empty silhouette. The new styling uses a three-column spatial arrangement for desktop widths, switches to a two-column fallback under the existing narrower breakpoint, gives each zone a visible accent bar and fill meter, keeps empty zones readable but subdued, and marks the strongest zone with a stronger outline.

At the same time, I removed the obsolete `mini-car*` rules and the styling for the diagnosis card’s deleted next-step block. This keeps the CSS honest about what the UI actually renders now.

### 4. Updated focused tests around the redesigned history panel

`apps/ui/tests/history_feature_modules.spec.ts` now verifies that rendered history details include the new zone markup and visible dB value, and that the removed `Inspect first` label is absent.

`apps/ui/tests/smoke.history.spec.ts` now checks the actual user-facing behavior in the browser:

- the expanded preview exposes a labeled heatmap zone with a visible dB value
- the old dot-only preview is gone
- the diagnosis card no longer shows `Inspect first`
- the loaded-insights path still keeps the summary above the supporting evidence while exposing the new preview treatment

These changes keep coverage anchored to the exact surfaces affected by the issue.

## Validation

I validated the change locally with:

- `CI=1 npx playwright test tests/history_feature_modules.spec.ts tests/smoke.history.spec.ts --project=laptop-light --workers=1`
- `make lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

One intermediate failure was environmental rather than code-related: Playwright initially reused an older dev server instance, which made the first smoke run exercise stale UI. After killing that specific process and forcing a fresh server run, the updated tests passed against the current branch.

I also retried the repo’s documented Docker-stack validation path. That remains blocked in this environment for the same reasons seen on earlier UI issues:

- `docker compose build --pull && docker compose up -d` fails because this host does not have the Docker Compose plugin
- `docker-compose build --pull && docker-compose up -d` fails because no Docker daemon socket is available

I did not silently skip that step; the blocker should remain documented with the issue run state.

## Risks and tradeoffs considered

The main tradeoff is density versus simplicity. The new grid is visually busier than the old dot silhouette, but that is intentional: the issue specifically called out that the previous preview felt like a placeholder and did not communicate location or intensity clearly enough. I kept the redesign bounded by reusing the existing summary data and leaving the rest of the history findings workflow intact.

I also chose not to invent new translated copy for the preview cards. The existing payload-provided location labels already describe the zones clearly, and using those labels avoids unnecessary i18n churn while still giving users readable location names in the preview itself.

## Out of scope

This change does not alter how history insights are generated, how confidence or findings are ranked, or how PDFs and exports are produced. The work is limited to the expanded history diagnosis presentation requested in #1839.
