### PR TITLE
Follow up #1731: label OBD2 speed consistently

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -1,5 +1,5 @@
 import { fmt } from "../../format";
-import { isManualEffectiveSpeedSource } from "../speed_source_state";
+import { deriveSpeedReadoutLabelKey } from "../speed_source_state";
 import type { UiDomElements } from "../ui_dom_registry";
 import type { RealtimeState, SettingsState, ShellState, TransportState } from "../ui_app_state";
 
@@ -50,11 +50,11 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
     const unitLabel = selectedSpeedUnitLabel();
     if (typeof realtime.speedMps === "number" && Number.isFinite(realtime.speedMps)) {
       const value = speedValueInSelectedUnit(realtime.speedMps);
-      const isOverride = isManualEffectiveSpeedSource(
+      const labelKey = deriveSpeedReadoutLabelKey(
         settings,
         realtime.rotationalSpeeds?.basis_speed_source ?? null,
       );
-      els.speed.textContent = ctx.t(isOverride ? "speed.override" : "speed.gps", {
+      els.speed.textContent = ctx.t(labelKey, {
         value: fmt(value, 1),
         unit: unitLabel,
       });

--- a/apps/ui/src/app/speed_source_state.ts
+++ b/apps/ui/src/app/speed_source_state.ts
@@ -7,6 +7,7 @@ export interface SpeedSourceStateSource {
 }
 
 export type DisplayedSpeedSourceMode = "gps" | "manual" | "obd2";
+export type SpeedReadoutLabelKey = "speed.gps" | "speed.override" | "speed.obd2";
 
 export function isManualLikeSpeedSource(source: string | null | undefined): boolean {
   return source === "manual" || source === "fallback_manual";
@@ -43,4 +44,15 @@ export function isManualEffectiveSpeedSource(
   runtimeSpeedSource?: string | null,
 ): boolean {
   return isManualLikeSpeedSource(resolveEffectiveSpeedSource(settings, runtimeSpeedSource));
+}
+
+export function deriveSpeedReadoutLabelKey(
+  settings: SpeedSourceStateSource,
+  runtimeSpeedSource?: string | null,
+): SpeedReadoutLabelKey {
+  const effectiveSource = resolveEffectiveSpeedSource(settings, runtimeSpeedSource);
+  if (effectiveSource === "obd2") {
+    return "speed.obd2";
+  }
+  return isManualLikeSpeedSource(effectiveSource) ? "speed.override" : "speed.gps";
 }

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -322,6 +322,7 @@
   "status.stopped": "Stopped",
   "status.unavailable": "Unavailable",
   "speed.gps": "{value} {unit} · GPS",
+  "speed.obd2": "{value} {unit} · OBD2",
   "speed.override": "{value} {unit} · Manual",
   "speed.none": "-- {unit}",
   "speed.unit": "Unit",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -322,6 +322,7 @@
   "status.stopped": "Gestopt",
   "status.unavailable": "Niet beschikbaar",
   "speed.gps": "{value} {unit} · GPS",
+  "speed.obd2": "{value} {unit} · OBD2",
   "speed.override": "{value} {unit} · Handmatig",
   "speed.none": "-- {unit}",
   "speed.unit": "Eenheid",

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -126,6 +126,60 @@ test("resolved fallback manual state stays coherent across header status, form, 
   await expect(page.locator("#manualSpeedInput")).toHaveValue("80");
 });
 
+test("resolved OBD2 state stays coherent across header status, form, and device summary", async ({ page }) => {
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/speed-source": {
+        speed_source: "obd2",
+        manual_speed_kph: null,
+        stale_timeout_s: 5,
+        obd_device_mac: "0022d9001bb1",
+        obd_device_name: "OBDLink CX",
+      },
+      "GET /api/settings/speed-source/status": gpsStatus({
+        gps_enabled: false,
+        connection_state: "disabled",
+        device: null,
+        raw_speed_kmh: null,
+        effective_speed_kmh: 81,
+        fallback_active: false,
+        speed_source: "obd2",
+      }),
+      "GET /api/settings/obd/status": {
+        configured_device_mac: "0022d9001bb1",
+        configured_device_name: "OBDLink CX",
+        paired: true,
+        trusted: true,
+        connected: true,
+        rfcomm_channel: 1,
+        last_rpm: 2200,
+        last_raw_response: "41 0C 1B 58",
+        debug_hint: null,
+      },
+    }),
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      speed_mps: 81 / 3.6,
+      clients: [],
+      spectra: { clients: {} },
+    },
+  });
+
+  await page.goto("/");
+  await expect(page.locator("#speed")).toContainText("81.0 km/h");
+  await expect(page.locator("#speed")).toContainText("OBD2");
+
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await expect(page.locator("#speedSourceCurrentSource")).toHaveText("OBD2");
+  await expect(page.locator("#speedSourceEffectiveSpeed")).toHaveText("81.0 km/h");
+  await expect(page.locator('input[name="speedSourceRadio"][value="obd2"]')).toBeChecked();
+  await expect(page.locator('input[name="speedSourceRadio"][value="gps"]')).not.toBeChecked();
+  await expect(page.locator("#obdConfiguredDevice")).toHaveText("OBDLink CX (0022d9001bb1)");
+});
+
 test("analysis bandwidth and uncertainty settings persist through API round-trip", async ({ page }) => {
   let persistedAnalysisSettings: Record<string, number> = {};
   let analysisPutCalls = 0;

--- a/apps/ui/tests/speed_source_state.spec.ts
+++ b/apps/ui/tests/speed_source_state.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   deriveDisplayedSpeedSourceMode,
+  deriveSpeedReadoutLabelKey,
   isManualEffectiveSpeedSource,
   resolveEffectiveSpeedSource,
 } from "../src/app/speed_source_state";
@@ -15,6 +16,7 @@ test.describe("speed source state helpers", () => {
     };
 
     expect(deriveDisplayedSpeedSourceMode(settings)).toBe("manual");
+    expect(deriveSpeedReadoutLabelKey(settings)).toBe("speed.override");
     expect(resolveEffectiveSpeedSource(settings)).toBe("fallback_manual");
     expect(isManualEffectiveSpeedSource(settings)).toBe(true);
   });
@@ -27,6 +29,7 @@ test.describe("speed source state helpers", () => {
     };
 
     expect(deriveDisplayedSpeedSourceMode(settings)).toBe("gps");
+    expect(deriveSpeedReadoutLabelKey(settings)).toBe("speed.gps");
     expect(resolveEffectiveSpeedSource(settings)).toBe("gps");
     expect(isManualEffectiveSpeedSource(settings)).toBe(false);
   });
@@ -39,6 +42,7 @@ test.describe("speed source state helpers", () => {
     };
 
     expect(deriveDisplayedSpeedSourceMode(settings)).toBe("manual");
+    expect(deriveSpeedReadoutLabelKey(settings)).toBe("speed.override");
     expect(resolveEffectiveSpeedSource(settings)).toBe("manual");
     expect(isManualEffectiveSpeedSource(settings)).toBe(true);
   });
@@ -51,7 +55,21 @@ test.describe("speed source state helpers", () => {
     };
 
     expect(deriveDisplayedSpeedSourceMode(settings)).toBe("gps");
+    expect(deriveSpeedReadoutLabelKey(settings)).toBe("speed.gps");
     expect(resolveEffectiveSpeedSource(settings)).toBe("none");
+    expect(isManualEffectiveSpeedSource(settings)).toBe(false);
+  });
+
+  test("renders an OBD2 header label when OBD2 is the resolved effective source", () => {
+    const settings = {
+      speedSource: "obd2" as const,
+      manualSpeedKph: null,
+      resolvedSpeedSource: "obd2" as const,
+    };
+
+    expect(deriveDisplayedSpeedSourceMode(settings)).toBe("obd2");
+    expect(deriveSpeedReadoutLabelKey(settings)).toBe("speed.obd2");
+    expect(resolveEffectiveSpeedSource(settings)).toBe("obd2");
     expect(isManualEffectiveSpeedSource(settings)).toBe(false);
   });
 });

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -494,6 +494,29 @@ test.describe("createUiShellStatusModule", () => {
     expect(speed.textContent).toContain("speed.override");
     expect(speed.textContent).toContain("\"unit\":\"speed.unit.kmh\"");
   });
+
+  test("renders OBD2 when OBD2 is the resolved speed source", () => {
+    const state = createAppState();
+    state.realtime.speedMps = 22.5;
+    state.settings.speedSource = "obd2";
+    state.settings.resolvedSpeedSource = "obd2";
+    state.shell.speedUnit = "kmh";
+    const { els, speed } = createShellDeps();
+    const module = createUiShellStatusModule({
+      shell: state.shell,
+      transport: state.transport,
+      realtime: state.realtime,
+      settings: state.settings,
+      els,
+      t: testTranslation,
+      setPillState: () => {},
+    });
+
+    module.renderSpeedReadout();
+
+    expect(speed.textContent).toContain("speed.obd2");
+    expect(speed.textContent).toContain("\"unit\":\"speed.unit.kmh\"");
+  });
 });
 
 test.describe("createUiShellLanguageRefreshModule", () => {


### PR DESCRIPTION
## Summary
This is a follow-up to closed issue #1731 and merged PR #1742. The original work correctly unified the GPS/manual/fallback-manual speed-source logic, but a later expansion of the Speed Source UI introduced an `obd2` effective source path without extending the high-visibility header speed label to match. On current `main`, that left a same-root contradiction in place: the Speed Source settings view could correctly show `OBD2` as the active source while the Live dashboard header still rendered the current speed as `… · GPS`.

That meant the issue was no longer truly “fixed” in the broader sense that #1731 required. The root problem was never just GPS vs manual wording. It was that the header, the settings controls, and the live/resolved source state could drift apart and force the user to reconcile overlapping clues. Once OBD2 became a first-class resolved source, the header path needed to consume the same resolved-source model too. This PR closes that remaining gap.

## Why the previous closure was insufficient
While reviewing recently closed issues on current `main`, I reproduced an OBD2 scenario with the following state:

- persisted settings source = `obd2`
- resolved live status source = `obd2`
- effective speed = `81 km/h`
- Speed Source settings view showing OBD2 selected and the configured adapter

In that state, the header still rendered `81.0 km/h · GPS`.

That is the exact kind of trust-breaking desynchronization #1731 set out to remove. The user-facing problem is not that one specific label was wrong during the original audit run. The problem is that the UI can tell different stories about where speed is coming from. The later OBD2 work reintroduced that inconsistency for a new effective source, so a follow-up was required.

## Implementation approach
I kept the remediation deliberately narrow. The existing shared helper in `apps/ui/src/app/speed_source_state.ts` already knew how to resolve an effective source across configured state and live status, and it already treated `obd2` as a valid displayed mode in the Speed Source form. The gap was that the header speed readout in `apps/ui/src/app/runtime/ui_shell_status_module.ts` still reduced the world to a binary choice: manual-like vs “everything else is GPS.”

Instead of scattering another special case into the header module, I extended the existing shared speed-source helper with one additional output: a readout translation key derived from the resolved effective source. That keeps the speed-source meaning centralized and lets the header consume the same resolved-source model as the rest of the UI.

## Main code changes
### Shared speed-source helper
In `apps/ui/src/app/speed_source_state.ts`, I added `SpeedReadoutLabelKey` plus `deriveSpeedReadoutLabelKey()`. The helper now returns one of three explicit header label keys:

- `speed.gps`
- `speed.override`
- `speed.obd2`

The logic is straightforward and intentionally mirrors the existing resolved-source behavior:

- `obd2` resolves to `speed.obd2`
- `manual` and `fallback_manual` resolve to `speed.override`
- everything else remains `speed.gps`

This keeps the OBD2 handling in the same shared state module that already owned the display-mode derivation for the settings UI.

### Header speed readout
In `apps/ui/src/app/runtime/ui_shell_status_module.ts`, the header now uses `deriveSpeedReadoutLabelKey()` instead of a manual-only boolean check. That is the behavioral fix. With live speed present, the header now labels the current speed using the resolved effective source rather than assuming every non-manual path is GPS.

### Localized user-facing copy
In `apps/ui/src/i18n/catalogs/en.json` and `apps/ui/src/i18n/catalogs/nl.json`, I added `speed.obd2` so the header has a proper localized format string for OBD2-driven speed readouts. I kept the format parallel to the existing GPS/manual entries to preserve the current visual rhythm.

## Regression coverage
I added three layers of regression protection because the bug crossed the shared helper, the shell header module, and the end-to-end UI state.

### Shared helper tests
`apps/ui/tests/speed_source_state.spec.ts` now verifies that an `obd2` resolved source produces:

- `obd2` as the displayed mode
- `speed.obd2` as the header readout key
- `obd2` as the effective source
- `false` for the manual-effective predicate

I also extended the existing GPS/manual tests to assert the header label key for those paths too, so the helper contract is now explicit across all current supported resolved-source families.

### Shell status module tests
`apps/ui/tests/ui_shell_runtime_modules.spec.ts` now includes a focused `createUiShellStatusModule` case that sets `resolvedSpeedSource = "obd2"` and verifies the rendered speed text uses `speed.obd2`. This protects the precise seam that regressed.

### Smoke coverage
`apps/ui/tests/smoke.settings.spec.ts` now includes an OBD2 coherence scenario that checks the cross-surface behavior on a real page load:

- the header shows `81.0 km/h` and `OBD2`
- the Speed Source page shows `OBD2` as the current source
- the effective speed matches
- the OBD2 choice is selected
- the configured adapter summary matches the same state

That complements the existing GPS/manual/fallback smoke coverage instead of replacing it, which is important because the original #1731 scenarios still need to stay green.

## Validation
I ran the following local validation after the fix:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts -g "gps status uses selected speed unit|gps status polling does not override websocket speed readout|manual speed save uses settings endpoint only|resolved fallback manual state stays coherent|resolved OBD2 state stays coherent|failed speed-source save reverts" --config=playwright.smoke.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/speed_source_state.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts -g "createUiShellStatusModule" --workers=1`

All of those checks passed.

I also repeated the required four-screenshot review for this UI issue after the remediation:

- normal desktop GPS state
- stressed desktop fallback-manual state
- narrow/mobile fallback-manual state
- related OBD2 state on the live dashboard

The screenshots show coherent labeling and no obvious layout, wrapping, or selection regressions. Most importantly, the related OBD2 screenshot now shows `81.0 km/h · OBD2` in the live header instead of the incorrect GPS label that reproduced on current `main` before this change.

## Risks and tradeoffs
This change intentionally does not broaden the speed-source model beyond the currently supported effective sources. It fixes the immediate trust problem by making the header consume the same resolved-source model the settings UI already used. If future sources are added, the shared helper is now the explicit place where header labeling must be extended.

I also kept the smoke test focused on stable sync surfaces instead of the slower OBD diagnostics poll table, because the regression here was the cross-surface source label mismatch, not polling cadence.

## Out of scope
This PR does not redesign the Speed Source page, alter backend contracts, or revisit the slower OBD diagnostics polling behavior. It is a narrow follow-up to make the resolved speed-source presentation genuinely consistent again after the later OBD2 expansion.
