### PR TITLE
Add breathing room to next-steps cards

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
+++ b/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
@@ -93,6 +93,71 @@ class TestNextStepFieldsRendered:
         assert "mount remains rigid" not in captured[1]
 
 
+class TestNextStepCardPadding:
+    """Regression: next-step row content should not crowd the row border."""
+
+    def test_first_row_uses_comfortable_top_and_left_insets(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        canvas = _make_canvas()
+        rect_calls: list[tuple[float, float, float, float]] = []
+        draw_calls: list[tuple[float, float, str]] = []
+        original_rect = canvas.rect
+        original_draw_string = canvas.drawString
+
+        def capture_rect(x: float, y: float, w: float, h: float, *args, **kwargs):
+            rect_calls.append((float(x), float(y), float(w), float(h)))
+            return original_rect(x, y, w, h, *args, **kwargs)
+
+        def capture_draw_string(x: float, y: float, text: str, *args, **kwargs):
+            draw_calls.append((float(x), float(y), str(text)))
+            return original_draw_string(x, y, text, *args, **kwargs)
+
+        monkeypatch.setattr(canvas, "rect", capture_rect)
+        monkeypatch.setattr(canvas, "drawString", capture_draw_string)
+
+        drawn = _draw_next_steps_table(
+            canvas,
+            20.0,
+            220.0,
+            180.0,
+            0.0,
+            [
+                NextStep(
+                    action=(
+                        "Inspect the rear-right wheel bearing preload and confirm "
+                        "whether the vibration changes with steering input"
+                    ),
+                    why="reproduce the strongest signature under the same load window",
+                    confirm="tone and vibration strength drop after the adjustment",
+                    eta="15 min",
+                ),
+            ],
+            tr=lambda key: {"WHY": "Why", "CONFIRM": "Confirm", "ETA": "ETA"}[key],
+        )
+
+        assert drawn == 1
+        row_x, row_y, _row_w, row_h = rect_calls[0]
+        row_top = row_y + row_h
+
+        number_x, _number_y, _number_text = next(
+            (x, y, text) for x, y, text in draw_calls if text == "1."
+        )
+        action_x, action_y, action_text = next(
+            (x, y, text) for x, y, text in draw_calls if text.startswith("Inspect the")
+        )
+        detail_x, _detail_y, detail_text = next(
+            (x, y, text) for x, y, text in draw_calls if text.startswith("Why:")
+        )
+
+        assert action_text
+        assert detail_text
+        assert number_x - row_x >= 1.8 * mm
+        assert detail_x == action_x
+        assert row_top - action_y >= 2.5 * mm
+
+
 class TestOrphanI18nKeysRemoved:
     """Regression: orphan g-unit i18n keys must not exist."""
 

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py
@@ -176,12 +176,20 @@ def _draw_next_steps_table(
     line_clr = _hex(LINE_CLR)
     text_clr = _hex(TEXT_CLR)
     row_pad = 1.5 * mm
-    number_y_off = 4.0 * mm
+    first_row_extra_pad = 1.0 * mm
+    first_row_number_pad_x = 2.0 * mm
+    default_number_pad_x = 2.0
+    first_row_top_pad = 3.0 * mm
+    default_top_pad = 2.0 * mm
     detail_gap = 0.4 * mm
 
     y = y_top
     drawn = 0
     for idx, step in enumerate(steps, start=start_number):
+        is_first_row = drawn == 0
+        number_pad_x = first_row_number_pad_x if is_first_row else default_number_pad_x
+        row_top_pad = first_row_top_pad if is_first_row else default_top_pad
+        number_y_off = row_top_pad + (2.0 * mm)
         detail_parts: list[str] = []
         if step.why:
             detail_parts.append(f"{tr('WHY')}: {step.why}")
@@ -202,6 +210,7 @@ def _draw_next_steps_table(
             max(len(action_lines), 1) * action_leading
             + detail_h
             + row_pad
+            + (first_row_extra_pad if is_first_row else 0.0)
             + (detail_gap if detail_text else 0.0),
         )
         if y - row_h < y_bottom:
@@ -213,12 +222,12 @@ def _draw_next_steps_table(
 
         c.setFillColor(text_clr)
         c.setFont(FONT_B, action_fs)
-        c.drawString(x + 2, y - number_y_off, f"{idx}.")
+        c.drawString(x + number_pad_x, y - number_y_off, f"{idx}.")
 
         action_bottom = _draw_text(
             c,
             x + col1_w,
-            y - 2 * mm,
+            y - row_top_pad,
             text_w,
             step.action,
             font=FONT_B,


### PR DESCRIPTION
Fixes #1880

## Summary

This change adds breathing room to the cramped `Next steps` recommendation card in the generated PDF without broadly reworking page-one or page-two report layout. The issue report pointed at the first recommendation card feeling pressed against its border even when nothing technically overlapped. After tracing the renderer, the problem turned out not to be a shared “card spacing” primitive but the inline next-step row drawing inside `apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py`. The first row in each `Next steps` table was being drawn with a very shallow top inset for the action title and a step-number gutter that started only a couple of points from the left stroke, which made the first row feel cramped in the rendered PDF.

## Problem

The user-facing complaint was visual, not semantic: the first recommendation card in the PDF’s `Next steps` section looked crowded because the text sat too close to the border. The renderer already kept the text inside the row, but it did so with minimal visual margin. Specifically, the first action line started only `2 * mm` below the row’s top stroke, the step number started almost flush with the left border, and the row-height calculation did not reserve any additional breathing room when that first-row content was shifted. The result was a report that was technically correct but looked cramped and less intentional than the rest of the page-one layout.

## Approach

I kept the fix scoped to the actual repro row instead of applying a broad PDF-spacing refactor. During investigation, I confirmed that the “recommendation card” in the issue is the inline row box drawn by `_draw_next_steps_table()`, not the outer rounded panel shell and not the systems-with-findings cards. I initially tried a broader adjustment that gave every next-step row more inset space and reduced text width to create extra breathing room. That version improved the cramped look locally, but it also caused an integration regression: long next-step sequences no longer fit across the existing page-one and page-two continuation layout, and `test_pdf_keeps_long_next_steps_without_ellipsis` started dropping one of the tail markers from the rendered PDF.

That failure was useful because it showed where the real boundary was. The issue report and screenshot were about the first visible recommendation card, so the final change narrows the extra spacing back to the first visible row in each `Next steps` table. That satisfies the visual complaint without spending extra height and wrap width on every subsequent row.

## Main code changes

In `apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py`, `_draw_next_steps_table()` now computes a small set of first-row-only insets. The first visible row gets:

- a larger left inset for the step number,
- a slightly deeper top inset for the action title baseline,
- and `1 mm` of extra row budget so the shifted content stays comfortably inside the box.

Later rows keep their prior text width and general spacing behavior. That was deliberate: it preserves the existing continuation density for long reports, avoids unnecessary reflow on page two, and limits the layout change to the exact row family called out in the issue.

I did not change shared panel styling, page geometry helpers, card colors, translation content, or any of the mapping/report-data layers. The content, numbering, and ordering of `Next steps` remain the same. This is purely a renderer-spacing adjustment in the row component that was visually too tight.

## Test coverage

I added a focused regression in `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`. The new test uses a real ReportLab `Canvas`, renders a real next-step row through `_draw_next_steps_table()`, captures both the row rectangle coordinates and the actual `drawString()` calls, and asserts that the first row now has:

- a meaningful left inset for the step number, and
- a larger top inset for the action title baseline.

I intentionally used geometry assertions rather than extracted PDF text because text extraction can prove that content exists, but it cannot prove that the spacing between text and borders is visually safe.

I also used the existing integration regression suite as the guardrail for layout blast radius. That mattered here because the first implementation attempt caused long next-step pagination fallout. The final version was shaped by that failure and preserves the previous long-content behavior.

## Validation

I ran the issue-focused and broader validations requested by the issue/repo workflow:

- `pytest -q apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
- `pytest -q apps/server/tests/integration/test_report_pipeline.py -k keeps_long_next_steps_without_ellipsis`
- `pytest -q apps/server/tests/adapters/pdf/`
- `make lint`
- `.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

One noteworthy validation detail: the first full backend CI-subset run failed in shard 4 because the broader first attempt made the long-next-steps PDF lose one of the `STEPENDxx` markers in `TestPdfReportValidation.test_pdf_keeps_long_next_steps_without_ellipsis`. After tightening the fix to the first visible row only and preserving later-row wrap width, I reran the focused regression, the exact failing integration test, the full PDF suite, lint, and the full venv-backed backend subset. Everything passed on the final run.

## Risks and tradeoffs

The main tradeoff here is intentional scope control. I did not convert all next-step rows or all report card-like boxes to a new shared padding abstraction because the issue did not justify that level of churn, and the broader attempt already showed that blanket spacing changes have pagination costs. The final result is therefore targeted: it improves the first visible recommendation row that users actually called out, while preserving the density characteristics of later rows and long continued-step reports.

If future backlog items ask for a more global spacing refresh across next-step rows, systems cards, or other page-one panels, that work should probably happen as a coordinated layout pass with explicit pagination expectations. For `#1880`, the safer and more maintainable fix is the narrow renderer adjustment in this PR.
