### PR TITLE
fix(firmware): correct recovery abandon metric

### DIFF
--- a/firmware/esp/lib/reliability/reliability.h
+++ b/firmware/esp/lib/reliability/reliability.h
@@ -70,6 +70,10 @@ struct SamplingRecoveryPlan {
   size_t missed_slots = 0;
 };
 
+inline bool sampling_recovery_abandoned(size_t missed_slots) {
+  return missed_slots > 1U;
+}
+
 inline SamplingRecoveryPlan sampling_recovery_plan(size_t due_slots,
                                                    size_t handoff_headroom,
                                                    size_t prefetch_count,

--- a/firmware/esp/src/runtime_sampling.cpp
+++ b/firmware/esp/src/runtime_sampling.cpp
@@ -295,7 +295,9 @@ void process_due_samples(SamplingState& state, uint32_t due_slots) {
 
   if (recovery.missed_slots > 0) {
     note_missed_samples(
-        state, static_cast<uint32_t>(recovery.missed_slots), recovery.missed_slots > 0);
+        state,
+        static_cast<uint32_t>(recovery.missed_slots),
+        vibesensor::reliability::sampling_recovery_abandoned(recovery.missed_slots));
     state.next_sample_due_us += static_cast<uint64_t>(recovery.missed_slots) * step_us;
   }
 }

--- a/firmware/esp/test/test_reliability_logic/test_main.cpp
+++ b/firmware/esp/test/test_reliability_logic/test_main.cpp
@@ -171,6 +171,12 @@ void test_sampling_recovery_plan_declares_misses_when_progress_is_not_credible()
   TEST_ASSERT_EQUAL_UINT64(4, shortfall.missed_slots);
 }
 
+void test_sampling_recovery_abandoned_only_for_multi_slot_backlog() {
+  TEST_ASSERT_FALSE(vibesensor::reliability::sampling_recovery_abandoned(0));
+  TEST_ASSERT_FALSE(vibesensor::reliability::sampling_recovery_abandoned(1));
+  TEST_ASSERT_TRUE(vibesensor::reliability::sampling_recovery_abandoned(2));
+}
+
 void test_retry_due_zero_retry_at_always_true() {
   // retry_at_ms == 0 means "fire immediately on first check".
   TEST_ASSERT_TRUE(vibesensor::reliability::retry_due(0, 0));
@@ -379,6 +385,7 @@ int main() {
   RUN_TEST(test_sampling_prefetch_refill_plan_uses_late_target_at_trigger_threshold);
   RUN_TEST(test_sampling_recovery_plan_uses_handoff_headroom_and_prefetch);
   RUN_TEST(test_sampling_recovery_plan_declares_misses_when_progress_is_not_credible);
+  RUN_TEST(test_sampling_recovery_abandoned_only_for_multi_slot_backlog);
   RUN_TEST(test_retry_due_zero_retry_at_always_true);
   RUN_TEST(test_retry_due_respects_wall_clock);
   RUN_TEST(test_saturating_inc_u8_does_not_wrap);


### PR DESCRIPTION
## Summary
This follow-up fixes one metric-semantics bug in the recent ESP sampling-task refactor. The main refactor introduced `sampling_recovery_abandons` to count cases where the firmware decides backlog recovery is no longer credible and explicitly skips remaining overdue samples. The post-merge review correctly pointed out that one call site was incrementing that counter for any non-zero `missed_slots`, including single missed samples, which overstated what the metric was meant to represent.

## What changed
The fix is intentionally small:

- added `vibesensor::reliability::sampling_recovery_abandoned()` as the explicit helper for this policy boundary
- updated `runtime_sampling.cpp` to use that helper when deciding whether a skipped backlog should increment the recovery-abandon counter
- added a native test that proves only multi-slot backlog misses count as abandoned recovery events

The resulting behavior now matches the intended distinction already used elsewhere in the sampling code: a single missed sample is still a miss, but it is not automatically treated as an abandoned backlog-recovery event.

## Validation
This follow-up was validated with the same firmware command set used for the main refactor:

- `cd firmware/esp && /workspace/VibeSensor/.venv/bin/python ../../tools/firmware/generate_protocol_contract_fixtures.py --check`
- `cd firmware/esp && pio test -e native`
- `cd firmware/esp && pio run -e m5stack_atom`
- `cd /workspace/VibeSensor && make lint`

## Risk
Risk is very low. The change affects only local status/telemetry semantics, not sampling cadence, queueing, packet layout, or device identity behavior.
