### PR TITLE
ci: rename weekly Pi image asset to VibeSensor-YY-MM-DD.img.zip

### DIFF
--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          build_label="$(date -u +%Y.%-m.%-d)"
+          build_label="$(date -u +%y-%m-%d)"
           {
             echo "build_label=${build_label}"
             echo "tag=weekly-pi-image"
@@ -74,26 +74,22 @@ jobs:
           mkdir -p "${release_dir}"
 
           artifact="$(find "${out_dir}" -maxdepth 1 -type f \
-            \( -name "image_*-vibesensor-lite*.img" -o -name "image_*-vibesensor-lite*.img.xz" -o -name "image_*-vibesensor-lite*.zip" \) \
+            -name "image_*-vibesensor-lite*.zip" \
             | sort | tail -n 1 || true)"
           if [ -z "${artifact}" ]; then
             echo "No Pi image artifact found in ${out_dir}" >&2
             exit 1
           fi
 
-          if [[ "${artifact}" == *.img ]]; then
-            release_artifact="${release_dir}/$(basename "${artifact}").xz"
-            xz -T0 -c "${artifact}" > "${release_artifact}"
-          else
-            release_artifact="${release_dir}/$(basename "${artifact}")"
-            cp "${artifact}" "${release_artifact}"
-          fi
+          short_date="$(date -u +%y-%m-%d)"
+          release_artifact="${release_dir}/VibeSensor-${short_date}.img.zip"
+          cp "${artifact}" "${release_artifact}"
 
           sha_file="${release_artifact}.sha256"
           sha256sum "${release_artifact}" > "${sha_file}"
 
           version_info_source="${out_dir}/$(basename "${artifact}").version.txt"
-          version_info_target="${release_dir}/$(basename "${release_artifact}").version.txt"
+          version_info_target="${release_dir}/VibeSensor-${short_date}.img.zip.version.txt"
           if [ -f "${version_info_source}" ]; then
             cp "${version_info_source}" "${version_info_target}"
           else
@@ -103,10 +99,10 @@ jobs:
           source_artifact=$(basename "${artifact}")
           EOF
           fi
-          echo "published_artifact=$(basename "${release_artifact}")" >> "${version_info_target}"
+          echo "published_artifact=VibeSensor-${short_date}.img.zip" >> "${version_info_target}"
 
           echo "release_dir=${release_dir}" >> "${GITHUB_OUTPUT}"
-          echo "artifact_name=$(basename "${release_artifact}")" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=VibeSensor-${short_date}.img.zip" >> "${GITHUB_OUTPUT}"
 
       - name: Upload weekly image workflow artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problem

Weekly CI was uploading assets with the full pi-gen output name:
`image_2026-03-28-vibesensor-rpi3a-plus-trixie-lite-vibesensor.img.zip`

## Change

The release and workflow artifacts are now named:
`VibeSensor-26-03-28.img.zip`

### Details
- Search only for `.zip` artifacts (the build always produces `.img.zip`) — removes the dead `.img` → `.img.xz` compression branch
- Rename to `VibeSensor-$(date +%y-%m-%d).img.zip` at copy time
- Align `build_label` date format to `YY-MM-DD` (`%y-%m-%d`) so the release title and workflow artifact name are consistent: `Weekly Pi Image 26-03-28`