### PR TITLE
Fix #1986 report guidance for ambiguous hotspots

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1895,6 +1895,14 @@
     "en": "Weak",
     "nl": "Zwak"
   },
+  "REPORT_LOCATION_MIXED_SIGNAL_BETWEEN": {
+    "en": "Mixed signal between {first_location} and {second_location}",
+    "nl": "Gemengd signaal tussen {first_location} en {second_location}"
+  },
+  "REPORT_LOCATION_MIXED_SIGNAL_LIST": {
+    "en": "Mixed signal across {locations}",
+    "nl": "Gemengd signaal over {locations}"
+  },
   "REPORT_MATCHED_WINDOWS_COLUMN": {
     "en": "Sensor matches",
     "nl": "Sensormatches"

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -8,8 +8,10 @@ import pytest
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import (
     RUN_END,
+    ambiguous_primary_location_summary,
     minimal_summary,
     sequential_same_source_summary,
+    trunk_primary_guidance_summary,
     write_jsonl,
 )
 from test_support.report_helpers import report_run_metadata as _run_metadata
@@ -178,7 +180,7 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
     )
 
     data = map_summary(prepare_report_input(summary))
-    assert len(data.next_steps) == 3
+    assert len(data.next_steps) == 2
     assert all(step.eta is None for step in data.next_steps)
     assert all("front-left wheel" in step.action.lower() for step in data.next_steps)
     rendered = " ".join(
@@ -194,6 +196,57 @@ def test_map_summary_next_steps_do_not_leak_placeholder_tokens() -> None:
     assert "{driveline_focus}" not in rendered
     assert "{" not in rendered
     assert "}" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("primary_source", "expected_text", "unexpected_text"),
+    [
+        pytest.param(
+            "engine",
+            "check engine mounts and accessory drive",
+            "tire damage",
+            id="engine-trunk-hotspot",
+        ),
+        pytest.param(
+            "driveline",
+            "inspect propshaft runout/balance",
+            "check driveline components near trunk",
+            id="driveline-trunk-hotspot",
+        ),
+    ],
+)
+def test_map_summary_keeps_generated_next_steps_on_primary_source_path_for_trunk_hotspots(
+    primary_source: str,
+    expected_text: str,
+    unexpected_text: str,
+) -> None:
+    data = map_summary(
+        prepare_report_input(trunk_primary_guidance_summary(primary_source=primary_source))
+    )
+
+    rendered = " ".join(
+        part
+        for step in data.next_steps
+        for part in (step.action, step.why, step.confirm, step.falsify)
+        if part
+    ).lower()
+
+    assert expected_text in rendered
+    assert unexpected_text not in rendered
+    assert "check trunk for tire damage" not in rendered
+    assert "imbalance or radial/lateral runout" not in rendered
+
+
+def test_map_summary_rephrases_ambiguous_primary_locations_as_mixed_signal() -> None:
+    data = map_summary(prepare_report_input(ambiguous_primary_location_summary()))
+
+    expected = "Mixed signal between Front-Left and Rear-Left"
+
+    assert data.verdict_page.inspect_first == expected
+    assert data.verdict_page.dominant_corner == expected
+    assert data.observed.strongest_location == expected
+    assert data.pattern_evidence.strongest_location == expected
+    assert "/" not in data.verdict_page.inspect_first
 
 
 def test_map_summary_formats_report_timestamps_for_header() -> None:
@@ -414,7 +467,7 @@ def test_most_likely_origin_summary_no_phase_onset_when_absent() -> None:
     )
 
     data = map_summary(prepare_report_input(summary))
-    assert data.observed.strongest_location == "Rear Left / Front Right"
+    assert data.observed.strongest_location == "Mixed signal between Rear-Left and Front-Right"
 
 
 def test_map_summary_peak_rows_use_persistence_metrics() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -12,8 +12,10 @@ from test_support.core import extract_pdf_text
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import (
     RUN_END,
+    ambiguous_primary_location_summary,
     minimal_summary,
     sequential_same_source_summary,
+    trunk_primary_guidance_summary,
     write_jsonl,
 )
 from test_support.report_helpers import report_run_metadata as _run_metadata
@@ -275,6 +277,27 @@ def test_build_report_pdf_replaces_limited_run_context_with_concrete_reason() ->
 
     assert "limited by run context" not in page_one_text
     assert "speed was not steady during measurement" in page_one_text
+
+
+def test_build_report_pdf_rephrases_ambiguous_primary_location_on_page_one() -> None:
+    pdf = build_report_pdf(map_summary(prepare_report_input(ambiguous_primary_location_summary())))
+    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+
+    assert "Mixed signal between Front-Left and Rear-Left" in text
+    assert "Front-Left / Rear-Left" not in text
+
+
+def test_build_report_pdf_avoids_trunk_specific_wheel_guidance_for_driveline_primary() -> None:
+    pdf = build_report_pdf(
+        map_summary(
+            prepare_report_input(trunk_primary_guidance_summary(primary_source="driveline"))
+        )
+    )
+    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+
+    assert "Inspect propshaft runout/balance" in text
+    assert "Check Trunk for tire damage" not in text
+    assert "Check driveline components near Trunk" not in text
 
 
 def test_build_report_pdf_renders_action_ready_status_on_page_one() -> None:

--- a/apps/server/tests/test_support/report_helpers.py
+++ b/apps/server/tests/test_support/report_helpers.py
@@ -188,6 +188,135 @@ def sequential_same_source_summary(*, weak_spatial: bool = False) -> dict:
     )
 
 
+_GENERATED_ACTION_STEPS: dict[str, dict[str, Any]] = {
+    "wheel_balance_and_runout": {
+        "action_id": "wheel_balance_and_runout",
+        "what": "ACTION_WHEEL_BALANCE_WHAT",
+        "why": "ACTION_WHEEL_BALANCE_WHY",
+        "confirm": "ACTION_WHEEL_BALANCE_CONFIRM",
+        "falsify": "ACTION_WHEEL_BALANCE_FALSIFY",
+        "eta": "20-45 min",
+    },
+    "wheel_tire_condition": {
+        "action_id": "wheel_tire_condition",
+        "what": "ACTION_TIRE_CONDITION_WHAT",
+        "why": "ACTION_TIRE_CONDITION_WHY",
+        "confirm": "ACTION_TIRE_CONDITION_CONFIRM",
+        "falsify": "ACTION_TIRE_CONDITION_FALSIFY",
+        "eta": "10-20 min",
+    },
+    "driveline_inspection": {
+        "action_id": "driveline_inspection",
+        "what": "ACTION_DRIVELINE_INSPECTION_WHAT",
+        "why": "ACTION_DRIVELINE_INSPECTION_WHY",
+        "confirm": "ACTION_DRIVELINE_INSPECTION_CONFIRM",
+        "falsify": "ACTION_DRIVELINE_INSPECTION_FALSIFY",
+        "eta": "20-35 min",
+    },
+    "driveline_mounts_and_fasteners": {
+        "action_id": "driveline_mounts_and_fasteners",
+        "what": "ACTION_DRIVELINE_MOUNTS_WHAT",
+        "why": "ACTION_DRIVELINE_MOUNTS_WHY",
+        "confirm": "ACTION_DRIVELINE_MOUNTS_CONFIRM",
+        "falsify": "ACTION_DRIVELINE_MOUNTS_FALSIFY",
+        "eta": "10-20 min",
+    },
+    "engine_mounts_and_accessories": {
+        "action_id": "engine_mounts_and_accessories",
+        "what": "ACTION_ENGINE_MOUNTS_WHAT",
+        "why": "ACTION_ENGINE_MOUNTS_WHY",
+        "confirm": "ACTION_ENGINE_MOUNTS_CONFIRM",
+        "falsify": "ACTION_ENGINE_MOUNTS_FALSIFY",
+        "eta": "15-30 min",
+    },
+    "engine_combustion_quality": {
+        "action_id": "engine_combustion_quality",
+        "what": "ACTION_ENGINE_COMBUSTION_WHAT",
+        "why": "ACTION_ENGINE_COMBUSTION_WHY",
+        "confirm": "ACTION_ENGINE_COMBUSTION_CONFIRM",
+        "falsify": "ACTION_ENGINE_COMBUSTION_FALSIFY",
+        "eta": "10-20 min",
+    },
+}
+
+
+def ambiguous_primary_location_summary() -> dict:
+    """Return a summary whose primary hotspot is explicitly ambiguous."""
+    primary = make_finding_payload(
+        finding_id="F_AMBIG",
+        suspected_source="wheel/tire",
+        confidence=0.82,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        dominance_ratio=2.0,
+        weak_spatial_separation=False,
+        location_hotspot={
+            "top_location": "Front Left",
+            "location": "Front Left",
+            "ambiguous_location": True,
+            "alternative_locations": ["Rear Left"],
+            "second_location": "Rear Left",
+        },
+    )
+    return minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[primary],
+        top_causes=[primary],
+        speed_stats={"steady_speed": True},
+    )
+
+
+def trunk_primary_guidance_summary(*, primary_source: str) -> dict:
+    """Return a summary with a trunk/body hotspot and mixed-source action plan."""
+    primary_action_ids = {
+        "engine": ("engine_mounts_and_accessories", "engine_combustion_quality"),
+        "driveline": ("driveline_inspection", "driveline_mounts_and_fasteners"),
+    }.get(primary_source)
+    if primary_action_ids is None:
+        raise ValueError(f"Unsupported primary source: {primary_source}")
+    primary = make_finding_payload(
+        finding_id="F_PRIMARY",
+        suspected_source=primary_source,
+        confidence=0.77,
+        strongest_location="Trunk",
+        strongest_speed_band="70-90 km/h",
+    )
+    alternative = make_finding_payload(
+        finding_id="F_WHEEL",
+        suspected_source="wheel/tire",
+        confidence=0.71,
+        strongest_location="Front Left",
+        strongest_speed_band="70-90 km/h",
+    )
+    return minimal_summary(
+        lang="en",
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[primary, alternative],
+        top_causes=[primary, alternative],
+        speed_stats={"steady_speed": True},
+        test_plan=[
+            dict(_GENERATED_ACTION_STEPS["wheel_balance_and_runout"]),
+            dict(_GENERATED_ACTION_STEPS["wheel_tire_condition"]),
+            *(dict(_GENERATED_ACTION_STEPS[action_id]) for action_id in primary_action_ids),
+        ],
+    )
+
+
 def report_run_metadata(
     run_id: str = "run-01",
     *,

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -64,7 +64,13 @@ from vibesensor.domain import (
     VibrationSource,
     speed_band_sort_key,
 )
-from vibesensor.report_i18n import human_location, human_source, normalize_lang, resolve_i18n
+from vibesensor.report_i18n import (
+    human_location,
+    human_source,
+    location_candidates,
+    normalize_lang,
+    resolve_i18n,
+)
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
 from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
@@ -123,7 +129,7 @@ def build_pattern_evidence(
     )
     return PatternEvidence(
         matched_systems=systems,
-        strongest_location=primary.primary_location,
+        strongest_location=_display_location(primary.primary_location, tr=tr),
         speed_band=primary.primary_speed,
         strength_label=primary.strength_text,
         strength_peak_db=primary.strength_db,
@@ -242,6 +248,18 @@ def _display_location(value: object, *, short: bool = True, tr: Callable[..., st
     text = str(value or "").strip()
     if not text:
         return tr("UNKNOWN")
+    candidates = location_candidates(text)
+    if len(candidates) == 2:
+        return tr(
+            "REPORT_LOCATION_MIXED_SIGNAL_BETWEEN",
+            first_location=human_location(candidates[0], short=short),
+            second_location=human_location(candidates[1], short=short),
+        )
+    if len(candidates) > 2:
+        return tr(
+            "REPORT_LOCATION_MIXED_SIGNAL_LIST",
+            locations=", ".join(human_location(candidate, short=short) for candidate in candidates),
+        )
     return human_location(text, short=short)
 
 
@@ -1626,6 +1644,7 @@ def _build_report_template_data(
         lang=lang,
     )
     observed = observed_signature(primary)
+    observed.strongest_location = _display_location(primary.primary_location, tr=tr)
     system_cards = build_system_cards(
         context,
         primary,
@@ -1635,6 +1654,7 @@ def _build_report_template_data(
     recapture_mode = report_facts.action_status_key == "recapture_before_acting"
     next_steps = build_next_steps(
         recommended_actions=report_facts.recommended_actions,
+        primary_source=primary.primary_source,
         primary_location=primary.primary_location,
         tier=primary.tier,
         cert_reason=primary.certainty_reason or tr("REPORT_CAPTURE_ISSUE_GENERIC"),

--- a/apps/server/vibesensor/adapters/pdf/report_sections.py
+++ b/apps/server/vibesensor/adapters/pdf/report_sections.py
@@ -6,7 +6,12 @@ from collections.abc import Callable, Sequence
 
 from vibesensor.adapters.pdf.report_data import DataTrustItem, NextStep
 from vibesensor.domain import RecommendedAction
-from vibesensor.report_i18n import is_i18n_ref, resolve_i18n
+from vibesensor.report_i18n import (
+    is_body_like_location,
+    is_composite_location,
+    is_i18n_ref,
+    resolve_i18n,
+)
 from vibesensor.shared.types.history_analysis_contracts import (
     RunSuitabilityCheck,
 )
@@ -29,11 +34,21 @@ _REPORT_FOCUSED_ACTION_SPECS: dict[str, tuple[str, bool]] = {
     "wheel_balance_and_runout": ("REPORT_NEXT_STEP_WHEEL_BALANCE_WHAT", True),
     "wheel_tire_condition": ("REPORT_NEXT_STEP_TIRE_CONDITION_WHAT", True),
 }
+_PRIMARY_SOURCE_ACTION_IDS: dict[str, tuple[str, ...]] = {
+    "wheel/tire": ("wheel_balance_and_runout", "wheel_tire_condition"),
+    "driveline": ("driveline_inspection", "driveline_mounts_and_fasteners"),
+    "engine": ("engine_mounts_and_accessories", "engine_combustion_quality"),
+    "body resonance": ("general_mechanical_inspection",),
+    "unknown resonance": ("general_mechanical_inspection",),
+    "transient_impact": ("general_mechanical_inspection",),
+    "unknown": ("general_mechanical_inspection",),
+}
 
 
 def build_next_steps(
     *,
     recommended_actions: Sequence[RecommendedAction],
+    primary_source: object | None = None,
     primary_location: str | None = None,
     tier: str,
     cert_reason: str,
@@ -52,7 +67,10 @@ def build_next_steps(
             )
         ]
 
-    report_actions = _report_actions_for_report(recommended_actions)
+    report_actions = _report_actions_for_report(
+        recommended_actions,
+        primary_source=primary_source,
+    )
     location_hint = _usable_primary_location(primary_location, tr=tr)
     next_steps: list[NextStep] = []
     for action in report_actions:
@@ -81,10 +99,15 @@ def build_next_steps(
 
 def _report_actions_for_report(
     recommended_actions: Sequence[RecommendedAction],
+    *,
+    primary_source: object | None,
 ) -> tuple[RecommendedAction, ...]:
     """Return the report-facing action list without disturbing custom summary steps."""
     actions = tuple(recommended_actions)
     if _uses_generated_action_plan(actions):
+        source_actions = _source_aligned_report_actions(actions, primary_source)
+        if source_actions:
+            return source_actions[:_REPORT_FOCUSED_ACTION_LIMIT]
         return actions[:_REPORT_FOCUSED_ACTION_LIMIT]
     return actions
 
@@ -94,6 +117,18 @@ def _uses_generated_action_plan(actions: Sequence[RecommendedAction]) -> bool:
     return bool(actions) and all(
         _normalized_action_id(action.action_id) in _REPORT_FOCUSED_ACTION_SPECS
         for action in actions
+    )
+
+
+def _source_aligned_report_actions(
+    actions: Sequence[RecommendedAction],
+    primary_source: object | None,
+) -> tuple[RecommendedAction, ...]:
+    action_ids = _PRIMARY_SOURCE_ACTION_IDS.get(str(primary_source or "").strip().lower(), ())
+    if not action_ids:
+        return ()
+    return tuple(
+        action for action in actions if _normalized_action_id(action.action_id) in action_ids
     )
 
 
@@ -125,6 +160,8 @@ def _usable_primary_location(
         return None
     unknown_tokens = {"unknown", str(tr("UNKNOWN")).strip().lower()}
     if location.lower() in unknown_tokens:
+        return None
+    if is_composite_location(location) or is_body_like_location(location):
         return None
     return location
 

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1895,6 +1895,14 @@
     "en": "Weak",
     "nl": "Zwak"
   },
+  "REPORT_LOCATION_MIXED_SIGNAL_BETWEEN": {
+    "en": "Mixed signal between {first_location} and {second_location}",
+    "nl": "Gemengd signaal tussen {first_location} en {second_location}"
+  },
+  "REPORT_LOCATION_MIXED_SIGNAL_LIST": {
+    "en": "Mixed signal across {locations}",
+    "nl": "Gemengd signaal over {locations}"
+  },
   "REPORT_MATCHED_WINDOWS_COLUMN": {
     "en": "Sensor matches",
     "nl": "Sensormatches"

--- a/apps/server/vibesensor/report_i18n.py
+++ b/apps/server/vibesensor/report_i18n.py
@@ -54,6 +54,9 @@ _SHORT_LOCATION_LABELS: dict[str, str] = {
     "rear-right wheel": "Rear-Right",
 }
 
+_AMBIGUOUS_LOCATION_PREFIX = "ambiguous location:"
+_BODY_LIKE_LOCATION_TOKENS = {"body", "cabin", "trunk"}
+
 
 @lru_cache(maxsize=1)
 def _load_translations() -> dict[str, dict[str, str]]:
@@ -122,6 +125,36 @@ def human_location(location: object, *, short: bool = True) -> str:
             return short_label
     title = " ".join(part for part in normalized.split() if part)
     return title.title() if title else "Unknown"
+
+
+def location_candidates(location: object) -> tuple[str, ...]:
+    """Split a report location into distinct location candidates."""
+    raw = str(location or "").strip()
+    if not raw:
+        return ()
+    normalized = raw
+    if raw.lower().startswith(_AMBIGUOUS_LOCATION_PREFIX):
+        normalized = raw.split(":", maxsplit=1)[1].strip()
+    parts = [part.strip() for part in normalized.split("/") if part.strip()]
+    unique_parts: list[str] = []
+    for part in parts or [normalized]:
+        if part and part not in unique_parts:
+            unique_parts.append(part)
+    return tuple(unique_parts)
+
+
+def is_composite_location(location: object) -> bool:
+    """Whether a location encodes multiple competing candidates."""
+    return len(location_candidates(location)) > 1
+
+
+def is_body_like_location(location: object) -> bool:
+    """Whether a location points to a broad body/cabin area, not a precise part."""
+    for candidate in location_candidates(location):
+        normalized = candidate.lower().replace("_", " ").replace("-", " ")
+        if _BODY_LIKE_LOCATION_TOKENS.intersection(normalized.split()):
+            return True
+    return False
 
 
 def resolve_i18n(


### PR DESCRIPTION
## Summary

This PR fixes the report-side guidance problem described in #1986, where the PDF could render mechanically incoherent next steps for body/trunk-heavy findings and could also present ambiguous slash-joined locations as though they were precise inspection destinations.

The issue was easiest to see in scenarios where the report landed on a body-adjacent hotspot such as `Trunk`, or on an unresolved tie such as `Front Left / Rear Left`, but then still emitted language that implied the system had narrowed the problem to a clean, inspectable mechanical location. In practice that created two kinds of confusing output. First, trunk/body-dominant reports could inherit wheel/tire-oriented generated action steps, producing instructions that read like “inspect the trunk for tire damage.” Second, ambiguous projected locations were shown verbatim as slash-separated labels, which looked more like unfinished internal state than user-facing guidance.

The fix stays intentionally narrow and report-focused. I did not change the diagnostic scoring, finding ranking, or hotspot generation logic. Instead, I adjusted how the report chooses and phrases the text that users actually see.

## Implementation approach

The investigation showed that the awkward guidance came from the handoff between report mapping and generated action planning, not from the upstream analyzer itself. The test-plan builder can legitimately aggregate candidate actions from more than one finding and then prioritize them globally. That is useful at the system level, but it becomes a UX problem when the report presents those actions as the “what to do next” answer for a single primary source and a single rendered hotspot.

To resolve that mismatch, the report now applies a presentation-layer filter before it turns generated actions into user-facing next steps. The next-step builder in `apps/server/vibesensor/adapters/pdf/report_sections.py` now accepts the primary source in addition to the primary location, and it uses that source to keep generated report actions aligned to the same path the verdict is already presenting. That means an engine/driveline/body-forward report no longer borrows a higher-priority wheel/tire step just because that step existed somewhere else in the synthesized action plan.

I also tightened the “can we safely phrase this as a focused location instruction?” decision. Previously, any non-empty non-unknown location string could flow into the location-specific templates. That worked for precise locations, but it was too permissive for body-like hotspots such as trunk/cabin/body and for slash-joined ambiguous locations. The report now treats those values as too broad or too unresolved for focused inspect-here wording and falls back to the generic action phrasing instead.

## Main code changes by area

In `apps/server/vibesensor/report_i18n.py`, I added small shared helpers for reasoning about report-facing locations. These helpers extract candidate locations, detect composite slash-style locations, and classify broad body-like areas. The goal was to keep that interpretation logic centralized so the mapper and report sections do not each reinvent slightly different rules.

In `apps/server/vibesensor/adapters/pdf/report_sections.py`, I updated the next-step pipeline to use the primary source when deciding which generated actions are appropriate for the report. I added a source-to-action mapping for the current report surfaces, filtered generated actions through that mapping, and preserved the generic fallback when no source-aligned generated action remains. I also tightened `_usable_primary_location()` so composite and body-like hotspots do not get plugged into the location-focused templates.

In `apps/server/vibesensor/adapters/pdf/mapping.py`, I changed location presentation so ambiguous slash-style hotspots are rewritten into explicit mixed-signal wording instead of being surfaced as raw `A / B` labels. That wording now flows into the verdict-page “inspect first” location, the dominant-corner text, the observed strongest-location field, and the pattern-evidence strongest-location field. The result is that the report reads as “mixed signal between Front-Left and Rear-Left” rather than pretending that `Front Left / Rear Left` is a literal place to inspect.

In both report i18n bundles (`apps/server/data/report_i18n.json` and `apps/server/vibesensor/data/report_i18n.json`), I added the localized strings needed for the mixed-signal phrasing. No config, API, or schema changes were required.

## Tests and validation

To keep the fix reviewable and repeatable, I extended the existing synthetic report helpers in `apps/server/tests/test_support/report_helpers.py` instead of depending on a heavier end-to-end simulator run for every iteration. I added a focused ambiguous-location summary fixture and a trunk-primary guidance fixture with generated action plans that intentionally mix wheel actions with engine/driveline actions. Those fixtures let the tests reproduce the exact report-layer failure mode directly.

I then added and updated regressions in `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py` and `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`. The new coverage verifies that:

- generated next steps stay aligned to the primary source path for trunk/body-style findings,
- ambiguous primary locations are rephrased as mixed-signal wording instead of raw slash labels,
- the rendered PDF text on page one reflects the same improved wording,
- the existing placeholder-token protection still works with the new source-aligned behavior.

For local validation I ran:

- `PYTHONPATH=apps/server:apps/server/tests ./.venv/bin/pytest apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py -q`
- `make lint`

The focused suites passed with `49 passed`, and `make lint` passed after applying the repo-native formatter.

## Risks, tradeoffs, and edge cases

The main tradeoff in this change is intentional: the report is now biased toward coherence with the chosen primary source rather than maximal reuse of every generated action the planner can produce. That means some alternative-path actions may no longer appear in the short “next steps” block when they come from a different source family than the report’s primary diagnosis. I believe that is the right tradeoff for this surface, because the prior behavior produced instructions that were more comprehensive on paper but less believable and less actionable in the actual PDF.

I also kept the location rewrite conservative. This PR does not attempt to infer richer semantic labels such as “left-side mixed signal” or “front-vs-rear tie” beyond what can be stated confidently from the existing location candidates. It simply stops presenting unresolved ties as precision destinations. If we want richer phrasing later, that can be layered on top of the new helpers without reworking the report pipeline again.

## Out of scope

This PR does not change upstream hotspot generation, ranking, or diagnostic evidence thresholds, and it does not address the broader insufficient-evidence recapture-page problem tracked separately in #1987. The goal here is narrower: make the report guidance and location wording mechanically coherent when the primary finding is broad-body/trunk-like or when the location signal is explicitly ambiguous.
