### PR TITLE
Move report decision logic out of the PDF mapper

### DIFF
--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -239,3 +239,23 @@ def test_mapping_module_no_longer_reexports_raw_summary_report_builder() -> None
     import vibesensor.adapters.pdf.mapping as mapping
 
     assert not hasattr(mapping, "build_report_from_summary")
+
+
+def test_mapping_section_builders_consume_prepared_display_facts() -> None:
+    from inspect import signature
+
+    import vibesensor.adapters.pdf.mapping as mapping
+
+    verdict_params = signature(mapping._build_verdict_page_data).parameters
+    assert "verdict" in verdict_params
+    assert "aggregate" not in verdict_params
+    assert "primary" not in verdict_params
+    assert "report_facts" not in verdict_params
+
+    appendix_a_params = signature(mapping._build_appendix_a_data).parameters
+    assert "appendix" in appendix_a_params
+    assert "report_facts" not in appendix_a_params
+
+    appendix_b_params = signature(mapping._build_appendix_b_data).parameters
+    assert "appendix" in appendix_b_params
+    assert "report_facts" not in appendix_b_params

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -162,6 +162,21 @@ def test_prepare_report_facts_keeps_phase_timeline_intervals() -> None:
     assert facts.timeline_intervals[1].has_fault_evidence is True
 
 
+def test_prepare_report_facts_precomputes_workflow_display_sections() -> None:
+    summary = _summary()
+    test_run = build_test_run_from_summary(summary)
+    assert test_run is not None
+
+    facts = prepare_report_facts(summary, test_run=test_run)
+
+    assert facts.display.verdict.action_status
+    assert facts.display.verdict.suspected_source
+    assert facts.display.appendix_a.mode == "workflow"
+    assert len(facts.display.appendix_a.ranked_candidates) == 1
+    assert facts.display.appendix_b.coverage_label == facts.display.verdict.coverage_label
+    assert len(facts.display.verdict.footer_routes) == 4
+
+
 @pytest.mark.parametrize(
     ("source", "order_label"),
     [
@@ -196,3 +211,18 @@ def test_prepare_report_facts_keeps_weak_spatial_wheel_findings_on_recapture_pat
 
     assert facts.location_confidence_key == "weak"
     assert facts.action_status_key == "recapture_before_acting"
+
+
+def test_prepare_report_facts_precomputes_recapture_display_guidance() -> None:
+    summary = _weak_spatial_order_summary(source="wheel/tire", order_label="1x wheel order")
+    test_run = build_test_run_from_summary(summary)
+    assert test_run is not None
+
+    facts = prepare_report_facts(summary, test_run=test_run)
+
+    assert facts.display.appendix_a.mode == "recapture"
+    assert facts.display.appendix_a.capture_issues
+    assert facts.display.appendix_a.capture_changes
+    assert facts.display.appendix_a.capture_conditions
+    assert facts.display.verdict.reason_sentence == facts.display.appendix_a.capture_issues[0]
+    assert len(facts.display.verdict.footer_routes) == 1

--- a/apps/server/vibesensor/adapters/pdf/mapping.py
+++ b/apps/server/vibesensor/adapters/pdf/mapping.py
@@ -1,9 +1,9 @@
 """report_mapping – thin mapper from prepared report inputs to template data.
 
-Context preparation now happens on the PDF side from the validated prepared
-report-input seam, while this module keeps focused PDF mapping logic plus the
-final renderer-facing orchestration. It receives an explicit prepared report
-input and maps it to :class:`ReportTemplateData` for the PDF renderer.
+History-side preparation owns semantic report facts and display decisions
+before the renderer boundary. This module consumes the validated prepared
+report-input seam, formats those prepared values into renderer dataclasses, and
+handles the final template-data orchestration for the PDF renderer.
 """
 
 from __future__ import annotations
@@ -75,6 +75,11 @@ from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
 from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
 from vibesensor.shared.types.json_types import JsonValue
+from vibesensor.use_cases.history.report_display_facts import (
+    PreparedAppendixADisplay,
+    PreparedAppendixBSummaryDisplay,
+    PreparedVerdictDisplay,
+)
 from vibesensor.use_cases.history.report_preparation import (
     PreparedReportFacts,
     PreparedReportInput,
@@ -179,71 +184,6 @@ def resolve_parts_context(
     return source_for_why, order_label
 
 
-def _action_status_text(action_status_key: str, *, tr: Callable[..., str]) -> str:
-    keys = {
-        "action_ready": "REPORT_ACTION_STATUS_READY",
-        "action_ready_caution": "REPORT_ACTION_STATUS_READY_CAUTION",
-        "recapture_before_acting": "REPORT_ACTION_STATUS_RECAPTURE",
-    }
-    return tr(keys.get(action_status_key, "REPORT_ACTION_STATUS_RECAPTURE"))
-
-
-def _location_confidence_text(location_confidence_key: str, *, tr: Callable[..., str]) -> str:
-    keys = {
-        "strong": "REPORT_LOCATION_CONFIDENCE_STRONG",
-        "limited": "REPORT_LOCATION_CONFIDENCE_LIMITED",
-        "mixed": "REPORT_LOCATION_CONFIDENCE_MIXED",
-        "weak": "REPORT_LOCATION_CONFIDENCE_WEAK",
-    }
-    return tr(keys.get(location_confidence_key, "REPORT_LOCATION_CONFIDENCE_MIXED"))
-
-
-def _presented_location_confidence_key(report_facts: PreparedReportFacts) -> str:
-    if (
-        report_facts.action_status_key == "action_ready_caution"
-        and report_facts.location_confidence_key != "weak"
-    ):
-        return "limited"
-    return report_facts.location_confidence_key
-
-
-def _first_confidence_reason_clause(primary: PrimaryCandidateContext) -> str | None:
-    for clause in str(primary.certainty_reason or "").split(";"):
-        text = clause.strip().rstrip(".")
-        if text:
-            return text
-    return None
-
-
-def _location_confidence_display_text(
-    *,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    data_trust: list[DataTrustItem],
-    tr: Callable[..., str],
-) -> str:
-    presented_key = _presented_location_confidence_key(report_facts)
-    if report_facts.action_status_key != "action_ready_caution":
-        return _location_confidence_text(presented_key, tr=tr)
-
-    reason = _first_confidence_reason_clause(primary)
-    if reason:
-        return reason
-
-    if report_facts.alternative_source_visible:
-        return tr("REPORT_LOCATION_CONFIDENCE_CLOSE_SCORES")
-
-    issue = _first_nonpass_detail(data_trust)
-    if issue:
-        return issue.rstrip(".")
-
-    dominance_ratio = report_facts.primary_candidate_facts.dominance_ratio
-    if dominance_ratio is not None:
-        return tr("REPORT_LOCATION_CONFIDENCE_RATIO_REASON", ratio=f"{dominance_ratio:.1f}")
-
-    return tr("REPORT_LOCATION_CONFIDENCE_MODERATE_DETAIL")
-
-
 def _display_location(value: object, *, short: bool = True, tr: Callable[..., str]) -> str:
     text = str(value or "").strip()
     if not text:
@@ -263,75 +203,6 @@ def _display_location(value: object, *, short: bool = True, tr: Callable[..., st
     return human_location(text, short=short)
 
 
-def _coverage_label(
-    report_facts: PreparedReportFacts,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    coverage = report_facts.coverage_summary
-    expected = len(coverage.expected_locations) or len(coverage.active_locations)
-    active = len(coverage.active_locations)
-    if expected <= 0:
-        return tr("REPORT_COVERAGE_UNKNOWN")
-    if not coverage.missing_locations and not coverage.partial_locations:
-        return tr("REPORT_COVERAGE_ALL_SEEN", active=active, expected=expected)
-    if coverage.partial_locations:
-        return tr("REPORT_COVERAGE_PARTIAL", active=active, expected=expected)
-    return tr("REPORT_COVERAGE_ACTIVE_OF_EXPECTED", active=active, expected=expected)
-
-
-def _coverage_notes(
-    report_facts: PreparedReportFacts,
-    *,
-    tr: Callable[..., str],
-) -> list[str]:
-    coverage = report_facts.coverage_summary
-    notes: list[str] = []
-    if coverage.missing_locations:
-        notes.append(
-            tr(
-                "REPORT_COVERAGE_NOTE_MISSING",
-                locations=", ".join(
-                    _display_location(location, short=False, tr=tr)
-                    for location in coverage.missing_locations
-                ),
-            ),
-        )
-    if coverage.partial_locations:
-        notes.append(
-            tr(
-                "REPORT_COVERAGE_NOTE_PARTIAL",
-                locations=", ".join(
-                    _display_location(location, short=False, tr=tr)
-                    for location in coverage.partial_locations
-                ),
-            ),
-        )
-    if not notes:
-        notes.append(tr("REPORT_COVERAGE_NOTE_COMPLETE"))
-    return notes
-
-
-def _first_nonpass_detail(data_trust: list[DataTrustItem]) -> str | None:
-    for item in data_trust:
-        if item.state != "pass":
-            detail = str(item.detail or item.check).strip()
-            if detail:
-                return detail
-    return None
-
-
-def _nonpass_detail_lines(data_trust: list[DataTrustItem]) -> list[str]:
-    lines: list[str] = []
-    for item in data_trust:
-        if item.state == "pass":
-            continue
-        detail = str(item.detail or item.check).strip()
-        if detail:
-            lines.append(detail)
-    return lines
-
-
 def _confidence_pct_text(finding: Finding) -> str:
     if finding.confidence_assessment is not None:
         return finding.confidence_assessment.pct_text
@@ -343,50 +214,6 @@ def _source_with_confidence(finding: Finding, *, tr: Callable[..., str]) -> str:
         "REPORT_SOURCE_WITH_CONFIDENCE",
         source=human_source(finding.suspected_source, tr=tr),
         confidence=_confidence_pct_text(finding),
-    )
-
-
-def _runner_up_corner(
-    report_facts: PreparedReportFacts,
-    *,
-    tr: Callable[..., str],
-) -> str | None:
-    ranked_rows = sorted(
-        report_facts.active_sensor_intensity,
-        key=lambda row: (
-            row.p95_intensity_db if row.p95_intensity_db is not None else float("-inf"),
-            row.mean_intensity_db if row.mean_intensity_db is not None else float("-inf"),
-        ),
-        reverse=True,
-    )
-    if len(ranked_rows) < 2:
-        return None
-    return _display_location(ranked_rows[1].location, tr=tr)
-
-
-def _build_primary_reason_sentence(
-    primary: PrimaryCandidateContext,
-    *,
-    report_facts: PreparedReportFacts,
-    tr: Callable[..., str],
-) -> str:
-    location = _display_location(primary.primary_location, tr=tr)
-    duration = str(report_facts.duration_text or "").strip() or tr("UNKNOWN")
-    sensor_count = len(report_facts.coverage_summary.active_locations) or primary.sensor_count
-    speed_window = str(primary.primary_speed or "").strip()
-    if speed_window and speed_window != tr("UNKNOWN"):
-        return tr(
-            "REPORT_REASON_RUN_SUMMARY",
-            duration=duration,
-            location=location,
-            speed=speed_window,
-            sensors=sensor_count,
-        )
-    return tr(
-        "REPORT_REASON_RUN_SUMMARY_NO_SPEED",
-        duration=duration,
-        location=location,
-        sensors=sensor_count,
     )
 
 
@@ -681,7 +508,7 @@ def _proof_summary_text(
         return sequence_summary
     ratio = report_facts.primary_candidate_facts.dominance_ratio
     location = _display_location(primary.primary_location, tr=tr)
-    runner_up = _runner_up_corner(report_facts, tr=tr)
+    runner_up = report_facts.display.appendix_b.runner_up_corner
     if ratio is not None:
         if runner_up is not None:
             return tr(
@@ -698,246 +525,21 @@ def _proof_summary_text(
     return tr("REPORT_PROOF_SUMMARY_SIMPLE_PLAIN", location=location)
 
 
-def _proof_caveat_text(
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    *,
-    tr: Callable[..., str],
-) -> str | None:
-    if report_facts.action_status_key == "action_ready_caution":
-        return None
-    reason = (
-        str(primary.certainty_reason or "").strip()
-        if report_facts.action_status_key != "action_ready"
-        else ""
-    )
-    if reason:
-        return reason
-    key = report_facts.location_confidence_key
-    if key == "weak":
-        return tr("REPORT_PROOF_CAVEAT_WEAK")
-    if key == "mixed":
-        return tr("REPORT_PROOF_CAVEAT_MIXED")
-    return None
-
-
-def _action_status_note_text(
-    *,
-    aggregate: TestRun,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    data_trust: list[DataTrustItem],
-    tr: Callable[..., str],
-) -> str | None:
-    if report_facts.action_status_key not in {"action_ready_caution", "recapture_before_acting"}:
-        return None
-    issue = _first_nonpass_detail(data_trust)
-    score_note: str | None = None
-    if (
-        report_facts.action_status_key == "action_ready_caution"
-        and report_facts.alternative_source_visible
-    ):
-        ranked_candidates = list(aggregate.effective_top_causes()[:2])
-        if len(ranked_candidates) > 1:
-            score_note = tr(
-                "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_SCORES",
-                primary=human_source(ranked_candidates[0].suspected_source, tr=tr),
-                primary_confidence=_confidence_pct_text(ranked_candidates[0]),
-                alternative=human_source(ranked_candidates[1].suspected_source, tr=tr),
-                alternative_confidence=_confidence_pct_text(ranked_candidates[1]),
-            )
-        else:
-            score_note = tr("REPORT_ACTION_STATUS_NOTE_GATE_CAUTION")
-    reason = score_note or _proof_caveat_text(primary, report_facts, tr=tr)
-    if issue and reason:
-        issue_norm = issue.rstrip(".")
-        reason_norm = reason.rstrip(".")
-        if reason_norm.casefold() not in issue_norm.casefold():
-            return tr(
-                "REPORT_ACTION_STATUS_NOTE_COMBINED",
-                issue=issue_norm,
-                reason=reason_norm,
-            )
-        return issue
-    return issue or reason
-
-
 def _run_limits_summary_text(
-    primary: PrimaryCandidateContext,
     report_facts: PreparedReportFacts,
     *,
     tr: Callable[..., str],
 ) -> str:
-    speed_window = str(primary.primary_speed or "").strip() or tr("UNKNOWN")
+    speed_window = str(report_facts.display.verdict.speed_window_label or "").strip() or tr(
+        "UNKNOWN"
+    )
     if (
         report_facts.action_status_key == "action_ready_caution"
         and report_facts.alternative_source_visible
     ):
         return tr("REPORT_RUN_LIMITS_RECAPTURE_RECIPE", speed=speed_window)
-    note = _proof_caveat_text(primary, report_facts, tr=tr)
+    note = report_facts.display.verdict.proof_caveat
     return note or tr("REPORT_CAPTURE_ISSUE_GENERIC")
-
-
-def _check_state(
-    report_facts: PreparedReportFacts,
-    check_key: str,
-) -> str:
-    target = check_key.strip().upper()
-    for check in report_facts.suitability_checks:
-        key = str(check.get("check_key") or "").strip().upper()
-        if key == target:
-            return str(check.get("state") or "").strip().lower()
-    return ""
-
-
-def _has_warning_code(report_facts: PreparedReportFacts, code: str) -> bool:
-    target = code.strip().lower()
-    return any(
-        str(warning.get("code") or "").strip().lower() == target
-        for warning in report_facts.warnings
-    )
-
-
-def _is_transient_primary(primary: PrimaryCandidateContext) -> bool:
-    finding = primary.primary_candidate
-    if finding is None:
-        return False
-    source = str(finding.suspected_source or "").strip().lower()
-    classification = str(finding.peak_classification or "").strip().lower()
-    return source == "transient_impact" or classification == "transient"
-
-
-def _has_source_overlap(
-    aggregate: TestRun,
-    *,
-    tr: Callable[..., str],
-) -> bool:
-    ranked = list(aggregate.effective_top_causes()[:2])
-    if len(ranked) < 2:
-        return False
-    return _uses_shared_overlap_wording(ranked[0], ranked[1], tr=tr)
-
-
-def _append_unique_line(lines: list[str], text: object) -> None:
-    value = str(text or "").strip()
-    if not value:
-        return
-    normalized = value.rstrip(".").casefold()
-    if any(existing.rstrip(".").casefold() == normalized for existing in lines):
-        return
-    lines.append(value)
-
-
-def _recapture_issue_lines(
-    *,
-    aggregate: TestRun,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    data_trust: list[DataTrustItem],
-    tr: Callable[..., str],
-) -> list[str]:
-    issues: list[str] = []
-    if _has_source_overlap(aggregate, tr=tr):
-        ranked = list(aggregate.effective_top_causes()[:2])
-        if len(ranked) > 1:
-            _append_unique_line(
-                issues,
-                tr(
-                    "REPORT_RECAPTURE_ISSUE_SOURCE_OVERLAP",
-                    primary=human_source(ranked[0].suspected_source, tr=tr),
-                    alternative=human_source(ranked[1].suspected_source, tr=tr),
-                ),
-            )
-    if report_facts.location_confidence_key == "weak":
-        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_WEAK_LOCATION"))
-    elif report_facts.location_confidence_key == "mixed":
-        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_MIXED_LOCATION"))
-    if _is_transient_primary(primary):
-        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_TRANSIENT"))
-    for detail in _nonpass_detail_lines(data_trust):
-        _append_unique_line(issues, detail)
-    if not issues:
-        note = _proof_caveat_text(primary, report_facts, tr=tr)
-        _append_unique_line(issues, note or tr("REPORT_CAPTURE_ISSUE_GENERIC"))
-    return issues[:4]
-
-
-def _recapture_next_steps(
-    *,
-    aggregate: TestRun,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    tr: Callable[..., str],
-) -> list[NextStep]:
-    expected = len(report_facts.coverage_summary.expected_locations) or len(
-        report_facts.coverage_summary.active_locations
-    )
-    actions: list[str] = []
-    if _has_source_overlap(aggregate, tr=tr):
-        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_COMPARE_PATHS"))
-    if _check_state(report_facts, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
-        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_STEADY_HOLD"))
-    if _is_transient_primary(primary):
-        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_REPEAT_EVENT"))
-    if (
-        report_facts.location_confidence_key in {"weak", "mixed"}
-        or _check_state(report_facts, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
-    ):
-        _append_unique_line(
-            actions,
-            tr("TIER_A_CAPTURE_MORE_SENSORS"),
-        )
-    if (
-        report_facts.primary_candidate_facts.has_reference_gaps
-        or _check_state(report_facts, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
-        or _has_warning_code(report_facts, "reference_context_incomplete")
-    ):
-        _append_unique_line(actions, tr("TIER_A_CAPTURE_REFERENCE_DATA"))
-    if not actions:
-        _append_unique_line(actions, tr("TIER_A_CAPTURE_WIDER_SPEED"))
-        _append_unique_line(
-            actions,
-            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
-        )
-    return [NextStep(action=action) for action in actions[:4]]
-
-
-def _recapture_condition_lines(
-    *,
-    aggregate: TestRun,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    tr: Callable[..., str],
-) -> list[str]:
-    expected = len(report_facts.coverage_summary.expected_locations) or len(
-        report_facts.coverage_summary.active_locations
-    )
-    lines: list[str] = []
-    if _check_state(report_facts, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
-        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_STEADY_HOLD"))
-    if _has_source_overlap(aggregate, tr=tr):
-        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_COMPARE_PATHS"))
-    if _is_transient_primary(primary):
-        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_REPEAT_EVENT"))
-    if (
-        report_facts.location_confidence_key in {"weak", "mixed"}
-        or _check_state(report_facts, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
-    ):
-        _append_unique_line(
-            lines,
-            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
-        )
-    if (
-        report_facts.primary_candidate_facts.has_reference_gaps
-        or _check_state(report_facts, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
-        or _has_warning_code(report_facts, "reference_context_incomplete")
-    ):
-        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
-    if not lines:
-        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_STEADY"))
-        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected))
-        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
-    return lines[:4]
 
 
 def _candidate_signal_text(finding: Finding, *, tr: Callable[..., str]) -> str:
@@ -976,80 +578,6 @@ def _uses_shared_overlap_wording(
         .strip()
         .lower()
     )
-
-
-def _candidate_reason_text(
-    finding: Finding,
-    *,
-    tr: Callable[..., str],
-    use_shared_overlap_wording: bool = False,
-) -> str:
-    speed_window = (
-        str(
-            finding.evidence.focused_speed_band
-            if finding.evidence and finding.evidence.focused_speed_band
-            else ""
-        ).strip()
-        or str(finding.strongest_speed_band or "").strip()
-    )
-    location = _display_location(finding.strongest_location, tr=tr)
-    signal = _candidate_signal_text(finding, tr=tr)
-    if use_shared_overlap_wording:
-        return tr(
-            "REPORT_CANDIDATE_REASON_OVERLAP",
-            signal=signal,
-            speed=speed_window or tr("UNKNOWN"),
-        )
-    if finding.weak_spatial_separation:
-        return tr(
-            "REPORT_CANDIDATE_REASON_WEAK",
-            signal=signal,
-            speed=speed_window or tr("UNKNOWN"),
-        )
-    return tr(
-        "REPORT_CANDIDATE_REASON_STRONG",
-        signal=signal,
-        location=location,
-        speed=speed_window or tr("UNKNOWN"),
-    )
-
-
-def _path_role_text(index: int, *, tr: Callable[..., str]) -> str:
-    if index == 0:
-        return tr("REPORT_PATH_ROLE_PRIMARY")
-    if index == 1:
-        return tr("REPORT_PATH_ROLE_ALTERNATIVE")
-    return tr("REPORT_PATH_ROLE_LOW_CONFIDENCE")
-
-
-def _ranked_candidates(
-    aggregate: TestRun,
-    *,
-    tr: Callable[..., str],
-) -> list[RankedCandidateRow]:
-    candidates = list(aggregate.effective_top_causes()[:3])
-    rows: list[RankedCandidateRow] = []
-    primary_finding = candidates[0] if candidates else None
-    for index, finding in enumerate(candidates):
-        use_shared_overlap_wording = (
-            index > 0
-            and primary_finding is not None
-            and _uses_shared_overlap_wording(primary_finding, finding, tr=tr)
-        )
-        rows.append(
-            RankedCandidateRow(
-                source_name=human_source(finding.suspected_source, tr=tr),
-                confidence_pct=_confidence_pct_text(finding),
-                inspect_first=_display_location(finding.strongest_location, tr=tr),
-                path_role=f"{index + 1}. {_path_role_text(index, tr=tr)}",
-                reason=_candidate_reason_text(
-                    finding,
-                    tr=tr,
-                    use_shared_overlap_wording=use_shared_overlap_wording,
-                ),
-            ),
-        )
-    return rows
 
 
 def _evidence_summary_text(
@@ -1160,22 +688,6 @@ def _context_summary_text(
         speed=speed_window,
         active=active,
         expected=expected,
-    )
-
-
-def _next_if_primary_clean(
-    aggregate: TestRun,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    candidates = list(aggregate.effective_top_causes()[:2])
-    if len(candidates) < 2:
-        return tr("REPORT_PRIMARY_CLEAN_GENERIC")
-    alternative = candidates[1]
-    return tr(
-        "REPORT_PRIMARY_CLEAN_ALT",
-        source=human_source(alternative.suspected_source, tr=tr),
-        location=_display_location(alternative.strongest_location, tr=tr),
     )
 
 
@@ -1439,148 +951,66 @@ def _build_timeline_graph_data(
 
 def _build_verdict_page_data(
     *,
-    aggregate: TestRun,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
-    data_trust: list[DataTrustItem],
-    duration_s: float | None,
-    tr: Callable[..., str],
+    verdict: PreparedVerdictDisplay,
+    proof_summary: str | None,
+    timeline_graph: TimelineGraphData | None,
 ) -> VerdictPageData:
-    recapture_before_acting = report_facts.action_status_key == "recapture_before_acting"
-    ranked_candidates = list(aggregate.effective_top_causes()[:2])
     return VerdictPageData(
-        speed_window_label=str(primary.primary_speed or "").strip() or None,
-        suspected_source=(
-            tr("REPORT_INCONCLUSIVE_SOURCE") if recapture_before_acting else primary.primary_system
-        ),
-        inspect_first=(
-            None if recapture_before_acting else _display_location(primary.primary_location, tr=tr)
-        ),
-        action_status=_action_status_text(report_facts.action_status_key, tr=tr),
-        action_status_note=_action_status_note_text(
-            aggregate=aggregate,
-            primary=primary,
-            report_facts=report_facts,
-            data_trust=data_trust,
-            tr=tr,
-        ),
-        reason_sentence=(
-            _recapture_issue_lines(
-                aggregate=aggregate,
-                primary=primary,
-                report_facts=report_facts,
-                data_trust=data_trust,
-                tr=tr,
-            )[0]
-            if recapture_before_acting
-            else _build_primary_reason_sentence(primary, report_facts=report_facts, tr=tr)
-        ),
-        dominant_corner=_display_location(primary.primary_location, tr=tr),
-        runner_up_corner=_runner_up_corner(report_facts, tr=tr),
-        location_confidence=_location_confidence_display_text(
-            primary=primary,
-            report_facts=report_facts,
-            data_trust=data_trust,
-            tr=tr,
-        ),
-        coverage_label=_coverage_label(report_facts, tr=tr),
-        also_consider=(
-            _source_with_confidence(ranked_candidates[1], tr=tr)
-            if not recapture_before_acting
-            and report_facts.alternative_source_visible
-            and len(ranked_candidates) > 1
-            else None
-        ),
-        proof_summary=_proof_summary_text(aggregate, primary, report_facts, tr=tr),
-        proof_caveat=_proof_caveat_text(primary, report_facts, tr=tr),
-        proof_panel_title=(
-            tr("REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE")
-            if recapture_before_acting
-            else tr("REPORT_PROOF_PANEL_TITLE")
-        ),
-        timeline_graph=_build_timeline_graph_data(report_facts, duration_s=duration_s),
-        footer_routes=(
-            (tr("REPORT_ROUTE_APPENDIX_A"),)
-            if recapture_before_acting
-            else (
-                tr("REPORT_ROUTE_APPENDIX_A"),
-                tr("REPORT_ROUTE_APPENDIX_B"),
-                tr("REPORT_ROUTE_APPENDIX_C"),
-                tr("REPORT_ROUTE_APPENDIX_D"),
-            )
-        ),
+        speed_window_label=verdict.speed_window_label,
+        suspected_source=verdict.suspected_source,
+        inspect_first=verdict.inspect_first,
+        action_status=verdict.action_status,
+        action_status_note=verdict.action_status_note,
+        reason_sentence=verdict.reason_sentence,
+        dominant_corner=verdict.dominant_corner,
+        runner_up_corner=verdict.runner_up_corner,
+        location_confidence=verdict.location_confidence,
+        coverage_label=verdict.coverage_label,
+        also_consider=verdict.also_consider,
+        proof_summary=proof_summary,
+        proof_caveat=verdict.proof_caveat,
+        proof_panel_title=verdict.proof_panel_title,
+        timeline_graph=timeline_graph,
+        footer_routes=verdict.footer_routes,
     )
 
 
 def _build_appendix_a_data(
     *,
-    aggregate: TestRun,
-    primary: PrimaryCandidateContext,
-    report_facts: PreparedReportFacts,
+    appendix: PreparedAppendixADisplay,
     next_steps: list[NextStep],
-    data_trust: list[DataTrustItem],
-    tr: Callable[..., str],
 ) -> AppendixAData:
-    ranked = _ranked_candidates(aggregate, tr=tr)
-    if report_facts.action_status_key == "recapture_before_acting":
+    if appendix.mode == "recapture":
         return AppendixAData(
             mode="recapture",
-            capture_issues=_recapture_issue_lines(
-                aggregate=aggregate,
-                primary=primary,
-                report_facts=report_facts,
-                data_trust=data_trust,
-                tr=tr,
-            ),
+            capture_issues=list(appendix.capture_issues),
             capture_changes=[step.action for step in next_steps],
-            capture_conditions=_recapture_condition_lines(
-                aggregate=aggregate,
-                primary=primary,
-                report_facts=report_facts,
-                tr=tr,
-            ),
+            capture_conditions=list(appendix.capture_conditions),
         )
-    alternative_source = (
-        tr(
-            "REPORT_SOURCE_WITH_CONFIDENCE",
-            source=ranked[1].source_name,
-            confidence=ranked[1].confidence_pct,
-        )
-        if report_facts.alternative_source_visible and len(ranked) > 1 and ranked[1].confidence_pct
-        else ranked[1].source_name
-        if report_facts.alternative_source_visible and len(ranked) > 1
-        else None
-    )
     return AppendixAData(
         mode="workflow",
-        primary_source=(
-            tr(
-                "REPORT_SOURCE_WITH_CONFIDENCE",
-                source=ranked[0].source_name,
-                confidence=ranked[0].confidence_pct,
+        primary_source=appendix.primary_source,
+        alternative_source=appendix.alternative_source,
+        why_primary_first=appendix.why_primary_first,
+        why_alternative_next=appendix.why_alternative_next,
+        next_if_clean=appendix.next_if_clean,
+        ranked_candidates=[
+            RankedCandidateRow(
+                source_name=row.source_name,
+                confidence_pct=row.confidence_pct,
+                inspect_first=row.inspect_first,
+                path_role=row.path_role,
+                reason=row.reason,
             )
-            if ranked and ranked[0].confidence_pct
-            else ranked[0].source_name
-            if ranked
-            else None
-        ),
-        alternative_source=alternative_source,
-        why_primary_first=(ranked[0].reason if ranked else None),
-        why_alternative_next=(
-            ranked[1].reason
-            if report_facts.alternative_source_visible and len(ranked) > 1
-            else None
-        ),
-        next_if_clean=_next_if_primary_clean(aggregate, tr=tr),
-        ranked_candidates=ranked,
+            for row in appendix.ranked_candidates
+        ],
     )
 
 
 def _build_appendix_b_data(
     *,
-    primary: PrimaryCandidateContext,
     aggregate: TestRun,
-    report_facts: PreparedReportFacts,
+    appendix: PreparedAppendixBSummaryDisplay,
     sensor_locations: list[str],
     sensor_intensity: list[LocationIntensitySummary],
     tr: Callable[..., str],
@@ -1592,7 +1022,6 @@ def _build_appendix_b_data(
         ),
         reverse=True,
     )
-    runner_up = ranked_rows[1].location if len(ranked_rows) > 1 else None
     intensity_rows = [
         TopologyIntensityRow(
             location=_display_location(row.location, short=False, tr=tr),
@@ -1610,21 +1039,13 @@ def _build_appendix_b_data(
         sensor_locations=sensor_locations,
         tr=tr,
     )
-    dominance_ratio = report_facts.primary_candidate_facts.dominance_ratio
     return AppendixBData(
-        dominant_corner=_display_location(primary.primary_location, tr=tr),
-        runner_up_corner=(_display_location(runner_up, tr=tr) if runner_up is not None else None),
-        dominance_ratio_text=(
-            tr("REPORT_DOMINANCE_RATIO_TEXT", ratio=f"{dominance_ratio:.2f}")
-            if dominance_ratio is not None
-            else tr("REPORT_DOMINANCE_RATIO_UNKNOWN")
-        ),
-        location_confidence=_location_confidence_text(
-            _presented_location_confidence_key(report_facts),
-            tr=tr,
-        ),
-        coverage_label=_coverage_label(report_facts, tr=tr),
-        coverage_notes=_coverage_notes(report_facts, tr=tr),
+        dominant_corner=appendix.dominant_corner,
+        runner_up_corner=appendix.runner_up_corner,
+        dominance_ratio_text=appendix.dominance_ratio_text,
+        location_confidence=appendix.location_confidence,
+        coverage_label=appendix.coverage_label,
+        coverage_notes=list(appendix.coverage_notes),
         intensity_rows=intensity_rows,
         sensor_observation_rows=sensor_observation_rows,
     )
@@ -1729,7 +1150,7 @@ def _build_appendix_c_data(
         evidence_summary=_evidence_summary_text(aggregate, primary, report_facts, tr=tr),
         measurement_guide=tr("REPORT_MEASUREMENT_GUIDE"),
         context_summary=_context_summary_text(primary, report_facts, tr=tr),
-        limits_summary=_run_limits_summary_text(primary, report_facts, tr=tr),
+        limits_summary=_run_limits_summary_text(report_facts, tr=tr),
         speed_band_summary=speed_summary,
         phase_summary=_phase_summary_text(aggregate, report_facts, tr=tr),
         observations=_observation_texts(aggregate, tr=tr),
@@ -1850,12 +1271,7 @@ def _build_report_template_data(
         tr=tr,
     )
     next_steps = (
-        _recapture_next_steps(
-            aggregate=context.domain_aggregate,
-            primary=primary,
-            report_facts=report_facts,
-            tr=tr,
-        )
+        [NextStep(action=action) for action in report_facts.display.appendix_a.capture_changes]
         if recapture_mode
         else build_next_steps(
             recommended_actions=report_facts.recommended_actions,
@@ -1889,26 +1305,20 @@ def _build_report_template_data(
         aggregate=context.domain_aggregate,
         tr=tr,
     )
+    proof_summary = _proof_summary_text(context.domain_aggregate, primary, report_facts, tr=tr)
+    timeline_graph = _build_timeline_graph_data(report_facts, duration_s=report.duration_s)
     verdict_page = _build_verdict_page_data(
-        aggregate=context.domain_aggregate,
-        primary=primary,
-        report_facts=report_facts,
-        data_trust=data_trust,
-        duration_s=report.duration_s,
-        tr=tr,
+        verdict=report_facts.display.verdict,
+        proof_summary=proof_summary,
+        timeline_graph=timeline_graph,
     )
     appendix_a = _build_appendix_a_data(
-        aggregate=context.domain_aggregate,
-        primary=primary,
-        report_facts=report_facts,
+        appendix=report_facts.display.appendix_a,
         next_steps=next_steps,
-        data_trust=data_trust,
-        tr=tr,
     )
     appendix_b = _build_appendix_b_data(
-        primary=primary,
         aggregate=context.domain_aggregate,
-        report_facts=report_facts,
+        appendix=report_facts.display.appendix_b,
         sensor_locations=context.sensor_locations_active,
         sensor_intensity=raw_sensor_intensity,
         tr=tr,

--- a/apps/server/vibesensor/use_cases/history/report_display_facts.py
+++ b/apps/server/vibesensor/use_cases/history/report_display_facts.py
@@ -1,0 +1,964 @@
+"""Prepared report display facts assembled on the history side."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, VibrationSource
+from vibesensor.report_i18n import (
+    human_location,
+    human_source,
+    is_i18n_ref,
+    location_candidates,
+    resolve_i18n,
+)
+from vibesensor.report_i18n import tr as _tr
+from vibesensor.shared.boundaries.report_interpretation import PrimaryReportFacts
+from vibesensor.shared.types.history_analysis_contracts import (
+    RunSuitabilityCheck,
+)
+from vibesensor.shared.types.history_analysis_contracts import (
+    SummaryWarningResponse as SummaryWarningPayload,
+)
+from vibesensor.shared.types.json_types import JsonValue
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedRankedCandidateDisplay:
+    source_name: str
+    confidence_pct: str | None
+    inspect_first: str | None
+    path_role: str | None
+    reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedVerdictDisplay:
+    speed_window_label: str | None
+    suspected_source: str | None
+    inspect_first: str | None
+    action_status: str
+    action_status_note: str | None
+    reason_sentence: str | None
+    dominant_corner: str | None
+    runner_up_corner: str | None
+    location_confidence: str
+    coverage_label: str
+    also_consider: str | None
+    proof_caveat: str | None
+    proof_panel_title: str
+    footer_routes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedAppendixADisplay:
+    mode: str
+    primary_source: str | None
+    alternative_source: str | None
+    why_primary_first: str | None
+    why_alternative_next: str | None
+    next_if_clean: str | None
+    ranked_candidates: tuple[PreparedRankedCandidateDisplay, ...]
+    capture_issues: tuple[str, ...]
+    capture_changes: tuple[str, ...]
+    capture_conditions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedAppendixBSummaryDisplay:
+    dominant_corner: str | None
+    runner_up_corner: str | None
+    dominance_ratio_text: str
+    location_confidence: str
+    coverage_label: str
+    coverage_notes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedReportDisplayFacts:
+    verdict: PreparedVerdictDisplay
+    appendix_a: PreparedAppendixADisplay
+    appendix_b: PreparedAppendixBSummaryDisplay
+
+
+def _action_status_text(action_status_key: str, *, tr: Callable[..., str]) -> str:
+    keys = {
+        "action_ready": "REPORT_ACTION_STATUS_READY",
+        "action_ready_caution": "REPORT_ACTION_STATUS_READY_CAUTION",
+        "recapture_before_acting": "REPORT_ACTION_STATUS_RECAPTURE",
+    }
+    return tr(keys.get(action_status_key, "REPORT_ACTION_STATUS_RECAPTURE"))
+
+
+def _location_confidence_text(location_confidence_key: str, *, tr: Callable[..., str]) -> str:
+    keys = {
+        "strong": "REPORT_LOCATION_CONFIDENCE_STRONG",
+        "limited": "REPORT_LOCATION_CONFIDENCE_LIMITED",
+        "mixed": "REPORT_LOCATION_CONFIDENCE_MIXED",
+        "weak": "REPORT_LOCATION_CONFIDENCE_WEAK",
+    }
+    return tr(keys.get(location_confidence_key, "REPORT_LOCATION_CONFIDENCE_MIXED"))
+
+
+def _presented_location_confidence_key(
+    *,
+    action_status_key: str,
+    location_confidence_key: str,
+) -> str:
+    if action_status_key == "action_ready_caution" and location_confidence_key != "weak":
+        return "limited"
+    return location_confidence_key
+
+
+def _first_confidence_reason_clause(primary_candidate_facts: PrimaryReportFacts) -> str | None:
+    finding = primary_candidate_facts.domain_primary
+    if finding is None or finding.confidence_assessment is None:
+        return None
+    for clause in str(finding.confidence_assessment.reason or "").split(";"):
+        text = clause.strip().rstrip(".")
+        if text:
+            return text
+    return None
+
+
+def _display_location(value: object, *, short: bool = True, tr: Callable[..., str]) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return tr("UNKNOWN")
+    candidates = location_candidates(text)
+    if len(candidates) == 2:
+        return tr(
+            "REPORT_LOCATION_MIXED_SIGNAL_BETWEEN",
+            first_location=human_location(candidates[0], short=short),
+            second_location=human_location(candidates[1], short=short),
+        )
+    if len(candidates) > 2:
+        return tr(
+            "REPORT_LOCATION_MIXED_SIGNAL_LIST",
+            locations=", ".join(human_location(candidate, short=short) for candidate in candidates),
+        )
+    return human_location(text, short=short)
+
+
+def _coverage_label(
+    *,
+    expected_locations: Sequence[str],
+    active_locations: Sequence[str],
+    missing_locations: Sequence[str],
+    partial_locations: Sequence[str],
+    tr: Callable[..., str],
+) -> str:
+    expected = len(expected_locations) or len(active_locations)
+    active = len(active_locations)
+    if expected <= 0:
+        return tr("REPORT_COVERAGE_UNKNOWN")
+    if not missing_locations and not partial_locations:
+        return tr("REPORT_COVERAGE_ALL_SEEN", active=active, expected=expected)
+    if partial_locations:
+        return tr("REPORT_COVERAGE_PARTIAL", active=active, expected=expected)
+    return tr("REPORT_COVERAGE_ACTIVE_OF_EXPECTED", active=active, expected=expected)
+
+
+def _coverage_notes(
+    *,
+    missing_locations: Sequence[str],
+    partial_locations: Sequence[str],
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    notes: list[str] = []
+    if missing_locations:
+        notes.append(
+            tr(
+                "REPORT_COVERAGE_NOTE_MISSING",
+                locations=", ".join(
+                    _display_location(location, short=False, tr=tr)
+                    for location in missing_locations
+                ),
+            ),
+        )
+    if partial_locations:
+        notes.append(
+            tr(
+                "REPORT_COVERAGE_NOTE_PARTIAL",
+                locations=", ".join(
+                    _display_location(location, short=False, tr=tr)
+                    for location in partial_locations
+                ),
+            ),
+        )
+    if not notes:
+        notes.append(tr("REPORT_COVERAGE_NOTE_COMPLETE"))
+    return tuple(notes)
+
+
+def _resolve_check_text(value: object, *, lang: str, tr: Callable[..., str]) -> str:
+    if is_i18n_ref(value):
+        return resolve_i18n(lang, value, tr=tr)
+    if isinstance(value, str) and value.startswith("SUITABILITY_CHECK_"):
+        return str(tr(value))
+    return str(value or "")
+
+
+def _resolve_detail_text(value: object, *, lang: str, tr: Callable[..., str]) -> str | None:
+    if is_i18n_ref(value) or isinstance(value, list):
+        resolved = resolve_i18n(lang, value, tr=tr).strip()
+    else:
+        resolved = str(value or "").strip()
+    return resolved or None
+
+
+def _first_nonpass_detail(
+    *,
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    lang: str,
+    tr: Callable[..., str],
+) -> str | None:
+    for check in suitability_checks:
+        if str(check.get("state") or "").strip().lower() == "pass":
+            continue
+        detail = _resolve_detail_text(check.get("explanation"), lang=lang, tr=tr)
+        if detail:
+            return detail
+        label = _resolve_check_text(check.get("check_key") or check.get("check"), lang=lang, tr=tr)
+        if label:
+            return label
+    for warning in warnings:
+        detail = _resolve_detail_text(
+            warning.get("detail") or warning.get("message"),
+            lang=lang,
+            tr=tr,
+        )
+        if detail:
+            return detail
+        title = _resolve_detail_text(warning.get("title"), lang=lang, tr=tr)
+        if title:
+            return title
+    return None
+
+
+def _nonpass_detail_lines(
+    *,
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    lang: str,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    lines: list[str] = []
+    for check in suitability_checks:
+        if str(check.get("state") or "").strip().lower() == "pass":
+            continue
+        detail = _resolve_detail_text(check.get("explanation"), lang=lang, tr=tr)
+        label = _resolve_check_text(check.get("check_key") or check.get("check"), lang=lang, tr=tr)
+        text = detail or label
+        if text:
+            lines.append(text)
+    for warning in warnings:
+        detail = _resolve_detail_text(
+            warning.get("detail") or warning.get("message"),
+            lang=lang,
+            tr=tr,
+        )
+        title = _resolve_detail_text(warning.get("title"), lang=lang, tr=tr)
+        warning_text: str | None = detail or title
+        if warning_text:
+            lines.append(warning_text)
+    return tuple(lines)
+
+
+def _confidence_pct_text(finding: Finding) -> str:
+    if finding.confidence_assessment is not None:
+        return finding.confidence_assessment.pct_text
+    return finding.confidence_pct_text
+
+
+def _source_with_confidence(finding: Finding, *, tr: Callable[..., str]) -> str:
+    return tr(
+        "REPORT_SOURCE_WITH_CONFIDENCE",
+        source=human_source(finding.suspected_source, tr=tr),
+        confidence=_confidence_pct_text(finding),
+    )
+
+
+def _runner_up_corner(
+    active_sensor_intensity: Sequence[LocationIntensitySummary],
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    ranked_rows = sorted(
+        active_sensor_intensity,
+        key=lambda row: (
+            row.p95_intensity_db if row.p95_intensity_db is not None else float("-inf"),
+            row.mean_intensity_db if row.mean_intensity_db is not None else float("-inf"),
+        ),
+        reverse=True,
+    )
+    if len(ranked_rows) < 2:
+        return None
+    return _display_location(ranked_rows[1].location, tr=tr)
+
+
+def _build_primary_reason_sentence(
+    *,
+    primary_candidate_facts: PrimaryReportFacts,
+    active_locations: Sequence[str],
+    duration_text: str | None,
+    tr: Callable[..., str],
+) -> str:
+    location = _display_location(primary_candidate_facts.primary_location, tr=tr)
+    duration = str(duration_text or "").strip() or tr("UNKNOWN")
+    sensor_count = len(active_locations) or primary_candidate_facts.sensor_count
+    speed_window = str(primary_candidate_facts.primary_speed or "").strip()
+    if speed_window and speed_window != tr("UNKNOWN"):
+        return tr(
+            "REPORT_REASON_RUN_SUMMARY",
+            duration=duration,
+            location=location,
+            speed=speed_window,
+            sensors=sensor_count,
+        )
+    return tr(
+        "REPORT_REASON_RUN_SUMMARY_NO_SPEED",
+        duration=duration,
+        location=location,
+        sensors=sensor_count,
+    )
+
+
+def _proof_caveat_text(
+    *,
+    primary_candidate_facts: PrimaryReportFacts,
+    action_status_key: str,
+    location_confidence_key: str,
+    tr: Callable[..., str],
+) -> str | None:
+    if action_status_key == "action_ready_caution":
+        return None
+    reason = (
+        _first_confidence_reason_clause(primary_candidate_facts)
+        if action_status_key != "action_ready"
+        else None
+    )
+    if reason:
+        return reason
+    if location_confidence_key == "weak":
+        return tr("REPORT_PROOF_CAVEAT_WEAK")
+    if location_confidence_key == "mixed":
+        return tr("REPORT_PROOF_CAVEAT_MIXED")
+    return None
+
+
+def _location_confidence_display_text(
+    *,
+    primary_candidate_facts: PrimaryReportFacts,
+    action_status_key: str,
+    location_confidence_key: str,
+    alternative_source_visible: bool,
+    dominance_ratio: float | None,
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    lang: str,
+    tr: Callable[..., str],
+) -> str:
+    presented_key = _presented_location_confidence_key(
+        action_status_key=action_status_key,
+        location_confidence_key=location_confidence_key,
+    )
+    if action_status_key != "action_ready_caution":
+        return _location_confidence_text(presented_key, tr=tr)
+
+    reason = _first_confidence_reason_clause(primary_candidate_facts)
+    if reason:
+        return reason
+    if alternative_source_visible:
+        return tr("REPORT_LOCATION_CONFIDENCE_CLOSE_SCORES")
+    issue = _first_nonpass_detail(
+        suitability_checks=suitability_checks,
+        warnings=warnings,
+        lang=lang,
+        tr=tr,
+    )
+    if issue:
+        return issue.rstrip(".")
+    if dominance_ratio is not None:
+        return tr("REPORT_LOCATION_CONFIDENCE_RATIO_REASON", ratio=f"{dominance_ratio:.1f}")
+    return tr("REPORT_LOCATION_CONFIDENCE_MODERATE_DETAIL")
+
+
+def _uses_shared_overlap_wording(
+    primary_finding: Finding,
+    alternative_finding: Finding,
+    *,
+    tr: Callable[..., str],
+) -> bool:
+    sources = {
+        primary_finding.source_normalized,
+        alternative_finding.source_normalized,
+    }
+    if sources != {VibrationSource.WHEEL_TIRE, VibrationSource.DRIVELINE}:
+        return False
+    primary_location = str(primary_finding.strongest_location or "").strip()
+    alternative_location = str(alternative_finding.strongest_location or "").strip()
+    if not primary_location or not alternative_location:
+        return False
+    return (
+        _display_location(primary_location, short=False, tr=tr).strip().lower()
+        == _display_location(alternative_location, short=False, tr=tr).strip().lower()
+    )
+
+
+def _has_source_overlap(aggregate: TestRun, *, tr: Callable[..., str]) -> bool:
+    ranked = list(aggregate.effective_top_causes()[:2])
+    if len(ranked) < 2:
+        return False
+    return _uses_shared_overlap_wording(ranked[0], ranked[1], tr=tr)
+
+
+def _is_transient_primary(primary_candidate_facts: PrimaryReportFacts) -> bool:
+    finding = primary_candidate_facts.domain_primary
+    if finding is None:
+        return False
+    source = str(finding.suspected_source or "").strip().lower()
+    classification = str(finding.peak_classification or "").strip().lower()
+    return source == "transient_impact" or classification == "transient"
+
+
+def _check_state(
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    check_key: str,
+) -> str:
+    target = check_key.strip().upper()
+    for check in suitability_checks:
+        key = str(check.get("check_key") or "").strip().upper()
+        if key == target:
+            return str(check.get("state") or "").strip().lower()
+    return ""
+
+
+def _has_warning_code(warnings: Sequence[SummaryWarningPayload], code: str) -> bool:
+    target = code.strip().lower()
+    return any(str(warning.get("code") or "").strip().lower() == target for warning in warnings)
+
+
+def _append_unique_line(lines: list[str], text: object) -> None:
+    value = str(text or "").strip()
+    if not value:
+        return
+    normalized = value.rstrip(".").casefold()
+    if any(existing.rstrip(".").casefold() == normalized for existing in lines):
+        return
+    lines.append(value)
+
+
+def _candidate_signal_text(finding: Finding, *, tr: Callable[..., str]) -> str:
+    if finding.signature_labels:
+        return ", ".join(finding.signature_labels[:2])
+    if finding.order:
+        return finding.order
+    if finding.frequency_hz is not None:
+        return f"{finding.frequency_hz:.1f} Hz"
+    return tr("REPORT_SIGNAL_FALLBACK")
+
+
+def _candidate_reason_text(
+    finding: Finding,
+    *,
+    tr: Callable[..., str],
+    use_shared_overlap_wording: bool = False,
+) -> str:
+    speed_window = (
+        str(
+            finding.evidence.focused_speed_band
+            if finding.evidence and finding.evidence.focused_speed_band
+            else ""
+        ).strip()
+        or str(finding.strongest_speed_band or "").strip()
+    )
+    location = _display_location(finding.strongest_location, tr=tr)
+    signal = _candidate_signal_text(finding, tr=tr)
+    if use_shared_overlap_wording:
+        return tr(
+            "REPORT_CANDIDATE_REASON_OVERLAP",
+            signal=signal,
+            speed=speed_window or tr("UNKNOWN"),
+        )
+    if finding.weak_spatial_separation:
+        return tr(
+            "REPORT_CANDIDATE_REASON_WEAK",
+            signal=signal,
+            speed=speed_window or tr("UNKNOWN"),
+        )
+    return tr(
+        "REPORT_CANDIDATE_REASON_STRONG",
+        signal=signal,
+        location=location,
+        speed=speed_window or tr("UNKNOWN"),
+    )
+
+
+def _path_role_text(index: int, *, tr: Callable[..., str]) -> str:
+    if index == 0:
+        return tr("REPORT_PATH_ROLE_PRIMARY")
+    if index == 1:
+        return tr("REPORT_PATH_ROLE_ALTERNATIVE")
+    return tr("REPORT_PATH_ROLE_LOW_CONFIDENCE")
+
+
+def _ranked_candidates(
+    aggregate: TestRun,
+    *,
+    tr: Callable[..., str],
+) -> tuple[PreparedRankedCandidateDisplay, ...]:
+    candidates = list(aggregate.effective_top_causes()[:3])
+    rows: list[PreparedRankedCandidateDisplay] = []
+    primary_finding = candidates[0] if candidates else None
+    for index, finding in enumerate(candidates):
+        use_shared_overlap_wording = (
+            index > 0
+            and primary_finding is not None
+            and _uses_shared_overlap_wording(primary_finding, finding, tr=tr)
+        )
+        rows.append(
+            PreparedRankedCandidateDisplay(
+                source_name=human_source(finding.suspected_source, tr=tr),
+                confidence_pct=_confidence_pct_text(finding),
+                inspect_first=_display_location(finding.strongest_location, tr=tr),
+                path_role=f"{index + 1}. {_path_role_text(index, tr=tr)}",
+                reason=_candidate_reason_text(
+                    finding,
+                    tr=tr,
+                    use_shared_overlap_wording=use_shared_overlap_wording,
+                ),
+            ),
+        )
+    return tuple(rows)
+
+
+def _next_if_primary_clean(
+    aggregate: TestRun,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    candidates = list(aggregate.effective_top_causes()[:2])
+    if len(candidates) < 2:
+        return None
+    alternative = candidates[1]
+    use_shared_overlap_wording = _uses_shared_overlap_wording(candidates[0], alternative, tr=tr)
+    return _candidate_reason_text(
+        alternative,
+        tr=tr,
+        use_shared_overlap_wording=use_shared_overlap_wording,
+    )
+
+
+def _recapture_issue_lines(
+    *,
+    aggregate: TestRun,
+    primary_candidate_facts: PrimaryReportFacts,
+    location_confidence_key: str,
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    lang: str,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    issues: list[str] = []
+    if _has_source_overlap(aggregate, tr=tr):
+        ranked = list(aggregate.effective_top_causes()[:2])
+        if len(ranked) > 1:
+            _append_unique_line(
+                issues,
+                tr(
+                    "REPORT_RECAPTURE_ISSUE_SOURCE_OVERLAP",
+                    primary=human_source(ranked[0].suspected_source, tr=tr),
+                    alternative=human_source(ranked[1].suspected_source, tr=tr),
+                ),
+            )
+    if location_confidence_key == "weak":
+        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_WEAK_LOCATION"))
+    elif location_confidence_key == "mixed":
+        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_MIXED_LOCATION"))
+    if _is_transient_primary(primary_candidate_facts):
+        _append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_TRANSIENT"))
+    for detail in _nonpass_detail_lines(
+        suitability_checks=suitability_checks,
+        warnings=warnings,
+        lang=lang,
+        tr=tr,
+    ):
+        _append_unique_line(issues, detail)
+    if not issues:
+        note = _proof_caveat_text(
+            primary_candidate_facts=primary_candidate_facts,
+            action_status_key="recapture_before_acting",
+            location_confidence_key=location_confidence_key,
+            tr=tr,
+        )
+        _append_unique_line(issues, note or tr("REPORT_CAPTURE_ISSUE_GENERIC"))
+    return tuple(issues[:4])
+
+
+def _recapture_actions(
+    *,
+    aggregate: TestRun,
+    primary_candidate_facts: PrimaryReportFacts,
+    location_confidence_key: str,
+    expected_locations: Sequence[str],
+    active_locations: Sequence[str],
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    expected = len(expected_locations) or len(active_locations)
+    actions: list[str] = []
+    if _has_source_overlap(aggregate, tr=tr):
+        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_COMPARE_PATHS"))
+    if _check_state(suitability_checks, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
+        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_STEADY_HOLD"))
+    if _is_transient_primary(primary_candidate_facts):
+        _append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_REPEAT_EVENT"))
+    if (
+        location_confidence_key in {"weak", "mixed"}
+        or _check_state(suitability_checks, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
+    ):
+        _append_unique_line(actions, tr("TIER_A_CAPTURE_MORE_SENSORS"))
+    if (
+        primary_candidate_facts.has_reference_gaps
+        or _check_state(suitability_checks, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
+        or _has_warning_code(warnings, "reference_context_incomplete")
+    ):
+        _append_unique_line(actions, tr("TIER_A_CAPTURE_REFERENCE_DATA"))
+    if not actions:
+        _append_unique_line(actions, tr("TIER_A_CAPTURE_WIDER_SPEED"))
+        _append_unique_line(
+            actions,
+            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
+        )
+    return tuple(actions[:4])
+
+
+def _recapture_condition_lines(
+    *,
+    aggregate: TestRun,
+    primary_candidate_facts: PrimaryReportFacts,
+    location_confidence_key: str,
+    expected_locations: Sequence[str],
+    active_locations: Sequence[str],
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    expected = len(expected_locations) or len(active_locations)
+    lines: list[str] = []
+    if _check_state(suitability_checks, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
+        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_STEADY_HOLD"))
+    if _has_source_overlap(aggregate, tr=tr):
+        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_COMPARE_PATHS"))
+    if _is_transient_primary(primary_candidate_facts):
+        _append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_REPEAT_EVENT"))
+    if (
+        location_confidence_key in {"weak", "mixed"}
+        or _check_state(suitability_checks, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
+    ):
+        _append_unique_line(
+            lines,
+            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
+        )
+    if (
+        primary_candidate_facts.has_reference_gaps
+        or _check_state(suitability_checks, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
+        or _has_warning_code(warnings, "reference_context_incomplete")
+    ):
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
+    if not lines:
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_STEADY"))
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected))
+        _append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
+    return tuple(lines[:4])
+
+
+def _action_status_note_text(
+    *,
+    aggregate: TestRun,
+    primary_candidate_facts: PrimaryReportFacts,
+    action_status_key: str,
+    location_confidence_key: str,
+    alternative_source_visible: bool,
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    lang: str,
+    tr: Callable[..., str],
+) -> str | None:
+    if action_status_key not in {"action_ready_caution", "recapture_before_acting"}:
+        return None
+    issue = _first_nonpass_detail(
+        suitability_checks=suitability_checks,
+        warnings=warnings,
+        lang=lang,
+        tr=tr,
+    )
+    score_note: str | None = None
+    if action_status_key == "action_ready_caution" and alternative_source_visible:
+        ranked_candidates = list(aggregate.effective_top_causes()[:2])
+        if len(ranked_candidates) > 1:
+            score_note = tr(
+                "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_SCORES",
+                primary=human_source(ranked_candidates[0].suspected_source, tr=tr),
+                primary_confidence=_confidence_pct_text(ranked_candidates[0]),
+                alternative=human_source(ranked_candidates[1].suspected_source, tr=tr),
+                alternative_confidence=_confidence_pct_text(ranked_candidates[1]),
+            )
+        else:
+            score_note = tr("REPORT_ACTION_STATUS_NOTE_GATE_CAUTION")
+    reason = score_note or _proof_caveat_text(
+        primary_candidate_facts=primary_candidate_facts,
+        action_status_key=action_status_key,
+        location_confidence_key=location_confidence_key,
+        tr=tr,
+    )
+    if issue and reason:
+        issue_norm = issue.rstrip(".")
+        reason_norm = reason.rstrip(".")
+        if reason_norm.casefold() not in issue_norm.casefold():
+            return tr(
+                "REPORT_ACTION_STATUS_NOTE_COMBINED",
+                issue=issue_norm,
+                reason=reason_norm,
+            )
+        return issue
+    return issue or reason
+
+
+def _primary_source_text(
+    primary_candidate_facts: PrimaryReportFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    if primary_candidate_facts.primary_source is None:
+        return tr("UNKNOWN")
+    return human_source(primary_candidate_facts.primary_source, tr=tr)
+
+
+def prepare_report_display_facts(
+    *,
+    aggregate: TestRun,
+    primary_candidate_facts: PrimaryReportFacts,
+    active_sensor_intensity: Sequence[LocationIntensitySummary],
+    duration_text: str | None,
+    action_status_key: str,
+    location_confidence_key: str,
+    alternative_source_visible: bool,
+    expected_locations: Sequence[str],
+    active_locations: Sequence[str],
+    missing_locations: Sequence[str],
+    partial_locations: Sequence[str],
+    suitability_checks: Sequence[RunSuitabilityCheck],
+    warnings: Sequence[SummaryWarningPayload],
+    lang: str,
+) -> PreparedReportDisplayFacts:
+    def tr(key: str, **kw: JsonValue) -> str:
+        return str(_tr(lang, key, **kw))
+
+    coverage_label = _coverage_label(
+        expected_locations=expected_locations,
+        active_locations=active_locations,
+        missing_locations=missing_locations,
+        partial_locations=partial_locations,
+        tr=tr,
+    )
+    coverage_notes = _coverage_notes(
+        missing_locations=missing_locations,
+        partial_locations=partial_locations,
+        tr=tr,
+    )
+    runner_up_corner = _runner_up_corner(active_sensor_intensity, tr=tr)
+    proof_caveat = _proof_caveat_text(
+        primary_candidate_facts=primary_candidate_facts,
+        action_status_key=action_status_key,
+        location_confidence_key=location_confidence_key,
+        tr=tr,
+    )
+    ranked_candidates = _ranked_candidates(aggregate, tr=tr)
+    recapture_before_acting = action_status_key == "recapture_before_acting"
+    recapture_issues = _recapture_issue_lines(
+        aggregate=aggregate,
+        primary_candidate_facts=primary_candidate_facts,
+        location_confidence_key=location_confidence_key,
+        suitability_checks=suitability_checks,
+        warnings=warnings,
+        lang=lang,
+        tr=tr,
+    )
+    recapture_actions = _recapture_actions(
+        aggregate=aggregate,
+        primary_candidate_facts=primary_candidate_facts,
+        location_confidence_key=location_confidence_key,
+        expected_locations=expected_locations,
+        active_locations=active_locations,
+        suitability_checks=suitability_checks,
+        warnings=warnings,
+        tr=tr,
+    )
+    recapture_conditions = _recapture_condition_lines(
+        aggregate=aggregate,
+        primary_candidate_facts=primary_candidate_facts,
+        location_confidence_key=location_confidence_key,
+        expected_locations=expected_locations,
+        active_locations=active_locations,
+        suitability_checks=suitability_checks,
+        warnings=warnings,
+        tr=tr,
+    )
+    verdict = PreparedVerdictDisplay(
+        speed_window_label=str(primary_candidate_facts.primary_speed or "").strip() or None,
+        suspected_source=(
+            tr("REPORT_INCONCLUSIVE_SOURCE")
+            if recapture_before_acting
+            else _primary_source_text(primary_candidate_facts, tr=tr)
+        ),
+        inspect_first=(
+            None
+            if recapture_before_acting
+            else _display_location(primary_candidate_facts.primary_location, tr=tr)
+        ),
+        action_status=_action_status_text(action_status_key, tr=tr),
+        action_status_note=_action_status_note_text(
+            aggregate=aggregate,
+            primary_candidate_facts=primary_candidate_facts,
+            action_status_key=action_status_key,
+            location_confidence_key=location_confidence_key,
+            alternative_source_visible=alternative_source_visible,
+            suitability_checks=suitability_checks,
+            warnings=warnings,
+            lang=lang,
+            tr=tr,
+        ),
+        reason_sentence=(
+            recapture_issues[0]
+            if recapture_before_acting and recapture_issues
+            else _build_primary_reason_sentence(
+                primary_candidate_facts=primary_candidate_facts,
+                active_locations=active_locations,
+                duration_text=duration_text,
+                tr=tr,
+            )
+        ),
+        dominant_corner=_display_location(primary_candidate_facts.primary_location, tr=tr),
+        runner_up_corner=runner_up_corner,
+        location_confidence=_location_confidence_display_text(
+            primary_candidate_facts=primary_candidate_facts,
+            action_status_key=action_status_key,
+            location_confidence_key=location_confidence_key,
+            alternative_source_visible=alternative_source_visible,
+            dominance_ratio=primary_candidate_facts.dominance_ratio,
+            suitability_checks=suitability_checks,
+            warnings=warnings,
+            lang=lang,
+            tr=tr,
+        ),
+        coverage_label=coverage_label,
+        also_consider=(
+            _source_with_confidence(aggregate.effective_top_causes()[1], tr=tr)
+            if not recapture_before_acting
+            and alternative_source_visible
+            and len(aggregate.effective_top_causes()) > 1
+            else None
+        ),
+        proof_caveat=proof_caveat,
+        proof_panel_title=(
+            tr("REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE")
+            if recapture_before_acting
+            else tr("REPORT_PROOF_PANEL_TITLE")
+        ),
+        footer_routes=(
+            (tr("REPORT_ROUTE_APPENDIX_A"),)
+            if recapture_before_acting
+            else (
+                tr("REPORT_ROUTE_APPENDIX_A"),
+                tr("REPORT_ROUTE_APPENDIX_B"),
+                tr("REPORT_ROUTE_APPENDIX_C"),
+                tr("REPORT_ROUTE_APPENDIX_D"),
+            )
+        ),
+    )
+    if recapture_before_acting:
+        appendix_a = PreparedAppendixADisplay(
+            mode="recapture",
+            primary_source=None,
+            alternative_source=None,
+            why_primary_first=None,
+            why_alternative_next=None,
+            next_if_clean=None,
+            ranked_candidates=(),
+            capture_issues=recapture_issues,
+            capture_changes=recapture_actions,
+            capture_conditions=recapture_conditions,
+        )
+    else:
+        primary_source = (
+            tr(
+                "REPORT_SOURCE_WITH_CONFIDENCE",
+                source=ranked_candidates[0].source_name,
+                confidence=ranked_candidates[0].confidence_pct,
+            )
+            if ranked_candidates and ranked_candidates[0].confidence_pct
+            else ranked_candidates[0].source_name
+            if ranked_candidates
+            else None
+        )
+        alternative_source = (
+            tr(
+                "REPORT_SOURCE_WITH_CONFIDENCE",
+                source=ranked_candidates[1].source_name,
+                confidence=ranked_candidates[1].confidence_pct,
+            )
+            if alternative_source_visible
+            and len(ranked_candidates) > 1
+            and ranked_candidates[1].confidence_pct
+            else ranked_candidates[1].source_name
+            if alternative_source_visible and len(ranked_candidates) > 1
+            else None
+        )
+        appendix_a = PreparedAppendixADisplay(
+            mode="workflow",
+            primary_source=primary_source,
+            alternative_source=alternative_source,
+            why_primary_first=ranked_candidates[0].reason if ranked_candidates else None,
+            why_alternative_next=(
+                ranked_candidates[1].reason
+                if alternative_source_visible and len(ranked_candidates) > 1
+                else None
+            ),
+            next_if_clean=_next_if_primary_clean(aggregate, tr=tr),
+            ranked_candidates=ranked_candidates,
+            capture_issues=(),
+            capture_changes=(),
+            capture_conditions=(),
+        )
+    dominance_ratio_text = (
+        tr(
+            "REPORT_DOMINANCE_RATIO_TEXT",
+            ratio=f"{primary_candidate_facts.dominance_ratio:.2f}",
+        )
+        if primary_candidate_facts.dominance_ratio is not None
+        else tr("REPORT_DOMINANCE_RATIO_UNKNOWN")
+    )
+    appendix_b = PreparedAppendixBSummaryDisplay(
+        dominant_corner=_display_location(primary_candidate_facts.primary_location, tr=tr),
+        runner_up_corner=runner_up_corner,
+        dominance_ratio_text=dominance_ratio_text,
+        location_confidence=_location_confidence_text(
+            _presented_location_confidence_key(
+                action_status_key=action_status_key,
+                location_confidence_key=location_confidence_key,
+            ),
+            tr=tr,
+        ),
+        coverage_label=coverage_label,
+        coverage_notes=coverage_notes,
+    )
+    return PreparedReportDisplayFacts(
+        verdict=verdict,
+        appendix_a=appendix_a,
+        appendix_b=appendix_b,
+    )

--- a/apps/server/vibesensor/use_cases/history/report_facts.py
+++ b/apps/server/vibesensor/use_cases/history/report_facts.py
@@ -14,6 +14,7 @@ from vibesensor.domain import (
     VibrationOrigin,
     coerce_float,
 )
+from vibesensor.report_i18n import normalize_lang
 from vibesensor.shared.boundaries.report_facts_projection import (
     report_suitability_checks,
     report_warning_payloads,
@@ -37,6 +38,10 @@ from vibesensor.shared.run_context_warning import RunContextWarningsInput
 from vibesensor.shared.types.history_analysis_contracts import RunSuitabilityCheck
 from vibesensor.shared.types.history_analysis_contracts import (
     SummaryWarningResponse as SummaryWarningPayload,
+)
+from vibesensor.use_cases.history.report_display_facts import (
+    PreparedReportDisplayFacts,
+    prepare_report_display_facts,
 )
 
 
@@ -68,6 +73,7 @@ class PreparedReportFacts:
     alternative_source_visible: bool
     confidence_gap_to_alternative: float | None
     timeline_intervals: tuple[ReportTimelineInterval, ...]
+    display: PreparedReportDisplayFacts
 
 
 @dataclass(frozen=True, slots=True)
@@ -345,10 +351,12 @@ def prepare_report_facts(
     payload: Mapping[str, object],
     *,
     test_run: TestRun,
+    language: str | None = None,
     warnings: RunContextWarningsInput = None,
 ) -> PreparedReportFacts:
     """Resolve semantic report facts shared by downstream PDF mapping."""
     metadata = summary_metadata(payload)
+    prepared_language = str(normalize_lang(language or payload.get("lang")))
     sensor_locations_active = active_sensor_locations(payload)
     origin = resolve_report_origin(test_run)
     origin_location = normalize_origin_location(origin)
@@ -389,11 +397,28 @@ def prepare_report_facts(
         suitability_checks=suitability_checks,
         warnings=warning_payloads,
     )
+    duration_text = str(payload.get("record_length") or "").strip() or None
+    display = prepare_report_display_facts(
+        aggregate=test_run,
+        primary_candidate_facts=primary_candidate_facts,
+        active_sensor_intensity=active_sensor_intensity,
+        duration_text=duration_text,
+        action_status_key=action_status_key,
+        location_confidence_key=location_confidence_key,
+        alternative_source_visible=alternative_source_visible,
+        expected_locations=coverage_summary.expected_locations,
+        active_locations=coverage_summary.active_locations,
+        missing_locations=coverage_summary.missing_locations,
+        partial_locations=coverage_summary.partial_locations,
+        suitability_checks=suitability_checks,
+        warnings=warning_payloads,
+        lang=prepared_language,
+    )
     return PreparedReportFacts(
         origin=origin,
         origin_location=origin_location,
         sensor_locations_active=sensor_locations_active,
-        duration_text=str(payload.get("record_length") or "").strip() or None,
+        duration_text=duration_text,
         start_time_utc=str(payload.get("start_time_utc") or "").strip() or None,
         end_time_utc=str(payload.get("end_time_utc") or "").strip() or None,
         sample_rate_hz=(
@@ -418,4 +443,5 @@ def prepare_report_facts(
         alternative_source_visible=alternative_source_visible,
         confidence_gap_to_alternative=confidence_gap_to_alternative,
         timeline_intervals=_timeline_intervals(payload),
+        display=display,
     )

--- a/apps/server/vibesensor/use_cases/history/report_preparation.py
+++ b/apps/server/vibesensor/use_cases/history/report_preparation.py
@@ -145,7 +145,12 @@ def _build_prepared_report_input(
     prepared_language = str(normalize_lang(language or payload.get("lang")))
     renderer_payload = build_report_renderer_payload(payload)
     report_facts = (
-        prepare_report_facts(payload, test_run=domain_test_run, warnings=warnings)
+        prepare_report_facts(
+            payload,
+            test_run=domain_test_run,
+            language=prepared_language,
+            warnings=warnings,
+        )
         if domain_test_run is not None
         else None
     )

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -76,11 +76,13 @@ History-side report preparation now lives in
 `PreparedReportInput` seam passed into the PDF adapter, projectability gating,
 domain reconstruction, filename/language normalization, and final prepared-input
 assembly. Semantic report-facts shaping now lives in the dedicated
-`vibesensor.use_cases.history.report_facts` module, which precomputes the
-origin, active sensor intensity, hotspot rows, primary-candidate facts,
-next-step inputs, and data-trust inputs the adapter needs. Pure report-domain
-interpretation that reads domain findings/test runs but does not perform i18n
-or PDF dataclass assembly still lives in
+`vibesensor.use_cases.history.report_facts` and
+`vibesensor.use_cases.history.report_display_facts` modules, which precompute
+the origin, active sensor intensity, hotspot rows, primary-candidate facts,
+verdict/appendix display decisions, next-step inputs, and data-trust inputs the
+adapter needs. Pure report-domain interpretation that reads domain
+findings/test runs but does not perform i18n or PDF dataclass assembly still
+lives in
 `vibesensor.shared.boundaries.report_interpretation`, but it is consumed by
 history-side preparation rather than imported directly by `adapters.pdf`
 modules.
@@ -121,7 +123,9 @@ needs:
 2. Add a corresponding field to `ReportTemplateData` in
    `vibesensor.adapters.pdf.report_data`.
 3. If the new section needs report-specific shaping, add it to
-   `vibesensor.use_cases.history.report_facts` (for semantic report facts) or
+   `vibesensor.use_cases.history.report_facts` /
+   `vibesensor.use_cases.history.report_display_facts` (for semantic report
+   facts and display decisions) or
    `vibesensor.use_cases.history.report_preparation` (for the outer prepared
    handoff), then populate the final renderer field in `map_summary()` in
    `vibesensor.adapters.pdf.mapping`.


### PR DESCRIPTION
Closes #1996

## Summary
This PR restores the “thin mapper” boundary described in `docs/report_pipeline.md` by moving the remaining report-decision branches for verdict and appendix display into a history-side preparation module. Before this change, `apps/server/vibesensor/adapters/pdf/mapping.py` still owned a large block of semantic logic: coverage copy, location-confidence phrasing, action-status notes, ranked-candidate reason text, and recapture issue/action/condition lists. The mapper was therefore not just formatting prepared values; it was still deciding what the report meant.

The main change is a new history-side module, `apps/server/vibesensor/use_cases/history/report_display_facts.py`, which computes typed display decisions from the reconstructed `TestRun`, `PrimaryReportFacts`, suitability checks, warnings, and localized language choice. `PreparedReportFacts` now carries those values through a `display` field, and `mapping.py` consumes them as prepared inputs instead of rebuilding them. The result is a narrower renderer boundary that matches the documented pipeline more closely without changing the outward report data model.

## Implementation approach
I kept the change focused on the semantic branches called out in the issue rather than trying to split the whole mapper at once. The goal was to remove decision ownership from `mapping.py` while preserving current output and existing renderer contracts. That meant extracting only the parts of the adapter that decide report wording or guidance, and leaving purely renderer-facing assembly plus appendix C/D formatting in place for now.

To do that safely, I first identified the helper block in `mapping.py` that still owned major report reasoning. The extracted scope includes coverage labels and notes, location-confidence display text, action-status note composition, ranked candidate path/reason assembly, “next if clean” wording, and the full recapture guidance set (issues, changes, and conditions). Those helpers now live together on the history side where they can read authoritative domain facts before the mapper boundary.

## Main code changes
The largest addition is `apps/server/vibesensor/use_cases/history/report_display_facts.py`. This module defines `PreparedVerdictDisplay`, `PreparedAppendixADisplay`, `PreparedAppendixBSummaryDisplay`, and the umbrella `PreparedReportDisplayFacts`. It computes localized, renderer-ready display decisions from history-side inputs. In practice, that means the history layer now owns the phrases and branches for verdict status, confidence wording, candidate explanations, appendix A workflow vs recapture mode, and appendix B coverage narrative.

`apps/server/vibesensor/use_cases/history/report_facts.py` now constructs this new display seam as part of `prepare_report_facts()`. `PreparedReportFacts` has a new `display` field, and `prepare_report_facts()` calls `prepare_report_display_facts(...)` after it resolves the primary candidate facts, coverage summary, action status, and warnings. This keeps the prepared report-facts object as the single semantic handoff from history preparation to the PDF adapter.

`apps/server/vibesensor/use_cases/history/report_preparation.py` now threads the canonical prepared language into `prepare_report_facts()`. That matters because these display facts are intentionally localized upstream. If the history side is going to own the wording decisions, it needs the normalized language at preparation time rather than forcing the mapper to localize those branches later.

On the adapter side, `apps/server/vibesensor/adapters/pdf/mapping.py` was reduced substantially. The old helper block that computed candidate ordering/reasons, coverage notes, action-status notes, and recapture guidance has been removed. The section builders now consume prepared display dataclasses directly: verdict page assembly takes a prepared verdict display object, appendix A assembly takes a prepared appendix A display object, and appendix B assembly takes a prepared appendix B display object. `mapping.py` still assembles the final `ReportTemplateData`, but it no longer owns those major decision branches. The remaining adapter-local logic is primarily renderer formatting and appendix C/D content that still depends on raw evidence presentation.

## Guardrails and documentation
I updated `docs/report_pipeline.md` to describe the new history-side seam explicitly. The docs now call out `report_display_facts.py` alongside `report_facts.py` as the owner of semantic report facts and display decisions. That keeps the architecture docs aligned with the implementation instead of continuing to describe a thinner mapper than the code actually had.

I also added regression and hygiene coverage so this boundary is harder to erode again. `apps/server/tests/use_cases/history/test_report_facts.py` now asserts that workflow and recapture display sections are prepared upstream, including precomputed appendix A guidance and verdict routing. `apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py` now checks that the mapper’s section builders consume prepared display objects instead of taking `report_facts` or aggregate inputs and rebuilding those semantics in place.

## Validation
I validated the refactor in layers. First, I ran the focused report/history slice that exercises the prepared input seam, report facts, mapper context, mapping pipeline, and hygiene guards:

- `python3.14 -m pytest -q apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_mapping_context.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py` → `44 passed`

Then I ran the broader report-mapping regression file that covers the concrete report content flows affected by these changes:

- `python3.14 -m pytest -q apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py` → `31 passed`

Finally, I ran the repository validation targets already used elsewhere in this run:

- `make lint`
- `make typecheck`

Both passed after two small follow-ups inside the new module: one line-length cleanup and a pair of typing/import-order fixes discovered by the existing repo checks.

## Risks, tradeoffs, and out-of-scope items
I deliberately did not try to solve every remaining size/cohesion problem in `mapping.py` here. Appendix C evidence narration and some adapter-local formatting helpers still live in the mapper because they were not the primary semantic branches called out in the issue, and I wanted this change to stay reviewable. Likewise, `_candidate_resolver.py` still exists as an adapter-side collaborator for primary presentation context. This PR restores the biggest missing boundary first instead of combining that with a full module split.

Another intentional tradeoff is that the new display seam is localized history-side. That matches the boundary goal, but it also means language normalization is now a strict part of prepared report-facts construction. I threaded the canonical language explicitly to keep that dependency obvious and deterministic.

## Follow-up view
After this PR, the mapper is much closer to what the docs describe: it mostly assembles prepared values into renderer data rather than deciding what the report should say. The next natural follow-up, if we want to keep pushing on this area, would be to split `mapping.py` into smaller section-focused modules and evaluate whether the remaining appendix C/D narrative assembly should also move behind a prepared display seam. That is intentionally out of scope for this change, which focuses on the concrete decision branches from `#1996`.
