### PR TITLE
Compact page-three PDF next steps panel

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py
+++ b/apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from reportlab.lib.units import mm
 
 from vibesensor.adapters.pdf.pdf_appendices import (
+    _estimate_action_steps_panel_height,
     _estimate_appendix_c_context_panel_height,
     _estimate_appendix_c_suitability_panel_height,
     _estimate_appendix_c_trace_panel_height,
     _estimate_worksheet_ranked_stack_height,
     _estimate_worksheet_top_panel_height,
+    _worksheet_first_actions_panel_height,
 )
 from vibesensor.adapters.pdf.pdf_page1 import _estimate_actions_block_height
-from vibesensor.adapters.pdf.pdf_style import GAP, MARGIN, PAGE_H, PANEL_HEADER_H
+from vibesensor.adapters.pdf.pdf_style import GAP, MARGIN, PAGE_H, PAGE_W, PANEL_HEADER_H
 from vibesensor.adapters.pdf.report_data import (
     AppendixAData,
     AppendixCData,
@@ -118,3 +120,30 @@ def test_estimate_worksheet_summary_panels_shrink_for_short_content() -> None:
 
     assert top_h < 56 * mm
     assert stack_h <= 48 * mm
+
+
+def test_estimate_worksheet_action_panel_shrinks_for_short_content() -> None:
+    appendix = AppendixAData(
+        primary_source="Wheel / Tire",
+        alternative_source="Driveline",
+        why_primary_first="Short reason.",
+        why_alternative_next="Backup reason.",
+        next_if_clean="Move to the alternative path.",
+    )
+    steps = [
+        NextStep(action="Check wheel balance", why="Start with the corner that won the ranking."),
+        NextStep(
+            action="Inspect tire condition",
+            why="Look for the simplest repeatable fault first.",
+        ),
+        NextStep(
+            action="Move to the backup path if clean",
+            why="Keep the alternative source active.",
+        ),
+    ]
+
+    max_panel_h = _worksheet_first_actions_panel_height(appendix, lang="en")
+    panel_h = _estimate_action_steps_panel_height(steps, width=PAGE_W - 2 * MARGIN)
+
+    assert panel_h < max_panel_h
+    assert panel_h >= PANEL_HEADER_H

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
@@ -1003,11 +1003,13 @@ def _draw_worksheet_page(
             col_widths=[0.20, 0.20, 0.18, 0.42],
             max_body_lines=2,
         )
-        matrix_h = stack_y - (MARGIN + 8 * mm)
+        matrix_top = stack_y - GAP
     else:
-        matrix_h = top_y - GAP - (MARGIN + 8 * mm)
+        matrix_top = top_y - GAP
 
-    matrix_y = MARGIN + 8 * mm
+    max_matrix_h = matrix_top - (MARGIN + 8 * mm)
+    matrix_h = min(max_matrix_h, _estimate_action_steps_panel_height(steps, width=width))
+    matrix_y = matrix_top - matrix_h
     _draw_action_steps_panel(
         c,
         steps=steps,
@@ -1037,6 +1039,13 @@ def _worksheet_continuation_panel_height() -> float:
     return float(title_y - (MARGIN + 8 * mm))
 
 
+def _estimate_action_steps_panel_height(steps: list[NextStep], *, width: float) -> float:
+    inner_w = width - 8 * mm
+    gaps_h = max(len(steps) - 1, 0) * 2.5 * mm
+    cards_h = sum(_estimate_action_step_card_height(step, width=inner_w) for step in steps)
+    return float(max(PANEL_HEADER_H + 12 * mm, PANEL_HEADER_H + 7 * mm + cards_h + gaps_h))
+
+
 def _fit_action_steps(steps: list[NextStep], *, panel_w: float, panel_h: float) -> int:
     inner_w = panel_w - 8 * mm
     row_y = panel_h - PANEL_HEADER_H - 2 * mm
@@ -1059,13 +1068,15 @@ def _draw_action_steps_continuation_page(
     start_number: int,
 ) -> None:
     width = PAGE_W - 2 * MARGIN
-    panel_h = title_y - (MARGIN + 8 * mm)
+    max_panel_h = title_y - (MARGIN + 8 * mm)
+    panel_h = min(max_panel_h, _estimate_action_steps_panel_height(steps, width=width))
+    panel_y = title_y - panel_h
     _draw_action_steps_panel(
         c,
         steps=steps,
         lang=lang,
         x=MARGIN,
-        y=MARGIN + 8 * mm,
+        y=panel_y,
         w=width,
         h=panel_h,
         start_number=start_number,


### PR DESCRIPTION
## Summary
- top-anchor and content-size the page-3 `Next inspection steps` panel so it no longer stretches to the full leftover page height
- keep a small fit buffer in the worksheet action-panel height estimate so the final step still renders on tight layouts
- add a focused regression test in the compact-panel suite for short worksheet action sections

## Report sample used
- fresh simulator-backed audit report: `.tmp/pdf-audit/audit-report.pdf`
- run id: `5d58cf6a30314473821eb25d23fbf53b`
- scenario: `one-wheel-mild`
- fault wheel: `rear-left`

## Affected pages and sections
- page 3: `Inspection Path`
- page 3: `Next inspection steps`

## Visual validation
This fix was identified and rechecked from rendered PDF screenshots rather than PDF internals.

Useful artifacts:
- before full page: `.tmp/pdf-audit/pages/page-03-full.png`
- before section crop: `.tmp/pdf-audit/crops/candidate-01-next-steps-empty-normal.png`
- before annotated crop: `.tmp/pdf-audit/annotated/candidate-01-next-steps-empty-annotated.png`
- after full page: `.tmp/pdf-audit/after/pages/page-03-full.png`
- after section crop: `.tmp/pdf-audit/after/crops/page-03-next-steps-after.png`
- before/after board: `.tmp/pdf-audit/after/comparisons/page-03-next-steps-before-after.png`

## Validation
- `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_analysis_separation.py`
- `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf`
- `make typecheck-backend`
- `make lint`
