### PR TITLE
Prevent observed signature label overlap

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
+++ b/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
@@ -7,11 +7,15 @@ from io import BytesIO
 
 import pytest
 from _paths import SERVER_ROOT
+from reportlab.lib.units import mm
 from reportlab.pdfgen.canvas import Canvas
 
+import vibesensor.adapters.pdf.panels._panel_header as panel_header
 import vibesensor.adapters.pdf.panels._panel_trust_steps as panel_trust_steps
 from vibesensor.adapters.pdf.panels._panel_trust_steps import _draw_next_steps_table
-from vibesensor.adapters.pdf.report_data import NextStep
+from vibesensor.adapters.pdf.pdf_style import FONT, FS_H2, PdfRenderContext
+from vibesensor.adapters.pdf.report_data import NextStep, PatternEvidence, ReportTemplateData
+from vibesensor.report_i18n import tr as report_tr
 
 
 def _make_canvas() -> Canvas:
@@ -107,3 +111,67 @@ class TestOrphanI18nKeysRemoved:
         data = json.loads(i18n_path.read_text())
         for key in self.ORPHAN_KEYS:
             assert key not in data, f"Orphan key {key!r} should have been removed"
+
+
+class TestObservedSignatureLayout:
+    """Regression: long observed-signature values must not start inside the label."""
+
+    def test_check_first_value_starts_after_rendered_label_width(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        canvas = _make_canvas()
+        draw_calls: list[tuple[float, float, str]] = []
+        original_draw_string = canvas.drawString
+
+        def capture_draw_string(x: float, y: float, text: str, *args, **kwargs):
+            draw_calls.append((float(x), float(y), str(text)))
+            return original_draw_string(x, y, text, *args, **kwargs)
+
+        monkeypatch.setattr(canvas, "drawString", capture_draw_string)
+
+        data = ReportTemplateData(
+            observed=PatternEvidence(
+                primary_system="Wheel / Tire",
+                strongest_location="Rear-Right / Front-Left",
+                speed_band="50-60 km/h",
+                strength_label="Moderate",
+                certainty_label="High",
+            ),
+            lang="en",
+            certainty_tier_key="C",
+        )
+        render_ctx = PdfRenderContext.from_data(data)
+
+        def tr(key: str) -> str:
+            return report_tr("en", key)
+
+        y_cursor = panel_header._draw_header_panel(
+            canvas,
+            data,
+            tr=tr,
+            width=render_ctx.width,
+            page_top=render_ctx.page_top,
+            na=tr("UNKNOWN"),
+        )
+        panel_header._draw_observed_signature_panel(
+            canvas,
+            data,
+            tr=tr,
+            width=render_ctx.width,
+            y_cursor=y_cursor,
+            na=tr("UNKNOWN"),
+        )
+
+        label_text = f"{tr('WHAT_TO_CHECK_FIRST')}:"
+        label_index = next(
+            index for index, (_x, _y, text) in enumerate(draw_calls) if text == label_text
+        )
+        label_x, _label_y, _ = draw_calls[label_index]
+        value_x, _value_y, value_text = next(
+            (x, y, text) for x, y, text in draw_calls[label_index + 1 :] if "Rear-Right" in text
+        )
+        label_end_x = label_x + canvas.stringWidth(label_text, FONT, FS_H2)
+
+        assert value_text
+        assert value_x >= label_end_x + (0.8 * mm)

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_header.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_header.py
@@ -49,10 +49,51 @@ def _first_check_target(data: ReportTemplateData, *, fallback: str) -> str:
     return _safe(data.observed.strongest_location, fallback)
 
 
-def _label_width(c: Canvas, label: str, *, default_w: float, col_w: float) -> float:
-    measured = c.stringWidth(f"{label}:", FONT, FS_BODY) + 1.2 * mm
+def _label_width(
+    c: Canvas,
+    label: str,
+    *,
+    default_w: float,
+    col_w: float,
+    font_size: float = FS_BODY,
+) -> float:
+    measured = c.stringWidth(f"{label}:", FONT, font_size) + 1.2 * mm
     max_allowed = max(default_w, col_w - 20 * mm)
     return float(min(max(default_w, measured), max_allowed))
+
+
+def _observed_label_width(
+    c: Canvas,
+    *,
+    tr: Callable[[str], str],
+    available_w: float,
+    show_strongest_sensor: bool,
+    has_certainty_reason: bool,
+) -> float:
+    labels = [
+        tr("WHAT_TO_CHECK_FIRST"),
+        tr("CERTAINTY_LABEL_FULL"),
+        tr("SPEED_BAND"),
+        tr("STRENGTH"),
+    ]
+    if show_strongest_sensor:
+        labels.append(tr("STRONGEST_SENSOR"))
+    if has_certainty_reason:
+        labels.append(tr("CERTAINTY_REASON"))
+
+    label_w = OBSERVED_LABEL_W
+    for label in labels:
+        label_w = max(
+            label_w,
+            _label_width(
+                c,
+                label,
+                default_w=OBSERVED_LABEL_W,
+                col_w=available_w,
+                font_size=FS_H2,
+            ),
+        )
+    return float(label_w)
 
 
 def _column_height(
@@ -255,6 +296,14 @@ def _draw_observed_signature_panel(
     oy = obs_y + observed_panel.h - PANEL_HEADER_H
     inspect_target = _first_check_target(data, fallback=na)
     cert_val = _cert_display(data.observed.certainty_label, data.observed.certainty_pct, na)
+    observed_label_w = _observed_label_width(
+        c,
+        tr=tr,
+        available_w=width - 8 * mm,
+        show_strongest_sensor=show_strongest_sensor,
+        has_certainty_reason=bool(data.observed.certainty_reason),
+    )
+    observed_value_w = width - 8 * mm - observed_label_w
 
     _draw_panel(c, MARGIN, obs_y, width, observed_panel.h, tr("OBSERVED_SIGNATURE"))
     oy = _draw_text(
@@ -272,9 +321,9 @@ def _draw_observed_signature_panel(
         oy,
         tr("WHAT_TO_CHECK_FIRST"),
         inspect_target,
-        label_w=OBSERVED_LABEL_W,
+        label_w=observed_label_w,
         fs=FS_H2,
-        value_w=width - 8 * mm - OBSERVED_LABEL_W,
+        value_w=observed_value_w,
     )
     oy -= 1.0 * mm
     if show_strongest_sensor:
@@ -284,10 +333,10 @@ def _draw_observed_signature_panel(
             oy,
             tr("STRONGEST_SENSOR"),
             _safe(data.observed.strongest_location, na),
-            label_w=OBSERVED_LABEL_W,
+            label_w=observed_label_w,
         )
         oy -= obs_step
-    _draw_kv(c, ox, oy, tr("CERTAINTY_LABEL_FULL"), cert_val, label_w=OBSERVED_LABEL_W)
+    _draw_kv(c, ox, oy, tr("CERTAINTY_LABEL_FULL"), cert_val, label_w=observed_label_w)
     oy -= obs_step
     _draw_kv(
         c,
@@ -295,7 +344,7 @@ def _draw_observed_signature_panel(
         oy,
         tr("SPEED_BAND"),
         _safe(data.observed.speed_band, na),
-        label_w=OBSERVED_LABEL_W,
+        label_w=observed_label_w,
     )
     oy -= obs_step
     _draw_kv(
@@ -309,7 +358,7 @@ def _draw_observed_signature_panel(
             fallback=na,
             peak_suffix=tr("STRENGTH_PEAK_SUFFIX"),
         ),
-        label_w=OBSERVED_LABEL_W,
+        label_w=observed_label_w,
     )
     oy -= obs_step
     if data.observed.certainty_reason:
@@ -319,8 +368,8 @@ def _draw_observed_signature_panel(
             oy,
             tr("CERTAINTY_REASON"),
             data.observed.certainty_reason,
-            label_w=OBSERVED_LABEL_W,
-            value_w=width - 8 * mm - OBSERVED_LABEL_W,
+            label_w=observed_label_w,
+            value_w=observed_value_w,
         )
     if data.certainty_tier_key == "A":
         oy -= obs_step


### PR DESCRIPTION
Fixes #1879

## Summary

This change fixes a page-1 PDF layout regression in the `Observed Signature` card where long `What to check first` values could start underneath the label text instead of to its right. The visible symptom from the issue report was the overlapping case `Rear-Right / Front-Left`, but the real problem was broader: the label/value layout for that row assumed a fixed label slot width that was smaller than the label’s actual rendered width at the font size used in the card.

The implementation keeps the existing report content and hierarchy intact. Instead of redesigning the card or changing the rendered fields, it makes the observed-signature label width responsive to the translated label text at the actual font size used in that panel. That preserves the existing visual structure while ensuring longer values begin after the label’s rendered end rather than colliding with it.

## Problem being solved

The page-1 `Observed Signature` panel is rendered from `apps/server/vibesensor/adapters/pdf/panels/_panel_header.py`. The `What to check first` row uses `_draw_kv()` with a fixed `OBSERVED_LABEL_W` of `28mm` and a larger display font size (`FS_H2`). `_draw_kv()` draws the label at `x` and the value at `x + label_w`, so if the label itself is wider than `label_w`, the first value line starts too early and visually overlaps the label.

That is exactly what happened for the issue’s repro. The panel was not suffering from a text-wrapping bug in the value column alone; it was using an undersized label slot for the actual rendered label. As a result, longer location-style values could collide even though the content itself was valid and the PDF generation pipeline remained otherwise healthy.

## Implementation approach

I chose the smallest complete fix that addresses the real root cause in the PDF renderer:

- keep the existing `Observed Signature` rows and hierarchy unchanged,
- keep the existing `What to check first` content source unchanged,
- keep the current label/value rendering helper (`_draw_kv()`) unchanged,
- compute a wider observed-signature label width before drawing the panel, using the translated labels and the actual font size used in that card.

This avoids broad layout churn and keeps the fix localized to the affected page-1 panel logic.

## Main code changes

### `apps/server/vibesensor/adapters/pdf/panels/_panel_header.py`

I updated `_label_width()` so it can measure labels using a caller-provided font size instead of always assuming the body font size. The header-column code still uses its existing default behavior, so the change is backwards-compatible inside the module.

I then added a small `_observed_label_width()` helper that computes a shared label width for the `Observed Signature` card using the translated labels that can appear there (`What to check first`, `Strongest sensor`, `Certainty`, `Speed band`, `Strength`, and `Certainty reason` when present). That helper measures those labels at `FS_H2`, which is the actual size used for the affected row.

The panel now computes `observed_label_w` and `observed_value_w` once and reuses them for the relevant rows. That keeps the card aligned and consistent instead of solving only the single failing row with an ad hoc one-off override.

### `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`

I added a focused regression test that exercises the real ReportLab page-1 renderer rather than only asserting extracted text content.

The test renders the header and observed-signature panel onto a real `Canvas`, captures `drawString()` calls, finds the `What to check first:` label draw, then checks that the first `Rear-Right / Front-Left` value draw starts to the right of the label’s measured rendered width. This directly guards the failure mode from the issue: the value must no longer start inside the label’s horizontal footprint.

I used this approach because plain PDF text extraction can confirm presence of text but cannot reliably prove that two strings did not overlap on the page.

## What did not change

I intentionally did not:

- change the report’s content or section hierarchy,
- change the text source for `What to check first`,
- redesign the card spacing or typography globally,
- alter other PDF panels that were not part of this bug.

There are nearby backlog items around report padding, wording, and other card behavior, but those are separate issues and I kept this PR narrowly scoped to the overlap regression in `Observed Signature`.

## Validation and tests performed

I ran the following local validation:

- `pytest -q apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
- `pytest -q apps/server/tests/adapters/pdf/`
- `make lint`

I also ran the requested backend CI subset.

As with recent tasks in this environment, the exact host-python command failed during bootstrap because `python3 -m pip install --upgrade pip` is blocked by the shared system Python’s externally managed environment. I therefore reran the equivalent repo-venv command:

- `.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

That repo-venv backend subset passed fully, including quality, typecheck, and all backend test shards.

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that the observed-signature label slot is now computed from the active translated labels instead of staying pinned to the old `28mm` constant. I think that is the correct tradeoff for this panel because the issue is fundamentally caused by a mismatch between actual rendered label width and the reserved label slot.

I explicitly avoided increasing the global constant blindly because that would still be a guess and would be less robust for translated labels or future wording changes. Measuring at the actual font size is safer and keeps the behavior tied to what the renderer really draws.

I also chose not to modify `_draw_kv()` to wrap labels or introduce a second, more complex layout mode. That would have broadened the blast radius across all PDF label/value rendering. Here, the existing primitive was fine; the panel was just passing it the wrong width.

## Out of scope / follow-up notes

During backlog reconciliation, new issues `#1885` and `#1886` appeared, but they are separate report/backlog items and were intentionally left untouched. This PR stays focused on the `Observed Signature` overlap bug only.
