### PR TITLE
Follow up #1754: hide empty-state spectrum toggle

### DIFF
--- a/apps/ui/src/styles/app.css
+++ b/apps/ui/src/styles/app.css
@@ -314,6 +314,8 @@ input:focus-visible,
   border: 1px solid transparent;
 }
 
+button[hidden],
+.btn[hidden],
 .pill[hidden],
 .badge[hidden],
 .status-pill[hidden] {

--- a/apps/ui/tests/smoke.spectrum.spec.ts
+++ b/apps/ui/tests/smoke.spectrum.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { installCommonRoutes, installFakeWebSocket } from "./smoke.helpers";
+
 test("spectrum controls simplify the chart and update the inspector", async ({ page }) => {
   await page.goto("/?demo=1");
 
@@ -28,4 +30,36 @@ test("spectrum controls simplify the chart and update the inspector", async ({ p
   await expect(allTracesChip).toHaveAttribute("aria-pressed", "true");
   await expect(sensorChip).toHaveAttribute("aria-pressed", "false");
   await expect(inspector).toContainText("Strongest trace:");
+});
+
+test("spectrum band toggle stays hidden when no spectrum data is available", async ({ page }) => {
+  await installCommonRoutes(page);
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      clients: [
+        {
+          id: "001122334455",
+          name: "Front Left",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 50,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_left_wheel",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: {
+        clients: {},
+      },
+    },
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("#spectrumOverlay")).toBeVisible();
+  await expect(page.locator("#spectrumBandToggle")).toBeHidden();
+  await expect(page.locator("#bandLegend")).toBeHidden();
 });


### PR DESCRIPTION
## Summary
This follow-up PR remediates a current-main regression I found while reviewing closed issue #1754, which originally simplified the Live spectrum presentation and interaction model. The main spectrum interaction work from PR #1763 is still good in its active states: the chart keeps the default view cleaner than before, the reference-band toggle is explicit instead of always-on, the contextual band legend only appears when it is relevant, and the focused-trace inspector wording still makes sense. The part that did not hold up was the empty-spectrum state.

During the required four-screenshot review, I checked the spectrum in four states: a normal desktop default view, a focused trace with reference bands enabled, a narrow/mobile state, and a related empty-overlay state. The first three held up. The fourth exposed that the `Show reference bands` toggle remained visibly rendered even when there was no spectrum data and `UiSpectrumController.renderBandToggle()` had already set `button.hidden = true`. That left a dead control visible inside the supposedly simplified empty state, which is directly at odds with the issue’s goal of reducing visual competition and making the spectrum feel more layered and intentional.

## Why the previous closure was too narrow
The original fix correctly improved the active chart experience, but it did not fully close the loop on the simplified presentation requirement because it relied on native hidden behavior without accounting for the app’s shared button styling. In `apps/ui/src/styles/app.css`, the global `button, .btn` rules force buttons to `display: inline-flex`. That means a button with a `hidden` attribute can still render unless there is an explicit CSS rule restoring the expected hidden behavior. PR #1763 already had to add `.legend[hidden] { display: none !important; }` for the same class of problem on legends, but the same underlying CSS interaction still affected the spectrum band toggle.

So, while the chart looked cleaner in the common data-present path, the empty state still showed an irrelevant control. That is not just a cosmetic nit. The empty state is where the page is supposed to be the most legible and low-noise, because the operator is waiting for trustworthy live data rather than interpreting a chart. Seeing a disabled but visible toggle there makes the spectrum controls feel less intentional and reintroduces precisely the kind of stacked visual explanation the issue was trying to reduce.

## What changed
The remediation is intentionally small and root-cause oriented.

First, I updated `apps/ui/src/styles/app.css` to add a generic hidden-button rule:

- `button[hidden], .btn[hidden] { display: none !important; }`

This is the minimal fix that makes the controller’s existing `hidden` toggling actually work under the shared button styles. I intentionally made the rule generic instead of adding a one-off selector for `#spectrumBandToggle`, because the root cause is not spectrum-specific. Anywhere in the UI that uses the shared button styles and toggles a button with the `hidden` attribute would otherwise be vulnerable to the same leak. We already had a narrow version of this for the recording buttons, and this change brings the shared behavior back in line with the platform expectation.

Second, I extended `apps/ui/tests/smoke.spectrum.spec.ts` with a regression test for the no-spectrum-data case. The new test installs a connected-client websocket payload that contains no spectrum series, loads the dashboard, and asserts all of the behavior that matters for this bug:

- the spectrum overlay is visible,
- the spectrum band toggle is hidden,
- the contextual band legend is hidden.

That coverage matters because the original active-state spectrum smoke test was already good enough to protect the focus and band-toggle workflow, but it did not verify the simplified empty state. This new test closes that gap directly.

## Validation
I validated the remediation with the frontend checks most relevant to the touched code and the reviewed issue behavior:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/visual.spec.ts --project=laptop-light --workers=1 --grep "Live view"`
- `cd apps/ui && NODE_PATH=/workspace/VibeSensor/apps/ui/node_modules npx playwright test --config=/workspace/VibeSensor/.ai-temp/playwright.issue1754.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run lint`

The spectrum smoke suite passed, including the new empty-state regression. The Live visual screenshot test passed. The dedicated four-screenshot harness also passed after the fix, covering normal desktop, focused-plus-bands desktop, narrow/mobile, and empty-overlay states.

`npm run lint` still reports the same pre-existing unrelated warnings already present in this checkout:

- unused `obdBoolLabel()` in `src/app/features/settings_speed_source_module.ts`
- unused imports in `src/app/runtime/ui_spectrum_controller.ts`
- two non-null-assertion warnings in `tests/ui_spectrum_controller.spec.ts`

I did not change those here because they predate this remediation and are outside the narrow bug I am fixing.

As with earlier frontend follow-ups in this review run, the Docker validation step remains environment-blocked in this session: `docker compose up -d` is unavailable because the Compose plugin is missing here, and `docker-compose up -d` cannot reach a Docker daemon/socket. I am treating that as an environment limitation rather than a code-level failure.

## Risks and tradeoffs
The risk here is low. The CSS change aligns the shared button styles with the browser’s native hidden semantics instead of inventing new behavior, and the new regression test covers the exact condition that failed during review. The only meaningful tradeoff is that the hidden-button rule is intentionally broader than the spectrum control itself, but that is a benefit in this case: it fixes the actual root cause and reduces the chance of similar hidden-button leaks elsewhere in the UI.

## Review context
This PR exists because the closed-issue audit found that #1754 was mostly, but not completely, fixed on current `main`. After this change, the simplified spectrum interaction model now holds in both active and empty states, so the issue’s intended “clean by default, richer on demand” presentation is genuinely consistent again.
