### PR TITLE
Replace raw order point minimums with duration- and continuity-based evidence gates

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_order_matching_evidence_gate.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_matching_evidence_gate.py
@@ -1,0 +1,176 @@
+"""Focused regressions for time-aware order-evidence gating."""
+
+from __future__ import annotations
+
+from test_support.report_helpers import diagnostics_context
+
+from vibesensor.domain import OrderMatchObservation, VibrationSource
+from vibesensor.use_cases.diagnostics.orders.matching import OrderMatchAccumulator
+from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis
+from vibesensor.use_cases.diagnostics.orders.pipeline import (
+    OrderAnalysisRequest,
+    OrderAnalysisSession,
+)
+
+
+def _make_accumulator(
+    *,
+    possible: int,
+    matched: int,
+    sample_indices: tuple[int, ...],
+    matched_speed_bins: dict[str, int] | None = None,
+    predicted_vals: list[float] | None = None,
+    measured_vals: list[float] | None = None,
+) -> OrderMatchAccumulator:
+    if predicted_vals is None:
+        predicted_vals = [50.0 + float(i) for i in range(matched)]
+    if measured_vals is None:
+        measured_vals = [value + 0.1 for value in predicted_vals]
+
+    matched_points = [
+        OrderMatchObservation(
+            predicted_hz=predicted_vals[idx],
+            matched_hz=measured_vals[idx],
+            rel_error=abs(measured_vals[idx] - predicted_vals[idx]) / predicted_vals[idx],
+            amp=0.05,
+            location="front_left",
+            speed_kmh=60.0 + float(idx),
+            t_s=0.25 * float(sample_indices[idx]),
+        )
+        for idx in range(matched)
+    ]
+    speed_bins = matched_speed_bins or {"60-70": matched}
+    return OrderMatchAccumulator(
+        possible=possible,
+        matched=matched,
+        matched_amp=[0.05] * matched,
+        matched_floor=[0.005] * matched,
+        rel_errors=[0.01] * matched,
+        predicted_vals=predicted_vals,
+        measured_vals=measured_vals,
+        matched_points=matched_points,
+        ref_sources={"speed+tire"},
+        possible_by_speed_bin={"60-70": possible},
+        matched_by_speed_bin=speed_bins,
+        possible_by_phase={},
+        matched_by_phase={},
+        possible_by_location={"front_left": possible},
+        matched_by_location={"front_left": matched},
+        has_phases=False,
+        compliance=1.0,
+        matched_sample_indices=sample_indices,
+    )
+
+
+def _session(
+    steady_speed: bool,
+    *,
+    feature_interval_s: float | None = 0.25,
+) -> OrderAnalysisSession:
+    return OrderAnalysisSession(
+        OrderAnalysisRequest(
+            context=diagnostics_context(feature_interval_s=feature_interval_s),
+            samples=[{"speed_kmh": 60.0, "top_peaks": [{"hz": 10.0, "amp": 0.05}]}],
+            speed_sufficient=True,
+            steady_speed=steady_speed,
+            speed_stddev_kmh=0.3 if steady_speed else 6.0,
+            tire_circumference_m=2.0,
+            engine_ref_sufficient=True,
+            raw_sample_rate_hz=800.0,
+            connected_locations={"front_left"},
+            lang="en",
+        ),
+    )
+
+
+class TestOrderMatchEvidenceGate:
+    def test_rejects_short_overlap_burst_even_when_raw_counts_pass(self) -> None:
+        match = _make_accumulator(
+            possible=6,
+            matched=4,
+            sample_indices=(0, 1, 2, 3),
+        )
+
+        assert match.is_eligible(feature_interval_s=0.25, steady_speed=True) is False
+
+    def test_accepts_steady_state_when_duration_and_contiguity_are_sufficient(self) -> None:
+        match = _make_accumulator(
+            possible=16,
+            matched=8,
+            sample_indices=(4, 5, 6, 7, 8, 9, 10, 11),
+        )
+
+        assert match.is_eligible(feature_interval_s=0.25, steady_speed=True) is True
+
+    def test_rejects_when_contiguous_streak_is_too_short(self) -> None:
+        match = _make_accumulator(
+            possible=20,
+            matched=8,
+            sample_indices=(0, 1, 2, 8, 9, 10, 16, 17),
+            matched_speed_bins={"50-60": 4, "60-70": 4},
+        )
+
+        assert match.is_eligible(feature_interval_s=0.25, steady_speed=True) is False
+
+    def test_rejects_variable_speed_single_bin_without_broad_tracking(self) -> None:
+        match = _make_accumulator(
+            possible=20,
+            matched=8,
+            sample_indices=(4, 5, 6, 7, 8, 9, 10, 11),
+            matched_speed_bins={"60-70": 8},
+            predicted_vals=[50.0] * 8,
+            measured_vals=[50.1] * 8,
+        )
+
+        assert match.is_eligible(feature_interval_s=0.25, steady_speed=False) is False
+
+    def test_accepts_variable_speed_with_multiple_matched_speed_bins(self) -> None:
+        match = _make_accumulator(
+            possible=20,
+            matched=8,
+            sample_indices=(4, 5, 6, 7, 8, 9, 10, 11),
+            matched_speed_bins={"50-60": 4, "60-70": 4},
+        )
+
+        assert match.is_eligible(feature_interval_s=0.25, steady_speed=False) is True
+
+    def test_accepts_variable_speed_with_strong_frequency_tracking(self) -> None:
+        match = _make_accumulator(
+            possible=20,
+            matched=8,
+            sample_indices=(4, 5, 6, 7, 8, 9, 10, 11),
+            matched_speed_bins={"60-70": 8},
+            predicted_vals=[50.0, 50.5, 51.0, 51.5, 52.0, 52.5, 53.0, 53.5],
+            measured_vals=[50.1, 50.6, 51.1, 51.6, 52.1, 52.6, 53.1, 53.6],
+        )
+
+        assert match.is_eligible(feature_interval_s=0.25, steady_speed=False) is True
+
+
+class TestOrderAnalysisSessionEvidenceGate:
+    def test_session_passes_feature_interval_and_steady_speed_into_match_gate(
+        self,
+        monkeypatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeAccumulator:
+            def is_eligible(self, **kwargs) -> bool:
+                captured.update(kwargs)
+                return False
+
+        monkeypatch.setattr(
+            "vibesensor.use_cases.diagnostics.orders.pipeline.match_samples_for_hypothesis",
+            lambda *args, **kwargs: FakeAccumulator(),
+        )
+
+        session = _session(steady_speed=True, feature_interval_s=0.25)
+        hypothesis = OrderHypothesis(
+            key="wheel_1x",
+            suspected_source=VibrationSource.WHEEL_TIRE,
+            order_label_base="wheel",
+            order=1.0,
+        )
+
+        assert session._test_hypothesis(hypothesis) is None
+        assert captured == {"feature_interval_s": 0.25, "steady_speed": True}

--- a/apps/server/vibesensor/shared/constants/analysis.py
+++ b/apps/server/vibesensor/shared/constants/analysis.py
@@ -109,6 +109,23 @@ ORDER_MIN_COVERAGE_POINTS: Final[int] = 6
 """Minimum number of coverage points (samples with valid speed and peak data)
 for an order finding to be considered."""
 
+ORDER_MIN_MATCH_DURATION_S: Final[float] = 2.0
+"""Minimum matched evidence duration required for an order finding."""
+
+ORDER_MIN_COVERAGE_DURATION_S: Final[float] = 4.0
+"""Minimum total eligible evidence duration required for an order finding."""
+
+ORDER_MIN_CONTIGUOUS_MATCH_DURATION_S: Final[float] = 1.5
+"""Minimum longest contiguous matched streak required for an order finding."""
+
+ORDER_VARIABLE_MIN_MATCHED_SPEED_BINS: Final[int] = 2
+"""Minimum matched speed bins for variable-speed order evidence without relying
+on frequency-correlation rescue."""
+
+ORDER_VARIABLE_MIN_CORRELATION: Final[float] = 0.9
+"""Minimum frequency correlation for variable-speed order evidence when matched
+samples do not span enough speed bins."""
+
 ORDER_MIN_CONFIDENCE: Final[float] = 0.25
 """Minimum confidence score for an order-tracking finding to be retained."""
 

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/matching.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/matching.py
@@ -8,10 +8,15 @@ from dataclasses import dataclass
 
 from vibesensor.domain import OrderMatchObservation, speed_bin_label
 from vibesensor.shared.constants.analysis import (
+    ORDER_MIN_CONTIGUOUS_MATCH_DURATION_S,
+    ORDER_MIN_COVERAGE_DURATION_S,
     ORDER_MIN_COVERAGE_POINTS,
+    ORDER_MIN_MATCH_DURATION_S,
     ORDER_MIN_MATCH_POINTS,
     ORDER_TOLERANCE_MIN_HZ,
     ORDER_TOLERANCE_REL,
+    ORDER_VARIABLE_MIN_CORRELATION,
+    ORDER_VARIABLE_MIN_MATCHED_SPEED_BINS,
     SPEED_BIN_WIDTH_KMH,
 )
 from vibesensor.use_cases.diagnostics._context import DiagnosticsContext
@@ -26,6 +31,7 @@ from vibesensor.use_cases.diagnostics._types import (
     PhaseLabels,
     ensure_analysis_sample,
 )
+from vibesensor.use_cases.diagnostics.math_utils import _corr_abs_clamped
 from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis
 from vibesensor.use_cases.diagnostics.speed_profile_helpers import _phase_to_str
 
@@ -51,6 +57,7 @@ class OrderMatchAccumulator:
     matched_by_location: dict[str, int]
     has_phases: bool
     compliance: float
+    matched_sample_indices: tuple[int, ...] = ()
 
     @property
     def match_rate(self) -> float:
@@ -65,11 +72,54 @@ class OrderMatchAccumulator:
     def is_eligible(
         self,
         *,
+        feature_interval_s: float | None = None,
+        steady_speed: bool = False,
         min_coverage: int = ORDER_MIN_COVERAGE_POINTS,
         min_matched: int = ORDER_MIN_MATCH_POINTS,
     ) -> bool:
         """Whether this match has enough data to produce a finding."""
-        return self.possible >= min_coverage and self.matched >= min_matched
+        if self.possible < min_coverage or self.matched < min_matched:
+            return False
+        if feature_interval_s is None or feature_interval_s <= 0:
+            return True
+
+        possible_duration_s = self.possible * feature_interval_s
+        matched_duration_s = self.matched * feature_interval_s
+        contiguous_match_duration_s = self.longest_contiguous_match_points * feature_interval_s
+        if (
+            possible_duration_s < ORDER_MIN_COVERAGE_DURATION_S
+            or matched_duration_s < ORDER_MIN_MATCH_DURATION_S
+            or contiguous_match_duration_s < ORDER_MIN_CONTIGUOUS_MATCH_DURATION_S
+        ):
+            return False
+        if steady_speed:
+            return True
+
+        matched_speed_bins = sum(1 for count in self.matched_by_speed_bin.values() if count > 0)
+        if matched_speed_bins >= ORDER_VARIABLE_MIN_MATCHED_SPEED_BINS:
+            return True
+        corr = _corr_abs_clamped(self.predicted_vals, self.measured_vals)
+        return corr is not None and corr >= ORDER_VARIABLE_MIN_CORRELATION
+
+    @property
+    def longest_contiguous_match_points(self) -> int:
+        """Largest streak of adjacent matched samples in acquisition order."""
+        if not self.matched_sample_indices:
+            return self.matched
+
+        longest = 1
+        current = 1
+        for prev_idx, sample_idx in zip(
+            self.matched_sample_indices,
+            self.matched_sample_indices[1:],
+            strict=False,
+        ):
+            if sample_idx == prev_idx + 1:
+                current += 1
+            else:
+                longest = max(longest, current)
+                current = 1
+        return max(longest, current)
 
 
 def match_samples_for_hypothesis(
@@ -90,6 +140,7 @@ def match_samples_for_hypothesis(
     predicted_vals: list[float] = []
     measured_vals: list[float] = []
     matched_points: list[OrderMatchObservation] = []
+    matched_sample_indices: list[int] = []
     ref_sources: set[str] = set()
     possible_by_speed_bin: dict[str, int] = defaultdict(int)
     matched_by_speed_bin: dict[str, int] = defaultdict(int)
@@ -141,6 +192,7 @@ def match_samples_for_hypothesis(
             continue
 
         matched += 1
+        matched_sample_indices.append(sample_idx)
         if sample_location:
             matched_by_location[sample_location] += 1
         if sample_speed_bin is not None:
@@ -189,4 +241,5 @@ def match_samples_for_hypothesis(
         matched_by_location=dict(matched_by_location),
         has_phases=has_phases,
         compliance=compliance,
+        matched_sample_indices=tuple(matched_sample_indices),
     )

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/pipeline.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/pipeline.py
@@ -186,7 +186,10 @@ class OrderAnalysisSession:
             self._per_sample_phases,
             self._lang,
         )
-        if not match.is_eligible():
+        if not match.is_eligible(
+            feature_interval_s=self._context.feature_interval_s,
+            steady_speed=self._steady_speed,
+        ):
             return None
 
         constant_speed = (

--- a/docs/run_schema_v2.md
+++ b/docs/run_schema_v2.md
@@ -19,7 +19,7 @@ Required fields:
 - `end_time_utc` (may be `null` while active)
 - `sensor_model`
 - `raw_sample_rate_hz`
-- `feature_interval_s`
+- `feature_interval_s` (used by time-aware order-evidence gating to convert logged match samples into durations)
 - `fft_window_size_samples`
 - `fft_window_type`
 - `peak_picker_method`


### PR DESCRIPTION
Closes #1933.

## Summary

This PR replaces the old raw-point-only order eligibility gate with a duration- and continuity-aware evidence gate driven by `feature_interval_s`. Before this change, tracked-order findings could become eligible as soon as they reached `matched >= 4` and `possible >= 6`. At the repository’s default logging cadence, that means only about `1.0 s` of matched evidence and `1.5 s` of eligible coverage, even though adjacent FFT-derived observations are only `0.25 s` apart and come from heavily overlapping `2.56 s` windows. In practice that made it too easy for a brief resonance or other short-lived alignment to look more persistent than it really was.

The issue asks for that gate to become time-aware, to use `feature_interval_s` so it stays correct if logging cadence changes, and to demand broader evidence in non-steady runs. The implementation here keeps the existing point-count thresholds only as secondary guardrails, but makes time-based evidence the primary gate. A finding now needs enough matched duration, enough total eligible duration, and a long enough contiguous matched streak to qualify. For non-steady runs, it also needs either evidence across multiple matched speed bins or strong predicted-versus-measured frequency correlation so a short single-band streak no longer qualifies on overlap alone.

## Implementation approach

I kept the change centered on the existing order-matching seam rather than introducing a parallel gating subsystem. `OrderMatchAccumulator.is_eligible()` was already the one place that decided whether a match had enough evidence to proceed into scoring and finding assembly, so I expanded that gate instead of adding a second policy layer elsewhere in the pipeline.

The new logic works in three stages. First, it preserves the old minimum raw counts as cheap secondary filters. That means obviously underspecified matches still fail early without any new math. Second, when `feature_interval_s` is available, it converts the accumulated `matched` and `possible` counts into durations and rejects evidence that is too short overall or too short as a contiguous streak. Third, for non-steady runs only, it checks whether the matched evidence spans multiple speed bins or, failing that, whether the matched predicted and measured frequencies still show strong correlation. That last step covers the acceptance criterion that variable-speed findings should need broader proof than a short streak at one speed.

## Main code changes by area

In `apps/server/vibesensor/shared/constants/analysis.py`, I added the new tuning constants that define the evidence gate: minimum matched duration, minimum eligible coverage duration, minimum contiguous matched duration, minimum matched speed-bin breadth for variable-speed runs, and the minimum correlation rescue threshold. Keeping these in the shared analysis constants file preserves the existing repository pattern where diagnostics tuning lives in one place rather than getting hidden inside a matcher method.

In `apps/server/vibesensor/use_cases/diagnostics/orders/matching.py`, I extended `OrderMatchAccumulator` with the minimal extra state the gate needs: the matched sample indices. That lets the accumulator compute the longest contiguous matched streak in acquisition order without changing any persistence schema or adding a new domain object. `is_eligible()` now accepts `feature_interval_s` and `steady_speed`, keeps the point-count guards, and then applies the new duration and variable-speed breadth rules. The matching loop now records the matched sample indices while it builds the accumulator, but it otherwise keeps the existing accumulation structure and downstream contracts intact.

In `apps/server/vibesensor/use_cases/diagnostics/orders/pipeline.py`, I threaded the two inputs the new gate needs from existing state that the session already owns: `self._context.feature_interval_s` and `self._steady_speed`. This keeps the evidence decision explicit in backend code while avoiding any new adapter or boundary plumbing.

I also made a small human-facing documentation update in `docs/run_schema_v2.md` so the run-schema description for `feature_interval_s` no longer reads like an inert metadata field. It now states that the field participates in time-aware order-evidence gating, which is the live reason this metadata matters.

## Tests and validation

I added a new focused backend test module, `apps/server/tests/use_cases/diagnostics/test_order_matching_evidence_gate.py`, rather than growing the existing order-object test file further. The new module covers the echos core failure modes and intended behavior:issue

- a `4/6` overlap-heavy burst now fails even though the old raw counts would have passed
- steady-state evidence succeeds once duration and contiguity are genuinely sufficient
- broken contiguity fails even when total counts are high enough
- variable-speed single-bin evidence fails without broader support
- variable-speed evidence succeeds when it spans multiple matched speed bins
- variable-speed evidence also succeeds when strong frequency tracking justifies a correlation-based rescue
- the pipeline test verifies that `feature_interval_s` and `steady_speed` are actually passed into the gate

For local validation, I ran:

- `cd apps/server && PYTHONPATH=. /usr/local/bin/python3.14 -m pytest -q -c /dev/null tests/use_cases/diagnostics/test_order_matching_evidence_gate.py tests/use_cases/diagnostics/test_order_objects.py tests/use_cases/diagnostics/test_order_scoring.py`
- `make lint`
- `make typecheck-backend`
- `make test-changed`

That broader changed-file sweep passed with `2105` backend tests green, which gave good coverage beyond the new focused module and verified that the new eligibility gate did not break the surrounding shared and diagnostics layers.

Per repository policy, I also re-attempted local Docker validation for this backend change. In this environment, `docker compose` is not available as a subcommand, and `docker-compose` cannot reach a Docker daemon because the Unix socket is unavailable. So compose-based runtime validation remains blocked by host capabilities rather than by this branch’s code. I am calling that out explicitly rather than silently omitting it.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is threshold selection. The new durations are intentionally much stricter than the old `4/6` counts, because the point-count gate was the root problem, but they are still a first calibrated pass rather than a final scientific truth. I chose to keep the existing raw count guardrails in place as secondary checks, because they still provide useful low-cost filtering and are consistent with the issue’s request that point counts may remain as secondary guardrails.

I also intentionally did not retune the downstream scoring, match-rate rescue, or confidence weighting logic in this PR. Those systems already operate after eligibility and solve different problems. This change focuses specifically on preventing weak evidence from reaching those later stages too early. Likewise, I did not add any schema or API changes, because the issue is wholly internal to the backend order-analysis gate.

One deliberate compatibility choice is that if `feature_interval_s` is unavailable, the gate falls back to the existing count-only behavior instead of suppressing order findings outright. That preserves analyzability for incomplete metadata cases while still making current runs cadence-aware, which is the important path for this issue.

Overall, this PR turns order eligibility from a count of heavily overlapping observations into a time-aware evidence check that is much closer to the behavior the issue calls for, while keeping the change small, explicit, and easy to validate.
