### PR TITLE
Populate known car for simulator runs

### DIFF
--- a/apps/server/tests/infra/processing/test_sample_builder.py
+++ b/apps/server/tests/infra/processing/test_sample_builder.py
@@ -206,6 +206,25 @@ class TestBuildRunMetadata:
 
         assert meta["tire_circumference_m"] == 2.345
 
+    def test_uses_default_simulator_car_when_active_car_missing(self) -> None:
+        meta = build_run_metadata(
+            **_default_run_metadata_kwargs(
+                firmware_version="sim-0.2",
+                active_car_snapshot=None,
+            ),
+        )
+
+        assert meta["car_name"] == "VibeSensor Simulator"
+        assert meta["car_type"] == "sedan"
+        assert meta["active_car_id"] == "simulator-default"
+        assert meta["active_car_snapshot"] == {
+            "id": "simulator-default",
+            "name": "VibeSensor Simulator",
+            "type": "sedan",
+            "variant": None,
+            "aspects": {},
+        }
+
 
 # ---------------------------------------------------------------------------
 # build_sample_records

--- a/apps/server/tests/integration/test_sim_ingestion.py
+++ b/apps/server/tests/integration/test_sim_ingestion.py
@@ -224,6 +224,13 @@ class TestSimulatorIngestion:
         sb = self.insights.get("speed_breakdown") or []
         assert len(sb) > 0, "Speed breakdown is empty"
 
+    def test_history_run_has_known_simulator_car(self) -> None:
+        """Simulator runs should persist a deterministic known car profile."""
+        history_run = _api_json(f"/api/history/{self.run_id}")
+        metadata = history_run.get("metadata") or {}
+        assert metadata.get("car_name") == "VibeSensor Simulator"
+        assert metadata.get("car_type") == "sedan"
+
     def test_report_pdf_accessible(self) -> None:
         """PDF report should be downloadable and valid."""
         pdf_bytes = _api_bytes(f"/api/history/{self.run_id}/report.pdf")
@@ -232,5 +239,5 @@ class TestSimulatorIngestion:
         reader = PdfReader(io.BytesIO(pdf_bytes))
         assert len(reader.pages) >= 2, f"PDF has only {len(reader.pages)} page(s)"
         pdf_text = "\n".join((page.extract_text() or "") for page in reader.pages).lower()
-        for token in ("next steps", "evidence", "front-left"):
+        for token in ("next steps", "evidence", "front-left", "vibesensor simulator"):
             assert token in pdf_text, f"Missing expected report content token: {token!r}"

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -298,6 +298,10 @@ def build_run_metadata(
     feature_interval_s = 1.0 / max(1.0, float(metrics_log_hz))
     raw_sample_rate_hz = default_sample_rate_hz if default_sample_rate_hz > 0 else None
     incomplete = raw_sample_rate_hz is None
+    run_car_snapshot = _car_snapshot_for_run(
+        active_car_snapshot=active_car_snapshot,
+        firmware_version=firmware_version,
+    )
     metadata: JsonObject = create_run_metadata(
         run_id=run_id,
         start_time_utc=start_time_utc,
@@ -316,9 +320,30 @@ def build_run_metadata(
     apply_run_context_snapshot(
         metadata,
         analysis_settings_snapshot=analysis_settings_snapshot,
-        active_car_snapshot=active_car_snapshot,
+        active_car_snapshot=run_car_snapshot,
     )
     metadata["incomplete_for_order_analysis"] = not order_reference_context_complete(metadata)
     if language_provider is not None:
         metadata["language"] = str(language_provider()).strip().lower() or "en"
     return dict(metadata)
+
+
+_SIMULATOR_DEFAULT_CAR = CarSnapshot(
+    car_id="simulator-default",
+    name="VibeSensor Simulator",
+    car_type="sedan",
+)
+
+
+def _car_snapshot_for_run(
+    *,
+    active_car_snapshot: CarSnapshot | None,
+    firmware_version: str | None,
+) -> CarSnapshot | None:
+    """Return the car snapshot to persist for a run."""
+    if active_car_snapshot is not None:
+        return active_car_snapshot
+    tokens = [token.strip().lower() for token in str(firmware_version or "").split(",")]
+    if any(token.startswith("sim-") for token in tokens if token):
+        return _SIMULATOR_DEFAULT_CAR
+    return None


### PR DESCRIPTION
## Summary
Closes #1885.

Simulator-driven runs were reaching history and PDF report output without any car metadata, so the generated artifacts displayed `Car: Unknown`. That made the simulator less useful for local report review because otherwise realistic sample data still produced a visibly incomplete header. This change gives simulator runs a deterministic built-in car profile when no real active car is selected, while preserving the existing behavior for all other runs.

## Problem
The issue asked for simulator reports to show a known car instead of `Unknown`, but there were a few possible seams where that could have been implemented. The report adapter could have special-cased missing simulator metadata during rendering. The simulator adapter could have been extended with a new explicit car-selection option. Or the runtime metadata builder could have assigned a default car once it knew the run came from simulator firmware.

After tracing the flow, the run-metadata builder turned out to be the cleanest place to make the change. `_build_run_metadata_record()` already passes both the resolved firmware version string and the current active car snapshot into `build_run_metadata()`. That means the backend already has the two facts needed to decide whether a run should keep a real selected car, stay empty, or receive a simulator-specific fallback. Fixing the issue there lets history, report generation, and any other downstream consumers all see the same persisted truth instead of layering a report-only presentation hack on top.

## Implementation approach
The implementation stays intentionally small and deterministic. `apps/server/vibesensor/use_cases/run/sample_builder.py` now resolves the car snapshot used for persisted run metadata through a focused helper, `_car_snapshot_for_run(...)`.

That helper follows a narrow precedence order:

1. If there is a real `active_car_snapshot`, keep it exactly as-is.
2. Otherwise, inspect the collected firmware version tokens for the run.
3. If any token starts with `sim-`, persist a fixed simulator car profile.
4. Otherwise, return `None` and preserve the existing behavior for non-simulator runs with no car.

The fixed simulator profile is represented as a `CarSnapshot` constant with ID `simulator-default`, name `VibeSensor Simulator`, and type `sedan`.

I chose this approach instead of adding a new config option because the issue explicitly allowed a deterministic default, and the current simulator workflow does not need another setup step just to make reports usable. I also intentionally did not push this logic into generic run-context helpers, because there is already existing coverage asserting that missing active-car context leaves car fields absent. Making the fallback decision in `build_run_metadata()` keeps the simulator behavior scoped to the point where firmware identity is available and avoids changing the semantics of generic context propagation.

## Code changes by area
In `apps/server/vibesensor/use_cases/run/sample_builder.py`, `build_run_metadata()` now computes `run_car_snapshot` before calling `apply_run_context_snapshot()`. The only functional change in that method is which car snapshot gets persisted into metadata. Everything else about run metadata creation remains unchanged.

The new `_SIMULATOR_DEFAULT_CAR` constant and `_car_snapshot_for_run(...)` helper are colocated with `build_run_metadata()` because they are implementation details of this assembly step, not new shared domain concepts. This keeps the logic discoverable without widening the API surface of unrelated modules.

In `apps/server/tests/infra/processing/test_sample_builder.py`, I added a focused unit regression that calls `build_run_metadata()` with simulator firmware and no active car snapshot, then asserts that `car_name`, `car_type`, `active_car_id`, and the serialized `active_car_snapshot` payload are all populated from the deterministic simulator profile.

In `apps/server/tests/integration/test_sim_ingestion.py`, I extended the existing live simulator ingestion test instead of creating a parallel end-to-end scenario. The test now verifies that the persisted history metadata for the generated run includes the simulator car name and type, and it also asserts that extracted report PDF text contains `VibeSensor Simulator`. That end-to-end check matters because the issue is explicitly about report output, not only the raw stored metadata.

## Validation
I ran the focused unit coverage first:

- `pytest -q apps/server/tests/infra/processing/test_sample_builder.py`
  - Result: `17 passed`

Then I reran the native live simulator ingestion smoke against a local backend server because that is the closest available end-to-end path in this environment:

- `./.venv/bin/vibesensor-server --config apps/server/config.dev.yaml`
- `pytest -q apps/server/tests/integration/test_sim_ingestion.py::TestSimulatorIngestion`
  - Result: `6 passed`

After that, I ran the broader issue-relevant suites requested by the issue scope:

- `pytest -q apps/server/tests/adapters/simulator/ apps/server/tests/adapters/pdf/ apps/server/tests/use_cases/history/`
  - Result: `621 passed`
- `make lint`
  - Result: passed
- `./.venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-quality --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`
  - Result: all selected jobs passed

Docker-based stack validation is still unavailable in this shared environment because the Docker daemon socket cannot be reached, so the live verification used the existing native `vibesensor-server` fallback path instead.

## Risks and tradeoffs considered
The main tradeoff here is that the simulator default is intentionally a fixed built-in profile rather than a user-selectable option. I chose that because it satisfies the issue with the smallest reliable change and keeps simulator workflows friction-free. If future work needs multiple simulator car identities, that can be added later on top of this metadata seam without undoing the current fix.

I also constrained the fallback to firmware tokens that start with `sim-`. That makes the behavior specific to actual simulator runs and avoids accidentally assigning a fake car to real runs that simply do not have an active car configured.

## Out of scope
This change does not attempt to redesign the simulator CLI, add a settings UI for choosing a simulator car, or alter how real device runs behave when no active car is selected. It only ensures that simulator-originated runs persist a deterministic known car so history and report artifacts stop rendering `Unknown`.
