### PR TITLE
Unify PDF recommendation status callout

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
+++ b/apps/server/tests/adapters/pdf/test_report_rendering_regressions.py
@@ -13,6 +13,7 @@ from reportlab.pdfgen.canvas import Canvas
 import vibesensor.adapters.pdf.panels._panel_header as panel_header
 import vibesensor.adapters.pdf.panels._panel_systems as panel_systems
 import vibesensor.adapters.pdf.panels._panel_trust_steps as panel_trust_steps
+import vibesensor.adapters.pdf.pdf_page1 as pdf_page1
 from vibesensor.adapters.pdf.panels._panel_observations import _draw_additional_observations
 from vibesensor.adapters.pdf.panels._panel_trust_steps import _draw_next_steps_table
 from vibesensor.adapters.pdf.pdf_style import FONT, FS_H2, PdfRenderContext
@@ -22,6 +23,7 @@ from vibesensor.adapters.pdf.report_data import (
     PatternEvidence,
     ReportTemplateData,
     SystemFindingCard,
+    VerdictPageData,
 )
 from vibesensor.report_i18n import tr as report_tr
 
@@ -164,6 +166,64 @@ class TestNextStepCardPadding:
         assert number_x - row_x >= 1.8 * mm
         assert detail_x == action_x
         assert row_top - action_y >= 2.5 * mm
+
+
+class TestHeroActionStatusCallout:
+    """Regression: hero status heading and explanation should share one callout."""
+
+    def test_draw_hero_block_uses_single_status_callout_container(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        canvas = _make_canvas()
+        round_rect_calls: list[tuple[float, float, float, float]] = []
+        drawn_text: list[str] = []
+        original_round_rect = canvas.roundRect
+        original_draw_string = canvas.drawString
+
+        def capture_round_rect(x: float, y: float, w: float, h: float, *args, **kwargs):
+            round_rect_calls.append((float(x), float(y), float(w), float(h)))
+            return original_round_rect(x, y, w, h, *args, **kwargs)
+
+        def capture_draw_string(x: float, y: float, text: str, *args, **kwargs):
+            drawn_text.append(str(text))
+            return original_draw_string(x, y, text, *args, **kwargs)
+
+        monkeypatch.setattr(canvas, "roundRect", capture_round_rect)
+        monkeypatch.setattr(canvas, "drawString", capture_draw_string)
+
+        pdf_page1._draw_hero_block(
+            canvas,
+            ReportTemplateData(
+                lang="en",
+                verdict_page=VerdictPageData(
+                    suspected_source="Wheel / Tire",
+                    action_status="Inspect first — moderate confidence",
+                    action_status_note=(
+                        "Start with the wheel path, but keep the driveline path live if the "
+                        "first inspection is clean."
+                    ),
+                ),
+            ),
+            tr=lambda key, **kwargs: {
+                "UNKNOWN": "Unknown",
+                "REPORT_ACTION_STATUS_LABEL": "Action status",
+                "REPORT_ACTION_STATUS_READY": "Action-ready",
+                "REPORT_ACTION_STATUS_READY_CAUTION": "Inspect first — moderate confidence",
+                "REPORT_ACTION_STATUS_RECAPTURE": "Recapture before acting",
+                "REPORT_SUSPECTED_SOURCE_LABEL": "Suspected source",
+            }[key],
+            x=20 * mm,
+            y=140 * mm,
+            w=170 * mm,
+            h=40 * mm,
+        )
+
+        drawn_text_blob = " ".join(drawn_text)
+
+        assert "Inspect first — moderate confidence" in drawn_text_blob
+        assert "keep the driveline path live" in drawn_text_blob
+        assert len(round_rect_calls) == 2
 
 
 class TestAdditionalObservationsContext:

--- a/apps/server/vibesensor/adapters/pdf/pdf_page1.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_page1.py
@@ -142,17 +142,63 @@ def _status_palette(text: str, *, tr: Callable[..., str]) -> tuple[str, str]:
     return (REPORT_COLORS["card_neutral_bg"], REPORT_COLORS["card_neutral_border"])
 
 
-def _draw_status_pill(c: Canvas, *, text: str, tr: Callable[..., str], x: float, y: float) -> None:
-    fill, border = _status_palette(text, tr=tr)
-    text_w = c.stringWidth(text, FONT_B, FS_SMALL)
-    pill_w = max(32 * mm, text_w + (6 * mm))
-    pill_h = 7 * mm
+def _draw_action_status_callout(
+    c: Canvas,
+    *,
+    status: str,
+    note: str | None,
+    tr: Callable[..., str],
+    x: float,
+    y_top: float,
+    w: float,
+) -> None:
+    fill, border = _status_palette(status, tr=tr)
+    content_w = w - 6 * mm
+    note_text = str(note or "").strip() or None
+    card_h = 4.0 * mm + _measure_text_height(
+        status,
+        w=content_w,
+        size=FS_SMALL,
+        leading=FS_SMALL + 1.0,
+        max_lines=2,
+    )
+    if note_text is not None:
+        card_h += 0.4 * mm + _measure_text_height(
+            note_text,
+            w=content_w,
+            size=FS_SMALL,
+            leading=FS_SMALL + 1.1,
+            max_lines=4,
+        )
+    card_h = float(max(12 * mm, card_h + 2.8 * mm))
     c.setFillColor(_hex(fill))
     c.setStrokeColor(_hex(border))
-    c.roundRect(x, y - pill_h + 1.2 * mm, pill_w, pill_h, 3 * mm, stroke=1, fill=1)
+    c.roundRect(x, y_top - card_h + 1.2 * mm, w, card_h, 2.5 * mm, stroke=1, fill=1)
     c.setFillColor(_hex(TEXT_CLR))
-    c.setFont(FONT_B, FS_SMALL)
-    c.drawString(x + 3 * mm, y - 3.5 * mm, text)
+    text_y = _draw_text(
+        c,
+        x + 3 * mm,
+        y_top - 3.2 * mm,
+        content_w,
+        status,
+        font=FONT_B,
+        size=FS_SMALL,
+        color=TEXT_CLR,
+        leading=FS_SMALL + 1.0,
+        max_lines=2,
+    )
+    if note_text is not None:
+        _draw_text(
+            c,
+            x + 3 * mm,
+            text_y - 0.4 * mm,
+            content_w,
+            note_text,
+            size=FS_SMALL,
+            color=TEXT_CLR,
+            leading=FS_SMALL + 1.1,
+            max_lines=4,
+        )
 
 
 def _draw_label_value(
@@ -243,40 +289,15 @@ def _draw_hero_block(
     c.setFillColor(_hex(SUB_CLR))
     c.setFont(FONT, FS_SMALL)
     c.drawString(right_x, inner_y + 1.2 * mm, tr("REPORT_ACTION_STATUS_LABEL"))
-    _draw_status_pill(
+    _draw_action_status_callout(
         c,
-        text=verdict.action_status or tr("UNKNOWN"),
+        status=verdict.action_status or tr("UNKNOWN"),
+        note=verdict.action_status_note,
         tr=tr,
         x=right_x,
-        y=inner_y - 1.5 * mm,
+        y_top=inner_y - 1.5 * mm,
+        w=right_w,
     )
-    if verdict.action_status_note:
-        note_fill, note_border = _status_palette(verdict.action_status or tr("UNKNOWN"), tr=tr)
-        note_lines = _wrap_lines(verdict.action_status_note, right_w - 6 * mm, FS_SMALL)[:4]
-        note_h = max(10 * mm, 4 * mm + (len(note_lines) * (FS_SMALL + 1.1)))
-        note_top = inner_y - 9.0 * mm
-        c.setFillColor(_hex(note_fill))
-        c.setStrokeColor(_hex(note_border))
-        c.roundRect(
-            right_x,
-            note_top - note_h + 1.2 * mm,
-            right_w,
-            note_h,
-            2.5 * mm,
-            stroke=1,
-            fill=1,
-        )
-        _draw_text(
-            c,
-            right_x + 3 * mm,
-            note_top - 2.0 * mm,
-            right_w - 6 * mm,
-            verdict.action_status_note,
-            size=FS_SMALL,
-            color=TEXT_CLR,
-            leading=FS_SMALL + 1.1,
-            max_lines=4,
-        )
 
 
 def _draw_proof_block(


### PR DESCRIPTION
Fixes #1957

## Summary

This PR merges the page-one PDF recommendation status heading and its explanatory note into a single shared visual callout. Before this change, the hero block rendered the status text as one bordered element and the supporting explanation as a second bordered element below it. The new rendering keeps the existing status palette and typography hierarchy, but presents both pieces inside one shared rounded container so the recommendation reads as one cohesive component.

## Problem

Issue #1957 described a specific visual problem in the PDF report: a recommendation section such as `Inspect first — moderate confidence` followed by its supporting explanation was being rendered as two separate bordered pieces instead of one unified block. The key part of the investigation was identifying the correct seam. It would have been easy to assume this was the larger `What to do next` panel lower on page one, but the actual issue lives in the hero block at the top of page one. In `pdf_page1.py`, the recommendation status was drawn as a standalone colored pill and the explanation text as a second rounded rectangle underneath it. That is exactly the fragmented visual the issue described.

## Implementation approach

I kept this fix deliberately narrow. The issue was about visual cohesion, not about changing the recommendation data model, the mapping layer, or the recommendation copy itself. The cleanest implementation was therefore to stay entirely inside the page-one renderer and preserve the existing `VerdictPageData` contract. Instead of creating new report data types or refactoring the mapping pipeline, I replaced the separate pill-plus-note rendering path with one hero-block status callout helper. That keeps the same content, color system, and status tone mapping while changing only the visual grouping.

## Main code changes

The production change is concentrated in `apps/server/vibesensor/adapters/pdf/pdf_page1.py`. I kept the existing `_status_palette()` helper so the status color mapping remains the same for action-ready, caution, recapture, and neutral cases. I removed the old rendering split where `_draw_status_pill()` handled the title and a second inline block handled the note. In its place, the file now uses a new `_draw_action_status_callout()` helper that measures the status heading and optional note together, computes one shared callout height, draws a single rounded rectangle, and then renders the heading followed by the note inside that same container.

The typography inside the unified callout stays intentionally close to the previous design system. The status heading remains the dominant element through bold text, while the note stays smaller supporting text below it. During review I also tightened a spacing mismatch between the height calculation and the actual drawing offset so the final box padding matches the rendered layout. I did not change the surrounding hero layout, the `What to do next` panel, the recommendation wording, or any appendix workflow content.

## Regression coverage

The supporting test change lives in `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`. I added a focused regression that exercises the private hero-block renderer directly with a real status heading and note. The test spies on `Canvas.roundRect()` and `Canvas.drawString()` so it can assert the important behavior the issue cares about:

- the rendered text still contains the recommendation heading and explanatory note,
- and the hero block now uses one shared status callout container rather than the previous split rendering.

The new assertion checks for two rounded rectangles total in that hero-block draw path: one for the outer hero panel and one for the unified status callout. Previously the equivalent rendering used an additional rounded rectangle because the note lived in its own second container. That makes the regression precise about the visual grouping without relying on fragile source-string matching.

Beyond the new focused regression, I reran the existing PDF rendering and layout tests that cover page-one content extraction and separation. Those tests confirm that the updated hero block still renders the expected report text and does not break other page-one surfaces while the recommendation area changes shape.

## Validation

I first ran a focused PDF slice around the touched renderer and related page-one report tests:

- `apps/server/tests/adapters/pdf/test_report_rendering_regressions.py`
- `apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`
- `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
- `apps/server/tests/adapters/pdf/test_report_analysis_separation.py`

That focused run passed with `38 passed`.

After that, I ran the broader backend validation path used for the recent PDF issue sequence:

- `ruff check` over backend/test/tool sources
- `ruff format --check`
- hygiene checks
- backend static guards
- config preflight for dev/docker/pi configs
- docs lint
- websocket and HTTP schema export checks
- `mypy` for the backend package
- `pytest -q apps/server/tests/adapters/pdf`

The only intermediate issue was an import-order lint failure in the new regression file, which Ruff fixed automatically. After that, the full validation path passed cleanly, including a clean mypy run and `596 passed` in the full PDF adapter suite. I reran the full validation chain once more after the final callout-spacing adjustment so the passing result corresponds to the exact committed diff in this PR.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this PR intentionally solves the split-block problem only at the specific page-one hero status seam described in the issue. It does not attempt a broader redesign of other recommendation panels, next-step tables, or appendix workflow cards. I also kept the existing status palette behavior instead of introducing new styling tokens or a new callout type. That reduces design risk and keeps the updated block consistent with the current report system.

As with the previous PDF issues in this run, I rechecked the local Docker smoke path because the repo guidance prefers that after backend changes. It remains blocked in this environment: `docker compose` is unavailable, `docker-compose` is installed, and `docker info` cannot connect to the Docker daemon socket. I did not treat that as a code blocker because the limitation is environmental rather than related to this renderer change.

## Follow-up

If later report-review feedback calls for broader consolidation of recommendation surfaces elsewhere in the PDF, that can be handled as a separate issue. For #1957, this PR keeps the scope crisp: the page-one recommendation heading and its explanation now render as one shared visual block with the existing status styling, which directly addresses the fragmentation the issue described.
