### PR TITLE
fix(firmware): stage sensor recovery before reinit

### DIFF
--- a/firmware/esp/HARDENING.md
+++ b/firmware/esp/HARDENING.md
@@ -13,6 +13,9 @@ dedicated sampling task.
   - I2C register and burst reads now return explicit success/failure
   - FIFO truncation and I2C errors are detected and counted
   - repeated sensor read errors trigger bounded sensor re-init attempts
+  - staged refill recovery now does one immediate retry, then one fast
+    bus-level recovery + retry, before escalating to the heavier reinit path
+  - FIFO status-read failures and FIFO data-read failures are tracked separately
 - Hardened Wi-Fi reconnect behavior:
   - reconnect now uses exponential backoff with jitter and an upper cap (`60s`)
   - retry failure counter uses saturating increment (prevents wrap-around)
@@ -118,7 +121,9 @@ Key fields:
 - `drop`: queue overflow drops
 - `tx_fail.pack|begin|end`: packet encoding / UDP begin / UDP send failures
 - `sensor.err`: sensor I2C read failures
+- `sensor.stat|data`: FIFO status-register failures vs FIFO data-read failures
 - `sensor.trunc`: FIFO truncation events (reader could not consume full FIFO depth in one pass)
+- `sensor.bus`: successful fast bus recoveries / attempted bus recoveries
 - `sensor.reinit`: `successes/attempts` of ADXL reinitialization after repeated errors
 - `sensor.miss`: missed/skipped sampling slots
 - `sensor.late`: backlog-abandon events where recovery was judged no longer credible

--- a/firmware/esp/README.md
+++ b/firmware/esp/README.md
@@ -62,11 +62,16 @@ firmware/esp/
 ## Error Handling
 
 - **I2C init**: Every register write during `ADXL345::begin()` is validated;
-  if any write fails the sensor is marked unavailable and production firmware
-  skips that sampling slot instead of injecting held or synthetic samples.
-- **I2C reads**: `read_reg()` and `read_multi()` return zeros on bus errors.
-  This is safe because the caller (`read_samples()`) only processes FIFO
-  entries reported by the hardware status register.
+  if any write fails the sensor is marked unavailable and the sampling task
+  falls back to bounded reinit attempts instead of injecting held or synthetic
+  samples.
+- **I2C reads**: FIFO status reads and FIFO data reads are classified
+  separately. The sampling task now tries one immediate bounded refill retry,
+  then one fast bus-recovery + retry step, before escalating to the heavier
+  ADXL reinit path.
+- **Partial FIFO progress**: samples completed before a burst-read failure are
+  preserved and appended into the software prefetch ring before miss accounting
+  is considered.
 - **Wi-Fi**: Automatic reconnect with configurable retry interval
   (`kWifiRetryIntervalMs`).
 
@@ -155,6 +160,16 @@ steady-state refills target `24` buffered samples, while late or refill-shortfal
 conditions target the full `32`-sample buffer. Late handling is now based on
 real recovery context (prefetch occupancy, handoff headroom, and recent refill
 progress) instead of a fixed loop-time budget.
+
+The ADXL345/I2C path now uses bounded staged recovery inside the sampling task:
+- one immediate retry after a transient refill/read failure
+- one fast bus reinitialization + retry step before heavier recovery
+- full ADXL reinit only after the lighter path is exhausted or the failure class
+  points at deeper sensor-state loss
+
+This is still a software-only resilience improvement: the code now gives
+transient bus faults a bounded chance to recover before declaring missed
+samples, but the real on-device benefit still needs hardware to prove.
 
 On ESP32 dual-core builds, the sampling task is now pinned explicitly instead of
 inheriting the startup core. By default it targets the opposite core from the

--- a/firmware/esp/lib/adxl345/adxl345.cpp
+++ b/firmware/esp/lib/adxl345/adxl345.cpp
@@ -21,6 +21,17 @@ constexpr uint8_t MASK_FIFO_WATERMARK = 0x1F;
 constexpr uint8_t MASK_FIFO_ENTRIES = 0x3F;
 constexpr uint32_t kI2cClockHz = 400000;
 constexpr unsigned int kFifoPopDelayUs = 5;
+
+void set_failure(ADXL345::FailureKind* out, ADXL345::FailureKind failure) {
+  if (out != nullptr) {
+    *out = failure;
+  }
+}
+
+void configure_bus(TwoWire& wire, int sda_pin, int scl_pin) {
+  wire.begin(sda_pin, scl_pin);
+  wire.setClock(kI2cClockHz);
+}
 }  // namespace
 
 ADXL345::ADXL345(TwoWire& wire,
@@ -35,36 +46,78 @@ ADXL345::ADXL345(TwoWire& wire,
       fifo_watermark_(fifo_watermark),
       available_(false) {}
 
-bool ADXL345::begin() {
-  wire_.begin(sda_pin_, scl_pin_);
-  wire_.setClock(kI2cClockHz);
+bool ADXL345::begin(FailureKind* failure_kind) {
+  set_failure(failure_kind, FailureKind::kNone);
+  configure_bus(wire_, sda_pin_, scl_pin_);
 
   uint8_t devid = 0;
   if (!read_reg(REG_DEVID, &devid)) {
+    set_failure(failure_kind, FailureKind::kDeviceIdRead);
     available_ = false;
     return false;
   }
   if (devid != VALUE_DEVID) {
+    set_failure(failure_kind, FailureKind::kDeviceIdMismatch);
     available_ = false;
     return false;
   }
 
   // Standby while configuring.
-  if (!write_reg(REG_POWER_CTL, VALUE_POWER_CTL_STANDBY)) { available_ = false; return false; }
+  if (!write_reg(REG_POWER_CTL, VALUE_POWER_CTL_STANDBY)) {
+    set_failure(failure_kind, FailureKind::kConfigWrite);
+    available_ = false;
+    return false;
+  }
   // Full resolution + +/-16g.
-  if (!write_reg(REG_DATA_FORMAT, VALUE_DATA_FORMAT_FULL_RES_16G)) { available_ = false; return false; }
+  if (!write_reg(REG_DATA_FORMAT, VALUE_DATA_FORMAT_FULL_RES_16G)) {
+    set_failure(failure_kind, FailureKind::kConfigWrite);
+    available_ = false;
+    return false;
+  }
   // 800 Hz output data rate.
-  if (!write_reg(REG_BW_RATE, VALUE_BW_RATE_800HZ)) { available_ = false; return false; }
+  if (!write_reg(REG_BW_RATE, VALUE_BW_RATE_800HZ)) {
+    set_failure(failure_kind, FailureKind::kConfigWrite);
+    available_ = false;
+    return false;
+  }
   // FIFO stream mode with configurable watermark.
   if (!write_reg(
           REG_FIFO_CTL,
           static_cast<uint8_t>(VALUE_FIFO_STREAM_MODE | (fifo_watermark_ & MASK_FIFO_WATERMARK)))) {
-    available_ = false; return false;
+    set_failure(failure_kind, FailureKind::kConfigWrite);
+    available_ = false;
+    return false;
   }
   // Enable watermark interrupt bit (optional, polled in this prototype).
-  if (!write_reg(REG_INT_ENABLE, VALUE_INT_ENABLE_WATERMARK)) { available_ = false; return false; }
+  if (!write_reg(REG_INT_ENABLE, VALUE_INT_ENABLE_WATERMARK)) {
+    set_failure(failure_kind, FailureKind::kConfigWrite);
+    available_ = false;
+    return false;
+  }
   // Measurement mode.
-  if (!write_reg(REG_POWER_CTL, VALUE_POWER_CTL_MEASURE)) { available_ = false; return false; }
+  if (!write_reg(REG_POWER_CTL, VALUE_POWER_CTL_MEASURE)) {
+    set_failure(failure_kind, FailureKind::kConfigWrite);
+    available_ = false;
+    return false;
+  }
+
+  available_ = true;
+  return true;
+}
+
+bool ADXL345::recover_bus(FailureKind* failure_kind) {
+  set_failure(failure_kind, FailureKind::kNone);
+  configure_bus(wire_, sda_pin_, scl_pin_);
+
+  uint8_t devid = 0;
+  if (!read_reg(REG_DEVID, &devid)) {
+    set_failure(failure_kind, FailureKind::kDeviceIdRead);
+    return false;
+  }
+  if (devid != VALUE_DEVID) {
+    set_failure(failure_kind, FailureKind::kDeviceIdMismatch);
+    return false;
+  }
 
   available_ = true;
   return true;
@@ -76,11 +129,9 @@ bool ADXL345::available() const {
 
 size_t ADXL345::read_samples(int16_t* xyz_interleaved,
                              size_t max_samples,
-                             bool* had_io_error,
+                             FailureKind* failure_kind,
                              bool* fifo_truncated) {
-  if (had_io_error != nullptr) {
-    *had_io_error = false;
-  }
+  set_failure(failure_kind, FailureKind::kNone);
   if (fifo_truncated != nullptr) {
     *fifo_truncated = false;
   }
@@ -90,9 +141,7 @@ size_t ADXL345::read_samples(int16_t* xyz_interleaved,
 
   uint8_t fifo_status = 0;
   if (!read_reg(REG_FIFO_STATUS, &fifo_status)) {
-    if (had_io_error != nullptr) {
-      *had_io_error = true;
-    }
+    set_failure(failure_kind, FailureKind::kFifoStatusRead);
     return 0;
   }
   size_t entries = static_cast<size_t>(fifo_status & MASK_FIFO_ENTRIES);
@@ -120,9 +169,7 @@ size_t ADXL345::read_samples(int16_t* xyz_interleaved,
       delayMicroseconds(kFifoPopDelayUs);
     }
     if (!read_multi(REG_DATAX0, raw, 6)) {
-      if (had_io_error != nullptr) {
-        *had_io_error = true;
-      }
+      set_failure(failure_kind, FailureKind::kFifoDataRead);
       return i;
     }
     const size_t out = i * 3;

--- a/firmware/esp/lib/adxl345/adxl345.h
+++ b/firmware/esp/lib/adxl345/adxl345.h
@@ -5,20 +5,30 @@
 
 class ADXL345 {
  public:
+  enum class FailureKind : uint8_t {
+    kNone = 0,
+    kFifoStatusRead = 1,
+    kFifoDataRead = 2,
+    kDeviceIdRead = 3,
+    kDeviceIdMismatch = 4,
+    kConfigWrite = 5,
+  };
+
   ADXL345(TwoWire& wire,
           uint8_t i2c_addr,
           int sda_pin,
           int scl_pin,
           uint8_t fifo_watermark = 16);
 
-  bool begin();
+  bool begin(FailureKind* failure_kind = nullptr);
+  bool recover_bus(FailureKind* failure_kind = nullptr);
   bool available() const;
 
   // Reads up to max_samples from FIFO and writes XYZ triples into xyz_interleaved.
   // Returns number of samples written.
   size_t read_samples(int16_t* xyz_interleaved,
                       size_t max_samples,
-                      bool* had_io_error = nullptr,
+                      FailureKind* failure_kind = nullptr,
                       bool* fifo_truncated = nullptr);
 
  private:

--- a/firmware/esp/lib/reliability/reliability.h
+++ b/firmware/esp/lib/reliability/reliability.h
@@ -28,6 +28,53 @@ inline uint64_t sampling_slots_due(uint64_t now_us,
   return ((now_us - next_due_us) / step_us) + 1;
 }
 
+enum class SensorFailureClass : uint8_t {
+  kNone = 0,
+  kRegisterAccess = 1,
+  kFifoData = 2,
+  kPartialFifoDrain = 3,
+  kRepeatedCommunication = 4,
+  kSensorIdentity = 5,
+  kSensorConfiguration = 6,
+};
+
+inline bool sensor_failure_is_communication(SensorFailureClass failure_class) {
+  return failure_class == SensorFailureClass::kRegisterAccess ||
+         failure_class == SensorFailureClass::kFifoData ||
+         failure_class == SensorFailureClass::kPartialFifoDrain ||
+         failure_class == SensorFailureClass::kRepeatedCommunication;
+}
+
+inline bool sensor_failure_requires_forced_reinit(SensorFailureClass failure_class) {
+  return failure_class == SensorFailureClass::kSensorIdentity ||
+         failure_class == SensorFailureClass::kSensorConfiguration;
+}
+
+struct SamplingRefillRetryStep {
+  bool retry_read = false;
+  bool recover_bus = false;
+};
+
+inline SamplingRefillRetryStep sampling_refill_retry_step(uint8_t exhausted_failures,
+                                                          SensorFailureClass failure_class,
+                                                          size_t requested_samples,
+                                                          size_t recovered_samples) {
+  SamplingRefillRetryStep step{};
+  if (requested_samples == 0 || recovered_samples >= requested_samples ||
+      !sensor_failure_is_communication(failure_class)) {
+    return step;
+  }
+  if (exhausted_failures == 0U) {
+    step.retry_read = true;
+    return step;
+  }
+  if (exhausted_failures == 1U) {
+    step.retry_read = true;
+    step.recover_bus = true;
+  }
+  return step;
+}
+
 struct SamplingRefillPlan {
   size_t request_samples = 0;
   size_t target_prefetch = 0;
@@ -104,9 +151,8 @@ inline SamplingRecoveryPlan sampling_recovery_plan(size_t due_slots,
     plan.missed_slots = due_slots - plan.attempt_slots;
     return plan;
   }
-  if (last_refill_count < last_refill_request && prefetch_count < 2U) {
-    plan.attempt_slots = 1U;
-    plan.missed_slots = due_slots - 1U;
+  if (last_refill_count < last_refill_request && prefetch_count == 0) {
+    plan.missed_slots = due_slots;
     return plan;
   }
 

--- a/firmware/esp/src/runtime_sampling.cpp
+++ b/firmware/esp/src/runtime_sampling.cpp
@@ -20,6 +20,15 @@ constexpr uint8_t kSamplingErrorFifoTruncated = 2;
 constexpr uint8_t kSamplingErrorMissedSample = 3;
 constexpr uint8_t kSamplingErrorHandoffOverflow = 14;
 
+using SensorFailureClass = vibesensor::reliability::SensorFailureClass;
+
+struct SensorRefillAttempt {
+  size_t recovered_samples = 0;
+  bool fifo_truncated = false;
+  ADXL345::FailureKind failure_kind = ADXL345::FailureKind::kNone;
+  SensorFailureClass failure_class = SensorFailureClass::kNone;
+};
+
 TaskHandle_t g_sampling_task_handle = nullptr;
 esp_timer_handle_t g_sampling_timer_handle = nullptr;
 portMUX_TYPE g_sampling_lock = portMUX_INITIALIZER_UNLOCKED;
@@ -81,12 +90,31 @@ void note_sensor_reinit_success(SamplingState& state) {
   portEXIT_CRITICAL(&g_sampling_lock);
 }
 
-void note_sensor_read_error(SamplingState& state) {
+void note_sensor_bus_recovery_attempt(SamplingState& state) {
+  portENTER_CRITICAL(&g_sampling_lock);
+  state.status.sensor_bus_recovery_attempts++;
+  sync_sampling_snapshot_locked(state);
+  portEXIT_CRITICAL(&g_sampling_lock);
+}
+
+void note_sensor_bus_recovery_success(SamplingState& state) {
+  portENTER_CRITICAL(&g_sampling_lock);
+  state.status.sensor_bus_recovery_success++;
+  sync_sampling_snapshot_locked(state);
+  portEXIT_CRITICAL(&g_sampling_lock);
+}
+
+void note_sensor_read_error(SamplingState& state, ADXL345::FailureKind failure_kind) {
   const uint32_t now_ms = millis();
   state.sensor_consecutive_errors =
       vibesensor::reliability::saturating_inc_u8(state.sensor_consecutive_errors);
   portENTER_CRITICAL(&g_sampling_lock);
   state.status.sensor_read_errors++;
+  if (failure_kind == ADXL345::FailureKind::kFifoStatusRead) {
+    state.status.sensor_fifo_status_failures++;
+  } else if (failure_kind == ADXL345::FailureKind::kFifoDataRead) {
+    state.status.sensor_fifo_data_failures++;
+  }
   record_sampling_error_locked(state, kSamplingErrorSensorRead, now_ms);
   sync_sampling_snapshot_locked(state);
   portEXIT_CRITICAL(&g_sampling_lock);
@@ -120,10 +148,87 @@ bool publish_sample(SamplingState& state, const PendingSample& sample) {
   return ok;
 }
 
-bool maybe_reinit_sensor(SamplingState& state) {
+SensorFailureClass classify_sensor_failure(ADXL345::FailureKind failure_kind,
+                                           size_t recovered_samples,
+                                           bool fifo_truncated) {
+  switch (failure_kind) {
+    case ADXL345::FailureKind::kNone:
+      return fifo_truncated ? SensorFailureClass::kPartialFifoDrain
+                            : SensorFailureClass::kNone;
+    case ADXL345::FailureKind::kFifoStatusRead:
+      return SensorFailureClass::kRegisterAccess;
+    case ADXL345::FailureKind::kFifoDataRead:
+      return (recovered_samples > 0 || fifo_truncated)
+                 ? SensorFailureClass::kPartialFifoDrain
+                 : SensorFailureClass::kFifoData;
+    case ADXL345::FailureKind::kDeviceIdRead:
+      return SensorFailureClass::kRepeatedCommunication;
+    case ADXL345::FailureKind::kDeviceIdMismatch:
+      return SensorFailureClass::kSensorIdentity;
+    case ADXL345::FailureKind::kConfigWrite:
+      return SensorFailureClass::kSensorConfiguration;
+  }
+  return SensorFailureClass::kNone;
+}
+
+size_t append_sensor_prefetch_samples(SamplingState& state,
+                                      const int16_t* batch_xyz,
+                                      size_t read_count) {
+  size_t appended = 0;
+  for (; appended < read_count && state.sensor_prefetch_count < kSensorPrefetchSamples; ++appended) {
+    const size_t src = appended * kAxesPerSample;
+    const size_t dst = state.sensor_prefetch_head * kAxesPerSample;
+    state.sensor_prefetch_xyz[dst + 0] = batch_xyz[src + 0];
+    state.sensor_prefetch_xyz[dst + 1] = batch_xyz[src + 1];
+    state.sensor_prefetch_xyz[dst + 2] = batch_xyz[src + 2];
+    state.sensor_prefetch_head = (state.sensor_prefetch_head + 1) % kSensorPrefetchSamples;
+    state.sensor_prefetch_count++;
+  }
+  return appended;
+}
+
+SensorRefillAttempt refill_sensor_prefetch_once(SamplingState& state, size_t request_samples) {
+  SensorRefillAttempt attempt{};
+  if (request_samples == 0) {
+    return attempt;
+  }
+
+  ADXL345::FailureKind failure_kind = ADXL345::FailureKind::kNone;
+  bool fifo_truncated = false;
+  const size_t read_count = state.adxl.read_samples(
+      state.sensor_batch_xyz, request_samples, &failure_kind, &fifo_truncated);
+  attempt.recovered_samples =
+      append_sensor_prefetch_samples(state, state.sensor_batch_xyz, read_count);
+  attempt.fifo_truncated = fifo_truncated;
+  attempt.failure_kind = failure_kind;
+  attempt.failure_class =
+      classify_sensor_failure(failure_kind, attempt.recovered_samples, fifo_truncated);
+  if (fifo_truncated) {
+    note_fifo_truncated(state);
+  }
+  return attempt;
+}
+
+bool recover_sensor_bus(SamplingState& state, ADXL345::FailureKind* failure_kind) {
+  note_sensor_bus_recovery_attempt(state);
+  const bool recovered = state.adxl.recover_bus(failure_kind);
+  if (recovered) {
+    note_sensor_bus_recovery_success(state);
+  }
+  return recovered;
+}
+
+bool maybe_reinit_sensor(SamplingState& state, bool force = false) {
   const uint32_t now_ms = millis();
   const bool initial_retry = state.last_sensor_reinit_ms == 0;
-  if (!initial_retry &&
+  const bool cooldown_ready =
+      initial_retry ||
+      static_cast<int32_t>(now_ms - state.last_sensor_reinit_ms) >=
+          static_cast<int32_t>(kSensorReinitCooldownMs);
+  if (!cooldown_ready) {
+    return false;
+  }
+  if (!force && !initial_retry &&
       !vibesensor::reliability::sensor_should_reinit(state.sensor_consecutive_errors,
                                                      kSensorReinitErrorThreshold,
                                                      now_ms,
@@ -147,7 +252,7 @@ bool maybe_reinit_sensor(SamplingState& state) {
 }
 
 bool ensure_sensor_ready(SamplingState& state) {
-  return state.sensor_ok || maybe_reinit_sensor(state);
+  return state.sensor_ok || maybe_reinit_sensor(state, true);
 }
 
 void maybe_refill_sensor_prefetch(SamplingState& state, size_t due_slots) {
@@ -174,38 +279,57 @@ void maybe_refill_sensor_prefetch(SamplingState& state, size_t due_slots) {
     return;
   }
 
-  bool io_error = false;
-  bool fifo_truncated = false;
   state.last_refill_request = plan.request_samples;
-  const size_t read_count = state.adxl.read_samples(
-      state.sensor_batch_xyz, plan.request_samples, &io_error, &fifo_truncated);
-  state.last_refill_count = read_count;
-  state.recent_refill_shortfall = read_count < plan.request_samples;
+  size_t recovered_samples = 0;
+  ADXL345::FailureKind final_failure_kind = ADXL345::FailureKind::kNone;
+  SensorFailureClass final_failure_class = SensorFailureClass::kNone;
+  uint8_t exhausted_failures = 0;
 
-  if (fifo_truncated) {
-    note_fifo_truncated(state);
+  while (recovered_samples < plan.request_samples) {
+    const SensorRefillAttempt attempt =
+        refill_sensor_prefetch_once(state, plan.request_samples - recovered_samples);
+    recovered_samples += attempt.recovered_samples;
+    final_failure_kind = attempt.failure_kind;
+    final_failure_class = attempt.failure_class;
+
+    if (attempt.failure_kind == ADXL345::FailureKind::kNone) {
+      final_failure_class = SensorFailureClass::kNone;
+      break;
+    }
+
+    const vibesensor::reliability::SamplingRefillRetryStep retry_step =
+        vibesensor::reliability::sampling_refill_retry_step(
+            exhausted_failures, final_failure_class, plan.request_samples, recovered_samples);
+    if (!retry_step.retry_read) {
+      break;
+    }
+
+    exhausted_failures++;
+    if (retry_step.recover_bus) {
+      ADXL345::FailureKind recovery_failure = ADXL345::FailureKind::kNone;
+      if (!recover_sensor_bus(state, &recovery_failure)) {
+        final_failure_kind = recovery_failure;
+        final_failure_class =
+            classify_sensor_failure(recovery_failure, recovered_samples, false);
+        break;
+      }
+    }
   }
 
-  for (size_t i = 0;
-       i < read_count && state.sensor_prefetch_count < kSensorPrefetchSamples;
-       ++i) {
-    const size_t src = i * kAxesPerSample;
-    const size_t dst = state.sensor_prefetch_head * kAxesPerSample;
-    state.sensor_prefetch_xyz[dst + 0] = state.sensor_batch_xyz[src + 0];
-    state.sensor_prefetch_xyz[dst + 1] = state.sensor_batch_xyz[src + 1];
-    state.sensor_prefetch_xyz[dst + 2] = state.sensor_batch_xyz[src + 2];
-    state.sensor_prefetch_head =
-        (state.sensor_prefetch_head + 1) % kSensorPrefetchSamples;
-    state.sensor_prefetch_count++;
-  }
+  state.last_refill_count = recovered_samples;
+  state.recent_refill_shortfall = recovered_samples < plan.request_samples;
 
-  if (io_error) {
-    note_sensor_read_error(state);
-    if (vibesensor::reliability::sensor_should_reinit(state.sensor_consecutive_errors,
-                                                      kSensorReinitErrorThreshold,
-                                                      millis(),
-                                                      state.last_sensor_reinit_ms,
-                                                      kSensorReinitCooldownMs)) {
+  if (final_failure_class != SensorFailureClass::kNone &&
+      recovered_samples < plan.request_samples) {
+    note_sensor_read_error(state, final_failure_kind);
+    if (vibesensor::reliability::sensor_failure_requires_forced_reinit(final_failure_class)) {
+      state.sensor_ok = false;
+      (void)maybe_reinit_sensor(state, true);
+    } else if (vibesensor::reliability::sensor_should_reinit(state.sensor_consecutive_errors,
+                                                             kSensorReinitErrorThreshold,
+                                                             millis(),
+                                                             state.last_sensor_reinit_ms,
+                                                             kSensorReinitCooldownMs)) {
       state.sensor_ok = false;
       (void)maybe_reinit_sensor(state);
     }

--- a/firmware/esp/src/runtime_status.cpp
+++ b/firmware/esp/src/runtime_status.cpp
@@ -37,7 +37,7 @@ void report_runtime_status(RuntimeStatus& status,
 
   Serial.printf(
       "status wifi=%d q=%u/%u drop=%lu tx_fail={pack:%lu begin:%lu end:%lu} "
-      "sensor={err:%lu trunc:%lu reinit:%lu/%lu miss:%lu late:%lu handoff:%lu "
+      "sensor={err:%lu stat:%lu data:%lu trunc:%lu bus:%lu/%lu reinit:%lu/%lu miss:%lu late:%lu handoff:%lu "
       "sq:%u/%u prefetch:%u refill:%u/%u} "
       "wifi_retry={attempts:%lu fail:%lu} "
       "parse={ctrl:%lu ack:%lu} last_error=%u@%lu\n",
@@ -49,7 +49,11 @@ void report_runtime_status(RuntimeStatus& status,
       static_cast<unsigned long>(status.tx_begin_failures),
       static_cast<unsigned long>(status.tx_end_failures),
       static_cast<unsigned long>(sampling.sensor_read_errors),
+      static_cast<unsigned long>(sampling.sensor_fifo_status_failures),
+      static_cast<unsigned long>(sampling.sensor_fifo_data_failures),
       static_cast<unsigned long>(sampling.sensor_fifo_truncated),
+      static_cast<unsigned long>(sampling.sensor_bus_recovery_success),
+      static_cast<unsigned long>(sampling.sensor_bus_recovery_attempts),
       static_cast<unsigned long>(sampling.sensor_reinit_success),
       static_cast<unsigned long>(sampling.sensor_reinit_attempts),
       static_cast<unsigned long>(sampling.sampling_missed_samples),

--- a/firmware/esp/src/runtime_status.h
+++ b/firmware/esp/src/runtime_status.h
@@ -20,7 +20,11 @@ struct RuntimeStatus {
 
 struct SamplingStatusSnapshot {
   uint32_t sensor_read_errors = 0;
+  uint32_t sensor_fifo_status_failures = 0;
+  uint32_t sensor_fifo_data_failures = 0;
   uint32_t sensor_fifo_truncated = 0;
+  uint32_t sensor_bus_recovery_attempts = 0;
+  uint32_t sensor_bus_recovery_success = 0;
   uint32_t sensor_reinit_attempts = 0;
   uint32_t sensor_reinit_success = 0;
   uint32_t sampling_missed_samples = 0;

--- a/firmware/esp/test/test_reliability_logic/test_main.cpp
+++ b/firmware/esp/test/test_reliability_logic/test_main.cpp
@@ -147,6 +147,51 @@ void test_sampling_prefetch_refill_plan_uses_late_target_at_trigger_threshold() 
   TEST_ASSERT_EQUAL_UINT64(8, plan.request_samples);
 }
 
+void test_sampling_refill_retry_step_stages_bounded_recovery() {
+  const vibesensor::reliability::SamplingRefillRetryStep immediate =
+      vibesensor::reliability::sampling_refill_retry_step(
+          0, vibesensor::reliability::SensorFailureClass::kRegisterAccess, 8, 0);
+  TEST_ASSERT_TRUE(immediate.retry_read);
+  TEST_ASSERT_FALSE(immediate.recover_bus);
+
+  const vibesensor::reliability::SamplingRefillRetryStep bus_recovery =
+      vibesensor::reliability::sampling_refill_retry_step(
+          1, vibesensor::reliability::SensorFailureClass::kPartialFifoDrain, 8, 3);
+  TEST_ASSERT_TRUE(bus_recovery.retry_read);
+  TEST_ASSERT_TRUE(bus_recovery.recover_bus);
+
+  const vibesensor::reliability::SamplingRefillRetryStep exhausted =
+      vibesensor::reliability::sampling_refill_retry_step(
+          2, vibesensor::reliability::SensorFailureClass::kFifoData, 8, 3);
+  TEST_ASSERT_FALSE(exhausted.retry_read);
+  TEST_ASSERT_FALSE(exhausted.recover_bus);
+}
+
+void test_sampling_refill_retry_step_stops_for_terminal_or_satisfied_cases() {
+  const vibesensor::reliability::SamplingRefillRetryStep satisfied =
+      vibesensor::reliability::sampling_refill_retry_step(
+          0, vibesensor::reliability::SensorFailureClass::kRegisterAccess, 8, 8);
+  TEST_ASSERT_FALSE(satisfied.retry_read);
+  TEST_ASSERT_FALSE(satisfied.recover_bus);
+
+  const vibesensor::reliability::SamplingRefillRetryStep terminal =
+      vibesensor::reliability::sampling_refill_retry_step(
+          0, vibesensor::reliability::SensorFailureClass::kSensorIdentity, 8, 0);
+  TEST_ASSERT_FALSE(terminal.retry_read);
+  TEST_ASSERT_FALSE(terminal.recover_bus);
+}
+
+void test_sensor_failure_requires_forced_reinit_only_for_sensor_state_loss() {
+  TEST_ASSERT_FALSE(vibesensor::reliability::sensor_failure_requires_forced_reinit(
+      vibesensor::reliability::SensorFailureClass::kRegisterAccess));
+  TEST_ASSERT_FALSE(vibesensor::reliability::sensor_failure_requires_forced_reinit(
+      vibesensor::reliability::SensorFailureClass::kRepeatedCommunication));
+  TEST_ASSERT_TRUE(vibesensor::reliability::sensor_failure_requires_forced_reinit(
+      vibesensor::reliability::SensorFailureClass::kSensorIdentity));
+  TEST_ASSERT_TRUE(vibesensor::reliability::sensor_failure_requires_forced_reinit(
+      vibesensor::reliability::SensorFailureClass::kSensorConfiguration));
+}
+
 void test_sampling_recovery_plan_uses_handoff_headroom_and_prefetch() {
   const vibesensor::reliability::SamplingRecoveryPlan limited =
       vibesensor::reliability::sampling_recovery_plan(4, 3, 4, 8, 8);
@@ -166,9 +211,16 @@ void test_sampling_recovery_plan_declares_misses_when_progress_is_not_credible()
   TEST_ASSERT_EQUAL_UINT64(4, empty.missed_slots);
 
   const vibesensor::reliability::SamplingRecoveryPlan shortfall =
+      vibesensor::reliability::sampling_recovery_plan(5, 5, 0, 12, 4);
+  TEST_ASSERT_EQUAL_UINT64(0, shortfall.attempt_slots);
+  TEST_ASSERT_EQUAL_UINT64(5, shortfall.missed_slots);
+}
+
+void test_sampling_recovery_plan_keeps_trying_after_partial_progress() {
+  const vibesensor::reliability::SamplingRecoveryPlan partial =
       vibesensor::reliability::sampling_recovery_plan(5, 5, 1, 12, 4);
-  TEST_ASSERT_EQUAL_UINT64(1, shortfall.attempt_slots);
-  TEST_ASSERT_EQUAL_UINT64(4, shortfall.missed_slots);
+  TEST_ASSERT_EQUAL_UINT64(5, partial.attempt_slots);
+  TEST_ASSERT_EQUAL_UINT64(0, partial.missed_slots);
 }
 
 void test_sampling_recovery_abandoned_only_for_multi_slot_backlog() {
@@ -383,8 +435,12 @@ int main() {
   RUN_TEST(test_sampling_prefetch_refill_plan_steady_state_refills_to_steady_target);
   RUN_TEST(test_sampling_prefetch_refill_plan_switches_to_late_target_when_behind);
   RUN_TEST(test_sampling_prefetch_refill_plan_uses_late_target_at_trigger_threshold);
+  RUN_TEST(test_sampling_refill_retry_step_stages_bounded_recovery);
+  RUN_TEST(test_sampling_refill_retry_step_stops_for_terminal_or_satisfied_cases);
+  RUN_TEST(test_sensor_failure_requires_forced_reinit_only_for_sensor_state_loss);
   RUN_TEST(test_sampling_recovery_plan_uses_handoff_headroom_and_prefetch);
   RUN_TEST(test_sampling_recovery_plan_declares_misses_when_progress_is_not_credible);
+  RUN_TEST(test_sampling_recovery_plan_keeps_trying_after_partial_progress);
   RUN_TEST(test_sampling_recovery_abandoned_only_for_multi_slot_backlog);
   RUN_TEST(test_retry_due_zero_retry_at_always_true);
   RUN_TEST(test_retry_due_respects_wall_clock);


### PR DESCRIPTION
## Summary
- add bounded staged ADXL345/I2C recovery before the heavier reinit path
- preserve and aggregate partial FIFO progress across staged refill attempts
- make late-handling less pessimistic after partial progress so missed samples are only declared after the bounded recovery sequence is exhausted

## Problem
The dedicated sampling task and explicit core placement already isolate sampling from Wi-Fi and loop work, but the ADXL345/I2C path was still the biggest remaining dropped-sample risk. A single refill failure could still leave the prefetch shallow, increment the generic sensor-error path, and lead to premature missed-sample accounting even when a bounded same-cycle recovery was still credible.

## What changed
- `ADXL345` now reports explicit failure kinds for:
  - FIFO status-register read failure
  - FIFO data-read failure
  - device-ID read failure
  - device-ID mismatch
  - config-write failure
- the sampling runtime now performs bounded staged refill recovery:
  1. initial refill read
  2. one immediate retry for transient communication loss
  3. one fast bus recovery (`Wire` reinit + device-ID reprobe) plus one final retry
  4. heavier ADXL reinit only after the lighter path is exhausted or the failure class indicates deeper sensor-state loss
- partial refill progress is preserved and accumulated across those bounded stages
- `sampling_recovery_plan()` now keeps bounded per-slot attempts alive after partial progress instead of pre-declaring misses early
- periodic status output now exposes `sensor.stat`, `sensor.data`, and `sensor.bus=success/attempts`

## Why this is safer
- transient I2C faults get a bounded same-cycle chance to recover before they count toward heavier recovery
- partial FIFO progress is no longer thrown away just because the refill ended with a later communication failure
- missed samples remain the last bounded step rather than an early consequence of a pessimistic shortfall decision
- the recovery path stays deterministic: no unbounded loops, no protocol changes, no sampling-task ownership changes

## Validation without hardware
Validated locally with:
- `cd firmware/esp && pio test -e native -f test_reliability_logic`
- `cd firmware/esp && pio test -e native`
- `cd firmware/esp && pio run -e m5stack_atom`
- `cd /workspace/VibeSensor && make lint`

Added/updated host-side proof points for:
- staged refill retry sequencing being bounded and deterministic
- terminal sensor-state failures skipping the light retry path
- partial refill progress keeping the bounded recovery plan alive longer
- protocol/layout remaining unchanged

## Remaining unknowns
We still do **not** have hardware access, so this PR does not claim proven on-device improvement. Remaining unknowns are hardware-only:
- real ESP32/ADXL345 bus timing under electrical noise or clock-stretching conditions
- real frequency and duration of transient bus faults on device
- exact interaction with physical board power and wiring conditions

## Risk
This is a narrow firmware-only change confined to the ADXL345 driver, sampling runtime, reliability helpers, status reporting, and focused tests. External protocol behavior, packet layout, device identity behavior, and the dedicated sampling-task architecture are unchanged.
