### PR TITLE
Add page-one PDF run timeline graph

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1959,6 +1959,18 @@
     "en": "Best available location signal",
     "nl": "Best beschikbare locatiesignaal"
   },
+  "REPORT_TIMELINE_TITLE": {
+    "en": "Run timeline",
+    "nl": "Tijdlijn van de rit"
+  },
+  "REPORT_TIMELINE_SPEED_LABEL": {
+    "en": "Speed",
+    "nl": "Snelheid"
+  },
+  "REPORT_TIMELINE_DETECTIONS_LABEL": {
+    "en": "Detections",
+    "nl": "Detecties"
+  },
   "REPORT_PROOF_SUMMARY_RATIO": {
     "en": "{location} outranked the next location by {ratio}x on matched-window linear intensity evidence.",
     "nl": "{location} was {ratio}x sterker dan de volgende locatie op basis van matched-window lineaire intensiteitsbewijzen."

--- a/apps/server/tests/adapters/pdf/test_pdf_timeline_render.py
+++ b/apps/server/tests/adapters/pdf/test_pdf_timeline_render.py
@@ -1,0 +1,65 @@
+"""Focused tests for the page-1 run timeline graph renderer."""
+
+from __future__ import annotations
+
+from reportlab.graphics.shapes import Circle, PolyLine, Rect, String
+
+from vibesensor.adapters.pdf.pdf_drawing import _hex
+from vibesensor.adapters.pdf.pdf_style import REPORT_COLORS
+from vibesensor.adapters.pdf.pdf_timeline_render import run_timeline_graph
+from vibesensor.adapters.pdf.report_data import TimelineGraphData, TimelineGraphInterval
+
+
+def _color_hex(color: object) -> str | None:
+    return color.hexval() if color is not None else None
+
+
+def test_run_timeline_graph_draws_speed_line_evidence_and_labels() -> None:
+    drawing = run_timeline_graph(
+        TimelineGraphData(
+            duration_s=12.0,
+            speed_ceiling_kmh=80.0,
+            intervals=(
+                TimelineGraphInterval(
+                    phase_label="cruise",
+                    start_t_s=0.0,
+                    end_t_s=4.0,
+                    speed_min_kmh=58.0,
+                    speed_max_kmh=63.0,
+                    has_fault_evidence=False,
+                ),
+                TimelineGraphInterval(
+                    phase_label="cruise",
+                    start_t_s=4.0,
+                    end_t_s=9.0,
+                    speed_min_kmh=64.0,
+                    speed_max_kmh=72.0,
+                    has_fault_evidence=True,
+                ),
+            ),
+        ),
+        tr=lambda key, **_kw: key,
+        graph_width=140.0,
+        graph_height=96.0,
+    )
+
+    strings = [item.text for item in drawing.contents if isinstance(item, String)]
+
+    assert "REPORT_TIMELINE_TITLE" in strings
+    assert "REPORT_TIMELINE_SPEED_LABEL" in strings
+    assert "REPORT_TIMELINE_DETECTIONS_LABEL" in strings
+    assert any(
+        isinstance(item, PolyLine)
+        and _color_hex(item.strokeColor) == _hex(REPORT_COLORS["brand"]).hexval()
+        for item in drawing.contents
+    )
+    assert any(
+        isinstance(item, Rect)
+        and _color_hex(item.fillColor) == _hex(REPORT_COLORS["card_error_bg"]).hexval()
+        for item in drawing.contents
+    )
+    assert any(
+        isinstance(item, Circle)
+        and _color_hex(item.fillColor) == _hex(REPORT_COLORS["danger"]).hexval()
+        for item in drawing.contents
+    )

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -585,3 +585,58 @@ def test_map_summary_certainty_reason_keeps_relevant_reference_gap() -> None:
     )
     data = map_summary(prepare_report_input(summary))
     assert "Missing reference data" in data.observed.certainty_reason
+
+
+def test_map_summary_builds_verdict_timeline_graph_from_phase_timeline() -> None:
+    finding = make_finding_payload(
+        finding_id="F_TIMELINE",
+        suspected_source="wheel/tire",
+        strongest_location="Front Left wheel",
+        strongest_speed_band="60-80 km/h",
+        confidence=0.82,
+    )
+    summary = minimal_summary(
+        lang="en",
+        duration_s=12.0,
+        findings=[finding],
+        top_causes=[finding],
+        phase_timeline=[
+            {
+                "phase": "cruise",
+                "start_t_s": 0.0,
+                "end_t_s": 4.0,
+                "speed_min_kmh": 58.0,
+                "speed_max_kmh": 63.0,
+                "has_fault_evidence": False,
+            },
+            {
+                "phase": "cruise",
+                "start_t_s": 4.0,
+                "end_t_s": 9.0,
+                "speed_min_kmh": 64.0,
+                "speed_max_kmh": 72.0,
+                "has_fault_evidence": True,
+            },
+            {
+                "phase": "decel",
+                "start_t_s": 9.0,
+                "end_t_s": 12.0,
+                "speed_min_kmh": 48.0,
+                "speed_max_kmh": 62.0,
+                "has_fault_evidence": False,
+            },
+        ],
+    )
+
+    data = map_summary(prepare_report_input(summary))
+
+    timeline = data.verdict_page.timeline_graph
+    assert timeline is not None
+    assert timeline.duration_s == 12.0
+    assert timeline.speed_ceiling_kmh >= 72.0
+    assert [(interval.start_t_s, interval.end_t_s) for interval in timeline.intervals] == [
+        (0.0, 4.0),
+        (4.0, 9.0),
+        (9.0, 12.0),
+    ]
+    assert [interval.has_fault_evidence for interval in timeline.intervals] == [False, True, False]

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -12,6 +12,7 @@ from _report_pdf_test_helpers import (
 from pypdf import PdfReader
 from reportlab.pdfgen.canvas import Canvas
 from test_support.core import extract_pdf_text
+from test_support.findings import make_finding_payload
 from test_support.report_helpers import (
     RUN_END,
     minimal_summary,
@@ -237,6 +238,63 @@ def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
     assert "pressure mismatch." in " ".join(text_blob.split())
     assert "Inspect propshaft runout/balance" not in text_blob
     assert "ETA:" not in text_blob
+
+
+def test_report_pdf_renders_run_timeline_graph_labels() -> None:
+    finding = make_finding_payload(
+        finding_id="F_TIMELINE",
+        suspected_source="wheel/tire",
+        strongest_location="Front Left wheel",
+        strongest_speed_band="60-80 km/h",
+        confidence=0.82,
+    )
+    summary = minimal_summary(
+        lang="en",
+        duration_s=12.0,
+        findings=[finding],
+        top_causes=[finding],
+        phase_timeline=[
+            {
+                "phase": "cruise",
+                "start_t_s": 0.0,
+                "end_t_s": 4.0,
+                "speed_min_kmh": 58.0,
+                "speed_max_kmh": 63.0,
+                "has_fault_evidence": False,
+            },
+            {
+                "phase": "cruise",
+                "start_t_s": 4.0,
+                "end_t_s": 9.0,
+                "speed_min_kmh": 64.0,
+                "speed_max_kmh": 72.0,
+                "has_fault_evidence": True,
+            },
+            {
+                "phase": "decel",
+                "start_t_s": 9.0,
+                "end_t_s": 12.0,
+                "speed_min_kmh": 48.0,
+                "speed_max_kmh": 62.0,
+                "has_fault_evidence": False,
+            },
+        ],
+    )
+
+    page_one_text = " ".join(
+        (
+            PdfReader(BytesIO(build_report_pdf(map_summary(prepare_report_input(summary)))))
+            .pages[0]
+            .extract_text()
+            or ""
+        )
+        .lower()
+        .split()
+    )
+
+    assert "run timeline" in page_one_text
+    assert "speed" in page_one_text
+    assert "detections" in page_one_text
 
 
 def test_report_pdf_compacts_actionable_system_cards() -> None:

--- a/apps/server/tests/shared/boundaries/test_report_payload_projection.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload_projection.py
@@ -6,6 +6,7 @@ from vibesensor.shared.boundaries.report_payload_projection import (
     active_sensor_locations,
     coerce_count,
     peak_table_rows,
+    phase_timeline_payload,
     report_duration_s,
     sensor_intensity_payload,
     summary_metadata,
@@ -69,6 +70,49 @@ def test_sensor_intensity_payload_returns_tuple_copy() -> None:
     payload = {"sensor_intensity_by_location": [{"location": "front-left"}]}
 
     assert sensor_intensity_payload(payload) == ({"location": "front-left"},)
+
+
+def test_phase_timeline_payload_returns_only_mapping_rows() -> None:
+    payload = {
+        "phase_timeline": [
+            {
+                "phase": "cruise",
+                "start_t_s": 0.0,
+                "end_t_s": 3.0,
+                "speed_min_kmh": 58.0,
+                "speed_max_kmh": 62.0,
+                "has_fault_evidence": False,
+            },
+            "skip-me",
+            {
+                "phase": "cruise",
+                "start_t_s": 3.0,
+                "end_t_s": 6.0,
+                "speed_min_kmh": 60.0,
+                "speed_max_kmh": 64.0,
+                "has_fault_evidence": True,
+            },
+        ]
+    }
+
+    assert phase_timeline_payload(payload) == (
+        {
+            "phase": "cruise",
+            "start_t_s": 0.0,
+            "end_t_s": 3.0,
+            "speed_min_kmh": 58.0,
+            "speed_max_kmh": 62.0,
+            "has_fault_evidence": False,
+        },
+        {
+            "phase": "cruise",
+            "start_t_s": 3.0,
+            "end_t_s": 6.0,
+            "speed_min_kmh": 60.0,
+            "speed_max_kmh": 64.0,
+            "has_fault_evidence": True,
+        },
+    )
 
 
 def test_coerce_count_defaults_invalid_values_to_zero() -> None:

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -69,3 +69,35 @@ def test_prepare_report_facts_shapes_warning_payloads() -> None:
     )
 
     assert [warning["code"] for warning in facts.warnings] == ["PERSISTED_ONLY"]
+
+
+def test_prepare_report_facts_keeps_phase_timeline_intervals() -> None:
+    summary = _summary()
+    summary["phase_timeline"] = [
+        {
+            "phase": "cruise",
+            "start_t_s": 0.0,
+            "end_t_s": 3.0,
+            "speed_min_kmh": 58.0,
+            "speed_max_kmh": 62.0,
+            "has_fault_evidence": False,
+        },
+        {
+            "phase": "accel",
+            "start_t_s": 3.0,
+            "end_t_s": 6.5,
+            "speed_min_kmh": 62.0,
+            "speed_max_kmh": 78.0,
+            "has_fault_evidence": True,
+        },
+    ]
+    test_run = build_test_run_from_summary(summary)
+    assert test_run is not None
+
+    facts = prepare_report_facts(summary, test_run=test_run)
+
+    assert len(facts.timeline_intervals) == 2
+    assert facts.timeline_intervals[0].phase == "cruise"
+    assert facts.timeline_intervals[0].speed_max_kmh == 62.0
+    assert facts.timeline_intervals[1].phase == "accel"
+    assert facts.timeline_intervals[1].has_fault_evidence is True

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -44,6 +44,8 @@ from vibesensor.adapters.pdf.report_data import (
     Report,
     ReportLabelValueRow,
     ReportTemplateData,
+    TimelineGraphData,
+    TimelineGraphInterval,
     TopologyIntensityRow,
     VerdictPageData,
     build_report_from_renderer_payload,
@@ -793,12 +795,67 @@ def _capture_condition_lines(
     ]
 
 
+def _build_timeline_graph_data(
+    report_facts: PreparedReportFacts,
+    *,
+    duration_s: float | None,
+) -> TimelineGraphData | None:
+    max_interval_end = max(
+        (interval.end_t_s or 0.0 for interval in report_facts.timeline_intervals),
+        default=0.0,
+    )
+    resolved_duration = max(float(duration_s or 0.0), max_interval_end)
+    if resolved_duration <= 0:
+        return None
+    intervals: list[TimelineGraphInterval] = []
+    max_speed = 0.0
+    ordered_intervals = sorted(
+        report_facts.timeline_intervals,
+        key=lambda interval: (
+            interval.start_t_s is None,
+            interval.start_t_s or 0.0,
+            interval.end_t_s or 0.0,
+        ),
+    )
+    for interval in ordered_intervals:
+        if interval.start_t_s is None or interval.end_t_s is None:
+            continue
+        start_t_s = max(0.0, interval.start_t_s)
+        end_t_s = min(resolved_duration, interval.end_t_s)
+        if end_t_s <= start_t_s:
+            continue
+        present_speeds = [
+            speed for speed in (interval.speed_min_kmh, interval.speed_max_kmh) if speed is not None
+        ]
+        if present_speeds:
+            max_speed = max(max_speed, *present_speeds)
+        intervals.append(
+            TimelineGraphInterval(
+                phase_label=interval.phase,
+                start_t_s=start_t_s,
+                end_t_s=end_t_s,
+                speed_min_kmh=interval.speed_min_kmh,
+                speed_max_kmh=interval.speed_max_kmh,
+                has_fault_evidence=interval.has_fault_evidence,
+            ),
+        )
+    if not intervals:
+        return None
+    speed_ceiling_kmh = max(10.0, max_speed * 1.10 if max_speed > 0 else 10.0)
+    return TimelineGraphData(
+        duration_s=resolved_duration,
+        speed_ceiling_kmh=speed_ceiling_kmh,
+        intervals=tuple(intervals),
+    )
+
+
 def _build_verdict_page_data(
     *,
     aggregate: TestRun,
     primary: PrimaryCandidateContext,
     report_facts: PreparedReportFacts,
     data_trust: list[DataTrustItem],
+    duration_s: float | None,
     tr: Callable[..., str],
 ) -> VerdictPageData:
     recapture_before_acting = report_facts.action_status_key == "recapture_before_acting"
@@ -845,6 +902,7 @@ def _build_verdict_page_data(
             if recapture_before_acting
             else tr("REPORT_PROOF_PANEL_TITLE")
         ),
+        timeline_graph=_build_timeline_graph_data(report_facts, duration_s=duration_s),
         footer_routes=(
             (tr("REPORT_ROUTE_APPENDIX_A"),)
             if recapture_before_acting
@@ -1135,6 +1193,7 @@ def _build_report_template_data(
         primary=primary,
         report_facts=report_facts,
         data_trust=data_trust,
+        duration_s=report.duration_s,
         tr=tr,
     )
     appendix_a = _build_appendix_a_data(

--- a/apps/server/vibesensor/adapters/pdf/pdf_page1.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_page1.py
@@ -26,6 +26,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     TEXT_CLR,
 )
 from vibesensor.adapters.pdf.pdf_text import _draw_text, _measure_text_height, _wrap_lines
+from vibesensor.adapters.pdf.pdf_timeline_render import run_timeline_graph
 from vibesensor.adapters.pdf.report_data import ReportTemplateData
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.types.json_types import JsonValue
@@ -293,7 +294,28 @@ def _draw_proof_block(
     inner_x = x + 4 * mm
     inner_y = y + h - PANEL_HEADER_H - 2 * mm
     diagram_w = w * 0.42
-    diagram_h = h - 20 * mm
+    left_x = inner_x
+    left_w = diagram_w - 2 * mm
+    left_bottom = y + 7 * mm
+    left_top = inner_y
+    left_content_h = left_top - left_bottom
+    timeline_graph = verdict.timeline_graph
+    diagram_y = left_bottom
+    diagram_h = left_content_h
+    if timeline_graph is not None:
+        timeline_gap = 3.5 * mm
+        desired_timeline_h = min(36 * mm, max(28 * mm, left_content_h * 0.24))
+        min_diagram_h = 220.0
+        if left_content_h >= min_diagram_h + desired_timeline_h + timeline_gap:
+            timeline_h = desired_timeline_h
+            diagram_h = left_content_h - timeline_h - timeline_gap
+            diagram_y = left_bottom + timeline_h + timeline_gap
+            run_timeline_graph(
+                timeline_graph,
+                tr=tr,
+                graph_width=left_w,
+                graph_height=timeline_h,
+            ).drawOn(c, left_x, left_bottom)
     diagram = car_location_diagram(
         data.top_causes or data.findings,
         {
@@ -304,10 +326,10 @@ def _draw_proof_block(
         content_width=w - 8 * mm,
         tr=tr,
         text_fn=lambda en, nl: nl if data.lang == "nl" else en,
-        diagram_width=diagram_w - 2 * mm,
-        diagram_height=diagram_h - 8 * mm,
+        diagram_width=left_w,
+        diagram_height=diagram_h - 2 * mm,
     )
-    diagram.drawOn(c, inner_x, y + 7 * mm)
+    diagram.drawOn(c, left_x, diagram_y)
 
     text_x = x + diagram_w + 5 * mm
     text_w = w - diagram_w - 9 * mm

--- a/apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py
@@ -1,0 +1,278 @@
+"""Drawing assembly for the compact run timeline graph on report page 1."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from vibesensor.adapters.pdf.pdf_drawing import _hex
+from vibesensor.adapters.pdf.pdf_style import FONT, FONT_B, FS_SMALL, REPORT_COLORS
+from vibesensor.adapters.pdf.report_data import TimelineGraphData, TimelineGraphInterval
+
+__all__ = ["run_timeline_graph"]
+
+
+def _format_time_label(seconds: float) -> str:
+    rounded = max(0, int(round(seconds)))
+    minutes, secs = divmod(rounded, 60)
+    if minutes:
+        return f"{minutes}:{secs:02d}"
+    return f"{secs}s"
+
+
+def _x_for_time(*, t_s: float, plot_x: float, plot_w: float, duration_s: float) -> float:
+    if duration_s <= 0:
+        return plot_x
+    bounded = min(max(t_s, 0.0), duration_s)
+    return plot_x + ((bounded / duration_s) * plot_w)
+
+
+def _speed_value(interval: TimelineGraphInterval) -> float | None:
+    speeds = [
+        speed for speed in (interval.speed_min_kmh, interval.speed_max_kmh) if speed is not None
+    ]
+    if not speeds:
+        return None
+    if len(speeds) == 1:
+        return speeds[0]
+    return (speeds[0] + speeds[1]) / 2.0
+
+
+def _y_for_speed(
+    *, speed_kmh: float, plot_y: float, plot_h: float, speed_ceiling_kmh: float
+) -> float:
+    if speed_ceiling_kmh <= 0:
+        return plot_y
+    bounded = min(max(speed_kmh, 0.0), speed_ceiling_kmh)
+    return plot_y + ((bounded / speed_ceiling_kmh) * plot_h)
+
+
+def run_timeline_graph(
+    timeline_graph: TimelineGraphData,
+    *,
+    tr: Callable[..., str],
+    graph_width: float,
+    graph_height: float,
+) -> Any:
+    """Build and return a ReportLab drawing for the proof-block run timeline."""
+    from reportlab.graphics.shapes import Circle, Drawing, Line, PolyLine, Rect, String
+
+    drawing = Drawing(graph_width, graph_height)
+    title_y = graph_height - 9.0
+    legend_y = graph_height - 10.0
+    plot_x = 24.0
+    plot_y = 12.0
+    plot_w = max(72.0, graph_width - 30.0)
+    plot_h = max(28.0, graph_height - 30.0)
+
+    drawing.add(
+        String(
+            0.0,
+            title_y,
+            tr("REPORT_TIMELINE_TITLE"),
+            fontName=FONT_B,
+            fontSize=7.5,
+            fillColor=_hex(REPORT_COLORS["text_primary"]),
+        ),
+    )
+
+    speed_legend_x = plot_x + 2.0
+    detection_legend_x = min(plot_x + (plot_w * 0.52), graph_width - 60.0)
+    drawing.add(
+        Line(
+            speed_legend_x,
+            legend_y,
+            speed_legend_x + 10.0,
+            legend_y,
+            strokeColor=_hex(REPORT_COLORS["brand"]),
+            strokeWidth=1.8,
+        ),
+    )
+    drawing.add(
+        String(
+            speed_legend_x + 13.0,
+            legend_y - 2.6,
+            tr("REPORT_TIMELINE_SPEED_LABEL"),
+            fontName=FONT,
+            fontSize=FS_SMALL,
+            fillColor=_hex(REPORT_COLORS["text_muted"]),
+        ),
+    )
+    drawing.add(
+        Circle(
+            detection_legend_x,
+            legend_y - 0.5,
+            2.4,
+            fillColor=_hex(REPORT_COLORS["danger"]),
+            strokeColor=_hex(REPORT_COLORS["danger"]),
+            strokeWidth=0.0,
+        ),
+    )
+    drawing.add(
+        String(
+            detection_legend_x + 5.0,
+            legend_y - 2.6,
+            tr("REPORT_TIMELINE_DETECTIONS_LABEL"),
+            fontName=FONT,
+            fontSize=FS_SMALL,
+            fillColor=_hex(REPORT_COLORS["text_muted"]),
+        ),
+    )
+
+    drawing.add(
+        Rect(
+            plot_x,
+            plot_y,
+            plot_w,
+            plot_h,
+            fillColor=_hex(REPORT_COLORS["surface"]),
+            strokeColor=_hex(REPORT_COLORS["border"]),
+            strokeWidth=0.8,
+        ),
+    )
+
+    mid_y = plot_y + (plot_h / 2.0)
+    for y_value in (plot_y, mid_y, plot_y + plot_h):
+        drawing.add(
+            Line(
+                plot_x,
+                y_value,
+                plot_x + plot_w,
+                y_value,
+                strokeColor=_hex(REPORT_COLORS["table_row_border"]),
+                strokeWidth=0.5,
+            ),
+        )
+
+    drawing.add(
+        String(
+            plot_x - 4.0,
+            plot_y - 2.0,
+            "0",
+            fontName=FONT,
+            fontSize=FS_SMALL,
+            fillColor=_hex(REPORT_COLORS["text_muted"]),
+            textAnchor="end",
+        ),
+    )
+    drawing.add(
+        String(
+            plot_x - 4.0,
+            plot_y + plot_h - 2.0,
+            str(int(round(timeline_graph.speed_ceiling_kmh))),
+            fontName=FONT,
+            fontSize=FS_SMALL,
+            fillColor=_hex(REPORT_COLORS["text_muted"]),
+            textAnchor="end",
+        ),
+    )
+    drawing.add(
+        String(
+            plot_x,
+            plot_y - 9.0,
+            "0",
+            fontName=FONT,
+            fontSize=FS_SMALL,
+            fillColor=_hex(REPORT_COLORS["text_muted"]),
+        ),
+    )
+    drawing.add(
+        String(
+            plot_x + plot_w,
+            plot_y - 9.0,
+            _format_time_label(timeline_graph.duration_s),
+            fontName=FONT,
+            fontSize=FS_SMALL,
+            fillColor=_hex(REPORT_COLORS["text_muted"]),
+            textAnchor="end",
+        ),
+    )
+
+    speed_line_points: list[float] = []
+    for interval in timeline_graph.intervals:
+        x_start = _x_for_time(
+            t_s=interval.start_t_s,
+            plot_x=plot_x,
+            plot_w=plot_w,
+            duration_s=timeline_graph.duration_s,
+        )
+        x_end = _x_for_time(
+            t_s=interval.end_t_s,
+            plot_x=plot_x,
+            plot_w=plot_w,
+            duration_s=timeline_graph.duration_s,
+        )
+        interval_w = max(1.5, x_end - x_start)
+        if interval.has_fault_evidence:
+            drawing.add(
+                Rect(
+                    x_start,
+                    plot_y,
+                    interval_w,
+                    plot_h,
+                    fillColor=_hex(REPORT_COLORS["card_error_bg"]),
+                    strokeColor=_hex(REPORT_COLORS["card_error_bg"]),
+                    strokeWidth=0.0,
+                ),
+            )
+        if interval.speed_min_kmh is not None or interval.speed_max_kmh is not None:
+            band_low = interval.speed_min_kmh
+            band_high = interval.speed_max_kmh
+            if band_low is None:
+                band_low = band_high
+            if band_high is None:
+                band_high = band_low
+            assert band_low is not None
+            assert band_high is not None
+            y_low = _y_for_speed(
+                speed_kmh=min(band_low, band_high),
+                plot_y=plot_y,
+                plot_h=plot_h,
+                speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
+            )
+            y_high = _y_for_speed(
+                speed_kmh=max(band_low, band_high),
+                plot_y=plot_y,
+                plot_h=plot_h,
+                speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
+            )
+            drawing.add(
+                Rect(
+                    x_start,
+                    y_low,
+                    interval_w,
+                    max(2.0, y_high - y_low),
+                    fillColor=_hex(REPORT_COLORS["brand_surface"]),
+                    strokeColor=_hex(REPORT_COLORS["brand_surface"]),
+                    strokeWidth=0.0,
+                ),
+            )
+        speed_value = _speed_value(interval)
+        if speed_value is not None:
+            y_speed = _y_for_speed(
+                speed_kmh=speed_value,
+                plot_y=plot_y,
+                plot_h=plot_h,
+                speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
+            )
+            speed_line_points.extend([x_start, y_speed, x_end, y_speed])
+            if interval.has_fault_evidence:
+                drawing.add(
+                    Circle(
+                        x_start + (interval_w / 2.0),
+                        y_speed,
+                        2.3,
+                        fillColor=_hex(REPORT_COLORS["danger"]),
+                        strokeColor=_hex(REPORT_COLORS["danger"]),
+                        strokeWidth=0.0,
+                    ),
+                )
+    if speed_line_points:
+        drawing.add(
+            PolyLine(
+                speed_line_points,
+                strokeColor=_hex(REPORT_COLORS["brand"]),
+                strokeWidth=1.8,
+            ),
+        )
+    return drawing

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -27,6 +27,8 @@ __all__ = [
     "ReportTemplateData",
     "RankedCandidateRow",
     "SystemFindingCard",
+    "TimelineGraphData",
+    "TimelineGraphInterval",
     "TopologyIntensityRow",
     "VerdictPageData",
 ]
@@ -150,6 +152,37 @@ class ReportLabelValueRow:
     value: str = ""
 
 
+@dataclass(frozen=True, slots=True)
+class TimelineGraphInterval:
+    """Presentation-ready interval for the page-1 run timeline graph."""
+
+    phase_label: str
+    start_t_s: float
+    end_t_s: float
+    speed_min_kmh: float | None = None
+    speed_max_kmh: float | None = None
+    has_fault_evidence: bool = False
+
+    def __post_init__(self) -> None:
+        if self.end_t_s < self.start_t_s:
+            raise ValueError("TimelineGraphInterval end_t_s must be >= start_t_s")
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineGraphData:
+    """Presentation-ready page-1 run timeline graph content."""
+
+    duration_s: float
+    speed_ceiling_kmh: float
+    intervals: tuple[TimelineGraphInterval, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.duration_s <= 0:
+            raise ValueError("TimelineGraphData duration_s must be positive")
+        if self.speed_ceiling_kmh <= 0:
+            raise ValueError("TimelineGraphData speed_ceiling_kmh must be positive")
+
+
 @dataclass
 class VerdictPageData:
     """Presentation-ready page-1 decision surface content."""
@@ -169,6 +202,7 @@ class VerdictPageData:
     proof_caveat: str | None = None
     proof_panel_title: str | None = None
     footer_routes: tuple[str, ...] = ()
+    timeline_graph: TimelineGraphData | None = None
 
 
 @dataclass

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1959,6 +1959,18 @@
     "en": "Best available location signal",
     "nl": "Best beschikbare locatiesignaal"
   },
+  "REPORT_TIMELINE_TITLE": {
+    "en": "Run timeline",
+    "nl": "Tijdlijn van de rit"
+  },
+  "REPORT_TIMELINE_SPEED_LABEL": {
+    "en": "Speed",
+    "nl": "Snelheid"
+  },
+  "REPORT_TIMELINE_DETECTIONS_LABEL": {
+    "en": "Detections",
+    "nl": "Detecties"
+  },
   "REPORT_PROOF_SUMMARY_RATIO": {
     "en": "{location} outranked the next location by {ratio}x on matched-window linear intensity evidence.",
     "nl": "{location} was {ratio}x sterker dan de volgende locatie op basis van matched-window lineaire intensiteitsbewijzen."

--- a/apps/server/vibesensor/shared/boundaries/report_payload_projection.py
+++ b/apps/server/vibesensor/shared/boundaries/report_payload_projection.py
@@ -7,10 +7,12 @@ from typing import cast
 
 from vibesensor.domain import coerce_float, coerce_int
 from vibesensor.shared.types.analysis_views import PeakTableRow
+from vibesensor.shared.types.history_analysis_contracts import PhaseTimelineEntryResponse
 
 __all__ = [
     "active_sensor_locations",
     "coerce_count",
+    "phase_timeline_payload",
     "peak_table_rows",
     "report_duration_s",
     "sensor_intensity_payload",
@@ -64,6 +66,18 @@ def sensor_intensity_payload(payload: Mapping[str, object]) -> tuple[object, ...
     if not isinstance(raw_sensor_intensity, list):
         return ()
     return tuple(raw_sensor_intensity)
+
+
+def phase_timeline_payload(payload: Mapping[str, object]) -> tuple[PhaseTimelineEntryResponse, ...]:
+    """Return normalized phase-timeline rows from the summary payload."""
+    raw_phase_timeline = payload.get("phase_timeline")
+    if not isinstance(raw_phase_timeline, list):
+        return ()
+    return tuple(
+        cast(PhaseTimelineEntryResponse, row)
+        for row in raw_phase_timeline
+        if isinstance(row, Mapping)
+    )
 
 
 def coerce_count(value: object) -> int:

--- a/apps/server/vibesensor/use_cases/history/report_facts.py
+++ b/apps/server/vibesensor/use_cases/history/report_facts.py
@@ -12,6 +12,7 @@ from vibesensor.domain import (
     RecommendedAction,
     TestRun,
     VibrationOrigin,
+    coerce_float,
 )
 from vibesensor.shared.boundaries.report_facts_projection import (
     report_suitability_checks,
@@ -28,6 +29,7 @@ from vibesensor.shared.boundaries.report_interpretation import (
 )
 from vibesensor.shared.boundaries.report_payload_projection import (
     active_sensor_locations,
+    phase_timeline_payload,
     sensor_intensity_payload,
     summary_metadata,
 )
@@ -65,6 +67,7 @@ class PreparedReportFacts:
     alternative_source: object | None
     alternative_source_visible: bool
     confidence_gap_to_alternative: float | None
+    timeline_intervals: tuple[ReportTimelineInterval, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,6 +78,18 @@ class ReportCoverageSummary:
     active_locations: tuple[str, ...]
     missing_locations: tuple[str, ...]
     partial_locations: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportTimelineInterval:
+    """Prepared semantic snapshot for one report timeline interval."""
+
+    phase: str
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    has_fault_evidence: bool
 
 
 def _normalized_location_token(value: object) -> str:
@@ -272,6 +287,34 @@ def _resolve_action_status_key(
     return "action_ready"
 
 
+def _coerce_optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return coerce_float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _timeline_intervals(payload: Mapping[str, object]) -> tuple[ReportTimelineInterval, ...]:
+    intervals: list[ReportTimelineInterval] = []
+    for row in phase_timeline_payload(payload):
+        phase = str(row.get("phase") or "").strip()
+        if not phase:
+            continue
+        intervals.append(
+            ReportTimelineInterval(
+                phase=phase,
+                start_t_s=_coerce_optional_float(row.get("start_t_s")),
+                end_t_s=_coerce_optional_float(row.get("end_t_s")),
+                speed_min_kmh=_coerce_optional_float(row.get("speed_min_kmh")),
+                speed_max_kmh=_coerce_optional_float(row.get("speed_max_kmh")),
+                has_fault_evidence=bool(row.get("has_fault_evidence")),
+            ),
+        )
+    return tuple(intervals)
+
+
 def prepare_report_facts(
     payload: Mapping[str, object],
     *,
@@ -348,4 +391,5 @@ def prepare_report_facts(
         alternative_source=alternative_source,
         alternative_source_visible=alternative_source_visible,
         confidence_gap_to_alternative=confidence_gap_to_alternative,
+        timeline_intervals=_timeline_intervals(payload),
     )


### PR DESCRIPTION
Fixes #1955

## Summary
This PR uses the space opened up by the smaller page-one car diagram to add a compact run timeline graph to the PDF report. The new chart sits directly below the car diagram inside the existing proof block and shows the run from start to finish with two clearly separated visual layers: a speed range/trace over time and highlighted vibration-detection intervals/events. The goal is to answer the exact questions from the issue in one glance: when notable detections happened, whether those detections were sustained or intermittent, and how they lined up with vehicle speed.

## Problem
Issue #1955 is a follow-up to #1954. The earlier car-diagram work made the proof block less crowded, but it also revealed that the left column still spent a lot of vertical space on a tall region that was no longer information-dense. The PDF could tell a reader which corner won, but it still could not show when during the run the vibration appeared or how the detections related to the speed profile. That missing temporal view made the report weaker than the updated layout allowed it to be.

The cleanest fix was not to add another appendix or a second page. The issue explicitly called for using the reclaimed space below the smaller car image, so this PR keeps the change on the shipped page-one verdict surface and reuses the current proof block rather than inventing a parallel report path.

## Implementation approach
A key design choice here was to reuse the persisted `phase_timeline` payload that the report summary already carries instead of trying to reconstruct time-localized events from higher-level finding strings such as `phases_detected`. The summary contract already stores interval-level timing, speed bounds, and `has_fault_evidence`, which is exactly the signal needed for a compact PDF timeline. Reusing that boundary data kept the implementation smaller and more faithful to the actual analyzed run.

From there, the pipeline becomes: summary payload projection -> history-side prepared facts -> PDF mapping -> page-one renderer. That keeps raw payload access at the boundary/helper layer, keeps semantic report preparation in `report_facts`, and lets the renderer consume a focused presentation model instead of ad hoc dictionaries.

## Main code changes by area
### 1. Lift timeline data through the existing report-preparation seam
I added a `phase_timeline_payload()` helper in `report_payload_projection.py` so report preparation can consume a normalized immutable view of the persisted timeline rows without reading raw summary lists directly. `prepare_report_facts()` now projects those rows into semantic `ReportTimelineInterval` values and stores them on `PreparedReportFacts.timeline_intervals`.

That means the PDF side now receives time-bounded intervals with start/end timestamps, min/max speed, and fault-evidence state through the same prepared-facts seam it already uses for coverage, suitability, warnings, and location reasoning. No new external report schema was required because the needed summary field already existed.

### 2. Extend the renderer-facing report model
On the PDF adapter side, I added `TimelineGraphInterval` and `TimelineGraphData` to `report_data.py`, along with an optional `timeline_graph` field on `VerdictPageData`. The mapper now turns prepared timeline intervals plus the already available report duration into a compact presentation model with validated interval bounds and a computed speed ceiling for rendering.

The mapper also clips unusable intervals, ignores missing timestamp rows, and falls back cleanly when there is not enough valid data to draw the graph. That keeps the renderer simple and avoids making page-one layout code responsible for payload sanitation.

### 3. Render the timeline below the existing car diagram
I added a new `pdf_timeline_render.py` helper that builds a small chart using ReportLab drawing primitives. The chart renders:

- the run timeline from 0 to the run duration,
- a speed range band per interval,
- a speed center trace across the run,
- highlighted detection intervals derived from `has_fault_evidence`, and
- event markers on the speed trace where those intervals occur.

The visual separation is deliberate: speed is shown in the report’s brand color, while vibration detections use the danger/error palette. That keeps the chart legible at normal PDF export size without relying on dense annotations or tiny labels.

`pdf_page1.py` now splits the left side of the proof block when timeline data is available. The car diagram remains at the top, the new run graph is drawn below it, and the right-side explanatory text remains unchanged. I also kept a safe fallback: if the proof block height or available timeline data is insufficient, the page can still render the original full-height car-diagram layout instead of forcing a broken chart.

### 4. Localized report text and packaged runtime data
Because this introduces user-facing text on the PDF itself, I added localized strings for the new panel title and legend labels in both `apps/server/data/report_i18n.json` and the packaged copy under `apps/server/vibesensor/data/report_i18n.json`. That keeps the runtime data sync hygiene intact and lets the timeline graph participate in the same i18n path as the rest of the report.

### 5. Tests
I added focused tests at each seam instead of relying on one end-to-end regression alone:

- `test_report_payload_projection.py` verifies the new payload projection helper.
- `test_report_facts.py` verifies timeline intervals are preserved during history-side report preparation.
- `test_report_new_modules_mapping.py` verifies `map_summary()` builds `VerdictPageData.timeline_graph` from `phase_timeline`.
- `test_pdf_timeline_render.py` verifies the new chart renderer emits the expected labels, speed line, and detection styling.
- `test_report_pdf_rendering.py` verifies the generated PDF page text now includes the new timeline graph labels.

## Validation
I ran focused tests first while iterating:

- `.venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_report_payload_projection.py apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/adapters/pdf/test_pdf_timeline_render.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`

Then I ran the broader repo-equivalent backend checks and the full PDF adapter suite:

- `.venv/bin/python -m ruff check apps/server/vibesensor apps/server/tests tools`
- `.venv/bin/python -m ruff format --check apps/server/vibesensor apps/server/tests tools`
- `.venv/bin/python tools/dev/check_hygiene.py`
- `(cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py)`
- `.venv/bin/python -m vibesensor.cli.preflight apps/server/config.dev.yaml`
- `.venv/bin/python -m vibesensor.cli.preflight apps/server/config.docker.yaml`
- `.venv/bin/python -m vibesensor.cli.preflight apps/server/config.pi.yaml`
- `.venv/bin/python tools/dev/docs_lint.py`
- `.venv/bin/python -m vibesensor.cli.ws_schema_export --check`
- `.venv/bin/python -m vibesensor.cli.http_api_schema_export --check`
- `(cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml)`
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf`

All of those checks passed locally.

## Risks, tradeoffs, and out-of-scope notes
The main tradeoff is that this chart intentionally uses interval-level summary data rather than a denser per-sample plotting pipeline. That keeps the PDF readable and the implementation compact, but it also means the speed layer is a summarized range/trace, not a raw telemetry plot. I think that is the right tradeoff for the report because the issue asked for a compact explanatory view rather than a diagnostic engineering chart.

I also kept the change scoped to the page-one report surface. This PR does not try to redesign other appendix charts, add new history APIs, or infer additional temporal detail from findings beyond what the persisted timeline already provides.

## Environment note
I rechecked the local Docker smoke path, but this environment still does not have a working `docker compose` command or an accessible Docker daemon socket, so product-style compose/simulator smoke validation remains blocked locally. The code-level and test-level validation above did complete successfully.
