### PR TITLE
Clarify timeline detection windows

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1996,8 +1996,8 @@
     "nl": "Snelheid"
   },
   "REPORT_TIMELINE_DETECTIONS_LABEL": {
-    "en": "Detections",
-    "nl": "Detecties"
+    "en": "Detection windows",
+    "nl": "Detectievensters"
   },
   "REPORT_PROOF_SUMMARY_RATIO": {
     "en": "{location} outranked the next location by {ratio}x on matched-window linear intensity evidence.",

--- a/apps/server/tests/adapters/pdf/test_pdf_timeline_render.py
+++ b/apps/server/tests/adapters/pdf/test_pdf_timeline_render.py
@@ -79,6 +79,32 @@ def test_run_timeline_graph_draws_speed_line_evidence_and_labels() -> None:
     )
 
 
+def test_run_timeline_graph_keeps_detection_windows_in_a_dedicated_lane() -> None:
+    drawing = run_timeline_graph(
+        _sample_timeline_graph(),
+        tr=lambda key, **_kw: key,
+        graph_width=180.0,
+        graph_height=96.0,
+    )
+
+    plot_rect = _plot_rect(drawing)
+    detection_rects = [
+        item
+        for item in drawing.contents
+        if isinstance(item, Rect)
+        and _color_hex(item.fillColor) == _hex(REPORT_COLORS["card_error_bg"]).hexval()
+        and item.width < plot_rect.width
+        and item.y < plot_rect.y + (plot_rect.height * 0.25)
+    ]
+
+    assert detection_rects
+    assert all(rect.height < (plot_rect.height * 0.25) for rect in detection_rects)
+    assert all(rect.y >= plot_rect.y for rect in detection_rects)
+    assert all(
+        rect.y + rect.height <= plot_rect.y + (plot_rect.height * 0.25) for rect in detection_rects
+    )
+
+
 def test_run_timeline_graph_keeps_title_and_legend_above_plot() -> None:
     drawing = run_timeline_graph(
         _sample_timeline_graph(),

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -313,7 +313,7 @@ def test_report_pdf_renders_run_timeline_graph_labels() -> None:
 
     assert "run timeline" in page_one_text
     assert "speed" in page_one_text
-    assert "detections" in page_one_text
+    assert "detection windows" in page_one_text
 
 
 def test_report_pdf_compacts_actionable_system_cards() -> None:

--- a/apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py
@@ -80,6 +80,10 @@ def run_timeline_graph(
     plot_w = max(72.0, graph_width - 30.0)
     plot_top = legend_y - 8.0
     plot_h = max(28.0, plot_top - plot_y)
+    detection_lane_h = min(8.0, max(6.0, plot_h * 0.16))
+    detection_lane_gap = 4.0
+    speed_plot_y = plot_y + detection_lane_h + detection_lane_gap
+    speed_plot_h = max(18.0, plot_h - detection_lane_h - detection_lane_gap)
 
     speed_legend_x = plot_x + 2.0
     detection_legend_x = min(plot_x + 78.0, plot_x + plot_w - 34.0)
@@ -104,18 +108,29 @@ def run_timeline_graph(
         ),
     )
     drawing.add(
-        Circle(
+        Rect(
             detection_legend_x,
-            legend_y - 0.5,
-            2.4,
-            fillColor=_hex(REPORT_COLORS["danger"]),
+            legend_y - 2.6,
+            10.0,
+            4.2,
+            fillColor=_hex(REPORT_COLORS["card_error_bg"]),
             strokeColor=_hex(REPORT_COLORS["danger"]),
-            strokeWidth=0.0,
+            strokeWidth=0.45,
+        ),
+    )
+    drawing.add(
+        Circle(
+            detection_legend_x + 5.0,
+            legend_y - 0.5,
+            2.2,
+            fillColor=_hex(REPORT_COLORS["danger"]),
+            strokeColor=_hex(REPORT_COLORS["surface"]),
+            strokeWidth=0.7,
         ),
     )
     drawing.add(
         String(
-            detection_legend_x + 5.0,
+            detection_legend_x + 13.0,
             legend_y - 2.6,
             tr("REPORT_TIMELINE_DETECTIONS_LABEL"),
             fontName=FONT,
@@ -135,9 +150,30 @@ def run_timeline_graph(
             strokeWidth=0.8,
         ),
     )
+    drawing.add(
+        Rect(
+            plot_x,
+            plot_y,
+            plot_w,
+            detection_lane_h,
+            fillColor=_hex(REPORT_COLORS["surface_alt"]),
+            strokeColor=None,
+            strokeWidth=0.0,
+        ),
+    )
+    drawing.add(
+        Line(
+            plot_x,
+            speed_plot_y - (detection_lane_gap / 2.0),
+            plot_x + plot_w,
+            speed_plot_y - (detection_lane_gap / 2.0),
+            strokeColor=_hex(REPORT_COLORS["table_row_border"]),
+            strokeWidth=0.5,
+        ),
+    )
 
-    mid_y = plot_y + (plot_h / 2.0)
-    for y_value in (plot_y, mid_y, plot_y + plot_h):
+    mid_y = speed_plot_y + (speed_plot_h / 2.0)
+    for y_value in (speed_plot_y, mid_y, speed_plot_y + speed_plot_h):
         drawing.add(
             Line(
                 plot_x,
@@ -152,7 +188,7 @@ def run_timeline_graph(
     drawing.add(
         String(
             plot_x - 4.0,
-            plot_y - 2.0,
+            speed_plot_y - 2.0,
             "0",
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -163,7 +199,7 @@ def run_timeline_graph(
     drawing.add(
         String(
             plot_x - 4.0,
-            plot_y + plot_h - 2.0,
+            speed_plot_y + speed_plot_h - 2.0,
             str(int(round(timeline_graph.speed_ceiling_kmh))),
             fontName=FONT,
             fontSize=FS_SMALL,
@@ -209,36 +245,27 @@ def run_timeline_graph(
         )
         interval_w = max(1.5, x_end - x_start)
         if interval.has_fault_evidence:
-            detection_y = plot_y + plot_h - 3.5
+            detection_bar_y = plot_y + 1.1
+            detection_bar_h = max(3.4, detection_lane_h - 2.2)
             drawing.add(
                 Rect(
                     x_start,
-                    plot_y,
+                    detection_bar_y,
                     interval_w,
-                    plot_h,
+                    detection_bar_h,
                     fillColor=_hex(REPORT_COLORS["card_error_bg"]),
-                    strokeColor=_hex(REPORT_COLORS["card_error_bg"]),
-                    strokeWidth=0.0,
-                ),
-            )
-            drawing.add(
-                Line(
-                    x_start,
-                    detection_y,
-                    x_start + interval_w,
-                    detection_y,
                     strokeColor=_hex(REPORT_COLORS["danger"]),
-                    strokeWidth=1.0,
+                    strokeWidth=0.45,
                 ),
             )
             drawing.add(
                 Circle(
                     x_start + (interval_w / 2.0),
-                    detection_y,
+                    detection_bar_y + (detection_bar_h / 2.0),
                     2.3,
                     fillColor=_hex(REPORT_COLORS["danger"]),
-                    strokeColor=_hex(REPORT_COLORS["danger"]),
-                    strokeWidth=0.0,
+                    strokeColor=_hex(REPORT_COLORS["surface"]),
+                    strokeWidth=0.75,
                 ),
             )
         if interval.speed_min_kmh is not None or interval.speed_max_kmh is not None:
@@ -252,14 +279,14 @@ def run_timeline_graph(
             assert band_high is not None
             y_low = _y_for_speed(
                 speed_kmh=min(band_low, band_high),
-                plot_y=plot_y,
-                plot_h=plot_h,
+                plot_y=speed_plot_y,
+                plot_h=speed_plot_h,
                 speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
             )
             y_high = _y_for_speed(
                 speed_kmh=max(band_low, band_high),
-                plot_y=plot_y,
-                plot_h=plot_h,
+                plot_y=speed_plot_y,
+                plot_h=speed_plot_h,
                 speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
             )
             drawing.add(
@@ -277,8 +304,8 @@ def run_timeline_graph(
         if speed_value is not None:
             y_speed = _y_for_speed(
                 speed_kmh=speed_value,
-                plot_y=plot_y,
-                plot_h=plot_h,
+                plot_y=speed_plot_y,
+                plot_h=speed_plot_h,
                 speed_ceiling_kmh=timeline_graph.speed_ceiling_kmh,
             )
             speed_line_points.extend([x_start, y_speed, x_end, y_speed])

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1996,8 +1996,8 @@
     "nl": "Snelheid"
   },
   "REPORT_TIMELINE_DETECTIONS_LABEL": {
-    "en": "Detections",
-    "nl": "Detecties"
+    "en": "Detection windows",
+    "nl": "Detectievensters"
   },
   "REPORT_PROOF_SUMMARY_RATIO": {
     "en": "{location} outranked the next location by {ratio}x on matched-window linear intensity evidence.",


### PR DESCRIPTION
## Summary

Closes #1976.

This PR clarifies the page-one run timeline graph by separating the speed trace from the detection visualization. In the baseline render, the graph asked the reader to decode three different red elements at once: a full-height pink/red background across the detection interval, a red horizontal line near the top of the plot, and red dots sitting in the same vertical region as the purple speed line. At normal PDF reading scale, that made the chart feel visually muddy and hard to interpret. A user could reasonably wonder whether the red fill meant confidence, alert severity, a selected area, or simply decoration. The issue specifically called out that ambiguity, and the screenshot review confirmed it.

## Problem in the baseline render

The baseline graph had two major readability problems.

First, the red detection treatment occupied the same visual field as the speed information. Because the speed trace is also drawn near the top of the chart for higher-speed intervals, the red line and red dots ended up either overlapping the speed line or feeling attached to it. That made it difficult to tell whether the red marks were separate events or part of the speed series itself.

Second, the full-height pink interval fill over-emphasized the detection region in a way that was not self-explanatory. It dominated the plot area more than the actual detection marker did, while still not clearly telling the reader what the fill represented. In practice, the user’s eye was drawn to the tinted block first, but the meaning of that block was not obvious.

## Chosen approach

The fix keeps the graph compact and page-one friendly, but changes the visual model so speed and detections are encoded in different lanes.

Instead of painting the entire plot height red for intervals with fault evidence, the graph now reserves a dedicated detection lane at the bottom of the chart. The speed trace stays in the main plot area above that lane. Detection windows are shown as red-outlined, lightly filled interval bars with a red center marker inside that dedicated band. This makes the temporal relationship clear without competing with the speed line.

I intentionally kept the overall page-one footprint and time axis the same. The goal was not to redesign the whole block, but to remove ambiguity in the existing compact layout. The result is that readers can now scan the graph in two steps: the purple line tells them how speed changed over time, and the red lane tells them when detections happened.

## Main code changes

### 1. Dedicated detection lane in `pdf_timeline_render.py`

The renderer now divides the plot into two zones:

- a main speed area for the purple speed trace and the pale speed range band
- a small detection lane at the bottom for detection windows

To support that, the code now computes a separate `speed_plot_y` / `speed_plot_h` region above the lane. Grid lines and the speed-axis labels use that speed-only region rather than the full plot height. This keeps the speed encoding visually coherent and prevents the detection lane from distorting the speed scale.

For detection intervals, the old full-height `card_error_bg` fill and top-of-plot red line were removed. Each fault-evidence interval now draws a compact bar inside the detection lane, with a light red fill, a red outline, and a red center marker. The marker uses a light stroke so it remains visible and does not disappear into the bar.

### 2. Legend alignment with the new encoding

Because detections are no longer just “a red dot somewhere on the chart,” the legend sample was updated to reflect the new interval-based visual language. The legend now shows a miniature window-style sample and the label text was updated from `Detections` to `Detection windows`. That small wording change matters because the new encoding is about timing spans, not just isolated points.

The speed legend remains the same purple line sample, so the legend now more accurately matches what readers see in the chart itself.

### 3. Regression coverage

I added focused renderer coverage in `test_pdf_timeline_render.py` to prove that the detection windows stay in a dedicated lane instead of filling the main plot height. This test specifically checks that the red detection rectangles are shallow and anchored low in the plot rather than spanning the full chart body.

I also updated the page-text regression in `test_report_pdf_rendering.py` to match the new `Detection windows` legend label so the user-facing wording is covered in the rendered PDF text surface.

## Files changed

- `apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py`
  - redesigned the compact timeline graph rendering logic to separate detection windows from speed
- `apps/server/vibesensor/data/report_i18n.json`
- `apps/server/data/report_i18n.json`
  - updated the legend label text to `Detection windows`
- `apps/server/tests/adapters/pdf/test_pdf_timeline_render.py`
  - added dedicated-lane regression coverage
- `apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`
  - updated rendered-text expectations for the legend label

## Validation

I ran the local validation path for the affected renderer and then the broader PDF surface:

- `ruff check` on the touched Python files
- `ruff format --check` on the touched Python files
- focused timeline/PDF tests covering the renderer and rendered legend text
- full PDF adapter suite: `pytest -q apps/server/tests/adapters/pdf` (`607 passed`)

That full-suite run matters here because the timeline graph is part of page-one composition and I wanted to make sure the lane split did not introduce any unexpected overlap or break nearby page-one assumptions.

## Visual verification

This issue explicitly called for screenshot-based confirmation, so I regenerated the timeline visual-audit scenario before and after the change. The local artifacts are under `.tmp/issue-1976/` and include:

- `issue-1976-baseline-page-1.png`
- `issue-1976-after-page-1.png`
- `issue-1976-baseline-timeline-crop.png`
- `issue-1976-after-timeline-crop.png`
- `issue-1976-timeline-compare.png`

The before/after comparison shows the key improvement clearly. In the baseline, the red shading stretches through the whole plot and visually merges with the purple speed trace. In the updated render, the purple line occupies the main chart area alone, while the red detection windows sit in their own dedicated band near the bottom. That makes the graph easier to read at a glance and removes the need for the reader to guess what the pink block is supposed to mean.

## Risks and tradeoffs

The main tradeoff is vertical density. Introducing a dedicated lane slightly reduces the height available to the speed plot, but in practice the clarity gain is much larger than the small loss in vertical plotting space. The speed trace remains readable because the compact chart still has a dedicated speed area, and the detection windows no longer compete with it.

I also intentionally did not add more explanatory copy inside the chart body. The issue allowed for additional legend/supporting labeling only if it materially improved comprehension. In this case, a clearer legend label plus a cleaner encoding solved the ambiguity without adding more textual clutter.

## Out of scope

This PR does not change the surrounding page-one layout, the speed values themselves, the timeline data model, or the upstream logic that decides whether an interval has fault evidence. It is a presentation-layer clarity fix only: the graph says the same thing as before, but it now says it in a way a normal report reader can decode without guesswork.
