### PR TITLE
Follow up #1736: keep History details readable on mobile

### DIFF
--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -1340,14 +1340,16 @@ input:focus-visible,
 .history-row__toggle-title {
   font-size: 0.82rem;
   font-weight: 700;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 .history-row__toggle-hint {
   color: var(--muted);
   font-size: 0.76rem;
   font-weight: 500;
   line-height: 1.35;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 .history-row__toggle-icon {
   width: 0;
@@ -2533,6 +2535,36 @@ input[aria-invalid="true"] {
     min-width: 0;
   }
   .history-details-preview { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 720px) {
+  .history-table {
+    table-layout: fixed;
+  }
+  .history-table th,
+  .history-table td {
+    padding: 0.6rem 0.5rem;
+  }
+  .history-table th:first-child,
+  .history-table td:first-child {
+    width: 48%;
+  }
+  .history-table th:nth-child(2),
+  .history-table td:nth-child(2) {
+    width: 18%;
+  }
+  .history-table th:nth-child(3),
+  .history-table td:nth-child(3) {
+    width: 10%;
+  }
+  .history-table th:nth-child(4),
+  .history-table td:nth-child(4) {
+    width: 24%;
+  }
+  .history-row .table-actions .btn {
+    min-width: 0;
+    width: 100%;
+  }
 }
 
 .strength-chart {

--- a/apps/ui/tests/smoke.history-layout.spec.ts
+++ b/apps/ui/tests/smoke.history-layout.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test";
+
+import { fulfillJson, installCommonRoutes, installFakeWebSocket, requestPath } from "./smoke.helpers";
+
+const historyListRun = {
+  run_id: "run-001",
+  status: "complete",
+  start_time_utc: "2026-01-01T00:00:00Z",
+  end_time_utc: "2026-01-01T00:00:12Z",
+  created_at: "2026-01-01T00:00:00Z",
+  sample_count: 42,
+  error_message: null,
+};
+
+test("history detail toggle stays readable on narrow screens", async ({ page }) => {
+  await page.setViewportSize({ width: 430, height: 1300 });
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      if (requestPath(route) === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+    historyHandler: async (route) => {
+      const pathname = requestPath(route);
+      if (!pathname.startsWith("/api/history") || pathname.includes("/insights")) {
+        await route.fallback();
+        return;
+      }
+      await fulfillJson(route, { runs: [historyListRun] });
+    },
+  });
+  await page.route("**/api/history/**/insights**", async (route) => {
+    await fulfillJson(route, {
+      run_id: "run-001",
+      status: "complete",
+      start_time_utc: "2026-01-01T00:00:00Z",
+      duration_s: 12.3,
+      sensor_count_used: 2,
+      findings: [],
+      sensor_intensity_by_location: [],
+    });
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-history").click();
+  const toggle = page.locator('[data-run-toggle="details"][data-run="run-001"]');
+  await expect(toggle).toBeVisible();
+
+  const metrics = await toggle.evaluate((button) => {
+    const title = button.querySelector<HTMLElement>(".history-row__toggle-title");
+    const hint = button.querySelector<HTMLElement>(".history-row__toggle-hint");
+    if (!title || !hint) {
+      throw new Error("history toggle content is missing");
+    }
+    const lineMetrics = (el: HTMLElement) => {
+      const style = getComputedStyle(el);
+      const fontSize = Number.parseFloat(style.fontSize) || 16;
+      const lineHeight = Number.parseFloat(style.lineHeight) || fontSize * 1.2;
+      return {
+        lines: Math.round(el.getBoundingClientRect().height / lineHeight),
+      };
+    };
+    return {
+      buttonWidth: Math.round(button.getBoundingClientRect().width),
+      titleLines: lineMetrics(title).lines,
+      hintLines: lineMetrics(hint).lines,
+    };
+  });
+
+  expect(metrics.buttonWidth).toBeGreaterThanOrEqual(140);
+  expect(metrics.titleLines).toBeLessThanOrEqual(2);
+  expect(metrics.hintLines).toBeLessThanOrEqual(3);
+  await expect(toggle).toContainText("Expand details");
+  await expect(toggle).toContainText("View diagnosis and heatmap");
+});


### PR DESCRIPTION
## Summary

Follow up #1736 by keeping the explicit History disclosure control readable on narrow screens.

The original fix for #1736 was directionally right: current `main` already exposed a real expand/collapse button, accessible labels, and an obvious linkage between the row and the detail panel on desktop. The problem I found while reviewing the closed issue on current `main` was that the same affordance degraded badly on a narrow/mobile viewport. On small screens, the History table kept squeezing the first column until the disclosure button became a thin vertical slab, and the button copy was allowed to break words anywhere. The result was a control that technically still existed but no longer felt explicit or discoverable, which is the same root problem the issue was meant to solve.

This follow-up keeps the remediation intentionally small and frontend-only. I did not redesign the History table, change the detail loading model, or touch the run data contracts. Instead, I tightened the responsive layout so the disclosure button gets enough space on narrow screens and the copy wraps at natural word boundaries instead of fragmenting into hard-to-read word shards.

## Why the previous closure was insufficient

While reviewing #1736 end to end, the desktop behavior initially looked fine. The current renderer still includes an explicit button, uses `aria-expanded`, and surfaces a visible hint (`View diagnosis and heatmap`) beneath the action label. The dedicated History smoke and module tests were also green.

The gap only became obvious during the required four-screenshot check. In the narrow/mobile screenshot, the run row still tried to fit the run identity, summary chips, timestamp, sample count, and action buttons into the same compressed table layout. Because the first column was not protected responsively, the disclosure button collapsed into a very narrow column. At the same time, the toggle title and hint were using `overflow-wrap: anywhere`, which caused text like `Expand details` and `View diagnosis and heatmap` to split into awkward mid-word fragments. That made the affordance much harder to scan and undercut the discoverability goal of the original issue.

Since this was the same underlying UX problem still present on current `main`, I treated #1736 as not fully good and fixed it directly instead of deferring to a later History review.

## Implementation approach

The chosen approach was the narrowest complete fix that addressed the responsive failure without destabilizing the rest of the History table.

First, I changed the disclosure copy so it wraps at normal word boundaries instead of using `overflow-wrap: anywhere`. That prevents the button text from breaking into unreadable fragments when the available width gets tight.

Second, I added a small-screen History table media rule at `max-width: 720px`. On narrow widths the table now switches to a fixed layout with explicit column proportions, tighter cell padding, and action buttons that are allowed to shrink to the available width instead of forcing the run column to collapse. That combination gives the disclosure button materially more room while preserving the existing table structure and button set.

I intentionally did not convert History into a completely different mobile card layout. That would have been a larger redesign than this issue required, and it would have overlapped heavily with the broader History polish issues already in the review queue. The responsive CSS tweak solves the actual regression while keeping the patch reviewable.

## Main code changes by area

In `apps/ui/src/styles/app.css`, I made two kinds of changes.

The first is local to the disclosure button itself. Both `.history-row__toggle-title` and `.history-row__toggle-hint` now use `overflow-wrap: break-word` with `word-break: normal` so the copy favors readable word-level wrapping.

The second is the narrow-screen History layout adjustment. Under `@media (max-width: 720px)`, the History table now uses a fixed layout with tuned column widths, slightly tighter padding, and action buttons that can shrink to the available cell width. This preserves space for the first column, where the discoverability affordance lives.

In `apps/ui/tests/smoke.history-layout.spec.ts`, I added a focused Playwright regression test for the exact bug found during review. The test loads a representative completed run on a `430px` wide viewport, opens History, measures the disclosure button, and asserts that:

- the button remains meaningfully wide,
- the title stays within two lines,
- the hint stays within three lines,
- and the expected disclosure copy is still present.

That gives this issue a direct regression guard for the mobile failure that was previously untested.

## Validation and tests

I validated the final change locally with:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts tests/history_feature_modules.spec.ts tests/smoke.history-layout.spec.ts --project=laptop-light --workers=1`

All of those passed for the final patch. `npm run lint` still reports the same pre-existing warnings in unrelated files (`cars_feature.ts`, `settings_speed_source_module.ts`, and existing spectrum-controller test/import cleanup items) that were already present before this follow-up. I did not change those unrelated areas as part of this issue-specific remediation.

I also re-ran the four-screenshot review after the fix. The updated screenshot set now shows:

- a clear collapsed disclosure button on desktop,
- a clean expanded desktop state tied to the detail panel,
- a readable narrow/mobile History row where the button text is no longer crushed into mid-word fragments,
- and a related loaded-insights state that still keeps the disclosure control visually tied to the richer detail content.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is that this is still a responsive table, not a bespoke mobile History card layout. That is intentional. The bug I found was specific: the explicit disclosure control lost readability because the table kept squeezing the run column and the copy was allowed to break anywhere. Fixing those two factors addresses the same-root issue without taking on a much larger History redesign inside the closed-issue review loop.

I also kept the action button set intact. The fix lets those buttons shrink on narrow screens, but it does not remove or reorder them. That preserves current behavior and avoids creating a second set of interaction changes while solving the discoverability regression.

Finally, I made the regression test measurement-based rather than snapshot-only. The screenshot review is what discovered the bug, but the new automated test is meant to fail on the actual layout problem: a disclosure button that becomes too narrow and starts wrapping its copy excessively. That should make the protection more durable than a purely visual assertion.
