### PR TITLE
Prioritize named OBD scan results and background rescans

### DIFF
--- a/apps/server/tests/adapters/obd/test_admin_helper.py
+++ b/apps/server/tests/adapters/obd/test_admin_helper.py
@@ -144,3 +144,86 @@ def test_scan_devices_uses_timed_scan_output_when_devices_list_is_empty() -> Non
         "scan",
         "on",
     ) in calls
+
+
+def test_scan_devices_sorts_human_readable_names_ahead_of_mac_aliases() -> None:
+    responses = {
+        ("rfkill", "unblock", "bluetooth"): (0, "", ""),
+        ("systemctl", "start", "bluetooth"): (0, "", ""),
+        ("bluetoothctl", "power", "on"): (0, "", ""),
+        (
+            "bluetoothctl",
+            "--timeout",
+            "8",
+            "scan",
+            "on",
+        ): (
+            0,
+            "\n".join(
+                [
+                    "[NEW] Device 53:40:AC:57:11:77 53-40-AC-57-11-77",
+                    "[NEW] Device 00:22:D9:00:1B:B1 Audioengine HD6",
+                    "[NEW] Device 11:22:33:44:55:66",
+                ]
+            ),
+            "",
+        ),
+        (
+            "bluetoothctl",
+            "devices",
+        ): (
+            0,
+            "\n".join(
+                [
+                    "Device 53:40:AC:57:11:77 53-40-AC-57-11-77",
+                    "Device 00:22:D9:00:1B:B1 Audioengine HD6",
+                    "Device 11:22:33:44:55:66",
+                ]
+            ),
+            "",
+        ),
+        ("bluetoothctl", "devices", "Paired"): (0, "", ""),
+        ("bluetoothctl", "paired-devices"): (0, "", ""),
+        ("bluetoothctl", "scan", "off"): (0, "", ""),
+        (
+            "bluetoothctl",
+            "info",
+            "53:40:AC:57:11:77",
+        ): (
+            0,
+            """
+            Device 53:40:AC:57:11:77
+            Alias: 53-40-AC-57-11-77
+            Paired: no
+            Trusted: no
+            Connected: no
+            """,
+            "",
+        ),
+        (
+            "bluetoothctl",
+            "info",
+            "11:22:33:44:55:66",
+        ): (
+            0,
+            """
+            Device 11:22:33:44:55:66
+            Paired: no
+            Trusted: no
+            Connected: no
+            """,
+            "",
+        ),
+    }
+
+    def runner(argv: list[str], timeout_s: int, allow_timeout: bool) -> tuple[int, str, str]:
+        del timeout_s, allow_timeout
+        return responses[tuple(argv)]
+
+    devices = BluetoothObdAdminHelper(runner=runner).scan_devices(timeout_s=8)
+
+    assert [device.mac_address for device in devices] == [
+        "0022d9001bb1",
+        "112233445566",
+        "5340ac571177",
+    ]

--- a/apps/server/vibesensor/adapters/obd/admin_helper.py
+++ b/apps/server/vibesensor/adapters/obd/admin_helper.py
@@ -64,6 +64,11 @@ def _looks_like_mac_alias(raw: str | None) -> bool:
     return True
 
 
+def _has_human_readable_bluetooth_name(raw: str | None) -> bool:
+    value = _clean_bluetooth_name(raw)
+    return value is not None and not _looks_like_mac_alias(value)
+
+
 def _preferred_bluetooth_name(*candidates: str | None) -> str | None:
     cleaned = [
         value for value in (_clean_bluetooth_name(candidate) for candidate in candidates) if value
@@ -320,6 +325,7 @@ class BluetoothObdAdminHelper:
             key=lambda device: (
                 not device.connected,
                 not device.paired,
+                not _has_human_readable_bluetooth_name(device.name),
                 (device.name or device.mac_address).lower(),
             ),
         )

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -11,6 +11,7 @@ import {
   updateSettingsSpeedSource,
 } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
+import { createPollingController } from "./polling_controller";
 import {
   type DisplayedSpeedSourceMode,
   deriveDisplayedSpeedSourceMode,
@@ -20,6 +21,8 @@ import {
 import type { SettingsState } from "../ui_app_state";
 
 const SPEED_SOURCE_KINDS = ["gps", "manual", "obd2"] as const satisfies readonly SpeedSourceKind[];
+const OBD_BACKGROUND_RESCAN_DELAY_MS = 2_000;
+const TAB_NAVIGATION_KEYS = new Set(["Enter", " ", "ArrowRight", "ArrowLeft", "Home", "End"]);
 
 export interface SettingsSpeedSourceModuleDeps extends FeatureDepsBase {
   settings: SettingsState;
@@ -44,6 +47,7 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
   let scannedDevices: ObdDevicePayload[] = [];
   let scanInFlight = false;
   let pairInFlightMac: string | null = null;
+  let backgroundRescanRequested = false;
 
   function isSpeedSourceKind(value: string): value is SpeedSourceKind {
     return SPEED_SOURCE_KINDS.some((kind) => kind === value);
@@ -129,11 +133,79 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     return value ? t("settings.speed.fallback_yes") : t("settings.speed.fallback_no");
   }
 
-  function mergeScannedDevice(device: ObdDevicePayload): void {
-    scannedDevices = [
-      device,
-      ...scannedDevices.filter((entry) => entry.mac_address !== device.mac_address),
-    ];
+  function looksLikeMacAlias(rawValue: string | null | undefined): boolean {
+    const value = rawValue?.trim();
+    return value != null && /^([0-9a-f]{2}[:-]){5}[0-9a-f]{2}$/i.test(value);
+  }
+
+  function hasHumanReadableDeviceName(device: ObdDevicePayload): boolean {
+    const value = device.name?.trim();
+    return Boolean(value) && !looksLikeMacAlias(value);
+  }
+
+  function compareScannedDevices(left: ObdDevicePayload, right: ObdDevicePayload): number {
+    const leftConnectedRank = Number(!left.connected);
+    const rightConnectedRank = Number(!right.connected);
+    if (leftConnectedRank !== rightConnectedRank) {
+      return leftConnectedRank - rightConnectedRank;
+    }
+    const leftPairedRank = Number(!left.paired);
+    const rightPairedRank = Number(!right.paired);
+    if (leftPairedRank !== rightPairedRank) {
+      return leftPairedRank - rightPairedRank;
+    }
+    const leftNamedRank = Number(!hasHumanReadableDeviceName(left));
+    const rightNamedRank = Number(!hasHumanReadableDeviceName(right));
+    if (leftNamedRank !== rightNamedRank) {
+      return leftNamedRank - rightNamedRank;
+    }
+    const labelCompare = (left.name?.trim() || left.mac_address).localeCompare(
+      right.name?.trim() || right.mac_address,
+    );
+    if (labelCompare !== 0) {
+      return labelCompare;
+    }
+    return left.mac_address.localeCompare(right.mac_address);
+  }
+
+  function setScannedDevices(devices: readonly ObdDevicePayload[]): void {
+    scannedDevices = [...devices].sort(compareScannedDevices);
+  }
+
+  function mergeScannedDevices(devices: readonly ObdDevicePayload[]): void {
+    const merged = new Map(scannedDevices.map((device) => [device.mac_address, device]));
+    devices.forEach((device) => {
+      merged.set(device.mac_address, device);
+    });
+    setScannedDevices(Array.from(merged.values()));
+  }
+
+  function isObdConfigVisible(): boolean {
+    if (!els.obdSpeedConfig || els.obdSpeedConfig.hidden) {
+      return false;
+    }
+    const activePanel = els.obdSpeedConfig.closest<HTMLElement>(".settings-tab-panel");
+    if (!activePanel || activePanel.hidden) {
+      return false;
+    }
+    const activeView = activePanel.closest<HTMLElement>(".view");
+    return activeView == null || !activeView.hidden;
+  }
+
+  function shouldRunBackgroundRescan(): boolean {
+    return backgroundRescanRequested && isObdConfigVisible();
+  }
+
+  function syncObdBackgroundRescan(): void {
+    if (shouldRunBackgroundRescan()) {
+      obdBackgroundRescan.start();
+      return;
+    }
+    obdBackgroundRescan.stop();
+  }
+
+  function scheduleObdBackgroundRescanSync(): void {
+    queueMicrotask(syncObdBackgroundRescan);
   }
 
   function obdDevicePrimaryLabel(device: ObdDevicePayload): string {
@@ -211,6 +283,17 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     renderObdDeviceList();
   }
 
+  const obdBackgroundRescan = createPollingController({
+    poll: async () => {
+      if (!shouldRunBackgroundRescan() || scanInFlight || pairInFlightMac !== null) {
+        return OBD_BACKGROUND_RESCAN_DELAY_MS;
+      }
+      await scanObdDevices("background");
+      return OBD_BACKGROUND_RESCAN_DELAY_MS;
+    },
+    onErrorDelayMs: OBD_BACKGROUND_RESCAN_DELAY_MS,
+  });
+
   function syncSpeedSourceSelectionUi(): void {
     const displayedMode = deriveDisplayedSpeedSourceMode(settings);
     if (!speedSourceDraftDirty) {
@@ -231,6 +314,7 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     }
     updateSpeedSourceSummary();
     renderObdControls();
+    syncObdBackgroundRescan();
   }
 
   function syncSpeedSourceInputs(): void {
@@ -270,24 +354,37 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     } catch (_err) { /* ignore */ }
   }
 
-  async function scanObdDevices(): Promise<void> {
+  async function scanObdDevices(mode: "manual" | "background" = "manual"): Promise<void> {
+    if (scanInFlight || pairInFlightMac !== null) {
+      return;
+    }
     scanInFlight = true;
-    obdScanStatusMessage = t("settings.speed.obd_scanning");
+    if (mode === "manual") {
+      obdScanStatusMessage = t("settings.speed.obd_scanning");
+    }
     renderObdControls();
     try {
       const payload = await scanSettingsObdDevices();
-      scannedDevices = payload.devices;
-      obdScanStatusMessage = payload.devices.length > 0
-        ? t("settings.speed.obd_scan_found", { count: payload.devices.length })
-        : t("settings.speed.obd_scan_empty");
+      if (mode === "manual") {
+        setScannedDevices(payload.devices);
+        backgroundRescanRequested = true;
+        obdScanStatusMessage = payload.devices.length > 0
+          ? t("settings.speed.obd_scan_found", { count: payload.devices.length })
+          : t("settings.speed.obd_scan_empty");
+      } else {
+        mergeScannedDevices(payload.devices);
+      }
       renderObdControls();
     } catch (error) {
-      obdScanStatusMessage = t("settings.speed.obd_scan_failed");
-      renderObdControls();
-      ctx.showError(error instanceof Error ? error.message : t("settings.speed.obd_scan_failed"));
+      if (mode === "manual") {
+        obdScanStatusMessage = t("settings.speed.obd_scan_failed");
+        renderObdControls();
+        ctx.showError(error instanceof Error ? error.message : t("settings.speed.obd_scan_failed"));
+      }
     } finally {
       scanInFlight = false;
       renderObdControls();
+      syncObdBackgroundRescan();
     }
   }
 
@@ -299,14 +396,14 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
       const payload = await pairSettingsObdDevice(macAddress);
       settings.obdDeviceMac = payload.configured_device_mac ?? null;
       settings.obdDeviceName = payload.configured_device_name ?? null;
-      mergeScannedDevice({
+      mergeScannedDevices([{
         mac_address: payload.configured_device_mac ?? macAddress,
         name: payload.configured_device_name ?? null,
         paired: payload.paired,
         trusted: payload.trusted,
         connected: payload.connected,
         rfcomm_channel: payload.rfcomm_channel,
-      });
+      }]);
       obdScanStatusMessage = t("settings.speed.obd_pair_success");
       syncSpeedSourceSelectionUi();
     } catch (error) {
@@ -316,6 +413,7 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     } finally {
       pairInFlightMac = null;
       renderObdControls();
+      syncObdBackgroundRescan();
     }
   }
 
@@ -346,6 +444,22 @@ export function createSettingsSpeedSourceModule(ctx: SettingsSpeedSourceModuleDe
     els.saveSpeedSourceBtn?.addEventListener("click", saveSpeedSourceFromInputs);
     els.scanObdDevicesBtn?.addEventListener("click", () => {
       void scanObdDevices();
+    });
+    els.settingsTabs.forEach((tab) => {
+      tab.addEventListener("click", scheduleObdBackgroundRescanSync);
+      tab.addEventListener("keydown", (event) => {
+        if (TAB_NAVIGATION_KEYS.has(event.key)) {
+          scheduleObdBackgroundRescanSync();
+        }
+      });
+    });
+    els.menuButtons.forEach((button) => {
+      button.addEventListener("click", scheduleObdBackgroundRescanSync);
+      button.addEventListener("keydown", (event) => {
+        if (TAB_NAVIGATION_KEYS.has(event.key)) {
+          scheduleObdBackgroundRescanSync();
+        }
+      });
     });
     els.obdDeviceList?.addEventListener("click", (event) => {
       const target = event.target;

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -397,6 +397,150 @@ test("failed speed-source save reverts the UI and shows an error", async ({ page
   await expect(page.locator("#manualSpeedInput")).toHaveValue("");
 });
 
+test("manual OBD scan sorts named devices first and background rescans progressively improve the list", async ({ page }) => {
+  let scanCalls = 0;
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/language": { language: "en" },
+      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
+      "GET /api/settings/speed-source": {
+        speed_source: "obd2",
+        manual_speed_kph: null,
+        stale_timeout_s: 5,
+        obd_device_mac: null,
+        obd_device_name: null,
+      },
+      "GET /api/settings/speed-source/status": gpsStatus({
+        speed_source: "obd2",
+        connection_state: "disconnected",
+      }),
+      "GET /api/settings/obd/status": {
+        configured_device_mac: null,
+        configured_device_name: null,
+        paired: false,
+        trusted: false,
+        connected: false,
+        rfcomm_channel: null,
+        last_rpm: null,
+        last_raw_response: null,
+        debug_hint: null,
+      },
+      "POST /api/settings/obd/scan": async () => {
+        scanCalls += 1;
+        if (scanCalls === 1) {
+          return {
+            devices: [
+              {
+                mac_address: "5340ac571177",
+                name: "53-40-AC-57-11-77",
+                paired: false,
+                trusted: false,
+                connected: false,
+                rfcomm_channel: null,
+              },
+              {
+                mac_address: "0022d9001bb1",
+                name: "Audioengine HD6",
+                paired: false,
+                trusted: false,
+                connected: false,
+                rfcomm_channel: null,
+              },
+            ],
+          };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2_500));
+        return {
+          devices: [
+            {
+              mac_address: "5340ac571177",
+              name: "Pim's iPhone",
+              paired: false,
+              trusted: false,
+              connected: false,
+              rfcomm_channel: null,
+            },
+          ],
+        };
+      },
+    }),
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await page.locator("#scanObdDevicesBtn").click();
+
+  const deviceNames = page.locator(".speed-source-device__name");
+  await expect(deviceNames.nth(0)).toHaveText("Audioengine HD6");
+  await expect(deviceNames.nth(1)).toHaveText("53-40-AC-57-11-77");
+  await expect(page.locator(".speed-source-device__mac").nth(0)).toHaveText("0022d9001bb1");
+
+  await expect.poll(() => scanCalls, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
+  await expect(deviceNames.nth(1)).toHaveText("Pim's iPhone");
+});
+
+test("background OBD rescans stop when the Speed Source OBD panel is no longer visible", async ({ page }) => {
+  let scanCalls = 0;
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/language": { language: "en" },
+      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
+      "GET /api/settings/speed-source": {
+        speed_source: "obd2",
+        manual_speed_kph: null,
+        stale_timeout_s: 5,
+        obd_device_mac: null,
+        obd_device_name: null,
+      },
+      "GET /api/settings/speed-source/status": gpsStatus({
+        speed_source: "obd2",
+        connection_state: "disconnected",
+      }),
+      "GET /api/settings/obd/status": {
+        configured_device_mac: null,
+        configured_device_name: null,
+        paired: false,
+        trusted: false,
+        connected: false,
+        rfcomm_channel: null,
+        last_rpm: null,
+        last_raw_response: null,
+        debug_hint: null,
+      },
+      "POST /api/settings/obd/scan": async () => {
+        scanCalls += 1;
+        return {
+          devices: [
+            {
+              mac_address: "0022d9001bb1",
+              name: "OBDLink CX",
+              paired: false,
+              trusted: false,
+              connected: false,
+              rfcomm_channel: null,
+            },
+          ],
+        };
+      },
+    }),
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await page.locator("#scanObdDevicesBtn").click();
+
+  await expect.poll(() => scanCalls, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
+  await page.locator('[data-speed-source-choice="gps"]').click();
+
+  const stoppedAt = scanCalls;
+  await page.waitForTimeout(2_500);
+  expect(scanCalls).toBe(stoppedAt);
+});
+
 test("failed language save reverts the selector and shows an error", async ({ page }) => {
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({


### PR DESCRIPTION
Closes #1891

## Summary

This change makes the Bluetooth OBD picker on the Speed Source page behave more intentionally in noisy Bluetooth environments. The core problem from the issue was not that scanning was failing outright, but that the results were hard to act on: devices with useful human-readable names were mixed together with MAC-like aliases, and the page only performed a one-shot manual scan, so the list stopped improving even if a better name became available a few seconds later.

The fix addresses both halves of that behavior. On the backend, Bluetooth scan results now sort human-readable device names ahead of alias-only or unnamed devices. On the frontend, the Speed Source module now treats the manual scan button as the entry point for a page-scoped background refresh loop: once the user successfully starts a scan, the page keeps rescanning in the background while the OBD configuration remains visible, progressively improves the same list, and stops cleanly when the panel is no longer visible.

## Problem

Issue #1891 described a UX problem that was showing up on live Pi hardware. Nearby Bluetooth discovery often returns a mix of recognizable devices such as phones or speakers together with less useful alias-only entries that look like MAC addresses. The scan itself was working, but the ordering made likely adapter candidates harder to spot. The page also required repeated manual rescans if the operator wanted the list to improve over time.

The existing code already contained one important clue: the backend Bluetooth helper knew how to recognize MAC-like aliases and already tried to resolve better names from `bluetoothctl info`. The problem was that the final sort step ignored that signal, so the response still grouped devices only by connected/paired state and alphabetical label. On the frontend side, the Speed Source module replaced the scanned list in one pass and only updated it again if the user clicked the scan button another time. Pairing a device also prepended it locally, which made ordering less stable once list refreshes were involved.

## Implementation approach

I kept the change at the narrowest seams that actually own this behavior.

On the backend, I extended the existing Bluetooth naming logic instead of inventing a new device-classification layer. The helper now distinguishes between truly human-readable names and alias-only or missing names, and the scan result sort order uses that classification directly. This keeps the canonical scan ordering close to the Bluetooth helper that already normalizes names.

On the frontend, I kept the page behavior inside `settings_speed_source_module.ts`, because that module already owns the OBD scan button, the rendered device list, and the pairing flow. I deliberately avoided adding abort-driven cancellation logic for in-flight scans. The issue explicitly called out timeout and abort regressions, so the implementation only stops future poll cycles when the panel is no longer needed; it does not try to interrupt an already running request.

## Main code changes

### Backend Bluetooth scan ordering

`apps/server/vibesensor/adapters/obd/admin_helper.py` now has a small helper that distinguishes human-readable Bluetooth names from MAC-like aliases. The final scan sort key still prefers connected devices first and paired devices second, but after that it now prefers human-readable names over alias-only or unnamed results before falling back to alphabetical label ordering.

This means the issue’s desired behavior happens at the source of truth for scan responses, not only in the page rendering layer.

### Frontend Speed Source scan lifecycle

`apps/ui/src/app/features/settings_speed_source_module.ts` received the main behavioral update.

The module now keeps a sorted device list using explicit compare/merge helpers rather than relying on replacement plus prepend behavior. That matters for two reasons:

- background rescans can improve an existing device entry in place instead of flickering backward when later results arrive,
- pairing updates no longer destabilize the ordering by forcing the selected device to the top regardless of name quality.

I also added a page-scoped polling controller for OBD rescans. It does not start automatically at app startup. Instead, a successful manual scan marks background rescanning as requested, which preserves the current “Scan for adapters” interaction as the user-visible trigger. After that point, the module keeps rescanning while the OBD configuration is still visible inside the active Settings view.

Visibility is intentionally checked at the UI seam that already owns the panel. The loop only continues while all of the following remain true:

- the user previously completed a successful manual scan,
- the OBD configuration section is still selected,
- the enclosing settings tab panel is visible,
- the enclosing shell view is still active.

When those conditions stop being true, the polling loop is stopped so no new scans are scheduled. To keep that responsive, the module now re-evaluates the background-scan state after speed-source mode changes and after settings-tab or shell-view navigation events.

## Tests and validation

I added focused regression coverage at both layers.

`apps/server/tests/adapters/obd/test_admin_helper.py` now covers the backend sort behavior directly, including the case where a human-readable device, an alias-only device, and an unnamed device appear in the same scan result.

`apps/ui/tests/smoke.settings.spec.ts` now covers two user-visible scenarios:

- a manual scan shows a named device ahead of a MAC-like alias and later background rescans improve the same list when a better name appears,
- background rescanning stops once the OBD panel is no longer visible.

Local validation completed successfully with:

- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/obd/test_admin_helper.py`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --config=playwright.smoke.config.ts --project=laptop-light --workers=1`
- `make lint`
- `make typecheck-backend`
- `cd apps/ui && npm run build`

## Risks and tradeoffs

The main tradeoff is that once a user has successfully kicked off OBD discovery, the page keeps rescanning only while the OBD panel is actually visible. That is intentional: it satisfies the issue’s “keep improving while the page stays open” requirement without introducing another always-on global Bluetooth poller.

I also chose not to clear the accumulated list on every background refresh. Later scans merge back into the existing list so newly discovered names can improve entries instead of causing the list to bounce around when Bluetooth discovery is noisy. That behavior is better aligned with the issue’s request for stable, understandable ordering.

## Out of scope

This change does not modify the Bluetooth pairing backend beyond the ordering and presentation improvements needed for scanning. It also does not add new API contracts or generated frontend artifacts, because the required fix was behavioral rather than schema-driven.
