### PR TITLE
fix(ui): streamline Run Recording pre-run copy

### DIFF
--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -325,7 +325,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     return {
       variant: "ok",
       text: t("dashboard.health.ready"),
-      summary: t("dashboard.logging.ready", { connected: connectedCount, assigned: assignedCount }),
+      summary: "",
       showOverviewPill: false,
     };
   }
@@ -571,9 +571,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       pillVariant: hasActiveClients ? "muted" : liveHealth.variant,
       pillText: t("dashboard.recording_phase.ready"),
       phaseText: t("dashboard.recording_phase.ready"),
-      summaryText: hasActiveClients
-        ? t("dashboard.logging.ready", { connected: connectedCount, assigned: assignedCount })
-        : liveHealth.summary,
+      summaryText: liveHealth.summary,
       runIdText,
       elapsedText: "--",
       samplesText,
@@ -595,6 +593,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     ctx.setStatValue(els.loggingElapsed, panelState.elapsedText);
     ctx.setStatValue(els.loggingSamples, panelState.samplesText);
     if (els.loggingSummary) {
+      els.loggingSummary.hidden = panelState.summaryText === "";
       els.loggingSummary.textContent = panelState.summaryText;
     }
     if (els.loggingRunId) {
@@ -626,6 +625,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       clearLoggingElapsedTimer();
       setDashboardPillState(els.loggingStatus, "bad", t("status.unavailable"));
       if (els.loggingSummary) {
+        els.loggingSummary.hidden = false;
         els.loggingSummary.textContent = t("status.unavailable");
       }
       if (els.loggingRunId) {

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -49,7 +49,6 @@
   "dashboard.logging.unassigned": "{count} live sensor(s) still need a location.",
   "dashboard.logging.frame_loss": "Frame loss is being detected on {count} sensor(s).",
   "dashboard.logging.offline": "{count} sensor(s) are offline, so coverage is incomplete.",
-  "dashboard.logging.ready": "Ready to record with {connected} online sensor(s) and {assigned} assigned location(s). Press Start Recording to begin a new run.",
   "dashboard.logging.running": "Recording is active with {connected} online sensor(s) and {assigned} assigned location(s). Press Stop Recording to save the run and start analysis.",
   "dashboard.logging.run_id": "Run ID: {runId}",
   "dashboard.logging.last_run_id": "Last run: {runId}",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -49,7 +49,6 @@
   "dashboard.logging.unassigned": "{count} live sensor(en) hebben nog een locatie nodig.",
   "dashboard.logging.frame_loss": "Er wordt frameverlies gedetecteerd op {count} sensor(en).",
   "dashboard.logging.offline": "{count} sensor(en) zijn offline, dus de dekking is onvolledig.",
-  "dashboard.logging.ready": "Klaar om op te nemen met {connected} online sensor(en) en {assigned} toegewezen locatie(s). Druk op Opname starten om een nieuwe meetrun te beginnen.",
   "dashboard.logging.running": "Opname is actief met {connected} online sensor(en) en {assigned} toegewezen locatie(s). Druk op Opname stoppen om de meetrun op te slaan en de analyse te starten.",
   "dashboard.logging.run_id": "Run-ID: {runId}",
   "dashboard.logging.last_run_id": "Laatste run: {runId}",

--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -756,6 +756,8 @@ input:focus-visible,
 .dashboard-grid__overview { grid-area: overview; min-width: 0; }
 .dashboard-grid__main { grid-area: main; min-width: 0; }
 .dashboard-grid__controls { grid-area: controls; min-width: 0; align-self: start; }
+.dashboard-grid__controls .card__header > :first-child { width: 100%; }
+.dashboard-grid__controls .card__subtle { text-align: left; }
 
 .live-overview__stats { margin-bottom: var(--space-3); }
 

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -135,9 +135,7 @@ test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) 
   await expect(page.locator(".spectrum-controls-panel")).toContainText("Use the trace chips to isolate one sensor at a time.");
   await expect(page.locator(".spectrum-controls-panel #spectrumInspector")).toBeVisible();
   await expect(page.locator(".spectrum-controls-panel #legend")).toContainText("Front Left");
-  await expect(page.locator("#loggingSummary")).toHaveText(
-    "Ready to record with 1 online sensor(s) and 1 assigned location(s). Press Start Recording to begin a new run.",
-  );
+  await expect(page.locator("#loggingSummary")).toBeHidden();
   await expect(page.locator("#loggingStatus")).toBeHidden();
   await expect(page.locator("#loggingPhase [data-value]")).toHaveText("Ready");
   await expect(page.locator("#loggingElapsed [data-value]")).toHaveText("--");

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -248,6 +248,7 @@ test("shows a live warning state until an active car is selected, then clears it
   await expect(page.locator("#loggingSummary")).toHaveText(
     "Recording is blocked until you select or create an active car.",
   );
+  await expect(page.locator("#loggingSummary")).toHaveCSS("text-align", "left");
   await expect(page.locator("#startLoggingBtn")).toBeVisible();
   await expect(page.locator("#startLoggingBtn")).toBeDisabled();
   await expect.poll(() => startCalls).toBe(0);


### PR DESCRIPTION
Closes #1853

## Summary
This PR tightens the pre-run presentation of the Live dashboard's `Run Recording` card so the content scans more cleanly before a run starts. The issue called out two problems: the helper copy under `Run Recording` felt visually centered in the card, and the default ready-state sentence repeated information already exposed by the `Run phase` field and the primary `Start Recording` action. The change keeps the overall card structure intact, removes only the redundant ready-state sentence, and preserves the richer helper summaries in the states where users still benefit from extra guidance.

## Problem
Before this change, a healthy pre-run state rendered a sentence along the lines of: `Ready to record with N online sensor(s) and N assigned location(s). Press Start Recording to begin a new run.` Functionally, that copy was accurate, but it did not add much value. The card already shows that the run phase is `Ready`, and the start button is already the dominant cue. Instead of clarifying the state, the sentence made the card feel wordier than necessary in the most common pre-run path.

The issue also noted that the helper copy under the `Run Recording` heading felt centered in a way that was visually off for this card. The visible helper text in blocked or warning states reads better when it anchors to the left edge of the content area instead of floating toward the middle.

## Implementation approach
I took the narrowest implementation path that fully addresses the issue: remove the redundant ready-state sentence at the state-computation layer, then make the summary UI render only when there is useful text to show. The issue body listed `index.html`, the locale catalogs, and CSS as expected touch points, but the actual ready-state sentence is produced in `apps/ui/src/app/features/realtime_feature.ts`. Because of that, the cleanest fix was not to blank out text in the template or swap in a placeholder translation. Instead, I changed the Live recording state model so the healthy ready state simply has no helper summary.

Once the ready-state summary becomes intentionally empty, the renderer can treat that part of the card as optional UI. Blocked, degraded, recording, stopping, processing, saved, and error states still provide explanatory text, while the normal ready state becomes quieter and relies on the existing structure of the card. I paired that logic change with a very local CSS rule for left alignment, so the issue is fixed in the targeted card without shifting unrelated cards that use shared typography classes.

## Main code changes
In `apps/ui/src/app/features/realtime_feature.ts`, the healthy ready state no longer synthesizes the removed sentence. The `computeLiveHealth()` path now returns an empty summary for the fully ready state, and `computeRecordingPanelState()` carries that value through instead of independently rebuilding the old sentence. This removes the duplicate message at the source rather than hiding one copy while leaving another caller behind.

The same file now treats `#loggingSummary` as optional presentation. In `renderLoggingStatus()`, the summary element is hidden whenever `panelState.summaryText` is empty and shown whenever a state supplies meaningful text. This preserves all existing guidance in the states where the helper copy is useful, such as missing active-car selection, incomplete sensor coverage, active recording, or post-run processing.

I also updated the error path in `refreshLoggingStatus()`. Without that small follow-up, a card that previously hid the summary in the ready state could stay visually empty if a later status refresh failed and attempted to write `status.unavailable` into a still-hidden element. The new logic explicitly unhides the summary before rendering the unavailable message, so failures remain visible and actionable.

In `apps/ui/src/styles/app.css`, I added a scoped alignment rule for the controls card instead of modifying global card behavior. The Run Recording card header now lets its main content block span the available width, and visible `card__subtle` text in that controls card is explicitly left-aligned. That keeps the change tightly bound to the exact card named in the issue and avoids unintended alignment changes elsewhere.

Because the removed ready-state sentence no longer has any live caller after the logic update, I deleted the now-dead `dashboard.logging.ready` key from both `apps/ui/src/i18n/catalogs/en.json` and `apps/ui/src/i18n/catalogs/nl.json`. That keeps the locale catalogs aligned with real UI behavior rather than leaving stale strings behind after the feature change.

## Test coverage and validation
The existing Playwright smoke coverage already exercised the two states most relevant to this change: the standard ready path and the blocked state where helper copy remains important. I updated those tests instead of adding new overlapping scenarios.

In `apps/ui/tests/smoke.bootstrap.spec.ts`, the ready-state assertion now checks that `#loggingSummary` is hidden instead of expecting the removed sentence. That matches the intended UX after this change: the card is still clearly actionable because it shows the `Ready` phase and the `Start Recording` button, but it no longer spends space on redundant prose.

In `apps/ui/tests/smoke.cars.spec.ts`, the blocked-state summary assertion remains in place, and I added a CSS assertion that the visible helper text is left-aligned. This covers the part of the UX where alignment actually matters once the ready-state sentence is gone.

I validated the final change set locally with:

- `CI=1 npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`
- `npm run typecheck`
- `npm run build`
- `npm run lint`

The first smoke run surfaced one remaining direct ready-state summary caller in `computeRecordingPanelState()`. I fixed that oversight and reran the full command set successfully. `npm run lint` still reports the repository's existing four unrelated warnings outside this diff, but the command exits successfully and this PR does not introduce new lint findings.

## Risks, tradeoffs, and edge cases
The main tradeoff is intentional: the pre-run ready state becomes quieter. That is the desired outcome from the issue, but it does mean the card now relies on its existing structure rather than helper prose to communicate readiness. I think that is the right trade because the card already has clear readiness signals: the `Ready` phase label, the visible `Start Recording` button, and the surrounding Live dashboard health context. Removing the sentence improves scanability without making the action ambiguous.

The main edge case worth preserving was the transition from a previously hidden summary back to a visible error state. The explicit unhide in the unavailable-status path is there so the card does not accidentally swallow an error message just because the last successful render happened in the quiet ready state.

## Out of scope
This PR does not restructure the Run Recording card, move buttons, rename phases, or add replacement filler copy for the ready state. It also does not alter other dashboard cards. The goal here is to make this one card read more cleanly with the smallest complete UI-only fix.
