### PR TITLE
Fix live Add a car CTA churn when no car is configured

### DIFF
--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -69,6 +69,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
   let pendingLoggingAction: "starting" | "stopping" | null = null;
   let loggingElapsedTimer: ReturnType<typeof setInterval> | null = null;
   let lastCompletedElapsedText = "--";
+  let renderedLoggingSummarySignature: string | null = null;
 
   const SHORTHAND_LOCATION_MAP: Record<string, string> = {
     "front left": "front_left_wheel",
@@ -502,6 +503,35 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     });
   }
 
+  function loggingSummarySignature(summaryText: string, summaryPanel: RecordingSummaryPanel | null): string {
+    if (summaryPanel === null) {
+      return `text:${summaryText}`;
+    }
+    const actionSignature = summaryPanel.action
+      ? `${summaryPanel.action.action}|${summaryPanel.action.label}|${summaryPanel.action.variant ?? ""}`
+      : "";
+    return `panel:${summaryPanel.title}|${summaryPanel.body}|${summaryPanel.detail ?? ""}|${actionSignature}`;
+  }
+
+  function renderLoggingSummaryContent(summaryText: string, summaryPanel: RecordingSummaryPanel | null): void {
+    if (!els.loggingSummary) {
+      return;
+    }
+    const loggingSummary = els.loggingSummary;
+    const nextSignature = loggingSummarySignature(summaryText, summaryPanel);
+
+    loggingSummary.hidden = summaryText === "" && summaryPanel === null;
+    if (renderedLoggingSummarySignature !== nextSignature) {
+      if (summaryPanel) {
+        loggingSummary.innerHTML = renderRecordingSummaryPanel(summaryPanel);
+      } else {
+        loggingSummary.textContent = summaryText;
+      }
+      renderedLoggingSummarySignature = nextSignature;
+    }
+    loggingSummary.classList.toggle("logging-summary--panel", summaryPanel !== null);
+  }
+
   function blockedRecordingPanel(): RecordingSummaryPanel {
     const selection = deriveCarSelectionState(settings);
     if (selection.kind === "no_cars") {
@@ -709,15 +739,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     if (els.loggingPhase) {
       els.loggingPhase.hidden = true;
     }
-    if (els.loggingSummary) {
-      els.loggingSummary.hidden = panelState.summaryText === "" && panelState.summaryPanel === null;
-      els.loggingSummary.classList.toggle("logging-summary--panel", panelState.summaryPanel !== null);
-      if (panelState.summaryPanel) {
-        els.loggingSummary.innerHTML = renderRecordingSummaryPanel(panelState.summaryPanel);
-      } else {
-        els.loggingSummary.textContent = panelState.summaryText;
-      }
-    }
+    renderLoggingSummaryContent(panelState.summaryText, panelState.summaryPanel);
     if (els.loggingRunId) {
       els.loggingRunId.hidden = panelState.runIdText === "";
       els.loggingRunId.textContent = panelState.runIdText;
@@ -750,11 +772,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       pendingLoggingAction = null;
       clearLoggingElapsedTimer();
       setDashboardPillState(els.loggingStatus, "bad", t("status.unavailable"));
-      if (els.loggingSummary) {
-        els.loggingSummary.hidden = false;
-        els.loggingSummary.classList.remove("logging-summary--panel");
-        els.loggingSummary.textContent = t("status.unavailable");
-      }
+      renderLoggingSummaryContent(t("status.unavailable"), null);
       if (els.loggingRunId) {
         els.loggingRunId.hidden = true;
         els.loggingRunId.textContent = "";
@@ -792,9 +810,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       const msg = err instanceof Error ? err.message : String(err);
       pendingLoggingAction = null;
       setDashboardPillState(els.loggingStatus, "bad", msg || t("status.unavailable"));
-      if (els.loggingSummary) {
-        els.loggingSummary.textContent = msg || t("status.unavailable");
-      }
+      renderLoggingSummaryContent(msg || t("status.unavailable"), null);
       return;
     }
     pendingLoggingAction = null;
@@ -813,9 +829,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       const msg = err instanceof Error ? err.message : String(err);
       pendingLoggingAction = null;
       setDashboardPillState(els.loggingStatus, "bad", msg || t("status.unavailable"));
-      if (els.loggingSummary) {
-        els.loggingSummary.textContent = msg || t("status.unavailable");
-      }
+      renderLoggingSummaryContent(msg || t("status.unavailable"), null);
       return;
     }
     pendingLoggingAction = null;

--- a/apps/ui/tests/realtime_logging_summary.spec.ts
+++ b/apps/ui/tests/realtime_logging_summary.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+import { fulfillJson, installCommonRoutes, installFakeWebSocket, requestPath } from "./smoke.helpers";
+
+test("keeps the no-car Live CTA stable while repeated websocket payloads arrive", async ({ page }) => {
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      const path = requestPath(route);
+      if (path === "/api/settings/cars") {
+        await fulfillJson(route, { cars: [], active_car_id: null });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      clients: [
+        {
+          id: "001122334455",
+          name: "Front Left",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 12,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_left_wheel",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: { clients: {} },
+    },
+    repeatPayloadCount: 16,
+    repeatPayloadIntervalMs: 25,
+  });
+
+  await page.goto("/");
+  const liveSummary = page.locator("#loggingSummary");
+  const addCarButton = liveSummary.getByRole("button", { name: "Add a car" });
+  await expect(addCarButton).toBeVisible();
+
+  await page.evaluate(() => {
+    const summary = document.querySelector<HTMLElement>("#loggingSummary");
+    const button = summary?.querySelector<HTMLElement>('[data-inline-state-action="open-add-car"]');
+    if (!summary || !button) {
+      throw new Error("Live logging summary button was not rendered");
+    }
+    const tracker = {
+      currentButton: button,
+      replacements: 0,
+    };
+    const observer = new MutationObserver(() => {
+      const nextButton = summary.querySelector<HTMLElement>('[data-inline-state-action="open-add-car"]');
+      if (nextButton && nextButton !== tracker.currentButton) {
+        tracker.currentButton = nextButton;
+        tracker.replacements += 1;
+      }
+    });
+    observer.observe(summary, { childList: true, subtree: true });
+    (
+      window as Window & typeof globalThis & {
+        __loggingSummaryTracker?: typeof tracker;
+        __loggingSummaryObserver?: MutationObserver;
+      }
+    ).__loggingSummaryTracker = tracker;
+    (
+      window as Window & typeof globalThis & {
+        __loggingSummaryTracker?: typeof tracker;
+        __loggingSummaryObserver?: MutationObserver;
+      }
+    ).__loggingSummaryObserver = observer;
+  });
+
+  await page.waitForTimeout(450);
+
+  expect(await page.evaluate(() => (
+    window as Window & typeof globalThis & {
+      __loggingSummaryTracker?: { replacements: number };
+    }
+  ).__loggingSummaryTracker?.replacements ?? -1)).toBe(0);
+
+  await addCarButton.click();
+  await expect(page.locator("#settingsView")).toHaveClass(/active/);
+  await expect(page.locator("#wizardBackdrop")).toBeVisible();
+});

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -4,10 +4,12 @@ import { EXPECTED_SCHEMA_VERSION } from "../src/contracts/ws_payload_types";
 export type FakeWebSocketOptions = {
   payload?: Record<string, unknown>;
   confirmResult?: boolean;
+  repeatPayloadCount?: number;
+  repeatPayloadIntervalMs?: number;
 };
 
 export async function installFakeWebSocket(page: Page, options: FakeWebSocketOptions = {}): Promise<void> {
-  await page.addInitScript(({ payload, confirmResult, schemaVersion }) => {
+  await page.addInitScript(({ payload, confirmResult, schemaVersion, repeatPayloadCount, repeatPayloadIntervalMs }) => {
     const mergedPayload = payload
       ? {
           schema_version: schemaVersion,
@@ -26,16 +28,37 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
       onmessage: ((event: MessageEvent<string>) => void) | null = null;
       onclose: ((event: CloseEvent) => void) | null = null;
       onerror: ((event: Event) => void) | null = null;
+      repeatTimer = 0;
       constructor() {
         queueMicrotask(() => this.onopen?.(new Event("open")));
         if (mergedPayload) {
-          queueMicrotask(() =>
-            this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(mergedPayload) })),
-          );
+          const emitPayload = () =>
+            this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(mergedPayload) }));
+          queueMicrotask(emitPayload);
+          if ((repeatPayloadCount ?? 0) > 0) {
+            let remainingRepeats = repeatPayloadCount ?? 0;
+            this.repeatTimer = window.setInterval(() => {
+              if (this.readyState !== FakeWebSocket.OPEN) {
+                window.clearInterval(this.repeatTimer);
+                this.repeatTimer = 0;
+                return;
+              }
+              emitPayload();
+              remainingRepeats -= 1;
+              if (remainingRepeats <= 0) {
+                window.clearInterval(this.repeatTimer);
+                this.repeatTimer = 0;
+              }
+            }, repeatPayloadIntervalMs ?? 50);
+          }
         }
       }
       send() {}
       close() {
+        if (this.repeatTimer) {
+          window.clearInterval(this.repeatTimer);
+          this.repeatTimer = 0;
+        }
         this.readyState = 3;
         this.onclose?.(new CloseEvent("close"));
       }


### PR DESCRIPTION
Fixes #1923.

## Summary

This PR fixes the Live dashboard regression where the inline `Add a car` CTA inside the Run Recording card behaved as if the page were constantly refreshing when no car was configured. The issue was not that the CTA lacked a handler or that navigation to the Cars flow was broken. The real problem was repeated DOM replacement. While live websocket payloads were arriving, the UI kept rebuilding the actionable empty-state panel inside `#loggingSummary`, which replaced the button element underneath the cursor often enough to reset hover styling and make manual clicks feel unreliable.

I kept the fix intentionally narrow and anchored it at the rendering seam that actually caused the visible instability. The current transport flow still calls `renderLoggingStatus()` on incoming payloads, but the summary panel no longer rewrites its HTML unless the rendered summary state has actually changed. That preserves the existing update flow and the current logging-status responsibilities while removing the user-facing DOM churn that made first-run setup feel broken.

## Problem being solved

Issue #1923 documented a particularly important first-run failure mode. On a fresh device with no configured car, the Live page correctly shows recording as blocked and offers the user an `Add a car` action. In practice, though, that action was unstable because the summary subtree was being recreated repeatedly during live updates. The issue report already narrowed the likely root cause to the interaction between `UiLiveTransportController.applyPayload()` and `renderLoggingStatus()`, and the current source still matched that analysis.

The key behavior in the repo today is that the transport controller applies each websocket payload and then calls `ports.renderLoggingStatus()`. Inside the realtime feature, the blocked no-car state renders an inline actionable panel and writes it into `#loggingSummary` with `innerHTML`. That is fine when the state genuinely changes, but in the no-car path the rendered content often stays semantically identical across frames. Reassigning `innerHTML` on every frame tears down and recreates the button node anyway, which is exactly what the issue described.

## Implementation approach

I considered two families of fixes. One option was to change the transport controller so it only invoked `renderLoggingStatus()` when the subset of state relevant to logging actually changed. That would reduce work overall, but it would also widen the blast radius of the change because the transport module would need more detailed knowledge about which payload differences matter to logging state. The other option was to keep the transport behavior intact and make the logging-summary renderer idempotent for unchanged visible output.

I chose the second option. It is smaller, safer, and directly addresses the UX bug. The UI still computes logging state when payloads arrive, but it no longer replaces the actionable summary DOM if the effective summary is the same as last time. That means the CTA stays mounted and interactive, while the rest of the Live rendering flow remains unchanged.

## Main code changes

The core change is in `apps/ui/src/app/features/realtime_feature.ts`. I introduced a semantic signature for the logging summary, based on the visible summary mode and content rather than the browser’s serialized `innerHTML`. This matters because comparing against `element.innerHTML` is not stable in practice; browsers normalize markup, which can make raw string comparisons unreliable even when the UI is effectively unchanged. The feature now tracks the last rendered summary signature and only rewrites the summary container when the signature changes.

I also centralized summary updates through a small helper in the same feature module. That helper handles both panel rendering and plain text fallback rendering, and it is now used from the normal logging-status render path as well as the error/fallback paths for logging refresh and start/stop failures. Routing those paths through the same helper keeps the signature cache coherent instead of letting one code path render a panel while another directly mutates text content behind its back.

On the test side, I extended `apps/ui/tests/smoke.helpers.ts` so the fake websocket can emit a repeated payload stream, not just a single initial frame. That let me write a focused browser-level regression in `apps/ui/tests/realtime_logging_summary.spec.ts` that reproduces the exact failure mode from the issue: no configured car, repeated websocket updates, and a mutation observer watching whether the `Add a car` button node gets replaced. The test asserts that the replacement count stays at zero and also verifies that clicking the CTA still opens the expected Cars/add-car flow.

I kept the existing `apps/ui/tests/smoke.cars.spec.ts` coverage in the validation run as a broader guard around the no-car and active-car guidance flows. That makes sure the targeted DOM-stability fix did not break the existing Live-to-Cars navigation behavior or the related car-guidance scenarios.

## Validation performed

I validated the change in layers.

First, I ran the frontend static gates:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Then I ran focused Playwright coverage:

- `NODE_PATH=/workspace/VibeSensor/apps/ui/node_modules npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`

That passed after tightening the implementation to use a semantic summary signature rather than relying on the browser’s `innerHTML` serialization.

I also performed a broader runtime check. The repo guidance asks for Docker-based stack validation, but this environment does not have a working Docker daemon/socket, so `docker-compose` could not connect. Instead of stopping there, I used the documented native fallback path: `python3 tools/build_ui_static.py`, then `vibesensor-server --config apps/server/config.dev.yaml`, and finally `vibesensor-sim --count 3 --duration 8 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`. I verified that the server served HTTP successfully on `:8000`, that `/api/clients` showed connected clients during the simulator run, and that the client snapshot stopped changing after the simulator exited.

## Risks, tradeoffs, and edge cases

The main tradeoff is that this PR fixes the visible DOM churn without redesigning when logging-status renders are triggered. In other words, the code still computes logging state on incoming payloads, but it avoids replacing the summary subtree when nothing user-visible changed. I consider that the right scope for this issue because it fixes the broken interaction with minimal risk and without re-plumbing the transport layer.

I also explicitly avoided adding compatibility shims or alternate rendering paths. The change stays within the current feature module, preserves existing translation keys and actions, and leaves unrelated Live rendering untouched. The semantic signature approach covers both the no-car actionable panel and the plain-text fallback cases, so it should be resilient if the same summary container is reused across nearby states.

## Out of scope

This PR does not attempt a broader transport/render optimization pass, and it does not address the separate issues currently tracked as #1924 and #1926. Those remain open in the backlog and should be handled in their own focused changes.
