### PR TITLE
Split OBD monitor into smaller collaborators

### DIFF
--- a/apps/server/tests/adapters/obd/test_polling.py
+++ b/apps/server/tests/adapters/obd/test_polling.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vibesensor.adapters.obd.elm327 import ObdTransportError
+from vibesensor.adapters.obd.polling import (
+    ObdPidFailureKind,
+    ObdPidPollResult,
+    ObdPollingCadence,
+    ObdPollPlan,
+    ObdPollResult,
+    execute_poll_plan,
+)
+
+
+class _FakeClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_execute_poll_plan_classifies_fatal_transport_and_skips_speed() -> None:
+    clock = _FakeClock()
+    session = MagicMock()
+
+    def request(command: str, *, timeout_s: float | None = None) -> str:
+        assert command == "010C"
+        assert timeout_s == 0.2
+        clock.advance(0.05)
+        raise ObdTransportError("Session is not connected")
+
+    session.request.side_effect = request
+
+    result = execute_poll_plan(
+        session,
+        plan=ObdPollPlan(
+            rpm_due=True,
+            speed_due=True,
+            rpm_timeout_s=0.2,
+            speed_timeout_s=0.2,
+        ),
+        monotonic=clock,
+    )
+
+    assert result.rpm.failure_kind is ObdPidFailureKind.FATAL_TRANSPORT
+    assert result.rpm.error == "PID 010C request failed: Session is not connected"
+    assert result.connection_lost is True
+    assert result.speed.executed is False
+    assert session.request.call_count == 1
+
+
+def test_polling_cadence_backs_off_and_reports_snapshot() -> None:
+    cadence = ObdPollingCadence(max_interval_s=0.75)
+    cadence.reset(now=0.0)
+
+    cadence.apply_result(
+        ObdPollResult(
+            rpm=ObdPidPollResult(
+                value=0x1AF8 / 4.0,
+                raw_response="410C1AF8",
+                error=None,
+                duration_s=0.12,
+                executed=True,
+                started_at_s=0.0,
+            ),
+            speed=ObdPidPollResult(
+                value=None,
+                raw_response=None,
+                error="Timed out waiting for PID 010D response",
+                duration_s=0.2,
+                executed=True,
+                started_at_s=0.12,
+                failure_kind=ObdPidFailureKind.TIMEOUT,
+            ),
+        ),
+        now=0.32,
+    )
+
+    snapshot = cadence.snapshot()
+    plan = cadence.prepare_poll(now=0.2)
+
+    assert snapshot.poll_mode == "rpm_only_backoff"
+    assert snapshot.backoff_active is True
+    assert snapshot.timeout_count == 1
+    assert snapshot.error_count == 0
+    assert snapshot.rpm_target_interval_ms == 75
+    assert snapshot.request_rtt_ms is not None
+    assert snapshot.last_raw_response == "410C1AF8"
+    assert plan.rpm_due is True
+    assert plan.speed_due is False
+    assert plan.rpm_timeout_s == 0.3

--- a/apps/server/tests/adapters/obd/test_status.py
+++ b/apps/server/tests/adapters/obd/test_status.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from vibesensor.adapters.obd.polling import ObdPollingSnapshot
+from vibesensor.adapters.obd.status import ObdMonitorStatusState, build_obd_status_snapshot
+
+
+def _polling_snapshot(*, backoff_active: bool = True) -> ObdPollingSnapshot:
+    return ObdPollingSnapshot(
+        rpm_target_interval_ms=75,
+        rpm_effective_hz=20.0,
+        request_rtt_ms=140.0,
+        timeout_count=1,
+        error_count=0,
+        poll_mode="rpm_only_backoff",
+        backoff_active=backoff_active,
+        last_raw_response="410C1AF8",
+    )
+
+
+def test_build_obd_status_snapshot_reports_disconnect_hint() -> None:
+    status = build_obd_status_snapshot(
+        ObdMonitorStatusState(
+            effective_connection_state="disconnected",
+            transport_connection_state="disconnected",
+            configured_device_mac="00043e5a4a4d",
+            configured_device_name="OBDLink MX+",
+            device_mac=None,
+            device_name=None,
+            paired=True,
+            trusted=True,
+            connected=False,
+            rfcomm_channel=1,
+            speed_snapshot=(10.0, 90.0),
+            engine_rpm=1726.0,
+            engine_rpm_ts=99.0,
+            obd_selected=True,
+            last_error="link down",
+            helper_error=None,
+            reconnect_delay_s=4.0,
+            polling=_polling_snapshot(),
+        ),
+        now_mono=100.0,
+    )
+
+    assert status.device_mac == "00043e5a4a4d"
+    assert status.device_name == "OBDLink MX+"
+    assert status.last_speed_kmh == 36.0
+    assert status.last_sample_age_s == 10.0
+    assert status.last_rpm == 1726.0
+    assert status.rpm_sample_age_s == 1.0
+    assert status.poll_mode is None
+    assert status.backoff_active is True
+    assert status.reconnect_delay_s == 4.0
+    assert "retrying automatically" in str(status.debug_hint).lower()
+
+
+def test_build_obd_status_snapshot_hides_obd_only_fields_when_not_selected() -> None:
+    status = build_obd_status_snapshot(
+        ObdMonitorStatusState(
+            effective_connection_state="connected",
+            transport_connection_state="connected",
+            configured_device_mac="00043e5a4a4d",
+            configured_device_name="OBDLink MX+",
+            device_mac="00043e5a4a4d",
+            device_name="OBDLink MX+",
+            paired=True,
+            trusted=True,
+            connected=True,
+            rfcomm_channel=1,
+            speed_snapshot=(10.0, 90.0),
+            engine_rpm=1726.0,
+            engine_rpm_ts=99.0,
+            obd_selected=False,
+            last_error=None,
+            helper_error=None,
+            reconnect_delay_s=1.0,
+            polling=_polling_snapshot(),
+        ),
+        now_mono=100.0,
+    )
+
+    assert status.rpm_sample_age_s is None
+    assert status.rpm_target_interval_ms is None
+    assert status.rpm_effective_hz is None
+    assert status.request_rtt_ms is None
+    assert status.poll_mode is None
+    assert status.backoff_active is False

--- a/apps/server/vibesensor/adapters/obd/monitor.py
+++ b/apps/server/vibesensor/adapters/obd/monitor.py
@@ -5,22 +5,23 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from threading import RLock
 
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution, SpeedResolutionPolicy
 from vibesensor.adapters.obd.admin_client import ObdAdminClient
-from vibesensor.adapters.obd.elm327 import (
-    Elm327Session,
-    ObdTransportError,
-    elm_response_has_no_data,
-    parse_pid_010c_rpm,
-    parse_pid_010d_speed_kmh,
-)
+from vibesensor.adapters.obd.elm327 import Elm327Session
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot, ObdStatusSnapshot
+from vibesensor.adapters.obd.polling import (
+    ObdPidPollResult,
+    ObdPollingCadence,
+    ObdPollResult,
+    execute_poll_plan,
+)
+from vibesensor.adapters.obd.status import ObdMonitorStatusState, build_obd_status_snapshot
 from vibesensor.domain import SpeedSourceKind
 from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
-from vibesensor.shared.constants.units import KMH_TO_MPS, MPS_TO_KMH
+from vibesensor.shared.constants.units import KMH_TO_MPS
 
 __all__ = ["OBDSpeedMonitor"]
 
@@ -28,92 +29,7 @@ _INITIAL_RECONNECT_DELAY_S = 1.0
 _MAX_RECONNECT_DELAY_S = 30.0
 _IDLE_POLL_S = 1.0
 _DEFAULT_POLL_INTERVAL_S = 0.75
-_ADAPTIVE_POLL_INTERVALS_S = (0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.5, 0.75)
-_MIN_REQUEST_TIMEOUT_S = 0.2
-_MAX_RPM_REQUEST_TIMEOUT_S = 2.0
-_MAX_SPEED_REQUEST_TIMEOUT_S = 0.75
-_SPEED_COMPANION_INTERVAL_MULTIPLIER = 4.0
-_MIN_SPEED_COMPANION_INTERVAL_S = 0.5
-_MAX_SPEED_COMPANION_INTERVAL_S = 1.5
-_REQUEST_RTT_EMA_WEIGHT = 0.25
-_RPM_INTERVAL_EMA_WEIGHT = 0.25
-_STABLE_POLLS_TO_SPEED_UP = 6
 _RPM_STALE_TIMEOUT_S = 2.0
-_FATAL_TRANSPORT_MARKERS = (
-    "closed the rfcomm socket",
-    "session is not connected",
-    "bad file descriptor",
-    "broken pipe",
-    "connection reset",
-    "host is down",
-)
-
-
-def _normalized_poll_interval_s(value: float) -> float:
-    return max(0.2, float(value))
-
-
-def _adaptive_interval_steps(max_interval_s: float) -> tuple[float, ...]:
-    normalized = _normalized_poll_interval_s(max_interval_s)
-    steps = tuple(step for step in _ADAPTIVE_POLL_INTERVALS_S if step <= normalized)
-    if not steps:
-        return (normalized,)
-    if steps[-1] != normalized:
-        return (*steps, normalized)
-    return steps
-
-
-def _update_ema(current: float | None, sample: float, *, weight: float) -> float:
-    return sample if current is None else ((1.0 - weight) * current) + (weight * sample)
-
-
-def _poll_error_is_timeout(error: str) -> bool:
-    return "timed out" in error.lower()
-
-
-def _poll_error_is_fatal_transport(error: str) -> bool:
-    lowered = error.lower()
-    return any(marker in lowered for marker in _FATAL_TRANSPORT_MARKERS)
-
-
-@dataclass(frozen=True, slots=True)
-class _PidPollResult:
-    value: float | None
-    raw_response: str | None
-    error: str | None
-    duration_s: float | None
-    timed_out: bool
-    no_data: bool
-    executed: bool
-    started_at_s: float | None = None
-    fatal_transport: bool = False
-
-    @classmethod
-    def skipped(cls) -> _PidPollResult:
-        return cls(
-            value=None,
-            raw_response=None,
-            error=None,
-            duration_s=None,
-            timed_out=False,
-            no_data=False,
-            executed=False,
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class _PollResult:
-    rpm: _PidPollResult
-    speed: _PidPollResult
-
-    @property
-    def raw_response(self) -> str | None:
-        raw_parts = [part for part in (self.rpm.raw_response, self.speed.raw_response) if part]
-        return " | ".join(raw_parts) if raw_parts else None
-
-    @property
-    def connection_lost(self) -> bool:
-        return self.rpm.fatal_transport or self.speed.fatal_transport
 
 
 SessionFactory = Callable[[], Elm327Session]
@@ -124,9 +40,7 @@ class OBDSpeedMonitor:
     """Manage Bluetooth RFCOMM polling plus stale/fallback resolution for OBD speed."""
 
     __slots__ = (
-        "_adaptive_interval_steps",
         "_admin_client",
-        "_avg_request_rtt_s",
         "_configured_device_mac",
         "_configured_device_name",
         "_connection_state",
@@ -134,28 +48,18 @@ class OBDSpeedMonitor:
         "_device_connected",
         "_device_mac",
         "_device_name",
-        "_effective_rpm_interval_s",
         "_engine_rpm",
         "_engine_rpm_ts",
-        "_error_count",
         "_last_error",
-        "_last_raw_response",
-        "_last_rpm_poll_started_at",
         "_lock",
         "_monotonic",
         "_paired",
         "_policy",
-        "_poll_interval_s",
+        "_polling",
         "_rfcomm_channel",
-        "_rpm_interval_index",
-        "_rpm_next_poll_at",
-        "_rpm_stable_poll_count",
         "_selected_source",
         "_session_factory",
-        "_speed_degraded",
-        "_speed_next_poll_at",
         "_speed_snapshot",
-        "_timeout_count",
         "_trusted",
     )
 
@@ -170,8 +74,7 @@ class OBDSpeedMonitor:
         self._admin_client = ObdAdminClient() if admin_client is None else admin_client
         self._session_factory = Elm327Session if session_factory is None else session_factory
         self._monotonic = monotonic
-        self._poll_interval_s = _normalized_poll_interval_s(poll_interval_s)
-        self._adaptive_interval_steps = _adaptive_interval_steps(self._poll_interval_s)
+        self._polling = ObdPollingCadence(max_interval_s=poll_interval_s)
         self._policy = SpeedResolutionPolicy(
             manual_source_selected=False,
             monotonic=monotonic,
@@ -191,18 +94,7 @@ class OBDSpeedMonitor:
         self._engine_rpm: float | None = None
         self._engine_rpm_ts: float | None = None
         self._last_error: str | None = None
-        self._last_raw_response: str | None = None
         self._current_reconnect_delay = _INITIAL_RECONNECT_DELAY_S
-        self._avg_request_rtt_s: float | None = None
-        self._effective_rpm_interval_s: float | None = None
-        self._last_rpm_poll_started_at: float | None = None
-        self._rpm_interval_index = 0
-        self._rpm_next_poll_at: float | None = None
-        self._rpm_stable_poll_count = 0
-        self._speed_degraded = False
-        self._speed_next_poll_at: float | None = None
-        self._timeout_count = 0
-        self._error_count = 0
 
     @property
     def speed_mps(self) -> float | None:
@@ -287,7 +179,6 @@ class OBDSpeedMonitor:
 
     def status_snapshot(self, *, refresh_admin: bool = False) -> ObdStatusSnapshot:
         helper_error: str | None = None
-        helper_device: ObdDeviceSnapshot | None = None
         configured_mac: str | None
         with self._lock:
             configured_mac = self._configured_device_mac
@@ -299,51 +190,29 @@ class OBDSpeedMonitor:
             else:
                 self._apply_device_snapshot(helper_device)
         with self._lock:
-            speed_mps, last_speed_ts = self._speed_snapshot
             now = self._monotonic()
-            last_speed_age_s = None if last_speed_ts is None else round(now - last_speed_ts, 2)
-            last_speed_kmh = None
-            if isinstance(speed_mps, NUMERIC_TYPES) and not isinstance(speed_mps, bool):
-                last_speed_kmh = round(float(speed_mps) * MPS_TO_KMH, 2)
-            rpm_age_s = None if self._engine_rpm_ts is None else round(now - self._engine_rpm_ts, 2)
-            current_error = self._last_error or helper_error
-            reconnect_delay = (
-                round(self._current_reconnect_delay, 1)
-                if self._connection_state == "disconnected"
-                else None
-            )
-            device_name = self._device_name
-            configured_name = self._configured_device_name
-            helper_name = helper_device.name if helper_device is not None else None
-            effective_name = device_name or configured_name or helper_name
-            obd_selected = self._selected_source is SpeedSourceKind.OBD2
-            return ObdStatusSnapshot(
-                configured_device_mac=self._configured_device_mac,
-                configured_device_name=configured_name,
-                connection_state=self._effective_connection_state_unlocked(),
-                device_mac=self._device_mac or self._configured_device_mac,
-                device_name=effective_name,
-                paired=self._paired,
-                trusted=self._trusted,
-                connected=self._device_connected,
-                rfcomm_channel=self._rfcomm_channel,
-                last_sample_age_s=last_speed_age_s,
-                last_speed_kmh=last_speed_kmh,
-                last_rpm=self._engine_rpm_unlocked(now),
-                rpm_sample_age_s=rpm_age_s if obd_selected else None,
-                rpm_target_interval_ms=(
-                    self._rpm_target_interval_ms_unlocked() if obd_selected else None
+            return build_obd_status_snapshot(
+                ObdMonitorStatusState(
+                    effective_connection_state=self._effective_connection_state_unlocked(),
+                    transport_connection_state=self._connection_state,
+                    configured_device_mac=self._configured_device_mac,
+                    configured_device_name=self._configured_device_name,
+                    device_mac=self._device_mac,
+                    device_name=self._device_name,
+                    paired=self._paired,
+                    trusted=self._trusted,
+                    connected=self._device_connected,
+                    rfcomm_channel=self._rfcomm_channel,
+                    speed_snapshot=self._speed_snapshot,
+                    engine_rpm=self._engine_rpm_unlocked(now),
+                    engine_rpm_ts=self._engine_rpm_ts,
+                    obd_selected=self._selected_source is SpeedSourceKind.OBD2,
+                    last_error=self._last_error or helper_error,
+                    helper_error=helper_error,
+                    reconnect_delay_s=self._current_reconnect_delay,
+                    polling=self._polling.snapshot(),
                 ),
-                rpm_effective_hz=self._rpm_effective_hz_unlocked() if obd_selected else None,
-                request_rtt_ms=self._request_rtt_ms_unlocked() if obd_selected else None,
-                timeout_count=self._timeout_count,
-                error_count=self._error_count,
-                poll_mode=self._poll_mode_unlocked(),
-                backoff_active=obd_selected and self._rpm_interval_index > 0,
-                last_error=current_error,
-                last_raw_response=self._last_raw_response,
-                reconnect_delay_s=reconnect_delay,
-                debug_hint=self._debug_hint_unlocked(helper_error=helper_error),
+                now_mono=now,
             )
 
     async def run(self) -> None:
@@ -393,7 +262,8 @@ class OBDSpeedMonitor:
                     self._apply_device_snapshot(device)
                     self._reset_poll_schedule()
                     self._set_connection_state("connected", error=None)
-                wait_s = self._next_poll_wait_s()
+                with self._lock:
+                    wait_s = self._polling.next_wait_s(now=self._monotonic())
                 if wait_s > 0:
                     await asyncio.sleep(wait_s)
                     continue
@@ -442,109 +312,15 @@ class OBDSpeedMonitor:
         )
         return session, device
 
-    def _poll_cycle_blocking(self, session: Elm327Session) -> _PollResult:
+    def _poll_cycle_blocking(self, session: Elm327Session) -> ObdPollResult:
+        with self._lock:
+            plan = self._polling.prepare_poll(now=self._monotonic())
+        return execute_poll_plan(session, plan=plan, monotonic=self._monotonic)
+
+    def _apply_poll_result(self, result: ObdPollResult) -> None:
         now = self._monotonic()
         with self._lock:
-            rpm_due = self._rpm_next_poll_at is None or now >= self._rpm_next_poll_at
-            speed_due = self._speed_next_poll_at is None or now >= self._speed_next_poll_at
-            rpm_timeout_s = self._rpm_request_timeout_s_unlocked()
-            speed_timeout_s = self._speed_request_timeout_s_unlocked()
-        rpm = (
-            self._request_pid(
-                session,
-                command="010C",
-                timeout_s=rpm_timeout_s,
-                parser=parse_pid_010c_rpm,
-                no_data_message="ECU returned no RPM data for PID 010C",
-                parse_error_message="Unexpected RPM response for PID 010C: {response}",
-            )
-            if rpm_due
-            else _PidPollResult.skipped()
-        )
-        speed = (
-            self._request_pid(
-                session,
-                command="010D",
-                timeout_s=speed_timeout_s,
-                parser=parse_pid_010d_speed_kmh,
-                no_data_message="ECU returned no speed data for PID 010D",
-                parse_error_message="Unexpected speed response for PID 010D: {response}",
-            )
-            if speed_due and not (rpm.executed and rpm.error is not None)
-            else _PidPollResult.skipped()
-        )
-        return _PollResult(rpm=rpm, speed=speed)
-
-    def _request_pid(
-        self,
-        session: Elm327Session,
-        *,
-        command: str,
-        timeout_s: float,
-        parser: Callable[[str], float | None],
-        no_data_message: str,
-        parse_error_message: str,
-    ) -> _PidPollResult:
-        started_at_s = self._monotonic()
-        try:
-            raw_response = session.request(command, timeout_s=timeout_s)
-        except ObdTransportError as exc:
-            duration_s = max(0.0, self._monotonic() - started_at_s)
-            transport_error = str(exc)
-            timed_out = _poll_error_is_timeout(transport_error)
-            if timed_out:
-                transport_error = f"Timed out waiting for PID {command} response"
-            else:
-                transport_error = f"PID {command} request failed: {transport_error}"
-            return _PidPollResult(
-                value=None,
-                raw_response=None,
-                error=transport_error,
-                duration_s=duration_s,
-                timed_out=timed_out,
-                no_data=False,
-                executed=True,
-                started_at_s=started_at_s,
-                fatal_transport=not timed_out and _poll_error_is_fatal_transport(transport_error),
-            )
-        duration_s = max(0.0, self._monotonic() - started_at_s)
-        value = parser(raw_response)
-        no_data = elm_response_has_no_data(raw_response)
-        error: str | None = None
-        if value is None:
-            if no_data:
-                error = no_data_message
-            else:
-                error = parse_error_message.format(response=raw_response or "<empty>")
-        return _PidPollResult(
-            value=value,
-            raw_response=raw_response,
-            error=error,
-            duration_s=duration_s,
-            timed_out=False,
-            no_data=no_data,
-            executed=True,
-            started_at_s=started_at_s,
-        )
-
-    def _apply_poll_result(self, result: _PollResult) -> None:
-        now = self._monotonic()
-        with self._lock:
-            self._record_pid_metrics_unlocked(result.rpm)
-            self._record_pid_metrics_unlocked(result.speed)
-            self._record_rpm_cadence_unlocked(result.rpm)
-            self._adapt_rpm_interval_unlocked(result.rpm)
-            current_target_interval_s = self._current_rpm_target_interval_unlocked()
-            if result.rpm.executed and result.rpm.started_at_s is not None:
-                self._rpm_next_poll_at = result.rpm.started_at_s + current_target_interval_s
-            elif self._rpm_next_poll_at is None:
-                self._rpm_next_poll_at = now
-            if result.speed.executed and result.speed.started_at_s is not None:
-                self._speed_next_poll_at = (
-                    result.speed.started_at_s + self._speed_companion_interval_unlocked()
-                )
-            elif self._speed_next_poll_at is None:
-                self._speed_next_poll_at = now
+            self._polling.apply_result(result, now=now)
             if (
                 result.speed.value is not None
                 and isinstance(result.speed.value, NUMERIC_TYPES)
@@ -552,9 +328,6 @@ class OBDSpeedMonitor:
             ):
                 speed_sample_time = self._completed_at(result.speed, fallback_now=now)
                 self._speed_snapshot = (float(result.speed.value) * KMH_TO_MPS, speed_sample_time)
-                self._speed_degraded = False
-            elif result.speed.executed and (result.speed.error is not None or result.speed.no_data):
-                self._speed_degraded = True
             if (
                 result.rpm.value is not None
                 and isinstance(result.rpm.value, NUMERIC_TYPES)
@@ -563,64 +336,10 @@ class OBDSpeedMonitor:
                 rpm_sample_time = self._completed_at(result.rpm, fallback_now=now)
                 self._engine_rpm = float(result.rpm.value)
                 self._engine_rpm_ts = rpm_sample_time
-            self._last_raw_response = result.raw_response
             self._last_error = result.rpm.error or result.speed.error
             self._device_connected = True
             self._connection_state = "connected"
             self._current_reconnect_delay = _INITIAL_RECONNECT_DELAY_S
-
-    def _record_pid_metrics_unlocked(self, result: _PidPollResult) -> None:
-        if not result.executed:
-            return
-        if result.duration_s is not None:
-            self._avg_request_rtt_s = _update_ema(
-                self._avg_request_rtt_s,
-                result.duration_s,
-                weight=_REQUEST_RTT_EMA_WEIGHT,
-            )
-        if result.error is None:
-            return
-        if result.timed_out:
-            self._timeout_count += 1
-        elif not result.no_data:
-            self._error_count += 1
-
-    def _record_rpm_cadence_unlocked(self, result: _PidPollResult) -> None:
-        if not result.executed or result.started_at_s is None:
-            return
-        if self._last_rpm_poll_started_at is not None:
-            interval_s = max(0.001, result.started_at_s - self._last_rpm_poll_started_at)
-            self._effective_rpm_interval_s = _update_ema(
-                self._effective_rpm_interval_s,
-                interval_s,
-                weight=_RPM_INTERVAL_EMA_WEIGHT,
-            )
-        self._last_rpm_poll_started_at = result.started_at_s
-
-    def _adapt_rpm_interval_unlocked(self, result: _PidPollResult) -> None:
-        if not result.executed:
-            return
-        target_interval_s = self._current_rpm_target_interval_unlocked()
-        should_backoff = (
-            result.error is not None
-            or result.no_data
-            or (result.duration_s is not None and result.duration_s > target_interval_s)
-        )
-        if should_backoff:
-            if self._rpm_interval_index < len(self._adaptive_interval_steps) - 1:
-                self._rpm_interval_index += 1
-            self._rpm_stable_poll_count = 0
-            return
-        self._rpm_stable_poll_count += 1
-        if self._rpm_interval_index <= 0 or self._rpm_stable_poll_count < _STABLE_POLLS_TO_SPEED_UP:
-            return
-        faster_interval_s = self._adaptive_interval_steps[self._rpm_interval_index - 1]
-        reference_rtt_s = (
-            self._avg_request_rtt_s if self._avg_request_rtt_s is not None else result.duration_s
-        )
-        if reference_rtt_s is not None and reference_rtt_s <= (faster_interval_s * 0.9):
-            self._rpm_interval_index -= 1
-            self._rpm_stable_poll_count = 0
 
     def _apply_device_snapshot(self, snapshot: ObdDeviceSnapshot) -> None:
         with self._lock:
@@ -673,87 +392,15 @@ class OBDSpeedMonitor:
             return None
         return float(self._engine_rpm)
 
-    def _current_rpm_target_interval_unlocked(self) -> float:
-        return self._adaptive_interval_steps[self._rpm_interval_index]
-
-    def _rpm_target_interval_ms_unlocked(self) -> int:
-        return int(round(self._current_rpm_target_interval_unlocked() * 1000.0))
-
-    def _rpm_effective_hz_unlocked(self) -> float | None:
-        if self._effective_rpm_interval_s is None or self._effective_rpm_interval_s <= 0:
-            return None
-        return round(1.0 / self._effective_rpm_interval_s, 2)
-
-    def _request_rtt_ms_unlocked(self) -> float | None:
-        if self._avg_request_rtt_s is None:
-            return None
-        return round(self._avg_request_rtt_s * 1000.0, 1)
-
-    def _speed_companion_interval_unlocked(self) -> float:
-        return min(
-            _MAX_SPEED_COMPANION_INTERVAL_S,
-            max(
-                _MIN_SPEED_COMPANION_INTERVAL_S,
-                self._current_rpm_target_interval_unlocked() * _SPEED_COMPANION_INTERVAL_MULTIPLIER,
-            ),
-        )
-
-    def _rpm_request_timeout_s_unlocked(self) -> float:
-        return min(
-            _MAX_RPM_REQUEST_TIMEOUT_S,
-            max(
-                _MIN_REQUEST_TIMEOUT_S,
-                self._current_rpm_target_interval_unlocked() * 4.0,
-            ),
-        )
-
-    def _speed_request_timeout_s_unlocked(self) -> float:
-        return min(
-            _MAX_SPEED_REQUEST_TIMEOUT_S,
-            max(
-                _MIN_REQUEST_TIMEOUT_S,
-                self._current_rpm_target_interval_unlocked() * 2.0,
-            ),
-        )
-
-    def _next_poll_wait_s(self) -> float:
-        with self._lock:
-            due_times = [
-                due for due in (self._rpm_next_poll_at, self._speed_next_poll_at) if due is not None
-            ]
-            if not due_times:
-                return 0.0
-            return max(0.0, min(due_times) - self._monotonic())
-
     def _reset_poll_schedule(self) -> None:
-        now = self._monotonic()
         with self._lock:
-            self._avg_request_rtt_s = None
-            self._effective_rpm_interval_s = None
-            self._last_rpm_poll_started_at = None
-            self._rpm_interval_index = 0
-            self._rpm_next_poll_at = now
-            self._rpm_stable_poll_count = 0
-            self._speed_degraded = False
-            self._speed_next_poll_at = now
-            self._timeout_count = 0
-            self._error_count = 0
-            self._last_raw_response = None
+            self._polling.reset(now=self._monotonic())
 
     @staticmethod
-    def _completed_at(result: _PidPollResult, *, fallback_now: float) -> float:
+    def _completed_at(result: ObdPidPollResult, *, fallback_now: float) -> float:
         if result.started_at_s is not None and result.duration_s is not None:
             return result.started_at_s + result.duration_s
         return fallback_now
-
-    def _poll_mode_unlocked(self) -> str | None:
-        if (
-            self._selected_source is not SpeedSourceKind.OBD2
-            or self._connection_state != "connected"
-        ):
-            return None
-        base_mode = "rpm_only" if self._speed_degraded else "rpm_priority"
-        return f"{base_mode}_backoff" if self._rpm_interval_index > 0 else base_mode
 
     def _effective_connection_state_unlocked(self) -> str:
         return self._policy.effective_connection_state(
@@ -761,36 +408,3 @@ class OBDSpeedMonitor:
             actual_connection_state=self._connection_state,
             speed_snapshot=self._speed_snapshot,
         )
-
-    def _debug_hint_unlocked(self, *, helper_error: str | None) -> str | None:
-        if helper_error is not None:
-            if "password" in helper_error.lower() or "sudo" in helper_error.lower():
-                return "Install the Bluetooth OBD sudo helper and NOPASSWD sudoers entry on the Pi."
-            return (
-                "Bluetooth admin helper failed; try scan/pair again after "
-                "power-cycling the adapter."
-            )
-        if self._configured_device_mac is None:
-            return (
-                "Pair a Bluetooth OBD adapter in Settings before selecting "
-                "OBD-II as the speed source."
-            )
-        if not self._paired:
-            return (
-                "Re-run Bluetooth pairing; the configured adapter is no longer paired with the Pi."
-            )
-        if not self._trusted:
-            return (
-                "Trust the configured OBD adapter again so reconnects can succeed without prompts."
-            )
-        if self._rfcomm_channel is None:
-            return (
-                "Rescan the adapter after power-cycling it; no RFCOMM serial "
-                "channel was advertised."
-            )
-        if self._connection_state == "disconnected":
-            return (
-                "Keep the adapter powered and in range; VibeSensor will keep "
-                "retrying automatically."
-            )
-        return None

--- a/apps/server/vibesensor/adapters/obd/polling.py
+++ b/apps/server/vibesensor/adapters/obd/polling.py
@@ -1,0 +1,436 @@
+"""PID polling and cadence helpers for Bluetooth OBD speed monitoring."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from vibesensor.adapters.obd.elm327 import (
+    Elm327Session,
+    ObdTransportError,
+    elm_response_has_no_data,
+    parse_pid_010c_rpm,
+    parse_pid_010d_speed_kmh,
+)
+
+__all__ = [
+    "ObdPidFailureKind",
+    "ObdPidPollResult",
+    "ObdPollPlan",
+    "ObdPollResult",
+    "ObdPollingCadence",
+    "ObdPollingSnapshot",
+    "execute_poll_plan",
+]
+
+_ADAPTIVE_POLL_INTERVALS_S = (0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.5, 0.75)
+_MIN_REQUEST_TIMEOUT_S = 0.2
+_MAX_RPM_REQUEST_TIMEOUT_S = 2.0
+_MAX_SPEED_REQUEST_TIMEOUT_S = 0.75
+_SPEED_COMPANION_INTERVAL_MULTIPLIER = 4.0
+_MIN_SPEED_COMPANION_INTERVAL_S = 0.5
+_MAX_SPEED_COMPANION_INTERVAL_S = 1.5
+_REQUEST_RTT_EMA_WEIGHT = 0.25
+_RPM_INTERVAL_EMA_WEIGHT = 0.25
+_STABLE_POLLS_TO_SPEED_UP = 6
+_FATAL_TRANSPORT_MARKERS = (
+    "closed the rfcomm socket",
+    "session is not connected",
+    "bad file descriptor",
+    "broken pipe",
+    "connection reset",
+    "host is down",
+)
+
+MonotonicFn = Callable[[], float]
+PidParser = Callable[[str], float | None]
+
+
+def _normalized_poll_interval_s(value: float) -> float:
+    return max(0.2, float(value))
+
+
+def _adaptive_interval_steps(max_interval_s: float) -> tuple[float, ...]:
+    normalized = _normalized_poll_interval_s(max_interval_s)
+    steps = tuple(step for step in _ADAPTIVE_POLL_INTERVALS_S if step <= normalized)
+    if not steps:
+        return (normalized,)
+    if steps[-1] != normalized:
+        return (*steps, normalized)
+    return steps
+
+
+def _update_ema(current: float | None, sample: float, *, weight: float) -> float:
+    return sample if current is None else ((1.0 - weight) * current) + (weight * sample)
+
+
+class ObdPidFailureKind(StrEnum):
+    """Typed failure categories for individual PID requests."""
+
+    TIMEOUT = "timeout"
+    TRANSPORT = "transport"
+    FATAL_TRANSPORT = "fatal_transport"
+    NO_DATA = "no_data"
+    PARSE_ERROR = "parse_error"
+
+
+@dataclass(frozen=True, slots=True)
+class ObdPidPollResult:
+    value: float | None
+    raw_response: str | None
+    error: str | None
+    duration_s: float | None
+    executed: bool
+    started_at_s: float | None = None
+    failure_kind: ObdPidFailureKind | None = None
+
+    @classmethod
+    def skipped(cls) -> ObdPidPollResult:
+        return cls(
+            value=None,
+            raw_response=None,
+            error=None,
+            duration_s=None,
+            executed=False,
+        )
+
+    @property
+    def timed_out(self) -> bool:
+        return self.failure_kind is ObdPidFailureKind.TIMEOUT
+
+    @property
+    def no_data(self) -> bool:
+        return self.failure_kind is ObdPidFailureKind.NO_DATA
+
+    @property
+    def fatal_transport(self) -> bool:
+        return self.failure_kind is ObdPidFailureKind.FATAL_TRANSPORT
+
+
+@dataclass(frozen=True, slots=True)
+class ObdPollResult:
+    rpm: ObdPidPollResult
+    speed: ObdPidPollResult
+
+    @property
+    def raw_response(self) -> str | None:
+        raw_parts = [part for part in (self.rpm.raw_response, self.speed.raw_response) if part]
+        return " | ".join(raw_parts) if raw_parts else None
+
+    @property
+    def connection_lost(self) -> bool:
+        return self.rpm.fatal_transport or self.speed.fatal_transport
+
+
+@dataclass(frozen=True, slots=True)
+class ObdPollPlan:
+    rpm_due: bool
+    speed_due: bool
+    rpm_timeout_s: float
+    speed_timeout_s: float
+
+
+@dataclass(frozen=True, slots=True)
+class ObdPollingSnapshot:
+    rpm_target_interval_ms: int
+    rpm_effective_hz: float | None
+    request_rtt_ms: float | None
+    timeout_count: int
+    error_count: int
+    poll_mode: str
+    backoff_active: bool
+    last_raw_response: str | None
+
+
+def _transport_failure_kind(error: str) -> ObdPidFailureKind:
+    lowered = error.lower()
+    if "timed out" in lowered:
+        return ObdPidFailureKind.TIMEOUT
+    if any(marker in lowered for marker in _FATAL_TRANSPORT_MARKERS):
+        return ObdPidFailureKind.FATAL_TRANSPORT
+    return ObdPidFailureKind.TRANSPORT
+
+
+def _request_pid(
+    session: Elm327Session,
+    *,
+    command: str,
+    timeout_s: float,
+    parser: PidParser,
+    no_data_message: str,
+    parse_error_message: str,
+    monotonic: MonotonicFn,
+) -> ObdPidPollResult:
+    started_at_s = monotonic()
+    try:
+        raw_response = session.request(command, timeout_s=timeout_s)
+    except ObdTransportError as exc:
+        duration_s = max(0.0, monotonic() - started_at_s)
+        raw_error = str(exc)
+        failure_kind = _transport_failure_kind(raw_error)
+        error = (
+            f"Timed out waiting for PID {command} response"
+            if failure_kind is ObdPidFailureKind.TIMEOUT
+            else f"PID {command} request failed: {raw_error}"
+        )
+        return ObdPidPollResult(
+            value=None,
+            raw_response=None,
+            error=error,
+            duration_s=duration_s,
+            executed=True,
+            started_at_s=started_at_s,
+            failure_kind=failure_kind,
+        )
+
+    duration_s = max(0.0, monotonic() - started_at_s)
+    value = parser(raw_response)
+    no_data = elm_response_has_no_data(raw_response)
+    if value is not None:
+        return ObdPidPollResult(
+            value=value,
+            raw_response=raw_response,
+            error=None,
+            duration_s=duration_s,
+            executed=True,
+            started_at_s=started_at_s,
+        )
+
+    failure_kind = ObdPidFailureKind.NO_DATA if no_data else ObdPidFailureKind.PARSE_ERROR
+    error = (
+        no_data_message
+        if failure_kind is ObdPidFailureKind.NO_DATA
+        else parse_error_message.format(response=raw_response or "<empty>")
+    )
+    return ObdPidPollResult(
+        value=None,
+        raw_response=raw_response,
+        error=error,
+        duration_s=duration_s,
+        executed=True,
+        started_at_s=started_at_s,
+        failure_kind=failure_kind,
+    )
+
+
+def execute_poll_plan(
+    session: Elm327Session,
+    *,
+    plan: ObdPollPlan,
+    monotonic: MonotonicFn,
+) -> ObdPollResult:
+    rpm = (
+        _request_pid(
+            session,
+            command="010C",
+            timeout_s=plan.rpm_timeout_s,
+            parser=parse_pid_010c_rpm,
+            no_data_message="ECU returned no RPM data for PID 010C",
+            parse_error_message="Unexpected RPM response for PID 010C: {response}",
+            monotonic=monotonic,
+        )
+        if plan.rpm_due
+        else ObdPidPollResult.skipped()
+    )
+    speed = (
+        _request_pid(
+            session,
+            command="010D",
+            timeout_s=plan.speed_timeout_s,
+            parser=parse_pid_010d_speed_kmh,
+            no_data_message="ECU returned no speed data for PID 010D",
+            parse_error_message="Unexpected speed response for PID 010D: {response}",
+            monotonic=monotonic,
+        )
+        if plan.speed_due and not (rpm.executed and rpm.error is not None)
+        else ObdPidPollResult.skipped()
+    )
+    return ObdPollResult(rpm=rpm, speed=speed)
+
+
+class ObdPollingCadence:
+    """Own the adaptive RPM cadence, backoff, and poll metrics."""
+
+    __slots__ = (
+        "_adaptive_interval_steps",
+        "_avg_request_rtt_s",
+        "_effective_rpm_interval_s",
+        "_error_count",
+        "_last_raw_response",
+        "_last_rpm_poll_started_at",
+        "_rpm_interval_index",
+        "_rpm_next_poll_at",
+        "_rpm_stable_poll_count",
+        "_speed_degraded",
+        "_speed_next_poll_at",
+        "_timeout_count",
+    )
+
+    def __init__(self, *, max_interval_s: float) -> None:
+        self._adaptive_interval_steps = _adaptive_interval_steps(max_interval_s)
+        self._avg_request_rtt_s: float | None = None
+        self._effective_rpm_interval_s: float | None = None
+        self._last_rpm_poll_started_at: float | None = None
+        self._rpm_interval_index = 0
+        self._rpm_next_poll_at: float | None = None
+        self._rpm_stable_poll_count = 0
+        self._speed_degraded = False
+        self._speed_next_poll_at: float | None = None
+        self._timeout_count = 0
+        self._error_count = 0
+        self._last_raw_response: str | None = None
+
+    def prepare_poll(self, *, now: float) -> ObdPollPlan:
+        rpm_due = self._rpm_next_poll_at is None or now >= self._rpm_next_poll_at
+        speed_due = self._speed_next_poll_at is None or now >= self._speed_next_poll_at
+        return ObdPollPlan(
+            rpm_due=rpm_due,
+            speed_due=speed_due,
+            rpm_timeout_s=self._rpm_request_timeout_s(),
+            speed_timeout_s=self._speed_request_timeout_s(),
+        )
+
+    def apply_result(self, result: ObdPollResult, *, now: float) -> None:
+        self._record_pid_metrics(result.rpm)
+        self._record_pid_metrics(result.speed)
+        self._record_rpm_cadence(result.rpm)
+        self._adapt_rpm_interval(result.rpm)
+        current_target_interval_s = self._current_rpm_target_interval_s()
+        if result.rpm.executed and result.rpm.started_at_s is not None:
+            self._rpm_next_poll_at = result.rpm.started_at_s + current_target_interval_s
+        elif self._rpm_next_poll_at is None:
+            self._rpm_next_poll_at = now
+        if result.speed.executed and result.speed.started_at_s is not None:
+            self._speed_next_poll_at = (
+                result.speed.started_at_s + self._speed_companion_interval_s()
+            )
+        elif self._speed_next_poll_at is None:
+            self._speed_next_poll_at = now
+        if result.speed.value is not None:
+            self._speed_degraded = False
+        elif result.speed.executed and (result.speed.error is not None or result.speed.no_data):
+            self._speed_degraded = True
+        self._last_raw_response = result.raw_response
+
+    def next_wait_s(self, *, now: float) -> float:
+        due_times = [
+            due for due in (self._rpm_next_poll_at, self._speed_next_poll_at) if due is not None
+        ]
+        if not due_times:
+            return 0.0
+        return max(0.0, min(due_times) - now)
+
+    def reset(self, *, now: float) -> None:
+        self._avg_request_rtt_s = None
+        self._effective_rpm_interval_s = None
+        self._last_rpm_poll_started_at = None
+        self._rpm_interval_index = 0
+        self._rpm_next_poll_at = now
+        self._rpm_stable_poll_count = 0
+        self._speed_degraded = False
+        self._speed_next_poll_at = now
+        self._timeout_count = 0
+        self._error_count = 0
+        self._last_raw_response = None
+
+    def snapshot(self) -> ObdPollingSnapshot:
+        return ObdPollingSnapshot(
+            rpm_target_interval_ms=int(round(self._current_rpm_target_interval_s() * 1000.0)),
+            rpm_effective_hz=(
+                None
+                if self._effective_rpm_interval_s is None or self._effective_rpm_interval_s <= 0
+                else round(1.0 / self._effective_rpm_interval_s, 2)
+            ),
+            request_rtt_ms=(
+                None
+                if self._avg_request_rtt_s is None
+                else round(self._avg_request_rtt_s * 1000.0, 1)
+            ),
+            timeout_count=self._timeout_count,
+            error_count=self._error_count,
+            poll_mode=(
+                f"{'rpm_only' if self._speed_degraded else 'rpm_priority'}_backoff"
+                if self._rpm_interval_index > 0
+                else ("rpm_only" if self._speed_degraded else "rpm_priority")
+            ),
+            backoff_active=self._rpm_interval_index > 0,
+            last_raw_response=self._last_raw_response,
+        )
+
+    def _record_pid_metrics(self, result: ObdPidPollResult) -> None:
+        if not result.executed:
+            return
+        if result.duration_s is not None:
+            self._avg_request_rtt_s = _update_ema(
+                self._avg_request_rtt_s,
+                result.duration_s,
+                weight=_REQUEST_RTT_EMA_WEIGHT,
+            )
+        if result.failure_kind is None:
+            return
+        if result.failure_kind is ObdPidFailureKind.TIMEOUT:
+            self._timeout_count += 1
+        elif result.failure_kind is not ObdPidFailureKind.NO_DATA:
+            self._error_count += 1
+
+    def _record_rpm_cadence(self, result: ObdPidPollResult) -> None:
+        if not result.executed or result.started_at_s is None:
+            return
+        if self._last_rpm_poll_started_at is not None:
+            interval_s = max(0.001, result.started_at_s - self._last_rpm_poll_started_at)
+            self._effective_rpm_interval_s = _update_ema(
+                self._effective_rpm_interval_s,
+                interval_s,
+                weight=_RPM_INTERVAL_EMA_WEIGHT,
+            )
+        self._last_rpm_poll_started_at = result.started_at_s
+
+    def _adapt_rpm_interval(self, result: ObdPidPollResult) -> None:
+        if not result.executed:
+            return
+        target_interval_s = self._current_rpm_target_interval_s()
+        should_backoff = (
+            result.error is not None
+            or result.no_data
+            or (result.duration_s is not None and result.duration_s > target_interval_s)
+        )
+        if should_backoff:
+            if self._rpm_interval_index < len(self._adaptive_interval_steps) - 1:
+                self._rpm_interval_index += 1
+            self._rpm_stable_poll_count = 0
+            return
+        self._rpm_stable_poll_count += 1
+        if self._rpm_interval_index <= 0 or self._rpm_stable_poll_count < _STABLE_POLLS_TO_SPEED_UP:
+            return
+        faster_interval_s = self._adaptive_interval_steps[self._rpm_interval_index - 1]
+        reference_rtt_s = (
+            self._avg_request_rtt_s if self._avg_request_rtt_s is not None else result.duration_s
+        )
+        if reference_rtt_s is not None and reference_rtt_s <= (faster_interval_s * 0.9):
+            self._rpm_interval_index -= 1
+            self._rpm_stable_poll_count = 0
+
+    def _current_rpm_target_interval_s(self) -> float:
+        return self._adaptive_interval_steps[self._rpm_interval_index]
+
+    def _speed_companion_interval_s(self) -> float:
+        return min(
+            _MAX_SPEED_COMPANION_INTERVAL_S,
+            max(
+                _MIN_SPEED_COMPANION_INTERVAL_S,
+                self._current_rpm_target_interval_s() * _SPEED_COMPANION_INTERVAL_MULTIPLIER,
+            ),
+        )
+
+    def _rpm_request_timeout_s(self) -> float:
+        return min(
+            _MAX_RPM_REQUEST_TIMEOUT_S,
+            max(_MIN_REQUEST_TIMEOUT_S, self._current_rpm_target_interval_s() * 4.0),
+        )
+
+    def _speed_request_timeout_s(self) -> float:
+        return min(
+            _MAX_SPEED_REQUEST_TIMEOUT_S,
+            max(_MIN_REQUEST_TIMEOUT_S, self._current_rpm_target_interval_s() * 2.0),
+        )

--- a/apps/server/vibesensor/adapters/obd/status.py
+++ b/apps/server/vibesensor/adapters/obd/status.py
@@ -1,0 +1,113 @@
+"""Status-presentation helpers for Bluetooth OBD monitoring."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from vibesensor.adapters.obd.models import ObdStatusSnapshot
+from vibesensor.adapters.obd.polling import ObdPollingSnapshot
+from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
+from vibesensor.shared.constants.units import MPS_TO_KMH
+
+__all__ = ["ObdMonitorStatusState", "build_obd_status_snapshot"]
+
+
+@dataclass(frozen=True, slots=True)
+class ObdMonitorStatusState:
+    """Immutable OBD runtime/admin snapshot for outward status presentation."""
+
+    effective_connection_state: str
+    transport_connection_state: str
+    configured_device_mac: str | None
+    configured_device_name: str | None
+    device_mac: str | None
+    device_name: str | None
+    paired: bool
+    trusted: bool
+    connected: bool
+    rfcomm_channel: int | None
+    speed_snapshot: tuple[float | None, float | None]
+    engine_rpm: float | None
+    engine_rpm_ts: float | None
+    obd_selected: bool
+    last_error: str | None
+    helper_error: str | None
+    reconnect_delay_s: float
+    polling: ObdPollingSnapshot
+
+
+def build_obd_status_snapshot(
+    state: ObdMonitorStatusState,
+    *,
+    now_mono: float | None = None,
+) -> ObdStatusSnapshot:
+    now = time.monotonic() if now_mono is None else now_mono
+
+    speed_mps, last_speed_ts = state.speed_snapshot
+    last_speed_age_s = None if last_speed_ts is None else round(now - last_speed_ts, 2)
+    last_speed_kmh = None
+    if isinstance(speed_mps, NUMERIC_TYPES) and not isinstance(speed_mps, bool):
+        last_speed_kmh = round(float(speed_mps) * MPS_TO_KMH, 2)
+
+    rpm_sample_age_s = None
+    if state.obd_selected and state.engine_rpm_ts is not None:
+        rpm_sample_age_s = round(now - state.engine_rpm_ts, 2)
+
+    poll_mode = (
+        state.polling.poll_mode
+        if state.obd_selected and state.transport_connection_state == "connected"
+        else None
+    )
+
+    return ObdStatusSnapshot(
+        configured_device_mac=state.configured_device_mac,
+        configured_device_name=state.configured_device_name,
+        connection_state=state.effective_connection_state,
+        device_mac=state.device_mac or state.configured_device_mac,
+        device_name=state.device_name or state.configured_device_name,
+        paired=state.paired,
+        trusted=state.trusted,
+        connected=state.connected,
+        rfcomm_channel=state.rfcomm_channel,
+        last_sample_age_s=last_speed_age_s,
+        last_speed_kmh=last_speed_kmh,
+        last_rpm=state.engine_rpm,
+        rpm_sample_age_s=rpm_sample_age_s,
+        rpm_target_interval_ms=state.polling.rpm_target_interval_ms if state.obd_selected else None,
+        rpm_effective_hz=state.polling.rpm_effective_hz if state.obd_selected else None,
+        request_rtt_ms=state.polling.request_rtt_ms if state.obd_selected else None,
+        timeout_count=state.polling.timeout_count,
+        error_count=state.polling.error_count,
+        poll_mode=poll_mode,
+        backoff_active=state.obd_selected and state.polling.backoff_active,
+        last_error=state.last_error,
+        last_raw_response=state.polling.last_raw_response,
+        reconnect_delay_s=(
+            round(state.reconnect_delay_s, 1)
+            if state.transport_connection_state == "disconnected"
+            else None
+        ),
+        debug_hint=_debug_hint(state),
+    )
+
+
+def _debug_hint(state: ObdMonitorStatusState) -> str | None:
+    helper_error = state.helper_error
+    if helper_error is not None:
+        if "password" in helper_error.lower() or "sudo" in helper_error.lower():
+            return "Install the Bluetooth OBD sudo helper and NOPASSWD sudoers entry on the Pi."
+        return "Bluetooth admin helper failed; try scan/pair again after power-cycling the adapter."
+    if state.configured_device_mac is None:
+        return (
+            "Pair a Bluetooth OBD adapter in Settings before selecting OBD-II as the speed source."
+        )
+    if not state.paired:
+        return "Re-run Bluetooth pairing; the configured adapter is no longer paired with the Pi."
+    if not state.trusted:
+        return "Trust the configured OBD adapter again so reconnects can succeed without prompts."
+    if state.rfcomm_channel is None:
+        return "Rescan the adapter after power-cycling it; no RFCOMM serial channel was advertised."
+    if state.transport_connection_state == "disconnected":
+        return "Keep the adapter powered and in range; VibeSensor will keep retrying automatically."
+    return None


### PR DESCRIPTION
## Summary

This PR tackles #1998 by splitting the largest non-policy responsibilities out of `OBDSpeedMonitor` without changing the public monitor API that the rest of the runtime already depends on. Before this change, the monitor owned Bluetooth admin/session orchestration, PID request execution, transport-failure classification, adaptive polling cadence and backoff bookkeeping, and the outward `ObdStatusSnapshot` presentation logic. That made the class hard to reason about because transport behavior, timing behavior, and presentation behavior all changed in the same file.

The refactor here keeps `OBDSpeedMonitor` as the top-level orchestrator for OBD speed monitoring, but moves two coherent responsibility groups into dedicated collaborators. The new `adapters/obd/polling.py` module owns typed PID failure classification, blocking PID request execution, poll planning, and adaptive cadence/backoff state. The new `adapters/obd/status.py` module owns outward `ObdStatusSnapshot` shaping and operator debug hints. The monitor now coordinates those collaborators instead of owning all of that logic inline.

## Problem being solved

`OBDSpeedMonitor` had drifted into a “do everything” class. The issue description called out protocol/session handling, polling cadence, and status projection as the main seams that needed separation, and the code matched that diagnosis. The monitor contained:

- Bluetooth device/admin state and RFCOMM session connection flow.
- PID request execution and transport error classification.
- Adaptive cadence state such as request RTT EMA, RPM interval backoff, timeout/error counters, next-poll scheduling, and speed-companion cadence.
- Outward `ObdStatusSnapshot` assembly, including stale-age conversion, reconnect delay presentation, and debug hint heuristics.

That meant a small change to poll timing or status presentation still required editing the same large class that also owns live runtime connection flow. It also made the poll/error behavior harder to test directly because the useful seams were buried inside the monitor.

## Implementation approach

I kept the refactor deliberately narrow and behavior-preserving. I did not try to break the monitor into a large object graph all at once. Instead, I pulled out the two most self-contained responsibilities that already had clear boundaries in the issue description and in the existing code.

First, I extracted the poll execution and cadence logic into `adapters/obd/polling.py`. That module now owns the typed request/result model for PID polling, the typed failure categories used to distinguish timeout, fatal transport, non-fatal transport, no-data, and parse failures, and the stateful cadence helper that tracks adaptive backoff, request RTT, effective RPM frequency, timeout/error counts, and next poll times.

Second, I extracted outward OBD status projection into `adapters/obd/status.py`. That module now takes an immutable OBD runtime snapshot and builds the outward `ObdStatusSnapshot`, including speed/rpm age conversions, connection-state presentation, reconnect delay display, and the operator-facing debug hint logic.

With those collaborators in place, `OBDSpeedMonitor` keeps the pieces that still make sense for it to own: speed-source policy coordination, admin/device settings, RFCOMM session lifecycle, and application of poll results into the monitor’s live speed/RPM state.

## Main code changes by area

In `apps/server/vibesensor/adapters/obd/polling.py`, I introduced `ObdPidFailureKind`, `ObdPidPollResult`, `ObdPollResult`, `ObdPollPlan`, `ObdPollingSnapshot`, `execute_poll_plan()`, and `ObdPollingCadence`. This is the new home for the monitor’s former PID request execution path and adaptive cadence bookkeeping. One important behavior change here is not user-visible but architecture-relevant: transport and poll failures are now represented with typed failure kinds instead of being inferred later from a mix of booleans and string inspection in the monitor.

In `apps/server/vibesensor/adapters/obd/status.py`, I introduced `ObdMonitorStatusState` and `build_obd_status_snapshot()`. This module owns the former status-building logic from the monitor, including the debug-hint rules that were previously embedded deep in `monitor.py`. The builder preserves the previous behavior around effective-vs-transport connection state, which matters for preserving poll-mode visibility when the monitor is connected at the transport layer but stale at the speed-source layer.

In `apps/server/vibesensor/adapters/obd/monitor.py`, I replaced the inline poll execution/cadence/status logic with delegation to the new collaborators. The monitor still owns `_connect_blocking()`, `_set_connection_state()`, live speed/RPM updates, and the top-level `run()` loop, but it no longer directly implements PID request parsing/classification, cadence/backoff math, or outward `ObdStatusSnapshot` shaping.

## Tests and validation

To make the extracted seams directly testable, I added two new focused test files.

`apps/server/tests/adapters/obd/test_polling.py` covers the new OBD polling helper directly. It asserts that fatal transport failures are classified as such and that the cadence helper enters backoff and reports its snapshot correctly after a timeout-heavy cycle.

`apps/server/tests/adapters/obd/test_status.py` covers the new status builder directly. It verifies disconnect-hint behavior, reconnect-delay/status shaping, and hiding OBD-only status fields when OBD is not the active source.

I kept the existing integrated behavior checks in `apps/server/tests/adapters/obd/test_monitor.py` and `apps/server/tests/adapters/speed/test_source_coordinator.py` green to confirm that the public monitor behavior did not drift while the internals were split.

Local validation for the final refactor was:

- `python3.14 -m pytest -q apps/server/tests/adapters/obd/test_monitor.py apps/server/tests/adapters/obd/test_polling.py apps/server/tests/adapters/obd/test_status.py apps/server/tests/adapters/speed/test_source_coordinator.py`
  - `10 passed`
- `python3.14 -m pytest -q apps/server/tests/adapters/obd/test_monitor.py apps/server/tests/adapters/obd/test_polling.py apps/server/tests/adapters/obd/test_status.py apps/server/tests/adapters/speed/test_source_coordinator.py apps/server/tests/infra/config/test_settings_runtime.py apps/server/tests/infra/runtime/test_runtime.py`
  - `26 passed`
- `make lint`
- `make typecheck`

## Risks, tradeoffs, and out-of-scope items

The main tradeoff in this PR is that `OBDSpeedMonitor` is still the top-level owner of session lifecycle and reconnect flow. That is intentional. The issue asks for smaller protocol, polling, and status collaborators, but pushing the connection/reconnect loop out into a separate orchestrator in the same PR would have broadened the risk profile substantially. This change focuses on the parts that were already naturally separable and that benefit most from direct tests.

I also preserved the public monitor surface instead of introducing new outward abstractions. Consumers such as the speed-source coordinator still use `OBDSpeedMonitor` the same way; the refactor is internal and behavior-preserving.

There are no schema, contract, or configuration changes in this PR. The outcome is a smaller monitor, more explicit typed poll-failure handling, directly testable polling/status helpers, and a cleaner path for any future OBD monitor decomposition if the remaining connection/session loop later warrants its own collaborator.
