### PR TITLE
Fix misleading PDF driveline overlap wording

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1687,6 +1687,10 @@
     "en": "{signal} stayed strongest near {location} in the {speed} window.",
     "nl": "{signal} bleef het sterkst bij {location} in het venster {speed}."
   },
+  "REPORT_CANDIDATE_REASON_OVERLAP": {
+    "en": "{signal} remains in scope because wheel and driveline evidence overlap in the {speed} window, so inspect it only if the primary path is clean.",
+    "nl": "{signal} blijft relevant omdat wiel- en aandrijflijnbewijs elkaar overlappen in het venster {speed}, dus inspecteer dit alleen als het primaire pad niets oplevert."
+  },
   "REPORT_CANDIDATE_REASON_WEAK": {
     "en": "{signal} is still in scope, but spatial separation stayed weak in the {speed} window.",
     "nl": "{signal} blijft relevant, maar de ruimtelijke scheiding bleef zwak in het venster {speed}."
@@ -1802,6 +1806,10 @@
   "REPORT_EVIDENCE_SUMMARY_ALT_DETAILED": {
     "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}. {alternative_signal} also stayed strongest near {alternative_location} in the {alternative_speed} band, so {alternative} remains the next path if the primary inspection is clean.",
     "nl": "{source} matchte {matches} bewijsvensters in de band {speed} en bleef het sterkst bij {location}. {alternative_signal} bleef ook het sterkst bij {alternative_location} in de band {alternative_speed}, dus {alternative} blijft het volgende pad als de eerste inspectie niets oplevert."
+  },
+  "REPORT_EVIDENCE_SUMMARY_ALT_OVERLAP": {
+    "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}. Wheel and driveline evidence overlap in that same band, so {alternative} remains the next path only if the primary inspection is clean.",
+    "nl": "{source} matchte {matches} bewijsvensters in de band {speed} en bleef het sterkst bij {location}. Wiel- en aandrijflijnbewijs overlappen in diezelfde band, dus {alternative} blijft alleen het volgende pad als de eerste inspectie niets oplevert."
   },
   "REPORT_EVIDENCE_SUMMARY_SIMPLE": {
     "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}.",

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -640,3 +640,99 @@ def test_map_summary_builds_verdict_timeline_graph_from_phase_timeline() -> None
         (9.0, 12.0),
     ]
     assert [interval.has_fault_evidence for interval in timeline.intervals] == [False, True, False]
+
+
+def test_map_summary_softens_same_corner_wheel_driveline_overlap_wording() -> None:
+    overlap_reason = (
+        "Wheel and driveline evidence overlap, so the system could not strongly "
+        "differentiate between them; inspect both areas."
+    )
+    wheel = make_finding_payload(
+        finding_id="F_WHEEL",
+        suspected_source="wheel/tire",
+        confidence=0.66,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        frequency_hz_or_order="1x wheel order",
+        signatures_observed=["1x wheel order"],
+        matched_points=[
+            {
+                "speed_kmh": 62.0,
+                "predicted_hz": 13.2,
+                "matched_hz": 13.4,
+                "location": "Front Left",
+            },
+            {
+                "speed_kmh": 68.0,
+                "predicted_hz": 14.0,
+                "matched_hz": 14.1,
+                "location": "Front Left",
+            },
+        ],
+        confidence_label_key="CONFIDENCE_MEDIUM",
+        confidence_tone="warn",
+        confidence_pct="66%",
+        confidence_reason=overlap_reason,
+    )
+    driveline = make_finding_payload(
+        finding_id="F_DRIVELINE",
+        suspected_source="driveline",
+        confidence=0.61,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        frequency_hz_or_order="1x driveshaft",
+        signatures_observed=["1x driveshaft"],
+        matched_points=[
+            {
+                "speed_kmh": 62.0,
+                "predicted_hz": 26.4,
+                "matched_hz": 26.8,
+                "location": "Front Left",
+            },
+            {
+                "speed_kmh": 68.0,
+                "predicted_hz": 28.0,
+                "matched_hz": 28.2,
+                "location": "Front Left",
+            },
+        ],
+        confidence_label_key="CONFIDENCE_MEDIUM",
+        confidence_tone="warn",
+        confidence_pct="61%",
+        confidence_reason=overlap_reason,
+    )
+    summary = minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        speed_stats={"steady_speed": True},
+        findings=[wheel, driveline],
+        top_causes=[wheel, driveline],
+        test_plan=[
+            {
+                "action_id": "wheel_balance_and_runout",
+                "what": "ACTION_WHEEL_BALANCE_WHAT",
+                "why": "ACTION_WHEEL_BALANCE_WHY",
+                "confirm": "ACTION_WHEEL_BALANCE_CONFIRM",
+            }
+        ],
+    )
+
+    data = map_summary(prepare_report_input(summary))
+
+    assert data.verdict_page.also_consider is not None
+    assert "Driveline" in data.verdict_page.also_consider
+    assert data.appendix_a.why_alternative_next is not None
+    alternative_reason = data.appendix_a.why_alternative_next.lower()
+    assert "wheel and driveline evidence overlap" in alternative_reason
+    assert "stayed strongest near front-left" not in alternative_reason
+    assert data.appendix_c.evidence_summary is not None
+    evidence_summary = data.appendix_c.evidence_summary.lower()
+    assert "wheel and driveline evidence overlap" in evidence_summary
+    assert "1x driveshaft also stayed strongest near front-left" not in evidence_summary

--- a/apps/server/tests/integration/test_sim_ingestion.py
+++ b/apps/server/tests/integration/test_sim_ingestion.py
@@ -253,3 +253,18 @@ class TestSimulatorIngestion:
         pdf_text = "\n".join((page.extract_text() or "") for page in reader.pages).lower()
         for token in ("what to do next", "evidence", "front-left", "vibesensor simulator"):
             assert token in pdf_text, f"Missing expected report content token: {token!r}"
+
+    def test_report_pdf_softens_wheel_driveline_overlap_wording(self) -> None:
+        """Wheel/driveline overlaps should not read like a localized driveline diagnosis."""
+        pdf_text = "\n".join(
+            page.extract_text() or ""
+            for page in PdfReader(
+                io.BytesIO(_api_bytes(f"/api/history/{self.run_id}/report.pdf")),
+            ).pages
+        ).lower()
+        causes = self.insights.get("top_causes") or []
+        sources = {str(cause.get("suspected_source") or "").lower() for cause in causes}
+
+        assert "1x driveshaft stayed strongest near front-left" not in pdf_text
+        if {"wheel/tire", "driveline"}.issubset(sources):
+            assert "wheel and driveline evidence overlap" in pdf_text

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -58,6 +58,7 @@ from vibesensor.domain import (
     LocationIntensitySummary,
     TestRun,
     VibrationOrigin,
+    VibrationSource,
 )
 from vibesensor.report_i18n import human_location, human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
@@ -432,7 +433,40 @@ def _candidate_signal_text(finding: Finding, *, tr: Callable[..., str]) -> str:
     return tr("REPORT_SIGNAL_FALLBACK")
 
 
-def _candidate_reason_text(finding: Finding, *, tr: Callable[..., str]) -> str:
+def _uses_shared_overlap_wording(
+    primary_finding: Finding,
+    alternative_finding: Finding,
+    *,
+    tr: Callable[..., str],
+) -> bool:
+    sources = {
+        primary_finding.source_normalized,
+        alternative_finding.source_normalized,
+    }
+    if sources != {VibrationSource.WHEEL_TIRE, VibrationSource.DRIVELINE}:
+        return False
+    primary_location = str(primary_finding.strongest_location or "").strip()
+    alternative_location = str(alternative_finding.strongest_location or "").strip()
+    if not primary_location or not alternative_location:
+        return False
+    return (
+        _display_location(primary_location, short=False, tr=tr).strip().lower()
+        == _display_location(
+            alternative_location,
+            short=False,
+            tr=tr,
+        )
+        .strip()
+        .lower()
+    )
+
+
+def _candidate_reason_text(
+    finding: Finding,
+    *,
+    tr: Callable[..., str],
+    use_shared_overlap_wording: bool = False,
+) -> str:
     speed_window = (
         str(
             finding.evidence.focused_speed_band
@@ -443,6 +477,12 @@ def _candidate_reason_text(finding: Finding, *, tr: Callable[..., str]) -> str:
     )
     location = _display_location(finding.strongest_location, tr=tr)
     signal = _candidate_signal_text(finding, tr=tr)
+    if use_shared_overlap_wording:
+        return tr(
+            "REPORT_CANDIDATE_REASON_OVERLAP",
+            signal=signal,
+            speed=speed_window or tr("UNKNOWN"),
+        )
     if finding.weak_spatial_separation:
         return tr(
             "REPORT_CANDIDATE_REASON_WEAK",
@@ -472,14 +512,24 @@ def _ranked_candidates(
 ) -> list[RankedCandidateRow]:
     candidates = list(aggregate.effective_top_causes()[:3])
     rows: list[RankedCandidateRow] = []
+    primary_finding = candidates[0] if candidates else None
     for index, finding in enumerate(candidates):
+        use_shared_overlap_wording = (
+            index > 0
+            and primary_finding is not None
+            and _uses_shared_overlap_wording(primary_finding, finding, tr=tr)
+        )
         rows.append(
             RankedCandidateRow(
                 source_name=human_source(finding.suspected_source, tr=tr),
                 confidence_pct=_confidence_pct_text(finding),
                 inspect_first=_display_location(finding.strongest_location, tr=tr),
                 path_role=f"{index + 1}. {_path_role_text(index, tr=tr)}",
-                reason=_candidate_reason_text(finding, tr=tr),
+                reason=_candidate_reason_text(
+                    finding,
+                    tr=tr,
+                    use_shared_overlap_wording=use_shared_overlap_wording,
+                ),
             ),
         )
     return rows
@@ -492,6 +542,7 @@ def _evidence_summary_text(
     *,
     tr: Callable[..., str],
 ) -> str:
+    effective_causes = aggregate.effective_top_causes()
     matched_windows = report_facts.primary_candidate_facts.matched_evidence_window_count
     speed_window = str(primary.primary_speed or "").strip() or tr("UNKNOWN")
     source = primary.primary_system
@@ -502,12 +553,21 @@ def _evidence_summary_text(
         else None
     )
     alternative_finding = (
-        aggregate.effective_top_causes()[1]
-        if report_facts.alternative_source_visible and len(aggregate.effective_top_causes()) > 1
+        effective_causes[1]
+        if report_facts.alternative_source_visible and len(effective_causes) > 1
         else None
     )
     if alternative is not None and matched_windows is not None:
         if alternative_finding is not None:
+            if _uses_shared_overlap_wording(effective_causes[0], alternative_finding, tr=tr):
+                return tr(
+                    "REPORT_EVIDENCE_SUMMARY_ALT_OVERLAP",
+                    source=source,
+                    matches=matched_windows,
+                    speed=speed_window,
+                    location=location,
+                    alternative=alternative,
+                )
             alternative_signal = _candidate_signal_text(alternative_finding, tr=tr)
             alternative_location = _display_location(alternative_finding.strongest_location, tr=tr)
             alternative_speed = (

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1687,6 +1687,10 @@
     "en": "{signal} stayed strongest near {location} in the {speed} window.",
     "nl": "{signal} bleef het sterkst bij {location} in het venster {speed}."
   },
+  "REPORT_CANDIDATE_REASON_OVERLAP": {
+    "en": "{signal} remains in scope because wheel and driveline evidence overlap in the {speed} window, so inspect it only if the primary path is clean.",
+    "nl": "{signal} blijft relevant omdat wiel- en aandrijflijnbewijs elkaar overlappen in het venster {speed}, dus inspecteer dit alleen als het primaire pad niets oplevert."
+  },
   "REPORT_CANDIDATE_REASON_WEAK": {
     "en": "{signal} is still in scope, but spatial separation stayed weak in the {speed} window.",
     "nl": "{signal} blijft relevant, maar de ruimtelijke scheiding bleef zwak in het venster {speed}."
@@ -1802,6 +1806,10 @@
   "REPORT_EVIDENCE_SUMMARY_ALT_DETAILED": {
     "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}. {alternative_signal} also stayed strongest near {alternative_location} in the {alternative_speed} band, so {alternative} remains the next path if the primary inspection is clean.",
     "nl": "{source} matchte {matches} bewijsvensters in de band {speed} en bleef het sterkst bij {location}. {alternative_signal} bleef ook het sterkst bij {alternative_location} in de band {alternative_speed}, dus {alternative} blijft het volgende pad als de eerste inspectie niets oplevert."
+  },
+  "REPORT_EVIDENCE_SUMMARY_ALT_OVERLAP": {
+    "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}. Wheel and driveline evidence overlap in that same band, so {alternative} remains the next path only if the primary inspection is clean.",
+    "nl": "{source} matchte {matches} bewijsvensters in de band {speed} en bleef het sterkst bij {location}. Wiel- en aandrijflijnbewijs overlappen in diezelfde band, dus {alternative} blijft alleen het volgende pad als de eerste inspectie niets oplevert."
   },
   "REPORT_EVIDENCE_SUMMARY_SIMPLE": {
     "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}.",


### PR DESCRIPTION
Fixes #1959.

## Summary

This change fixes the report wording that made some one-wheel simulator runs read like the system had found a clearly localized driveline fault at the same corner as the injected wheel fault. The underlying diagnostic pipeline was already treating those runs as an ambiguous wheel/tire versus driveline overlap, but the PDF presentation layer was more specific than the evidence justified. In practice that meant the report could keep the correct primary wheel/tire diagnosis while still phrasing the alternative path as if a driveshaft-style signal had independently “stayed strongest near Front-Right” or “Front-Left,” which is exactly the misleading readout called out in the issue.

The important distinction here is that the issue was not simply “a driveline alternative exists.” In the reproduced simulator scenario, the one-wheel mild scene still injects shared shaft-order content, so a near-tied driveline alternative can remain visible even when the top cause is correctly wheel/tire. The problem was that the PDF wording turned that already-ambiguous overlap into language that sounded like a cleanly localized secondary diagnosis. This patch keeps the caution-path alternative visible when it is legitimately close enough to matter, but changes the wording so readers understand it as overlapping wheel/driveline evidence rather than as a separately localized driveline fault.

## Implementation approach

I kept the fix intentionally narrow and report-focused. During investigation I rechecked the simulator and diagnostics layers first because the issue body explicitly mentioned shared shaft-order content in the simulator and overlap behavior in the ranking. That inspection showed three important things.

First, `apply_one_wheel_mild_scenario()` still gives the faulted wheel a mild common-event contribution, which explains why shared shaft-order energy can remain in scope during this scenario. Second, `select_top_causes()` already annotates surfaced wheel/driveline pairs with an explicit “wheel and driveline evidence overlap” confidence reason. Third, the report preparation layer only exposes an alternative source on the caution / near-tie path. Put together, that meant the ambiguity was already being modeled correctly upstream. The misleading step happened later, when the PDF mapping layer converted the alternative finding into human-facing text.

Based on that, I did not suppress the alternative outright and I did not change simulator composition or ranking thresholds. Instead, I added a targeted report-mapping rule: when the primary and alternative findings are exactly a wheel/tire + driveline pair and they resolve to the same displayed corner, the report switches from location-specific alternative wording to explicit overlap wording.

## Main code changes

The core logic lives in `apps/server/vibesensor/adapters/pdf/mapping.py`.

I added `_uses_shared_overlap_wording()`, which identifies the specific ambiguity this issue is about. The helper checks that the pair consists of `wheel/tire` and `driveline`, that both findings have non-empty locations, and that those locations normalize to the same displayed corner using the same location-rendering path the PDF already uses. That keeps the rule aligned with report semantics instead of inventing a second location-normalization system.

I then threaded that helper into two places.

First, `_ranked_candidates()` now tells `_candidate_reason_text()` when a non-primary alternative row should use shared-overlap wording instead of the normal “stayed strongest near {location}” phrasing. That changes appendix-A workflow copy for the alternative path without touching the primary finding’s reasoning.

Second, `_evidence_summary_text()` now chooses a new overlap-specific summary string instead of `REPORT_EVIDENCE_SUMMARY_ALT_DETAILED` when the same wheel/driveline same-corner condition is present. This is the report summary path that previously produced wording closest to the issue’s example sentence.

I also added two localized strings in both `apps/server/data/report_i18n.json` and `apps/server/vibesensor/data/report_i18n.json`:

- `REPORT_CANDIDATE_REASON_OVERLAP`
- `REPORT_EVIDENCE_SUMMARY_ALT_OVERLAP`

Those strings deliberately explain the alternative as overlapping wheel/driveline evidence that should only be inspected after the primary path is checked. I kept both runtime i18n copies in sync because the repository has a hygiene guard for packaged runtime data parity.

## Tests and validation

I added a focused regression in `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py` that builds a medium-confidence wheel/tire primary and driveline alternative at the same corner, with matched windows on both findings so the full appendix-C evidence-summary path is exercised. The test proves three things at once: the alternative still remains visible, appendix A no longer phrases it as “stayed strongest near Front-Left,” and appendix C also avoids the old localized driveshaft sentence while explicitly using the overlap wording.

I also tightened the existing long-simulator report test in `apps/server/tests/integration/test_sim_ingestion.py`. That test now asserts the generated PDF does not regress to the old localized `1x driveshaft stayed strongest near front-left` wording, and when both `wheel/tire` and `driveline` are present in the analyzed top causes it requires the overlap phrase to appear in the PDF instead.

Local validation was run in two layers.

Focused validation:

- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/integration/test_sim_ingestion.py`
- Result: `22 passed, 8 skipped`

Broader backend validation:

- `ruff check`
- `ruff format --check`
- hygiene checks
- backend static guards
- config preflight for dev / docker / pi configs
- docs lint
- websocket and HTTP schema export checks
- mypy
- `pytest -q apps/server/tests/adapters/pdf`
- Result: full chain passed, including `596 passed` in the PDF suite

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that this patch intentionally treats this as a presentation correctness problem, not as a simulator or ranking redesign. That is deliberate. The diagnostics layer is still allowed to keep a close driveline alternative in scope when the overlap is real; the change is that the PDF no longer overstates what that alternative means. This preserves caution for mechanics and reviewers without flattening potentially relevant ambiguity.

I also limited the new wording gate to the already-ambiguous case the report is surfacing: wheel/tire plus driveline, same displayed corner, alternative already visible. That keeps the change from spilling into unrelated alternative-source wording elsewhere in the report.

Out of scope for this PR: changing one-wheel simulator signal composition, re-ranking top causes, or introducing a new structured overlap flag into finding serialization. Those may be reasonable future follow-ups if the project decides to reduce how often the alternative appears at all, but they were not required to fix the misleading PDF wording reported in this issue.
