### PR TITLE
Fix #1987 scenario-specific recapture guidance

### DIFF
--- a/apps/server/data/report_i18n.json
+++ b/apps/server/data/report_i18n.json
@@ -1715,6 +1715,18 @@
     "en": "Capture a longer steady-speed window before treating the corner call as final.",
     "nl": "Leg eerst een langere stabiele snelheidsperiode vast voordat je de hoekindicatie als definitief ziet."
   },
+  "REPORT_RECAPTURE_CONDITION_COMPARE_PATHS": {
+    "en": "Cover the same speed band in separate drive/coast or load-change passes so competing sources separate cleanly.",
+    "nl": "Dek dezelfde snelheidsband af in aparte aangedreven/uitrollende of belastingswissel-passes zodat concurrerende bronnen schoner uit elkaar vallen."
+  },
+  "REPORT_RECAPTURE_CONDITION_REPEAT_EVENT": {
+    "en": "Repeat the same trigger with enough before/after baseline so the transient event can recur cleanly.",
+    "nl": "Herhaal dezelfde trigger met genoeg basislijn voor en na het event zodat de tijdelijke gebeurtenis schoon kan terugkomen."
+  },
+  "REPORT_RECAPTURE_CONDITION_STEADY_HOLD": {
+    "en": "Hold a repeatable steady-speed window through the problem band before changing throttle or load.",
+    "nl": "Houd een herhaalbare stabiele snelheidsfase aan door de probleemzone voordat gas of belasting verandert."
+  },
   "REPORT_CAPTURE_ISSUES_TITLE": {
     "en": "What was insufficient in this run",
     "nl": "Wat onvoldoende was in deze run"
@@ -1722,6 +1734,34 @@
   "REPORT_CAPTURE_ISSUE_GENERIC": {
     "en": "Current evidence is not strong enough to support an action-ready verdict.",
     "nl": "Het huidige bewijs is niet sterk genoeg voor een direct bruikbaar oordeel."
+  },
+  "REPORT_RECAPTURE_ISSUE_MIXED_LOCATION": {
+    "en": "Location evidence stayed mixed between multiple positions instead of narrowing to one inspect-first area.",
+    "nl": "Het locatiebewijs bleef gemengd tussen meerdere posities in plaats van te vernauwen naar één eerste inspectiegebied."
+  },
+  "REPORT_RECAPTURE_ISSUE_SOURCE_OVERLAP": {
+    "en": "{primary} and {alternative} evidence overlapped in the same window, so this run did not separate one inspection path cleanly.",
+    "nl": "Bewijs voor {primary} en {alternative} overlapte in hetzelfde venster, waardoor deze run geen enkel inspectiepad schoon scheidde."
+  },
+  "REPORT_RECAPTURE_ISSUE_TRANSIENT": {
+    "en": "The strongest signal was transient or intermittent, so it did not repeat cleanly enough for an inspection-first verdict.",
+    "nl": "Het sterkste signaal was tijdelijk of intermitterend en herhaalde zich daardoor niet schoon genoeg voor een inspectie-eerste conclusie."
+  },
+  "REPORT_RECAPTURE_ISSUE_WEAK_LOCATION": {
+    "en": "Location evidence stayed spread across multiple positions instead of separating one inspect-first area.",
+    "nl": "Het locatiebewijs bleef verspreid over meerdere posities in plaats van één eerste inspectiegebied te scheiden."
+  },
+  "REPORT_RECAPTURE_ACTION_COMPARE_PATHS": {
+    "en": "Repeat the same speed band with separate drive/coast or load-change passes to separate the overlapping source paths.",
+    "nl": "Herhaal dezelfde snelheidsband met aparte aangedreven/uitrollende of belastingswissel-passes om overlappende bronpaden te scheiden."
+  },
+  "REPORT_RECAPTURE_ACTION_REPEAT_EVENT": {
+    "en": "Repeat the same trigger several times and capture before/during/after the event so the transient signal can recur cleanly.",
+    "nl": "Herhaal dezelfde trigger meerdere keren en meet voor/tijdens/na het event zodat het tijdelijke signaal schoon kan terugkomen."
+  },
+  "REPORT_RECAPTURE_ACTION_STEADY_HOLD": {
+    "en": "Repeat the same speed band with a longer steady hold before adding accel/decel transitions.",
+    "nl": "Herhaal dezelfde snelheidsband met een langere stabiele fase voordat accel/decel-overgangen worden toegevoegd."
   },
   "REPORT_COVERAGE_ACTIVE_OF_EXPECTED": {
     "en": "{active} of {expected} expected positions stayed connected.",

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -10,6 +10,7 @@ from test_support.report_helpers import (
     RUN_END,
     ambiguous_primary_location_summary,
     minimal_summary,
+    recapture_guidance_summary,
     sequential_same_source_summary,
     trunk_primary_guidance_summary,
     write_jsonl,
@@ -245,8 +246,53 @@ def test_map_summary_rephrases_ambiguous_primary_locations_as_mixed_signal() -> 
     assert data.verdict_page.inspect_first == expected
     assert data.verdict_page.dominant_corner == expected
     assert data.observed.strongest_location == expected
-    assert data.pattern_evidence.strongest_location == expected
-    assert "/" not in data.verdict_page.inspect_first
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_issue", "expected_step", "expected_condition"),
+    [
+        pytest.param(
+            "steady",
+            "Speed range never settled into a usable diagnostic band",
+            "Repeat the same speed band with a longer steady hold",
+            "Hold a repeatable steady-speed window",
+            id="steady-speed-recature-guidance",
+        ),
+        pytest.param(
+            "overlap",
+            "Wheel / Tire and Driveline evidence overlapped",
+            "Repeat the same speed band with separate drive/coast or load-change passes",
+            "Cover the same speed band in separate drive/coast or load-change passes",
+            id="source-overlap-recature-guidance",
+        ),
+        pytest.param(
+            "weak",
+            "Location evidence stayed spread across multiple positions",
+            "Add sensor locations",
+            "Keep all 4 expected positions connected throughout the run",
+            id="weak-location-recature-guidance",
+        ),
+        pytest.param(
+            "transient",
+            "The strongest signal was transient or intermittent",
+            "Repeat the same trigger several times",
+            "Repeat the same trigger with enough before/after baseline",
+            id="transient-recature-guidance",
+        ),
+    ],
+)
+def test_map_summary_builds_scenario_specific_recapture_guidance(
+    mode: str,
+    expected_issue: str,
+    expected_step: str,
+    expected_condition: str,
+) -> None:
+    data = map_summary(prepare_report_input(recapture_guidance_summary(mode)))
+
+    assert data.appendix_a.mode == "recapture"
+    assert any(expected_issue in line for line in data.appendix_a.capture_issues)
+    assert any(expected_step in step.action for step in data.next_steps)
+    assert any(expected_condition in line for line in data.appendix_a.capture_conditions)
 
 
 def test_map_summary_formats_report_timestamps_for_header() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -14,6 +14,7 @@ from test_support.report_helpers import (
     RUN_END,
     ambiguous_primary_location_summary,
     minimal_summary,
+    recapture_guidance_summary,
     sequential_same_source_summary,
     trunk_primary_guidance_summary,
     write_jsonl,
@@ -516,6 +517,41 @@ def test_build_report_pdf_keeps_same_source_temporal_shift_visible_in_recapture_
     assert "Front-Left" in text
     assert "Rear-Right" in text
     assert "No single corner stayed dominant through the whole run" in text
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_page_two_text"),
+    [
+        pytest.param(
+            "steady",
+            "Speed range never settled into a usable diagnostic band",
+            id="steady-speed-page-two-guidance",
+        ),
+        pytest.param(
+            "overlap",
+            "Wheel / Tire and Driveline evidence overlapped",
+            id="source-overlap-page-two-guidance",
+        ),
+        pytest.param(
+            "weak",
+            "Location evidence stayed spread across multiple positions",
+            id="weak-location-page-two-guidance",
+        ),
+        pytest.param(
+            "transient",
+            "The strongest signal was transient or intermittent",
+            id="transient-page-two-guidance",
+        ),
+    ],
+)
+def test_build_report_pdf_recapture_page_uses_scenario_specific_guidance(
+    mode: str,
+    expected_page_two_text: str,
+) -> None:
+    pdf = build_report_pdf(map_summary(prepare_report_input(recapture_guidance_summary(mode))))
+    page_two_text = " ".join((PdfReader(BytesIO(pdf)).pages[1].extract_text() or "").split())
+
+    assert expected_page_two_text in page_two_text
 
 
 def test_build_page1_layout_prioritizes_observed_signature_panel() -> None:

--- a/apps/server/tests/test_support/report_helpers.py
+++ b/apps/server/tests/test_support/report_helpers.py
@@ -317,6 +317,119 @@ def trunk_primary_guidance_summary(*, primary_source: str) -> dict:
     )
 
 
+def recapture_guidance_summary(mode: str) -> dict:
+    """Return a recapture-mode summary tailored to one insufficiency mode."""
+    base = {
+        "lang": "en",
+        "record_length": "00:20.0",
+        "sensor_count_used": 4,
+        "sensor_locations": ["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        "sensor_locations_connected_throughout": [
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        "speed_stats": {"steady_speed": False},
+    }
+    if mode == "steady":
+        finding = make_finding_payload(
+            finding_id="F_STEADY",
+            suspected_source="wheel/tire",
+            confidence=0.34,
+            strongest_location="Front Left",
+            strongest_speed_band="40-60 km/h",
+            confidence_label_key="CONFIDENCE_LOW",
+            confidence_tone="neutral",
+            confidence_pct="34%",
+            confidence_reason="Speed was not steady during measurement",
+        )
+        return minimal_summary(
+            **base,
+            findings=[finding],
+            top_causes=[finding],
+            run_suitability=[
+                {
+                    "check": "SUITABILITY_CHECK_SPEED_VARIATION",
+                    "check_key": "SUITABILITY_CHECK_SPEED_VARIATION",
+                    "state": "warn",
+                    "explanation": "SUITABILITY_SPEED_VARIATION_WARN",
+                }
+            ],
+        )
+    if mode == "overlap":
+        overlap_reason = (
+            "Wheel and driveline evidence overlap, so the system could not strongly "
+            "differentiate between them; inspect both areas."
+        )
+        wheel = make_finding_payload(
+            finding_id="F_WHEEL_RECAPTURE",
+            suspected_source="wheel/tire",
+            confidence=0.35,
+            strongest_location="Front Left",
+            strongest_speed_band="60-80 km/h",
+            signatures_observed=["1x wheel order"],
+            confidence_label_key="CONFIDENCE_LOW",
+            confidence_tone="neutral",
+            confidence_pct="35%",
+            confidence_reason=overlap_reason,
+        )
+        driveline = make_finding_payload(
+            finding_id="F_DRIVELINE_RECAPTURE",
+            suspected_source="driveline",
+            confidence=0.33,
+            strongest_location="Front Left",
+            strongest_speed_band="60-80 km/h",
+            signatures_observed=["1x driveshaft"],
+            confidence_label_key="CONFIDENCE_LOW",
+            confidence_tone="neutral",
+            confidence_pct="33%",
+            confidence_reason=overlap_reason,
+        )
+        return minimal_summary(
+            **base,
+            findings=[wheel, driveline],
+            top_causes=[wheel, driveline],
+        )
+    if mode == "weak":
+        finding = make_finding_payload(
+            finding_id="F_WEAK",
+            suspected_source="wheel/tire",
+            confidence=0.55,
+            strongest_location="Front Left",
+            strongest_speed_band="50-70 km/h",
+            weak_spatial_separation=True,
+            confidence_label_key="CONFIDENCE_MEDIUM",
+            confidence_tone="warn",
+            confidence_pct="55%",
+            confidence_reason="Vibration spread across multiple locations",
+        )
+        return minimal_summary(
+            **base,
+            findings=[finding],
+            top_causes=[finding],
+        )
+    if mode == "transient":
+        finding = make_finding_payload(
+            finding_id="F_TRANSIENT",
+            suspected_source="transient_impact",
+            confidence=0.28,
+            strongest_location="Rear Left",
+            strongest_speed_band="20-30 km/h",
+            peak_classification="transient",
+            confidence_label_key="CONFIDENCE_LOW",
+            confidence_tone="neutral",
+            confidence_pct="28%",
+            confidence_reason="Confidence downgraded due to negligible vibration strength",
+        )
+        return minimal_summary(
+            **base,
+            findings=[finding],
+            top_causes=[finding],
+        )
+    raise ValueError(f"Unsupported recapture guidance mode: {mode}")
+
+
 def report_run_metadata(
     run_id: str = "run-01",
     *,

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -321,6 +321,17 @@ def _first_nonpass_detail(data_trust: list[DataTrustItem]) -> str | None:
     return None
 
 
+def _nonpass_detail_lines(data_trust: list[DataTrustItem]) -> list[str]:
+    lines: list[str] = []
+    for item in data_trust:
+        if item.state == "pass":
+            continue
+        detail = str(item.detail or item.check).strip()
+        if detail:
+            lines.append(detail)
+    return lines
+
+
 def _confidence_pct_text(finding: Finding) -> str:
     if finding.confidence_assessment is not None:
         return finding.confidence_assessment.pct_text
@@ -765,6 +776,168 @@ def _run_limits_summary_text(
         return tr("REPORT_RUN_LIMITS_RECAPTURE_RECIPE", speed=speed_window)
     note = _proof_caveat_text(primary, report_facts, tr=tr)
     return note or tr("REPORT_CAPTURE_ISSUE_GENERIC")
+
+
+def _check_state(
+    report_facts: PreparedReportFacts,
+    check_key: str,
+) -> str:
+    target = check_key.strip().upper()
+    for check in report_facts.suitability_checks:
+        key = str(check.get("check_key") or "").strip().upper()
+        if key == target:
+            return str(check.get("state") or "").strip().lower()
+    return ""
+
+
+def _has_warning_code(report_facts: PreparedReportFacts, code: str) -> bool:
+    target = code.strip().lower()
+    return any(
+        str(warning.get("code") or "").strip().lower() == target
+        for warning in report_facts.warnings
+    )
+
+
+def _is_transient_primary(primary: PrimaryCandidateContext) -> bool:
+    finding = primary.primary_candidate
+    if finding is None:
+        return False
+    source = str(finding.suspected_source or "").strip().lower()
+    classification = str(finding.peak_classification or "").strip().lower()
+    return source == "transient_impact" or classification == "transient"
+
+
+def _has_source_overlap(
+    aggregate: TestRun,
+    *,
+    tr: Callable[..., str],
+) -> bool:
+    ranked = list(aggregate.effective_top_causes()[:2])
+    if len(ranked) < 2:
+        return False
+    return _uses_shared_overlap_wording(ranked[0], ranked[1], tr=tr)
+
+
+def _append_unique_line(lines: list[str], text: object) -> None:
+    value = str(text or "").strip()
+    if not value:
+        return
+    normalized = value.rstrip(".").casefold()
+    if any(existing.rstrip(".").casefold() == normalized for existing in lines):
+        return
+    lines.append(value)
+
+
+def _recapture_issue_lines(
+    *,
+    aggregate: TestRun,
+    primary: PrimaryCandidateContext,
+    report_facts: PreparedReportFacts,
+    data_trust: list[DataTrustItem],
+    tr: Callable[..., str],
+) -> list[str]:
+    issues: list[str] = []
+    if _has_source_overlap(aggregate, tr=tr):
+        ranked = list(aggregate.effective_top_causes()[:2])
+        if len(ranked) > 1:
+            _append_unique_line(
+                issues,
+                tr(
+                    "REPORT_RECAPTURE_ISSUE_SOURCE_OVERLAP",
+                    primary=human_source(ranked[0].suspected_source, tr=tr),
+                    alternative=human_source(ranked[1].suspected_source, tr=tr),
+                ),
+            )
+    if report_facts.location_confidence_key == "weak":
+        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_WEAK_LOCATION"))
+    elif report_facts.location_confidence_key == "mixed":
+        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_MIXED_LOCATION"))
+    if _is_transient_primary(primary):
+        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_TRANSIENT"))
+    for detail in _nonpass_detail_lines(data_trust):
+        _append_unique_line(issues, detail)
+    if not issues:
+        note = _proof_caveat_text(primary, report_facts, tr=tr)
+        _append_unique_line(issues, note or tr("REPORT_CAPTURE_ISSUE_GENERIC"))
+    return issues[:4]
+
+
+def _recapture_next_steps(
+    *,
+    aggregate: TestRun,
+    primary: PrimaryCandidateContext,
+    report_facts: PreparedReportFacts,
+    tr: Callable[..., str],
+) -> list[NextStep]:
+    expected = len(report_facts.coverage_summary.expected_locations) or len(
+        report_facts.coverage_summary.active_locations
+    )
+    actions: list[str] = []
+    if _has_source_overlap(aggregate, tr=tr):
+        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_COMPARE_PATHS"))
+    if _check_state(report_facts, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
+        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_STEADY_HOLD"))
+    if _is_transient_primary(primary):
+        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_REPEAT_EVENT"))
+    if (
+        report_facts.location_confidence_key in {"weak", "mixed"}
+        or _check_state(report_facts, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
+    ):
+        _append_unique_line(
+            actions,
+            tr("TIER_A_CAPTURE_MORE_SENSORS"),
+        )
+    if (
+        report_facts.primary_candidate_facts.has_reference_gaps
+        or _check_state(report_facts, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
+        or _has_warning_code(report_facts, "reference_context_incomplete")
+    ):
+        _append_unique_line(actions, tr("TIER_A_CAPTURE_REFERENCE_DATA"))
+    if not actions:
+        _append_unique_line(actions, tr("TIER_A_CAPTURE_WIDER_SPEED"))
+        _append_unique_line(
+            actions,
+            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
+        )
+    return [NextStep(action=action) for action in actions[:4]]
+
+
+def _recapture_condition_lines(
+    *,
+    aggregate: TestRun,
+    primary: PrimaryCandidateContext,
+    report_facts: PreparedReportFacts,
+    tr: Callable[..., str],
+) -> list[str]:
+    expected = len(report_facts.coverage_summary.expected_locations) or len(
+        report_facts.coverage_summary.active_locations
+    )
+    lines: list[str] = []
+    if _check_state(report_facts, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
+        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_STEADY_HOLD"))
+    if _has_source_overlap(aggregate, tr=tr):
+        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_COMPARE_PATHS"))
+    if _is_transient_primary(primary):
+        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_REPEAT_EVENT"))
+    if (
+        report_facts.location_confidence_key in {"weak", "mixed"}
+        or _check_state(report_facts, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
+    ):
+        _append_unique_line(
+            lines,
+            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
+        )
+    if (
+        report_facts.primary_candidate_facts.has_reference_gaps
+        or _check_state(report_facts, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
+        or _has_warning_code(report_facts, "reference_context_incomplete")
+    ):
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
+    if not lines:
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_STEADY"))
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected))
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
+    return lines[:4]
 
 
 def _candidate_signal_text(finding: Finding, *, tr: Callable[..., str]) -> str:
@@ -1292,7 +1465,13 @@ def _build_verdict_page_data(
             tr=tr,
         ),
         reason_sentence=(
-            tr("REPORT_REASON_RECAPTURE_GENERIC")
+            _recapture_issue_lines(
+                aggregate=aggregate,
+                primary=primary,
+                report_facts=report_facts,
+                data_trust=data_trust,
+                tr=tr,
+            )[0]
             if recapture_before_acting
             else _build_primary_reason_sentence(primary, report_facts=report_facts, tr=tr)
         ),
@@ -1336,6 +1515,7 @@ def _build_verdict_page_data(
 def _build_appendix_a_data(
     *,
     aggregate: TestRun,
+    primary: PrimaryCandidateContext,
     report_facts: PreparedReportFacts,
     next_steps: list[NextStep],
     data_trust: list[DataTrustItem],
@@ -1345,9 +1525,20 @@ def _build_appendix_a_data(
     if report_facts.action_status_key == "recapture_before_acting":
         return AppendixAData(
             mode="recapture",
-            capture_issues=_capture_issue_lines(data_trust, tr=tr),
+            capture_issues=_recapture_issue_lines(
+                aggregate=aggregate,
+                primary=primary,
+                report_facts=report_facts,
+                data_trust=data_trust,
+                tr=tr,
+            ),
             capture_changes=[step.action for step in next_steps],
-            capture_conditions=_capture_condition_lines(report_facts, tr=tr),
+            capture_conditions=_recapture_condition_lines(
+                aggregate=aggregate,
+                primary=primary,
+                report_facts=report_facts,
+                tr=tr,
+            ),
         )
     alternative_source = (
         tr(
@@ -1652,21 +1843,30 @@ def _build_report_template_data(
         tr,
     )
     recapture_mode = report_facts.action_status_key == "recapture_before_acting"
-    next_steps = build_next_steps(
-        recommended_actions=report_facts.recommended_actions,
-        primary_source=primary.primary_source,
-        primary_location=primary.primary_location,
-        tier=primary.tier,
-        cert_reason=primary.certainty_reason or tr("REPORT_CAPTURE_ISSUE_GENERIC"),
-        recapture_mode=recapture_mode,
-        lang=lang,
-        tr=tr,
-    )
     data_trust = build_data_trust(
         suitability_checks=report_facts.suitability_checks,
         warnings=report_facts.warnings,
         lang=lang,
         tr=tr,
+    )
+    next_steps = (
+        _recapture_next_steps(
+            aggregate=context.domain_aggregate,
+            primary=primary,
+            report_facts=report_facts,
+            tr=tr,
+        )
+        if recapture_mode
+        else build_next_steps(
+            recommended_actions=report_facts.recommended_actions,
+            primary_source=primary.primary_source,
+            primary_location=primary.primary_location,
+            tier=primary.tier,
+            cert_reason=primary.certainty_reason or tr("REPORT_CAPTURE_ISSUE_GENERIC"),
+            recapture_mode=recapture_mode,
+            lang=lang,
+            tr=tr,
+        )
     )
     pattern_evidence = build_pattern_evidence(
         context,
@@ -1699,6 +1899,7 @@ def _build_report_template_data(
     )
     appendix_a = _build_appendix_a_data(
         aggregate=context.domain_aggregate,
+        primary=primary,
         report_facts=report_facts,
         next_steps=next_steps,
         data_trust=data_trust,

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1715,6 +1715,18 @@
     "en": "Capture a longer steady-speed window before treating the corner call as final.",
     "nl": "Leg eerst een langere stabiele snelheidsperiode vast voordat je de hoekindicatie als definitief ziet."
   },
+  "REPORT_RECAPTURE_CONDITION_COMPARE_PATHS": {
+    "en": "Cover the same speed band in separate drive/coast or load-change passes so competing sources separate cleanly.",
+    "nl": "Dek dezelfde snelheidsband af in aparte aangedreven/uitrollende of belastingswissel-passes zodat concurrerende bronnen schoner uit elkaar vallen."
+  },
+  "REPORT_RECAPTURE_CONDITION_REPEAT_EVENT": {
+    "en": "Repeat the same trigger with enough before/after baseline so the transient event can recur cleanly.",
+    "nl": "Herhaal dezelfde trigger met genoeg basislijn voor en na het event zodat de tijdelijke gebeurtenis schoon kan terugkomen."
+  },
+  "REPORT_RECAPTURE_CONDITION_STEADY_HOLD": {
+    "en": "Hold a repeatable steady-speed window through the problem band before changing throttle or load.",
+    "nl": "Houd een herhaalbare stabiele snelheidsfase aan door de probleemzone voordat gas of belasting verandert."
+  },
   "REPORT_CAPTURE_ISSUES_TITLE": {
     "en": "What was insufficient in this run",
     "nl": "Wat onvoldoende was in deze run"
@@ -1722,6 +1734,34 @@
   "REPORT_CAPTURE_ISSUE_GENERIC": {
     "en": "Current evidence is not strong enough to support an action-ready verdict.",
     "nl": "Het huidige bewijs is niet sterk genoeg voor een direct bruikbaar oordeel."
+  },
+  "REPORT_RECAPTURE_ISSUE_MIXED_LOCATION": {
+    "en": "Location evidence stayed mixed between multiple positions instead of narrowing to one inspect-first area.",
+    "nl": "Het locatiebewijs bleef gemengd tussen meerdere posities in plaats van te vernauwen naar één eerste inspectiegebied."
+  },
+  "REPORT_RECAPTURE_ISSUE_SOURCE_OVERLAP": {
+    "en": "{primary} and {alternative} evidence overlapped in the same window, so this run did not separate one inspection path cleanly.",
+    "nl": "Bewijs voor {primary} en {alternative} overlapte in hetzelfde venster, waardoor deze run geen enkel inspectiepad schoon scheidde."
+  },
+  "REPORT_RECAPTURE_ISSUE_TRANSIENT": {
+    "en": "The strongest signal was transient or intermittent, so it did not repeat cleanly enough for an inspection-first verdict.",
+    "nl": "Het sterkste signaal was tijdelijk of intermitterend en herhaalde zich daardoor niet schoon genoeg voor een inspectie-eerste conclusie."
+  },
+  "REPORT_RECAPTURE_ISSUE_WEAK_LOCATION": {
+    "en": "Location evidence stayed spread across multiple positions instead of separating one inspect-first area.",
+    "nl": "Het locatiebewijs bleef verspreid over meerdere posities in plaats van één eerste inspectiegebied te scheiden."
+  },
+  "REPORT_RECAPTURE_ACTION_COMPARE_PATHS": {
+    "en": "Repeat the same speed band with separate drive/coast or load-change passes to separate the overlapping source paths.",
+    "nl": "Herhaal dezelfde snelheidsband met aparte aangedreven/uitrollende of belastingswissel-passes om overlappende bronpaden te scheiden."
+  },
+  "REPORT_RECAPTURE_ACTION_REPEAT_EVENT": {
+    "en": "Repeat the same trigger several times and capture before/during/after the event so the transient signal can recur cleanly.",
+    "nl": "Herhaal dezelfde trigger meerdere keren en meet voor/tijdens/na het event zodat het tijdelijke signaal schoon kan terugkomen."
+  },
+  "REPORT_RECAPTURE_ACTION_STEADY_HOLD": {
+    "en": "Repeat the same speed band with a longer steady hold before adding accel/decel transitions.",
+    "nl": "Herhaal dezelfde snelheidsband met een langere stabiele fase voordat accel/decel-overgangen worden toegevoegd."
   },
   "REPORT_COVERAGE_ACTIVE_OF_EXPECTED": {
     "en": "{active} of {expected} expected positions stayed connected.",


### PR DESCRIPTION
## Summary

This PR fixes the recapture-guidance problem described in #1987. The insufficient-evidence path already distinguishes several different failure modes in the prepared report inputs, but the PDF was flattening those differences into almost the same recapture page every time. In practice, page 2 kept repeating the same generic “what changed / what conditions / recapture before acting” pattern whether the run failed because speed never stabilized, source evidence overlapped, location evidence stayed weak, or the strongest signal was only transient.

The result was technically safe but not very helpful. A reader could tell that the run was not action-ready, but not what specifically prevented the report from becoming actionable. The issue examples in `highway-window-shudder`, `launch-engine-flare`, `pothole-recovery-loop`, `lane-change-left-right`, and `driveline-coastdown` all point to that same UX problem: the report is correctly cautious, but the recapture path is too generic to teach the operator what to improve next.

The fix stays intentionally in the report layer. I did not change finding generation, confidence scoring, or the action-status gate that decides whether a run lands on `recapture_before_acting`. Instead, I changed how the PDF mapper translates the already-available report facts into user-facing recapture guidance.

## Implementation approach

The investigation traced the flattening to a few report-side seams in `apps/server/vibesensor/adapters/pdf/mapping.py`.

First, page 1 always used the same `REPORT_REASON_RECAPTURE_GENERIC` sentence in recapture mode. That meant the summary explanation on the verdict surface did not reflect whether the limiting factor was speed stability, localization quality, transient evidence, or source overlap.

Second, the recapture `next_steps` list was still coming from the generic Tier-A fallback path, which always produced the same high-level three-step capture recipe. Those action titles also feed the page-1 actions panel, so the generic behavior was visible before the user even reached Appendix A.

Third, Appendix A recapture mode built its `capture_issues` from non-pass trust items but then paired that with a fixed list of capture conditions and the same boilerplate action sequence. The page layout itself was not the main problem; the content feeding those panels was too repetitive.

To address that, the mapper now derives recapture guidance from existing structured signals in prepared report facts and data-trust items. The change uses signals the system already knew about: non-pass suitability checks, reference-context warnings, weak vs mixed localization, overlap between the top two source paths, and transient-primary findings. That gives the report a scenario-aware explanation without creating new diagnostics behavior or introducing a second competing reasoning pipeline.

## Main code changes by area

In `apps/server/vibesensor/adapters/pdf/mapping.py`, I added focused helper functions that classify recapture-facing guidance from existing facts. These helpers build three things:

- scenario-specific recapture issue lines,
- scenario-specific recapture action titles,
- scenario-specific capture conditions.

The helper logic currently distinguishes the concrete categories the issue called out: unstable speed windows, overlapping source paths, weak or mixed location evidence, transient-only evidence, and reference/coverage limitations. The mapper now uses that information in three places:

- page-1 recapture `reason_sentence` now comes from the first scenario-specific recapture issue instead of the old generic sentence,
- recapture `next_steps` now use scenario-specific action titles so the page-1 actions panel is more relevant,
- Appendix A recapture mode now renders scenario-specific `capture_issues`, `capture_changes`, and `capture_conditions` instead of boilerplate lists.

In the two report i18n bundles (`apps/server/data/report_i18n.json` and `apps/server/vibesensor/data/report_i18n.json`), I added the new localized strings for these recapture scenarios. The new copy covers source-overlap, weak-location, mixed-location, and transient-evidence issue lines, plus targeted action/condition wording for steady holds, overlap-separation passes, and repeatable transient capture. I left existing generic recapture copy in place as a safe fallback when none of the more specific branches apply.

In `apps/server/tests/test_support/report_helpers.py`, I added a focused synthetic fixture builder for recapture guidance. Rather than relying on expensive end-to-end scenario reproduction for every test, the new helper creates report-ready summaries for four representative recapture buckets:

- missing steady hold,
- overlapping source paths,
- weak spatial separation,
- transient-only evidence.

That keeps the tests targeted while still exercising the same report-preparation and mapping seams that the real scenarios use.

## Tests and validation

I added new regressions in both focused PDF test modules.

In `apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py`, the new parameterized recapture-guidance test verifies that the mapped report data changes by scenario. It asserts that the appendix issues, page-1 recapture actions, and appendix conditions all reflect the correct failure mode instead of falling back to the same boilerplate output.

In `apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`, the new parameterized PDF test renders recapture-mode PDFs and asserts that page 2 text reflects the expected scenario-specific issue wording. That gives coverage at the actual rendered-PDF surface the issue is concerned with, not only at the intermediate mapping layer.

For local validation I ran:

- `PYTHONPATH=apps/server:apps/server/tests ./.venv/bin/pytest apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py -q`
- `PYTHONPATH=apps/server:apps/server/tests ./.venv/bin/pytest apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_report_pdf.py -q`
- `make lint`

The focused suites passed (`57 passed`), the broader adjacent coverage passed (`84 passed`), and `make lint` passed after applying the repo-native formatter.

## Risks, tradeoffs, and edge cases

The main tradeoff is that this PR intentionally keeps the reasoning lightweight and report-facing. It does not attempt to infer an exhaustive taxonomy of every possible insufficient-evidence state. Instead, it promotes the most useful already-available signals into clearer recapture guidance. That means the report is substantially more scenario-aware than before while still keeping the logic reviewable and predictable.

I also kept the fallback behavior intact. If a recapture run does not hit one of the specific branches added here, the mapper still falls back to the previous generic guidance instead of failing or emitting partial content. That preserves safety for edge cases the new tests do not yet model.

Another tradeoff is that some guidance categories are intentionally broad. For example, “source overlap” is currently driven by the same overlap semantics already used elsewhere in the report, rather than a brand-new generalized overlap detector. That keeps the implementation anchored to behavior the codebase already recognizes and tests.

## Out of scope

This PR does not change the underlying recapture-vs-action-ready decision, finding ranking, or diagnostics confidence math. It also does not try to redesign the recapture page layout itself or collapse page 2. The goal here is narrower and directly aligned to #1987: keep the existing recapture flow, but make the visible guidance explain what specifically failed in a scenario-aware way.
