### PR TITLE
Fix PDF Sensor Topology title consistency

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1668,8 +1668,8 @@
     "nl": "Hermeetplan"
   },
   "REPORT_APPENDIX_B_TITLE": {
-    "en": "Appendix B: Sensor Topology",
-    "nl": "Bijlage B: Sensortopologie"
+    "en": "Sensor Topology",
+    "nl": "Sensortopologie"
   },
   "REPORT_APPENDIX_C_TITLE": {
     "en": "Evidence and Run Context",

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -129,7 +129,9 @@ def test_report_pdf_action_ready_flow_includes_appendix_b_before_evidence() -> N
     reader = PdfReader(BytesIO(pdf))
 
     assert len(reader.pages) == 4
-    assert "Appendix B: Sensor Topology" in (reader.pages[1].extract_text() or "")
+    page_two_text = reader.pages[1].extract_text() or ""
+    assert "Sensor Topology" in page_two_text
+    assert "Appendix B" not in page_two_text
     assert "Evidence and Run Context" in (reader.pages[2].extract_text() or "")
 
 

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1668,8 +1668,8 @@
     "nl": "Hermeetplan"
   },
   "REPORT_APPENDIX_B_TITLE": {
-    "en": "Appendix B: Sensor Topology",
-    "nl": "Bijlage B: Sensortopologie"
+    "en": "Sensor Topology",
+    "nl": "Sensortopologie"
   },
   "REPORT_APPENDIX_C_TITLE": {
     "en": "Evidence and Run Context",


### PR DESCRIPTION
Fixes #1973

## Summary

This PR removes the lone `Appendix B` prefix from the visible Sensor Topology page title in the generated PDF report.

The issue was a report-structure inconsistency rather than a layout bug: the topology page rendered as `Appendix B: Sensor Topology`, while the neighboring pages in the same report rendered as plain section titles such as `Evidence and Run Context` and `Inspection Path`. For a reader looking only at the generated PDF, that isolated `Appendix B` label suggests that Appendix A and Appendix C should also be visibly present in the same naming scheme, but they are not. The result feels incomplete and confusing even though the underlying report data is fine.

The fix keeps the change narrow and user-facing: the page title now renders as `Sensor Topology`, matching the plain-title style already used by the surrounding appendix/workbook pages.

## Problem being solved

Issue #1973 called out a concrete piece of user feedback: “This is called appendix b - but there is no appendix a or c.” I verified that behavior against the live code path rather than assuming it from the issue text.

Using the existing server-side PDF generation flow, I built a representative report sample and extracted the rendered page text. That confirmed the issue exactly as described:

- page 2 rendered `Appendix B: Sensor Topology`
- page 3 rendered `Evidence and Run Context`
- page 4 rendered `Inspection Path`

So the current output was visibly mixing two section-labeling strategies on adjacent report pages. The problem was not that the report had no appendix-related internals at all; it was that the reader-facing titles shown in the PDF did not form a coherent visible sequence.

## Chosen implementation approach

I considered both options implied by the issue:

1. keep appendix lettering and make the whole visible sequence coherent
2. remove the isolated appendix lettering from the topology title

I chose the second option because it is the smallest complete fix and the least risky one for this codebase.

Why that choice makes sense here:

- the inconsistency is currently exposed by a single visible title string
- adjacent pages already use plain, descriptive titles
- expanding the appendix-letter scheme would require broader title changes and could still leave readers with a confusing visible order depending on which pages are present in a particular report
- removing the lone prefix resolves the user-facing confusion without changing page order, layout, data mapping, or report structure semantics

In other words, this PR fixes the actual problem users see in the PDF instead of broadening the change into a bigger report-taxonomy rewrite.

## Main code changes by area

### 1. Report i18n title source

I updated the `REPORT_APPENDIX_B_TITLE` translation in both JSON copies used by the backend report stack:

- `apps/server/vibesensor/data/report_i18n.json`
- `apps/server/data/report_i18n.json`

The English value changed from `Appendix B: Sensor Topology` to `Sensor Topology`.

The Dutch value changed from `Bijlage B: Sensortopologie` to `Sensortopologie`.

This keeps the change exactly where the rendered title originates, so the report behavior changes through the normal translation/data path instead of through renderer-side string overrides.

### 2. PDF regression coverage

I updated the targeted regression in:

- `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`

Instead of asserting the old title text, the test now:

- requires `Sensor Topology` on page 2
- explicitly asserts that `Appendix B` is no longer present on that page
- keeps the existing assertion for `Evidence and Run Context` on the following page

That makes the test cover the issue more directly. It no longer just checks that a page title exists; it checks that the stale standalone appendix label is gone from the user-visible output.

## Schema, contract, config, and documentation impact

There are no schema, API contract, or configuration changes in this PR.

I also did not change renderer layout logic, footer routing, or page ordering. Those areas were inspected while scoping the issue, but they were not necessary to resolve the concrete inconsistency reported in #1973.

I intentionally kept internal design-document taxonomy changes out of this PR as well. The issue is about the generated PDF seen by users, and the minimal runtime fix is the title-string normalization above. If the team later wants to standardize all conceptual appendix naming across design docs and footer route copy, that can be handled as a separate follow-up rather than being bundled into this small production fix.

## Validation performed

I validated the change in four ways:

1. `ruff check tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
2. `ruff format --check tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
3. `pytest -q apps/server/tests/adapters/pdf`
4. a manual sample-PDF verification using the existing backend report pipeline, then extracting page text to confirm:
   - page 2 starts with `Sensor Topology`
   - `Appendix B` is no longer present on page 2

The PDF adapter suite passed in full after the change.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is that this PR standardizes the visible title style around the existing plain-title pages rather than formalizing a full visible appendix-lettering system.

I believe that is the right tradeoff for this issue because:

- it directly addresses the reported user confusion
- it avoids expanding scope into broader report-information architecture changes
- it preserves current layout and pagination behavior
- it keeps the change easy to review and low risk to merge

I also checked whether visible `See A / See B / See C / See D` route copy was surfacing in the extracted sample PDF text and did not find user-visible appendix-letter references there in the same way the page title was visible. Given that result, I kept the fix focused on the proven reader-facing inconsistency rather than speculating about footer behavior that was not necessary to solve the issue.

## Out of scope / follow-ups

Out of scope for this PR:

- redesigning the full appendix naming scheme
- reordering appendix/workbook pages
- changing footer route language
- broader documentation taxonomy cleanup

If we later want every deeper report section to use a single, explicit appendix naming convention everywhere, that should be treated as a larger content-architecture pass. This PR just removes the one user-visible label that currently implies missing appendix sections.
