### PR TITLE
[codex] Add light and dark header logos

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -10,7 +10,12 @@
       <header class="site-header">
         <div class="site-header__main">
           <div class="site-header__nav">
-            <h1 class="title" data-i18n="title.main">VibeSensor</h1>
+            <h1 class="title" aria-label="VibeSensor">
+              <picture class="brandmark">
+                <source srcset="/branding/vibesensor-logo-header-dark.svg" media="(prefers-color-scheme: dark)" />
+                <img src="/branding/vibesensor-logo-header-light.svg" alt="VibeSensor" width="116" height="24" />
+              </picture>
+            </h1>
             <nav class="menu" aria-label="Primary" role="tablist">
               <button type="button" class="menu-btn active" data-view="dashboardView" id="tab-dashboard" role="tab" aria-controls="dashboardView" aria-selected="true" tabindex="0">
                 <span data-i18n="nav.live">Live</span>

--- a/apps/ui/public/branding/vibesensor-logo-header-dark.svg
+++ b/apps/ui/public/branding/vibesensor-logo-header-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="24" viewBox="0 0 116 24" role="img" aria-labelledby="title desc">
+  <title id="title">VibeSensor header logo dark</title>
+  <desc id="desc">Pulse-ring icon with a two-tone VibeSensor wordmark for dark surfaces.</desc>
+  <circle cx="9" cy="12" r="6.5" fill="none" stroke="#c4b5fd" stroke-width="1.7"/>
+  <path d="M4.6 12h2l1.4-3.2 2.1 6 1.6-3.1h2" fill="none" stroke="#4ade80" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="19" y="16.2" font-family="'Segoe UI','Trebuchet MS',Arial,sans-serif" font-size="15.25" font-weight="700" letter-spacing="0.01em" textLength="95" lengthAdjust="spacingAndGlyphs">
+    <tspan fill="#f7f8fc">Vibe</tspan><tspan fill="#c4b5fd">Sensor</tspan>
+  </text>
+</svg>

--- a/apps/ui/public/branding/vibesensor-logo-header-light.svg
+++ b/apps/ui/public/branding/vibesensor-logo-header-light.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="24" viewBox="0 0 116 24" role="img" aria-labelledby="title desc">
+  <title id="title">VibeSensor header logo light</title>
+  <desc id="desc">Pulse-ring icon with a two-tone VibeSensor wordmark for light surfaces.</desc>
+  <circle cx="9" cy="12" r="6.5" fill="none" stroke="#7c3aed" stroke-width="1.7"/>
+  <path d="M4.6 12h2l1.4-3.2 2.1 6 1.6-3.1h2" fill="none" stroke="#0f9d58" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="19" y="16.2" font-family="'Segoe UI','Trebuchet MS',Arial,sans-serif" font-size="15.25" font-weight="700" letter-spacing="0.01em" textLength="95" lengthAdjust="spacingAndGlyphs">
+    <tspan fill="#1a1c24">Vibe</tspan><tspan fill="#7c3aed">Sensor</tspan>
+  </text>
+</svg>

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -1,5 +1,4 @@
 {
-  "title.main": "VibeSensor",
   "nav.live": "Live",
   "nav.history": "History",
   "nav.settings": "Settings",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -1,5 +1,4 @@
 {
-  "title.main": "VibeSensor",
   "nav.live": "Live",
   "nav.history": "Geschiedenis",
   "nav.settings": "Instellingen",

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -157,6 +157,19 @@ body {
   font-size: 1.2rem;
   font-weight: 700;
   letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+}
+
+.brandmark {
+  display: block;
+  line-height: 0;
+}
+
+.brandmark img {
+  display: block;
+  width: 116px;
+  height: 24px;
 }
 
 select,


### PR DESCRIPTION
## What changed
- replace the plain text header title with the selected pulse logo concept
- add separate light and dark SVG assets and swap them with a `<picture>` element sized to the existing header slot
- add the small header brandmark styles needed to keep the logo aligned
- remove the now-unused `title.main` i18n entry

## Why it changed
The UI review picked the first logo concept, and we need it to read cleanly on both light and dark surfaces without changing the header layout.

## User impact
The header now shows the selected VibeSensor brandmark instead of raw text while keeping the same footprint in the navigation bar.

## Validation
- `cd apps/ui && npx -y node@20 ../../tools/config/sync_shared_contracts_to_ui.mjs --check`
- `cd apps/ui && npx -y node@20 ./node_modules/typescript/bin/tsc --noEmit`
- `cd apps/ui && npx -y node@20 ./node_modules/vite/bin/vite.js build`
- `docker compose build --pull`
- `docker compose up -d`
- `cd apps/server && python3 -m vibesensor.adapters.simulator.sim_sender --count 3 --duration 15 --server-host 127.0.0.1 --server-http-port 8000 --no-auto-server --no-interactive`
- `cd apps/server && python3 -m vibesensor.adapters.simulator.ws_smoke --uri ws://127.0.0.1:8000/ws --min-clients 1 --timeout 20`