### PR TITLE
Add PDF sensor-by-sensor appendix view

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1843,6 +1843,14 @@
     "en": "Location snapshot (context p95 dB)",
     "nl": "Locatiesnapshot (context p95 dB)"
   },
+  "REPORT_SENSOR_OBSERVATION_MATRIX_TITLE": {
+    "en": "Sensor-by-sensor signal view",
+    "nl": "Signaalbeeld per sensor"
+  },
+  "REPORT_SENSOR_OBSERVATION_MATRIX_NOTE": {
+    "en": "Cells show each sensor's matched p95 level for that signal relative to the strongest sensor in the row. 0 dB = strongest sensor; lower values mean weaker observation; — = no matched observation retained.",
+    "nl": "Cellen tonen per signaal het gematchte p95-niveau van elke sensor ten opzichte van de sterkste sensor in die regel. 0 dB = sterkste sensor; lagere waarden betekenen zwakkere waarneming; — = geen bewaarde matchwaarneming."
+  },
   "REPORT_LOCATION_COLUMN": {
     "en": "Location",
     "nl": "Locatie"

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -736,3 +736,76 @@ def test_map_summary_softens_same_corner_wheel_driveline_overlap_wording() -> No
     evidence_summary = data.appendix_c.evidence_summary.lower()
     assert "wheel and driveline evidence overlap" in evidence_summary
     assert "1x driveshaft also stayed strongest near front-left" not in evidence_summary
+
+
+def test_map_summary_builds_sensor_observation_matrix_rows() -> None:
+    wheel = make_finding_payload(
+        finding_id="F_SENSOR_MATRIX",
+        suspected_source="wheel/tire",
+        confidence=0.82,
+        strongest_location="Front Left wheel",
+        strongest_speed_band="60-80 km/h",
+        frequency_hz_or_order="1x wheel order",
+        signatures_observed=["1x wheel order"],
+        matched_points=[
+            {
+                "speed_kmh": 62.0,
+                "predicted_hz": 13.2,
+                "matched_hz": 13.3,
+                "location": "Front Left wheel",
+                "amp": 0.10,
+            },
+            {
+                "speed_kmh": 67.0,
+                "predicted_hz": 14.2,
+                "matched_hz": 14.3,
+                "location": "Front Left wheel",
+                "amp": 0.08,
+            },
+            {
+                "speed_kmh": 62.0,
+                "predicted_hz": 13.2,
+                "matched_hz": 13.4,
+                "location": "Front Right wheel",
+                "amp": 0.05,
+            },
+            {
+                "speed_kmh": 67.0,
+                "predicted_hz": 14.2,
+                "matched_hz": 14.4,
+                "location": "Rear Left wheel",
+                "amp": 0.025,
+            },
+        ],
+    )
+    summary = minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[wheel],
+        top_causes=[wheel],
+    )
+
+    data = map_summary(prepare_report_input(summary))
+
+    assert len(data.appendix_b.sensor_observation_rows) == 1
+    row = data.appendix_b.sensor_observation_rows[0]
+    assert row.source_name == "Wheel / Tire"
+    assert row.signal_label == "1x wheel order"
+    assert [cell.location for cell in row.sensor_levels] == [
+        "Front-Left",
+        "Front-Right",
+        "Rear-Left",
+        "Rear-Right",
+    ]
+    assert row.sensor_levels[0].relative_level_db == pytest.approx(0.0)
+    assert row.sensor_levels[1].relative_level_db == pytest.approx(-5.6, abs=0.5)
+    assert row.sensor_levels[2].relative_level_db is not None
+    assert row.sensor_levels[2].relative_level_db < row.sensor_levels[1].relative_level_db
+    assert row.sensor_levels[3].relative_level_db is None

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -9,7 +9,8 @@ import pytest
 from pypdf import PdfReader
 from reportlab.lib.units import mm
 from test_support.core import extract_pdf_text
-from test_support.report_helpers import RUN_END, write_jsonl
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import RUN_END, minimal_summary, write_jsonl
 from test_support.report_helpers import report_run_metadata as _run_metadata
 from test_support.report_helpers import report_sample as _base_sample
 
@@ -66,7 +67,7 @@ def test_report_pdf_no_car_metadata(tmp_path: Path) -> None:
     assert len(reader.pages) == 2
 
 
-def test_report_pdf_two_pages(tmp_path: Path) -> None:
+def test_report_pdf_includes_appendix_b_for_generated_summary(tmp_path: Path) -> None:
     run_path = tmp_path / "two_pages.jsonl"
     records: list[dict[str, object]] = [_run_metadata(tire_circumference_m=2.2)]
     for idx in range(30):
@@ -82,6 +83,54 @@ def test_report_pdf_two_pages(tmp_path: Path) -> None:
     pdf = build_report_pdf(map_summary(prepare_report_input(summary)))
     reader = PdfReader(BytesIO(pdf))
     assert len(reader.pages) == 2
+
+
+def test_report_pdf_action_ready_flow_includes_appendix_b_before_evidence() -> None:
+    finding = make_finding_payload(
+        finding_id="F_APPENDIX_B",
+        suspected_source="wheel/tire",
+        strongest_location="Front Left wheel",
+        strongest_speed_band="60-80 km/h",
+        confidence=0.82,
+        frequency_hz_or_order="1x wheel order",
+        signatures_observed=["1x wheel order"],
+        matched_points=[
+            {
+                "speed_kmh": 62.0,
+                "predicted_hz": 13.2,
+                "matched_hz": 13.3,
+                "location": "Front Left wheel",
+                "amp": 0.10,
+            },
+            {
+                "speed_kmh": 64.0,
+                "predicted_hz": 13.6,
+                "matched_hz": 13.7,
+                "location": "Front Right wheel",
+                "amp": 0.05,
+            },
+        ],
+    )
+    summary = minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[finding],
+        top_causes=[finding],
+    )
+
+    pdf = build_report_pdf(map_summary(prepare_report_input(summary)))
+    reader = PdfReader(BytesIO(pdf))
+
+    assert len(reader.pages) == 4
+    assert "Appendix B: Sensor Topology" in (reader.pages[1].extract_text() or "")
+    assert "Evidence and Run Context" in (reader.pages[2].extract_text() or "")
 
 
 def test_fit_rect_preserve_aspect_wider_box() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -210,6 +210,55 @@ def test_report_pdf_next_steps_do_not_leak_template_tokens() -> None:
     assert "ETA:" not in text_blob
 
 
+def test_report_pdf_renders_sensor_observation_matrix_on_appendix_b() -> None:
+    finding = make_finding_payload(
+        finding_id="F_SENSOR_MATRIX",
+        suspected_source="wheel/tire",
+        strongest_location="Front Left wheel",
+        strongest_speed_band="60-80 km/h",
+        confidence=0.82,
+        frequency_hz_or_order="1x wheel order",
+        signatures_observed=["1x wheel order"],
+        matched_points=[
+            {
+                "speed_kmh": 62.0,
+                "predicted_hz": 13.2,
+                "matched_hz": 13.3,
+                "location": "Front Left wheel",
+                "amp": 0.10,
+            },
+            {
+                "speed_kmh": 64.0,
+                "predicted_hz": 13.6,
+                "matched_hz": 13.7,
+                "location": "Front Right wheel",
+                "amp": 0.05,
+            },
+        ],
+    )
+    summary = minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[finding],
+        top_causes=[finding],
+    )
+
+    pdf = build_report_pdf(map_summary(prepare_report_input(summary)))
+    reader = PdfReader(BytesIO(pdf))
+
+    assert len(reader.pages) >= 3
+    page_two_text = reader.pages[1].extract_text() or ""
+    assert "Sensor-by-sensor signal view" in page_two_text
+    assert "0 dB = strongest sensor" in page_two_text
+
+
 def test_report_pdf_renders_run_timeline_graph_labels() -> None:
     finding = make_finding_payload(
         finding_id="F_TIMELINE",

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
@@ -11,6 +11,7 @@ from vibesensor.vibration_strength import (
     median,
     noise_floor_amp_p20_g,
     percentile,
+    relative_level_db_scalar,
 )
 
 # -- median -------------------------------------------------------------------
@@ -111,3 +112,20 @@ class TestNoiseFloorAmpP20G:
         result = noise_floor_amp_p20_g(combined_spectrum_amp_g=[-1.0, -2.0, 0.01, 0.02])
         # Only non-negative finite values are used
         assert result >= 0.0
+
+
+# -- relative_level_db_scalar --------------------------------------------------
+
+
+class TestRelativeLevelDbScalar:
+    def test_strongest_sensor_stays_at_zero_db(self) -> None:
+        assert relative_level_db_scalar(
+            level_amp_g=0.12,
+            reference_amp_g=0.12,
+        ) == pytest.approx(0.0)
+
+    def test_weaker_sensor_returns_negative_relative_db(self) -> None:
+        assert relative_level_db_scalar(level_amp_g=0.06, reference_amp_g=0.12) == pytest.approx(
+            -5.6,
+            abs=0.3,
+        )

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from math import isfinite
 
 from vibesensor.adapters.pdf._candidate_resolver import (
     PrimaryCandidateContext,
@@ -42,6 +43,8 @@ from vibesensor.adapters.pdf.report_data import (
     Report,
     ReportLabelValueRow,
     ReportTemplateData,
+    SensorObservationCell,
+    SensorObservationMatrixRow,
     TimelineGraphData,
     TimelineGraphInterval,
     TopologyIntensityRow,
@@ -71,6 +74,7 @@ from vibesensor.use_cases.history.report_preparation import (
     prepare_report_input,
     validate_prepared_report_input,
 )
+from vibesensor.vibration_strength import percentile, relative_level_db_scalar
 
 __all__ = [
     "PrimaryCandidateContext",
@@ -1023,7 +1027,9 @@ def _build_appendix_a_data(
 def _build_appendix_b_data(
     *,
     primary: PrimaryCandidateContext,
+    aggregate: TestRun,
     report_facts: PreparedReportFacts,
+    sensor_locations: list[str],
     sensor_intensity: list[LocationIntensitySummary],
     tr: Callable[..., str],
 ) -> AppendixBData:
@@ -1047,6 +1053,11 @@ def _build_appendix_b_data(
         )
         for row in ranked_rows
     ]
+    sensor_observation_rows = _sensor_observation_matrix_rows(
+        aggregate,
+        sensor_locations=sensor_locations,
+        tr=tr,
+    )
     dominance_ratio = report_facts.primary_candidate_facts.dominance_ratio
     return AppendixBData(
         dominant_corner=_display_location(primary.primary_location, tr=tr),
@@ -1063,7 +1074,85 @@ def _build_appendix_b_data(
         coverage_label=_coverage_label(report_facts, tr=tr),
         coverage_notes=_coverage_notes(report_facts, tr=tr),
         intensity_rows=intensity_rows,
+        sensor_observation_rows=sensor_observation_rows,
     )
+
+
+def _sensor_observation_matrix_rows(
+    aggregate: TestRun,
+    *,
+    sensor_locations: list[str],
+    tr: Callable[..., str],
+) -> list[SensorObservationMatrixRow]:
+    if not sensor_locations:
+        return []
+    sensor_labels = [
+        _display_location(location, short=True, tr=tr) for location in sensor_locations
+    ]
+    rows: list[SensorObservationMatrixRow] = []
+    for finding in aggregate.effective_top_causes()[:4]:
+        sensor_levels = _sensor_observation_levels(
+            finding,
+            sensor_labels=sensor_labels,
+            tr=tr,
+        )
+        if not any(cell.relative_level_db is not None for cell in sensor_levels):
+            continue
+        rows.append(
+            SensorObservationMatrixRow(
+                source_name=human_source(finding.suspected_source, tr=tr),
+                signal_label=_candidate_signal_text(finding, tr=tr),
+                sensor_levels=sensor_levels,
+            )
+        )
+    return rows
+
+
+def _sensor_observation_levels(
+    finding: Finding,
+    *,
+    sensor_labels: list[str],
+    tr: Callable[..., str],
+) -> list[SensorObservationCell]:
+    matched_amps_by_location: dict[str, list[float]] = {}
+    for point in finding.matched_points:
+        amp = float(point.amp)
+        if not isfinite(amp) or amp < 0.0:
+            continue
+        location = _display_location(point.location, short=True, tr=tr)
+        matched_amps_by_location.setdefault(location, []).append(amp)
+    representative_amps = {
+        location: percentile(sorted(values), 0.95)
+        for location, values in matched_amps_by_location.items()
+        if values
+    }
+    if not representative_amps:
+        strongest_location = str(finding.strongest_location or "").strip()
+        strongest_label = (
+            _display_location(strongest_location, short=True, tr=tr) if strongest_location else None
+        )
+        return [
+            SensorObservationCell(
+                location=label,
+                relative_level_db=0.0 if label == strongest_label else None,
+            )
+            for label in sensor_labels
+        ]
+    strongest_amp = max(representative_amps.values())
+    return [
+        SensorObservationCell(
+            location=label,
+            relative_level_db=(
+                relative_level_db_scalar(
+                    representative_amps[label],
+                    strongest_amp,
+                )
+                if label in representative_amps
+                else None
+            ),
+        )
+        for label in sensor_labels
+    ]
 
 
 def _build_appendix_c_data(
@@ -1254,7 +1343,9 @@ def _build_report_template_data(
     )
     appendix_b = _build_appendix_b_data(
         primary=primary,
+        aggregate=context.domain_aggregate,
         report_facts=report_facts,
+        sensor_locations=context.sensor_locations_active,
         sensor_intensity=raw_sensor_intensity,
         tr=tr,
     )

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
@@ -31,6 +31,7 @@ from vibesensor.adapters.pdf.pdf_text import (
 )
 from vibesensor.adapters.pdf.report_data import (
     AppendixAData,
+    AppendixBData,
     NextStep,
     ReportLabelValueRow,
     ReportTemplateData,
@@ -433,26 +434,87 @@ def _appendix_b_page(c: Canvas, data: ReportTemplateData) -> None:
 
     bottom_h = top_y - (MARGIN + 8 * mm)
     bottom_y = MARGIN + 8 * mm
-    _draw_panel(
-        c, MARGIN, bottom_y, width, bottom_h, _tr(data.lang, "REPORT_INTENSITY_LADDER_TITLE")
-    )
-    rows = [
-        [row.location, _fmt_db(row.p95_db), row.coverage_state or _tr(data.lang, "UNKNOWN")]
-        for row in appendix.intensity_rows
-    ]
-    _draw_table(
-        c,
-        x=MARGIN + 4 * mm,
-        y=bottom_y + bottom_h - 13 * mm,
-        w=width - 8 * mm,
-        y_bottom=bottom_y + 4 * mm,
-        headers=[
-            _tr(data.lang, "REPORT_LOCATION_COLUMN"),
-            _tr(data.lang, "REPORT_P95_DB_COLUMN"),
-            _tr(data.lang, "REPORT_COVERAGE_STATE_COLUMN"),
-        ],
-        rows=rows,
-        col_widths=[0.42, 0.18, 0.40],
+    if appendix.sensor_observation_rows:
+        _draw_panel(
+            c,
+            MARGIN,
+            bottom_y,
+            width,
+            bottom_h,
+            _tr(data.lang, "REPORT_SENSOR_OBSERVATION_MATRIX_TITLE"),
+        )
+        table_top = (
+            _draw_text(
+                c,
+                MARGIN + 4 * mm,
+                bottom_y + bottom_h - 13 * mm,
+                width - 8 * mm,
+                _tr(data.lang, "REPORT_SENSOR_OBSERVATION_MATRIX_NOTE"),
+                size=FS_SMALL,
+                color=SUB_CLR,
+                leading=FS_SMALL + 1.0,
+                max_lines=3,
+            )
+            - 1.2 * mm
+        )
+        headers = [_tr(data.lang, "REPORT_SIGNAL_COLUMN")] + [
+            cell.location for cell in appendix.sensor_observation_rows[0].sensor_levels
+        ]
+        sensor_column_count = max(1, len(headers) - 1)
+        rows = [
+            [
+                f"{row.source_name}\n{row.signal_label}",
+                *[_fmt_relative_db(cell.relative_level_db) for cell in row.sensor_levels],
+            ]
+            for row in appendix.sensor_observation_rows
+        ]
+        _draw_table(
+            c,
+            x=MARGIN + 4 * mm,
+            y=table_top,
+            w=width - 8 * mm,
+            y_bottom=bottom_y + 4 * mm,
+            headers=headers,
+            rows=rows,
+            col_widths=[0.32] + ([0.68 / sensor_column_count] * sensor_column_count),
+            max_body_lines=3,
+        )
+    else:
+        _draw_panel(
+            c, MARGIN, bottom_y, width, bottom_h, _tr(data.lang, "REPORT_INTENSITY_LADDER_TITLE")
+        )
+        rows = [
+            [row.location, _fmt_db(row.p95_db), row.coverage_state or _tr(data.lang, "UNKNOWN")]
+            for row in appendix.intensity_rows
+        ]
+        _draw_table(
+            c,
+            x=MARGIN + 4 * mm,
+            y=bottom_y + bottom_h - 13 * mm,
+            w=width - 8 * mm,
+            y_bottom=bottom_y + 4 * mm,
+            headers=[
+                _tr(data.lang, "REPORT_LOCATION_COLUMN"),
+                _tr(data.lang, "REPORT_P95_DB_COLUMN"),
+                _tr(data.lang, "REPORT_COVERAGE_STATE_COLUMN"),
+            ],
+            rows=rows,
+            col_widths=[0.42, 0.18, 0.40],
+        )
+
+
+def _has_appendix_b_content(appendix: AppendixBData) -> bool:
+    return any(
+        (
+            appendix.dominant_corner,
+            appendix.runner_up_corner,
+            appendix.dominance_ratio_text,
+            appendix.location_confidence,
+            appendix.coverage_label,
+            appendix.coverage_notes,
+            appendix.intensity_rows,
+            appendix.sensor_observation_rows,
+        )
     )
 
 
@@ -1242,6 +1304,15 @@ def _fmt_hz(value: float | None) -> str:
     if value is None:
         return "—"
     return f"{value:.1f} Hz"
+
+
+def _fmt_relative_db(value: float | None) -> str:
+    if value is None:
+        return "—"
+    clamped = min(0.0, float(value))
+    if clamped > -0.5:
+        return "0 dB"
+    return f"{clamped:.0f} dB"
 
 
 def _draw_table(

--- a/apps/server/vibesensor/adapters/pdf/pdf_engine.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_engine.py
@@ -9,7 +9,9 @@ from reportlab.pdfgen.canvas import Canvas
 
 from vibesensor.adapters.pdf.pdf_appendices import (
     _appendix_a_page,
+    _appendix_b_page,
     _appendix_c_page,
+    _has_appendix_b_content,
     worksheet_step_pages,
 )
 from vibesensor.adapters.pdf.pdf_drawing import _draw_footer
@@ -54,7 +56,10 @@ def _build_canvas_pdf(data: ReportTemplateData) -> bytes:
         if recapture_mode
         else worksheet_step_pages(data.appendix_a, list(data.next_steps), lang=data.lang)
     )
-    total_pages = 2 if recapture_mode else 2 + len(appendix_a_pages)
+    render_appendix_b = not recapture_mode and _has_appendix_b_content(data.appendix_b)
+    total_pages = (
+        2 if recapture_mode else 2 + len(appendix_a_pages) + (1 if render_appendix_b else 0)
+    )
 
     _page1(canvas, data, ctx=ctx)
     _draw_footer(canvas, 1, total_pages, data.title)
@@ -64,17 +69,24 @@ def _build_canvas_pdf(data: ReportTemplateData) -> bytes:
         _appendix_a_page(canvas, data)
         _draw_footer(canvas, 2, total_pages, data.title)
     else:
+        current_page = 2
+        if render_appendix_b:
+            _appendix_b_page(canvas, data)
+            _draw_footer(canvas, current_page, total_pages, data.title)
+            canvas.showPage()
+            current_page += 1
         _appendix_c_page(canvas, data)
-        _draw_footer(canvas, 2, total_pages, data.title)
+        _draw_footer(canvas, current_page, total_pages, data.title)
         rendered_steps = 0
-        for page_number, page_steps in enumerate(appendix_a_pages, start=3):
+        first_appendix_a_page = current_page + 1
+        for page_number, page_steps in enumerate(appendix_a_pages, start=first_appendix_a_page):
             canvas.showPage()
             _appendix_a_page(
                 canvas,
                 data,
                 steps=page_steps,
                 start_number=rendered_steps + 1,
-                continued=page_number > 3,
+                continued=page_number > first_appendix_a_page,
             )
             _draw_footer(canvas, page_number, total_pages, data.title)
             rendered_steps += len(page_steps)

--- a/apps/server/vibesensor/adapters/pdf/report_data.py
+++ b/apps/server/vibesensor/adapters/pdf/report_data.py
@@ -27,6 +27,8 @@ __all__ = [
     "ReportTemplateData",
     "RankedCandidateRow",
     "SystemFindingCard",
+    "SensorObservationCell",
+    "SensorObservationMatrixRow",
     "TimelineGraphData",
     "TimelineGraphInterval",
     "TopologyIntensityRow",
@@ -226,6 +228,23 @@ class TopologyIntensityRow:
 
 
 @dataclass
+class SensorObservationCell:
+    """One per-sensor relative observation cell for a signal row."""
+
+    location: str = ""
+    relative_level_db: float | None = None
+
+
+@dataclass
+class SensorObservationMatrixRow:
+    """One detected signal row in the Appendix B sensor-observation matrix."""
+
+    source_name: str = ""
+    signal_label: str = ""
+    sensor_levels: list[SensorObservationCell] = field(default_factory=list)
+
+
+@dataclass
 class MeasurementRow:
     """One supporting-measurement row in the evidence appendix."""
 
@@ -271,7 +290,7 @@ class AppendixAData:
 
 @dataclass
 class AppendixBData:
-    """Spatial-proof appendix content."""
+    """Spatial-proof appendix content and sensor-by-signal view."""
 
     dominant_corner: str | None = None
     runner_up_corner: str | None = None
@@ -280,6 +299,7 @@ class AppendixBData:
     coverage_label: str | None = None
     coverage_notes: list[str] = field(default_factory=list)
     intensity_rows: list[TopologyIntensityRow] = field(default_factory=list)
+    sensor_observation_rows: list[SensorObservationMatrixRow] = field(default_factory=list)
 
 
 @dataclass

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1843,6 +1843,14 @@
     "en": "Location snapshot (context p95 dB)",
     "nl": "Locatiesnapshot (context p95 dB)"
   },
+  "REPORT_SENSOR_OBSERVATION_MATRIX_TITLE": {
+    "en": "Sensor-by-sensor signal view",
+    "nl": "Signaalbeeld per sensor"
+  },
+  "REPORT_SENSOR_OBSERVATION_MATRIX_NOTE": {
+    "en": "Cells show each sensor's matched p95 level for that signal relative to the strongest sensor in the row. 0 dB = strongest sensor; lower values mean weaker observation; — = no matched observation retained.",
+    "nl": "Cellen tonen per signaal het gematchte p95-niveau van elke sensor ten opzichte van de sterkste sensor in die regel. 0 dB = sterkste sensor; lagere waarden betekenen zwakkere waarneming; — = geen bewaarde matchwaarneming."
+  },
   "REPORT_LOCATION_COLUMN": {
     "en": "Location",
     "nl": "Locatie"

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -46,6 +46,7 @@ __all__ = [
     "noise_floor_amp_p20_g",
     "peak_band_rms_amp_g",
     "percentile",
+    "relative_level_db_scalar",
     "strength_floor_amp_g",
     "VibrationStrengthMetrics",
     "vibration_strength_db_scalar",
@@ -401,6 +402,20 @@ def compute_db(peak_amplitude_g: float, noise_floor_g: float) -> float:
     return vibration_strength_db_scalar(
         peak_band_rms_amp_g=peak_amplitude_g,
         floor_amp_g=noise_floor_g,
+    )
+
+
+def relative_level_db_scalar(level_amp_g: float, reference_amp_g: float) -> float:
+    """Compute a relative dB level against a reference amplitude.
+
+    Uses the canonical vibration-strength formula so report-facing relative views
+    stay aligned with the repo's single dB definition while still producing
+    intuitive ``0 dB`` strongest-row values and negative offsets for weaker
+    sensor observations.
+    """
+    return vibration_strength_db_scalar(
+        peak_band_rms_amp_g=level_amp_g,
+        floor_amp_g=reference_amp_g,
     )
 
 


### PR DESCRIPTION
Fixes #1960

## Summary

This PR adds the missing sensor-by-sensor signal view to the PDF report by finally activating the Appendix B page when the report actually has Appendix B content and filling that page with a per-signal/per-sensor observation matrix. The issue behind #1960 was not that the backend lacked useful per-sensor data, but that the shipped report never surfaced it in a dedicated, legible place. The prepared report input already reconstructs domain findings with `matched_points`, including sensor location, matched frequency, speed window context, and raw observed amplitude. The report pipeline simply stopped short of turning that data into a report-facing view.

The implementation keeps the fix scoped to the existing PDF/report path instead of reopening the analysis pipeline. Appendix B already existed as an unused report seam with a top-level topology layout and a full-width bottom panel. This change wires that page into `build_report_pdf()` for action-ready reports that actually have Appendix B content, keeps recapture-mode behavior unchanged, and upgrades the bottom panel from a generic location snapshot into a dedicated sensor-by-sensor view when detailed matched-point data is available.

## Problem

Issue #1960 asks for a report segment that shows all active sensors, the important detected vibrations, and how much each sensor observed each vibration. Before this change, the report footer already advertised Appendix B, and the codebase even had an `_appendix_b_page()` renderer, but the shipped PDF flow skipped that page entirely. The only spatial appendix that users saw was Appendix C, which focuses on evidence chains and measurements, not cross-sensor comparison.

That meant the report could tell a user which source looked strongest overall while still hiding a useful diagnostic question: for a given detected vibration, which sensors actually saw it strongly, weakly, or not at all? The data required to answer that question was already present in `Finding.matched_points`, and those points survive serialization and reconstruction into the report preparation path. The gap was presentation and mapping, not signal analysis.

## Implementation approach

I kept the fix on the report side and reused the existing Appendix B seam rather than inventing a new page or a second analysis pass.

The main implementation decisions were:

- activate Appendix B only when it has meaningful content, so manually constructed or recapture-mode PDFs that do not populate it keep their existing flow;
- derive the new matrix from `effective_top_causes()` and each finding’s `matched_points`, so the report stays aligned with the same ranked signals the rest of the PDF already presents;
- express the matrix in dB terms to stay within the repo’s post-stop output policy;
- compute each cell as a relative per-sensor matched-point p95 level versus the strongest sensor for that signal, which gives a stable and legible comparison without pretending the report has a new absolute per-signal per-sensor metric.

To keep dB math centralized, I added a small shared helper, `relative_level_db_scalar()`, in `vibration_strength.py` instead of embedding ad hoc logarithms in the PDF adapter.

## Code changes

### Shared strength math

`apps/server/vibesensor/vibration_strength.py`

I added `relative_level_db_scalar(level_amp_g, reference_amp_g)`, which is a semantic wrapper around the repo’s canonical vibration-strength dB formula. This keeps the report adapter on shared math while making the new matrix intent obvious at the call site.

### PDF data model and mapping

`apps/server/vibesensor/adapters/pdf/report_data.py`
`apps/server/vibesensor/adapters/pdf/mapping.py`

I extended `AppendixBData` with a new `sensor_observation_rows` field and introduced lightweight row/cell dataclasses for the matrix. The mapper now builds those rows from the top detected findings using grouped `matched_points` per location.

For each finding, the mapper:

- normalizes sensor labels through the existing report location helpers;
- groups matched-point amplitudes by sensor location;
- computes a representative p95 amplitude for each participating sensor;
- finds the strongest sensor for that signal;
- converts each observed sensor level into a relative dB value against that strongest sensor;
- leaves cells blank when no matched observation was retained for that sensor.

There is also a conservative fallback path for findings without retained matched-point amplitudes: the strongest location still gets a `0 dB` marker while other sensors stay blank instead of inventing unsupported values.

### PDF rendering and page flow

`apps/server/vibesensor/adapters/pdf/pdf_appendices.py`
`apps/server/vibesensor/adapters/pdf/pdf_engine.py`

I activated Appendix B in the canvas render flow when the mapped report actually has Appendix B content. When the report is in recapture mode, the prior recapture flow is unchanged.

Within Appendix B, the top panels remain the same topology and dominance summary blocks. The bottom full-width panel now renders a new “Sensor-by-sensor signal view” table when the matrix data exists. Each row combines the source and detected signal label, and each sensor column shows its relative dB participation for that signal. If detailed matrix data is absent, the panel falls back to the previous location snapshot ladder instead of leaving the appendix empty.

### i18n and copy

`apps/server/data/report_i18n.json`
`apps/server/vibesensor/data/report_i18n.json`

I added the new Appendix B panel title and interpretation note in both canonical and packaged runtime copies so the matrix stays synchronized with the existing runtime-data hygiene checks.

## Validation

I validated this change in two stages.

Focused coverage:

- `pytest -q apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`
- Result: `72 passed`

Broader backend validation:

- `ruff check apps/server/vibesensor apps/server/tests tools`
- `ruff format --check apps/server/vibesensor apps/server/tests tools`
- `python tools/dev/check_hygiene.py`
- `python tools/dev/verify_backend_static_guards.py`
- preflight checks for dev/docker/pi configs
- `python tools/dev/docs_lint.py`
- schema export checks for WS and HTTP API contracts
- backend mypy run
- `pytest -q apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/adapters/pdf`
- Result: all checks passed, including `623 passed` in the final pytest slice

## Risks, tradeoffs, and edge cases

The main design tradeoff here is that the new matrix uses matched-point p95 amplitudes expressed as relative dB versus the strongest sensor for that signal. That is intentional. The issue needs a trustworthy comparison view, but the report path does not currently carry a canonical absolute per-signal per-sensor dB metric. Reusing the matched-point amplitudes and converting them through shared dB math gives a readable diagnostic comparison without fabricating a new contract.

Another important edge case is reports without detailed matched-point coverage. In those cases the appendix still renders safely, and the matrix either falls back to sparse strongest-location-only values or the panel falls back to the previous location snapshot table. That keeps the report robust across older or thinner summaries.

## Out of scope

This PR does not change signal ranking, report conclusions, or the evidence-chain logic in Appendix C. It also does not redesign the topology diagram itself; that remains separate work tracked by later PDF issues. The goal here is to expose already-available cross-sensor evidence in a dedicated report segment, not to broaden the report system beyond what #1960 asks for.
