### PR TITLE
Clarify PDF evidence section context

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
@@ -16,6 +16,7 @@ from vibesensor.adapters.pdf.presentation import (
     strength_label,
     strength_text,
 )
+from vibesensor.adapters.pdf.report_data import FindingPresentation
 from vibesensor.adapters.pdf.report_sections import (
     build_data_trust,
     build_next_steps,
@@ -123,6 +124,27 @@ def test_build_peak_row_high_presence_transient_uses_repeatability_label() -> No
         }[key],
     )
     assert row.relevance == "Repeated pattern"
+
+
+def test_peak_row_system_label_falls_back_to_matching_finding_order() -> None:
+    label = peak_row_system_label(
+        {
+            "frequency_hz": 11.0,
+            "order_label": "1x wheel",
+            "suspected_source": "",
+        },
+        findings=[
+            FindingPresentation(
+                suspected_source="wheel/tire",
+                order="1x wheel",
+                frequency_hz=10.9,
+            )
+        ],
+        tr=lambda key, **_kw: {
+            "SOURCE_WHEEL_TIRE": "Wheel / Tire",
+        }[key],
+    )
+    assert label == "Wheel / Tire"
 
 
 def test_extracted_pdf_builders_are_importable() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from test_support.findings import make_finding_payload
 from test_support.report_helpers import RUN_END, minimal_summary, write_jsonl
 from test_support.report_helpers import report_run_metadata as _run_metadata
 from test_support.report_helpers import report_sample as _base_sample
@@ -189,6 +190,51 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
     assert "{driveline_focus}" not in rendered
     assert "{" not in rendered
     assert "}" not in rendered
+
+
+def test_map_summary_backfills_peak_system_from_matching_finding() -> None:
+    summary = minimal_summary(
+        findings=[
+            make_finding_payload(
+                finding_id="F_PEAK",
+                suspected_source="wheel/tire",
+                confidence=0.82,
+                strongest_location="front-left wheel",
+                frequency_hz=41.0,
+                frequency_hz_or_order="41.0 Hz",
+            )
+        ],
+        top_causes=[
+            make_finding_payload(
+                finding_id="F_PEAK",
+                suspected_source="wheel/tire",
+                confidence=0.82,
+                strongest_location="front-left wheel",
+                frequency_hz=41.0,
+                frequency_hz_or_order="41.0 Hz",
+            )
+        ],
+        plots={
+            "peaks_table": [
+                {
+                    "rank": 1,
+                    "frequency_hz": 41.0,
+                    "order_label": "",
+                    "suspected_source": "",
+                    "p95_intensity_db": 18.0,
+                    "strength_db": 18.0,
+                    "presence_ratio": 0.8,
+                    "peak_classification": "persistent",
+                    "typical_speed_band": "50-80 km/h",
+                }
+            ]
+        },
+    )
+
+    data = map_summary(prepare_report_input(summary))
+
+    assert len(data.peak_rows) == 1
+    assert data.peak_rows[0].system == "Wheel / Tire"
 
 
 def test_map_summary_uses_connected_sensors_for_report_evidence() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
+++ b/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
@@ -13,9 +13,11 @@ from reportlab.pdfgen.canvas import Canvas
 import vibesensor.adapters.pdf.panels._panel_header as panel_header
 import vibesensor.adapters.pdf.panels._panel_systems as panel_systems
 import vibesensor.adapters.pdf.panels._panel_trust_steps as panel_trust_steps
+from vibesensor.adapters.pdf.panels._panel_observations import _draw_additional_observations
 from vibesensor.adapters.pdf.panels._panel_trust_steps import _draw_next_steps_table
 from vibesensor.adapters.pdf.pdf_style import FONT, FS_H2, PdfRenderContext
 from vibesensor.adapters.pdf.report_data import (
+    FindingPresentation,
     NextStep,
     PatternEvidence,
     ReportTemplateData,
@@ -162,6 +164,44 @@ class TestNextStepCardPadding:
         assert number_x - row_x >= 1.8 * mm
         assert detail_x == action_x
         assert row_top - action_y >= 2.5 * mm
+
+
+class TestAdditionalObservationsContext:
+    """Regression: additional observations should include useful source/location context."""
+
+    def test_transient_observation_lists_source_location_and_signature(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        canvas = _make_canvas()
+        captured: list[str] = []
+        original_draw_string = canvas.drawString
+
+        def capture_draw_string(x: float, y: float, text: str, *args, **kwargs):
+            captured.append(str(text))
+            return original_draw_string(x, y, text, *args, **kwargs)
+
+        monkeypatch.setattr(canvas, "drawString", capture_draw_string)
+        _draw_additional_observations(
+            canvas,
+            0,
+            80,
+            120,
+            50,
+            [
+                FindingPresentation(
+                    suspected_source="transient_impact",
+                    strongest_location="rear-right wheel",
+                    order="1x wheel",
+                )
+            ],
+            lambda key: {
+                "ADDITIONAL_OBSERVATIONS": "Supporting Observations",
+                "SOURCE_TRANSIENT_IMPACT": "Transient impact",
+            }[key],
+        )
+
+        assert any(text == "• Transient impact | rear-right wheel | 1x wheel" for text in captured)
 
 
 class TestOrphanI18nKeysRemoved:

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -251,7 +251,16 @@ def _build_report_template_data(
         lang,
         tr,
     )
-    peak_rows = build_peak_rows(prepared.renderer_payload.peak_table_rows, lang=lang, tr=tr)
+    findings = [_finding_to_presentation(f) for f in context.domain_aggregate.findings]
+    top_causes = [
+        _finding_to_presentation(f) for f in context.domain_aggregate.effective_top_causes()
+    ]
+    peak_rows = build_peak_rows(
+        prepared.renderer_payload.peak_table_rows,
+        findings=findings,
+        lang=lang,
+        tr=tr,
+    )
     version_marker = build_version_marker()
 
     return build_template_data(
@@ -266,10 +275,8 @@ def _build_report_template_data(
         pattern_evidence=pattern_evidence,
         peak_rows=peak_rows,
         version_marker=version_marker,
-        findings=[_finding_to_presentation(f) for f in context.domain_aggregate.findings],
-        top_causes=[
-            _finding_to_presentation(f) for f in context.domain_aggregate.effective_top_causes()
-        ],
+        findings=findings,
+        top_causes=top_causes,
         sensor_intensity=raw_sensor_intensity,
         hotspot_rows=list(report_facts.location_hotspot_rows),
     )

--- a/apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py
+++ b/apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py
@@ -10,6 +10,7 @@ from reportlab.pdfgen.canvas import Canvas
 from vibesensor.adapters.pdf.pdf_drawing import _draw_panel, _hex
 from vibesensor.adapters.pdf.pdf_style import FONT, MUTED_CLR, SOFT_BG
 from vibesensor.adapters.pdf.report_data import FindingPresentation
+from vibesensor.report_i18n import human_source
 
 
 def _draw_additional_observations(
@@ -33,10 +34,23 @@ def _draw_additional_observations(
     for finding in transient_findings[:3]:
         if y_cursor < y_min:
             break
-        order_label = finding.order.strip()
-        if not order_label and finding.frequency_hz is not None:
-            order_label = f"{finding.frequency_hz:.1f} Hz"
-        if not order_label:
-            order_label = tr("SOURCE_TRANSIENT_IMPACT")
-        c.drawString(x_pad, y_cursor, f"• {order_label}")
+        c.drawString(x_pad, y_cursor, f"• {_observation_text(finding, tr=tr)}")
         y_cursor -= step
+
+
+def _observation_text(
+    finding: FindingPresentation,
+    *,
+    tr: Callable[[str], str],
+) -> str:
+    """Return a compact, human-readable transient observation summary."""
+    source = str(finding.suspected_source or "").strip()
+    parts = [human_source(source, tr=tr) if source else tr("SOURCE_TRANSIENT_IMPACT")]
+    if finding.strongest_location:
+        parts.append(str(finding.strongest_location))
+    order_label = str(finding.order or "").strip()
+    if order_label:
+        parts.append(order_label)
+    elif finding.frequency_hz is not None:
+        parts.append(f"{finding.frequency_hz:.1f} Hz")
+    return " | ".join(part for part in parts if part)

--- a/apps/server/vibesensor/adapters/pdf/peak_table.py
+++ b/apps/server/vibesensor/adapters/pdf/peak_table.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 
 from vibesensor.adapters.pdf.presentation import order_label_human, peak_classification_text
-from vibesensor.adapters.pdf.report_data import PeakRow
+from vibesensor.adapters.pdf.report_data import FindingPresentation, PeakRow
 from vibesensor.adapters.pdf.report_types import PeakTableRow
 from vibesensor.domain import VibrationSource
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
@@ -16,10 +16,19 @@ __all__ = [
     "peak_row_system_label",
 ]
 
+_SOURCE_I18N_KEYS: dict[str, str] = {
+    VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
+    VibrationSource.ENGINE: "SOURCE_ENGINE",
+    VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
+    VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
+}
+_PEAK_FINDING_TOLERANCE_HZ = 2.0
+
 
 def build_peak_rows(
     rows: Sequence[PeakTableRow],
     *,
+    findings: Sequence[FindingPresentation] = (),
     lang: str,
     tr: Callable[..., str],
 ) -> list[PeakRow]:
@@ -27,10 +36,16 @@ def build_peak_rows(
     raw_peaks = [row for row in rows if isinstance(row, Mapping)]
     above_noise = [row for row in raw_peaks if (_as_float(row.get("strength_db")) or 0.0) > 0]
     ranked = above_noise or raw_peaks
-    return [build_peak_row(row, lang=lang, tr=tr) for row in ranked[:8]]
+    return [build_peak_row(row, findings=findings, lang=lang, tr=tr) for row in ranked[:8]]
 
 
-def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> PeakRow:
+def build_peak_row(
+    row: PeakTableRow,
+    *,
+    findings: Sequence[FindingPresentation] = (),
+    lang: str,
+    tr: Callable[..., str],
+) -> PeakRow:
     """Build one report peak row from a plot peak-table row."""
     rank_val = _as_float(row.get("rank"))
     rank = str(int(rank_val)) if rank_val is not None else "—"
@@ -46,7 +61,7 @@ def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> P
     speed = str(row.get("typical_speed_band") or "—")
     return PeakRow(
         rank=rank,
-        system=peak_row_system_label(row, tr=tr),
+        system=peak_row_system_label(row, findings=findings, tr=tr),
         freq_hz=freq,
         order=order,
         peak_db=peak_db,
@@ -56,19 +71,79 @@ def build_peak_row(row: PeakTableRow, *, lang: str, tr: Callable[..., str]) -> P
     )
 
 
-def peak_row_system_label(row: PeakTableRow, *, tr: Callable[..., str]) -> str:
+def peak_row_system_label(
+    row: PeakTableRow,
+    *,
+    findings: Sequence[FindingPresentation] = (),
+    tr: Callable[..., str],
+) -> str:
     """Resolve the system label shown for one peak row."""
-    source_hint = str(row.get("suspected_source") or "").strip().lower()
-    source_map: dict[str, str] = {
-        VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
-        VibrationSource.ENGINE: "SOURCE_ENGINE",
-        VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
-        VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
-    }
-    i18n_key = source_map.get(source_hint)
+    source_hint = _peak_row_source_hint(row, findings=findings)
+    i18n_key = _SOURCE_I18N_KEYS.get(source_hint)
     if i18n_key:
         return str(tr(i18n_key))
     return "—"
+
+
+def _peak_row_source_hint(
+    row: PeakTableRow,
+    *,
+    findings: Sequence[FindingPresentation],
+) -> str:
+    """Return the best available source hint for a peak row."""
+    source_hint = str(row.get("suspected_source") or "").strip().lower()
+    if source_hint in _SOURCE_I18N_KEYS:
+        return source_hint
+    order_source = _source_hint_for_order(row, findings=findings)
+    if order_source is not None:
+        return order_source
+    frequency_source = _source_hint_for_frequency(row, findings=findings)
+    if frequency_source is not None:
+        return frequency_source
+    return source_hint
+
+
+def _source_hint_for_order(
+    row: PeakTableRow,
+    *,
+    findings: Sequence[FindingPresentation],
+) -> str | None:
+    """Match peak rows to findings by shared order label before frequency fallback."""
+    order_label = str(row.get("order_label") or "").strip().lower()
+    if not order_label:
+        return None
+    for finding in findings:
+        candidate_source = str(finding.suspected_source or "").strip().lower()
+        if candidate_source not in _SOURCE_I18N_KEYS:
+            continue
+        if str(finding.order or "").strip().lower() == order_label:
+            return candidate_source
+    return None
+
+
+def _source_hint_for_frequency(
+    row: PeakTableRow,
+    *,
+    findings: Sequence[FindingPresentation],
+) -> str | None:
+    """Match peak rows to the closest recognized finding frequency."""
+    frequency_hz = _as_float(row.get("frequency_hz"))
+    if frequency_hz is None:
+        return None
+    best_source: str | None = None
+    best_score: tuple[float, float] | None = None
+    for finding in findings:
+        candidate_source = str(finding.suspected_source or "").strip().lower()
+        if candidate_source not in _SOURCE_I18N_KEYS or finding.frequency_hz is None:
+            continue
+        distance = abs(finding.frequency_hz - frequency_hz)
+        if distance > _PEAK_FINDING_TOLERANCE_HZ:
+            continue
+        score = (distance, -finding.effective_confidence)
+        if best_score is None or score < best_score:
+            best_score = score
+            best_source = candidate_source
+    return best_source
 
 
 def _peak_row_meaning(row: PeakTableRow, *, tr: Callable[..., str]) -> str:


### PR DESCRIPTION
## Summary

This PR addresses `#1883` by making the PDF report evidence section more usable without expanding the upstream diagnostics contract. The visible problem in the issue screenshot was twofold: the `Supporting Measurements` table looked broken because the `System` column was blank, and the adjacent `Supporting Observations` panel added very little context for a human trying to understand why the report suspected a given source or location.

After tracing the report pipeline, the clearest seam turned out to be the PDF adapter layer rather than the diagnostics core. The upstream peak-table preparation code and persisted summary reconstruction both have narrow `F_ORDER`-centric source annotation logic, but broadening that contract would have meant changing non-report behavior and duplicating more logic across domain and boundary layers. For this issue, the report already had access to richer finding context during mapping, so the safer and smaller fix was to keep the diagnostics outputs as they are and improve how the PDF adapter projects them into page-2 evidence content.

## Implementation approach

The chosen approach was to make the evidence section more informative in two targeted ways:

1. Backfill report-facing peak-row system labels from real findings when the raw peak row does not already carry a recognized `suspected_source`.
2. Make `Supporting Observations` render compact human-readable context (`source | location | order/frequency`) instead of a bare transient label or frequency fragment.

This keeps the report grounded in actual finding data and avoids rewriting the broader diagnostics summary or persistence path just to solve a PDF presentation problem.

## Main code changes

### 1. Reuse mapped findings when building peak rows

`apps/server/vibesensor/adapters/pdf/mapping.py` now precomputes the report-facing `FindingPresentation` list once and passes that list into `build_peak_rows(...)`. Before this change, peak-row rendering only had the raw peak-table payload rows, which meant it could only show a system when the raw row already had a populated `suspected_source`. In practice that left the PDF table with a column full of em dashes, which is what made the report look broken.

Passing the mapped findings into the peak-table builder keeps the responsibility in the adapter layer where the report projection already lives, and it avoids a second pass over domain objects later in rendering.

### 2. Backfill blank systems from real finding context

`apps/server/vibesensor/adapters/pdf/peak_table.py` is where the main behavior change lives.

The peak-row builder still preserves explicit row-provided system hints when they are present and recognized. The new logic only kicks in when the row is otherwise blank or unknown. In that case it now tries two increasingly broad matches against the mapped findings:

- First, it looks for a finding with the same order label. This is the strongest match because the order label already expresses the same pattern identity the table is presenting.
- If there is no order match, it falls back to a close frequency match within a bounded tolerance (`2.0 Hz`) and prefers the nearest/highest-confidence finding among recognized source types.

Once a credible source hint is found, the existing translation mapping is reused so the visible label still comes from the normal report i18n path (`Wheel / Tire`, `Driveline`, `Engine`, `Transient impact`, etc.).

The important tradeoff here is that the code still returns `—` when there is no trustworthy match. I intentionally did not replace every blank with a speculative guess, because the issue asked for a more useful section, not a more confident-looking but less honest one. This makes the system column informative when the report already has evidence to support it, while preserving the previous conservative behavior for truly unmatched peaks.

### 3. Make supporting observations explain themselves

`apps/server/vibesensor/adapters/pdf/panels/_panel_observations.py` now renders transient observations as a concise summary composed from fields the report already had available:

- localized source label
- strongest location when known
- order label if present, otherwise frequency

So instead of bullets that effectively read like a leftover raw tag, the panel now produces lines closer to:

`Transient impact | rear-right wheel | 1x wheel`

That keeps the panel compact enough for the existing layout while making it much clearer why the observation is present and how it relates to the surrounding report evidence. I deliberately kept this as a formatting improvement rather than turning the panel into a second prose explanation block, because the issue was about usefulness and clarity, not adding more narrative text to an already dense PDF page.

## Tests and regression coverage

I added focused coverage at the seams that changed:

- `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`
  - verifies that `map_summary(...)` backfills the peak-row `system` field from a matching finding when the raw peak row is blank.
- `apps/server/tests/adapters/pdf/test_report_new_modules_labels.py`
  - verifies that system labels can be resolved from matching finding order labels even when the peak row itself has no source.
- `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
  - verifies that `Supporting Observations` now renders a bullet containing source, location, and signature context rather than a minimal leftover label.

These sit alongside the pre-existing report/PDF tests instead of replacing them, so the change is covered both at the focused unit level and in the broader report pipeline.

## Validation performed

I ran the following local validation before opening this PR:

- `pytest -q apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
  - `62 passed`
- `pytest -q apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_persistence_findings.py apps/server/tests/adapters/pdf/test_report_analysis_findings_integration.py apps/server/tests/integration/test_report_pipeline.py`
  - `82 passed`
- `make lint`
- `./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`
- native live smoke because Docker is not available in this shared environment:
  - started `./.venv/bin/vibesensor-server --config apps/server/config.dev.yaml`
  - ran `pytest -q apps/server/tests/integration/test_sim_ingestion.py::TestSimulatorIngestion`
  - `5 passed`

That last smoke is especially relevant here because it exercises recording, persistence, analysis completion, and PDF report download through the real local server path after the evidence-section change.

## Risks, tradeoffs, and out-of-scope items

The primary tradeoff is that this PR improves the report projection without changing the upstream summary payload semantics. That is the correct boundary here because the user-facing problem is specific to the PDF evidence section, and the adapter already had enough context to fix it safely.

I also kept the section structure intact instead of redesigning the whole page-2 evidence layout. After the adapter changes, the `System` column now has useful content in normal matched cases and the observations panel contributes context instead of noise, so the existing structure now meets the issue’s acceptance criteria without introducing a broader layout rewrite.

There are no schema, persistence, or contract changes in this PR, and no docs needed updating because the change is confined to report rendering/mapping behavior and regression coverage.
