### PR TITLE
Standardize failure handling across runtime loops

### DIFF
--- a/apps/server/tests/adapters/websocket/test_tick_controller.py
+++ b/apps/server/tests/adapters/websocket/test_tick_controller.py
@@ -8,7 +8,10 @@ from unittest.mock import patch
 
 import pytest
 
-from vibesensor.adapters.websocket.tick_controller import BroadcastTickController
+from vibesensor.adapters.websocket.tick_controller import (
+    BroadcastTickController,
+    BroadcastTickLoopFailure,
+)
 
 
 @pytest.mark.asyncio
@@ -66,20 +69,19 @@ async def test_controller_on_tick_exception_logs_warning_and_continues(caplog) -
 
 
 @pytest.mark.asyncio
-async def test_controller_backs_off_after_consecutive_failures(caplog) -> None:
+async def test_controller_escalates_after_consecutive_failures(caplog) -> None:
     logger = logging.getLogger("vibesensor.adapters.websocket.hub")
     controller = BroadcastTickController(
         hz=10,
         logger=logger,
         max_consecutive_failures=2,
-        backoff_multiplier=5,
     )
     sleep_calls: list[float] = []
+    original_sleep = asyncio.sleep
 
     async def fake_sleep(duration: float) -> None:
         sleep_calls.append(duration)
-        if len(sleep_calls) >= 2:
-            raise asyncio.CancelledError
+        await original_sleep(0)
 
     async def failing_broadcast() -> None:
         raise RuntimeError("boom")
@@ -90,14 +92,13 @@ async def test_controller_backs_off_after_consecutive_failures(caplog) -> None:
             side_effect=fake_sleep,
         ),
         caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"),
-        pytest.raises(asyncio.CancelledError),
+        pytest.raises(BroadcastTickLoopFailure, match="2 consecutive times"),
     ):
         await controller.run(broadcast_tick=failing_broadcast)
 
-    assert sleep_calls[0] == pytest.approx(0.1, rel=0.2)
-    assert sleep_calls[1] == pytest.approx(0.5, rel=0.01)
+    assert sleep_calls == [pytest.approx(0.1, rel=0.2)]
     assert any("1 consecutive" in record.message for record in caplog.records)
-    assert any("2 consecutive times; backing off." in record.message for record in caplog.records)
+    assert any("2 consecutive times; escalating." in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/run/test_post_analysis_worker.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_worker.py
@@ -302,6 +302,25 @@ class TestPostAnalysisWorkerErrorHandling:
         assert worker.wait(timeout_s=3.0)
         assert seen == ["run-ok"]
 
+    def test_unexpected_worker_failure_updates_snapshot_and_error_callback(
+        self,
+        make_worker,
+    ) -> None:
+        errors: list[str] = []
+
+        def _fail(_rid: str) -> None:
+            raise RuntimeError("worker boom")
+
+        worker = make_worker(run_fn=_fail, error_callback=errors.append)
+
+        worker.schedule("run-unexpected")
+        assert worker.wait(timeout_s=3.0)
+
+        snapshot = worker.snapshot()
+        assert snapshot.last_completed_run_id == "run-unexpected"
+        assert snapshot.last_completed_error == "worker boom"
+        assert errors == ["post-analysis failed for run run-unexpected: worker boom"]
+
     def test_worker_retries_retryable_failure_until_success(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -97,8 +97,9 @@ class WebSocketHub:
 
         *on_tick* (if provided) is called synchronously before each broadcast so
         the caller can update shared state atomically with payload generation.
-        Consecutive broadcast failures trigger back-off to avoid thundering-herd
-        log spam.
+        Repeated broadcast failures escalate out to the managed task supervisor,
+        which owns restart/backoff policy and health reporting for the
+        background ws-broadcast loop.
         """
         controller = BroadcastTickController(hz=hz, logger=LOGGER)
         await controller.run(

--- a/apps/server/vibesensor/adapters/websocket/tick_controller.py
+++ b/apps/server/vibesensor/adapters/websocket/tick_controller.py
@@ -1,4 +1,4 @@
-"""Broadcast tick scheduling and backoff control for WebSocket run loops."""
+"""Broadcast tick scheduling and failure escalation for WebSocket run loops."""
 
 from __future__ import annotations
 
@@ -6,14 +6,27 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 
-__all__ = ["BroadcastTickController"]
+from vibesensor.shared.failure_utils import bounded_failure_message
+
+__all__ = ["BroadcastTickController", "BroadcastTickLoopFailure"]
 
 _MAX_CONSECUTIVE_FAILURES: int = 10
-_BACKOFF_MULTIPLIER: int = 5
+
+
+class BroadcastTickLoopFailure(RuntimeError):
+    """Repeated broadcast-loop failure escalated to outer runtime supervision."""
+
+    def __init__(self, *, consecutive_failures: int, cause: Exception) -> None:
+        self.consecutive_failures = consecutive_failures
+        self.cause = cause
+        super().__init__(
+            "WebSocket broadcast tick failed "
+            f"{consecutive_failures} consecutive times: {bounded_failure_message(cause)}"
+        )
 
 
 class BroadcastTickController:
-    """Drive a broadcast loop with fixed-rate timing and failure backoff."""
+    """Drive a broadcast loop with fixed-rate timing and bounded local retries."""
 
     def __init__(
         self,
@@ -21,7 +34,6 @@ class BroadcastTickController:
         hz: int,
         logger: logging.Logger,
         max_consecutive_failures: int = _MAX_CONSECUTIVE_FAILURES,
-        backoff_multiplier: int = _BACKOFF_MULTIPLIER,
     ) -> None:
         if hz <= 0:
             logger.warning(
@@ -31,7 +43,6 @@ class BroadcastTickController:
         self._logger = logger
         self._interval = 1.0 / max(1, hz)
         self._max_consecutive_failures = max_consecutive_failures
-        self._backoff_multiplier = backoff_multiplier
 
     async def run(
         self,
@@ -39,7 +50,13 @@ class BroadcastTickController:
         broadcast_tick: Callable[[], Awaitable[None]],
         on_tick: Callable[[], None] | None = None,
     ) -> None:
-        """Drive the loop until cancelled, preserving existing retry behavior."""
+        """Drive the loop until cancelled.
+
+        Transient failures still retry inside the tick loop, but once the
+        failure streak crosses the configured threshold this controller raises
+        to the caller so runtime supervision can own restart/backoff policy and
+        health reporting for the managed task.
+        """
 
         consecutive_failures = 0
         loop = asyncio.get_running_loop()
@@ -56,22 +73,22 @@ class BroadcastTickController:
                         )
                 await broadcast_tick()
                 consecutive_failures = 0
-            except Exception:
+            except Exception as exc:
                 consecutive_failures += 1
                 if consecutive_failures >= self._max_consecutive_failures:
                     self._logger.error(
-                        "WebSocket broadcast tick failed %d consecutive times; backing off.",
+                        "WebSocket broadcast tick failed %d consecutive times; escalating.",
                         consecutive_failures,
                         exc_info=True,
                     )
-                    await asyncio.sleep(self._interval * self._backoff_multiplier)
-                    tick_start = loop.time()
-                    consecutive_failures = 0
-                else:
-                    self._logger.warning(
-                        "WebSocket broadcast tick failed (%d consecutive); will retry.",
-                        consecutive_failures,
-                        exc_info=True,
-                    )
+                    raise BroadcastTickLoopFailure(
+                        consecutive_failures=consecutive_failures,
+                        cause=exc,
+                    ) from exc
+                self._logger.warning(
+                    "WebSocket broadcast tick failed (%d consecutive); will retry.",
+                    consecutive_failures,
+                    exc_info=True,
+                )
             elapsed = loop.time() - tick_start
             await asyncio.sleep(max(0, self._interval - elapsed))

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -15,6 +15,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from vibesensor.shared.exceptions import ProcessingError
+from vibesensor.shared.failure_utils import bounded_failure_message
 from vibesensor.shared.ports import ClockSyncBroadcaster
 
 if TYPE_CHECKING:
@@ -110,10 +111,7 @@ class ProcessingLoop:
 
     @staticmethod
     def _truncate_failure_message(exc: Exception) -> str:
-        message = str(exc).strip() or exc.__class__.__name__
-        if len(message) > _MAX_FAILURE_MESSAGE_LEN:
-            return f"{message[: _MAX_FAILURE_MESSAGE_LEN - 1]}..."
-        return message
+        return bounded_failure_message(exc, max_length=_MAX_FAILURE_MESSAGE_LEN)
 
     def _record_failure(self, category: str, exc: Exception) -> None:
         state = self.state

--- a/apps/server/vibesensor/infra/runtime/task_supervisor.py
+++ b/apps/server/vibesensor/infra/runtime/task_supervisor.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Callable, Coroutine
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
+from vibesensor.shared.failure_utils import bounded_failure_message
 
 __all__ = ["TaskSupervisor", "task_failure_message"]
 
@@ -22,8 +23,7 @@ _TASK_RESTART_RESET_AFTER_S = 60.0
 def task_failure_message(exc: BaseException) -> str:
     """Normalize a task failure into a bounded health-state message."""
 
-    message = str(exc).strip() or exc.__class__.__name__
-    return message[:240]
+    return bounded_failure_message(exc, max_length=240)
 
 
 class TaskSupervisor:

--- a/apps/server/vibesensor/shared/failure_utils.py
+++ b/apps/server/vibesensor/shared/failure_utils.py
@@ -1,0 +1,16 @@
+"""Shared failure-message normalization helpers."""
+
+from __future__ import annotations
+
+__all__ = ["bounded_failure_message"]
+
+
+def bounded_failure_message(exc: BaseException, *, max_length: int = 240) -> str:
+    """Normalize an exception into a bounded, non-empty operator-facing message."""
+
+    message = str(exc).strip() or exc.__class__.__name__
+    if max_length <= 0 or len(message) <= max_length:
+        return message
+    if max_length <= 3:
+        return message[:max_length]
+    return f"{message[: max_length - 3]}..."

--- a/apps/server/vibesensor/use_cases/run/post_analysis.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from threading import Event, RLock, Thread
 
+from vibesensor.shared.failure_utils import bounded_failure_message
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.use_cases.run.post_analysis_executor import (
     PostAnalysisAttemptResult,
@@ -246,8 +247,8 @@ class PostAnalysisWorker:
                 self._analysis_active_started_at = time.time()
             try:
                 self._run_post_analysis(run_id)
-            except Exception:
-                LOGGER.exception("Unexpected error in analysis worker for run %s", run_id)
+            except Exception as exc:
+                self._record_unexpected_worker_failure(run_id, exc)
             finally:
                 with self._lock:
                     self._analysis_enqueued_run_ids.discard(run_id)
@@ -320,3 +321,11 @@ class PostAnalysisWorker:
 
         for error_msg in _execution_callback_errors(result):
             self._error_cb(error_msg)
+
+    def _record_unexpected_worker_failure(self, run_id: str, exc: Exception) -> None:
+        completed_error = bounded_failure_message(exc)
+        with self._lock:
+            self._last_completed_run_id = run_id
+            self._last_completed_error = completed_error
+        self._error_cb(f"post-analysis failed for run {run_id}: {completed_error}")
+        LOGGER.exception("Unexpected error in analysis worker for run %s", run_id)


### PR DESCRIPTION
## Summary

This PR narrows one of the bigger inconsistencies called out in #1997: long-running runtime loops were not all surfacing failure state through the same supervision path. The backend already had a solid supervision boundary in `TaskSupervisor` and a fairly mature failure model in `ProcessingLoop`, but two important loops still behaved differently from that contract. The WebSocket broadcast tick loop absorbed repeated failures inside its own retry policy, and the post-analysis worker logged unexpected worker-loop crashes without reliably surfacing them through its observable completion state. The result was fragmented operator visibility: some failures updated health state and restarted under supervision, while others stayed local to the loop that hit the error.

The changes here standardize those failure paths without turning this issue into a broad runtime-framework rewrite. Repeated `ws-broadcast` failures now escalate out of `BroadcastTickController` after a bounded local streak so the managed task can use the existing `TaskSupervisor` restart/backoff and health-state semantics. Unexpected post-analysis worker-loop exceptions now update the worker snapshot and notify the configured error callback instead of being log-only. I also introduced one small shared helper for bounded, non-empty operator-facing failure messages and reused it in the main runtime reporting paths touched by this issue.

## Problem being solved

Before this change, the codebase had three noticeably different patterns for long-running loop failures:

- `ProcessingLoop` already categorized failures, bounded failure messages, and escalated after repeated fatal cycles.
- `TaskSupervisor` already owned restart/backoff policy and health-state recording for managed background tasks.
- `BroadcastTickController` retried broad exceptions using its own local policy indefinitely, which meant a persistently failing `ws-broadcast` loop could stay inside the controller instead of cleanly flowing through the supervisor-owned restart path.
- `PostAnalysisWorker._worker_loop()` caught broad unexpected exceptions and logged them, but those failures were not consistently reflected in `snapshot().last_completed_error` or the worker error callback.

That mismatch made it harder to reason about what the runtime considered transient, what it considered escalated, and what an operator or health snapshot would actually show after a failure.

## Implementation approach

I kept the fix intentionally narrow. Instead of introducing a brand-new shared loop abstraction, I used the runtime seams that already existed and tightened the outliers toward them.

For the WebSocket broadcast path, the key decision was to keep a small amount of local tolerance but stop letting the leaf loop own the full restart story. `BroadcastTickController` still retries transient failures inside the loop so one-off broadcast blips do not immediately tear down the task. However, once failures reach the configured consecutive threshold, the controller now raises a dedicated `BroadcastTickLoopFailure`. Because the `ws-broadcast` loop is already a managed task, that exception can now flow into `TaskSupervisor`, which already knows how to record comparable failure state, apply restart/backoff, and expose the problem via runtime health.

For the post-analysis path, I kept the existing typed `execute_post_analysis()` result model for expected retryable and persistence failures. The gap was the truly unexpected exception path around `_run_post_analysis()`. Rather than only logging that crash, `_worker_loop()` now routes it through `_record_unexpected_worker_failure()`, which updates the last-completed snapshot fields and triggers the configured error callback with the same style of operator-facing message used elsewhere.

## Main code changes by area

In `apps/server/vibesensor/shared/failure_utils.py`, I added `bounded_failure_message()`. This helper normalizes exceptions into non-empty, length-bounded strings and centralizes the truncation behavior that was previously duplicated across runtime paths.

In `apps/server/vibesensor/infra/runtime/task_supervisor.py`, `task_failure_message()` now delegates to that shared helper instead of maintaining its own message normalization logic.

In `apps/server/vibesensor/infra/runtime/processing_loop.py`, `_truncate_failure_message()` now also delegates to the same helper. I deliberately left the rest of `ProcessingLoop` alone because it already had the richer runtime-specific escalation policy this issue is trying to preserve, not replace.

In `apps/server/vibesensor/adapters/websocket/tick_controller.py`, I introduced `BroadcastTickLoopFailure` and changed the controller’s retry loop so consecutive broadcast failures no longer reset forever. The controller still warns and retries below the threshold, but once the streak reaches the configured limit it logs an escalation message and raises to the caller.

In `apps/server/vibesensor/adapters/websocket/hub.py`, I updated the `run()` docstring to make the new contract explicit: repeated broadcast failures now escalate to the outer managed-task supervisor, which owns restart/backoff and health reporting for the background broadcast loop.

In `apps/server/vibesensor/use_cases/run/post_analysis.py`, unexpected worker-loop exceptions now call `_record_unexpected_worker_failure()`. That helper sets `last_completed_run_id`, sets `last_completed_error`, invokes the configured error callback, and logs with traceback. This keeps the worker’s observable state aligned with what actually happened.

## Tests and validation

I updated `apps/server/tests/adapters/websocket/test_tick_controller.py` to assert the new escalation behavior instead of the old unbounded local retry story. The test now verifies that the controller retries the first failure, preserves the expected sleep interval, and raises `BroadcastTickLoopFailure` once the consecutive threshold is reached.

I added coverage in `apps/server/tests/use_cases/run/test_post_analysis_worker.py` to verify that an unexpected worker exception updates the worker snapshot and emits the expected callback message.

Local validation for the final change set was:

- `python3.14 -m pytest -q apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/infra/runtime/test_task_supervisor.py apps/server/tests/infra/runtime/test_background_task_coordinator.py apps/server/tests/adapters/websocket/test_tick_controller.py apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/use_cases/test_system_health.py`
  - `78 passed`
- `make lint`
- `make typecheck`

## Risks, tradeoffs, and out-of-scope items

The main behavior change is that persistent ws-broadcast failure now trips the managed-task restart path instead of staying inside controller-local retries forever. That is intentional, but it also means repeated broadcast breakage becomes more visible in health state and logs, which is the point of the issue.

I did not try to force every loop in the codebase into one shared class. `ProcessingLoop` already has domain-specific fatality and degraded-state behavior, so this PR only standardizes the pieces that were clearly fragmented. I also did not refactor `apps/server/vibesensor/adapters/http/websocket.py` in this pass. Its per-connection error handling is a different boundary from the supervised background loop, and folding that in here would have broadened the issue beyond the narrow runtime supervision seam this PR improves.

There are no schema, contract, or configuration changes in this PR.
