### PR TITLE
Fix OBD scan sudo failure handling

### DIFF
--- a/apps/server/tests/adapters/http/test_settings_obd_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_obd_endpoints.py
@@ -57,6 +57,24 @@ def test_scan_obd_devices_endpoint_returns_serialized_devices() -> None:
     speed_service.scan_obd_devices.assert_called_once_with()
 
 
+def test_scan_obd_devices_endpoint_returns_structured_runtime_error_detail() -> None:
+    client, _, speed_service = _build_client()
+    speed_service.scan_obd_devices.side_effect = RuntimeError(
+        "Bluetooth OBD scan requires the Pi sudo helper and NOPASSWD sudoers entry "
+        "to run non-interactively."
+    )
+
+    response = client.post("/api/settings/obd/scan")
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": (
+            "Bluetooth OBD scan requires the Pi sudo helper and NOPASSWD sudoers entry "
+            "to run non-interactively."
+        )
+    }
+
+
 def test_pair_obd_device_endpoint_normalizes_mac_and_persists_config() -> None:
     client, settings_store, speed_service = _build_client()
     speed_service.pair_obd_device.return_value = ObdDeviceSnapshot(

--- a/apps/server/tests/adapters/obd/test_admin_client.py
+++ b/apps/server/tests/adapters/obd/test_admin_client.py
@@ -58,3 +58,40 @@ def test_pair_device_raises_runtime_error_from_helper_json(tmp_path: Path) -> No
 
     with pytest.raises(RuntimeError, match="Bluetooth OBD pairing failed"):
         client.pair_device("00043e5a4a4d")
+
+
+def test_scan_devices_reports_noninteractive_sudo_failure_cleanly(tmp_path: Path) -> None:
+    helper_script = tmp_path / "vibesensor_obd_admin.py"
+
+    def runner(argv: list[str], timeout_s: int) -> CommandResult:
+        del argv, timeout_s
+        return CommandResult(
+            returncode=1,
+            stdout="",
+            stderr="sudo: a password is required",
+        )
+
+    client = ObdAdminClient(helper_script=helper_script, runner=runner)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Bluetooth OBD scan requires the Pi sudo helper and NOPASSWD sudoers entry",
+    ):
+        client.scan_devices()
+
+
+def test_scan_devices_still_reports_invalid_json_when_stdout_is_malformed(tmp_path: Path) -> None:
+    helper_script = tmp_path / "vibesensor_obd_admin.py"
+
+    def runner(argv: list[str], timeout_s: int) -> CommandResult:
+        del argv, timeout_s
+        return CommandResult(
+            returncode=0,
+            stdout="sudo: a password is required",
+            stderr="",
+        )
+
+    client = ObdAdminClient(helper_script=helper_script, runner=runner)
+
+    with pytest.raises(RuntimeError, match="Bluetooth OBD helper returned invalid JSON"):
+        client.scan_devices()

--- a/apps/server/vibesensor/adapters/obd/admin_client.py
+++ b/apps/server/vibesensor/adapters/obd/admin_client.py
@@ -13,6 +13,15 @@ from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 
 __all__ = ["CommandResult", "ObdAdminClient"]
 
+_OBD_SUDO_HELPER_ERROR = (
+    "Bluetooth OBD scan requires the Pi sudo helper and NOPASSWD sudoers entry "
+    "to run non-interactively."
+)
+_OBD_HELPER_LAUNCH_ERROR = (
+    "Bluetooth OBD helper failed before returning structured output. "
+    "Verify the helper installation on the Pi and try again."
+)
+
 
 @dataclass(frozen=True, slots=True)
 class CommandResult:
@@ -75,6 +84,9 @@ class ObdAdminClient:
     def _run_helper(self, args: list[str], *, timeout_s: int) -> dict[str, Any]:
         argv = [self._sudo_path, "-n", str(self._helper_script), *args]
         result = self._runner(argv, timeout_s)
+        launch_error = self._pre_json_failure(result)
+        if launch_error is not None:
+            raise RuntimeError(launch_error)
         raw_output = result.stdout or result.stderr or ""
         try:
             payload_raw = json.loads(raw_output or "{}")
@@ -95,6 +107,23 @@ class ObdAdminClient:
             )
             raise RuntimeError(error)
         return payload
+
+    @staticmethod
+    def _pre_json_failure(result: CommandResult) -> str | None:
+        if result.returncode == 0 or result.stdout:
+            return None
+        stderr = result.stderr.strip()
+        if not stderr or stderr.lstrip().startswith("{"):
+            return None
+        lowered = stderr.lower()
+        if (
+            "sudo:" in lowered
+            or "password is required" in lowered
+            or "a terminal is required" in lowered
+            or "no tty present" in lowered
+        ):
+            return _OBD_SUDO_HELPER_ERROR
+        return _OBD_HELPER_LAUNCH_ERROR
 
     @staticmethod
     def _device_from_payload(raw: object) -> ObdDeviceSnapshot:


### PR DESCRIPTION
Closes #1870.

## Summary

This PR fixes the Bluetooth OBD adapter scan failure that currently surfaces in the Speed Source UI as `Bluetooth OBD helper returned invalid JSON: sudo: a password is required`. The underlying issue is not that the helper is returning malformed JSON on the happy path. The real problem is that the backend admin-client boundary treats raw `stderr` from a failed `sudo -n` invocation as if it were helper JSON, so the UI ends up showing a parse failure instead of a clean, user-safe operational error. This change keeps the existing non-interactive privileged-helper model intact, but makes the error boundary explicit and predictable when the helper cannot launch.

## Problem

The current OBD scan flow already has the right high-level architecture. The UI calls `POST /api/settings/obd/scan`, the route delegates to the speed-source coordinator, and that ultimately invokes the privileged Bluetooth helper through `sudo -n`. The Pi image also already installs a `NOPASSWD` sudoers entry for `vibesensor_obd_admin.py`, so the intended deployment path is not “prompt the user for sudo” and never was.

The bug lives inside `ObdAdminClient._run_helper()`. After executing the subprocess, the client builds `raw_output` from `stdout` or `stderr`, then tries to decode that as JSON. When `sudo` rejects the command and prints a line like `sudo: a password is required` to `stderr`, the code attempts to parse that text as JSON and wraps the result as `Bluetooth OBD helper returned invalid JSON`. That message is both misleading and noisy: it blames the helper format instead of the privilege boundary, and it leaks raw process stderr into the user-facing error path.

## Approach

I kept the current behavior where the helper is invoked via `sudo -n` and returns structured JSON for successful scans and for helper-level failures that already emit JSON. I did not change the route contract, UI request flow, or Pi image privilege model. Instead, I narrowed the fix to the place where subprocess results are classified.

The new behavior detects “pre-JSON” launch failures before any JSON decoding is attempted. Specifically, if the helper process exits non-zero, produces no `stdout`, and emits plain `stderr`, the admin client now treats that as a launch/runtime failure rather than a malformed helper payload. For known sudo-style messages such as password prompts or TTY-required failures, the client raises a clean backend error that explains what is missing in user-safe language: the Pi sudo helper and `NOPASSWD` sudoers entry required for non-interactive operation. For other stderr-only launch failures, it now raises a generic structured error indicating that the helper failed before returning structured output.

This means the UI can keep doing what it already does today: display the backend detail string from the structured HTTP error response. The difference is that the detail is now actionable and safe instead of being a JSON parse wrapper around raw stderr.

## Main code changes

### `apps/server/vibesensor/adapters/obd/admin_client.py`

The core code change is here. I added two focused internal error messages: one for sudo-related non-interactive privilege failures and one generic fallback for helper launch failures that never returned structured output.

I also added a new `_pre_json_failure()` helper that inspects the subprocess result before JSON decoding. It exits early only when all of the following are true:

- the command failed,
- there is no `stdout` payload to parse,
- there is meaningful `stderr`, and
- that `stderr` is not itself JSON.

That keeps the existing JSON-based behavior intact for successful responses and for helper-generated structured errors. It also preserves the old invalid-JSON path for genuinely malformed `stdout`, which is still useful when the helper does produce output but the payload is broken.

### `apps/server/tests/adapters/obd/test_admin_client.py`

I extended unit coverage in the most direct place.

First, I added a regression test for the exact issue scenario: a non-zero command result with empty `stdout` and `stderr="sudo: a password is required"`. The new expected behavior is a clear runtime error about requiring the Pi sudo helper and `NOPASSWD` sudoers configuration, not an invalid-JSON failure.

Second, I added a guard test for the adjacent path that this refactor touches: malformed `stdout`. That test confirms we still raise the existing invalid-JSON error when the process claims success but returns garbage output instead of helper JSON. This helps keep the fix narrow and behavior-safe rather than silently broadening all parsing rules.

### `apps/server/tests/adapters/http/test_settings_obd_endpoints.py`

I added one HTTP-layer test to cover the user-visible contract. When the scan service raises the new runtime error, the route still responds with a structured `503` JSON payload containing `detail`. That verifies the backend/UI seam expected by the issue without requiring a UI behavior rewrite. The frontend already surfaces `detail` from failed API responses, so this test is the missing proof that the improved message reaches the browser in structured form.

## What did not change

I intentionally did not change the UI scan flow, the helper CLI implementation, or the Pi image build scripts in this PR. The current UI already renders a clear error banner from the backend detail string, and the Pi image already provisions the helper sudoers entry. Because of that, the smallest complete fix was at the backend subprocess boundary, not in the frontend or image build path.

I also did not add new API schema fields or compatibility layers. The existing `HTTPException(detail=...)` contract is already sufficient once the message itself is clean.

## Validation

I validated the change locally with the commands requested in the issue, adjusted only where this environment required it:

- `make lint`
- `.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/obd/test_admin_client.py apps/server/tests/adapters/http/test_settings_obd_endpoints.py`
- `.venv/bin/python -m pytest -q -n 0 apps/server/tests -k "obd or speed_source or bluetooth"`
- `cd apps/ui && npm run typecheck`

The broader pytest selection was run with `-n 0` because the default xdist configuration in this environment hit `Unexpectedly no active workers available`, and the issue’s suggested `-k "obd or speed source or bluetooth"` expression also needed the repo-valid selector form `speed_source` to avoid pytest parsing the space as an invalid token. The underlying tests passed cleanly once run with those environment-safe adjustments.

## Risks and tradeoffs

The main tradeoff here is that stderr-only helper-launch failures are now classified before the JSON parser runs. That is intentional, because these cases are exactly the ones that were previously misreported. The implementation remains conservative by only short-circuiting when there is no `stdout` payload to parse and when `stderr` is clearly plain text rather than JSON.

If a future helper intentionally emits JSON on `stderr` with no `stdout`, the new guard will still allow that through by checking for JSON-shaped stderr first. For now, the helper writes structured output to `stdout`, so this remains aligned with current behavior.

## Follow-up

If we continue seeing the sudo-specific message on real Pi deployments after this merges, the next step should be operational: verify the device is actually running the current image/deployment path and that `/etc/sudoers.d/vibesensor-update` contains the expected `vibesensor_obd_admin.py` entry for the `pi` user. This PR makes that class of problem visible in a clean way; it does not try to hide or bypass the privilege requirement.
