### PR TITLE
Extend OBD scan timeout in the Settings UI

### DIFF
--- a/apps/ui/src/api/http.ts
+++ b/apps/ui/src/api/http.ts
@@ -1,6 +1,7 @@
 const DEFAULT_TIMEOUT_MS = 10000;
 const NOOP = () => {};
 const WHITESPACE_RE = /\s+/g;
+const DEFAULT_TIMEOUT_MESSAGE = "Request timed out.";
 
 function composeSignal(
   timeoutSignal: AbortSignal,
@@ -37,14 +38,22 @@ export interface ApiJsonResponse<T> {
   body: T | undefined;
 }
 
+export interface ApiJsonInit extends RequestInit {
+  timeoutMs?: number;
+}
+
 export async function apiJsonResponse<T = unknown>(
   path: string,
-  init?: RequestInit,
+  init?: ApiJsonInit,
 ): Promise<ApiJsonResponse<T>> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: externalSignal, ...requestInit } = init ?? {};
   const timeoutController = new AbortController();
-  const timeoutId = window.setTimeout(() => timeoutController.abort(), DEFAULT_TIMEOUT_MS);
-  const { signal, cleanup } = composeSignal(timeoutController.signal, init?.signal ?? undefined);
-  const response = await fetch(path, { ...init, signal }).finally(() => {
+  const timeoutId = window.setTimeout(
+    () => timeoutController.abort(new DOMException(DEFAULT_TIMEOUT_MESSAGE, "AbortError")),
+    timeoutMs,
+  );
+  const { signal, cleanup } = composeSignal(timeoutController.signal, externalSignal ?? undefined);
+  const response = await fetch(path, { ...requestInit, signal }).finally(() => {
     window.clearTimeout(timeoutId);
     cleanup();
   });
@@ -78,7 +87,7 @@ export async function apiJsonResponse<T = unknown>(
   }
 }
 
-export async function apiJson<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+export async function apiJson<T = unknown>(path: string, init?: ApiJsonInit): Promise<T> {
   const response = await apiJsonResponse<T>(path, init);
   return response.body as T;
 }

--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -27,6 +27,7 @@ import type {
 } from "./types";
 
 const JSON_HEADERS: HeadersInit = { "Content-Type": "application/json" };
+const OBD_SCAN_TIMEOUT_MS = 20_000;
 
 export async function getSettingsLanguage(): Promise<LanguagePayload> {
   return apiJson("/api/settings/language");
@@ -117,6 +118,7 @@ export async function getSpeedSourceStatus(): Promise<SpeedSourceStatusPayload> 
 export async function scanSettingsObdDevices(): Promise<ObdScanPayload> {
   return apiJson("/api/settings/obd/scan", {
     method: "POST",
+    timeoutMs: OBD_SCAN_TIMEOUT_MS,
   });
 }
 

--- a/apps/ui/tests/api_http.spec.ts
+++ b/apps/ui/tests/api_http.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { apiJson } from "../src/api/http";
-import { installWindowGlobal } from "./async_test_helpers";
+import { createDeferred, installTimerHarness, installWindowGlobal, jsonResponse } from "./async_test_helpers";
 
 test.describe("apiJson", () => {
   test.beforeEach(() => {
@@ -41,6 +41,37 @@ test.describe("apiJson", () => {
       globalThis.fetch = originalFetch;
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  test("supports custom timeout overrides and clears their timers after a successful response", async () => {
+    const originalFetch = globalThis.fetch;
+    const timerHarness = installTimerHarness();
+    const response = createDeferred<Response>();
+    let requestedPath = "";
+    let requestedMethod = "";
+    globalThis.fetch = ((path: string | URL | RequestInfo, init?: RequestInit) => {
+      requestedPath = String(path);
+      requestedMethod = init?.method ?? "GET";
+      return response.promise;
+    }) as typeof fetch;
+
+    try {
+      const request = apiJson<{ ok: boolean }>("/timeout/custom", {
+        method: "POST",
+        timeoutMs: 20_000,
+      });
+
+      expect(timerHarness.pendingDelays()).toEqual([20_000]);
+      expect(requestedPath).toContain("/timeout/custom");
+      expect(requestedMethod).toBe("POST");
+
+      response.resolve(jsonResponse({ ok: true }));
+      await expect(request).resolves.toEqual({ ok: true });
+      expect(timerHarness.pendingDelays()).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      timerHarness.restore();
     }
   });
 

--- a/apps/ui/tests/settings_obd_scan_timeout.spec.ts
+++ b/apps/ui/tests/settings_obd_scan_timeout.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createSettingsHandlerFromMap,
+  gpsStatus,
+  installCommonRoutes,
+  installFakeWebSocket,
+} from "./smoke.helpers";
+
+test("manual OBD scan waits for a slow successful response without surfacing an abort banner", async ({ page }) => {
+  test.slow();
+
+  let scanCalls = 0;
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/language": { language: "en" },
+      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
+      "GET /api/settings/speed-source": {
+        speed_source: "obd2",
+        manual_speed_kph: null,
+        stale_timeout_s: 5,
+        obd_device_mac: null,
+        obd_device_name: null,
+      },
+      "GET /api/settings/speed-source/status": gpsStatus({
+        speed_source: "obd2",
+        connection_state: "disconnected",
+      }),
+      "GET /api/settings/obd/status": {
+        configured_device_mac: null,
+        configured_device_name: null,
+        paired: false,
+        trusted: false,
+        connected: false,
+        rfcomm_channel: null,
+        last_rpm: null,
+        last_raw_response: null,
+        debug_hint: null,
+      },
+      "POST /api/settings/obd/scan": async () => {
+        scanCalls += 1;
+        if (scanCalls === 1) {
+          await new Promise((resolve) => setTimeout(resolve, 10_500));
+        }
+        return {
+          devices: [
+            {
+              mac_address: "0022d9001bb1",
+              name: "OBDLink CX",
+              paired: false,
+              trusted: false,
+              connected: false,
+              rfcomm_channel: null,
+            },
+          ],
+        };
+      },
+    }),
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await page.locator("#scanObdDevicesBtn").click();
+
+  const scanStatus = page.locator("#obdDeviceScanStatus");
+  await expect(scanStatus).toContainText("Scanning for Bluetooth OBD adapters...");
+  await expect(scanStatus).toContainText("1 adapter(s) found.", { timeout: 20_000 });
+  await expect(page.locator(".speed-source-device__name").first()).toHaveText("OBDLink CX");
+  await expect(page.locator("#appErrorBanner")).toBeHidden();
+});


### PR DESCRIPTION
## Summary

Fixes #1926.

This PR extends the frontend timeout used for manual OBD adapter scans so the Settings UI no longer aborts a successful `/api/settings/obd/scan` request just past the generic 10 second budget. It also gives timeout-driven aborts a clearer message than the browser-default `The operation was aborted.` text, which was especially misleading in this flow because the backend scan could still be completing successfully.

## Problem being solved

The issue report correctly described the user-visible failure mode on the Pi: clicking **Settings → Speed Source → Scan for adapters** could raise the top-level app error banner with `The operation was aborted.` while the backend scan itself still finished successfully. The practical outcome was that the OBD area showed a failed scan state even though the server was actually returning a valid device list shortly after the client-side abort.

When I refreshed the current repo state, I found that the frontend source in this checkout still routed `scanSettingsObdDevices()` through the generic `apiJson()` path with the default `10000 ms` timeout from `apps/ui/src/api/http.ts`. In other words, the current source still had the exact timeout behavior that could produce the false failure. This meant the core fix belonged in the frontend API layer rather than in the backend scan path.

At the same time, I traced the packaging path for shipped UI assets. `tools/build_ui_static.py` already rebuilds `apps/ui/dist/` and syncs it into `apps/server/vibesensor/static/`, and the Pi image artifact flow in `infra/pi-image/pi-gen/lib/app_artifacts.sh` already rsyncs that bundle into the shipped app artifacts and wheel build root. So the packaging handoff itself was already correct once the right frontend behavior exists in source. The missing piece was that the source bundle still needed a dedicated OBD scan timeout.

## Implementation approach

I kept the fix deliberately narrow.

Instead of changing the global API timeout for every request, I added an explicit per-request timeout override seam to the shared frontend HTTP helper. That preserves the existing default behavior for fast endpoints while letting slower operations opt in to a larger budget when they genuinely need it. OBD scan is the right candidate for that treatment because Bluetooth discovery can legitimately take longer than ordinary settings requests, especially when the backend is also enriching or filtering results.

I also chose to improve the timeout error text in the helper itself. If a timeout really does happen, `Request timed out.` is clearer and more actionable than the browser’s raw abort wording. This keeps the behavior improvement local to the API helper rather than spreading timeout-message handling into individual feature modules.

## Main code changes

In `apps/ui/src/api/http.ts`, I introduced an exported `ApiJsonInit` type that extends `RequestInit` with an optional `timeoutMs` property. `apiJsonResponse()` now reads that override, falls back to the existing `DEFAULT_TIMEOUT_MS` when none is provided, and keeps the signal-composition cleanup behavior that was already present.

The helper now aborts timeout-driven requests with a `DOMException` carrying the message `Request timed out.` and the `AbortError` name. That preserves the expected abort semantics while producing a better surfaced message if a request really exceeds its budget.

In `apps/ui/src/api/settings.ts`, I added a dedicated `OBD_SCAN_TIMEOUT_MS = 20_000` constant and used it only for `scanSettingsObdDevices()`. No other settings endpoints were changed, so the default timeout remains in place everywhere else.


## Test coverage

I added two focused regression layers.

First, `apps/ui/tests/api_http.spec.ts` now includes a helper-level test that proves `apiJson()` honors a custom timeout override and clears its timer once a successful response resolves. That locks down the reusable seam added in `api/http.ts`.

Second, I added `apps/ui/tests/settings_obd_scan_timeout.spec.ts`, a browser-side regression that reproduces the user-facing failure mode directly. The test simulates a manual OBD scan that returns successfully after `10.5` seconds, which is deliberately long enough to fail under the old global `10` second timeout. It verifies that the Settings UI eventually shows a found-adapters status, renders the returned adapter in the device list, and does **not** surface the abort banner.

I also kept the broader Settings smoke coverage in the validation loop. `apps/ui/tests/smoke.settings.spec.ts` still passed, including the existing OBD scan and background-rescan flows. That matters because the fix touches a shared API helper and a high-traffic settings module, so I wanted confirmation that the slower-scan change did not regress the normal OBD UX or unrelated Settings behavior.

## Validation performed

Local validation for this PR included:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && NODE_PATH=/workspace/VibeSensor/apps/ui/node_modules npx playwright test tests/api_http.spec.ts tests/settings_obd_scan_timeout.spec.ts tests/smoke.settings.spec.ts --project=laptop-light --workers=1`

All of those checks passed.

Because this issue was specifically about what ends up served from the packaged app path, I also validated the packaged-static handoff rather than relying only on the Vite test server. I ran `python3 tools/build_ui_static.py --skip-npm-ci --skip-typecheck`, confirmed the rebuilt bundle was synced into `apps/server/vibesensor/static/`, verified the generated server asset contained both the new timeout message and the dedicated OBD scan timeout marker, then started `vibesensor-server --config apps/server/config.dev.yaml` and confirmed `/` was serving that rebuilt hashed asset.

I also attempted `python3 tools/tests/run_release_smoke.py --skip-npm-ci` because it is the repo’s closest existing packaged-release validator. That run did not complete in this environment, but the failure was unrelated to this frontend change: the smoke venv used Python `3.11`, while `apps/server/pyproject.toml` currently requires Python `>=3.13`. I am calling that out explicitly because it is an environment validation limitation, not a regression introduced by this PR.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this PR introduces a slightly richer request-init type in the shared API helper. I think that is the right tradeoff here because it gives the codebase a precise, reusable escape hatch for genuinely slower calls without weakening the default timeout everywhere.

I intentionally did **not** increase the default timeout globally. That would make all requests more tolerant of slowness, but it would also delay failure feedback for endpoints that should remain fast. Keeping the longer budget scoped to OBD scan preserves the current expectations for the rest of the app.

I also did not change the backend OBD scan behavior. The issue evidence already showed the backend could succeed; the client-side timeout budget was the problem. Likewise, I did not change the Pi image packaging flow because the current scripts already rebuild and sync the UI bundle correctly once the source behavior is fixed.

Out of scope for this PR are broader deployment concerns around devices already running an older bundle. This change makes the correct behavior part of the current source and packaged-static path. Getting that newer bundle onto a previously built device still depends on the normal rebuild/release/update flow rather than a separate compatibility shim in the frontend.
