### PR TITLE
Make PDF orb colors reflect vibration strength

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -2115,6 +2115,10 @@
     "en": "Sensor map",
     "nl": "Sensorkaart"
   },
+  "REPORT_TOPOLOGY_MAP_NOTE": {
+    "en": "Marker color shows relative vibration strength.",
+    "nl": "Markerkleur toont relatieve trillingssterkte."
+  },
   "REPORT_TRACEABILITY_PANEL_TITLE": {
     "en": "Traceability",
     "nl": "Herleidbaarheid"

--- a/apps/server/tests/adapters/pdf/test_diagram_layout.py
+++ b/apps/server/tests/adapters/pdf/test_diagram_layout.py
@@ -161,6 +161,8 @@ def test_choose_label_plan_prefers_inward_offset_before_outward_overflow() -> No
 # ── build_sensor_render_plan ─────────────────────────────────────────────────
 
 _COLORS = {
+    "brand": "#7c3aed",
+    "axis": "#7b8da0",
     "text_secondary": "#52555e",
     "surface_alt": "#f1f2f6",
     "ink": "#1a1c24",
@@ -203,6 +205,7 @@ def test_build_sensor_render_plan_multiple_sensors() -> None:
     assert single is False
     assert len(markers) == 2
     assert labels == []
+    assert markers[0].fill != markers[1].fill
     assert markers[0].outer_radius > markers[0].mid_radius > markers[0].radius
     assert markers[1].outer_radius > markers[1].mid_radius > markers[1].radius
 

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -131,6 +131,7 @@ def test_report_pdf_action_ready_flow_includes_appendix_b_before_evidence() -> N
     assert len(reader.pages) == 4
     page_two_text = reader.pages[1].extract_text() or ""
     assert "Sensor Topology" in page_two_text
+    assert "Marker color shows relative vibration strength." in page_two_text
     assert "Appendix B" not in page_two_text
     assert "Evidence and Run Context" in (reader.pages[2].extract_text() or "")
 

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -89,7 +89,7 @@ def test_sensor_state_mapping_connected_active_inactive_and_disconnected() -> No
     assert states["engine bay"] == "disconnected"
 
 
-def test_marker_gradients_keep_diagnostic_core_color_and_expand_with_intensity() -> None:
+def test_marker_gradients_keep_diagnostic_stroke_and_expand_with_intensity() -> None:
     location_points = {
         "front-left wheel": (40.0, 180.0),
         "front-right wheel": (160.0, 180.0),
@@ -111,7 +111,8 @@ def test_marker_gradients_keep_diagnostic_core_color_and_expand_with_intensity()
     )
     marker_by_name = {marker.name: marker for marker in markers}
 
-    assert marker_by_name["rear-left wheel"].fill == REPORT_COLORS["danger"]
+    assert marker_by_name["rear-left wheel"].fill != REPORT_COLORS["danger"]
+    assert marker_by_name["rear-left wheel"].stroke == REPORT_COLORS["danger"]
     assert (
         marker_by_name["rear-left wheel"].outer_radius
         > marker_by_name["rear-left wheel"].mid_radius
@@ -123,6 +124,8 @@ def test_marker_gradients_keep_diagnostic_core_color_and_expand_with_intensity()
         > marker_by_name["front-left wheel"].mid_radius
     )
     assert marker_by_name["front-left wheel"].mid_radius > marker_by_name["front-left wheel"].radius
+    assert marker_by_name["front-left wheel"].stroke == marker_by_name["front-left wheel"].fill
+    assert marker_by_name["front-left wheel"].fill != marker_by_name["front-right wheel"].fill
     assert marker_by_name["front-left wheel"].radius > marker_by_name["rear-left wheel"].radius
     assert marker_by_name["engine bay"].state == "disconnected"
     assert marker_by_name["engine bay"].outer_fill != marker_by_name["engine bay"].fill
@@ -410,8 +413,9 @@ def test_render_plan_prefers_diagnosed_location_when_intensity_hotspot_differs()
         colors=REPORT_COLORS,
     )
     marker_by_name = {marker.name: marker for marker in markers}
-    assert marker_by_name["front-left wheel"].fill == REPORT_COLORS["text_secondary"]
-    assert marker_by_name["rear-left wheel"].fill == REPORT_COLORS["danger"]
+    assert marker_by_name["front-left wheel"].fill != marker_by_name["rear-left wheel"].fill
+    assert marker_by_name["rear-left wheel"].fill != REPORT_COLORS["danger"]
+    assert marker_by_name["rear-left wheel"].stroke == REPORT_COLORS["danger"]
 
 
 def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> None:

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -121,6 +121,12 @@ def _blend_hex(base: str, target: str, *, target_weight: float) -> str:
     return f"#{mixed[0]:02x}{mixed[1]:02x}{mixed[2]:02x}"
 
 
+def _intensity_fill(*, normalized: float, colors: Mapping[str, str]) -> str:
+    low = colors.get("axis", "#7b8da0")
+    high = colors.get("brand", "#7c3aed")
+    return _blend_hex(low, high, target_weight=_clamp_unit(normalized))
+
+
 def _gradient_layers(
     *,
     base_fill: str,
@@ -266,6 +272,16 @@ def build_sensor_render_plan(
         amp = amp_by_location[name]
         return _clamp_unit((amp - min_amp) / (max_amp - min_amp))
 
+    def intensity_fill_weight(name: str) -> float:
+        if name not in amp_by_location:
+            return 0.45
+        if min_amp is None or max_amp is None:
+            return 0.72
+        if min_amp == max_amp:
+            return 1.0 if active_count == 1 else 0.72
+        amp = amp_by_location[name]
+        return _clamp_unit((amp - min_amp) / (max_amp - min_amp))
+
     def active_radius(name: str, *, highlighted: bool) -> float:
         normalized = intensity_emphasis(name)
         if highlighted:
@@ -276,24 +292,33 @@ def build_sensor_render_plan(
     for name, (px, py) in location_points.items():
         state = states[name]
         if state == "connected-active":
-            if name in highlight:
+            if single_sensor and name in highlight:
                 fill = highlight[name]
+                stroke = fill
                 radius = active_radius(name, highlighted=True)
+                stroke_width = 0.75
             else:
-                fill = colors["text_secondary"]
-                radius = active_radius(name, highlighted=False)
-            stroke_width = 0.75
+                fill = _intensity_fill(
+                    normalized=intensity_fill_weight(name),
+                    colors=colors,
+                )
+                stroke = highlight.get(name, fill)
+                radius = active_radius(name, highlighted=name in highlight)
+                stroke_width = 0.9 if name in highlight else 0.75
         elif state == "connected-inactive":
             if name in highlight:
                 fill = highlight[name]
+                stroke = highlight[name]
                 radius = 3.6
                 stroke_width = 0.62
             else:
                 fill = colors["surface_alt"]
+                stroke = fill
                 radius = 3.15
                 stroke_width = 0.58
         else:
             fill = "#d8dfea"
+            stroke = fill
             radius = 2.6
             stroke_width = 0.5
         emphasis = intensity_emphasis(name) if state == "connected-active" else 0.45
@@ -309,7 +334,7 @@ def build_sensor_render_plan(
             y=py,
             state=state,
             fill=fill,
-            stroke=fill,
+            stroke=stroke,
             stroke_width=stroke_width,
             radius=radius,
             mid_fill=mid_fill,

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices.py
@@ -334,6 +334,17 @@ def _appendix_b_page(c: Canvas, data: ReportTemplateData) -> None:
     top_y = title_y - top_h
 
     _draw_panel(c, MARGIN, top_y, left_w, top_h, _tr(data.lang, "REPORT_TOPOLOGY_MAP_TITLE"))
+    _draw_text(
+        c,
+        MARGIN + 4 * mm,
+        top_y + top_h - PANEL_HEADER_H - 2 * mm,
+        left_w - 8 * mm,
+        _tr(data.lang, "REPORT_TOPOLOGY_MAP_NOTE"),
+        size=FS_SMALL,
+        color=SUB_CLR,
+        leading=FS_SMALL + 1.0,
+        max_lines=1,
+    )
     diagram = car_location_diagram(
         data.top_causes or data.findings,
         {

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2115,6 +2115,10 @@
     "en": "Sensor map",
     "nl": "Sensorkaart"
   },
+  "REPORT_TOPOLOGY_MAP_NOTE": {
+    "en": "Marker color shows relative vibration strength.",
+    "nl": "Markerkleur toont relatieve trillingssterkte."
+  },
   "REPORT_TRACEABILITY_PANEL_TITLE": {
     "en": "Traceability",
     "nl": "Herleidbaarheid"


### PR DESCRIPTION
Fixes #1974

## Summary

This PR makes the car-diagram sensor orbs in the PDF report communicate a meaningful report value instead of relying on decorative or source-colored styling.

Before this change, the orb treatment did not let a reader quickly understand relative vibration strength. In practice, the diagnosed location could be shown with a source-derived accent color while the other active sensors stayed neutral, and intensity only affected size/halo. That meant the map visually emphasized diagnosis, but it did not actually tell the reader which sensors measured stronger or weaker vibration at a glance.

After this change, connected active orb **fill color** is driven by relative vibration intensity, so stronger sensors render with a stronger purple tone and weaker sensors step down toward a cooler muted tone. I kept a smaller amount of diagnostic emphasis by using the diagnosed location as a **stroke/fallback** rather than letting source color override the intensity fill. I also added a short note on the Sensor map panel so the report explicitly tells the reader that marker color represents relative vibration strength.

## Problem being solved

Issue #1974 came from report-review feedback that the sensor orbs should have a meaningful color, for example the strength of vibration detected at each sensor. I verified that concern against a real rendered sample before changing code.

Using the existing backend PDF generation flow, I built a representative page-2 sample with four connected wheel sensors and intentionally different p95 intensity values. The baseline render confirmed the issue clearly:

- the dominant front-left orb used a strong purple treatment
- the other active wheel orbs stayed largely gray/neutral
- relative strength differences such as `0 dB`, `-2 dB`, `-6 dB`, and `-10 dB` in the table below were not expressed clearly by orb color on the map

So the current map did not fail because it lacked data; it failed because the visual encoding on the orbs was not tied strongly enough to that data.

## Chosen implementation approach

I chose a two-part fix:

1. make active orb fill colors intensity-driven on a consistent within-report scale
2. add a small page-2 note so the meaning of the color treatment is explicit to the reader

I intentionally did **not** turn this into a broader redesign of the page or an absolute dB heat legend. The issue asked for meaningful orb color, not a new visualization system. A relative within-report scale is enough to make the map informative and reviewable without changing the underlying report model or cluttering the diagram with heavy annotation.

I also chose not to remove diagnosed-location emphasis entirely. Instead of source color owning the orb fill, the diagnosed location can still retain an accent stroke or existing fallback behavior in edge cases where intensity color is not the right signal (for example, highlighted locations without active intensity data, or single-sensor fallback behavior already covered by tests). That keeps diagnosis emphasis available without breaking the core requirement that orb color itself should communicate strength.

## Main code changes by area

### 1. Intensity-driven orb fill planning

The core behavior change lives in:

- `apps/server/vibesensor/adapters/pdf/diagram_layout.py`

The marker render plan now computes a fill color for connected active markers from relative intensity rather than defaulting to source highlight or a neutral text color.

Concretely:

- I added an intensity-fill helper that interpolates across a stable sequential color ramp for active markers.
- I kept radius/halo growth tied to intensity, so size and color now reinforce the same data dimension instead of competing with each other.
- For multi-sensor active cases, diagnosed/source highlight no longer overrides the fill color. Instead, the diagnosed location can keep a stronger stroke so diagnosis emphasis is still visible without defeating the intensity encoding.
- Connected inactive and disconnected markers keep neutral/fallback behavior, because those states do not carry the same comparable active-intensity signal.
- Single-sensor highlighted fallback behavior is preserved where a relative color scale would not add meaningful comparison value.

### 2. Reader-facing cue on the report page

I added a short explanatory note to the Appendix B / Sensor Topology page in:

- `apps/server/vibesensor/adapters/pdf/pdf_appendices.py`

The note reads:

- `Marker color shows relative vibration strength.`

This is small, local to the Sensor map panel, and intentionally low-noise. It gives readers the missing semantic cue without introducing a bulky legend or changing the page’s overall structure.

### 3. i18n data updates

I added the new note string in both backend report i18n JSON files:

- `apps/server/vibesensor/data/report_i18n.json`
- `apps/server/data/report_i18n.json`

No schema, API, or contract changes were needed.

### 4. Regression coverage updates

I updated the relevant PDF tests to cover the new semantics:

- `apps/server/tests/adapters/pdf/test_diagram_layout.py`
- `apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py`
- `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`

The test updates do three important things:

- assert that multiple active sensors no longer collapse to the same neutral fill when their intensities differ
- assert that diagnosed emphasis is retained as stroke/fallback rather than fill override for active multi-sensor cases
- assert that page 2 now includes the explicit Sensor map note explaining the color meaning

## Validation performed

I validated the change at three levels.

### Static / local checks

- `ruff check` on the touched PDF renderer and test files
- `ruff format --check` on the touched files

### Automated tests

- `pytest -q apps/server/tests/adapters/pdf`

The full PDF adapter suite passed after the change.

### Fresh rendered PDF review

I regenerated a representative page-2 sample before and after the change and reviewed the rendered output from the PDF itself.

In the final render:

- all active wheel sensors now participate in a visible strength gradient
- the weakest rear-right orb is visually quieter than the stronger front-side sensors
- the map no longer relies on one decorative accent orb plus neutral neighbors
- the panel note makes the color meaning explicit without crowding the car diagram

The local comparison artifacts used for review are under:

- `.tmp/issue-1974/issue-1974-page2-car-crop.png`
- `.tmp/issue-1974/issue-1974-after-page2-car-crop.png`
- `.tmp/issue-1974/issue-1974-final-page2-car-crop.png`
- `.tmp/issue-1974/issue-1974-final-page-2.png`

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that this introduces a stronger within-report intensity palette, which slightly reduces the old source-color dominance on active markers. I think that tradeoff is correct because the issue specifically asks for orb color to communicate measurement strength.

I also considered adding a larger legend, but that would have been more layout-heavy than necessary. The one-line cue is enough to explain the visual encoding while keeping the page clean.

For edge cases, I preserved fallback behavior for cases where relative intensity coloring is not meaningful enough on its own, especially around non-active or single-sensor situations already covered by the existing tests.

## Out of scope

This PR does not:

- redesign the entire Sensor map panel
- add an absolute dB heatmap legend
- change the sensor-by-sensor table structure
- change the underlying report data model

It focuses on making the existing orb visualization meaningful, legible, and explicit in the rendered PDF.
