### PR TITLE
Fix ARM pi-gen Docker base image

### DIFF
--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -189,6 +189,10 @@ During pi-gen repo preparation, the build also patches upstream:
 - `export-image/prerun.sh` to size the boot partition at `1 GiB`. Current
   Raspberry Pi kernel/security updates overflow the stock `512 MiB` bootfs
   during export-image upgrades.
+- `build-docker.sh` to keep `x86_64` hosts on the upstream `i386/debian:trixie`
+  base image but let `aarch64` hosts use the native `debian:trixie` image.
+  GitHub-hosted ARM runners cannot resolve the upstream `i386/debian:trixie`
+  manifest, so the ARM-hosted manual workflow needs the native Debian base.
 - `stage0/files/raspberrypi.gpg` to replace the stale armhf bootstrap keyring
   that still carries SHA-1 self-signatures in upstream `master`. Trixie
   debootstrap rejects that key on modern GnuPG policies, so VibeSensor vendors

--- a/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
+++ b/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
@@ -45,6 +45,46 @@ patch_build_docker_qemu_interpreter() {
     "${build_docker}"
 }
 
+patch_build_docker_base_image() {
+  local build_docker="${PI_GEN_DIR}/build-docker.sh"
+  local stock_block='case "$(uname -m)" in
+  x86_64|aarch64)
+    BASE_IMAGE=i386/debian:trixie
+    ;;
+  *)
+    BASE_IMAGE=debian:trixie
+    ;;
+esac'
+  local patched_block='case "$(uname -m)" in
+  x86_64)
+    BASE_IMAGE=i386/debian:trixie
+    ;;
+  *)
+    BASE_IMAGE=debian:trixie
+    ;;
+esac'
+
+  BUILD_DOCKER="${build_docker}" STOCK_BLOCK="${stock_block}" PATCHED_BLOCK="${patched_block}" python3 - <<'PY'
+from pathlib import Path
+import os
+import sys
+
+path = Path(os.environ["BUILD_DOCKER"])
+stock = os.environ["STOCK_BLOCK"]
+patched = os.environ["PATCHED_BLOCK"]
+text = path.read_text(encoding="utf-8")
+
+if patched in text:
+    raise SystemExit(0)
+if stock not in text:
+    raise SystemExit(
+        f"Unexpected build-docker.sh base-image selection in {path}"
+    )
+
+path.write_text(text.replace(stock, patched), encoding="utf-8")
+PY
+}
+
 refresh_stage0_bootstrap_keyring() {
   local vendored_keyring="${TEMPLATE_ROOT}/stage0-bootstrap-raspberrypi.gpg"
   local upstream_keyring="${PI_GEN_DIR}/stage0/files/raspberrypi.gpg"
@@ -90,6 +130,7 @@ prepare_pi_gen_repo() {
 
   rewrite_pi_gen_mirror_sources
   patch_export_image_boot_size
+  patch_build_docker_base_image
   patch_build_docker_qemu_interpreter
   refresh_stage0_bootstrap_keyring
 }


### PR DESCRIPTION
## Summary
- patch the repo-managed pi-gen `build-docker.sh` preparation so `x86_64` keeps using `i386/debian:trixie` but `aarch64` uses native `debian:trixie`
- preserve the existing x64 weekly build behavior while unblocking the new GitHub-hosted ARM manual image workflow
- document the host-architecture-specific pi-gen patch in the Pi image README

## Validation
- reproduced the original ARM failure from run `23704874053` (`i386/debian:trixie` manifest missing on GitHub ARM runners)
- validated the patch logic locally against a temp `build-docker.sh` sample
- reran the manual ARM workflow on this branch successfully: `23704955002`
- uploaded workflow artifact: `manual-pi-image-arm-26-03-29-run-2-attempt-1`