### PR TITLE
Fix PDF car diagram sizing and markers

### DIFF
--- a/apps/server/tests/adapters/pdf/test_diagram_layout.py
+++ b/apps/server/tests/adapters/pdf/test_diagram_layout.py
@@ -180,7 +180,10 @@ def test_build_sensor_render_plan_single_sensor() -> None:
     )
     assert single is True
     assert len(markers) == 1
+    assert labels == []
     assert markers[0].fill == "#ff0000"
+    assert markers[0].outer_radius > markers[0].mid_radius > markers[0].radius
+    assert markers[0].outer_fill != markers[0].fill
 
 
 def test_build_sensor_render_plan_multiple_sensors() -> None:
@@ -199,7 +202,9 @@ def test_build_sensor_render_plan_multiple_sensors() -> None:
     )
     assert single is False
     assert len(markers) == 2
-    assert len(labels) == 2
+    assert labels == []
+    assert markers[0].outer_radius > markers[0].mid_radius > markers[0].radius
+    assert markers[1].outer_radius > markers[1].mid_radius > markers[1].radius
 
 
 # ── canonical_location ───────────────────────────────────────────────────────

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -44,6 +44,34 @@ def _text_item_box(item: object) -> tuple[float, float, float, float]:
     return (x0, y - 1.0, x0 + width, y + size + 1.0)
 
 
+def _item_box(item: object) -> tuple[float, float, float, float] | None:
+    if hasattr(item, "radius") and hasattr(item, "x") and hasattr(item, "y"):
+        x = float(getattr(item, "x", 0.0))
+        y = float(getattr(item, "y", 0.0))
+        radius = float(getattr(item, "radius", 0.0))
+        return (x - radius, y - radius, x + radius, y + radius)
+    if hasattr(item, "x1") and hasattr(item, "y1") and hasattr(item, "x2") and hasattr(item, "y2"):
+        x1 = float(getattr(item, "x1", 0.0))
+        y1 = float(getattr(item, "y1", 0.0))
+        x2 = float(getattr(item, "x2", 0.0))
+        y2 = float(getattr(item, "y2", 0.0))
+        return (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
+    if (
+        hasattr(item, "width")
+        and hasattr(item, "height")
+        and hasattr(item, "x")
+        and hasattr(item, "y")
+    ):
+        x = float(getattr(item, "x", 0.0))
+        y = float(getattr(item, "y", 0.0))
+        width = float(getattr(item, "width", 0.0))
+        height = float(getattr(item, "height", 0.0))
+        return (x, y, x + width, y + height)
+    if hasattr(item, "text"):
+        return _text_item_box(item)
+    return None
+
+
 def test_sensor_state_mapping_connected_active_inactive_and_disconnected() -> None:
     states = resolve_marker_states(
         ["front-left wheel", "front-right wheel", "engine bay"],
@@ -56,7 +84,7 @@ def test_sensor_state_mapping_connected_active_inactive_and_disconnected() -> No
     assert states["engine bay"] == "disconnected"
 
 
-def test_marker_colors_follow_diagnostic_highlight_and_use_single_color_markers() -> None:
+def test_marker_gradients_keep_diagnostic_core_color_and_expand_with_intensity() -> None:
     location_points = {
         "front-left wheel": (40.0, 180.0),
         "front-right wheel": (160.0, 180.0),
@@ -79,13 +107,20 @@ def test_marker_colors_follow_diagnostic_highlight_and_use_single_color_markers(
     marker_by_name = {marker.name: marker for marker in markers}
 
     assert marker_by_name["rear-left wheel"].fill == REPORT_COLORS["danger"]
-    assert marker_by_name["rear-left wheel"].radius > marker_by_name["front-left wheel"].radius
-    assert marker_by_name["front-left wheel"].fill == REPORT_COLORS["text_secondary"]
-    assert marker_by_name["front-right wheel"].fill == REPORT_COLORS["text_secondary"]
-    assert marker_by_name["rear-left wheel"].stroke == marker_by_name["rear-left wheel"].fill
-    assert marker_by_name["front-left wheel"].stroke == marker_by_name["front-left wheel"].fill
+    assert (
+        marker_by_name["rear-left wheel"].outer_radius
+        > marker_by_name["rear-left wheel"].mid_radius
+    )
+    assert marker_by_name["rear-left wheel"].mid_radius > marker_by_name["rear-left wheel"].radius
+    assert marker_by_name["rear-left wheel"].outer_fill != marker_by_name["rear-left wheel"].fill
+    assert (
+        marker_by_name["front-left wheel"].outer_radius
+        > marker_by_name["front-left wheel"].mid_radius
+    )
+    assert marker_by_name["front-left wheel"].mid_radius > marker_by_name["front-left wheel"].radius
+    assert marker_by_name["front-left wheel"].radius > marker_by_name["rear-left wheel"].radius
     assert marker_by_name["engine bay"].state == "disconnected"
-    assert marker_by_name["engine bay"].stroke == marker_by_name["engine bay"].fill
+    assert marker_by_name["engine bay"].outer_fill != marker_by_name["engine bay"].fill
 
 
 def test_marker_radius_grows_with_local_intensity_for_active_locations() -> None:
@@ -134,7 +169,7 @@ def test_highlighted_location_without_intensity_keeps_diagnostic_color() -> None
     assert marker_by_name["front-left wheel"].stroke == REPORT_COLORS["danger"]
 
 
-def test_label_placement_stays_in_bounds_and_avoids_overlap_for_dense_layout() -> None:
+def test_dense_layout_uses_gradient_markers_without_sensor_labels() -> None:
     location_points = {
         "front-left wheel": (36.0, 198.0),
         "front-right wheel": (164.0, 198.0),
@@ -155,30 +190,17 @@ def test_label_placement_stays_in_bounds_and_avoids_overlap_for_dense_layout() -
         colors=REPORT_COLORS,
     )
 
-    marker_boxes = {
-        marker.name: (
-            marker.x - marker.radius - 1.0,
-            marker.y - marker.radius - 1.0,
-            marker.x + marker.radius + 1.0,
-            marker.y + marker.radius + 1.0,
-        )
-        for marker in markers
-    }
-
-    assert len(labels) == len(location_points)
-    for label in labels:
-        assert label.bbox[0] >= 0.0
-        assert label.bbox[1] >= 0.0
-        assert label.bbox[2] <= 200.0
-        assert label.bbox[3] <= 252.0
-        for marker_name, marker_box in marker_boxes.items():
-            if marker_name != label.name:
-                assert not _rectangles_overlap(label.bbox, marker_box)
-
-    _assert_no_pairwise_overlap([label.bbox for label in labels])
+    assert labels == []
+    assert len(markers) == len(location_points)
+    for marker in markers:
+        assert marker.outer_radius > marker.mid_radius > marker.radius
+        assert marker.x - marker.outer_radius >= 0.0
+        assert marker.y - marker.outer_radius >= 0.0
+        assert marker.x + marker.outer_radius <= 200.0
+        assert marker.y + marker.outer_radius <= 252.0
 
 
-def test_sparse_layout_renders_only_connected_sensor_labels() -> None:
+def test_sparse_layout_omits_sensor_location_labels() -> None:
     summary = {
         "sensor_locations": ["front-left wheel", "rear-right wheel"],
         "sensor_intensity_by_location": [
@@ -196,12 +218,12 @@ def test_sparse_layout_renders_only_connected_sensor_labels() -> None:
         diagram_height=252.0,
     )
 
-    labels = {
+    sensor_labels = {
         str(item.text)
         for item in diagram.contents
         if hasattr(item, "text") and "wheel" in str(getattr(item, "text", ""))
     }
-    assert labels == {"front-left wheel", "rear-right wheel"}
+    assert sensor_labels == set()
 
 
 def test_single_sensor_uses_diagnostic_highlight_color() -> None:
@@ -264,16 +286,27 @@ def test_diagram_omits_source_legend_and_keeps_text_within_bounds() -> None:
     ]
     assert source_labels == []
 
-    boxes: list[tuple[float, float, float, float]] = []
-    for item in source_labels:
+    for item in text_items:
         box = _text_item_box(item)
         assert box[0] >= 0.0
         assert box[2] <= float(diagram.width) + 0.1
+    assert all(
+        str(getattr(item, "text", ""))
+        not in {
+            "front-left wheel",
+            "front-right wheel",
+            "rear-left wheel",
+            "rear-right wheel",
+            "engine bay",
+            "driver seat",
+            "driveshaft tunnel",
+            "trunk",
+        }
+        for item in text_items
+    )
 
-    _assert_no_pairwise_overlap(boxes)
 
-
-def test_diagram_keeps_right_wheel_labels_inside_narrow_page1_bounds() -> None:
+def test_tall_narrow_page1_diagram_stays_inside_bounds_without_sensor_labels() -> None:
     summary = {
         "sensor_locations": [
             "front-left wheel",
@@ -295,33 +328,38 @@ def test_diagram_keeps_right_wheel_labels_inside_narrow_page1_bounds() -> None:
         content_width=300.0,
         tr=lambda key, **kwargs: key,
         text_fn=lambda en, nl: en,
-        diagram_width=124.0,
-        diagram_height=252.0,
+        diagram_width=128.0,
+        diagram_height=490.0,
     )
 
-    wheel_labels = [
-        item
+    sensor_texts = [
+        str(item.text)
         for item in diagram.contents
-        if hasattr(item, "text") and str(getattr(item, "text", "")).endswith("wheel")
+        if hasattr(item, "text")
+        and str(getattr(item, "text", ""))
+        in {
+            "front-left wheel",
+            "front-right wheel",
+            "rear-left wheel",
+            "rear-right wheel",
+            "engine bay",
+            "driver seat",
+            "driveshaft tunnel",
+            "trunk",
+        }
     ]
-
-    assert {str(item.text) for item in wheel_labels} == {
-        "front-left wheel",
-        "front-right wheel",
-        "rear-left wheel",
-        "rear-right wheel",
-    }
-
-    box_by_label = {str(item.text): _text_item_box(item) for item in wheel_labels}
-    for label in ("front-right wheel", "rear-right wheel"):
-        box = box_by_label[label]
+    assert sensor_texts == []
+    for item in diagram.contents:
+        box = _item_box(item)
+        if box is None:
+            continue
+        assert box[0] >= -0.1
+        assert box[1] >= -0.1
         assert box[2] <= float(diagram.width) + 0.1
-
-    boxes = list(box_by_label.values())
-    _assert_no_pairwise_overlap(boxes)
+        assert box[3] <= float(diagram.height) + 0.1
 
 
-def test_narrow_page1_layout_keeps_left_wheel_labels_clear_of_wheel_markers() -> None:
+def test_narrow_page1_layout_returns_no_sensor_labels() -> None:
     location_points = {
         "front-left wheel": (18.0, 198.0),
         "front-right wheel": (106.0, 198.0),
@@ -342,11 +380,7 @@ def test_narrow_page1_layout_keeps_left_wheel_labels_clear_of_wheel_markers() ->
         highlight={"rear-left wheel": REPORT_COLORS["danger"]},
         colors=REPORT_COLORS,
     )
-
-    label_by_name = {label.name: label for label in labels}
-    for name in ("front-left wheel", "rear-left wheel"):
-        marker_x, _ = location_points[name]
-        assert label_by_name[name].bbox[0] >= marker_x + 14.0
+    assert labels == []
 
 
 def test_render_plan_prefers_diagnosed_location_when_intensity_hotspot_differs() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -264,7 +264,7 @@ def test_report_pdf_compacts_actionable_system_cards() -> None:
     assert long_location not in text
 
 
-def test_car_diagram_wheel_labels_stay_within_bounds_without_overlap() -> None:
+def test_car_diagram_omits_sensor_labels() -> None:
     diagram = car_location_diagram(
         [{"strongest_location": "front-left wheel", "suspected_source": "wheel/tire"}],
         {
@@ -285,6 +285,17 @@ def test_car_diagram_wheel_labels_stay_within_bounds_without_overlap() -> None:
     labels = [
         item
         for item in diagram.contents
-        if hasattr(item, "text") and str(getattr(item, "text", "")).endswith("wheel")
+        if hasattr(item, "text")
+        and str(getattr(item, "text", ""))
+        in {
+            "front-left wheel",
+            "front-right wheel",
+            "rear-left wheel",
+            "rear-right wheel",
+            "engine bay",
+            "driver seat",
+            "driveshaft tunnel",
+            "trunk",
+        }
     ]
-    assert len(labels) == 4
+    assert labels == []

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -29,6 +29,10 @@ class MarkerRenderPlan:
     stroke: str
     stroke_width: float
     radius: float
+    mid_fill: str
+    mid_radius: float
+    outer_fill: str
+    outer_radius: float
 
 
 @dataclass(frozen=True)
@@ -94,6 +98,53 @@ def bounds_overflow(
     bottom = max(0.0, margin - box[1])
     top = max(0.0, box[3] - (height - margin))
     return left + right + bottom + top
+
+
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    token = value.strip().lstrip("#")
+    if len(token) != 6:
+        raise ValueError(f"Expected a 6-digit hex color, got {value!r}")
+    return (int(token[0:2], 16), int(token[2:4], 16), int(token[4:6], 16))
+
+
+def _blend_hex(base: str, target: str, *, target_weight: float) -> str:
+    weight = _clamp_unit(target_weight)
+    base_rgb = _hex_to_rgb(base)
+    target_rgb = _hex_to_rgb(target)
+    mixed = tuple(
+        round((base_rgb[idx] * (1.0 - weight)) + (target_rgb[idx] * weight)) for idx in range(3)
+    )
+    return f"#{mixed[0]:02x}{mixed[1]:02x}{mixed[2]:02x}"
+
+
+def _gradient_layers(
+    *,
+    base_fill: str,
+    core_radius: float,
+    emphasis: float,
+    state: MarkerState,
+) -> tuple[str, float, str, float]:
+    normalized = _clamp_unit(emphasis)
+    if state == "connected-active":
+        mid_fill = _blend_hex(base_fill, "#ffffff", target_weight=0.46 - (normalized * 0.16))
+        outer_fill = _blend_hex(base_fill, "#ffffff", target_weight=0.74 - (normalized * 0.24))
+        mid_radius = core_radius + 1.3 + (normalized * 0.3)
+        outer_radius = mid_radius + 1.6 + (normalized * 0.5)
+    elif state == "connected-inactive":
+        mid_fill = _blend_hex(base_fill, "#ffffff", target_weight=0.58)
+        outer_fill = _blend_hex(base_fill, "#ffffff", target_weight=0.82)
+        mid_radius = core_radius + 1.1
+        outer_radius = mid_radius + 1.4
+    else:
+        mid_fill = _blend_hex(base_fill, "#ffffff", target_weight=0.38)
+        outer_fill = _blend_hex(base_fill, "#ffffff", target_weight=0.66)
+        mid_radius = core_radius + 0.9
+        outer_radius = mid_radius + 1.1
+    return (mid_fill, mid_radius, outer_fill, outer_radius)
 
 
 # ── Marker state resolution ─────────────────────────────────────────────────
@@ -207,19 +258,21 @@ def build_sensor_render_plan(
     active_count = sum(1 for value in states.values() if value == "connected-active")
     single_sensor = active_count == 1 and (min_amp is None or min_amp == max_amp)
 
-    def active_radius(name: str, *, highlighted: bool) -> float:
+    def intensity_emphasis(name: str) -> float:
+        if name not in amp_by_location:
+            return 0.45
         if min_amp is None or max_amp is None or min_amp == max_amp:
-            return 6.8 if highlighted else 5.2
-        amp = amp_by_location.get(name)
-        if amp is None:
-            return 6.8 if highlighted else 5.2
-        normalized = (amp - min_amp) / (max_amp - min_amp)
+            return 1.0
+        amp = amp_by_location[name]
+        return _clamp_unit((amp - min_amp) / (max_amp - min_amp))
+
+    def active_radius(name: str, *, highlighted: bool) -> float:
+        normalized = intensity_emphasis(name)
         if highlighted:
-            return 6.2 + (normalized * 0.9)
-        return 4.8 + (normalized * 1.1)
+            return 5.4 + (normalized * 0.7)
+        return 4.6 + (normalized * 0.9)
 
     markers: list[MarkerRenderPlan] = []
-    occupied_boxes: list[tuple[float, float, float, float]] = []
     for name, (px, py) in location_points.items():
         state = states[name]
         if state == "connected-active":
@@ -232,12 +285,19 @@ def build_sensor_render_plan(
             stroke_width = 0.8
         elif state == "connected-inactive":
             fill = highlight.get(name, colors["surface_alt"])
-            radius = 4.8
-            stroke_width = 0.8
+            radius = 4.4
+            stroke_width = 0.7
         else:
-            fill = "#e3e8f1"
-            radius = 4.0
+            fill = "#d8dfea"
+            radius = 3.6
             stroke_width = 0.6
+        emphasis = intensity_emphasis(name) if state == "connected-active" else 0.45
+        mid_fill, mid_radius, outer_fill, outer_radius = _gradient_layers(
+            base_fill=fill,
+            core_radius=radius,
+            emphasis=emphasis,
+            state=state,
+        )
         marker = MarkerRenderPlan(
             name=name,
             x=px,
@@ -247,47 +307,13 @@ def build_sensor_render_plan(
             stroke=fill,
             stroke_width=stroke_width,
             radius=radius,
+            mid_fill=mid_fill,
+            mid_radius=mid_radius,
+            outer_fill=outer_fill,
+            outer_radius=outer_radius,
         )
         markers.append(marker)
-        occupied_boxes.append(
-            (px - radius - 1.0, py - radius - 1.0, px + radius + 1.0, py + radius + 1.0),
-        )
-
-    marker_by_name = {marker.name: marker for marker in markers}
-    labels: list[LabelRenderPlan] = []
-    label_states = frozenset({"connected-active", "connected-inactive"})
-    labeled_names = {
-        marker.name
-        for marker in markers
-        if marker.state in label_states or marker.name in highlight
-    }
-    for name in sorted(
-        labeled_names,
-        key=lambda value: (location_points[value][1], location_points[value][0]),
-    ):
-        px, py = location_points[name]
-        found_marker = marker_by_name.get(name)
-        if found_marker is None:
-            continue
-        if found_marker.state == "connected-active":
-            color = colors["ink"]
-        elif found_marker.state == "connected-inactive":
-            color = colors["text_secondary"]
-        else:
-            color = colors["text_muted"]
-        label = choose_label_plan(
-            name=name,
-            px=px,
-            py=py,
-            width=drawing_width,
-            height=drawing_height,
-            occupied_boxes=occupied_boxes,
-            font_size=6.8,
-            color=color,
-        )
-        labels.append(label)
-        occupied_boxes.append(label.bbox)
-    return markers, labels, single_sensor
+    return markers, [], single_sensor
 
 
 # ── Location canonicalization ────────────────────────────────────────────────

--- a/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
@@ -68,6 +68,27 @@ def _build_sensor_render_plan(
     )
 
 
+def _fit_vehicle_shell_rect(
+    *, drawing_width: float, drawing_height: float
+) -> tuple[float, float, float, float]:
+    vehicle_ratio = _BMW_WIDTH_MM / _BMW_LENGTH_MM
+    horizontal_pad = max(12.0, drawing_width * 0.10)
+    orientation_reserve = 20.0
+    top_bottom_pad = 12.0
+    box_w = max(44.0, drawing_width - (2.0 * horizontal_pad))
+    box_h = max(92.0, drawing_height - (2.0 * orientation_reserve) - top_bottom_pad)
+    box_ratio = box_w / box_h if box_h > 0 else vehicle_ratio
+    if box_ratio > vehicle_ratio:
+        car_h = box_h
+        car_w = car_h * vehicle_ratio
+    else:
+        car_w = box_w
+        car_h = car_w / vehicle_ratio
+    x0 = (drawing_width - car_w) / 2.0
+    y0 = orientation_reserve + ((box_h - car_h) / 2.0)
+    return (x0, y0, car_w, car_h)
+
+
 # ── Canvas drawing functions ─────────────────────────────────────────────────
 
 
@@ -87,14 +108,21 @@ def _draw_vehicle_shell(
     from reportlab.graphics.shapes import Circle, Line, Rect, String
 
     center_x = x0 + (car_w / 2)
+    body_corner = max(12.0, car_w * 0.16)
+    cabin_corner = max(9.0, car_w * 0.11)
+    wheel_radius = max(7.0, car_w * 0.09)
+    cabin_x = x0 + (car_w * 0.21)
+    cabin_y = y0 + (car_h * 0.24)
+    cabin_w = car_w * 0.58
+    cabin_h = car_h * 0.52
     drawing.add(
         Rect(
             x0,
             y0,
             car_w,
             car_h,
-            rx=24,
-            ry=24,
+            rx=body_corner,
+            ry=body_corner,
             fillColor=color_surface,
             strokeColor=color_border,
             strokeWidth=1.4,
@@ -102,25 +130,117 @@ def _draw_vehicle_shell(
     )
     drawing.add(
         Rect(
-            x0 + (car_w * 0.08),
-            y0 + (car_h * 0.10),
-            car_w * 0.84,
-            car_h * 0.80,
-            rx=16,
-            ry=16,
+            cabin_x,
+            cabin_y,
+            cabin_w,
+            cabin_h,
+            rx=cabin_corner,
+            ry=cabin_corner,
             fillColor=hex_color("#ffffff"),
+            strokeColor=color_row_border,
+            strokeWidth=0.8,
+        ),
+    )
+    drawing.add(
+        Line(
+            center_x,
+            y0 + (car_h * 0.10),
+            center_x,
+            y0 + car_h - (car_h * 0.10),
+            strokeColor=color_row_border,
+            strokeWidth=0.8,
+        ),
+    )
+    roof_x0 = cabin_x + (cabin_w * 0.10)
+    roof_x1 = cabin_x + (cabin_w * 0.90)
+    hood_y = y0 + (car_h * 0.77)
+    hatch_y = y0 + (car_h * 0.23)
+    drawing.add(
+        Line(
+            roof_x0,
+            hood_y,
+            roof_x1,
+            hood_y,
             strokeColor=color_row_border,
             strokeWidth=0.7,
         ),
     )
     drawing.add(
         Line(
-            center_x,
-            y0 + 18,
-            center_x,
-            y0 + car_h - 18,
+            roof_x0,
+            hatch_y,
+            roof_x1,
+            hatch_y,
             strokeColor=color_row_border,
-            strokeWidth=0.8,
+            strokeWidth=0.7,
+        ),
+    )
+    front_cap_y = y0 + (car_h * 0.90)
+    rear_cap_y = y0 + (car_h * 0.10)
+    shoulder_left = x0 + (car_w * 0.15)
+    shoulder_right = x0 + (car_w * 0.85)
+    drawing.add(
+        Line(
+            shoulder_left,
+            front_cap_y,
+            roof_x0,
+            hood_y,
+            strokeColor=color_row_border,
+            strokeWidth=0.7,
+        ),
+    )
+    drawing.add(
+        Line(
+            shoulder_right,
+            front_cap_y,
+            roof_x1,
+            hood_y,
+            strokeColor=color_row_border,
+            strokeWidth=0.7,
+        ),
+    )
+    drawing.add(
+        Line(
+            shoulder_left,
+            rear_cap_y,
+            roof_x0,
+            hatch_y,
+            strokeColor=color_row_border,
+            strokeWidth=0.7,
+        ),
+    )
+    drawing.add(
+        Line(
+            shoulder_right,
+            rear_cap_y,
+            roof_x1,
+            hatch_y,
+            strokeColor=color_row_border,
+            strokeWidth=0.7,
+        ),
+    )
+    door_left_x = cabin_x + (cabin_w * 0.22)
+    door_right_x = cabin_x + (cabin_w * 0.78)
+    belt_low_y = cabin_y + (cabin_h * 0.34)
+    belt_high_y = cabin_y + (cabin_h * 0.66)
+    drawing.add(
+        Line(
+            door_left_x,
+            belt_low_y,
+            door_left_x,
+            belt_high_y,
+            strokeColor=color_row_border,
+            strokeWidth=0.6,
+        ),
+    )
+    drawing.add(
+        Line(
+            door_right_x,
+            belt_low_y,
+            door_right_x,
+            belt_high_y,
+            strokeColor=color_row_border,
+            strokeWidth=0.6,
         ),
     )
     front_axle_y = y0 + (car_h * 0.84)
@@ -147,26 +267,35 @@ def _draw_vehicle_shell(
         (wheel_x_right, rear_axle_y),
     ):
         drawing.add(
-            Circle(wx, wy, 11, fillColor=wheel_fill, strokeColor=wheel_stroke, strokeWidth=1.0),
+            Circle(
+                wx,
+                wy,
+                wheel_radius,
+                fillColor=wheel_fill,
+                strokeColor=wheel_stroke,
+                strokeWidth=1.0,
+            ),
         )
     drawing.add(
         String(
-            center_x - 16,
-            y0 + car_h + 16,
+            center_x,
+            y0 + car_h + 13,
             "DIAGRAM_LABEL_FRONT",
             fontName="Helvetica-Bold",
-            fontSize=8,
+            fontSize=7.5,
             fillColor=color_text_primary,
+            textAnchor="middle",
         ),
     )
     drawing.add(
         String(
-            center_x - 14,
-            y0 - 16,
+            center_x,
+            y0 - 15,
             "DIAGRAM_LABEL_REAR",
             fontName="Helvetica-Bold",
-            fontSize=8,
+            fontSize=7.5,
             fillColor=color_text_primary,
+            textAnchor="middle",
         ),
     )
 
@@ -177,6 +306,26 @@ def _draw_markers_and_labels(
     from reportlab.graphics.shapes import Circle, String
 
     for marker in markers:
+        drawing.add(
+            Circle(
+                marker.x,
+                marker.y,
+                marker.outer_radius,
+                fillColor=hex_color(marker.outer_fill),
+                strokeColor=hex_color(marker.outer_fill),
+                strokeWidth=0.0,
+            ),
+        )
+        drawing.add(
+            Circle(
+                marker.x,
+                marker.y,
+                marker.mid_radius,
+                fillColor=hex_color(marker.mid_fill),
+                strokeColor=hex_color(marker.mid_fill),
+                strokeWidth=0.0,
+            ),
+        )
         drawing.add(
             Circle(
                 marker.x,
@@ -223,10 +372,10 @@ def car_location_diagram(
     length_width_ratio = _BMW_LENGTH_MM / _BMW_WIDTH_MM
     drawing_h = max(220.0, float(diagram_height))
     drawing = Drawing(drawing_w, drawing_h)
-    car_h = max(162.0, drawing_h - 88.0)
-    car_w = car_h / length_width_ratio
-    x0 = (drawing_w - car_w) / 2.0
-    y0 = 54.0
+    x0, y0, car_w, car_h = _fit_vehicle_shell_rect(
+        drawing_width=drawing_w,
+        drawing_height=drawing_h,
+    )
 
     rendered_ratio = car_h / car_w if car_w > 0 else 0.0
     if abs(rendered_ratio - length_width_ratio) / length_width_ratio >= 0.02:


### PR DESCRIPTION
Fixes #1954.

## Summary

This change fixes the PDF report car diagram so it behaves like a bounded visual inside the page-one proof block instead of a height-driven drawing that can spill sideways into adjacent verdict text. The update also replaces the old flat sensor dots with layered intensity gradients, adds enough internal body lines for the vehicle to read like a simple wireframe car, and removes the sensor location text labels that were contributing most of the visual clutter.

The most important detail from the investigation is that the currently shipped `build_report_pdf()` flow does not render `pdf_page2`; it renders the shared `car_location_diagram()` through the page-one proof panel. Because of that, the right fix was not to tweak an unused page-two layout but to change the shared diagram renderer and its planner so the live report path gets the benefit immediately.

## Problem being solved

Issue #1954 called out several related problems in the current report diagram:

- the car art looked too large for the available space,
- the diagram could visually collide with nearby text,
- sensor intensity was only hinted at through small radius changes on flat markers,
- the body drawing was too plain to stand on its own,
- and sensor text labels made the panel feel crowded.

The root cause behind the overlap risk turned out to be a sizing mismatch inside `car_location_diagram()`. The old renderer chose the vehicle height from the available drawing height and then derived width from the BMW aspect ratio. That is fine for a roomy portrait box, but the page-one proof block gives the diagram a narrow column and a tall height. In that shape, height-based sizing could produce a vehicle width wider than the drawing box itself, which is exactly how the diagram could intrude into neighboring content even when the surrounding page layout looked reasonable on paper.

## Implementation approach

I kept the fix concentrated in the shared PDF diagram pipeline instead of widening the whole page-one proof layout. That was the smallest complete fix because it addresses the real overflow mechanism while also solving the requested visual improvements in the same rendering path.

The implementation has three main parts:

1. Fit the vehicle shell into the diagram bounds using both width and height, rather than treating height as the only sizing input.
2. Upgrade every sensor marker from a single flat circle to a small layered gradient built from outer, mid, and core circles.
3. Remove sensor location labels and make the vehicle body self-explanatory enough that the diagram still reads clearly with only front/rear orientation labels.

## Main code changes by area

### `apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py`

This file now owns a small `_fit_vehicle_shell_rect()` helper that calculates the car shell rectangle from the actual drawing box. The helper preserves the real vehicle aspect ratio but constrains it by both width and height, with explicit reserves for the orientation labels. That removes the sideways overflow mode that was possible before in the page-one proof panel.

The vehicle shell drawing itself was also upgraded. The outer body is still simple and maintainable, but it now includes a more recognizable wireframe treatment: a centered cabin, roof/hood/hatch seams, shoulder taper lines, and door divider lines. I also changed wheel sizing to scale off the fitted vehicle width, which keeps the proportions balanced when the car is intentionally drawn smaller.

Finally, marker rendering now paints three concentric circles per sensor instead of one. The outer and middle circles provide the gradient feel, while the inner core keeps the canonical marker center. This gives the diagram a stronger visual intensity signal without introducing a heavyweight gradient dependency in ReportLab.

### `apps/server/vibesensor/adapters/pdf/diagram_layout.py`

The planner now produces richer marker render plans. `MarkerRenderPlan` gained `mid_fill`, `mid_radius`, `outer_fill`, and `outer_radius` so the rendering layer can draw a gradient stack without re-deriving presentation logic.

I added small pure helpers for hex-color blending and gradient layer generation. The layout code keeps existing state semantics (`connected-active`, `connected-inactive`, `disconnected`) but now maps them to layered marker visuals instead of a single filled circle. Active markers still scale with local intensity, highlighted diagnostic locations still keep their highlight core color, and low-information states remain visually muted.

This file is also where the sensor text labels were effectively retired from the diagram. `build_sensor_render_plan()` now returns the marker plans and an empty label list. I deliberately left the pure label-planning helpers in place because they are still isolated geometry utilities and their existing tests remain useful, but they are no longer part of the live diagram output.

## Test changes

The focused PDF tests were updated to validate the new behavior instead of the old label-heavy layout:

- unit tests now assert the presence of gradient layers on marker plans,
- integration tests assert that sensor location labels are absent,
- a new tall-and-narrow diagram scenario guards the actual page-one overflow shape that motivated this issue,
- and existing diagram assertions were updated to reflect the new separation between diagnostic highlighting and raw intensity strength.

This was important because several tests previously locked in the exact wheel-label behavior that the issue explicitly asked to remove.

## Schema, contracts, config, and docs

There were no schema, API contract, or runtime config changes for this issue. I also did not touch end-user docs because the change is internal to PDF rendering behavior and the existing report documentation did not become inaccurate as a result.

## Validation performed

I ran focused validation first, then widened it to the full relevant backend surface:

- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_diagram_layout.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py -k 'diagram or aspect or fit_rect'`
- `.venv/bin/python -m ruff check apps/server/vibesensor apps/server/tests tools`
- `.venv/bin/python -m ruff format --check apps/server/vibesensor apps/server/tests tools`
- `.venv/bin/python tools/dev/check_hygiene.py`
- `cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py`
- `.venv/bin/python -m vibesensor.cli.preflight apps/server/config.dev.yaml`
- `.venv/bin/python -m vibesensor.cli.preflight apps/server/config.docker.yaml`
- `.venv/bin/python -m vibesensor.cli.preflight apps/server/config.pi.yaml`
- `.venv/bin/python tools/dev/docs_lint.py`
- `.venv/bin/python -m vibesensor.cli.ws_schema_export --check`
- `.venv/bin/python -m vibesensor.cli.http_api_schema_export --check`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf`

I also attempted the requested local Docker smoke pass, but this environment has Docker installed without an accessible daemon socket and without the `docker compose` plugin, so the product-style compose smoke could not be completed here.

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that removing sensor labels puts more weight on the diagram itself to communicate placement. I kept the front/rear orientation labels and added wireframe detail specifically to make that tradeoff acceptable.

I also kept the page-one layout widths unchanged. That was intentional: the root problem was renderer overflow, not insufficient panel math. Fixing the renderer keeps the change smaller and avoids preempting follow-on layout work like issue #1955, which explicitly wants to repurpose any newly freed diagram space.

The gradient implementation uses layered circles rather than a renderer-specific gradient primitive. That is a conscious reliability choice: it keeps the effect deterministic in ReportLab and easy to test from the existing render plan model.

## Out of scope

This PR does not try to redesign the entire proof panel, add the future timeline visualization, or revisit the broader multi-page page-two concept. It focuses on making the shipped diagram smaller, clearer, bounded, and intensity-aware in the live PDF path.
