### PR TITLE
Clear stale car-added feedback after leaving Settings Car

### DIFF
--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -80,6 +80,98 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     highlightedCarFeedback = null;
   }
 
+  function dismissHighlightedCarFeedback(): void {
+    if (highlightedCarFeedback === null) {
+      return;
+    }
+    clearHighlightedCarFeedback();
+    syncCarDependentUiState();
+    renderCarList();
+  }
+
+  function settingsTabIdAt(index: number): string | null {
+    if (!els.settingsTabs.length) {
+      return null;
+    }
+    const safeIndex = ((index % els.settingsTabs.length) + els.settingsTabs.length) % els.settingsTabs.length;
+    return els.settingsTabs[safeIndex].getAttribute("data-settings-tab");
+  }
+
+  function primaryViewIdAt(index: number): string | undefined {
+    if (!els.menuButtons.length) {
+      return undefined;
+    }
+    const safeIndex = ((index % els.menuButtons.length) + els.menuButtons.length) % els.menuButtons.length;
+    return els.menuButtons[safeIndex].dataset.view;
+  }
+
+  function bindHighlightedCarFeedbackResetEvents(): void {
+    const dismissForSettingsTab = (tabId: string | null): void => {
+      if (tabId && tabId !== "carTab") {
+        dismissHighlightedCarFeedback();
+      }
+    };
+    const dismissForPrimaryView = (viewId: string | undefined): void => {
+      if (viewId && viewId !== "settingsView") {
+        dismissHighlightedCarFeedback();
+      }
+    };
+
+    els.settingsTabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => {
+        dismissForSettingsTab(tab.getAttribute("data-settings-tab"));
+      });
+      tab.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          dismissForSettingsTab(tab.getAttribute("data-settings-tab"));
+          return;
+        }
+        if (event.key === "ArrowRight") {
+          dismissForSettingsTab(settingsTabIdAt(index + 1));
+          return;
+        }
+        if (event.key === "ArrowLeft") {
+          dismissForSettingsTab(settingsTabIdAt(index - 1));
+          return;
+        }
+        if (event.key === "Home") {
+          dismissForSettingsTab(settingsTabIdAt(0));
+          return;
+        }
+        if (event.key === "End") {
+          dismissForSettingsTab(settingsTabIdAt(els.settingsTabs.length - 1));
+        }
+      });
+    });
+
+    els.menuButtons.forEach((button, index) => {
+      button.addEventListener("click", () => {
+        dismissForPrimaryView(button.dataset.view);
+      });
+      button.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          dismissForPrimaryView(button.dataset.view);
+          return;
+        }
+        if (event.key === "ArrowRight") {
+          dismissForPrimaryView(primaryViewIdAt(index + 1));
+          return;
+        }
+        if (event.key === "ArrowLeft") {
+          dismissForPrimaryView(primaryViewIdAt(index - 1));
+          return;
+        }
+        if (event.key === "Home") {
+          dismissForPrimaryView(primaryViewIdAt(0));
+          return;
+        }
+        if (event.key === "End") {
+          dismissForPrimaryView(primaryViewIdAt(els.menuButtons.length - 1));
+        }
+      });
+    });
+  }
+
   function renderCarSelectionGuidance(carSelectionState: CarSelectionState): void {
     const guidance = els.carSelectionGuidance;
     if (!guidance) {
@@ -328,6 +420,7 @@ export function createSettingsFeature(ctx: SettingsFeatureDeps): SettingsFeature
     }
     handlersBound = true;
     bindSettingsTabs(els);
+    bindHighlightedCarFeedbackResetEvents();
     bindCarListEvents();
     analysisModule.bindHandlers();
     speedSourceModule.bindHandlers();

--- a/apps/ui/tests/settings_car_feedback_reset.spec.ts
+++ b/apps/ui/tests/settings_car_feedback_reset.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+import { fulfillJson, installCommonRoutes, installFakeWebSocket, requestPath } from "./smoke.helpers";
+
+test("clears transient car creation feedback after leaving and re-entering the car screen", async ({ page }) => {
+  let cars = [] as Array<Record<string, unknown>>;
+  let activeCarId: string | null = null;
+
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      const path = requestPath(route);
+      const method = route.request().method();
+      if (path === "/api/settings/cars" && method === "GET") {
+        await fulfillJson(route, { cars, active_car_id: activeCarId });
+        return;
+      }
+      if (path === "/api/settings/cars" && method === "POST") {
+        cars = [{
+          id: "car-1",
+          name: "Track Demo",
+          type: "Coupe",
+          aspects: {
+            tire_width_mm: 225,
+            tire_aspect_pct: 45,
+            rim_in: 18,
+            final_drive_ratio: 3.08,
+            current_gear_ratio: 0.64,
+          },
+        }];
+        await fulfillJson(route, { cars, active_car_id: activeCarId });
+        return;
+      }
+      if (path === "/api/settings/cars/active" && method === "PUT") {
+        activeCarId = "car-1";
+        await fulfillJson(route, { cars, active_car_id: activeCarId });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+  await page.getByRole("button", { name: "+ Add Car" }).click();
+  await page.locator("#wizardCustomBrand").fill("Track");
+  await page.locator("#wizardCustomBrandBtn").click();
+  await page.locator("#wizardCustomType").fill("Coupe");
+  await page.locator("#wizardCustomTypeBtn").click();
+  await page.locator("#wizardCustomModel").fill("Demo");
+  await page.locator("#wizardCustomModelBtn").click();
+  await page.locator("#wizTireWidth").fill("225");
+  await page.locator("#wizTireAspect").fill("45");
+  await page.locator("#wizRim").fill("18");
+  await page.locator("#wizFinalDrive").fill("3.08");
+  await page.locator("#wizGearRatio").fill("0.64");
+  await page.locator("#wizardManualAddBtn").click();
+
+  const guidance = page.locator("#carSelectionGuidance");
+  const createdRow = page.locator('#carListBody tr[data-car-id="car-1"]');
+  await expect(guidance).toContainText("Car added");
+  await expect(createdRow).toHaveClass(/car-list-row--highlighted/);
+  await expect(createdRow).toContainText("New");
+
+  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+
+  await expect(guidance).toBeHidden();
+  await expect(createdRow).not.toHaveClass(/car-list-row--highlighted/);
+  await expect(createdRow).not.toContainText("New");
+
+  await page.locator("#tab-dashboard").click();
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+
+  await expect(guidance).toBeHidden();
+  await expect(createdRow).not.toHaveClass(/car-list-row--highlighted/);
+  await expect(createdRow).not.toContainText("New");
+});


### PR DESCRIPTION
## Summary

Fixes #1924.

This PR clears the transient `Car added` confirmation state after the user leaves **Settings → Car** or leaves **Settings** entirely, while keeping the immediate post-wizard success feedback intact. The issue was not that the add flow failed or that the selected car state was wrong. The problem was that a short-lived UI confirmation was being stored in local Settings feature state and then treated like durable screen state. As a result, the success panel and the special highlight on the newly added row survived ordinary navigation and looked stale when the user came back later.

## Problem being solved

The Settings feature already tracks car creation feedback in `highlightedCarFeedback`. That local state is used in two different places: the guidance panel above the car table renders the `Car added` success copy whenever the active-car state is valid and feedback still exists, and the car list renderer uses the same state to apply the temporary highlight and `New` badge to the created row. Existing code only cleared that feedback in a few explicit car-management flows such as activate, complete setup, or delete. If the user simply moved to another Settings tab, switched back to the dashboard, or otherwise resumed normal navigation, nothing reset the feedback.

That produced a sticky, confusing experience. The add flow looked as if it had just happened even after the user had already left and returned. The user was not seeing a broken saved state; they were seeing transient confirmation UI that had outlived its purpose.

## Implementation approach

I chose to solve this at the Settings feature lifecycle boundary rather than by adding timers or changing the wizard flow. The issue description explicitly frames the panel as transient confirmation feedback that should remain visible immediately after creation but disappear once the user leaves the relevant screen. The cleanest way to model that is to keep the current local feedback state, preserve its existing behavior on the first render, and clear it when navigation indicates the user has moved on.

This keeps the change narrow and avoids inventing a second state machine or introducing timeout-based UX that might disappear too early. It also keeps the logic close to the feature that already owns the feedback instead of spreading knowledge of this transient state into unrelated modules.

## Main code changes

In `apps/ui/src/app/features/settings_feature.ts`, I added a small helper named `dismissHighlightedCarFeedback()`. That helper centralizes the existing reset behavior by clearing `highlightedCarFeedback`, re-running car-dependent UI sync, and re-rendering the car list so the guidance panel and highlighted row update together.

I then added navigation-aware reset binding inside the same feature. The new `bindHighlightedCarFeedbackResetEvents()` helper watches Settings tab navigation and top-level primary view navigation. When the user moves away from `carTab`, the transient feedback is dismissed. When the user leaves `settingsView`, the transient feedback is also dismissed. This means the success panel still appears immediately after a car is created, but it no longer survives a later return to the screen.

Because the existing tab and shell navigation controllers handle both pointer and keyboard navigation, the reset logic mirrors those interaction patterns. It covers click activation and keyboard-driven tab/view changes, including Enter, Space, ArrowLeft, ArrowRight, Home, and End. That matters here because the stale state bug is about leaving the screen, not just clicking somewhere else with a mouse.

I intentionally kept the change local to `settings_feature.ts` instead of refactoring the shared navigation controllers to add new callback hooks. That broader refactor would have touched more code for a single consumer. Keeping the reset listeners next to `highlightedCarFeedback` preserves a straightforward ownership model: the feature that owns the transient feedback also owns the rules for dismissing it.

## Test coverage

I added a new browser Playwright regression at `apps/ui/tests/settings_car_feedback_reset.spec.ts`. The test drives the actual add-car wizard flow, verifies that the immediate success state is still present, then navigates away and back in the same ways users do. It checks two key expectations from the issue:

- the `Car added` guidance panel disappears after leaving and re-entering the Car tab
- the created row no longer has the temporary highlight or `New` badge after that normal re-entry

The test also leaves Settings entirely and comes back again to prove the feedback does not persist across a higher-level menu exit.

I kept existing broader coverage in the validation loop as well. `tests/smoke.cars.spec.ts` still verifies the immediate post-create success state and highlighted row, which guards against accidentally clearing the feedback too early. I also ran `tests/smoke.settings.spec.ts` because the change binds into general Settings navigation and I wanted coverage over unrelated Settings flows before opening the PR.

## Docs, contracts, and config

There are no schema, contract, API, config, or documentation changes in this PR. The bug is entirely in frontend feature state and its dismissal lifecycle.

## Validation performed

I ran the following local validation before opening this PR:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && NODE_PATH=/workspace/VibeSensor/apps/ui/node_modules npx playwright test tests/settings_car_feedback_reset.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && NODE_PATH=/workspace/VibeSensor/apps/ui/node_modules npx playwright test tests/smoke.settings.spec.ts --project=laptop-light --workers=1`

I also exercised the local runtime using the documented native fallback path because Docker is not usable in this environment right now. I rebuilt the static UI, started `vibesensor-server` with `apps/server/config.dev.yaml`, and ran `vibesensor-sim` against `127.0.0.1:8000`. The server responded successfully, `/api/clients` showed connected clients during simulation, and the client snapshot stopped changing after the simulator exited. I also re-checked Docker availability: the `docker compose` plugin is unavailable here, and `docker-compose` cannot connect because the Docker socket/daemon is absent.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this fix adds local navigation listeners inside `settings_feature.ts` because the existing navigation helpers do not expose activation callbacks. I judged that to be the smallest maintainable change for this issue. If more features eventually need the same lifecycle hooks, it could make sense to extract a shared callback seam later, but I did not add that abstraction speculatively here.

This PR also does not change the duration or wording of the success message while the user remains on the Car screen. That is intentional. The issue asked for transient feedback that disappears once the user leaves the screen, not for a timer-based auto-dismiss while the user is still reviewing the newly created row.

Out of scope for this PR are any broader changes to other transient notices in Settings, wizard flow redesign, or changes to persisted car state. The selected car behavior itself was already correct; only the dismissal lifecycle of the temporary confirmation UI was wrong.
