### PR TITLE
Show PDF run date in recorded local timezone

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_context.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_context.py
@@ -195,7 +195,11 @@ class TestPrepareReportMappingContext:
             {
                 "run_id": "report-context-metadata",
                 "lang": "en",
-                "metadata": {"car_name": "Track Car", "car_type": "coupe"},
+                "metadata": {
+                    "car_name": "Track Car",
+                    "car_type": "coupe",
+                    "recorded_utc_offset_seconds": 7200,
+                },
                 "report_date": "2026-03-25T10:00:00Z",
                 "record_length": "5m",
                 "start_time_utc": "2026-03-25T09:55:00Z",
@@ -218,7 +222,7 @@ class TestPrepareReportMappingContext:
 
         assert context.car_name == "Track Car"
         assert context.car_type == "coupe"
-        assert context.date_str == "2026-03-25 10:00:00 UTC"
+        assert context.date_str == "2026-03-25 12:00:00 UTC+02:00"
         assert context.start_time_utc == "2026-03-25 09:55:00 UTC"
         assert context.end_time_utc == "2026-03-25 10:00:00 UTC"
         assert context.origin is prepared.report_facts.origin

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -197,11 +197,12 @@ def test_map_summary_formats_report_timestamps_for_header() -> None:
         report_date="2026-03-25T10:00:00Z",
         start_time_utc="2026-03-25T09:55:00.536855+00:00",
         end_time_utc="2026-03-25T10:00:11.901770+00:00",
+        metadata={"recorded_utc_offset_seconds": 7200},
     )
 
     data = map_summary(prepare_report_input(summary))
 
-    assert data.run_datetime == "2026-03-25 10:00:00 UTC"
+    assert data.run_datetime == "2026-03-25 12:00:00 UTC+02:00"
     assert data.start_time_utc == "2026-03-25 09:55:00 UTC"
     assert data.end_time_utc == "2026-03-25 10:00:11 UTC"
 

--- a/apps/server/tests/integration/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/integration/test_io_and_time_guard_regressions.py
@@ -6,7 +6,7 @@ Covers:
   3. gps_speed.resolve_speed() – TOCTOU snapshot of speed_mps
   4. gps_speed._is_gps_stale() – TOCTOU snapshot of last_update_ts
   5. report_cli.main() – PDF generation errors return 1 instead of traceback
-  6. report_mapping_pipeline date_str – includes UTC suffix
+  6. report_mapping_pipeline date_str – uses recorded offset with UTC fallback
 """
 
 from __future__ import annotations
@@ -223,26 +223,22 @@ class TestReportCliErrorHandling:
 
 
 # ------------------------------------------------------------------
-# 6. report_mapping_pipeline – UTC suffix on date_str
+# 6. report_mapping_pipeline – recorded offset on date_str
 # ------------------------------------------------------------------
 
 
-class TestReportDataBuilderUTCSuffix:
-    """date_str in report data must end with ' UTC'."""
+class TestReportDataBuilderRecordedTimezone:
+    """date_str should prefer the recorded offset while keeping a UTC fallback."""
 
-    def test_date_str_has_utc_suffix(self) -> None:
+    def test_date_str_uses_recorded_offset_when_present(self) -> None:
         summary = _make_summary(
             "2025-06-01T14:30:00Z",
-            metadata={"car_name": "TestCar"},
+            metadata={"car_name": "TestCar", "recorded_utc_offset_seconds": 7200},
         )
         result = map_summary(prepare_report_input(summary))
-        assert result.run_datetime is not None
-        assert result.run_datetime.endswith(" UTC"), (
-            f"Expected UTC suffix, got: {result.run_datetime!r}"
-        )
-        assert "2025-06-01 14:30:00" in result.run_datetime
+        assert result.run_datetime == "2025-06-01 16:30:00 UTC+02:00"
 
-    def test_date_str_no_tz_input_still_has_utc(self) -> None:
+    def test_date_str_falls_back_to_utc_when_offset_missing(self) -> None:
         summary = _make_summary("2025-03-15T09:45:22")
         result = map_summary(prepare_report_input(summary))
         assert result.run_datetime == "2025-03-15 09:45:22 UTC"

--- a/apps/server/tests/shared/boundaries/test_report_renderer_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_renderer_payload.py
@@ -11,7 +11,11 @@ from vibesensor.shared.boundaries.report_renderer_payload import (
 def test_build_report_renderer_payload_cleans_metadata_and_date() -> None:
     payload = {
         "run_id": "run-123",
-        "metadata": {"car_name": "  Track Car  ", "car_type": " coupe "},
+        "metadata": {
+            "car_name": "  Track Car  ",
+            "car_type": " coupe ",
+            "recorded_utc_offset_seconds": "7200",
+        },
         "report_date": " 2026-03-25T10:00:00Z ",
     }
 
@@ -26,6 +30,7 @@ def test_build_report_renderer_payload_cleans_metadata_and_date() -> None:
         sample_count=0,
         sensor_count=0,
         peak_table_rows=(),
+        recorded_utc_offset_seconds=7200,
     )
 
 
@@ -82,3 +87,14 @@ def test_build_report_renderer_payload_keeps_peak_table_rows() -> None:
         {"rank": 1, "strength_db": 12.0},
         {"rank": 2, "strength_db": 8.5},
     )
+
+
+def test_build_report_renderer_payload_drops_invalid_recorded_offset() -> None:
+    renderer_payload = build_report_renderer_payload(
+        {
+            "run_id": "bad-offset",
+            "metadata": {"recorded_utc_offset_seconds": "bad"},
+        },
+    )
+
+    assert renderer_payload.recorded_utc_offset_seconds is None

--- a/apps/server/tests/shared/boundaries/test_run_log.py
+++ b/apps/server/tests/shared/boundaries/test_run_log.py
@@ -14,7 +14,13 @@ from vibesensor.shared.boundaries.run_log import (
 )
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
 from vibesensor.shared.sampling import bounded_sample
-from vibesensor.shared.time_utils import format_utc_timestamp, parse_iso8601, utc_now_iso
+from vibesensor.shared.time_utils import (
+    coerce_utc_offset_seconds,
+    format_timestamp_in_recorded_timezone,
+    format_utc_timestamp,
+    parse_iso8601,
+    utc_now_iso,
+)
 from vibesensor.use_cases.run.sample_builder import create_run_metadata
 
 # -- Helpers -------------------------------------------------------------------
@@ -86,6 +92,47 @@ def test_parse_iso8601_returns_none_for_bad_input(value: object) -> None:
 )
 def test_format_utc_timestamp(value: object, expected: str | None) -> None:
     assert format_utc_timestamp(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (7200, 7200),
+        ("7200", 7200),
+        (-19800, -19800),
+        (None, None),
+        ("bad", None),
+        (15 * 60 * 60, None),
+        (True, None),
+    ],
+)
+def test_coerce_utc_offset_seconds(value: object, expected: int | None) -> None:
+    assert coerce_utc_offset_seconds(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "recorded_utc_offset_seconds", "expected"),
+    [
+        ("2025-01-15T10:30:00Z", 7200, "2025-01-15 12:30:00 UTC+02:00"),
+        ("2025-01-15T10:30:00Z", -19800, "2025-01-15 05:00:00 UTC-05:30"),
+        ("2025-01-15 10:30:00", 7200, "2025-01-15 12:30:00 UTC+02:00"),
+        ("2025-01-15T10:30:00Z", None, "2025-01-15 10:30:00 UTC"),
+        ("not-a-date", 7200, "not-a-date"),
+        ("", 7200, None),
+        (None, 7200, None),
+    ],
+)
+def test_format_timestamp_in_recorded_timezone(
+    value: object,
+    recorded_utc_offset_seconds: object,
+    expected: str | None,
+) -> None:
+    assert format_timestamp_in_recorded_timezone(value, recorded_utc_offset_seconds) == expected
+
+
+def test_create_run_metadata_keeps_recorded_utc_offset_seconds() -> None:
+    metadata = _make_run_metadata(recorded_utc_offset_seconds=7200)
+    assert metadata["recorded_utc_offset_seconds"] == 7200
 
 
 # -- as_float_or_none ---------------------------------------------------------

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -669,6 +669,21 @@ def test_run_metadata_captures_active_car_snapshot(make_logger) -> None:
     assert active_car_snapshot["name"] == "Primary"
 
 
+def test_run_metadata_captures_recorded_utc_offset(
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = make_logger()
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run._recorder_types.current_utc_offset_seconds",
+        lambda: 7200,
+    )
+
+    metadata = _build_run_metadata_record(logger, "run-1", "2026-01-01T00:00:00Z")
+
+    assert metadata["recorded_utc_offset_seconds"] == 7200
+
+
 def test_db_persists_when_jsonl_disabled(make_logger, tmp_path: Path) -> None:
     history_db = HistoryDB(tmp_path / "history.db")
     logger = make_logger(history_db=history_db, persist_history_db=True)

--- a/apps/server/vibesensor/adapters/pdf/report_context.py
+++ b/apps/server/vibesensor/adapters/pdf/report_context.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 
 from vibesensor.adapters.pdf.report_data import PatternEvidence
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
-from vibesensor.shared.time_utils import format_utc_timestamp, utc_now_iso
+from vibesensor.shared.time_utils import (
+    format_timestamp_in_recorded_timezone,
+    format_utc_timestamp,
+    utc_now_iso,
+)
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportInput,
     ValidatedPreparedReportInput,
@@ -89,7 +93,10 @@ def prepare_report_mapping_context(
     validated = validate_prepared_report_input(prepared)
     report_facts = validated.report_facts
     report_date = validated.renderer_payload.report_date or utc_now_iso()
-    date_str = format_utc_timestamp(report_date) or str(report_date)
+    date_str = format_timestamp_in_recorded_timezone(
+        report_date,
+        validated.renderer_payload.recorded_utc_offset_seconds,
+    ) or str(report_date)
     return ReportMappingContext(
         car_name=validated.renderer_payload.car_name,
         car_type=validated.renderer_payload.car_type,

--- a/apps/server/vibesensor/shared/boundaries/report_renderer_payload.py
+++ b/apps/server/vibesensor/shared/boundaries/report_renderer_payload.py
@@ -11,6 +11,7 @@ from vibesensor.shared.boundaries.report_payload_projection import (
     report_duration_s,
     summary_metadata,
 )
+from vibesensor.shared.time_utils import coerce_utc_offset_seconds
 from vibesensor.shared.types.analysis_views import PeakTableRow
 
 __all__ = [
@@ -31,6 +32,7 @@ class PreparedReportRendererPayload:
     sample_count: int
     sensor_count: int
     peak_table_rows: tuple[PeakTableRow, ...]
+    recorded_utc_offset_seconds: int | None = None
 
 
 def build_report_renderer_payload(
@@ -47,6 +49,9 @@ def build_report_renderer_payload(
     if isinstance(report_date, str):
         normalized_report_date = report_date.strip()
         report_date_str = normalized_report_date or None
+    recorded_utc_offset_seconds = coerce_utc_offset_seconds(
+        metadata.get("recorded_utc_offset_seconds"),
+    )
     return PreparedReportRendererPayload(
         run_id=str(payload.get("run_id") or "unknown") or "unknown",
         car_name=str(metadata.get("car_name") or "").strip() or None,
@@ -56,4 +61,5 @@ def build_report_renderer_payload(
         sample_count=sample_count,
         sensor_count=sensor_count,
         peak_table_rows=peak_table_rows(payload),
+        recorded_utc_offset_seconds=recorded_utc_offset_seconds,
     )

--- a/apps/server/vibesensor/shared/time_utils.py
+++ b/apps/server/vibesensor/shared/time_utils.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from math import isfinite
+
+_MIN_UTC_OFFSET_SECONDS = -(12 * 60 * 60)
+_MAX_UTC_OFFSET_SECONDS = 14 * 60 * 60
 
 
 def utc_now_iso() -> str:
@@ -36,6 +39,69 @@ def format_utc_timestamp(value: object) -> str | None:
     if dt is None:
         return raw
     return dt.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def coerce_utc_offset_seconds(value: object) -> int | None:
+    """Return a validated UTC offset in seconds, or ``None`` for invalid input."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        offset_seconds = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            return None
+        offset_seconds = int(value)
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            offset_seconds = int(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not (_MIN_UTC_OFFSET_SECONDS <= offset_seconds <= _MAX_UTC_OFFSET_SECONDS):
+        return None
+    return offset_seconds
+
+
+def current_utc_offset_seconds() -> int | None:
+    """Return the current local UTC offset in seconds."""
+    offset = datetime.now().astimezone().utcoffset()
+    if offset is None:
+        return None
+    return coerce_utc_offset_seconds(int(offset.total_seconds()))
+
+
+def _format_utc_offset_label(offset_seconds: int) -> str:
+    if offset_seconds == 0:
+        return "UTC"
+    sign = "+" if offset_seconds > 0 else "-"
+    total_minutes = abs(offset_seconds) // 60
+    hours, minutes = divmod(total_minutes, 60)
+    return f"UTC{sign}{hours:02d}:{minutes:02d}"
+
+
+def format_timestamp_in_recorded_timezone(
+    value: object,
+    recorded_utc_offset_seconds: object,
+) -> str | None:
+    """Format a timestamp in the recorded local offset, falling back to UTC when absent."""
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    dt = parse_iso8601(raw)
+    if dt is None:
+        return raw
+    offset_seconds = coerce_utc_offset_seconds(recorded_utc_offset_seconds)
+    if offset_seconds is None:
+        return format_utc_timestamp(raw)
+    recorded_tz = timezone(timedelta(seconds=offset_seconds))
+    localized = dt.astimezone(recorded_tz)
+    return localized.strftime("%Y-%m-%d %H:%M:%S") + " " + _format_utc_offset_label(offset_seconds)
 
 
 def format_duration_mm_ss(seconds: float) -> str:

--- a/apps/server/vibesensor/use_cases/run/_recorder_types.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from vibesensor.shared.time_utils import current_utc_offset_seconds
 from vibesensor.shared.types.json_types import JsonObject
 
 from .sample_builder import build_run_metadata, firmware_version_for_run
@@ -64,6 +65,7 @@ def _build_run_metadata_record(
         accel_scale_g_per_lsb=recorder.accel_scale_g_per_lsb,
         active_car_snapshot=run_context.car,
         language_provider=recorder._language_provider,
+        recorded_utc_offset_seconds=current_utc_offset_seconds(),
     )
 
 

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -17,6 +17,7 @@ from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.constants.units import MPS_TO_KMH
 from vibesensor.shared.ports import ClientTracker, SensorMetadataReader
 from vibesensor.shared.sensor_metadata import resolve_sensor_presentation
+from vibesensor.shared.time_utils import coerce_utc_offset_seconds
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.payload_types import ClientMetrics
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -267,9 +268,10 @@ def create_run_metadata(
     firmware_version: str | None = None,
     end_time_utc: str | None = None,
     incomplete_for_order_analysis: bool = False,
+    recorded_utc_offset_seconds: int | None = None,
 ) -> JsonObject:
     """Build and return a run-metadata dict from the supplied fields."""
-    return RunMetadata.create(
+    metadata = RunMetadata.create(
         run_id=run_id,
         start_time_utc=start_time_utc,
         sensor_model=sensor_model,
@@ -281,6 +283,10 @@ def create_run_metadata(
         end_time_utc=end_time_utc,
         incomplete_for_order_analysis=incomplete_for_order_analysis,
     ).to_dict()
+    normalized_offset = coerce_utc_offset_seconds(recorded_utc_offset_seconds)
+    if normalized_offset is not None:
+        metadata["recorded_utc_offset_seconds"] = normalized_offset
+    return metadata
 
 
 def build_run_metadata(
@@ -296,6 +302,7 @@ def build_run_metadata(
     accel_scale_g_per_lsb: float | None,
     active_car_snapshot: CarSnapshot | None = None,
     language_provider: Callable[[], str] | None = None,
+    recorded_utc_offset_seconds: int | None = None,
 ) -> JsonObject:
     """Assemble comprehensive run metadata."""
     settings = asdict(analysis_settings_snapshot)
@@ -317,6 +324,7 @@ def build_run_metadata(
         fft_window_size_samples=(fft_window_size_samples if fft_window_size_samples > 0 else None),
         accel_scale_g_per_lsb=accel_scale_g_per_lsb,
         incomplete_for_order_analysis=incomplete,
+        recorded_utc_offset_seconds=recorded_utc_offset_seconds,
     )
     metadata.update(settings)
     metadata["tire_circumference_m"] = (


### PR DESCRIPTION
Fixes #1956

## Summary

This change updates the PDF report so the displayed run date is no longer hard-pinned to UTC. Instead, the report now prefers the timezone offset that was present when the run was recorded and renders the visible date as a localized timestamp with an explicit `UTC±HH:MM` suffix. If older data or incomplete metadata does not include a recorded offset, the report still falls back to the prior UTC rendering path so report generation remains stable and unambiguous.

## Problem

Issue #1956 called out that the current PDF report always shows the run date in UTC, for example `2026-04-01 06:01:16 UTC`, even when the recording happened in a different local timezone. That makes the report less useful because the timestamp is detached from the context in which the vehicle was actually driven and recorded. The issue also explicitly warned against using the timezone of the machine that happens to generate or view the PDF later.

The root cause turned out to be fairly narrow. In the PDF mapping path, `prepare_report_mapping_context()` formats the visible run date through `format_utc_timestamp()`. That function is correct for UTC presentation, but the report path had no separate notion of the recording-session offset to use instead. The existing run metadata stored UTC timestamps such as `start_time_utc` and `end_time_utc`, but it did not surface a fixed recorded timezone offset for the report pipeline.

## Implementation approach

The goal here was to make the smallest complete change that satisfies the issue without broadening the semantics of every timestamp in the system. I intentionally did not reinterpret all stored timestamps as local times, and I did not change the existing UTC-oriented metadata fields that other parts of the product already use. Instead, I added one explicit piece of context: `recorded_utc_offset_seconds`.

That value is captured once at recording time, stored in run metadata, threaded through the prepared report payload, and used only when formatting the user-facing PDF run date. This keeps the behavior tightly scoped to the issue while still making the rendered report date meaningful and reproducible. It also matches the issue’s requirement that the date be based on the recording context rather than the later runtime environment of the renderer.

## Main code changes

The first part of the diff lives in `apps/server/vibesensor/shared/time_utils.py`. I added focused helpers to validate and normalize UTC offsets, capture the current local UTC offset in seconds, and format a timestamp using a recorded offset with an explicit UTC fallback. The coercion helper rejects invalid inputs such as booleans, out-of-range offsets, and non-integer float values so we do not silently serialize malformed timezone data. The formatter keeps the output explicit by rendering values like `UTC+02:00` instead of producing a localized time without a visible offset.

The recorder-side metadata path was then updated in `apps/server/vibesensor/use_cases/run/_recorder_types.py` and `apps/server/vibesensor/use_cases/run/sample_builder.py`. `_build_run_metadata_record()` now captures the current UTC offset when it creates run metadata. `create_run_metadata()` and `build_run_metadata()` now accept that optional offset and persist it only when it validates cleanly. This means newly recorded runs retain the offset that was true when the session started, even if the report is generated later on another machine or under a different local timezone.

On the report boundary side, `apps/server/vibesensor/shared/boundaries/report_renderer_payload.py` now extracts `recorded_utc_offset_seconds` from the summary metadata and makes it available on `PreparedReportRendererPayload`. That preserves a clean contract between the stored summary payload and the PDF mapping layer. The PDF-specific change in `apps/server/vibesensor/adapters/pdf/report_context.py` is deliberately narrow: only the visible `date_str` field now uses the recorded offset formatter. The existing UTC start/end timestamps remain unchanged, which avoids unexpectedly shifting the meaning of other report fields that were not part of this issue.

## Tests and regression coverage

The tests were expanded at every seam touched by the change so the behavior is checked end to end instead of only at one helper layer.

`apps/server/tests/shared/boundaries/test_run_log.py` now covers offset coercion rules, localized timestamp formatting, UTC fallback behavior, and metadata preservation when `create_run_metadata()` receives a recorded offset. `apps/server/tests/use_cases/run/test_metrics_log_helpers.py` adds a recorder-path assertion proving that `_build_run_metadata_record()` actually captures `recorded_utc_offset_seconds` during metadata creation rather than relying on some later reconstruction step.

`apps/server/tests/shared/boundaries/test_report_renderer_payload.py` verifies that the boundary decoder exposes the recorded offset on `PreparedReportRendererPayload`, including the fallback path for missing or invalid values. `apps/server/tests/adapters/pdf/test_report_mapping_context.py` and `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py` verify the actual PDF-facing mapping output.

I also updated `apps/server/tests/integration/test_io_and_time_guard_regressions.py`, which previously enforced the older hard-UTC rendering behavior. That regression test now asserts the behavior that issue #1956 actually wants: prefer the recorded offset when present, and fall back to UTC when it is absent. This protects the contract at an integration level so the mapping path does not quietly regress back to unconditional UTC formatting later.

## Validation

I first ran the focused time/report regression slice:

- `.venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_run_log.py apps/server/tests/shared/boundaries/test_report_renderer_payload.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py -k 'offset or timezone or report_renderer_payload or mapping_context or timestamps or run_metadata'`

That focused run passed with `40 passed`.

After that, I ran the broader backend validation path used for the recent PDF issues:

- `ruff check` over backend/test/tool sources
- `ruff format --check`
- hygiene checks
- backend static guards
- config preflight for dev/docker/pi configs
- docs lint
- websocket and HTTP schema export checks
- `mypy` for the backend package
- `pytest -q apps/server/tests/adapters/pdf`

The first broad pass found only formatting changes in two touched files; after running `ruff format` on those files, the full broad validation suite passed, including `595 passed` in the PDF adapter suite and a clean mypy run.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this change scopes the localization to the displayed report run date instead of reinterpreting every stored timestamp in local time. That is intentional. It solves the user-facing PDF problem without silently changing the meaning of UTC fields that other consumers may depend on. The implementation also stores a fixed numeric offset rather than an IANA timezone name. That is enough for the report requirement, but it does mean this PR is not attempting to reconstruct daylight-saving rules or named timezone identities.

I also rechecked local Docker smoke validation because the repository guidance prefers that after backend changes. That remains blocked in this environment: `docker compose` is unavailable here, `docker-compose` is installed, and `docker info` cannot reach the Docker daemon socket.

## Follow-up

If a future issue wants other report timestamps or other product surfaces to use recorded local time, that can build on the same persisted `recorded_utc_offset_seconds` seam introduced here. For this issue, the change stays intentionally narrow: the PDF report’s run date now reflects the recording timezone when available, clearly labels the offset, and falls back to UTC explicitly when older data does not provide that metadata.
