### PR TITLE
Align proof panel and explain caution confidence

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1867,6 +1867,18 @@
     "en": "Limited by run context",
     "nl": "Beperkt door runcontext"
   },
+  "REPORT_LOCATION_CONFIDENCE_CLOSE_SCORES": {
+    "en": "Top causes stayed too close to separate cleanly",
+    "nl": "De belangrijkste oorzaken bleven te dicht bij elkaar om ze duidelijk te scheiden"
+  },
+  "REPORT_LOCATION_CONFIDENCE_RATIO_REASON": {
+    "en": "Top corner was only {ratio}x stronger than the next corner",
+    "nl": "De sterkste hoek was slechts {ratio}x sterker dan de volgende hoek"
+  },
+  "REPORT_LOCATION_CONFIDENCE_MODERATE_DETAIL": {
+    "en": "Evidence separation stayed moderate in this run",
+    "nl": "De scheiding in het bewijs bleef in deze run gematigd"
+  },
   "REPORT_LOCATION_CONFIDENCE_STRONG": {
     "en": "Strong",
     "nl": "Sterk"

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -211,6 +211,67 @@ def test_build_report_pdf_renders_data_trust_warning_detail() -> None:
     assert "frame integrity" in text
 
 
+def test_build_report_pdf_replaces_limited_run_context_with_concrete_reason() -> None:
+    summary = minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        sensor_intensity_by_location=[
+            {"location": "Front Left", "p95_intensity_db": 24.0, "mean_intensity_db": 20.0},
+            {"location": "Front Right", "p95_intensity_db": 12.0, "mean_intensity_db": 9.0},
+            {"location": "Rear Left", "p95_intensity_db": 9.0, "mean_intensity_db": 7.0},
+            {"location": "Rear Right", "p95_intensity_db": 8.0, "mean_intensity_db": 6.0},
+        ],
+        findings=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.65,
+                "strongest_location": "Front Left",
+                "strongest_speed_band": "60-80 km/h",
+                "dominance_ratio": 1.9,
+            }
+        ],
+        top_causes=[
+            {
+                "finding_id": "F001",
+                "suspected_source": "wheel/tire",
+                "confidence": 0.65,
+                "strongest_location": "Front Left",
+                "strongest_speed_band": "60-80 km/h",
+                "dominance_ratio": 1.9,
+            }
+        ],
+        run_suitability=[
+            {
+                "check": "Potential saturation samples detected",
+                "check_key": "SUITABILITY_CHECK_SATURATION_AND_OUTLIERS",
+                "state": "warn",
+            },
+            {
+                "check": "Frame integrity",
+                "check_key": "SUITABILITY_CHECK_FRAME_INTEGRITY",
+                "state": "pass",
+            },
+        ],
+        samples=[],
+    )
+
+    pdf = build_report_pdf(map_summary(prepare_report_input(summary)))
+    page_one_text = " ".join(
+        (PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split()
+    )
+
+    assert "limited by run context" not in page_one_text
+    assert "speed was not steady during measurement" in page_one_text
+
+
 def test_build_report_pdf_renders_action_ready_status_on_page_one() -> None:
     pdf = build_report_pdf(
         ReportTemplateData(

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -367,6 +367,53 @@ def test_tall_narrow_page1_diagram_stays_inside_bounds_without_sensor_labels() -
         assert box[3] <= float(diagram.height) + 0.1
 
 
+def test_tall_narrow_page1_diagram_can_top_align_orientation_labels() -> None:
+    summary = {
+        "sensor_locations": [
+            "front-left wheel",
+            "front-right wheel",
+            "rear-left wheel",
+            "rear-right wheel",
+        ],
+        "sensor_intensity_by_location": [
+            LocationIntensitySummary(location="front-left wheel", p95_intensity_db=31.1),
+            LocationIntensitySummary(location="front-right wheel", p95_intensity_db=34.9),
+            LocationIntensitySummary(location="rear-left wheel", p95_intensity_db=30.9),
+            LocationIntensitySummary(location="rear-right wheel", p95_intensity_db=31.4),
+        ],
+    }
+    centered = car_location_diagram(
+        [{"strongest_location": "front-right wheel", "suspected_source": "wheel/tire"}],
+        summary,
+        [],
+        content_width=300.0,
+        tr=lambda key, **kwargs: key,
+        text_fn=lambda en, nl: en,
+        diagram_width=128.0,
+        diagram_height=490.0,
+    )
+    top_aligned = car_location_diagram(
+        [{"strongest_location": "front-right wheel", "suspected_source": "wheel/tire"}],
+        summary,
+        [],
+        content_width=300.0,
+        tr=lambda key, **kwargs: key,
+        text_fn=lambda en, nl: en,
+        diagram_width=128.0,
+        diagram_height=490.0,
+        vertical_align="top",
+    )
+
+    def label_y(diagram: object, text: str) -> float:
+        for item in getattr(diagram, "contents", []):
+            if hasattr(item, "text") and str(getattr(item, "text", "")) == text:
+                return float(item.y)
+        raise AssertionError(f"Label {text!r} not found")
+
+    assert label_y(top_aligned, "DIAGRAM_LABEL_FRONT") > label_y(centered, "DIAGRAM_LABEL_FRONT")
+    assert label_y(top_aligned, "DIAGRAM_LABEL_REAR") > label_y(centered, "DIAGRAM_LABEL_REAR")
+
+
 def test_narrow_page1_layout_returns_no_sensor_labels() -> None:
     location_points = {
         "front-left wheel": (18.0, 198.0),

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -199,6 +199,43 @@ def _presented_location_confidence_key(report_facts: PreparedReportFacts) -> str
     return report_facts.location_confidence_key
 
 
+def _first_confidence_reason_clause(primary: PrimaryCandidateContext) -> str | None:
+    for clause in str(primary.certainty_reason or "").split(";"):
+        text = clause.strip().rstrip(".")
+        if text:
+            return text
+    return None
+
+
+def _location_confidence_display_text(
+    *,
+    primary: PrimaryCandidateContext,
+    report_facts: PreparedReportFacts,
+    data_trust: list[DataTrustItem],
+    tr: Callable[..., str],
+) -> str:
+    presented_key = _presented_location_confidence_key(report_facts)
+    if report_facts.action_status_key != "action_ready_caution":
+        return _location_confidence_text(presented_key, tr=tr)
+
+    reason = _first_confidence_reason_clause(primary)
+    if reason:
+        return reason
+
+    if report_facts.alternative_source_visible:
+        return tr("REPORT_LOCATION_CONFIDENCE_CLOSE_SCORES")
+
+    issue = _first_nonpass_detail(data_trust)
+    if issue:
+        return issue.rstrip(".")
+
+    dominance_ratio = report_facts.primary_candidate_facts.dominance_ratio
+    if dominance_ratio is not None:
+        return tr("REPORT_LOCATION_CONFIDENCE_RATIO_REASON", ratio=f"{dominance_ratio:.1f}")
+
+    return tr("REPORT_LOCATION_CONFIDENCE_MODERATE_DETAIL")
+
+
 def _display_location(value: object, *, short: bool = True, tr: Callable[..., str]) -> str:
     text = str(value or "").strip()
     if not text:
@@ -939,8 +976,10 @@ def _build_verdict_page_data(
         ),
         dominant_corner=_display_location(primary.primary_location, tr=tr),
         runner_up_corner=_runner_up_corner(report_facts, tr=tr),
-        location_confidence=_location_confidence_text(
-            _presented_location_confidence_key(report_facts),
+        location_confidence=_location_confidence_display_text(
+            primary=primary,
+            report_facts=report_facts,
+            data_trust=data_trust,
             tr=tr,
         ),
         coverage_label=_coverage_label(report_facts, tr=tr),

--- a/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
@@ -69,7 +69,10 @@ def _build_sensor_render_plan(
 
 
 def _fit_vehicle_shell_rect(
-    *, drawing_width: float, drawing_height: float
+    *,
+    drawing_width: float,
+    drawing_height: float,
+    vertical_align: str = "center",
 ) -> tuple[float, float, float, float]:
     vehicle_ratio = _BMW_WIDTH_MM / _BMW_LENGTH_MM
     horizontal_pad = max(10.0, drawing_width * 0.085)
@@ -85,7 +88,13 @@ def _fit_vehicle_shell_rect(
         car_w = box_w
         car_h = car_w / vehicle_ratio
     x0 = (drawing_width - car_w) / 2.0
-    y0 = orientation_reserve + ((box_h - car_h) / 2.0)
+    spare_h = max(0.0, box_h - car_h)
+    if vertical_align == "top":
+        y0 = orientation_reserve + spare_h
+    elif vertical_align == "center":
+        y0 = orientation_reserve + (spare_h / 2.0)
+    else:
+        raise ValueError("vertical_align must be 'center' or 'top'")
     return (x0, y0, car_w, car_h)
 
 
@@ -408,6 +417,7 @@ def car_location_diagram(
     text_fn: Callable[..., str],
     diagram_width: float | None = None,
     diagram_height: float = 252,
+    vertical_align: str = "center",
 ) -> Any:
     """Build and return a ReportLab car location diagram Drawing."""
     from reportlab.graphics.shapes import Drawing
@@ -421,6 +431,7 @@ def car_location_diagram(
     x0, y0, car_w, car_h = _fit_vehicle_shell_rect(
         drawing_width=drawing_w,
         drawing_height=drawing_h,
+        vertical_align=vertical_align,
     )
 
     rendered_ratio = car_h / car_w if car_w > 0 else 0.0

--- a/apps/server/vibesensor/adapters/pdf/pdf_page1.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_page1.py
@@ -344,6 +344,7 @@ def _draw_proof_block(
         text_fn=lambda en, nl: nl if data.lang == "nl" else en,
         diagram_width=left_w,
         diagram_height=diagram_h - 2 * mm,
+        vertical_align="top",
     )
     diagram.drawOn(c, left_x, diagram_y)
 
@@ -384,14 +385,20 @@ def _draw_proof_block(
             value=verdict.runner_up_corner,
             value_size=FS_BODY,
         )
+    location_confidence = verdict.location_confidence or tr("UNKNOWN")
+    confidence_value_size = (
+        FS_BODY if len(_wrap_lines(location_confidence, text_w, FS_H2)) > 1 else FS_H2
+    )
+    confidence_max_lines = 3 if confidence_value_size == FS_BODY else 2
     text_y = _draw_label_value(
         c,
         x=text_x,
         y=text_y,
         width=text_w,
         label=tr("REPORT_LOCATION_CONFIDENCE_LABEL"),
-        value=verdict.location_confidence or tr("UNKNOWN"),
-        value_size=FS_H2,
+        value=location_confidence,
+        value_size=confidence_value_size,
+        max_lines=confidence_max_lines,
     )
     text_y = _draw_label_value(
         c,

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1867,6 +1867,18 @@
     "en": "Limited by run context",
     "nl": "Beperkt door runcontext"
   },
+  "REPORT_LOCATION_CONFIDENCE_CLOSE_SCORES": {
+    "en": "Top causes stayed too close to separate cleanly",
+    "nl": "De belangrijkste oorzaken bleven te dicht bij elkaar om ze duidelijk te scheiden"
+  },
+  "REPORT_LOCATION_CONFIDENCE_RATIO_REASON": {
+    "en": "Top corner was only {ratio}x stronger than the next corner",
+    "nl": "De sterkste hoek was slechts {ratio}x sterker dan de volgende hoek"
+  },
+  "REPORT_LOCATION_CONFIDENCE_MODERATE_DETAIL": {
+    "en": "Evidence separation stayed moderate in this run",
+    "nl": "De scheiding in het bewijs bleef in deze run gematigd"
+  },
   "REPORT_LOCATION_CONFIDENCE_STRONG": {
     "en": "Strong",
     "nl": "Sterk"


### PR DESCRIPTION
## Summary

Closes #1975.

This change tightens the page-one `Why this corner wins` proof panel in two related ways that showed up clearly in the rendered PDF. First, the proof text and the car graphic were not starting at the same visual height. In the baseline screenshot, the right-hand text stack began immediately under the panel title while the left-hand car diagram did not begin its meaningful content until much lower, leaving the panel feeling top-heavy and visually split into two unrelated halves. Second, caution-state reports were showing the generic phrase `Limited by run context` under `Location confidence`, which is internally understandable but too vague for an end reader. The issue asked for both the alignment and the wording to be improved, and this PR keeps the fix focused on exactly those surfaces.

## What I changed

The implementation has three main parts.

### 1. Page-one diagram alignment

The proof-panel diagram was already being drawn into a tall, narrow box, but the car shell inside that box was vertically centered. In a page-one context, that centering choice creates a large dead zone above the `FRONT` label because the diagram width, not the available height, is what limits the actual vehicle size. That means the graphic cannot grow to fill the column, so vertical centering just adds empty space above and below it.

To fix that without changing the appendix layout or other diagram contexts, I added an optional vertical alignment control to `car_location_diagram()` and its shell-fit helper. The default remains the existing centered behavior, so Appendix B and other call sites keep their current composition. Page one now opts into a top-aligned fit for the proof panel only. This lifts the `FRONT` label and the car body so the left-side graphic starts much closer to the proof summary on the right, which makes the panel read as a single row again.

### 2. Concrete caution-state confidence wording

The current caution-state logic intentionally replaced the location-confidence display with `Limited by run context` whenever the report was in `action_ready_caution`. That made the output less useful at exactly the point where readers need the most help understanding why the report is being cautious.

The PDF mapper already had better inputs available. In many caution-state runs, `primary.certainty_reason` contains a concrete explanation such as weak spatial separation, missing reference data, single-sensor limits, or unsteady speed. This PR adds a small display helper that uses that factual reasoning first when the report is in the caution state. If that reason is absent, the helper falls back in a clear order: close-score wording when two top causes stayed too close to separate cleanly, then any non-pass issue detail, then a dominance-ratio explanation, and finally a more readable moderate-detail fallback. The result is that the page now shows an actual reason instead of a generic placeholder.

For the rendered caution-state sample used in this PR, the proof panel now says `Speed was not steady during measurement` where it previously said `Limited by run context`.

### 3. Proof-panel text sizing for longer reasons

A concrete explanation is naturally longer than the old generic phrase, so I also adjusted the page-one proof-panel renderer to avoid letting that row become visually heavy or awkwardly wrapped. The `Location confidence` value now checks its wrapped length at the larger heading size and automatically steps down to the body-size emphasis when it would span multiple lines. That keeps the row readable and preserves hierarchy with the dominant-corner values above it.

## Files changed by area

- `apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py`
  - Added page-selectable diagram vertical alignment with a non-breaking default.
- `apps/server/vibesensor/adapters/pdf/pdf_page1.py`
  - Switched the proof-panel diagram to top alignment and tuned confidence-row sizing for longer, explanatory text.
- `apps/server/vibesensor/adapters/pdf/mapping.py`
  - Replaced the caution-state confidence placeholder with concrete reason selection based on existing report facts.
- `apps/server/vibesensor/data/report_i18n.json`
- `apps/server/data/report_i18n.json`
  - Added the new fallback strings for close-score, ratio-based, and moderate-detail caution explanations.
- `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
  - Added a regression ensuring caution-state page text no longer contains `Limited by run context` and instead includes a concrete reason.
- `apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py`
  - Added a regression proving the top-aligned fit lifts the orientation labels in tall page-one-style diagram boxes.

## Validation

I ran the full local validation path for the changed surface:

- `ruff check` on all touched Python files
- `ruff format --check` on all touched Python files
- focused PDF regressions in `test_report_new_modules_pdf_layout.py` and `test_report_pdf_diagram_hotspots.py` (`31 passed`)
- full PDF adapter suite: `pytest -q apps/server/tests/adapters/pdf` (`606 passed`)

## Visual verification

This issue specifically called for screenshot-based review, so I regenerated a representative caution-state PDF sample and compared the rendered page before and after the code change. The artifacts are local development outputs under `.tmp/issue-1975/` and include:

- `issue-1975-caution-baseline-page-1.png`
- `issue-1975-caution-after-page-1.png`
- `issue-1975-caution-proof-crop.png`
- `issue-1975-caution-after-proof-crop.png`
- `issue-1975-caution-proof-compare.png`

The before/after comparison shows the diagram moved upward so the `FRONT` label and car body sit much closer to the first proof line, removing the large dead zone that made the panel feel off-balance. It also shows the caution copy changing from the abstract `Limited by run context` label to the concrete `Speed was not steady during measurement`, which is easier for a normal report reader to understand at a glance.

## Risks and tradeoffs

I kept the diagram alignment change page-one-specific on purpose. The appendix diagram has a different layout context and should not inherit a page-one tuning decision unless a separate visual review shows it needs the same treatment. I also kept the confidence-reason logic narrowly focused on presentation: the underlying report-fact calculation and action-status gating are unchanged, so this PR improves explanation quality without changing the actual diagnostic thresholds or decision path.

One tradeoff is that caution-state explanations can now be longer than the previous single-line placeholder. That is intentional, but the page-one renderer now scales that row down when needed so the panel remains readable rather than shouting a long sentence in heading-sized type.

## Out of scope

This PR does not change the action-status callout wording, the next-steps panel, Appendix B, or the underlying suitability / confidence-scoring model. Those surfaces already have their own logic and were left untouched unless they were directly necessary to make the proof panel clearer and visually balanced.
