### PR TITLE
Focus PDF report next steps on top diagnostics

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1047,6 +1047,34 @@
     "en": "VibeSensor Diagnostic Report",
     "nl": "VibeSensor-diagnoserapport"
   },
+  "REPORT_NEXT_STEP_DRIVELINE_INSPECTION_WHAT": {
+    "en": "Check driveline components near {location} for play, runout, or bad bearings.",
+    "nl": "Controleer aandrijflijncomponenten bij {location} op speling, slingering of slechte lagers."
+  },
+  "REPORT_NEXT_STEP_DRIVELINE_MOUNTS_WHAT": {
+    "en": "Check driveline mounts and couplings near {location} for looseness or cracked rubber.",
+    "nl": "Controleer aandrijflijnsteunen en koppelingen bij {location} op losheid of gescheurd rubber."
+  },
+  "REPORT_NEXT_STEP_ENGINE_COMBUSTION_WHAT": {
+    "en": "Check misfire counters and fuel/ignition corrections for cylinders contributing to the vibration.",
+    "nl": "Controleer misfire-tellers en brandstof-/ontstekingscorrecties op cilinders die aan de trilling bijdragen."
+  },
+  "REPORT_NEXT_STEP_ENGINE_MOUNTS_WHAT": {
+    "en": "Check engine mounts and accessory drive for play or resonance.",
+    "nl": "Controleer motorsteunen en hulpaandrijving op speling of resonantie."
+  },
+  "REPORT_NEXT_STEP_GENERAL_INSPECTION_WHAT": {
+    "en": "Check the hotspot near {location} for loose fasteners, worn bushings, bearing play, or mount movement.",
+    "nl": "Controleer de hotspot bij {location} op losse bevestigingen, versleten rubbers, lagerspeling of bewegende steunen."
+  },
+  "REPORT_NEXT_STEP_TIRE_CONDITION_WHAT": {
+    "en": "Check {location} for tire damage, flat spots, belt shift, uneven wear, or pressure mismatch.",
+    "nl": "Controleer {location} op bandschade, vlakke plekken, gordelverschuiving, ongelijk slijtagebeeld of drukverschil."
+  },
+  "REPORT_NEXT_STEP_WHEEL_BALANCE_WHAT": {
+    "en": "Check {location} for imbalance or radial/lateral runout.",
+    "nl": "Controleer {location} op onbalans of radiale/laterale slingering."
+  },
   "REQUIRED_COLUMN": {
     "en": "Required Column",
     "nl": "Verplicht veld"

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -119,10 +119,11 @@ def test_map_summary_uses_domain_action_render_queries_for_next_steps() -> None:
     data = map_summary(prepare_report_input(summary))
 
     assert data.next_steps[0].action
+    assert "engine mount" in data.next_steps[0].action.lower()
     assert data.next_steps[0].why
     assert data.next_steps[0].confirm
     assert data.next_steps[0].falsify is None
-    assert data.next_steps[0].eta == "15-30 min"
+    assert data.next_steps[0].eta is None
 
 
 def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
@@ -132,6 +133,7 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
                 "finding_id": "F001",
                 "suspected_source": "wheel/tire",
                 "confidence": 0.74,
+                "strongest_location": "front-left wheel",
             }
         ],
         top_causes=[
@@ -139,6 +141,7 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
                 "finding_id": "F001",
                 "suspected_source": "wheel/tire",
                 "confidence": 0.74,
+                "strongest_location": "front-left wheel",
             }
         ],
         test_plan=[
@@ -170,6 +173,9 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
     )
 
     data = map_summary(prepare_report_input(summary))
+    assert len(data.next_steps) == 2
+    assert all(step.eta is None for step in data.next_steps)
+    assert all("front-left wheel" in step.action.lower() for step in data.next_steps)
     rendered = " ".join(
         part
         for step in data.next_steps

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -184,6 +184,7 @@ def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
                 "finding_id": "F001",
                 "suspected_source": "wheel/tire",
                 "confidence": 0.74,
+                "strongest_location": "front-left wheel",
             }
         ],
         top_causes=[
@@ -191,6 +192,7 @@ def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
                 "finding_id": "F001",
                 "suspected_source": "wheel/tire",
                 "confidence": 0.74,
+                "strongest_location": "front-left wheel",
             }
         ],
         test_plan=[
@@ -227,8 +229,14 @@ def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
     assert "{speed_hint}" not in text_blob
     assert "{location_hint}" not in text_blob
     assert "{driveline_focus}" not in text_blob
-    assert "Inspect propshaft runout/balance" in text_blob
-    assert "Inspect the relevant wheel/tire assemblies" in text_blob
+    assert "Check front-left wheel for imbalance or radial/lateral runout." in text_blob
+    assert (
+        "Check front-left wheel for tire damage, flat spots, belt shift, uneven wear, or"
+        in text_blob
+    )
+    assert "pressure mismatch." in text_blob
+    assert "Inspect propshaft runout/balance" not in text_blob
+    assert "ETA:" not in text_blob
 
 
 def test_report_pdf_compacts_actionable_system_cards() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
@@ -118,14 +118,8 @@ class TestPeakDbEqualsStrengthDb:
         assert pr.strength_db == "15.1"
 
 
-class TestNextStepFieldsNotRendered:
-    """NextStep dataclass has confirm, falsify, eta, speed_band fields
-    that are populated by the builder but the PDF renderer only reads
-    step.action and step.why.
-
-    Evidence: `panels/_panel_trust_steps.py` is the panel-level next-steps renderer.
-    Impact: actionable diagnostic guidance is lost in PDF output.
-    """
+class TestNextStepFieldProjection:
+    """Report projection keeps useful diagnostic detail and drops ETA text."""
 
     def test_nextstep_fields_populated_by_builder(self) -> None:
         """Verify the builder does populate these fields."""
@@ -170,7 +164,7 @@ class TestNextStepFieldsNotRendered:
         ns = matching[0]
         assert ns.confirm == "Noise disappears at low speed"
         assert ns.falsify == "Noise persists with new bearing"
-        assert ns.eta == "30 min"
+        assert ns.eta is None
 
 
 class TestTopCausesFallbackBypassesPersistenceRanking:

--- a/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
+++ b/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
@@ -60,7 +60,7 @@ class TestNextStepNumberingContinuation:
 
 
 class TestNextStepFieldsRendered:
-    """Regression: action renders separately from compact why/confirm/eta details."""
+    """Regression: action renders separately from compact why/confirm details."""
 
     def test_optional_fields_are_included_in_rendered_text(
         self,
@@ -88,14 +88,14 @@ class TestNextStepFieldsRendered:
                     eta="15 min",
                 ),
             ],
-            tr=lambda key: {"WHY": "Why", "CONFIRM": "Confirm", "ETA": "ETA"}[key],
+            tr=lambda key: {"WHY": "Why", "CONFIRM": "Confirm"}[key],
         )
 
         assert len(captured) == 2
         assert captured[0] == "Inspect mount"
         assert "Why: verify looseness" in captured[1]
         assert "Confirm: movement increases" in captured[1]
-        assert "ETA: 15 min" in captured[1]
+        assert "ETA:" not in captured[1]
         assert "mount remains rigid" not in captured[1]
 
 

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -233,6 +233,7 @@ def _build_report_template_data(
     )
     next_steps = build_next_steps(
         recommended_actions=report_facts.recommended_actions,
+        primary_location=primary.primary_location,
         tier=primary.tier,
         cert_reason=primary.certainty_reason,
         lang=lang,

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py
@@ -193,12 +193,7 @@ def _draw_next_steps_table(
         detail_parts: list[str] = []
         if step.why:
             detail_parts.append(f"{tr('WHY')}: {step.why}")
-        if step.eta:
-            eta_text = f"{tr('ETA')}: {step.eta}"
-            if step.confirm:
-                detail_parts.append(f"{tr('CONFIRM')}: {step.confirm}")
-            detail_parts.append(eta_text)
-        elif step.confirm:
+        if step.confirm:
             detail_parts.append(f"{tr('CONFIRM')}: {step.confirm}")
         detail_text = " | ".join(detail_parts)
 

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -73,7 +73,7 @@ class SystemFindingCard:
 
 @dataclass
 class NextStep:
-    """A recommended diagnostic next step (action, rationale, ETA)."""
+    """A recommended diagnostic next step and its supporting detail."""
 
     action: str = ""
     why: str | None = None

--- a/apps/server/vibesensor/adapters/pdf/report_sections.py
+++ b/apps/server/vibesensor/adapters/pdf/report_sections.py
@@ -19,10 +19,22 @@ __all__ = [
     "build_next_steps",
 ]
 
+_REPORT_FOCUSED_ACTION_LIMIT = 2
+_REPORT_FOCUSED_ACTION_SPECS: dict[str, tuple[str, bool]] = {
+    "driveline_inspection": ("REPORT_NEXT_STEP_DRIVELINE_INSPECTION_WHAT", True),
+    "driveline_mounts_and_fasteners": ("REPORT_NEXT_STEP_DRIVELINE_MOUNTS_WHAT", True),
+    "engine_combustion_quality": ("REPORT_NEXT_STEP_ENGINE_COMBUSTION_WHAT", False),
+    "engine_mounts_and_accessories": ("REPORT_NEXT_STEP_ENGINE_MOUNTS_WHAT", False),
+    "general_mechanical_inspection": ("REPORT_NEXT_STEP_GENERAL_INSPECTION_WHAT", True),
+    "wheel_balance_and_runout": ("REPORT_NEXT_STEP_WHEEL_BALANCE_WHAT", True),
+    "wheel_tire_condition": ("REPORT_NEXT_STEP_TIRE_CONDITION_WHAT", True),
+}
+
 
 def build_next_steps(
     *,
     recommended_actions: Sequence[RecommendedAction],
+    primary_location: str | None = None,
     tier: str,
     cert_reason: str,
     lang: str,
@@ -39,11 +51,17 @@ def build_next_steps(
             )
         ]
 
+    report_actions = _report_actions_for_report(recommended_actions)
+    location_hint = _usable_primary_location(primary_location, tr=tr)
     next_steps: list[NextStep] = []
-    for action in recommended_actions:
+    for action in report_actions:
         next_steps.append(
             NextStep(
-                action=_resolve_step_value(action.instruction, lang=lang, tr=tr),
+                action=_resolve_step_value(
+                    _report_action_value(action, primary_location=location_hint),
+                    lang=lang,
+                    tr=tr,
+                ),
                 why=_resolve_optional_step_value(action.rationale, lang=lang, tr=tr),
                 confirm=_resolve_optional_step_value(
                     action.confirmation_signal,
@@ -55,10 +73,64 @@ def build_next_steps(
                     lang=lang,
                     tr=tr,
                 ),
-                eta=action.estimated_duration,
             ),
         )
     return next_steps
+
+
+def _report_actions_for_report(
+    recommended_actions: Sequence[RecommendedAction],
+) -> tuple[RecommendedAction, ...]:
+    """Return the report-facing action list without disturbing custom summary steps."""
+    actions = tuple(recommended_actions)
+    if _uses_generated_action_plan(actions):
+        return actions[:_REPORT_FOCUSED_ACTION_LIMIT]
+    return actions
+
+
+def _uses_generated_action_plan(actions: Sequence[RecommendedAction]) -> bool:
+    """Return whether the actions came from the built-in planner action set."""
+    return bool(actions) and all(
+        _normalized_action_id(action.action_id) in _REPORT_FOCUSED_ACTION_SPECS
+        for action in actions
+    )
+
+
+def _report_action_value(
+    action: RecommendedAction,
+    *,
+    primary_location: str | None,
+) -> object:
+    """Return focused report wording when the action came from the built-in planner."""
+    spec = _REPORT_FOCUSED_ACTION_SPECS.get(_normalized_action_id(action.action_id))
+    if spec is None:
+        return action.instruction
+    key, needs_location = spec
+    if not needs_location:
+        return key
+    if primary_location is None:
+        return action.instruction
+    return {"_i18n_key": key, "location": primary_location}
+
+
+def _usable_primary_location(
+    primary_location: str | None,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    """Return the report hotspot when it is known enough to render directly."""
+    location = str(primary_location or "").strip()
+    if not location:
+        return None
+    unknown_tokens = {"unknown", str(tr("UNKNOWN")).strip().lower()}
+    if location.lower() in unknown_tokens:
+        return None
+    return location
+
+
+def _normalized_action_id(value: object) -> str:
+    """Return the canonical action identifier for planner/report matching."""
+    return str(value or "").strip().lower()
 
 
 def _resolve_step_value(value: object, *, lang: str, tr: Callable[..., str]) -> str:

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1047,6 +1047,34 @@
     "en": "VibeSensor Diagnostic Report",
     "nl": "VibeSensor-diagnoserapport"
   },
+  "REPORT_NEXT_STEP_DRIVELINE_INSPECTION_WHAT": {
+    "en": "Check driveline components near {location} for play, runout, or bad bearings.",
+    "nl": "Controleer aandrijflijncomponenten bij {location} op speling, slingering of slechte lagers."
+  },
+  "REPORT_NEXT_STEP_DRIVELINE_MOUNTS_WHAT": {
+    "en": "Check driveline mounts and couplings near {location} for looseness or cracked rubber.",
+    "nl": "Controleer aandrijflijnsteunen en koppelingen bij {location} op losheid of gescheurd rubber."
+  },
+  "REPORT_NEXT_STEP_ENGINE_COMBUSTION_WHAT": {
+    "en": "Check misfire counters and fuel/ignition corrections for cylinders contributing to the vibration.",
+    "nl": "Controleer misfire-tellers en brandstof-/ontstekingscorrecties op cilinders die aan de trilling bijdragen."
+  },
+  "REPORT_NEXT_STEP_ENGINE_MOUNTS_WHAT": {
+    "en": "Check engine mounts and accessory drive for play or resonance.",
+    "nl": "Controleer motorsteunen en hulpaandrijving op speling of resonantie."
+  },
+  "REPORT_NEXT_STEP_GENERAL_INSPECTION_WHAT": {
+    "en": "Check the hotspot near {location} for loose fasteners, worn bushings, bearing play, or mount movement.",
+    "nl": "Controleer de hotspot bij {location} op losse bevestigingen, versleten rubbers, lagerspeling of bewegende steunen."
+  },
+  "REPORT_NEXT_STEP_TIRE_CONDITION_WHAT": {
+    "en": "Check {location} for tire damage, flat spots, belt shift, uneven wear, or pressure mismatch.",
+    "nl": "Controleer {location} op bandschade, vlakke plekken, gordelverschuiving, ongelijk slijtagebeeld of drukverschil."
+  },
+  "REPORT_NEXT_STEP_WHEEL_BALANCE_WHAT": {
+    "en": "Check {location} for imbalance or radial/lateral runout.",
+    "nl": "Controleer {location} op onbalans of radiale/laterale slingering."
+  },
   "REQUIRED_COLUMN": {
     "en": "Required Column",
     "nl": "Verplicht veld"


### PR DESCRIPTION
Closes #1882

## Summary

This change makes the PDF report’s `Next steps` section behave like a short diagnostic plan instead of a broad maintenance checklist. Before this patch, the PDF adapter projected the full prepared action list directly into the report, which meant the visible steps inherited the domain planner’s more general wording, showed every generated action, and still rendered `ETA` text inline with the recommendation details. In practice that produced the exact problem described in the issue: too many steps, wording that felt like “inspect everything,” and visual clutter from repeated duration estimates.

The fix keeps the shared domain `test_plan` contract intact and moves the report-specific narrowing into the PDF adapter layer, where the presentation decision actually belongs. Generated planner actions now collapse to a focused two-step report plan, their visible action text becomes more specific to the likely source and hotspot location when that location is known, and ETA is removed from both the report projection and the renderer.

## Implementation approach

I deliberately did **not** rewrite `apps/server/vibesensor/domain/test_plan.py`. That domain service still owns the broader machine-readable recommendation set used by other consumers, and changing it would have widened the blast radius into history payloads, diagnostics summaries, and any non-PDF consumer of the test-plan contract. Instead, I treated this as a report-projection problem:

- keep the upstream planner untouched,
- recognize the generated planner action IDs only when building PDF `NextStep` rows,
- condense the visible report guidance there,
- and leave custom/manual summary steps alone unless they are part of that fully generated plan.

That separation keeps the behavior change tightly scoped to the report output the issue is talking about while preserving the existing domain boundaries and serialization contracts.

## Main code changes

### 1. Focus report-facing next steps in `report_sections.py`

`apps/server/vibesensor/adapters/pdf/report_sections.py` now has a focused report-action mapping for the built-in planner action IDs. The key behavior changes are:

- generated action lists are recognized by their stable semantic `action_id`s,
- purely generated plans are capped to the top two report-facing steps,
- action text is rewritten with report-only wording keys,
- hotspot location is interpolated into the visible action text when the primary location is actually known,
- and ETA is no longer copied into the report-facing `NextStep` dataclass.

This means the PDF now shows recommendations more like “Check front-left wheel for imbalance or radial/lateral runout” instead of the older “Inspect and balance the relevant wheel/tire assemblies...” phrasing. When the report does not have a trustworthy hotspot location, the builder falls back to the original instruction text rather than manufacturing misleading wording.

I also kept the adapter conservative around custom or mixed input. The narrowing only applies when the action list is clearly the generated planner set, which avoids silently rewriting arbitrary custom summary-step fixtures.

### 2. Pass prepared hotspot context into the next-step builder

`apps/server/vibesensor/adapters/pdf/mapping.py` now passes `primary.primary_location` into `build_next_steps()`. That keeps the location-specific wording grounded in the already prepared primary-candidate facts rather than re-deriving location hints inside the section builder.

### 3. Remove ETA from rendered report output

`apps/server/vibesensor/adapters/pdf/panels/_panel_trust_steps.py` no longer appends `ETA` into the compact detail line. The row now renders only the actionable explanation fields that still help the user decide what to check: `Why` and `Confirm`.

I also updated the `NextStep` docstring in `apps/server/vibesensor/adapters/pdf/report_data.py` so it no longer describes ETA as a core part of the report-facing recommendation shape.

### 4. Add report-only localized wording and keep packaged data in sync

I added new `REPORT_NEXT_STEP_*` keys to both:

- `apps/server/data/report_i18n.json`
- `apps/server/vibesensor/data/report_i18n.json`

These new keys provide the shorter, location-aware visible wording used only by the report projection layer. As with the earlier PDF wording issue, I updated both the canonical and packaged runtime copies together so the packaged-data sync guard continues to pass.

## Tests and validation

I updated and extended the PDF regression coverage to match the new contract:

- `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py` now checks that generated report next steps are narrowed, location-specific, and no longer carry ETA in the report projection.
- `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py` now asserts that rendered detail text includes `Why` and `Confirm` but no `ETA`.
- `apps/server/tests/adapters/pdf/test_report_pipeline_audit.py` now reflects that confirm/falsify remain useful internal detail while ETA is intentionally dropped from the report-facing projection.
- `apps/server/tests/adapters/pdf/test_report_pdf_rendering.py` now pins the new focused PDF text and confirms the removed driveline overreach/ETA clutter do not leak back in.

During broader validation, one shard surfaced a stale assertion in `test_report_pdf_rendering.py` that still expected the pre-issue generic driveline wording. I updated that regression to assert the new focused wheel/hotspot wording instead of the old text, then reran the affected PDF files and the full backend subset.

Local validation performed for this change:

- `pytest -q apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_rendering_regressions.py apps/server/tests/adapters/pdf/test_report_pipeline_audit.py apps/server/tests/adapters/pdf/test_report_tier_gating.py apps/server/tests/integration/test_report_pipeline.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `pytest -q apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_rendering_regressions.py apps/server/tests/adapters/pdf/test_report_pipeline_audit.py`
- `make lint`
- `./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

I also ran a live runtime smoke against a native local server because this environment does not expose a working Docker daemon socket, so `docker-compose up -d --build` could not be used here. The fallback smoke used the existing recording lifecycle (`/api/recording/start` → simulator with `--no-auto-server` → `/api/recording/stop`), confirmed the run persisted, waited for analysis completion, downloaded the generated report PDF, and verified history stopped changing after the simulator stopped. That run persisted as `9a57caec8ee74398acc453b7be03ad9e`, completed analysis successfully, and produced a valid PDF.

## Risks and tradeoffs

The main tradeoff here is that the PDF now intentionally treats generated plans as a report-specific summary rather than a verbatim mirror of the entire test-plan payload. That is the desired behavior for the issue, but it does mean the PDF can show fewer visible steps than the underlying domain plan contains. I kept that behavior constrained to clearly generated planner actions so custom/manual summary-step fixtures are not unexpectedly rewritten.

If we later decide other report consumers should use the same focused phrasing, we can pull the report-only wording deeper into a shared report-preparation seam. For now, keeping it in the PDF adapter is the safest change because it addresses the user-visible report problem without changing the broader diagnostics contract.
