### PR TITLE
Clarify system card uncertainty labels

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1360,8 +1360,8 @@
     "nl": "Betrouwbaarheid is te laag om trillingen aan specifieke systemen toe te schrijven. Verbeter datakwaliteit en run opnieuw."
   },
   "TIER_B_HYPOTHESIS_LABEL": {
-    "en": "Hypothesis (unconfirmed)",
-    "nl": "Hypothese (onbevestigd)"
+    "en": "Possible source",
+    "nl": "Mogelijke bron"
   },
   "TIER_B_VERIFICATION_HEADER": {
     "en": "Verification steps (not repair recommendations)",

--- a/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
+++ b/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
@@ -11,10 +11,16 @@ from reportlab.lib.units import mm
 from reportlab.pdfgen.canvas import Canvas
 
 import vibesensor.adapters.pdf.panels._panel_header as panel_header
+import vibesensor.adapters.pdf.panels._panel_systems as panel_systems
 import vibesensor.adapters.pdf.panels._panel_trust_steps as panel_trust_steps
 from vibesensor.adapters.pdf.panels._panel_trust_steps import _draw_next_steps_table
 from vibesensor.adapters.pdf.pdf_style import FONT, FS_H2, PdfRenderContext
-from vibesensor.adapters.pdf.report_data import NextStep, PatternEvidence, ReportTemplateData
+from vibesensor.adapters.pdf.report_data import (
+    NextStep,
+    PatternEvidence,
+    ReportTemplateData,
+    SystemFindingCard,
+)
 from vibesensor.report_i18n import tr as report_tr
 
 
@@ -240,3 +246,57 @@ class TestObservedSignatureLayout:
 
         assert value_text
         assert value_x >= label_end_x + (0.8 * mm)
+
+
+class TestSystemCardStatusLabelLayout:
+    """Regression: Tier B system cards should render a separate status label line."""
+
+    def test_status_label_renders_between_title_and_body_lines(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        canvas = _make_canvas()
+        draw_calls: list[tuple[float, float, str]] = []
+        original_draw_string = canvas.drawString
+
+        def capture_draw_string(x: float, y: float, text: str, *args, **kwargs):
+            draw_calls.append((float(x), float(y), str(text)))
+            return original_draw_string(x, y, text, *args, **kwargs)
+
+        monkeypatch.setattr(canvas, "drawString", capture_draw_string)
+
+        panel_systems._draw_system_card(
+            canvas,
+            40.0,
+            120.0,
+            160.0,
+            90.0,
+            SystemFindingCard(
+                system_name="Wheel / Tire",
+                status_label="Possible source",
+                strongest_location="Rear-right wheel",
+                pattern_summary="1.0x wheel order harmonic",
+                parts=[],
+            ),
+            tr=lambda key: {
+                "NOT_AVAILABLE": "N/A",
+                "STRONGEST_SENSOR": "Strongest sensor",
+                "PATTERN_SUMMARY": "Pattern summary",
+            }[key],
+        )
+
+        title_x, title_y, title_text = next(
+            (x, y, text) for x, y, text in draw_calls if text == "Wheel / Tire"
+        )
+        status_x, status_y, status_text = next(
+            (x, y, text) for x, y, text in draw_calls if text == "Possible source"
+        )
+        body_x, body_y, body_text = next(
+            (x, y, text) for x, y, text in draw_calls if text.startswith("Strongest sensor:")
+        )
+
+        assert title_text
+        assert status_text
+        assert body_text
+        assert title_x == status_x == body_x
+        assert title_y > status_y > body_y

--- a/apps/server/tests/adapters/pdf/test_report_tier_gating.py
+++ b/apps/server/tests/adapters/pdf/test_report_tier_gating.py
@@ -163,11 +163,11 @@ class TestTierBReportOutput:
         assert tier_b_data.certainty_tier_key == "B"
         assert len(tier_b_data.system_cards) > 0
 
-    def test_tier_b_cards_labeled_hypothesis(self, tier_b_data):
+    def test_tier_b_cards_use_possible_source_status_label(self, tier_b_data):
         for card in tier_b_data.system_cards:
-            assert (
-                "hypothesis" in card.system_name.lower() or "hypothese" in card.system_name.lower()
-            )
+            assert card.system_name
+            assert "hypothesis" not in card.system_name.lower()
+            assert card.status_label == "Possible source"
 
     def test_tier_b_no_repair_parts(self, tier_b_data):
         for card in tier_b_data.system_cards:
@@ -202,6 +202,7 @@ class TestTierCReportOutput:
     def test_tier_c_cards_no_hypothesis_label(self, tier_c_data):
         for card in tier_c_data.system_cards:
             assert "hypothesis" not in card.system_name.lower()
+            assert card.status_label is None
 
     def test_tier_c_next_steps_from_test_plan(self, tier_c_data):
         assert len(tier_c_data.next_steps) > 0
@@ -257,9 +258,8 @@ class TestCertaintyTierNL:
         actions_text = " ".join(s.action for s in data.next_steps)
         assert "snelheidsvariatie" in actions_text or "sensorlocaties" in actions_text
 
-    def test_tier_b_nl_hypothesis_label(self):
+    def test_tier_b_nl_status_label(self):
         data = map_summary(prepare_report_input(_make_summary(confidence=0.50, lang="nl")))
         for card in data.system_cards:
-            assert (
-                "hypothese" in card.system_name.lower() or "hypothesis" in card.system_name.lower()
-            )
+            assert "hypothese" not in card.system_name.lower()
+            assert card.status_label == "Mogelijke bron"

--- a/apps/server/vibesensor/adapters/pdf/_card_builder.py
+++ b/apps/server/vibesensor/adapters/pdf/_card_builder.py
@@ -65,14 +65,16 @@ def build_system_cards(
         parts_list = parts_for_pattern(source, order_label, lang=lang)
 
         card_system_name = source_human
+        card_status_label: str | None = None
         card_parts = [PartSuggestion(name=part) for part in parts_list]
         if tier == "B":
-            card_system_name = f"{source_human} — {tr('TIER_B_HYPOTHESIS_LABEL')}"
+            card_status_label = tr("TIER_B_HYPOTHESIS_LABEL")
             card_parts = []
 
         cards.append(
             SystemFindingCard(
                 system_name=card_system_name,
+                status_label=card_status_label,
                 strongest_location=location,
                 pattern_summary=pattern_text,
                 parts=card_parts,

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py
@@ -113,12 +113,27 @@ def _draw_system_card(
         color=TEXT_CLR,
         max_lines=2,
     )
+    details_top = title_bottom - 1.2 * mm
+    if card.status_label:
+        details_top = (
+            _draw_text(
+                c,
+                cx,
+                title_bottom - 0.8 * mm,
+                content_w,
+                card.status_label,
+                size=FS_BODY,
+                color=SUB_CLR,
+                max_lines=1,
+            )
+            - 1.0 * mm
+        )
 
     if card.parts:
         pattern_bottom = _draw_text(
             c,
             cx,
-            title_bottom - 1.2 * mm,
+            details_top,
             content_w,
             f"{tr('PATTERN_SUMMARY')}: {_safe(card.pattern_summary, na)}",
             size=FS_BODY,
@@ -140,7 +155,7 @@ def _draw_system_card(
     strongest_bottom = _draw_text(
         c,
         cx,
-        title_bottom - 1.2 * mm,
+        details_top,
         content_w,
         f"{tr('STRONGEST_SENSOR')}: {_safe(card.strongest_location, na)}",
         size=FS_BODY,

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -64,6 +64,7 @@ class SystemFindingCard:
     """A per-system diagnostic finding card for the report, with location and parts."""
 
     system_name: str = ""
+    status_label: str | None = None
     strongest_location: str | None = None
     pattern_summary: str | None = None
     parts: list[PartSuggestion] = field(default_factory=list)

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1360,8 +1360,8 @@
     "nl": "Betrouwbaarheid is te laag om trillingen aan specifieke systemen toe te schrijven. Verbeter datakwaliteit en run opnieuw."
   },
   "TIER_B_HYPOTHESIS_LABEL": {
-    "en": "Hypothesis (unconfirmed)",
-    "nl": "Hypothese (onbevestigd)"
+    "en": "Possible source",
+    "nl": "Mogelijke bron"
   },
   "TIER_B_VERIFICATION_HEADER": {
     "en": "Verification steps (not repair recommendations)",


### PR DESCRIPTION
Fixes #1881

## Summary

This change makes the `Systems with findings` cards easier to read by separating uncertainty wording from the system title and using that reclaimed space as a purposeful status line inside the card. The issue report called out two related problems in the medium-certainty cards: titles such as `Wheel / Tire — Hypothesis (unconfirmed)` were awkward for normal readers, and the cards looked under-used because the top of the card contained only a title plus two short body lines, leaving an obvious empty gap below. The final change keeps the system title clean, moves the cautionary wording into a dedicated Tier B status line, and updates the user-facing copy to a simpler label that still communicates uncertainty.

## Problem

The root cause was split across the card-building and rendering layers. In `apps/server/vibesensor/adapters/pdf/_card_builder.py`, Tier B cards were created by concatenating the uncertainty label directly into `SystemFindingCard.system_name`, which produced titles like `Wheel / Tire — Hypothesis (unconfirmed)`. That phrasing was both clunky and visually heavy because it forced the caution text to compete with the actual system name in the most prominent part of the card.

On the rendering side, `apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py` drew Tier B cards using the same fixed-height card shell as other system cards, but Tier B cards intentionally omit repair-part suggestions. In practice that meant the card body usually contained only two short lines (`Strongest sensor` and `Pattern summary`) beneath a long title. The result was not a broken layout, but a card that felt under-designed: a confusing title at the top and too much unused space below it.

## Approach

I treated the wording and whitespace complaints as one coupled presentation problem rather than two unrelated issues. A pure string replacement would have improved readability, but it would also have shortened the title and potentially made the card feel even emptier. A pure layout compression change would have tightened space usage, but it would still have left the awkward `Hypothesis (unconfirmed)` phrasing in the title. The cleanest fix was to split the two responsibilities:

- keep the card title focused on the actual system name,
- represent uncertainty as a smaller, separate status line,
- and let that extra line use the space that previously felt wasted.

That preserves the report’s directional caution without making the system name harder to scan.

## Main code changes

In `apps/server/vibesensor/adapters/pdf/report_data.py`, `SystemFindingCard` now carries an optional `status_label`. This stays within the existing PDF template-data model and avoids string-parsing hacks in the renderer.

In `apps/server/vibesensor/adapters/pdf/_card_builder.py`, Tier B cards now keep `system_name` as the plain localized source name and populate `status_label` from `TIER_B_HYPOTHESIS_LABEL`. Tier C behavior remains unchanged: those cards still render as plain system titles with actionable parts when available.

In `apps/server/vibesensor/adapters/pdf/panels/_panel_systems.py`, `_draw_system_card()` now renders `status_label` as a dedicated subtitle line beneath the title when present. That creates a clearer visual hierarchy:

- title = system name,
- subtitle = uncertainty/caution state,
- body = strongest sensor or parts + pattern summary.

This uses the existing fixed card height more intentionally and makes the Tier B cards feel more balanced without shrinking the card shell or forcing tighter line spacing.

I also updated the Tier B label text in both canonical and packaged runtime copies of `report_i18n.json`. The old wording:

- English: `Hypothesis (unconfirmed)`
- Dutch: `Hypothese (onbevestigd)`

now becomes:

- English: `Possible source`
- Dutch: `Mogelijke bron`

That wording is shorter, clearer for non-technical readers, and still clearly directional rather than diagnostic-final.

## Test coverage

I updated the tier-gating tests in `apps/server/tests/adapters/pdf/test_report_tier_gating.py` to reflect the new mapped card shape. Tier B cards now assert against `status_label == "Possible source"` (and the Dutch equivalent), while Tier C cards assert that `status_label is None`. This keeps the medium-certainty and high-certainty behaviors explicitly separated.

I also added a focused renderer regression in `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`. The new test renders a real `SystemFindingCard` onto a real ReportLab `Canvas`, captures the `drawString()` calls, and asserts that:

- the plain system title is still rendered,
- the Tier B status label is rendered separately,
- and the status label sits between the title and the body line.

That gives us a layout-aware regression instead of relying only on extracted PDF text.

## Validation

I ran the direct and broader validations for the touched PDF/backend surfaces:

- `pytest -q apps/server/tests/adapters/pdf/test_report_tier_gating.py`
- `pytest -q apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
- `pytest -q apps/server/tests/adapters/pdf/`
- `pytest -q apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `make lint`
- `.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

There was one validation follow-up worth noting. The first backend CI-subset rerun failed only on `test_packaged_runtime_data_matches_canonical_source`, which is the expected hygiene guard when canonical runtime JSON changes but the packaged copy has not yet been synced. That was not a renderer regression; it was simply drift between:

- `apps/server/data/report_i18n.json`
- `apps/server/vibesensor/data/report_i18n.json`

I synced the packaged copy, reran the targeted hygiene test, reran lint, and reran the full venv-backed backend subset. Everything passed after that follow-up.

## Risks and tradeoffs

The main tradeoff here is that I intentionally did not redesign the system-card geometry wholesale. The issue only justified a clearer uncertainty presentation and better use of the existing card space, so I avoided introducing a new general-purpose card-layout mode, dynamic card heights, or broader page-one geometry changes. That keeps the diff small and the behavior easy to reason about.

The final result is also intentionally specific to Tier B-style uncertainty presentation. High-certainty cards still behave the same way, and the fix does not change report ranking, next steps, or domain diagnosis logic. If future feedback asks for a broader visual refresh of all system cards, that should happen as a coordinated layout pass. For `#1881`, the cleaner and lower-risk solution is to separate the status label from the title and use that line to make the existing card space feel intentional.
