### PR TITLE
fix(ci): scope Wheel / ESP release cleanup

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -293,7 +293,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Create combined release
+      - name: Create combined Wheel / ESP release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -326,7 +326,7 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --tag "${{ steps.version.outputs.tag }}" \
             --target "${GITHUB_SHA}" \
-            --title "Release ${{ steps.version.outputs.version }}" \
+            --title "Wheel / ESP release ${{ steps.version.outputs.version }}" \
             --notes-file "${notes_file}" \
             "${release_args[@]}"
 
@@ -342,14 +342,16 @@ jobs:
             --preserve-existing \
             --commit-message "docs(wiki): refresh screenshots for release ${{ steps.version.outputs.version }}"
 
-      - name: Remove superseded releases
+      - name: Remove superseded Wheel / ESP releases
         uses: actions/github-script@v8
         env:
           CURRENT_TAG: ${{ steps.version.outputs.tag }}
+          WHEEL_ESP_RELEASE_TITLE_PREFIX: Wheel / ESP release
         with:
           script: |
             const currentTag = process.env.CURRENT_TAG;
-            const tagPatterns = [/^server-v/, /^fw-v/];
+            const releaseTitlePrefix = `${process.env.WHEEL_ESP_RELEASE_TITLE_PREFIX} `;
+            const legacyTitlePrefix = "Release ";
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -358,14 +360,22 @@ jobs:
 
             for (const release of releases) {
               const tag = release.tag_name || "";
+              const title = release.name || "";
               if (tag === currentTag) {
                 continue;
               }
-              if (!tagPatterns.some((pattern) => pattern.test(tag))) {
+              if (!tag.startsWith("server-v")) {
+                continue;
+              }
+              if (
+                !title.startsWith(releaseTitlePrefix) &&
+                !title.startsWith(legacyTitlePrefix)
+              ) {
+                core.info(`Skipping ${tag} because it is not a Wheel / ESP release`);
                 continue;
               }
 
-              core.info(`Deleting superseded release ${tag}`);
+              core.info(`Deleting superseded Wheel / ESP release ${tag}`);
               await github.rest.repos.deleteRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/apps/server/tests/hygiene/test_main_release_workflow.py
+++ b/apps/server/tests/hygiene/test_main_release_workflow.py
@@ -43,3 +43,31 @@ def test_main_release_workflow_fetches_full_history_and_validates_release_artifa
     assert _LIVE_MODULE in run_script
     assert "validate-firmware-manifest" in run_script
     assert _STALE_MODULE not in run_script
+
+
+def test_main_release_workflow_labels_and_cleans_only_wheel_esp_releases() -> None:
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "main-release.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    release_job = workflow["jobs"]["release"]
+    steps = release_job["steps"]
+
+    create_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Create combined Wheel / ESP release"
+    )
+    create_script = create_step["run"]
+    assert '--title "Wheel / ESP release ${{ steps.version.outputs.version }}"' in create_script
+
+    cleanup_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Remove superseded Wheel / ESP releases"
+    )
+    assert cleanup_step["env"]["WHEEL_ESP_RELEASE_TITLE_PREFIX"] == "Wheel / ESP release"
+    cleanup_script = cleanup_step["with"]["script"]
+    assert 'tag.startsWith("server-v")' in cleanup_script
+    assert "title.startsWith(releaseTitlePrefix)" in cleanup_script
+    assert "title.startsWith(legacyTitlePrefix)" in cleanup_script
+    assert "weekly-pi-image" not in cleanup_script
+    assert "/^fw-v/" not in cleanup_script


### PR DESCRIPTION
## Summary

This PR tightens the `Main Release` workflow so the combined server wheel + ESP firmware release is explicitly identified as the Wheel / ESP release family and only cleans up prior releases from that same family. The immediate motivation is a release-management regression: the current workflow publishes the combined release with the generic title `Release <version>`, and the user reported that the release automation removed the Pi image release instead of limiting cleanup to the previous Wheel / ESP release. The fix in this branch does two things together so the release family is unmistakable to both humans and automation: it changes the published GitHub release title to `Wheel / ESP release <version>` and narrows the post-publish cleanup logic to older `server-v*` releases that still belong to the Wheel / ESP line.

This keeps the existing release tag contract intact. The release is still published under the `server-v<version>` tag, so downstream consumers that key off the tag name do not have to change. The behavioral adjustment is limited to how the release is labeled in the GitHub UI and how the cleanup step decides which older releases are safe to delete.

## Problem

The existing workflow made the main release look like a generic repository release by naming it `Release <version>`. That title did not distinguish the combined wheel/firmware release from other release-like artifacts in the repository, especially the weekly Raspberry Pi image release. At the same time, the cleanup step was described generically as removing superseded releases, which made the intended scope less obvious when reading or maintaining the workflow.

Even though the main release already uses `server-v*` tags, the workflow did not clearly encode the idea that it owns only the Wheel / ESP release family. That ambiguity is risky in a repository that now has multiple release pipelines with different assets, titles, retention expectations, and user-facing purposes. The weekly Pi image workflow already uses its own separate tag (`weekly-pi-image`) and a distinct release title (`Weekly Pi Image <build_label>`), so the main release flow should be equally explicit about its own identity and cleanup boundaries.

## Implementation approach

I kept the change intentionally small and workflow-focused rather than introducing a new helper or changing the release tag scheme. The main workflow already calls `tools/publish_github_release.py` with an explicit `--title`, so there was no need to modify the release publisher itself. Instead, I changed the workflow wiring where the real behavior lives.

The `Create combined release` step has been renamed to `Create combined Wheel / ESP release`, and its call to the publisher now passes `--title "Wheel / ESP release ${{ steps.version.outputs.version }}"`. This makes the release list much clearer for humans scanning GitHub Releases and also makes the release family explicit in the workflow source itself.

The cleanup step has also been renamed from `Remove superseded releases` to `Remove superseded Wheel / ESP releases`. More importantly, its filtering logic is now tighter and more intentional. Instead of matching a broad regular-expression list that included both `server-v` and `fw-v`, the step now only considers tags that start with `server-v`, which is the tag family used by the combined wheel/firmware release published by this workflow.

On top of the tag filter, the step now checks the release title and only treats a release as eligible for cleanup if its name matches either the new explicit Wheel / ESP title prefix or the legacy `Release ` prefix. That second allowance is a transition safeguard so the next run can still delete the previously published combined release that used the old generic title. After the repository has rolled forward, newer releases will all use the explicit Wheel / ESP naming.

This means the workflow now encodes the release family in three aligned ways: the step names, the release title, and the cleanup predicate. That combination is what should prevent future accidental broadening when someone revisits the workflow later.

## Code changes by area

In `.github/workflows/main-release.yml`, I updated the release publishing step name and changed the release title passed to `tools/publish_github_release.py`. I then adjusted the cleanup step to use a dedicated `WHEEL_ESP_RELEASE_TITLE_PREFIX` environment value, filter to `server-v*` tags only, allow the current title prefix plus the old legacy prefix, and log explicitly that it is deleting superseded Wheel / ESP releases.

In `apps/server/tests/hygiene/test_main_release_workflow.py`, I extended the existing YAML-parsing workflow hygiene coverage rather than adding a second test style. The new test asserts that the main workflow publishes the explicit `Wheel / ESP release <version>` title and that the cleanup script remains constrained to `server-v` releases, still acknowledges the legacy title prefix for migration, and does not reference weekly Pi image cleanup behavior. This keeps the regression guard close to the existing workflow validation patterns already used by the repository.

## Validation

I validated the change with the existing targeted hygiene coverage for the release workflow and release publisher:

- `.venv/bin/python -m pytest -q -o addopts='' apps/server/tests/hygiene/test_main_release_workflow.py apps/server/tests/hygiene/test_publish_github_release.py`
- `make lint`

The targeted pytest run passed after using the repo venv interpreter, and `make lint` passed after formatting the new test with Ruff. I also manually inspected the diff and reviewed the most recent successful `Main Release` workflow run to confirm the current workflow behavior before changing it. That log review showed the workflow creating `server-v2026.3.28.24` as `Release 2026.3.28.24` and then deleting the prior `server-v2026.3.28.23` release, which reinforced that the workflow needed clearer family labeling and tighter cleanup intent in code.

## Risks and tradeoffs

The main tradeoff is that the cleanup step now intentionally ignores any older non-`server-v` release families, including legacy firmware-only tags. I believe that is the safer behavior for this repository because the workflow’s actual published artifact is the combined `server-v*` release, and the user specifically wants Pi image releases left alone. If older legacy release families need their own cleanup policy, that should be handled explicitly instead of being swept up by the main release job.

I also kept a legacy title fallback in the cleanup predicate. That is slightly more complex than matching only the new title, but it is necessary to avoid leaving the immediately previous generic `Release <version>` entry behind during the transition to the new title format. Once the repository has moved past the older naming, the fallback can be reconsidered if we want to simplify further.

## Out of scope and follow-up

This PR does not change the weekly Pi image workflow itself, the `server-v*` tag contract, or the GitHub release publishing helper. After this lands, the next operational step is to trigger the Pi image workflow again from updated `main` so the Pi release is republished under the corrected release-family setup.
