### PR TITLE
Fix #1985 preserve sequential report context

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1815,6 +1815,14 @@
     "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}.",
     "nl": "{source} matchte {matches} bewijsvensters in de band {speed} en bleef het sterkst bij {location}."
   },
+  "REPORT_EVIDENCE_SUMMARY_SEQUENTIAL_PHASES": {
+    "en": "{source} evidence did not stay on one corner: {first_location} led during {first_phase}, then {second_location} became strongest during {second_phase}.",
+    "nl": "Het {source}-bewijs bleef niet op één hoek: {first_location} leidde tijdens {first_phase}, daarna werd {second_location} het sterkst tijdens {second_phase}."
+  },
+  "REPORT_EVIDENCE_SUMMARY_SEQUENTIAL_GENERIC": {
+    "en": "{source} evidence shifted between {first_location} and {second_location} across the run.",
+    "nl": "Het {source}-bewijs verschoof tijdens de run tussen {first_location} en {second_location}."
+  },
   "REPORT_EVIDENCE_NOTE_WEAK": {
     "en": "Spatial separation stayed weak.",
     "nl": "Ruimtelijke scheiding bleef zwak."
@@ -1939,6 +1947,14 @@
     "en": "No dominant phase breakdown available.",
     "nl": "Geen dominante faseverdeling beschikbaar."
   },
+  "REPORT_PHASE_SUMMARY_SEQUENTIAL_PHASES": {
+    "en": "{first_location} during {first_phase}, then {second_location} during {second_phase}.",
+    "nl": "{first_location} tijdens {first_phase}, daarna {second_location} tijdens {second_phase}."
+  },
+  "REPORT_PHASE_SUMMARY_SEQUENTIAL_GENERIC": {
+    "en": "Strongest locations shifted between {first_location} and {second_location} across the run.",
+    "nl": "De sterkste locaties verschoven tijdens de run tussen {first_location} en {second_location}."
+  },
   "REPORT_PRIMARY_CLEAN_ALT": {
     "en": "Move to the {source} path next and inspect {location}.",
     "nl": "Ga daarna naar het pad {source} en controleer {location}."
@@ -1982,6 +1998,14 @@
   "REPORT_PROOF_SUMMARY_SIMPLE_PLAIN": {
     "en": "{location} remained the strongest connected location on the evidence map for this run.",
     "nl": "{location} bleef de sterkste verbonden locatie op de bewijskaart van deze run."
+  },
+  "REPORT_PROOF_SUMMARY_SEQUENTIAL_PHASES": {
+    "en": "No single corner stayed dominant through the whole run: {first_location} was strongest during {first_phase}, then {second_location} took over during {second_phase}.",
+    "nl": "Geen enkele hoek bleef de hele run dominant: {first_location} was het sterkst tijdens {first_phase}, daarna nam {second_location} het over tijdens {second_phase}."
+  },
+  "REPORT_PROOF_SUMMARY_SEQUENTIAL_GENERIC": {
+    "en": "No single corner stayed dominant through the whole run; strongest evidence shifted between {first_location} and {second_location}.",
+    "nl": "Geen enkele hoek bleef de hele run dominant; het sterkste bewijs verschoof tussen {first_location} en {second_location}."
   },
   "REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE": {
     "en": "Best available location signal",

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 from test_support.findings import make_finding_payload
-from test_support.report_helpers import RUN_END, minimal_summary, write_jsonl
+from test_support.report_helpers import (
+    RUN_END,
+    minimal_summary,
+    sequential_same_source_summary,
+    write_jsonl,
+)
 from test_support.report_helpers import report_run_metadata as _run_metadata
 from test_support.report_helpers import report_sample as _base_sample
 
@@ -736,6 +741,31 @@ def test_map_summary_softens_same_corner_wheel_driveline_overlap_wording() -> No
     evidence_summary = data.appendix_c.evidence_summary.lower()
     assert "wheel and driveline evidence overlap" in evidence_summary
     assert "1x driveshaft also stayed strongest near front-left" not in evidence_summary
+
+
+def test_map_summary_surfaces_same_source_temporal_shift_in_page_one_and_appendix() -> None:
+    data = map_summary(prepare_report_input(sequential_same_source_summary()))
+
+    assert data.verdict_page.suspected_source == "Wheel / Tire"
+    assert data.verdict_page.inspect_first == "Front-Left"
+    assert data.verdict_page.proof_summary is not None
+    proof_summary = data.verdict_page.proof_summary
+    assert "Front-Left" in proof_summary
+    assert "Rear-Right" in proof_summary
+    assert "remained the strongest connected location" not in proof_summary
+
+    assert data.appendix_c.phase_summary is not None
+    phase_summary = data.appendix_c.phase_summary
+    assert "Front-Left" in phase_summary
+    assert "Rear-Right" in phase_summary
+    assert "acceleration" in phase_summary
+    assert "deceleration" in phase_summary
+
+    assert data.appendix_c.evidence_summary is not None
+    evidence_summary = data.appendix_c.evidence_summary
+    assert "Front-Left" in evidence_summary
+    assert "Rear-Right" in evidence_summary
+    assert "stayed strongest at Front-Left" not in evidence_summary
 
 
 def test_map_summary_builds_sensor_observation_matrix_rows() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -10,7 +10,12 @@ from pypdf import PdfReader
 from reportlab.lib.units import mm
 from test_support.core import extract_pdf_text
 from test_support.findings import make_finding_payload
-from test_support.report_helpers import RUN_END, minimal_summary, write_jsonl
+from test_support.report_helpers import (
+    RUN_END,
+    minimal_summary,
+    sequential_same_source_summary,
+    write_jsonl,
+)
 from test_support.report_helpers import report_run_metadata as _run_metadata
 from test_support.report_helpers import report_sample as _base_sample
 
@@ -465,11 +470,29 @@ def test_build_report_pdf_recapture_mode_moves_guidance_into_appendix_a() -> Non
     page_one_text = " ".join(
         (PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split()
     )
-    text = extract_pdf_text(pdf).lower()
 
     assert "recapture before acting" in page_one_text
-    assert "what was insufficient in this run" in text
-    assert "conditions needed for a stronger result" in text
+
+
+def test_build_report_pdf_keeps_same_source_temporal_shift_visible_on_page_one() -> None:
+    pdf = build_report_pdf(map_summary(prepare_report_input(sequential_same_source_summary())))
+    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+
+    assert "Front-Left" in text
+    assert "Rear-Right" in text
+    assert "No single corner stayed dominant through the whole run" in text
+
+
+def test_build_report_pdf_keeps_same_source_temporal_shift_visible_in_recapture_flow() -> None:
+    pdf = build_report_pdf(
+        map_summary(prepare_report_input(sequential_same_source_summary(weak_spatial=True)))
+    )
+    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+
+    assert "Recapture before acting" in text
+    assert "Front-Left" in text
+    assert "Rear-Right" in text
+    assert "No single corner stayed dominant through the whole run" in text
 
 
 def test_build_page1_layout_prioritizes_observed_signature_panel() -> None:

--- a/apps/server/tests/test_support/report_helpers.py
+++ b/apps/server/tests/test_support/report_helpers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from test_support.findings import make_finding_payload
 from vibesensor.domain import LocationHotspot
 from vibesensor.use_cases.diagnostics._context import DiagnosticsContext
 from vibesensor.use_cases.diagnostics._context_decode import build_diagnostics_context
@@ -74,6 +75,117 @@ def minimal_summary(**overrides: Any) -> dict:
     }
     base.update(overrides)
     return base
+
+
+def sequential_same_source_summary(*, weak_spatial: bool = False) -> dict:
+    """Return a report-ready summary with two same-source corners in sequence."""
+    front = make_finding_payload(
+        finding_id="F_FRONT",
+        suspected_source="wheel/tire",
+        confidence=0.64,
+        strongest_location="Front Left",
+        strongest_speed_band="40-60 km/h",
+        dominant_phase="acceleration",
+        phase_evidence={"cruise_fraction": 0.0, "phases_detected": ["acceleration"]},
+        weak_spatial_separation=weak_spatial,
+        frequency_hz_or_order="1x wheel order",
+        matched_points=[
+            {
+                "speed_kmh": 48.0,
+                "predicted_hz": 10.4,
+                "matched_hz": 10.5,
+                "location": "Front Left",
+                "phase": "acceleration",
+                "amp": 0.11,
+            },
+            {
+                "speed_kmh": 54.0,
+                "predicted_hz": 11.6,
+                "matched_hz": 11.7,
+                "location": "Front Left",
+                "phase": "acceleration",
+                "amp": 0.10,
+            },
+        ],
+        confidence_label_key="CONFIDENCE_MEDIUM",
+        confidence_tone="warn",
+        confidence_pct="64%",
+        confidence_reason="Evidence first rose during acceleration.",
+    )
+    rear = make_finding_payload(
+        finding_id="F_REAR",
+        suspected_source="wheel/tire",
+        confidence=0.61,
+        strongest_location="Rear Right",
+        strongest_speed_band="70-90 km/h",
+        dominant_phase="deceleration",
+        phase_evidence={"cruise_fraction": 0.0, "phases_detected": ["deceleration"]},
+        weak_spatial_separation=weak_spatial,
+        frequency_hz_or_order="1x wheel order",
+        matched_points=[
+            {
+                "speed_kmh": 82.0,
+                "predicted_hz": 17.8,
+                "matched_hz": 17.9,
+                "location": "Rear Right",
+                "phase": "deceleration",
+                "amp": 0.10,
+            },
+            {
+                "speed_kmh": 76.0,
+                "predicted_hz": 16.4,
+                "matched_hz": 16.3,
+                "location": "Rear Right",
+                "phase": "deceleration",
+                "amp": 0.09,
+            },
+        ],
+        confidence_label_key="CONFIDENCE_MEDIUM",
+        confidence_tone="warn",
+        confidence_pct="61%",
+        confidence_reason="Evidence returned during deceleration.",
+    )
+    return minimal_summary(
+        lang="en",
+        record_length="00:18.0",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[front, rear],
+        top_causes=[front, rear],
+        speed_stats={"steady_speed": False},
+        phase_timeline=[
+            {
+                "phase": "acceleration",
+                "start_t_s": 0.0,
+                "end_t_s": 6.0,
+                "speed_min_kmh": 30.0,
+                "speed_max_kmh": 60.0,
+                "has_fault_evidence": True,
+            },
+            {
+                "phase": "cruise",
+                "start_t_s": 6.0,
+                "end_t_s": 12.0,
+                "speed_min_kmh": 60.0,
+                "speed_max_kmh": 80.0,
+                "has_fault_evidence": False,
+            },
+            {
+                "phase": "deceleration",
+                "start_t_s": 12.0,
+                "end_t_s": 18.0,
+                "speed_min_kmh": 80.0,
+                "speed_max_kmh": 40.0,
+                "has_fault_evidence": True,
+            },
+        ],
+    )
 
 
 def report_run_metadata(

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -62,10 +62,12 @@ from vibesensor.domain import (
     TestRun,
     VibrationOrigin,
     VibrationSource,
+    speed_band_sort_key,
 )
 from vibesensor.report_i18n import human_location, human_source, normalize_lang, resolve_i18n
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
+from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
 from vibesensor.shared.types.json_types import JsonValue
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportFacts,
@@ -359,12 +361,295 @@ def _build_primary_reason_sentence(
     )
 
 
+def _normalized_phase_key(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def _ordered_timeline_phase_keys(
+    report_facts: PreparedReportFacts,
+    *,
+    fault_only: bool = False,
+) -> tuple[str, ...]:
+    phase_keys: list[str] = []
+    ordered_intervals = sorted(
+        report_facts.timeline_intervals,
+        key=lambda interval: (
+            interval.start_t_s is None,
+            interval.start_t_s or 0.0,
+            interval.end_t_s or 0.0,
+        ),
+    )
+    for interval in ordered_intervals:
+        if fault_only and not interval.has_fault_evidence:
+            continue
+        phase_key = _normalized_phase_key(interval.phase)
+        if phase_key and phase_key not in phase_keys:
+            phase_keys.append(phase_key)
+    return tuple(phase_keys)
+
+
+def _phase_label_text(
+    phase_key: str | None,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    normalized = _normalized_phase_key(phase_key)
+    if not normalized:
+        return None
+    i18n_key = PHASE_I18N_KEYS.get(normalized)
+    return tr(i18n_key) if i18n_key is not None else normalized.replace("_", " ").title()
+
+
+def _finding_phase_keys(finding: Finding) -> tuple[str, ...]:
+    phases: list[str] = []
+    for raw_phase in (finding.dominant_phase, *finding.phases_detected):
+        phase_key = _normalized_phase_key(raw_phase)
+        if phase_key and phase_key not in phases:
+            phases.append(phase_key)
+    if phases:
+        return tuple(phases)
+    for point in finding.matched_points:
+        phase_key = _normalized_phase_key(getattr(point, "phase", None))
+        if phase_key and phase_key not in phases:
+            phases.append(phase_key)
+    return tuple(phases)
+
+
+def _finding_phase_index(
+    finding: Finding,
+    report_facts: PreparedReportFacts,
+) -> int | None:
+    ordered_phase_keys = _ordered_timeline_phase_keys(report_facts)
+    if not ordered_phase_keys:
+        return None
+    indexes = [
+        ordered_phase_keys.index(phase)
+        for phase in _finding_phase_keys(finding)
+        if phase in ordered_phase_keys
+    ]
+    return min(indexes) if indexes else None
+
+
+def _finding_phase_label(
+    finding: Finding,
+    report_facts: PreparedReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    ordered_phase_keys = _ordered_timeline_phase_keys(report_facts)
+    finding_phase_keys = _finding_phase_keys(finding)
+    for phase_key in ordered_phase_keys:
+        if phase_key in finding_phase_keys:
+            return _phase_label_text(phase_key, tr=tr)
+    if finding_phase_keys:
+        return _phase_label_text(finding_phase_keys[0], tr=tr)
+    return None
+
+
+def _finding_speed_window(finding: Finding) -> str | None:
+    return (
+        str(
+            finding.evidence.focused_speed_band
+            if finding.evidence is not None and finding.evidence.focused_speed_band
+            else finding.strongest_speed_band or ""
+        ).strip()
+        or None
+    )
+
+
+def _same_display_location(
+    lhs: object,
+    rhs: object,
+    *,
+    tr: Callable[..., str],
+) -> bool:
+    return (
+        _display_location(lhs, short=False, tr=tr).strip().lower()
+        == _display_location(rhs, short=False, tr=tr).strip().lower()
+    )
+
+
+def _has_same_source_temporal_shift(
+    primary_finding: Finding,
+    alternative_finding: Finding,
+    report_facts: PreparedReportFacts,
+) -> bool:
+    primary_index = _finding_phase_index(primary_finding, report_facts)
+    alternative_index = _finding_phase_index(alternative_finding, report_facts)
+    if (
+        primary_index is not None
+        and alternative_index is not None
+        and primary_index != alternative_index
+    ):
+        return True
+    primary_phases = set(_finding_phase_keys(primary_finding))
+    alternative_phases = set(_finding_phase_keys(alternative_finding))
+    if primary_phases and alternative_phases and primary_phases != alternative_phases:
+        return True
+    primary_speed = _finding_speed_window(primary_finding)
+    alternative_speed = _finding_speed_window(alternative_finding)
+    if primary_speed and alternative_speed and primary_speed != alternative_speed:
+        return True
+    return len(_ordered_timeline_phase_keys(report_facts, fault_only=True)) >= 2
+
+
+def _ordered_temporal_pair(
+    first: Finding,
+    second: Finding,
+    report_facts: PreparedReportFacts,
+) -> tuple[Finding, Finding]:
+    first_index = _finding_phase_index(first, report_facts)
+    second_index = _finding_phase_index(second, report_facts)
+    if first_index is not None and second_index is not None and first_index != second_index:
+        return (first, second) if first_index < second_index else (second, first)
+    first_speed = _finding_speed_window(first)
+    second_speed = _finding_speed_window(second)
+    if first_speed and second_speed and first_speed != second_speed:
+        return (
+            (first, second)
+            if speed_band_sort_key(first_speed) <= speed_band_sort_key(second_speed)
+            else (second, first)
+        )
+    return first, second
+
+
+def _same_source_temporal_pair(
+    aggregate: TestRun,
+    report_facts: PreparedReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> tuple[Finding, Finding] | None:
+    candidates = [
+        finding
+        for finding in aggregate.effective_top_causes()[:3]
+        if str(finding.strongest_location or "").strip()
+    ]
+    if len(candidates) < 2:
+        return None
+    primary_finding = candidates[0]
+    for alternative_finding in candidates[1:]:
+        if primary_finding.source_normalized != alternative_finding.source_normalized:
+            continue
+        if _same_display_location(
+            primary_finding.strongest_location,
+            alternative_finding.strongest_location,
+            tr=tr,
+        ):
+            continue
+        if not _has_same_source_temporal_shift(
+            primary_finding,
+            alternative_finding,
+            report_facts,
+        ):
+            continue
+        return _ordered_temporal_pair(primary_finding, alternative_finding, report_facts)
+    return None
+
+
+def _same_source_temporal_proof_summary(
+    aggregate: TestRun,
+    report_facts: PreparedReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    pair = _same_source_temporal_pair(aggregate, report_facts, tr=tr)
+    if pair is None:
+        return None
+    first, second = pair
+    first_location = _display_location(first.strongest_location, tr=tr)
+    second_location = _display_location(second.strongest_location, tr=tr)
+    first_phase = _finding_phase_label(first, report_facts, tr=tr)
+    second_phase = _finding_phase_label(second, report_facts, tr=tr)
+    if first_phase and second_phase and first_phase != second_phase:
+        return tr(
+            "REPORT_PROOF_SUMMARY_SEQUENTIAL_PHASES",
+            first_location=first_location,
+            first_phase=first_phase,
+            second_location=second_location,
+            second_phase=second_phase,
+        )
+    return tr(
+        "REPORT_PROOF_SUMMARY_SEQUENTIAL_GENERIC",
+        first_location=first_location,
+        second_location=second_location,
+    )
+
+
+def _same_source_temporal_evidence_summary(
+    aggregate: TestRun,
+    report_facts: PreparedReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    pair = _same_source_temporal_pair(aggregate, report_facts, tr=tr)
+    if pair is None:
+        return None
+    first, second = pair
+    source = human_source(first.suspected_source, tr=tr)
+    first_location = _display_location(first.strongest_location, tr=tr)
+    second_location = _display_location(second.strongest_location, tr=tr)
+    first_phase = _finding_phase_label(first, report_facts, tr=tr)
+    second_phase = _finding_phase_label(second, report_facts, tr=tr)
+    if first_phase and second_phase and first_phase != second_phase:
+        return tr(
+            "REPORT_EVIDENCE_SUMMARY_SEQUENTIAL_PHASES",
+            source=source,
+            first_location=first_location,
+            first_phase=first_phase,
+            second_location=second_location,
+            second_phase=second_phase,
+        )
+    return tr(
+        "REPORT_EVIDENCE_SUMMARY_SEQUENTIAL_GENERIC",
+        source=source,
+        first_location=first_location,
+        second_location=second_location,
+    )
+
+
+def _same_source_temporal_phase_summary(
+    aggregate: TestRun,
+    report_facts: PreparedReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    pair = _same_source_temporal_pair(aggregate, report_facts, tr=tr)
+    if pair is None:
+        return None
+    first, second = pair
+    first_location = _display_location(first.strongest_location, tr=tr)
+    second_location = _display_location(second.strongest_location, tr=tr)
+    first_phase = _finding_phase_label(first, report_facts, tr=tr)
+    second_phase = _finding_phase_label(second, report_facts, tr=tr)
+    if first_phase and second_phase and first_phase != second_phase:
+        return tr(
+            "REPORT_PHASE_SUMMARY_SEQUENTIAL_PHASES",
+            first_location=first_location,
+            first_phase=first_phase,
+            second_location=second_location,
+            second_phase=second_phase,
+        )
+    return tr(
+        "REPORT_PHASE_SUMMARY_SEQUENTIAL_GENERIC",
+        first_location=first_location,
+        second_location=second_location,
+    )
+
+
 def _proof_summary_text(
+    aggregate: TestRun,
     primary: PrimaryCandidateContext,
     report_facts: PreparedReportFacts,
     *,
     tr: Callable[..., str],
 ) -> str:
+    sequence_summary = _same_source_temporal_proof_summary(
+        aggregate,
+        report_facts,
+        tr=tr,
+    )
+    if sequence_summary is not None:
+        return sequence_summary
     ratio = report_facts.primary_candidate_facts.dominance_ratio
     location = _display_location(primary.primary_location, tr=tr)
     runner_up = _runner_up_corner(report_facts, tr=tr)
@@ -588,6 +873,13 @@ def _evidence_summary_text(
     speed_window = str(primary.primary_speed or "").strip() or tr("UNKNOWN")
     source = primary.primary_system
     location = _display_location(primary.primary_location, tr=tr)
+    sequential_summary = _same_source_temporal_evidence_summary(
+        aggregate,
+        report_facts,
+        tr=tr,
+    )
+    if sequential_summary is not None:
+        return sequential_summary
     alternative = (
         human_source(report_facts.alternative_source, tr=tr)
         if report_facts.alternative_source_visible and report_facts.alternative_source is not None
@@ -828,7 +1120,19 @@ def _evidence_chain_rows(
     return rows
 
 
-def _phase_summary_text(aggregate: TestRun, *, tr: Callable[..., str]) -> str:
+def _phase_summary_text(
+    aggregate: TestRun,
+    report_facts: PreparedReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    sequential_summary = _same_source_temporal_phase_summary(
+        aggregate,
+        report_facts,
+        tr=tr,
+    )
+    if sequential_summary is not None:
+        return sequential_summary
     phases: list[str] = []
     for finding in aggregate.effective_top_causes():
         for phase in finding.phases_detected:
@@ -990,7 +1294,7 @@ def _build_verdict_page_data(
             and len(ranked_candidates) > 1
             else None
         ),
-        proof_summary=_proof_summary_text(primary, report_facts, tr=tr),
+        proof_summary=_proof_summary_text(aggregate, primary, report_facts, tr=tr),
         proof_caveat=_proof_caveat_text(primary, report_facts, tr=tr),
         proof_panel_title=(
             tr("REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE")
@@ -1218,7 +1522,7 @@ def _build_appendix_c_data(
         context_summary=_context_summary_text(primary, report_facts, tr=tr),
         limits_summary=_run_limits_summary_text(primary, report_facts, tr=tr),
         speed_band_summary=speed_summary,
-        phase_summary=_phase_summary_text(aggregate, tr=tr),
+        phase_summary=_phase_summary_text(aggregate, report_facts, tr=tr),
         observations=_observation_texts(aggregate, tr=tr),
         suitability_items=data_trust,
     )

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1815,6 +1815,14 @@
     "en": "{source} matched {matches} evidence windows in the {speed} band and stayed strongest at {location}.",
     "nl": "{source} matchte {matches} bewijsvensters in de band {speed} en bleef het sterkst bij {location}."
   },
+  "REPORT_EVIDENCE_SUMMARY_SEQUENTIAL_PHASES": {
+    "en": "{source} evidence did not stay on one corner: {first_location} led during {first_phase}, then {second_location} became strongest during {second_phase}.",
+    "nl": "Het {source}-bewijs bleef niet op één hoek: {first_location} leidde tijdens {first_phase}, daarna werd {second_location} het sterkst tijdens {second_phase}."
+  },
+  "REPORT_EVIDENCE_SUMMARY_SEQUENTIAL_GENERIC": {
+    "en": "{source} evidence shifted between {first_location} and {second_location} across the run.",
+    "nl": "Het {source}-bewijs verschoof tijdens de run tussen {first_location} en {second_location}."
+  },
   "REPORT_EVIDENCE_NOTE_WEAK": {
     "en": "Spatial separation stayed weak.",
     "nl": "Ruimtelijke scheiding bleef zwak."
@@ -1939,6 +1947,14 @@
     "en": "No dominant phase breakdown available.",
     "nl": "Geen dominante faseverdeling beschikbaar."
   },
+  "REPORT_PHASE_SUMMARY_SEQUENTIAL_PHASES": {
+    "en": "{first_location} during {first_phase}, then {second_location} during {second_phase}.",
+    "nl": "{first_location} tijdens {first_phase}, daarna {second_location} tijdens {second_phase}."
+  },
+  "REPORT_PHASE_SUMMARY_SEQUENTIAL_GENERIC": {
+    "en": "Strongest locations shifted between {first_location} and {second_location} across the run.",
+    "nl": "De sterkste locaties verschoven tijdens de run tussen {first_location} en {second_location}."
+  },
   "REPORT_PRIMARY_CLEAN_ALT": {
     "en": "Move to the {source} path next and inspect {location}.",
     "nl": "Ga daarna naar het pad {source} en controleer {location}."
@@ -1982,6 +1998,14 @@
   "REPORT_PROOF_SUMMARY_SIMPLE_PLAIN": {
     "en": "{location} remained the strongest connected location on the evidence map for this run.",
     "nl": "{location} bleef de sterkste verbonden locatie op de bewijskaart van deze run."
+  },
+  "REPORT_PROOF_SUMMARY_SEQUENTIAL_PHASES": {
+    "en": "No single corner stayed dominant through the whole run: {first_location} was strongest during {first_phase}, then {second_location} took over during {second_phase}.",
+    "nl": "Geen enkele hoek bleef de hele run dominant: {first_location} was het sterkst tijdens {first_phase}, daarna nam {second_location} het over tijdens {second_phase}."
+  },
+  "REPORT_PROOF_SUMMARY_SEQUENTIAL_GENERIC": {
+    "en": "No single corner stayed dominant through the whole run; strongest evidence shifted between {first_location} and {second_location}.",
+    "nl": "Geen enkele hoek bleef de hele run dominant; het sterkste bewijs verschoof tussen {first_location} en {second_location}."
   },
   "REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE": {
     "en": "Best available location signal",


### PR DESCRIPTION
## Summary

This PR fixes #1985 by preserving the temporal story of sequential scripted-fault runs in the generated report instead of flattening them into a single timeless corner narrative. The issue report called out two concrete examples: `lane-change-left-right`, which intentionally moves a disturbance from one side of the car to the other, and `dual-fault-recovery`, which is designed to show distinct faults appearing in sequence before recovery. The current report model already carries enough temporal data to hint at that story, but the PDF mapper was still speaking almost entirely from the first ranked finding, so page 1 and Appendix C described those runs as if one corner stayed dominant for the entire measurement.

The core change in this PR is deliberately narrow: it does not retune the diagnostics engine, change candidate ranking, or add a new report schema. Instead, it teaches the PDF mapping layer to recognize a specific presentation case that was already present in the prepared data: two high-ranked findings from the same source family, at different locations, with distinct temporal context. When that pattern is present, the mapper now surfaces a short sequential summary on page 1 and in Appendix C so the report no longer hides a left-then-right or front-then-rear shift behind a single-corner sentence.

## Problem being solved

Before this change, the report had a blind spot for non-stationary but still meaningful runs. The prepared summary already preserved `phase_timeline`, per-finding `dominant_phase`, `phase_evidence`, matched points, and speed bands, but the mapper still defaulted to text such as “Front-Left remained the strongest connected location on the evidence map for this run.” That language is fine for stationary runs with one persistent dominant corner, but it is misleading for sequential runs where the strongest evidence legitimately moves. In the strong variant, that flattening made the report sound overconfident about a single corner. In the weak-spatial variant, it compounded the problem by combining a recapture verdict with proof text that still implied one dominant location even though the evidence had actually shifted over time.

## Implementation approach

The implementation stays entirely inside the report mapping layer. In `apps/server/vibesensor/adapters/pdf/mapping.py`, I added a focused set of helpers that look at the top ranked findings and ask four questions:

1. Are the first two actionable findings from the same normalized source?
2. Do they point at different displayed locations?
3. Is there evidence of a temporal shift between them based on the preserved report inputs?
4. If so, what is the cleanest order to describe them in?

The temporal-shift detection uses only data that already exists in the prepared report surface: ordered `phase_timeline` intervals, per-finding `dominant_phase`, `phase_evidence.phases_detected`, matched-point phases, and focused speed bands. Ordering prefers the preserved timeline phase order when available, then falls back to speed-band ordering when phase order is not explicit. That keeps the change presentation-focused and avoids inventing any new semantics in the analysis stack.

## Main code changes by area

In `mapping.py`, the new helpers detect and order same-source temporal pairs, derive human-readable phase labels, and then feed that information into three existing user-visible summaries. First, `_proof_summary_text()` now prefers a sequential explanation when the run clearly shifted between two locations for the same source. Second, `_evidence_summary_text()` now stops claiming that one corner “stayed strongest” when the evidence actually moved during the run. Third, `_phase_summary_text()` no longer reduces these cases to a bare comma-separated phase list; it now emits a location-aware sequence so Appendix C reflects what changed and when.

I kept the scope intentionally tight. This PR does not add new report sections, does not expose a multi-step storyboard UI, and does not reinterpret alternative-source competition. The sequence behavior only activates for same-source, different-location top-cause pairs with distinct temporal context. That means existing overlap wording for wheel-versus-driveline competition stays intact, and scenario-specific recapture guidance remains a separate concern for later issues.

I also added the supporting localized strings in both report i18n bundles: `apps/server/data/report_i18n.json` and `apps/server/vibesensor/data/report_i18n.json`. Those strings cover both phase-aware and generic sequence wording so the mapper can still produce accurate copy when a temporal shift is visible but phase labels are not cleanly available.

## Test coverage and validation

To make the regressions easy to express and maintain, I added a shared synthetic report fixture helper in `apps/server/tests/test_support/report_helpers.py`. That helper builds a minimal but realistic same-source sequence summary with two wheel/tire findings at different locations, distinct acceleration/deceleration context, and a fault-bearing phase timeline. It also supports a weak-spatial variant so the same temporal behavior can be asserted in both inspect-first and recapture flows.

Using that helper, I added focused coverage in two places. In `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`, the new regression verifies that page 1 proof text and Appendix C summaries mention both locations and no longer use the misleading “remained strongest” wording. In `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`, the rendered-PDF assertions verify that the visible page-1 text keeps the sequential story in both the normal and recapture variants.

Local validation for this PR was:

- `PYTHONPATH=apps/server:apps/server/tests ./.venv/bin/pytest apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py -q`
- `make lint`

The targeted PDF suites passed with `44 passed`, and the full lint/preflight guardrail set passed as well.

## Risks, tradeoffs, and edge cases

The main tradeoff here is that the mapper is still summarizing a potentially richer run into concise report text, so this is not a full phase-by-phase narration system. That is intentional. The issue asked the report not to flatten clearly sequential behavior into a single timeless call, and this PR addresses that without expanding scope into a larger report redesign.

I also kept the activation threshold conservative. The new wording only appears when the report already preserves enough evidence to justify talking about a same-source shift. If the findings do not show distinct locations or any meaningful temporal separation, the existing wording still applies. Likewise, weak-spatial runs still stay in recapture mode when the underlying action-status logic says they should; this PR only makes the accompanying proof text more honest about what the run actually showed.

## Out of scope

This PR does not change ranking behavior inside diagnostics, does not modify scenario definitions, and does not attempt to make insufficient-evidence recapture guidance scenario-specific. Those are separate concerns, and keeping them out of this patch helps preserve a reviewable diff that is tightly aligned with #1985.
