### PR TITLE
[codex] Increase header logo size

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -13,7 +13,7 @@
             <h1 class="title" aria-label="VibeSensor">
               <picture class="brandmark">
                 <source srcset="/branding/vibesensor-logo-header-dark.svg" media="(prefers-color-scheme: dark)" />
-                <img src="/branding/vibesensor-logo-header-light.svg" alt="VibeSensor" width="116" height="24" />
+                <img src="/branding/vibesensor-logo-header-light.svg" alt="VibeSensor" width="222" height="46" />
               </picture>
             </h1>
             <nav class="menu" aria-label="Primary" role="tablist">

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -65,6 +65,7 @@
   --radius-md: 14px;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06), 0 2px 6px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --header-brandmark-height: 46px;
 }
 
 * { box-sizing: border-box; }
@@ -159,17 +160,21 @@ body {
   letter-spacing: 0.01em;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+  line-height: 0;
 }
 
 .brandmark {
-  display: block;
+  display: flex;
+  align-items: center;
   line-height: 0;
 }
 
 .brandmark img {
   display: block;
-  width: 116px;
-  height: 24px;
+  width: calc(var(--header-brandmark-height) * 29 / 6);
+  height: var(--header-brandmark-height);
+  max-width: 100%;
 }
 
 select,


### PR DESCRIPTION
## What changed
- enlarge the header logo so it matches the adjacent nav control height instead of sitting noticeably smaller
- update the reserved image dimensions in the header markup to match the new rendered size
- make the header brandmark sizing use a dedicated CSS token so the footprint stays consistent

## Why it changed
The selected logo looked undersized next to the Live/History/Settings control in the header. This change brings the logo up to the same visual height as the neighboring nav capsule.

## User impact
The header branding reads more intentionally and no longer looks shrunken beside the primary navigation.

## Validation
- `cd apps/ui && npx -y node@20 ./node_modules/typescript/bin/tsc --noEmit`
- `cd apps/ui && npx -y node@20 ./node_modules/vite/bin/vite.js build`