### PR TITLE
Tighten page-1 PDF spacing

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py
+++ b/apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py
@@ -48,6 +48,29 @@ def test_estimate_actions_block_height_shrinks_for_short_content() -> None:
     assert actions_h >= PANEL_HEADER_H
 
 
+def test_estimate_actions_block_height_stays_compact_for_two_preview_steps() -> None:
+    width = PAGE_W - 2 * MARGIN
+    actions_w = width - (width * 0.58) - GAP
+    data = ReportTemplateData(
+        lang="en",
+        verdict_page=VerdictPageData(),
+        next_steps=[
+            NextStep(
+                action=(
+                    "Check Rear-Left for tire damage, flat spots, belt shift, uneven wear, "
+                    "or pressure mismatch."
+                )
+            ),
+            NextStep(action="Check Rear-Left for imbalance or radial/lateral runout."),
+        ],
+    )
+
+    actions_h = _estimate_actions_block_height(data, tr=_tr, w=actions_w)
+
+    assert actions_h < 55 * mm
+    assert actions_h >= PANEL_HEADER_H
+
+
 def test_estimate_appendix_c_lower_panels_shrink_for_short_content() -> None:
     data = ReportTemplateData(
         lang="en",

--- a/apps/server/vibesensor/adapters/pdf/pdf_page1.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_page1.py
@@ -241,7 +241,7 @@ def _draw_hero_block(
 
     c.setFillColor(_hex(SUB_CLR))
     c.setFont(FONT, FS_SMALL)
-    c.drawString(right_x, inner_y, tr("REPORT_ACTION_STATUS_LABEL"))
+    c.drawString(right_x, inner_y + 1.2 * mm, tr("REPORT_ACTION_STATUS_LABEL"))
     _draw_status_pill(
         c,
         text=verdict.action_status or tr("UNKNOWN"),
@@ -404,10 +404,10 @@ def _draw_action_row(
     title_lines = _wrap_lines(title, text_w, FS_BODY)[:2]
     why_lines = _wrap_lines(why or "", text_w, FS_SMALL)[:2] if why else []
     row_h = max(
-        18 * mm,
-        8.5 * mm
-        + (len(title_lines) * (FS_BODY + 1.2))
-        + (0 if not why_lines else 1.2 * mm + (len(why_lines) * (FS_SMALL + 1.0))),
+        16 * mm,
+        7.0 * mm
+        + (len(title_lines) * (FS_BODY + 1.0))
+        + (0 if not why_lines else 1.0 * mm + (len(why_lines) * (FS_SMALL + 1.0))),
     )
     c.setFillColor(_hex(REPORT_COLORS["surface"]))
     c.setStrokeColor(_hex(REPORT_COLORS["border"]))
@@ -420,7 +420,7 @@ def _draw_action_row(
     c.drawCentredString(x + 5.5 * mm, y_top - 6.4 * mm, str(index))
     c.setFillColor(_hex(TEXT_CLR))
     c.setFont(FONT_B, FS_BODY)
-    title_y = y_top - 5.4 * mm
+    title_y = y_top - 4.8 * mm
     for line in title_lines:
         c.drawString(x + 12 * mm, title_y, line)
         title_y -= FS_BODY + 1.2
@@ -437,7 +437,7 @@ def _draw_action_row(
 def _estimate_action_row_height(*, title: str, w: float) -> float:
     text_w = w - 14 * mm
     title_lines = _wrap_lines(title, text_w, FS_BODY)[:2]
-    return float(max(18 * mm, 8.5 * mm + (len(title_lines) * (FS_BODY + 1.2))))
+    return float(max(16 * mm, 7.0 * mm + (len(title_lines) * (FS_BODY + 1.0))))
 
 
 def _estimate_actions_block_height(
@@ -452,8 +452,10 @@ def _estimate_actions_block_height(
         content_h += _measure_text_height(tr("NO_NEXT_STEPS"), w=content_w, size=FS_BODY)
     else:
         shown_steps = data.next_steps[:2]
-        for step in shown_steps:
-            content_h += _estimate_action_row_height(title=step.action, w=content_w) + 2.5 * mm
+        for index, step in enumerate(shown_steps):
+            content_h += _estimate_action_row_height(title=step.action, w=content_w)
+            if index < len(shown_steps) - 1:
+                content_h += 2.5 * mm
         if len(data.next_steps) > len(shown_steps):
             content_h += 0.5 * mm + _measure_text_height(
                 tr("REPORT_ACTIONS_PAGE1_MORE"),


### PR DESCRIPTION
## Summary
- add breathing room between the page-1 `Action status` label and its status pill
- compact the page-1 `What to do next` preview rows and block height so the bordered panel no longer leaves a conspicuous empty lower area
- add a focused regression test for the two-step page-1 preview height estimate

## Report sample used
- simulator-backed report generated via `.tmp/pdf-audit/generate_report.py`
- latest verified sample: `.tmp/pdf-audit/audit-report.pdf`
- latest verified run id: `bbeafbd3171447bfaf8ef78a95542d64`

## Affected PDF areas
- page 1 hero card: `Action status`
- page 1 lower-right panel: `What to do next`

## Validation
- visual confirmation from rendered PDF screenshots and before/after boards
- `./.tmp/pdf-audit/current/confirm/crops/candidate-01-action-status-normal.png`
- `./.tmp/pdf-audit/current/confirm/comparisons/candidate-01-action-status-comparison.png`
- `./.tmp/pdf-audit/current/after-page1/comparisons/candidate-01-action-status-before-after.png`
- `./.tmp/pdf-audit/current/confirm/crops/candidate-02-page1-balance-normal.png`
- `./.tmp/pdf-audit/current/confirm/comparisons/candidate-02-page1-balance-comparison.png`
- `./.tmp/pdf-audit/current/after-page1/comparisons/candidate-02-page1-balance-before-after.png`
- `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/adapters/pdf/test_report_analysis_separation.py`
- `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf`
- `make typecheck-backend`
- `make lint`
