### PR TITLE
Follow up #1739: sync manual Add Car summary

### DIFF
--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -76,7 +76,7 @@ const WIZARD_STEP_LABEL_KEYS = [
 ] as const;
 
 export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
-  const { els, escapeHtml, t } = ctx;
+  const { els, escapeHtml, fmt, t } = ctx;
   const wizState: WizardState = {
     step: 0,
     brand: "",
@@ -121,6 +121,89 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
     return tire.name ? `${tire.name} · ${size}` : size;
   }
 
+  function readPositiveWizardNumber(input: HTMLInputElement | null | undefined): number | null {
+    const value = Number(input?.value);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  }
+
+  function formatWizardRimSize(rim: number): string {
+    return fmt(rim, Number.isInteger(rim) ? 0 : 1);
+  }
+
+  function readManualTireValues(): {
+    width: number;
+    aspect: number;
+    rim: number;
+  } | null {
+    if (wizState.step < 4) {
+      return null;
+    }
+    const width = readPositiveWizardNumber(els.wizTireWidthInput);
+    const aspect = readPositiveWizardNumber(els.wizTireAspectInput);
+    const rim = readPositiveWizardNumber(els.wizRimInput);
+    if (width == null || aspect == null || rim == null) {
+      return null;
+    }
+    return { width, aspect, rim };
+  }
+
+  function readManualGearboxValues(): {
+    finalDrive: number;
+    topGear: number;
+  } | null {
+    if (wizState.step < 4) {
+      return null;
+    }
+    const finalDrive = readPositiveWizardNumber(els.wizFinalDriveInput);
+    const topGear = readPositiveWizardNumber(els.wizGearRatioInput);
+    if (finalDrive == null || topGear == null) {
+      return null;
+    }
+    return { finalDrive, topGear };
+  }
+
+  function formatManualTireSummary(
+    manualTire: {
+      width: number;
+      aspect: number;
+      rim: number;
+    },
+  ): string {
+    return t("settings.car.wizard_summary_manual_tire", {
+      width: fmt(manualTire.width, 0),
+      aspect: fmt(manualTire.aspect, 0),
+      rim: formatWizardRimSize(manualTire.rim),
+    });
+  }
+
+  function formatManualGearboxSummary(
+    manualGearbox: {
+      finalDrive: number;
+      topGear: number;
+    },
+  ): string {
+    return t("settings.car.wizard_summary_manual_gearbox", {
+      finalDrive: fmt(manualGearbox.finalDrive, 2),
+      topGear: fmt(manualGearbox.topGear, 2),
+    });
+  }
+
+  function selectedTireMatchesManualValues(
+    tire: CarLibraryTireOption | null,
+    manualTire: {
+      width: number;
+      aspect: number;
+      rim: number;
+    } | null,
+  ): boolean {
+    if (!tire || !manualTire) {
+      return false;
+    }
+    return tire.tire_width_mm === manualTire.width
+      && tire.tire_aspect_pct === manualTire.aspect
+      && tire.rim_in === manualTire.rim;
+  }
+
   function resetWizardState(): void {
     wizState.step = 0;
     wizState.brand = "";
@@ -151,6 +234,9 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
       && (wizState.selectedModel.variants?.length ?? 0) === 0
       && wizState.step >= 4,
     );
+    const manualTire = readManualTireValues();
+    const manualGearbox = readManualGearboxValues();
+    const selectedTireLabel = formatWizardTireLabel(wizState.selectedTire);
     return {
       profileName: wizState.model
         ? buildWizardCarName(wizState.brand, wizState.model, wizState.selectedVariant)
@@ -160,8 +246,11 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
       model: wizState.model || null,
       variant: wizState.selectedVariant?.name
         || (variantIsImplicit ? t("settings.car.wizard_summary_not_needed") : null),
-      tire: formatWizardTireLabel(wizState.selectedTire),
-      gearbox: wizState.selectedGearbox?.name || null,
+      tire: selectedTireMatchesManualValues(wizState.selectedTire, manualTire)
+        ? selectedTireLabel
+        : (manualTire ? formatManualTireSummary(manualTire) : selectedTireLabel),
+      gearbox: wizState.selectedGearbox?.name
+        || (manualGearbox ? formatManualGearboxSummary(manualGearbox) : null),
     };
   }
 
@@ -400,7 +489,7 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
           wizState.step -= 1;
           if (
             wizState.step === 3
-            && (!wizState.selectedModel || !(wizState.selectedModel.variants?.length))
+            && !(wizState.selectedModel?.variants?.length)
           ) {
             wizState.step = 2;
           }
@@ -491,6 +580,19 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
         variantName,
       );
       closeWizard();
+    });
+    [
+      els.wizTireWidthInput,
+      els.wizTireAspectInput,
+      els.wizRimInput,
+      els.wizFinalDriveInput,
+      els.wizGearRatioInput,
+    ].forEach((input) => {
+      input?.addEventListener("input", () => {
+        if (!els.addCarWizard?.hidden && wizState.step === 4) {
+          refreshWizardChrome();
+        }
+      });
     });
   }
 

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -196,6 +196,8 @@
   "settings.car.wizard_summary_variant": "Variant",
   "settings.car.wizard_summary_tire": "Tires",
   "settings.car.wizard_summary_gearbox": "Gearbox",
+  "settings.car.wizard_summary_manual_tire": "{width}/{aspect}R{rim}",
+  "settings.car.wizard_summary_manual_gearbox": "Final drive {finalDrive} · Top gear {topGear}",
   "settings.car.or_custom_brand": "Or type a custom brand:",
   "settings.car.or_custom_type": "Or type a custom type:",
   "settings.car.or_custom_model": "Or type a custom model:",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -196,6 +196,8 @@
   "settings.car.wizard_summary_variant": "Variant",
   "settings.car.wizard_summary_tire": "Banden",
   "settings.car.wizard_summary_gearbox": "Versnellingsbak",
+  "settings.car.wizard_summary_manual_tire": "{width}/{aspect}R{rim}",
+  "settings.car.wizard_summary_manual_gearbox": "Eindreductie {finalDrive} · Hoogste versnelling {topGear}",
   "settings.car.or_custom_brand": "Of typ een eigen merk:",
   "settings.car.or_custom_type": "Of typ een eigen type:",
   "settings.car.or_custom_model": "Of typ een eigen model:",

--- a/apps/ui/tests/smoke.car-wizard.spec.ts
+++ b/apps/ui/tests/smoke.car-wizard.spec.ts
@@ -130,8 +130,15 @@ test("keeps the manual branch deliberate while summarizing selections and activa
 
   await expect(page.locator("#wizardProgressText")).toContainText("Step 5 of 5");
   await expect(page.locator("#wizardSummaryPanel")).toContainText("BMW X5 M60i");
+  await expect(page.locator("#wizardSummaryPanel")).toContainText("225/45R18");
+  await expect(page.locator("#wizardSummaryPanel")).toContainText("Final drive 3.08");
+  await expect(page.locator("#wizardSummaryPanel")).toContainText("Top gear 0.64");
   await expect(page.locator(".wizard-custom-specs__note")).toBeVisible();
   await expect(page.locator("#wizardGearboxList")).toContainText("Enter specs manually below.");
+  await page.locator("#wizTireWidth").fill("245");
+  await page.locator("#wizGearRatio").fill("0.68");
+  await expect(page.locator("#wizardSummaryPanel")).toContainText("245/45R18");
+  await expect(page.locator("#wizardSummaryPanel")).toContainText("Top gear 0.68");
 
   await page.locator("#wizardManualAddBtn").click();
 
@@ -140,5 +147,8 @@ test("keeps the manual branch deliberate while summarizing selections and activa
   await expect(page.locator("#wizardBackdrop")).toBeHidden();
   const newRow = page.locator('#carListBody tr[data-car-id="car-2"]');
   await expect(newRow).toContainText("BMW X5 M60i");
+  await expect(newRow).toContainText("245/45R18");
+  await expect(newRow).toContainText("3.08");
+  await expect(newRow).toContainText("0.68");
   await expect(newRow.locator(".car-active-pill")).toHaveClass(/active/);
 });


### PR DESCRIPTION
## Summary
This follow-up finishes a gap left behind by `#1750` / issue `#1739`. The original Add Car wizard redesign successfully moved the flow into a focused modal surface, added clear progress chips, kept the surrounding Settings page out of the way, and made completion return cleanly to the car list. Those improvements are still present on current `main`, and the focused browser coverage continued to pass when I reviewed the issue. The problem showed up only when I ran the required four-screenshot check against the current UI: in the step-5 manual-spec branch, the summary card on the right still showed `Not selected yet` for tires and gearbox even while those manual values were visible in the form and about to be saved.

That mismatch undercut one of the original issue’s core promises: the current selections should stay summarized as the user progresses. In practice, the wizard looked polished on the outside but still broke trust on the exact branch intended to help users when the library stops short. This PR fixes that narrow same-root gap by making the summary card reflect the live manual tire and gearbox inputs, and by adding regression coverage for the path that the earlier tests did not fully exercise.

## Why the earlier closure was insufficient
The earlier PR correctly improved the shell around the wizard, but its summary logic still depended on `selectedTire` and `selectedGearbox`. That works for the library-driven path, because those selections are made through the rendered option buttons. It does not work for the manual-spec branch, because the values a user enters there live in the text/number inputs rather than in the wizard’s `selected*` objects. As a result, the summary card could keep saying “not selected yet” even though the manual inputs had valid numbers and the green submit button was about to persist them.

I confirmed the problem in three ways. First, the screenshots made it obvious visually: the manual branch showed filled wheel and ratio inputs on the left while the summary still claimed those values were missing. Second, reading `cars_feature.ts` showed the root cause directly: `buildWizardSummaryData()` only read `selectedTire` and `selectedGearbox`, and nothing refreshed summary state when the manual inputs changed. Third, the existing smoke test only asserted that the profile name, brand, and type summary updated on the manual branch; it never checked the tire and gearbox rows. So the earlier closure was directionally right, but not complete.

## Implementation approach
I kept the remediation intentionally small and frontend-only. There was no need to reshape the wizard flow, change the saved payload, or introduce a new state model. The current form already held the right values; the bug was simply that the summary card was reading the wrong source of truth for that branch.

The fix follows two principles. First, keep using the existing selected library data whenever it still matches the manual inputs, so the summary preserves richer library labels like named tire options where appropriate. Second, once the user is on step 5 and the manual inputs contain the values that would actually be saved, let the summary derive from those live inputs instead of pretending nothing has been chosen.

## Main code changes
In `apps/ui/src/app/features/cars_feature.ts`, I added small helpers to read positive numeric values from the manual tire and gearbox inputs, format those values into summary-ready strings, and compare manual tire dimensions against the currently selected library tire. `buildWizardSummaryData()` now uses those helpers so the wizard summary can show `245/45R18` and a readable gearbox ratio summary on the manual branch instead of falling back to the pending placeholder.

The implementation deliberately preserves the existing library-first experience. If the current manual tire inputs still match a selected library tire option, the summary keeps the richer selected-tire label instead of replacing it with a generic size string. That keeps the follow-up narrow: fix the manual-branch blind spot without regressing the library path that already worked.

I also wired the manual tire and gearbox inputs to `refreshWizardChrome()` on `input` events while step 5 is active. That means the summary updates live as the user edits the values, rather than only catching up when they click the final submit button. This is important because the issue was about the wizard feeling like a deliberate, trustworthy task flow while the user is still deciding, not just after the save succeeds.

To support the new summary strings cleanly, I added localized formatting entries in both `apps/ui/src/i18n/catalogs/en.json` and `apps/ui/src/i18n/catalogs/nl.json` for manual tire and gearbox summaries. There are no backend, schema, or contract changes in this PR.

## Tests and visual validation
I extended `apps/ui/tests/smoke.car-wizard.spec.ts`, which is the dedicated browser-level coverage introduced for the original wizard redesign. The strengthened manual-branch test now asserts that the summary shows the default manual tire and gearbox values as soon as the flow reaches step 5, that the summary updates when the user edits those inputs, and that the values ultimately persisted to the car list match what the summary showed before submission.

I re-ran the focused wizard validation and supporting frontend checks:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/car_wizard_view.spec.ts tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`

The touched-area lint is clean; the remaining warnings are pre-existing baseline warnings in unrelated spectrum and speed-source files. I also repeated the four-screenshot UI review after the fix. The updated manual-branch desktop and mobile screenshots now show the summary card keeping up with the entered tire and gearbox values, while the normal desktop wizard-open and post-completion screenshots still confirm the broader `#1739` goals: focused task ownership, explicit progress, responsive layout, and clean return to the car list.

Per the repo’s normal validation workflow, I also attempted local Docker stack bring-up. On this host, `docker compose` is unavailable as a subcommand, and the legacy `docker-compose up -d` path fails because there is no reachable Docker daemon/socket (`FileNotFoundError` from the Docker client). I am calling that out explicitly because it is an environment limitation during validation, not a change introduced by this branch.

## Risks, tradeoffs, and scope boundaries
This PR intentionally does not revisit the wizard container, step layout, save flow, or library APIs. Those parts were already behaving as intended on current `main`. The goal here is to close the specific review gap revealed by the manual-spec screenshots and make the summary card trustworthy on the branch where users most need reassurance.

The main tradeoff is that the manual gearbox summary uses concise formatted ratio text rather than introducing a larger secondary layout inside the summary card. That keeps the fix readable and localized without expanding the sidebar’s visual weight. If a future UX pass wants even richer manual-spec recap content, it can build on this without needing to rediscover the missing live sync that this follow-up addresses.
