### PR TITLE
Polish PDF report layout spacing

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py
+++ b/apps/server/tests/adapters/pdf/test_report_compact_panel_heights.py
@@ -112,6 +112,82 @@ def test_estimate_appendix_c_lower_panels_shrink_for_short_content() -> None:
     assert min(context_h, suitability_h, trace_h) >= 34 * mm
 
 
+def test_estimate_appendix_c_lower_panels_stay_tighter_for_unbalanced_card_content() -> None:
+    data = ReportTemplateData(
+        lang="en",
+        verdict_page=VerdictPageData(action_status_note="skip duplicate"),
+        appendix_c=AppendixCData(
+            context_summary=(
+                "A steady 100-110 km/h capture with 4 of 4 expected wheel positions connected "
+                "makes this run usable for source comparison."
+            ),
+            speed_band_summary="100-110 km/h",
+            phase_summary="Cruise",
+            observations=[],
+            limits_summary=(
+                "Treat this run as directional, not final. If the first inspection is clean, "
+                "rerun with a longer steady hold plus accel/decel and drive/coast comparison "
+                "through the 100-110 km/h band."
+            ),
+            suitability_items=[
+                DataTrustItem(
+                    check="Speed variation",
+                    detail=(
+                        "Speed range stayed in a usable diagnostic band for steady-state "
+                        "diagnosis and order tracking."
+                    ),
+                    state="pass",
+                ),
+                DataTrustItem(
+                    check="Sensor coverage",
+                    detail="Multiple sensor locations observed.",
+                    state="pass",
+                ),
+                DataTrustItem(
+                    check="Reference completeness",
+                    detail="Required order references are present.",
+                    state="pass",
+                ),
+                DataTrustItem(
+                    check="Saturation and outliers",
+                    detail="No obvious saturation detected.",
+                    state="pass",
+                ),
+                DataTrustItem(
+                    check="Frame integrity",
+                    detail="No dropped frames or queue overflows detected.",
+                    state="pass",
+                ),
+            ],
+        ),
+        appendix_d=AppendixDData(
+            rows=[
+                ReportLabelValueRow(label="Run date", value="2026-04-01 01:05:30 UTC"),
+                ReportLabelValueRow(label="Run ID", value="a2d18c88451f4d688b61e60b48d9949b"),
+                ReportLabelValueRow(label="tire size", value="285/30R21"),
+                ReportLabelValueRow(label="Sensor Model", value="ADXL345"),
+                ReportLabelValueRow(label="Firmware Version", value="sim-0.2"),
+                ReportLabelValueRow(label="Analysis rows", value="124"),
+                ReportLabelValueRow(label="Raw Sample Rate (Hz)", value="800"),
+                ReportLabelValueRow(label="Report version", value="v0.0.0-dev"),
+            ],
+        ),
+    )
+
+    width = PAGE_W - 2 * MARGIN
+    context_w = width * 0.24
+    suitability_w = width * 0.31
+    trace_w = width - context_w - suitability_w - (2 * GAP)
+
+    context_h = _estimate_appendix_c_context_panel_height(data, width=context_w)
+    suitability_h = _estimate_appendix_c_suitability_panel_height(data, width=suitability_w)
+    trace_h = _estimate_appendix_c_trace_panel_height(data, width=trace_w)
+
+    assert context_h < trace_h
+    assert suitability_h < trace_h
+    assert trace_h < 72 * mm
+
+
 def test_estimate_worksheet_summary_panels_shrink_for_short_content() -> None:
     appendix = AppendixAData(
         primary_source="Wheel / Tire",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -321,6 +321,34 @@ def test_diagram_keeps_right_wheel_labels_inside_narrow_page1_bounds() -> None:
     _assert_no_pairwise_overlap(boxes)
 
 
+def test_narrow_page1_layout_keeps_left_wheel_labels_clear_of_wheel_markers() -> None:
+    location_points = {
+        "front-left wheel": (18.0, 198.0),
+        "front-right wheel": (106.0, 198.0),
+        "rear-left wheel": (18.0, 76.0),
+        "rear-right wheel": (106.0, 76.0),
+    }
+    _, labels, _ = build_sensor_render_plan(
+        location_points=location_points,
+        drawing_width=124.0,
+        drawing_height=252.0,
+        connected_locations=set(location_points.keys()),
+        amp_by_location={
+            "front-left wheel": 31.1,
+            "front-right wheel": 34.9,
+            "rear-left wheel": 30.9,
+            "rear-right wheel": 31.4,
+        },
+        highlight={"rear-left wheel": REPORT_COLORS["danger"]},
+        colors=REPORT_COLORS,
+    )
+
+    label_by_name = {label.name: label for label in labels}
+    for name in ("front-left wheel", "rear-left wheel"):
+        marker_x, _ = location_points[name]
+        assert label_by_name[name].bbox[0] >= marker_x + 14.0
+
+
 def test_render_plan_prefers_diagnosed_location_when_intensity_hotspot_differs() -> None:
     location_points = {
         "front-left wheel": (40.0, 180.0),

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -119,17 +119,19 @@ def resolve_marker_states(
 
 # ── Label collision resolution ───────────────────────────────────────────────
 
+_INLINE_LABEL_GAP = 16.0
+
 _LABEL_CANDIDATES_RIGHT: tuple[tuple[float, float, str], ...] = (
-    (10.0, -2.0, "start"),
-    (-10.0, -2.0, "end"),
+    (_INLINE_LABEL_GAP, -2.0, "start"),
+    (-_INLINE_LABEL_GAP, -2.0, "end"),
     (0.0, 9.0, "middle"),
     (0.0, -11.0, "middle"),
 )
 _LABEL_CANDIDATES_LEFT: tuple[tuple[float, float, str], ...] = (
-    (-10.0, -2.0, "end"),
-    (-10.0, 18.0, "end"),
-    (-10.0, -20.0, "end"),
-    (10.0, -2.0, "start"),
+    (-_INLINE_LABEL_GAP, -2.0, "end"),
+    (-_INLINE_LABEL_GAP, 18.0, "end"),
+    (-_INLINE_LABEL_GAP, -20.0, "end"),
+    (_INLINE_LABEL_GAP, -2.0, "start"),
     (0.0, 9.0, "middle"),
     (0.0, -11.0, "middle"),
 )

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
@@ -111,7 +111,7 @@ def _estimate_appendix_c_traceability_row_height(
     row: ReportLabelValueRow, *, width: float
 ) -> float:
     return float(
-        4.2 * mm
+        3.4 * mm
         + _measure_text_height(
             row.value,
             w=width,
@@ -119,7 +119,7 @@ def _estimate_appendix_c_traceability_row_height(
             leading=FS_BODY + 1.2,
             max_lines=3,
         )
-        + 0.8 * mm
+        + 0.4 * mm
     )
 
 
@@ -782,7 +782,7 @@ def _appendix_c_page(c: Canvas, data: ReportTemplateData) -> None:
                 y=trace_y,
                 w=trace_w - 8 * mm,
             )
-            - 0.8 * mm
+            - 0.4 * mm
         )
         if trace_y < lower_y + 4 * mm:
             break
@@ -1221,7 +1221,7 @@ def _draw_traceability_row(
     return _draw_text(
         c,
         x,
-        y - 4.2 * mm,
+        y - 3.4 * mm,
         w,
         row.value,
         font=FONT_B,


### PR DESCRIPTION
## Summary
- tighten the appendix-C lower card row so the page-2 bottom cards no longer leave an obviously uneven empty lower area
- increase inline wheel-label clearance in the vehicle diagram so the page-1 left wheel labels no longer sit visibly jammed against the markers

## Report sample used
- `.tmp/pdf-audit/iteration-1/audit-report.pdf` (baseline run `a2d18c88451f4d688b61e60b48d9949b`)
- `.tmp/pdf-audit/iteration-2/audit-report.pdf` (post-iteration-1 rerender run `34e6d94cdb42421d82269cf3c7ef0364`)
- `.tmp/pdf-audit/iteration-3/audit-report.pdf` (final rerender run `10e28c6ab4de4e129704e5b534ac4691`)

## Affected pages and sections
- page 1: `Why this corner wins` vehicle diagram
- page 2: appendix-C lower card row (`Supporting context`, `Run quality and limits`, `Traceability`)

## Iteration summary
- iteration 1: confirmed and fixed the page-2 lower-card empty-depth imbalance; added compactness regression coverage
- iteration 2: confirmed and fixed the page-1 left wheel-label crowding; added diagram-spacing regression coverage
- iteration 3: reran the five-specialist screenshot review on a fresh PDF and intentionally made no further code changes because no new high-confidence defects remained

## Validation notes
- visual validation was done from rendered PDF screenshots only
- before/after evidence artifacts live under:
  - `.tmp/pdf-audit/iteration-1/confirm/`
  - `.tmp/pdf-audit/iteration-1/after/`
  - `.tmp/pdf-audit/iteration-2/confirm/`
  - `.tmp/pdf-audit/iteration-2/after/`
- code validation:
  - `make lint`
  - `make typecheck-backend`
  - `/usr/local/bin/python3.14 -m pytest -q apps/server/tests/adapters/pdf`
