### PR TITLE
fix(ui): separate ESP flash scan panels

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -575,19 +575,33 @@
                      </select>
                      <button type="button" id="espFlashRefreshPortsBtn" class="btn btn--muted" data-i18n="settings.esp_flash.refresh_ports">Refresh</button>
                    </div>
-                   <div class="maintenance-note" data-i18n="settings.esp_flash.preflight_note">Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.</div>
-                   <div class="maintenance-action-row">
-                     <button type="button" id="espFlashStartBtn" class="btn btn--success" data-i18n="settings.esp_flash.start">Flash latest</button>
-                     <button type="button" id="espFlashCancelBtn" class="btn btn--danger" data-i18n="settings.esp_flash.cancel" disabled>Cancel</button>
-                   </div>
-                  <div class="maintenance-card__header" style="margin-top:1rem;">
-                    <div>
-                      <div class="maintenance-card__title" data-i18n="settings.esp_flash.current_status_title">Current readiness</div>
+                    <div class="maintenance-note" data-i18n="settings.esp_flash.preflight_note">Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.</div>
+                    <div class="maintenance-action-row">
+                      <button type="button" id="espFlashStartBtn" class="btn btn--success" data-i18n="settings.esp_flash.start">Flash latest</button>
+                      <button type="button" id="espFlashCancelBtn" class="btn btn--danger" data-i18n="settings.esp_flash.cancel" disabled>Cancel</button>
                     </div>
-                    <span id="espFlashStatusBanner" class="pill pill--muted" data-i18n="settings.esp_flash.state.idle">Idle</span>
-                  </div>
-                  <div id="espFlashReadinessPanel" class="maintenance-stack maintenance-stack--tight" aria-live="polite"></div>
                 </section>
+
+                <div class="maintenance-pair-grid">
+                  <section class="maintenance-card">
+                    <div class="maintenance-card__header">
+                      <div>
+                        <div class="maintenance-card__title" data-i18n="settings.esp_flash.current_status_title">Current readiness</div>
+                      </div>
+                      <span id="espFlashStatusBanner" class="pill pill--muted" data-i18n="settings.esp_flash.state.idle">Idle</span>
+                    </div>
+                    <div id="espFlashReadinessPanel" class="maintenance-stack maintenance-stack--tight" aria-live="polite"></div>
+                  </section>
+
+                  <section class="maintenance-card">
+                    <div class="maintenance-card__header">
+                      <div>
+                        <div class="maintenance-card__title" data-i18n="settings.esp_flash.journey_title">Expected stages</div>
+                      </div>
+                    </div>
+                    <div id="espFlashJourneyPanel" class="maintenance-stack maintenance-stack--tight" aria-live="polite"></div>
+                  </section>
+                </div>
 
                 <section class="maintenance-card">
                   <div class="maintenance-card__header">

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -139,7 +139,6 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
       ? `<div class="maintenance-note maintenance-note--bad">${escapeHtml(t(`settings.esp_flash.journey_terminal.${terminalState}`))}</div>`
       : "";
     return `<div class="maintenance-journey">
-      <div class="maintenance-journey__title">${escapeHtml(t("settings.esp_flash.journey_title"))}</div>
       ${terminalNote}
       <ol class="maintenance-stage-list">${items}</ol>
     </div>`;
@@ -225,7 +224,12 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
     const errorHtml = latestStatus.error
       ? `<div class="maintenance-note maintenance-note--bad">${escapeHtml(latestStatus.error)}</div>`
       : "";
-    els.espFlashReadinessPanel.innerHTML = `<div class="subtle">${escapeHtml(readinessSummary(latestStatus))}</div><div class="status-grid">${rows.join("")}</div>${renderJourney(latestStatus)}${errorHtml}`;
+    els.espFlashReadinessPanel.innerHTML = `<div class="subtle">${escapeHtml(readinessSummary(latestStatus))}</div><div class="status-grid">${rows.join("")}</div>${errorHtml}`;
+  }
+
+  function renderJourneyPanel(): void {
+    if (!els.espFlashJourneyPanel || !latestStatus) return;
+    els.espFlashJourneyPanel.innerHTML = renderJourney(latestStatus);
   }
 
   function renderLogsEmptyState(status: EspFlashStatusPayload): string {
@@ -307,6 +311,7 @@ export function createEspFlashFeature(ctx: EspFlashFeatureDeps): EspFlashFeature
     if (els.espFlashPortSelect) els.espFlashPortSelect.disabled = status.state === "running";
     if (status.state !== "running") nextLogIndex = status.log_count || 0;
     renderReadinessPanel();
+    renderJourneyPanel();
   }
 
   async function refreshLogs(status: EspFlashStatusPayload): Promise<void> {

--- a/apps/ui/src/app/ui_dom_registry.ts
+++ b/apps/ui/src/app/ui_dom_registry.ts
@@ -104,6 +104,7 @@ export interface UiDomElements {
   espFlashCancelBtn: HTMLButtonElement | null;
   espFlashStatusBanner: HTMLElement | null;
   espFlashReadinessPanel: HTMLElement | null;
+  espFlashJourneyPanel: HTMLElement | null;
   espFlashLogPanel: HTMLElement | null;
   espFlashHistoryPanel: HTMLElement | null;
   gpsStatusPanel: HTMLElement | null;
@@ -255,6 +256,7 @@ export function createUiDomRegistry(): UiDomElements {
     espFlashCancelBtn: btnEl("espFlashCancelBtn"),
     espFlashStatusBanner: el("espFlashStatusBanner"),
     espFlashReadinessPanel: el("espFlashReadinessPanel"),
+    espFlashJourneyPanel: el("espFlashJourneyPanel"),
     espFlashLogPanel: el("espFlashLogPanel"),
     espFlashHistoryPanel: el("espFlashHistoryPanel"),
     gpsStatusPanel: el("gpsStatusPanel"),

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -411,6 +411,13 @@ input:focus-visible,
   gap: var(--space-3);
 }
 
+.maintenance-pair-grid {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
 .maintenance-stack--tight { gap: var(--space-2); }
 
 .maintenance-card {

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -109,6 +109,7 @@ function createDeps() {
   const espFlashCancelBtn = createButton();
   const espFlashStatusBanner = createPanel();
   const espFlashReadinessPanel = createPanel();
+  const espFlashJourneyPanel = createPanel();
   const espFlashLogPanel = createPanel();
   const espFlashHistoryPanel = createPanel();
 
@@ -123,6 +124,7 @@ function createDeps() {
     espFlashCancelBtn,
     espFlashStatusBanner,
     espFlashReadinessPanel,
+    espFlashJourneyPanel,
     espFlashLogPanel,
     espFlashHistoryPanel,
   } as unknown as UiDomElements;
@@ -132,6 +134,7 @@ function createDeps() {
     espFlashStartBtn,
     espFlashCancelBtn,
     espFlashReadinessPanel,
+    espFlashJourneyPanel,
     t: (key: string) => key,
     escapeHtml: (value: unknown) => String(value ?? ""),
     showError: () => {},
@@ -263,8 +266,9 @@ test.describe("createEspFlashFeature polling", () => {
       expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.readiness.summary.ready_ports");
       expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.readiness.one_port");
       expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.auto_detect");
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.journey_title");
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.phase.validating");
+      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain("settings.esp_flash.journey_title");
+      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain("settings.esp_flash.phase.validating");
+      expect(deps.espFlashJourneyPanel.innerHTML).toContain("settings.esp_flash.phase.validating");
       expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain("settings.esp_flash.logs_idle_title");
       expect((deps.els.espFlashHistoryPanel as HTMLElement).innerHTML).toContain("settings.esp_flash.history_empty_title");
     } finally {
@@ -304,9 +308,9 @@ test.describe("createEspFlashFeature polling", () => {
       feature.startPolling();
       await flushAsyncWork();
 
-      const html = deps.espFlashReadinessPanel.innerHTML;
+      const html = deps.espFlashJourneyPanel.innerHTML;
       expect(html).toMatch(/data-stage-phase="flashing" data-stage-state="active" aria-current="step"/);
-      expect(html).toContain("settings.esp_flash.readiness.current_step");
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.readiness.current_step");
       expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
       expect(html.match(/<span class="maintenance-stage__marker">✓<\/span>/g)).toHaveLength(3);
     } finally {
@@ -357,10 +361,10 @@ test.describe("createEspFlashFeature polling", () => {
       feature.startPolling();
       await flushAsyncWork();
 
-      const html = deps.espFlashReadinessPanel.innerHTML;
+      const html = deps.espFlashJourneyPanel.innerHTML;
       expect(html).toMatch(/data-stage-phase="flashing" data-stage-state="attention"/);
       expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
-      expect(html).toContain("serial port disconnected");
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain("serial port disconnected");
     } finally {
       restoreFetch();
     }

--- a/apps/ui/tests/smoke.esp-flash.spec.ts
+++ b/apps/ui/tests/smoke.esp-flash.spec.ts
@@ -45,16 +45,32 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({ pa
   await page.locator("#espFlashStartBtn").click();
   statusState = "running";
   logCursor = 2;
+  const pairedLayout = await page.evaluate(() => {
+    const readinessCard = document.querySelector("#espFlashReadinessPanel")?.closest(".maintenance-card");
+    const journeyCard = document.querySelector("#espFlashJourneyPanel")?.closest(".maintenance-card");
+    if (!(readinessCard instanceof HTMLElement) || !(journeyCard instanceof HTMLElement)) {
+      return null;
+    }
+    const readinessRect = readinessCard.getBoundingClientRect();
+    const journeyRect = journeyCard.getBoundingClientRect();
+    return {
+      topDelta: Math.abs(readinessRect.top - journeyRect.top),
+      leftDelta: journeyRect.left - readinessRect.left,
+    };
+  });
+  expect(pairedLayout).not.toBeNull();
+  expect(pairedLayout?.topDelta ?? 999).toBeLessThan(8);
+  expect(pairedLayout?.leftDelta ?? 0).toBeGreaterThan(40);
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Running");
   await expect(page.locator("#espFlashReadinessPanel")).toContainText("/dev/ttyUSB0");
-  await expect(page.locator("#espFlashReadinessPanel")).toContainText("Expected stages");
-  await expect(page.locator("#espFlashReadinessPanel")).toContainText("Write firmware");
-  await expect(page.locator('#espFlashReadinessPanel .maintenance-stage[aria-current="step"]')).toHaveAttribute("data-stage-phase", "flashing");
-  await expect(page.locator('#espFlashReadinessPanel .maintenance-stage[data-stage-state="done"]')).toHaveCount(3);
-  await expect(page.locator('#espFlashReadinessPanel .maintenance-stage[data-stage-phase="validating"] .maintenance-stage__marker')).toHaveText("✓");
+  await expect(page.locator("#espFlashReadinessPanel")).not.toContainText("Expected stages");
+  await expect(page.locator("#espFlashJourneyPanel")).toContainText("Write firmware");
+  await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[aria-current="step"]')).toHaveAttribute("data-stage-phase", "flashing");
+  await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[data-stage-state="done"]')).toHaveCount(3);
+  await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[data-stage-phase="validating"] .maintenance-stage__marker')).toHaveText("✓");
   await expect(page.locator("#espFlashLogPanel")).toContainText("erase ok");
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Success");
-  await expect(page.locator('#espFlashReadinessPanel .maintenance-stage[data-stage-state="done"]')).toHaveCount(5);
+  await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[data-stage-state="done"]')).toHaveCount(5);
   await expect(page.locator("#espFlashHistoryPanel")).toContainText("/dev/ttyUSB0");
 });
 
@@ -82,8 +98,8 @@ test("settings esp flash status falls back to idle when API omits state", async 
   await page.locator('[data-settings-tab="espFlashTab"]').click();
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Idle");
   await expect(page.locator("#espFlashReadinessPanel")).toContainText("No serial device is detected yet");
-  await expect(page.locator("#espFlashReadinessPanel")).toContainText("Expected stages");
-  await expect(page.locator("#espFlashReadinessPanel")).toContainText("Validate board and bundle");
+  await expect(page.locator("#espFlashReadinessPanel")).not.toContainText("Expected stages");
+  await expect(page.locator("#espFlashJourneyPanel")).toContainText("Validate board and bundle");
   await expect(page.locator("#espFlashTab")).not.toContainText("Before flashing");
   await expect(page.locator("#espFlashTab")).not.toContainText("What flashing will do");
   await expect(page.locator("#espFlashTab")).not.toContainText("Troubleshooting and recovery");


### PR DESCRIPTION
## Summary

Fixes #1840 by separating the ESP Flash page’s present-state readiness summary from the staged flash journey, then laying those two surfaces out as separate sibling cards that sit side by side when the viewport has enough room.

## Problem

The ESP Flash settings page currently mixes three concerns into one long vertical flow: choosing the target, understanding current readiness, and tracking the expected flash stages. The flash target controls belong in their own setup block, but the readiness section is embedded at the bottom of that same card. On top of that, the feature module renders the `Expected stages` journey inside the readiness panel itself. The result is that “what is true right now?” and “what sequence should I expect?” are visually stacked together inside one tall section.

That structure makes the page harder to scan than it needs to be. Because readiness and journey live in the same rendered surface, the immediate status feels buried and the whole tab reads like one long maintenance note rather than a set of distinct operator checkpoints.

Issue #1840 asked for a targeted UX cleanup: move `Current readiness` into its own dedicated block, place `Current readiness` and `Expected stages` side by side when space allows, and make the screen easier to scan by separating the present-state view from the staged journey.

## Implementation approach

I kept the data contracts, polling behavior, and flash lifecycle logic unchanged. The issue is not about how the Pi determines readiness or stage progress; it is about how those existing surfaces are organized and rendered in the UI.

Because of that, the implementation focuses on structural separation rather than behavior changes: split the DOM into distinct cards, give the journey its own panel in the DOM registry, render readiness and journey independently in the feature module, and prove the new ownership plus desktop side-by-side layout in focused tests. This avoids introducing parallel state, new API calls, or one-off layout hacks.

## Main code changes

### 1. Reworked the ESP Flash tab structure in `index.html`

The most visible change is in `apps/ui/index.html`.

Previously, the `Flash target` card contained the serial-port selector, the flash action buttons, and then the `Current readiness` section at the bottom. The journey content was not represented as its own card at all; it was injected into the readiness panel by the feature module.

Now `Current readiness` and `Expected stages` are sibling cards inside a shared pair grid, while `Flash target`, `Live flash output`, and `Recent attempts` remain their own cards. That gives each scan surface a dedicated heading instead of treating readiness and journey as nested content inside one long block.

### 2. Added a dedicated journey panel to the UI DOM registry

To make the structural split real in code, `apps/ui/src/app/ui_dom_registry.ts` now includes `espFlashJourneyPanel`. Without that, the HTML split would only be cosmetic because the feature would still have a single target element. The ESP Flash unit-test harness was updated in `apps/ui/tests/esp_flash_feature.spec.ts` to provide that additional panel.

### 3. Split readiness rendering from journey rendering

The main behavior change lives in `apps/ui/src/app/features/esp_flash_feature.ts`.

Before this change, `renderReadinessPanel()` built the readiness summary, the status-grid rows, any current error note, and the full journey markup in one HTML string.

Now the feature renders those pieces separately: `renderReadinessPanel()` only handles the readiness summary, status-grid rows, and readiness-scoped error note; `renderJourneyPanel()` writes the stage journey into the new dedicated panel; and `renderStatus()` updates both panels whenever polling returns a new status payload. The journey content itself still uses the same lifecycle logic for active, done, attention, and upcoming stages, so the change improves presentation without changing stage semantics.

I also removed the duplicated journey title from the generated journey markup, because the title is now owned by the card header in the static HTML structure. That keeps the card clean and avoids introducing a second “Expected stages” heading inside the same block.

### 4. Added responsive pair-layout styling

`apps/ui/src/styles/app.css` now includes a reusable `maintenance-pair-grid` layout.

This grid uses `repeat(auto-fit, minmax(280px, 1fr))`, which gives the page the exact behavior the issue asked for:

- when there is enough horizontal room, readiness and journey appear side by side
- when there is not, they collapse into a single-column stack without needing a separate special-case breakpoint

The existing maintenance card styling remains unchanged, so the new layout matches the rest of the settings area instead of introducing a one-off visual system.

### 5. Updated focused tests to lock the new UI contract

The targeted tests were updated instead of introducing a new parallel validation path.

`apps/ui/tests/esp_flash_feature.spec.ts` now verifies that readiness no longer contains journey content and that the stage markup renders into the dedicated journey panel instead. It also keeps the prior behavioral checks around active stage state, completed stages, and error display.

`apps/ui/tests/smoke.esp-flash.spec.ts` now checks the real browser behavior: the readiness panel still shows selected-target and status information, the journey panel owns the stage list and stage markers, the readiness panel no longer contains `Expected stages`, and at the smoke-test desktop viewport the two cards share the same top row with a meaningful left/right separation.

## Validation

I validated the change locally with:

- `CI=1 npx playwright test tests/esp_flash_feature.spec.ts tests/smoke.esp-flash.spec.ts --project=laptop-light --workers=1`
- `make lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

I also retried the repo’s documented Docker validation path for completeness. That remains blocked in this environment for the same reasons seen on the previous UI issues:

- `docker compose build --pull && docker compose up -d` fails because this host does not have the Docker Compose plugin
- `docker-compose build --pull && docker-compose up -d` fails because no Docker daemon socket is available

I did not treat that step as optional; the blocker remains explicitly documented.

## Risks and tradeoffs considered

The main tradeoff here is introducing one more DOM element and one more panel handle to make the separation explicit. I chose that over trying to infer a two-column split inside a single rendered blob, because the latter would keep the feature contract muddled and make the layout more brittle. I also kept the journey content and stage logic intact rather than redesigning the stage component itself.

## Out of scope

This change does not alter serial-port detection, flash start/cancel behavior, polling cadence, history retention, or log streaming. It also does not change the meaning of any ESP Flash lifecycle states or stage transitions. The work is limited to presenting readiness and expected stages as clearer, separate scan surfaces on the ESP Flash settings tab.
