### PR TITLE
Keep PDF wheel labels inside the page-one gutter

### DIFF
--- a/apps/server/tests/adapters/pdf/test_diagram_layout.py
+++ b/apps/server/tests/adapters/pdf/test_diagram_layout.py
@@ -135,6 +135,29 @@ def test_choose_label_plan_avoids_occupied_boxes() -> None:
     assert isinstance(label, LabelRenderPlan)
 
 
+def test_choose_label_plan_prefers_inward_offset_before_outward_overflow() -> None:
+    blocked_inward_box = label_bbox(
+        x=74.3,
+        y=188.0,
+        text="front-right wheel",
+        anchor="end",
+        font_size=6.8,
+    )
+    label = choose_label_plan(
+        name="front-right wheel",
+        px=84.3,
+        py=190.0,
+        width=124.0,
+        height=252.0,
+        occupied_boxes=[blocked_inward_box],
+        font_size=6.8,
+        color="#000",
+    )
+    assert label.anchor == "end"
+    assert label.bbox[0] >= 2.0
+    assert label.bbox[2] <= 122.0
+
+
 # ── build_sensor_render_plan ─────────────────────────────────────────────────
 
 _COLORS = {

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -28,6 +28,22 @@ def _assert_no_pairwise_overlap(boxes: list[tuple[float, float, float, float]]) 
             assert not _rectangles_overlap(boxes[idx], boxes[jdx])
 
 
+def _text_item_box(item: object) -> tuple[float, float, float, float]:
+    text = str(getattr(item, "text", ""))
+    x = float(getattr(item, "x", 0.0))
+    y = float(getattr(item, "y", 0.0))
+    size = float(getattr(item, "fontSize", 5.5))
+    anchor = str(getattr(item, "textAnchor", "start"))
+    width = estimate_text_width(text, font_size=size)
+    if anchor == "end":
+        x0 = x - width
+    elif anchor == "middle":
+        x0 = x - (width / 2.0)
+    else:
+        x0 = x
+    return (x0, y - 1.0, x0 + width, y + size + 1.0)
+
+
 def test_sensor_state_mapping_connected_active_inactive_and_disconnected() -> None:
     states = resolve_marker_states(
         ["front-left wheel", "front-right wheel", "engine bay"],
@@ -250,16 +266,58 @@ def test_diagram_omits_source_legend_and_keeps_text_within_bounds() -> None:
 
     boxes: list[tuple[float, float, float, float]] = []
     for item in source_labels:
-        text = str(getattr(item, "text", ""))
-        x = float(getattr(item, "x", 0.0))
-        y = float(getattr(item, "y", 0.0))
-        size = float(getattr(item, "fontSize", 5.5))
-        width = estimate_text_width(text, font_size=size)
-        box = (x, y - 1.0, x + width, y + size + 1.0)
-        boxes.append(box)
+        box = _text_item_box(item)
         assert box[0] >= 0.0
         assert box[2] <= float(diagram.width) + 0.1
 
+    _assert_no_pairwise_overlap(boxes)
+
+
+def test_diagram_keeps_right_wheel_labels_inside_narrow_page1_bounds() -> None:
+    summary = {
+        "sensor_locations": [
+            "front-left wheel",
+            "front-right wheel",
+            "rear-left wheel",
+            "rear-right wheel",
+        ],
+        "sensor_intensity_by_location": [
+            LocationIntensitySummary(location="front-left wheel", p95_intensity_db=31.1),
+            LocationIntensitySummary(location="front-right wheel", p95_intensity_db=34.9),
+            LocationIntensitySummary(location="rear-left wheel", p95_intensity_db=30.9),
+            LocationIntensitySummary(location="rear-right wheel", p95_intensity_db=31.4),
+        ],
+    }
+    diagram = car_location_diagram(
+        [{"strongest_location": "front-right wheel", "suspected_source": "wheel/tire"}],
+        summary,
+        [],
+        content_width=300.0,
+        tr=lambda key, **kwargs: key,
+        text_fn=lambda en, nl: en,
+        diagram_width=124.0,
+        diagram_height=252.0,
+    )
+
+    wheel_labels = [
+        item
+        for item in diagram.contents
+        if hasattr(item, "text") and str(getattr(item, "text", "")).endswith("wheel")
+    ]
+
+    assert {str(item.text) for item in wheel_labels} == {
+        "front-left wheel",
+        "front-right wheel",
+        "rear-left wheel",
+        "rear-right wheel",
+    }
+
+    box_by_label = {str(item.text): _text_item_box(item) for item in wheel_labels}
+    for label in ("front-right wheel", "rear-right wheel"):
+        box = box_by_label[label]
+        assert box[2] <= float(diagram.width) + 0.1
+
+    boxes = list(box_by_label.values())
     _assert_no_pairwise_overlap(boxes)
 
 

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -127,6 +127,8 @@ _LABEL_CANDIDATES_RIGHT: tuple[tuple[float, float, str], ...] = (
 )
 _LABEL_CANDIDATES_LEFT: tuple[tuple[float, float, str], ...] = (
     (-10.0, -2.0, "end"),
+    (-10.0, 18.0, "end"),
+    (-10.0, -20.0, "end"),
     (10.0, -2.0, "start"),
     (0.0, 9.0, "middle"),
     (0.0, -11.0, "middle"),


### PR DESCRIPTION
Closes #1944.

## Summary

This change fixes the page-1 PDF diagram alignment problem where the right-side wheel labels visually pressed into the narrative gutter in the `Why this corner wins` panel. The issue was easiest to see in the freshly generated `one-wheel-mild` report from the local audit flow: at page-1 widths, the `front-right wheel` and `rear-right wheel` labels were being placed on outward `start` anchors, so the label text extended beyond the intended diagram block and made the diagram feel like it was bleeding into the adjacent explanatory copy.

The fix keeps the diagram self-contained without redesigning the whole page-1 panel. Instead of widening the page layout or changing the narrative column geometry, the change adjusts the shared diagram label planner so right-half markers get better inward fallback placements before the planner resorts to outward overflow. That preserves the overall composition of the page while addressing the actual root cause of the visual defect.

## Problem being solved

Issue #1944 came from a screenshot-based audit of a real generated PDF, not from a code-first inspection. The defect was specifically visual: the diagram annotations on the right side no longer ended with a clear gutter before the narrative column began. The upper-right and lower-right wheel labels looked pinned to the split line, which weakened the feeling that the vehicle diagram was a cleanly bounded card inside the page-1 proof panel.

After tracing the page-1 render path, the root cause turned out to be narrower than the issue might suggest. The overall page split was not the main problem. Instead, the shared planner in `diagram_layout.py` had too few viable inward placements for labels on the right half of the vehicle. At page-1 widths, the planner would try the default inward placement, reject it because of a collision with nearby diagram occupants, and then fall back to an outward `start` placement that technically fit the planner’s score better even though it visually leaked into the gutter.

That meant the best fix was not to rebalance the page proportions. It was to improve the planner so the right-side labels could still remain inside the diagram block when the immediate inward position was unavailable.

## Implementation approach

The implementation stays intentionally small and focused.

In `apps/server/vibesensor/adapters/pdf/diagram_layout.py`, I updated the candidate list for right-half marker labels. The planner already had a preferred inward `end` placement and an outward `start` fallback. The problem was that the fallback kicked in too early. I added two additional inward `end` candidates with larger vertical offsets before the outward option is considered. In practice, that gives the planner more room to route right-side labels above or below nearby hotspots while still keeping the text inside the diagram region.

I left the left-half candidate ordering unchanged. The visual regression that motivated this issue was specifically on the right side of the page-1 diagram, and the left side already had acceptable behavior in the audited report. Keeping the change asymmetric reduced the blast radius and avoided introducing a second layout regression on the left edge.

This also keeps the page-1 proof panel structure stable. The narrative column width, diagram container split, and surrounding card layout are unchanged. The fix is confined to the label placement logic that was actually causing the crowding.

## Main code changes by area

`apps/server/vibesensor/adapters/pdf/diagram_layout.py`

This file contains the pure geometry planner for marker and label placement. I changed the `_LABEL_CANDIDATES_LEFT` sequence so right-half labels now try two additional inward `end` offsets before falling back to the outward `start` placement. Those offsets are large enough to clear the front-left marker and trunk marker in the narrow page-1 geometry that triggered the visual defect.

`apps/server/tests/adapters/pdf/test_diagram_layout.py`

I added a focused unit test that exercises the planner directly. The test blocks the default inward slot for a right-side wheel label and verifies that the planner still prefers an inward offset that remains inside bounds instead of immediately choosing the outward overflow path. This keeps the regression guard close to the pure planning logic.

`apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py`

I added a small helper for computing text bounds from rendered text items, reused it in the existing narrow-width legend test, and added a new regression test that targets the actual failure mode from #1944. The new test renders a narrow vehicle diagram representative of the page-1 PDF geometry and asserts that the right-side wheel labels stay within the diagram width while the full set of wheel labels still avoids pairwise overlap.

## Validation performed

I validated the change in progressively broader steps.

First, I ran the focused diagram tests:

- `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf/test_diagram_layout.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py`

That suite passed with `47 passed`.

Next, I ran the broader PDF adapter suite:

- `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf`

That suite passed with `585 passed`.

Then I ran the backend type gate:

- `make typecheck-backend`

That completed successfully with no type issues.

Finally, I re-ran the realistic simulator-backed PDF generation flow used during the original audit. I started the server on the isolated `.tmp/pdf-audit/config.yaml` config, ran `.tmp/pdf-audit/generate_report.py`, and generated a fresh report at `.tmp/pdf-audit/audit-report.pdf`. The resulting run completed successfully with run id `440c0d000b0d4ef492d6406873c99343`, and I rendered page 1 again to confirm the report artifact was current rather than stale.

## Risks, tradeoffs, and edge cases

The main tradeoff is that right-side labels may now move farther vertically from their markers when the narrow geometry is crowded. I think that is the right tradeoff for this issue: the rendered PDF is clearer when the diagram remains self-contained than when labels cling to the panel split. The new candidates are still inward placements, so the diagram continues to read as one bounded block.

I did not attempt to solve issue #1945 here. That separate issue concerns panel depth and empty lower space across several report sections. This change is intentionally scoped to the page-1 diagram label gutter regression only.
