### PR TITLE
Show friendly names in OBD scan results

### DIFF
--- a/apps/server/tests/adapters/obd/test_admin_helper.py
+++ b/apps/server/tests/adapters/obd/test_admin_helper.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from vibesensor.adapters.obd.admin_helper import (
+    BluetoothObdAdminHelper,
+    parse_bluetooth_device_info,
+)
+
+
+def test_parse_bluetooth_device_info_prefers_local_name_over_mac_alias() -> None:
+    device = parse_bluetooth_device_info(
+        """
+        Device 57:17:41:56:58:40
+        Alias: 57-17-41-56-58-40
+        LocalName: Vgate iCar Pro BLE 4.0
+        Paired: no
+        Trusted: no
+        Connected: no
+        """,
+        "57:17:41:56:58:40",
+    )
+
+    assert device.name == "Vgate iCar Pro BLE 4.0"
+    assert device.mac_address == "571741565840"
+
+
+def test_parse_bluetooth_device_info_keeps_human_readable_alias_when_name_missing() -> None:
+    device = parse_bluetooth_device_info(
+        """
+        Device 57:17:41:56:58:40
+        Alias: OBDLink CX
+        Paired: yes
+        Trusted: yes
+        Connected: no
+        """,
+        "57:17:41:56:58:40",
+    )
+
+    assert device.name == "OBDLink CX"
+    assert device.paired is True
+    assert device.trusted is True
+
+
+def test_scan_devices_prefers_detailed_name_over_mac_alias() -> None:
+    responses = {
+        ("rfkill", "unblock", "bluetooth"): (0, "", ""),
+        ("systemctl", "start", "bluetooth"): (0, "", ""),
+        ("bluetoothctl", "power", "on"): (0, "", ""),
+        ("bluetoothctl", "scan", "on"): (124, "", ""),
+        (
+            "bluetoothctl",
+            "devices",
+        ): (0, "Device 57:17:41:56:58:40 57-17-41-56-58-40", ""),
+        ("bluetoothctl", "paired-devices"): (0, "", ""),
+        ("bluetoothctl", "scan", "off"): (0, "", ""),
+        (
+            "bluetoothctl",
+            "info",
+            "57:17:41:56:58:40",
+        ): (
+            0,
+            """
+            Device 57:17:41:56:58:40
+            Name: Veepeak BLE+
+            Alias: 57-17-41-56-58-40
+            Paired: no
+            Trusted: no
+            Connected: no
+            """,
+            "",
+        ),
+    }
+    calls: list[tuple[str, ...]] = []
+
+    def runner(argv: list[str], timeout_s: int, allow_timeout: bool) -> tuple[int, str, str]:
+        del timeout_s, allow_timeout
+        key = tuple(argv)
+        calls.append(key)
+        return responses[key]
+
+    devices = BluetoothObdAdminHelper(runner=runner).scan_devices(timeout_s=8)
+
+    assert len(devices) == 1
+    assert devices[0].name == "Veepeak BLE+"
+    assert ("bluetoothctl", "info", "57:17:41:56:58:40") in calls
+    assert not any(call and call[0] == "sdptool" for call in calls)

--- a/apps/server/vibesensor/adapters/obd/admin_helper.py
+++ b/apps/server/vibesensor/adapters/obd/admin_helper.py
@@ -36,6 +36,39 @@ def _coerce_text(raw: str | bytes | None) -> str:
     return raw
 
 
+def _clean_bluetooth_name(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value or None
+
+
+def _looks_like_mac_alias(raw: str | None) -> bool:
+    value = _clean_bluetooth_name(raw)
+    if value is None:
+        return False
+    compact = value.replace(":", "").replace("-", "")
+    if len(compact) != 12:
+        return False
+    try:
+        bytes.fromhex(compact)
+    except ValueError:
+        return False
+    return True
+
+
+def _preferred_bluetooth_name(*candidates: str | None) -> str | None:
+    cleaned = [
+        value for value in (_clean_bluetooth_name(candidate) for candidate in candidates) if value
+    ]
+    if not cleaned:
+        return None
+    for candidate in cleaned:
+        if not _looks_like_mac_alias(candidate):
+            return candidate
+    return cleaned[0]
+
+
 def _default_runner(argv: list[str], timeout_s: int, allow_timeout: bool) -> tuple[int, str, str]:
     try:
         completed = subprocess.run(
@@ -66,7 +99,7 @@ def parse_bluetooth_devices(output: str) -> list[ObdDeviceSnapshot]:
             mac_address = normalize_obd_mac(raw_mac)
         except ValueError:
             continue
-        name = " ".join(name_parts).strip() or None
+        name = _clean_bluetooth_name(" ".join(name_parts))
         devices[mac_address] = ObdDeviceSnapshot(
             mac_address=mac_address,
             name=name,
@@ -81,15 +114,19 @@ def parse_bluetooth_devices(output: str) -> list[ObdDeviceSnapshot]:
 def parse_bluetooth_device_info(output: str, mac_address: str) -> ObdDeviceSnapshot:
     """Parse ``bluetoothctl info`` output into an ``ObdDeviceSnapshot``."""
     name: str | None = None
+    local_name: str | None = None
+    alias: str | None = None
     paired = False
     trusted = False
     connected = False
     for raw_line in output.splitlines():
         line = raw_line.strip()
         if line.startswith("Name:"):
-            name = line.partition(":")[2].strip() or name
-        elif line.startswith("Alias:") and name is None:
-            name = line.partition(":")[2].strip() or None
+            name = _clean_bluetooth_name(line.partition(":")[2]) or name
+        elif line.startswith("LocalName:"):
+            local_name = _clean_bluetooth_name(line.partition(":")[2]) or local_name
+        elif line.startswith("Alias:"):
+            alias = _clean_bluetooth_name(line.partition(":")[2]) or alias
         elif line.startswith("Paired:"):
             paired = line.partition(":")[2].strip().lower() == "yes"
         elif line.startswith("Trusted:"):
@@ -98,7 +135,7 @@ def parse_bluetooth_device_info(output: str, mac_address: str) -> ObdDeviceSnaps
             connected = line.partition(":")[2].strip().lower() == "yes"
     return ObdDeviceSnapshot(
         mac_address=normalize_obd_mac(mac_address),
-        name=name,
+        name=_preferred_bluetooth_name(name, local_name, alias),
         paired=paired,
         trusted=trusted,
         connected=connected,
@@ -158,13 +195,21 @@ class BluetoothObdAdminHelper:
         self._run(["systemctl", "start", "bluetooth"], timeout_s=10, allow_timeout=False)
         self._bluetoothctl("power", "on", timeout_s=10)
 
-    def device_info(self, mac_address: str, *, ensure_ready: bool = True) -> ObdDeviceSnapshot:
+    def device_info(
+        self,
+        mac_address: str,
+        *,
+        ensure_ready: bool = True,
+        resolve_rfcomm: bool = True,
+    ) -> ObdDeviceSnapshot:
         normalized = normalize_obd_mac(mac_address)
         if ensure_ready:
             self._prepare_controller()
         bt_mac = bluetooth_mac_address(normalized)
         info_output = self._bluetoothctl("info", bt_mac, timeout_s=8, ignore_errors=True)
         device = parse_bluetooth_device_info(info_output, normalized)
+        if not resolve_rfcomm:
+            return device
         try:
             channel_output = self._run(
                 ["sdptool", "browse", bt_mac],
@@ -197,14 +242,26 @@ class BluetoothObdAdminHelper:
             self._bluetoothctl("scan", "off", timeout_s=5, ignore_errors=True)
         resolved: list[ObdDeviceSnapshot] = []
         for device in devices.values():
-            if device.mac_address in paired_devices:
+            needs_detailed_info = (
+                device.mac_address in paired_devices
+                or device.name is None
+                or _looks_like_mac_alias(device.name)
+            )
+            if needs_detailed_info:
                 try:
-                    detailed = self.device_info(device.mac_address, ensure_ready=False)
+                    detailed = self.device_info(
+                        device.mac_address,
+                        ensure_ready=False,
+                        resolve_rfcomm=False,
+                    )
                 except _HelperFailure:
-                    detailed = replace(device, paired=True)
+                    detailed = replace(device, paired=device.mac_address in paired_devices)
                 else:
-                    if detailed.name is None and device.name is not None:
-                        detailed = replace(detailed, name=device.name)
+                    detailed = replace(
+                        detailed,
+                        name=_preferred_bluetooth_name(detailed.name, device.name),
+                        paired=detailed.paired or device.mac_address in paired_devices,
+                    )
                 resolved.append(detailed)
             else:
                 resolved.append(device)

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -136,6 +136,14 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     ];
   }
 
+  function obdDevicePrimaryLabel(device: ObdDevicePayload): string {
+    return device.name?.trim() || device.mac_address;
+  }
+
+  function obdDeviceSecondaryLabel(device: ObdDevicePayload): string | null {
+    return device.name?.trim() ? device.mac_address : null;
+  }
+
   function renderObdDeviceList(): void {
     if (!els.obdDeviceList) {
       return;
@@ -167,12 +175,13 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
         : device.paired && device.trusted
           ? t("settings.speed.obd_use")
           : t("settings.speed.obd_pair_and_use");
+      const secondaryLabel = obdDeviceSecondaryLabel(device);
       return `
         <div class="speed-source-device">
           <div class="speed-source-device__header">
             <div class="speed-source-device__identity">
-              <div class="speed-source-device__name">${escapeHtml(device.name ?? t("settings.speed.obd_unknown_name"))}</div>
-              <div class="speed-source-device__mac">${escapeHtml(device.mac_address)}</div>
+              <div class="speed-source-device__name">${escapeHtml(obdDevicePrimaryLabel(device))}</div>
+              ${secondaryLabel ? `<div class="speed-source-device__mac">${escapeHtml(secondaryLabel)}</div>` : ""}
             </div>
             <div class="speed-source-device__badges">${badges.join("")}</div>
           </div>


### PR DESCRIPTION
Closes #1873.

## Summary

This PR fixes the Bluetooth OBD scan labels shown in the Speed Source settings flow so the adapter list prefers human-readable device names when BlueZ can resolve them, instead of showing MAC-derived alias strings like `57-17-41-56-58-40` as the primary label. The main problem was not in the UI template itself. The UI was faithfully rendering the `device.name` supplied by the backend. The real issue was that the privileged Bluetooth helper treated scan-time names and `bluetoothctl info` names too literally, without distinguishing between a real friendly name and an alias that is effectively just the address written with separators.

## Problem

The current scan flow uses the Pi-side privileged helper to collect devices, then returns structured JSON to the browser. That architecture is correct and needed to stay intact, especially after the recent fix to the non-interactive `sudo -n` error path. However, the name-selection behavior inside the helper was too shallow.

`bluetoothctl devices` can return a label that looks like a name but is really just a MAC-derived alias. For paired devices the helper already fetched richer metadata through `bluetoothctl info`, but for non-paired devices it often stopped at the weaker scan-time name. Even when `info` was available, the parser only had a simple `Name` / `Alias` fallback and did not try to distinguish a real alias like `OBDLink CX` from a placeholder alias like `57-17-41-56-58-40`. That meant the backend could keep forwarding address-shaped strings as `device.name`, and the UI would then show those strings prominently.

## Approach

I kept the existing privileged helper / JSON / HTTP structure exactly as it is. The fix is concentrated in the helper layer and a very small UI fallback improvement.

On the backend, I introduced name-cleaning and name-selection helpers in `apps/server/vibesensor/adapters/obd/admin_helper.py`. These helpers normalize candidate Bluetooth labels, detect MAC-like alias placeholders, and choose the best available display name from the sources BlueZ exposes. The selection rule is intentionally simple and behavior-safe: prefer the first non-empty candidate that does not look like a MAC alias; if every available candidate is MAC-like, keep the first fallback rather than dropping all context.

I then updated `parse_bluetooth_device_info()` so it considers `Name`, `LocalName`, and `Alias` instead of only using `Name` and a naive alias fallback. This matters because some devices expose a richer Bluetooth name through `LocalName`, while others only expose a human-friendly alias. The parser now prefers those human-readable values over address-shaped placeholders.

## Main code changes

### `apps/server/vibesensor/adapters/obd/admin_helper.py`

This file contains the core fix.

I added `_clean_bluetooth_name()`, `_looks_like_mac_alias()`, and `_preferred_bluetooth_name()` to centralize the name-selection rules. That keeps the logic explicit and avoids scattering MAC-alias heuristics across the scan flow.

I also extended `parse_bluetooth_device_info()` to capture three different naming fields from `bluetoothctl info`: `Name`, `LocalName`, and `Alias`. The returned `ObdDeviceSnapshot.name` is now chosen via `_preferred_bluetooth_name(...)` instead of blindly accepting the first fallback.

The more important behavioral improvement is in `BluetoothObdAdminHelper.scan_devices()`. The helper now fetches richer `bluetoothctl info` metadata not only for paired devices, but also for devices whose scan-time label is weak — specifically, devices with no name or with a MAC-like alias. That keeps scan overhead modest because devices that already have a strong human-readable label are not forced through an extra metadata round-trip. At the same time, devices that need better naming information now get it.

To avoid slowing scans further, I updated `device_info()` with a `resolve_rfcomm` flag. The scan flow uses `resolve_rfcomm=False`, so it can enrich names and pairing state without running `sdptool browse` for every discovered device. Existing code paths that genuinely need the RFCOMM channel still use the default behavior.

### `apps/server/tests/adapters/obd/test_admin_helper.py`

There was no focused helper-level test coverage for this naming behavior, so I added a small targeted test module.

The new tests cover three important cases:

- `LocalName` should win over a MAC-like alias placeholder.
- A genuinely human-readable alias should still be kept when no better name exists.
- The scan flow should replace a MAC-like scan label with a richer friendly name from `bluetoothctl info`, and it should do that without triggering `sdptool` lookups during scan-time enrichment.

These tests exercise the real helper seam instead of only higher-level HTTP serialization, which makes the regression harder to reintroduce accidentally.

### `apps/ui/src/app/features/settings_speed_source_module.ts`

The backend change is the primary fix, but I made one small UI improvement so nameless devices degrade more cleanly. The adapter list now uses the device MAC address as the primary label when no backend name is available, rather than showing a generic “Unnamed adapter” label above the same MAC. If a friendly name exists, the UI still shows that name prominently and keeps the MAC address as secondary metadata.

This matches the issue’s requested behavior more closely: real names are primary, and address-based fallback remains clear when a real name is unavailable.

## What did not change

I did not change the HTTP route contract, the OBD admin client JSON boundary, or the privileged helper invocation model. The recently fixed non-interactive sudo path remains untouched. I also did not add new API fields or separate alias-display fields to the payload shape; the existing `name` + `mac_address` contract is enough once name selection is better.

## Validation

I validated the change locally with focused and broader checks:

- `make lint`
- `.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/obd/ apps/server/tests/adapters/http/`
- `cd apps/ui && npm run typecheck`
- `.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

The issue’s exact host-python command `python3 tools/tests/run_ci_parallel.py ...` is not reliable in this shared environment because `/usr/bin/python3` is externally managed, lacks `mypy` / `pytest-xdist`, and also hits an unrelated global `pip check` mismatch. I recorded that in the local tracker and reran the same backend CI subset through the repo virtualenv to get a meaningful CI-equivalent signal. That repo-local run completed successfully.

## Risks and tradeoffs

The main tradeoff is that scan-time enrichment now calls `bluetoothctl info` for devices with weak labels, not just for paired devices. That slightly broadens scan-time metadata lookup, but only for devices that need it. The new `resolve_rfcomm=False` path keeps that cost bounded.

The MAC-alias detection is intentionally conservative: it only treats strings as placeholders when they are clearly MAC-shaped. Human-readable aliases remain valid.

## Follow-up

If real Pi testing still shows address-shaped names for specific adapters after this merges, the next place to inspect is the raw BlueZ output for those models. The helper now uses the richer available fields and filters obvious placeholder aliases, so any remaining cases are likely device-specific Bluetooth advertising quirks rather than a generic scan/render bug.
