### PR TITLE
Format report timestamps consistently

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_context.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_context.py
@@ -219,6 +219,8 @@ class TestPrepareReportMappingContext:
         assert context.car_name == "Track Car"
         assert context.car_type == "coupe"
         assert context.date_str == "2026-03-25 10:00:00 UTC"
+        assert context.start_time_utc == "2026-03-25 09:55:00 UTC"
+        assert context.end_time_utc == "2026-03-25 10:00:00 UTC"
         assert context.origin is prepared.report_facts.origin
         assert context.origin_location == prepared.report_facts.origin_location
         assert context.sensor_locations_active == ["rear-right"]

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -192,6 +192,20 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
     assert "}" not in rendered
 
 
+def test_map_summary_formats_report_timestamps_for_header() -> None:
+    summary = minimal_summary(
+        report_date="2026-03-25T10:00:00Z",
+        start_time_utc="2026-03-25T09:55:00.536855+00:00",
+        end_time_utc="2026-03-25T10:00:11.901770+00:00",
+    )
+
+    data = map_summary(prepare_report_input(summary))
+
+    assert data.run_datetime == "2026-03-25 10:00:00 UTC"
+    assert data.start_time_utc == "2026-03-25 09:55:00 UTC"
+    assert data.end_time_utc == "2026-03-25 10:00:11 UTC"
+
+
 def test_map_summary_backfills_peak_system_from_matching_finding() -> None:
     summary = minimal_summary(
         findings=[

--- a/apps/server/tests/shared/boundaries/test_run_log.py
+++ b/apps/server/tests/shared/boundaries/test_run_log.py
@@ -14,7 +14,7 @@ from vibesensor.shared.boundaries.run_log import (
 )
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
 from vibesensor.shared.sampling import bounded_sample
-from vibesensor.shared.time_utils import parse_iso8601, utc_now_iso
+from vibesensor.shared.time_utils import format_utc_timestamp, parse_iso8601, utc_now_iso
 from vibesensor.use_cases.run.sample_builder import create_run_metadata
 
 # -- Helpers -------------------------------------------------------------------
@@ -71,6 +71,21 @@ def test_parse_iso8601_z_suffix() -> None:
 )
 def test_parse_iso8601_returns_none_for_bad_input(value: object) -> None:
     assert parse_iso8601(value) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2025-01-15T10:30:00Z", "2025-01-15 10:30:00 UTC"),
+        ("2025-01-15T12:30:00+02:00", "2025-01-15 10:30:00 UTC"),
+        ("2025-01-15 10:30:00", "2025-01-15 10:30:00 UTC"),
+        ("not-a-date", "not-a-date"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_format_utc_timestamp(value: object, expected: str | None) -> None:
+    assert format_utc_timestamp(value) == expected
 
 
 # -- as_float_or_none ---------------------------------------------------------

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.report_data import PatternEvidence
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.time_utils import format_utc_timestamp, utc_now_iso
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportInput,
     ValidatedPreparedReportInput,
@@ -89,7 +89,7 @@ def prepare_report_mapping_context(
     validated = validate_prepared_report_input(prepared)
     report_facts = validated.report_facts
     report_date = validated.renderer_payload.report_date or utc_now_iso()
-    date_str = str(report_date)[:19].replace("T", " ") + " UTC"
+    date_str = format_utc_timestamp(report_date) or str(report_date)
     return ReportMappingContext(
         car_name=validated.renderer_payload.car_name,
         car_type=validated.renderer_payload.car_type,
@@ -98,8 +98,8 @@ def prepare_report_mapping_context(
         origin_location=report_facts.origin_location,
         sensor_locations_active=list(report_facts.sensor_locations_active),
         duration_text=report_facts.duration_text,
-        start_time_utc=report_facts.start_time_utc,
-        end_time_utc=report_facts.end_time_utc,
+        start_time_utc=format_utc_timestamp(report_facts.start_time_utc),
+        end_time_utc=format_utc_timestamp(report_facts.end_time_utc),
         sample_rate_hz=report_facts.sample_rate_hz,
         tire_spec_text=report_facts.tire_spec_text,
         sample_count=report_facts.sample_count,

--- a/apps/server/vibesensor/shared/time_utils.py
+++ b/apps/server/vibesensor/shared/time_utils.py
@@ -25,6 +25,19 @@ def parse_iso8601(value: object) -> datetime | None:
         return None
 
 
+def format_utc_timestamp(value: object) -> str | None:
+    """Format a timestamp as ``YYYY-MM-DD HH:MM:SS UTC`` for human-facing UTC display."""
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    dt = parse_iso8601(raw)
+    if dt is None:
+        return raw
+    return dt.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 def format_duration_mm_ss(seconds: float) -> str:
     """Format a duration as ``MM:SS.s`` while clamping invalid inputs to zero."""
     total = max(0.0, round(float(seconds), 1)) if isfinite(seconds) else 0.0


### PR DESCRIPTION
## Summary

This PR fixes `#1884` by making the PDF report’s `Start Time (UTC)` and `End Time (UTC)` fields render in the same human-friendly UTC format already used for `Run date`. Before this change, the report header mixed a polished display such as `2026-03-29 17:52:11 UTC` with raw ISO timestamp strings such as `2026-03-29T17:50:55.536855+00:00`, which made the report look inconsistent and more like an internal debug payload than a finished human-facing document.

The issue was intentionally narrow: keep UTC clarity, keep enough precision for troubleshooting, and align the formatting style with the existing report metadata instead of inventing a second presentation convention. That is exactly what this PR does.

## Root cause and implementation seam

The root cause was that the PDF report pipeline already had two different timestamp treatments:

- `Run date` was being formatted inside `apps/server/vibesensor/adapters/pdf/report_context.py` by slicing the ISO string, replacing the `T`, and appending `UTC`.
- `Start Time (UTC)` and `End Time (UTC)` were being passed through from prepared report facts as raw strings and then rendered verbatim in the header panel.

So the visible inconsistency was not a renderer layout bug. It was a preparation-layer inconsistency: one header field was normalized for people, and two adjacent header fields were not.

The smallest correct fix was therefore not in the PDF header drawing code. It was in the metadata formatting seam that prepares `ReportMappingContext`, because that is where the report-facing values are shaped before they reach the template data and renderer.

## Main code changes

### 1. Added a shared UTC timestamp formatter

I added `format_utc_timestamp()` to `apps/server/vibesensor/shared/time_utils.py`.

This helper:

- accepts the ISO-like strings already flowing through the app,
- reuses the existing `parse_iso8601()` logic,
- normalizes aware datetimes to UTC,
- treats naive datetimes as UTC in the same way the existing parser already does,
- formats successful parses as `YYYY-MM-DD HH:MM:SS UTC`,
- and preserves the original raw string if parsing fails rather than hiding the value.

That last behavior is important. I did not want the report to silently drop timestamps or replace bad values with blanks if some unexpected payload ever slips through. The user-facing improvement should make good data look polished without reducing diagnosability for edge cases.

### 2. Reused the helper for all report-header timestamps

`apps/server/vibesensor/adapters/pdf/report_context.py` now uses `format_utc_timestamp()` for:

- `Run date`
- `Start Time (UTC)`
- `End Time (UTC)`

This removes the previous split behavior where `Run date` had a one-off formatting path and `Start/End` were left raw. It also gives the report one clear timestamp presentation rule instead of multiple slightly different ones.

An important detail here is that the fix stays in report-context preparation rather than in the low-level renderer. `_panel_header.py` still just renders whatever report-facing text it receives. That keeps the rendering layer simple and pushes the display-shaping concern into the adapter-owned mapping context, which is already responsible for normalizing report metadata.

### 3. Left the rest of the report contract alone

I intentionally did not change the underlying prepared report facts structure, history preparation, or any persistence schema. This issue is about how timestamps appear in the PDF, not about how raw timestamps are stored or transported internally.

By keeping the change scoped to shared formatting plus report-context preparation, the blast radius stays small while the visible output becomes consistent everywhere that matters to the issue.

## Tests and regression coverage

I added and updated regression coverage at the two layers affected by the change:

### Shared helper coverage

`apps/server/tests/shared/boundaries/test_run_log.py` now covers `format_utc_timestamp()` directly. The new assertions verify that it:

- formats a `Z`-suffix timestamp correctly,
- converts offset timestamps into UTC before formatting,
- formats naive timestamps as UTC,
- preserves an invalid raw string instead of hiding it,
- and returns `None` for empty or missing input.

That locks down the helper behavior independently of the PDF code so the shared utility can be reused confidently later.

### PDF mapping coverage

`apps/server/tests/adapters/pdf/test_report_mapping_context.py` now verifies that `prepare_report_mapping_context()` formats `start_time_utc` and `end_time_utc` into the same human-friendly UTC style as `date_str`.

`apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py` adds a focused mapping regression that runs `map_summary(prepare_report_input(...))` and asserts the final report-facing timestamps are:

- `2026-03-25 10:00:00 UTC`
- `2026-03-25 09:55:00 UTC`
- `2026-03-25 10:00:11 UTC`

That test is especially useful for this issue because it exercises the actual summary-to-report mapping path that feeds the PDF template, not just the helper in isolation.

## Validation performed

I ran the following local validation before opening this PR:

- `pytest -q apps/server/tests/shared/boundaries/test_run_log.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`
  - `86 passed`
- `pytest -q apps/server/tests/adapters/pdf/`
  - `581 passed`
- `make lint`
- `./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

Because this repository’s preferred Docker validation path is not usable in the current shared environment, I also ran the same validated native smoke path I used on the previous PDF issues:

- started `./.venv/bin/vibesensor-server --config apps/server/config.dev.yaml`
- ran `pytest -q apps/server/tests/integration/test_sim_ingestion.py::TestSimulatorIngestion`
  - `5 passed`

That smoke matters here even though the code change is small, because it confirms the real server path still records, persists, analyzes, and produces a downloadable PDF report after the timestamp formatting change.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is the fallback behavior when timestamp parsing fails. I chose to preserve the original string rather than blank it out or raise, because that keeps report output debuggable and avoids silently losing information. For normal valid inputs, the output is now clean and consistent; for unexpected inputs, the report still surfaces what it received.

I also did not localize the timestamp value format beyond the existing `UTC` suffix. That is consistent with the current `Run date` behavior and with the issue request, which was to make the fields human-friendly and visually consistent rather than to introduce locale-specific date formatting rules.

No documentation updates were needed because this is a localized report presentation fix with regression coverage, not a workflow or architectural change.
