### PR TITLE
Add manual ARM Pi image workflow

### DIFF
--- a/.github/workflows/manual-pi-image-arm.yml
+++ b/.github/workflows/manual-pi-image-arm.yml
@@ -1,0 +1,108 @@
+name: Manual Pi Image ARM
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manual-pi-image-arm
+  cancel-in-progress: false
+
+jobs:
+  build-image:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute ARM image metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          build_label="$(date -u +%y-%m-%d)-run-${GITHUB_RUN_NUMBER}-attempt-${GITHUB_RUN_ATTEMPT}"
+          artifact_prefix="VibeSensor-arm-${build_label}"
+          {
+            echo "build_label=${build_label}"
+            echo "artifact_prefix=${artifact_prefix}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: apps/ui/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+          cache: pip
+          cache-dependency-path: apps/server/pyproject.toml
+
+      - name: Install Pi image build prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y qemu-user qemu-user-static rsync xz-utils
+
+      - name: Build Pi image
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./infra/pi-image/pi-gen/build.sh
+
+      - name: Collect ARM workflow artifacts
+        id: assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          out_dir="infra/pi-image/pi-gen/out"
+          release_dir="${RUNNER_TEMP}/manual-pi-image-arm"
+          mkdir -p "${release_dir}"
+
+          artifact="$(find "${out_dir}" -maxdepth 1 -type f \
+            -name "image_*-vibesensor-lite*.zip" \
+            | sort | tail -n 1 || true)"
+          if [ -z "${artifact}" ]; then
+            echo "No Pi image artifact found in ${out_dir}" >&2
+            exit 1
+          fi
+
+          release_artifact="${release_dir}/${{ steps.metadata.outputs.artifact_prefix }}.img.zip"
+          cp "${artifact}" "${release_artifact}"
+
+          sha_file="${release_artifact}.sha256"
+          sha256sum "${release_artifact}" > "${sha_file}"
+
+          version_info_source="${out_dir}/$(basename "${artifact}").version.txt"
+          version_info_target="${release_dir}/${{ steps.metadata.outputs.artifact_prefix }}.img.zip.version.txt"
+          if [ -f "${version_info_source}" ]; then
+            cp "${version_info_source}" "${version_info_target}"
+          else
+            printf 'git_sha=%s\ngit_ref=%s\nsource_artifact=%s\n' \
+              "${GITHUB_SHA}" \
+              "${GITHUB_REF}" \
+              "$(basename "${artifact}")" \
+              > "${version_info_target}"
+          fi
+          {
+            echo "workflow_name=${GITHUB_WORKFLOW}"
+            echo "runner_label=ubuntu-24.04-arm"
+            echo "run_id=${GITHUB_RUN_ID}"
+          } >> "${version_info_target}"
+
+          echo "release_dir=${release_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload ARM image workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: manual-pi-image-arm-${{ steps.metadata.outputs.build_label }}
+          path: ${{ steps.assets.outputs.release_dir }}/*
+          if-no-files-found: error
+          retention-days: 21

--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -161,6 +161,14 @@ These weekly builds reuse the same `./infra/pi-image/pi-gen/build.sh` pipeline
 documented above, so the GitHub Release artifact follows the same supported
 image-build path as local builds.
 
+The repository also provides a manual ARM-hosted validation workflow:
+
+- workflow: [`.github/workflows/manual-pi-image-arm.yml`](../../../.github/workflows/manual-pi-image-arm.yml)
+- trigger: manual `workflow_dispatch` only
+- runner: GitHub-hosted `ubuntu-24.04-arm`
+- output: workflow artifacts only; it does not replace the `weekly-pi-image`
+  GitHub Release
+
 ## Pipeline layout
 
 The pi-image pipeline now has three explicit ownership layers:


### PR DESCRIPTION
## Summary
- add a separate manual-only Pi image workflow that runs on the GitHub-hosted `ubuntu-24.04-arm` runner
- keep it artifact-only so it validates ARM-hosted builds without replacing the weekly Pi image release
- document the manual ARM workflow alongside the existing weekly release workflow

## Validation
- parsed `.github/workflows/manual-pi-image-arm.yml` locally with PyYAML
- branch dispatch attempt showed GitHub requires the new `workflow_dispatch` workflow to exist on the default branch before it can be triggered
- after merge, dispatch the new workflow on `main` and monitor it to completion