### PR TITLE
Split update transport control plane

### DIFF
--- a/apps/server/tests/use_cases/updates/test_interrupted_recovery.py
+++ b/apps/server/tests/use_cases/updates/test_interrupted_recovery.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from vibesensor.use_cases.updates.models import UpdateJobStatus, UpdatePhase, UpdateState
+from vibesensor.use_cases.updates.models import (
+    UpdateJobStatus,
+    UpdatePhase,
+    UpdateState,
+    UpdateTransport,
+)
 from vibesensor.use_cases.updates.recovery import InterruptedUpdateRecovery
 from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
 
@@ -24,24 +30,36 @@ def _running_status(
     phase: UpdatePhase,
     *,
     finished_at: float | None = None,
+    transport: UpdateTransport = UpdateTransport.wifi,
 ) -> UpdateJobStatus:
     return UpdateJobStatus(
         state=UpdateState.running,
         phase=phase,
+        transport=transport,
         started_at=time.time() - 60,
         finished_at=finished_at,
     )
 
 
+def _transport_sessions(session: object) -> SimpleNamespace:
+    return SimpleNamespace(for_transport=lambda transport: session)
+
+
 class TestNeedsRecovery:
     def test_running_without_finished_at_needs_recovery(self) -> None:
         tracker = _make_tracker(_running_status(UpdatePhase.installing))
-        recovery = InterruptedUpdateRecovery(tracker=tracker, wifi_factory=lambda: None)
+        recovery = InterruptedUpdateRecovery(
+            tracker=tracker,
+            transport_sessions_factory=lambda: _transport_sessions(None),
+        )
         assert recovery.needs_recovery() is True
 
     def test_idle_does_not_need_recovery(self) -> None:
         tracker = _make_tracker(UpdateJobStatus())
-        recovery = InterruptedUpdateRecovery(tracker=tracker, wifi_factory=lambda: None)
+        recovery = InterruptedUpdateRecovery(
+            tracker=tracker,
+            transport_sessions_factory=lambda: _transport_sessions(None),
+        )
         assert recovery.needs_recovery() is False
 
     def test_running_with_finished_at_does_not_need_recovery(self) -> None:
@@ -51,21 +69,30 @@ class TestNeedsRecovery:
                 finished_at=time.time() - 30,
             ),
         )
-        recovery = InterruptedUpdateRecovery(tracker=tracker, wifi_factory=lambda: None)
+        recovery = InterruptedUpdateRecovery(
+            tracker=tracker,
+            transport_sessions_factory=lambda: _transport_sessions(None),
+        )
         assert recovery.needs_recovery() is False
 
     def test_failed_does_not_need_recovery(self) -> None:
         tracker = _make_tracker(
             UpdateJobStatus(state=UpdateState.failed, finished_at=time.time()),
         )
-        recovery = InterruptedUpdateRecovery(tracker=tracker, wifi_factory=lambda: None)
+        recovery = InterruptedUpdateRecovery(
+            tracker=tracker,
+            transport_sessions_factory=lambda: _transport_sessions(None),
+        )
         assert recovery.needs_recovery() is False
 
     def test_success_does_not_need_recovery(self) -> None:
         tracker = _make_tracker(
             UpdateJobStatus(state=UpdateState.success, finished_at=time.time()),
         )
-        recovery = InterruptedUpdateRecovery(tracker=tracker, wifi_factory=lambda: None)
+        recovery = InterruptedUpdateRecovery(
+            tracker=tracker,
+            transport_sessions_factory=lambda: _transport_sessions(None),
+        )
         assert recovery.needs_recovery() is False
 
 
@@ -73,10 +100,10 @@ class TestRecover:
     @pytest.mark.asyncio
     async def test_marks_as_failed_and_persists(self) -> None:
         tracker = _make_tracker(_running_status(UpdatePhase.downloading))
-        wifi = AsyncMock()
+        session = AsyncMock()
         recovery = InterruptedUpdateRecovery(
             tracker=tracker,
-            wifi_factory=lambda: wifi,
+            transport_sessions_factory=lambda: _transport_sessions(session),
         )
 
         await recovery.recover()
@@ -85,20 +112,38 @@ class TestRecover:
         assert tracker.status.finished_at is not None
         issue_messages = [i.message for i in tracker.status.issues]
         assert any("interrupted" in m.lower() or "restart" in m.lower() for m in issue_messages)
-        wifi.recover_interrupted_update.assert_awaited_once()
+        session.recover_interrupted_update.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_calls_wifi_cleanup(self) -> None:
+    async def test_calls_transport_cleanup_for_wifi_state(self) -> None:
         tracker = _make_tracker(_running_status(UpdatePhase.connecting_wifi))
-        wifi = AsyncMock()
+        session = AsyncMock()
         recovery = InterruptedUpdateRecovery(
             tracker=tracker,
-            wifi_factory=lambda: wifi,
+            transport_sessions_factory=lambda: _transport_sessions(session),
         )
 
         await recovery.recover()
 
-        wifi.recover_interrupted_update.assert_awaited_once()
+        session.recover_interrupted_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_calls_transport_cleanup_for_usb_state(self) -> None:
+        tracker = _make_tracker(
+            _running_status(
+                UpdatePhase.connecting_usb_internet,
+                transport=UpdateTransport.usb_internet,
+            ),
+        )
+        session = AsyncMock()
+        recovery = InterruptedUpdateRecovery(
+            tracker=tracker,
+            transport_sessions_factory=lambda: _transport_sessions(session),
+        )
+
+        await recovery.recover()
+
+        session.recover_interrupted_update.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_persists_state_after_recovery(self, tmp_path) -> None:
@@ -111,10 +156,10 @@ class TestRecover:
             state_store=store,
             status=store.load(),
         )
-        wifi = AsyncMock()
+        session = AsyncMock()
         recovery = InterruptedUpdateRecovery(
             tracker=tracker,
-            wifi_factory=lambda: wifi,
+            transport_sessions_factory=lambda: _transport_sessions(session),
         )
 
         await recovery.recover()

--- a/apps/server/tests/use_cases/updates/test_release_application.py
+++ b/apps/server/tests/use_cases/updates/test_release_application.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vibesensor.use_cases.updates.release_application import UpdateReleaseApplication
+from vibesensor.use_cases.updates.releases import UpdateReleaseCheck
+from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
+
+
+class _TransportSession:
+    def __init__(self) -> None:
+        self.complete_success = AsyncMock(return_value=True)
+
+
+def _build_application(
+    tmp_path: Path,
+    *,
+    cancel_requested=lambda: False,
+) -> tuple[UpdateReleaseApplication, MagicMock, MagicMock, MagicMock]:
+    tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "state.json"))
+    commands = MagicMock()
+    commands.run = AsyncMock(return_value=(0, "", ""))
+    installer = MagicMock()
+    installer.snapshot_for_rollback = AsyncMock(return_value=True)
+    installer.install_release = AsyncMock(return_value=True)
+    firmware_refresher = MagicMock()
+    firmware_refresher.refresh_esp_firmware = AsyncMock()
+    application = UpdateReleaseApplication(
+        tracker=tracker,
+        commands=commands,
+        installer=installer,
+        firmware_refresher=firmware_refresher,
+        cancel_requested=cancel_requested,
+        rollback_dir=tmp_path / "rollback",
+        service_name="vibesensor.service",
+        restart_unit="vibesensor-post-update-restart",
+    )
+    return application, commands, installer, firmware_refresher
+
+
+@pytest.mark.asyncio
+async def test_execute_marks_success_through_transport_when_already_up_to_date(
+    tmp_path: Path,
+) -> None:
+    application, commands, installer, firmware_refresher = _build_application(tmp_path)
+    session = _TransportSession()
+
+    with (
+        patch("vibesensor.__version__", "2026.4.3"),
+        patch(
+            "vibesensor.use_cases.updates.release_application.check_for_update",
+            new=AsyncMock(
+                return_value=UpdateReleaseCheck(
+                    release=None,
+                    latest_tag="server-v2026.4.3",
+                ),
+            ),
+        ),
+    ):
+        await application.execute(session)
+
+    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
+        pinned_tag="server-v2026.4.3",
+    )
+    session.complete_success.assert_awaited_once_with(
+        "No server update needed; ESP firmware checked",
+    )
+    installer.snapshot_for_rollback.assert_not_awaited()
+    commands.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_downloads_and_installs_before_transport_success(tmp_path: Path) -> None:
+    application, commands, installer, firmware_refresher = _build_application(tmp_path)
+    session = _TransportSession()
+    wheel_path = tmp_path / "release.whl"
+    wheel_path.write_text("wheel", encoding="utf-8")
+    release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="")
+
+    with (
+        patch("vibesensor.__version__", "2026.4.3"),
+        patch(
+            "vibesensor.use_cases.updates.release_application.check_for_update",
+            new=AsyncMock(return_value=UpdateReleaseCheck(release=release)),
+        ),
+        patch(
+            "vibesensor.use_cases.updates.release_application.download_release",
+            new=AsyncMock(return_value=wheel_path),
+        ),
+        patch(
+            "vibesensor.use_cases.updates.release_application.verify_download",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        await application.execute(session)
+
+    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
+        pinned_tag="server-v2026.4.4",
+    )
+    installer.snapshot_for_rollback.assert_awaited_once_with()
+    installer.install_release.assert_awaited_once_with(wheel_path, "2026.4.4")
+    session.complete_success.assert_awaited_once_with("Update completed successfully")
+    commands.run.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_schedule_restart_when_transport_finalize_fails(
+    tmp_path: Path,
+) -> None:
+    application, commands, installer, firmware_refresher = _build_application(tmp_path)
+    session = _TransportSession()
+    session.complete_success.return_value = False
+    wheel_path = tmp_path / "release.whl"
+    wheel_path.write_text("wheel", encoding="utf-8")
+    release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="")
+
+    with (
+        patch("vibesensor.__version__", "2026.4.3"),
+        patch(
+            "vibesensor.use_cases.updates.release_application.check_for_update",
+            new=AsyncMock(return_value=UpdateReleaseCheck(release=release)),
+        ),
+        patch(
+            "vibesensor.use_cases.updates.release_application.download_release",
+            new=AsyncMock(return_value=wheel_path),
+        ),
+        patch(
+            "vibesensor.use_cases.updates.release_application.verify_download",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        await application.execute(session)
+
+    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
+        pinned_tag="server-v2026.4.4",
+    )
+    installer.snapshot_for_rollback.assert_awaited_once_with()
+    installer.install_release.assert_awaited_once_with(wheel_path, "2026.4.4")
+    session.complete_success.assert_awaited_once_with("Update completed successfully")
+    commands.run.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/test_update_job_lifecycle.py
+++ b/apps/server/tests/use_cases/updates/test_update_job_lifecycle.py
@@ -109,6 +109,22 @@ async def test_cleanup_re_raises_wifi_diagnostics_bug_after_finishing_cleanup(tm
     assert manager.status.state == UpdateState.failed
 
 
+@pytest.mark.asyncio
+async def test_cleanup_skips_wifi_cleanup_for_usb_transport(tmp_path) -> None:
+    manager, _runner, _repo = setup_update_env(tmp_path)
+    manager.status.transport = UpdateTransport.usb_internet
+    manager.status.state = UpdateState.running
+    manager.status.phase = UpdatePhase.installing
+
+    with patch(
+        "vibesensor.use_cases.updates.wifi.wifi_orchestrator.parse_wifi_diagnostics",
+        side_effect=AssertionError("Wi-Fi diagnostics should not run for USB transport"),
+    ):
+        await manager._lifecycle.cleanup_after_update()
+
+    assert manager.status.finished_at is not None
+
+
 def test_handle_cancelled_cleanup_error_logs_warning(tmp_path, caplog) -> None:
     manager, _runner, _repo = setup_update_env(tmp_path)
 

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -99,7 +99,7 @@ class TestUpdateManagerAsync:
             patch("shutil.which", mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
             patch(
-                "vibesensor.use_cases.updates.workflow.check_for_update",
+                "vibesensor.use_cases.updates.release_application.check_for_update",
                 side_effect=AssertionError("check_for_update should not run without privileges"),
             ),
         ):

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -460,7 +460,7 @@ class TestPersistenceDuringLifecycle:
             patch("shutil.which", _mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
             patch(
-                "vibesensor.use_cases.updates.workflow.check_for_update",
+                "vibesensor.use_cases.updates.release_application.check_for_update",
                 side_effect=AssertionError("check_for_update should not run without privileges"),
             ),
         ):

--- a/apps/server/tests/use_cases/updates/test_update_workflow.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vibesensor.use_cases.updates.models import (
+    UpdateRequest,
+    UpdateTransport,
+    UpdateValidationConfig,
+)
+from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
+from vibesensor.use_cases.updates.workflow import UpdateWorkflow
+
+
+class _Session:
+    def __init__(self, transport: UpdateTransport) -> None:
+        self.transport = transport
+        self.prepare = AsyncMock(return_value=True)
+        self.complete_success = AsyncMock(return_value=True)
+        self.cleanup_after_update = AsyncMock()
+        self.recover_interrupted_update = AsyncMock()
+
+
+def _build_workflow(
+    tmp_path: Path,
+    *,
+    cancel_requested,
+    release_application: AsyncMock | None = None,
+) -> tuple[UpdateWorkflow, _Session, _Session, AsyncMock]:
+    tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "state.json"))
+    wifi = _Session(UpdateTransport.wifi)
+    usb_internet = _Session(UpdateTransport.usb_internet)
+    sessions = UpdateTransportSessions(wifi=wifi, usb_internet=usb_internet)
+    release = release_application or AsyncMock()
+    workflow = UpdateWorkflow(
+        tracker=tracker,
+        commands=MagicMock(),
+        transport_sessions=sessions,
+        release_application=release,
+        cancel_requested=cancel_requested,
+        validation_config=UpdateValidationConfig(
+            rollback_dir=tmp_path / "rollback",
+            min_free_disk_bytes=1,
+        ),
+    )
+    return workflow, wifi, usb_internet, release
+
+
+@pytest.mark.asyncio
+async def test_execute_uses_transport_session_for_request(tmp_path: Path) -> None:
+    workflow, wifi, usb_internet, release = _build_workflow(
+        tmp_path,
+        cancel_requested=lambda: False,
+    )
+    request = UpdateRequest(
+        transport=UpdateTransport.usb_internet,
+        ssid=None,
+        password="",
+    )
+
+    with patch(
+        "vibesensor.use_cases.updates.workflow.validate_prerequisites",
+        new=AsyncMock(return_value=True),
+    ):
+        await workflow.execute(request)
+
+    usb_internet.prepare.assert_awaited_once_with(request)
+    wifi.prepare.assert_not_awaited()
+    release.execute.assert_awaited_once_with(usb_internet)
+
+
+@pytest.mark.asyncio
+async def test_execute_stops_after_validation_failure(tmp_path: Path) -> None:
+    workflow, wifi, usb_internet, release = _build_workflow(
+        tmp_path,
+        cancel_requested=lambda: False,
+    )
+    request = UpdateRequest(
+        transport=UpdateTransport.wifi,
+        ssid="TestNet",
+        password="pass123",
+    )
+
+    with patch(
+        "vibesensor.use_cases.updates.workflow.validate_prerequisites",
+        new=AsyncMock(return_value=False),
+    ):
+        await workflow.execute(request)
+
+    wifi.prepare.assert_not_awaited()
+    usb_internet.prepare.assert_not_awaited()
+    release.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_stops_when_transport_prepare_fails(tmp_path: Path) -> None:
+    workflow, wifi, _usb_internet, release = _build_workflow(
+        tmp_path,
+        cancel_requested=lambda: False,
+    )
+    wifi.prepare.return_value = False
+    request = UpdateRequest(
+        transport=UpdateTransport.wifi,
+        ssid="TestNet",
+        password="pass123",
+    )
+
+    with patch(
+        "vibesensor.use_cases.updates.workflow.validate_prerequisites",
+        new=AsyncMock(return_value=True),
+    ):
+        await workflow.execute(request)
+
+    wifi.prepare.assert_awaited_once_with(request)
+    release.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_honors_cancellation_after_transport_prepare(tmp_path: Path) -> None:
+    cancel_results = iter((False, True))
+    workflow, wifi, _usb_internet, release = _build_workflow(
+        tmp_path,
+        cancel_requested=lambda: next(cancel_results),
+    )
+    request = UpdateRequest(
+        transport=UpdateTransport.wifi,
+        ssid="TestNet",
+        password="pass123",
+    )
+
+    with patch(
+        "vibesensor.use_cases.updates.workflow.validate_prerequisites",
+        new=AsyncMock(return_value=True),
+    ):
+        await workflow.execute(request)
+
+    wifi.prepare.assert_awaited_once_with(request)
+    release.execute.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_orchestrator.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_orchestrator.py
@@ -41,11 +41,11 @@ def _build_orchestrator(
     return orchestrator, runner, tracker
 
 
-def _wifi_request(ssid: str = "TestNet") -> UpdateRequest:
+def _wifi_request(ssid: str = "TestNet", password: str = "") -> UpdateRequest:
     return UpdateRequest(
         transport=UpdateTransport.wifi,
         ssid=ssid,
-        password="",
+        password=password,
     )
 
 
@@ -64,6 +64,18 @@ async def test_recover_interrupted_update_cleans_uplink_and_restores_hotspot(
     assert any(
         "startup_recover: hotspot restored successfully" in line for line in tracker.status.log_tail
     )
+
+
+@pytest.mark.asyncio
+async def test_prepare_stops_hotspot_and_connects_uplink(tmp_path: Path) -> None:
+    orchestrator, runner, tracker = _build_orchestrator(tmp_path)
+
+    assert await orchestrator.prepare(_wifi_request(password="pass123")) is True
+
+    commands = [" ".join(call[0]) for call in runner.calls]
+    assert any("connection down VibeSensor-AP" in command for command in commands)
+    assert any("connection add type wifi" in command for command in commands)
+    assert tracker.status.phase == UpdatePhase.connecting_wifi
 
 
 @pytest.mark.asyncio
@@ -93,9 +105,11 @@ async def test_cleanup_restore_hotspot_records_issue_on_failure(tmp_path: Path) 
         restore_retries=1,
         restore_delay_s=0,
     )
+    tracker.start_job(_wifi_request())
+    tracker.transition(UpdatePhase.installing)
     runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
 
-    await orchestrator.cleanup_restore_hotspot()
+    await orchestrator.cleanup_after_update()
 
     assert any(
         issue.phase == "cleanup" and issue.message == "Failed to restore hotspot during cleanup"
@@ -105,7 +119,7 @@ async def test_cleanup_restore_hotspot_records_issue_on_failure(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_collect_cleanup_diagnostics_returns_parsed_issues(tmp_path: Path) -> None:
+async def test_cleanup_after_update_collects_cleanup_diagnostics(tmp_path: Path) -> None:
     orchestrator, _runner, _tracker = _build_orchestrator(tmp_path)
     expected_issues = [
         UpdateIssue(
@@ -119,15 +133,17 @@ async def test_collect_cleanup_diagnostics_returns_parsed_issues(tmp_path: Path)
         "vibesensor.use_cases.updates.wifi.wifi_orchestrator.parse_wifi_diagnostics",
         return_value=expected_issues,
     ):
-        assert await orchestrator.collect_cleanup_diagnostics() == expected_issues
+        await orchestrator.cleanup_after_update()
+
+    assert _tracker.status.issues == expected_issues
 
 
 @pytest.mark.asyncio
-async def test_complete_update_success_restores_hotspot_and_marks_success(tmp_path: Path) -> None:
+async def test_complete_success_restores_hotspot_and_marks_success(tmp_path: Path) -> None:
     orchestrator, _runner, tracker = _build_orchestrator(tmp_path)
     tracker.start_job(_wifi_request())
 
-    assert await orchestrator.complete_update_success("Update completed successfully") is True
+    assert await orchestrator.complete_success("Update completed successfully") is True
 
     assert tracker.status.state == UpdateState.success
     assert tracker.status.phase == UpdatePhase.done
@@ -135,7 +151,7 @@ async def test_complete_update_success_restores_hotspot_and_marks_success(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_complete_update_success_marks_failed_when_restore_fails(tmp_path: Path) -> None:
+async def test_complete_success_marks_failed_when_restore_fails(tmp_path: Path) -> None:
     orchestrator, runner, tracker = _build_orchestrator(
         tmp_path,
         restore_retries=1,
@@ -144,7 +160,7 @@ async def test_complete_update_success_marks_failed_when_restore_fails(tmp_path:
     tracker.start_job(_wifi_request())
     runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
 
-    assert await orchestrator.complete_update_success("Update completed successfully") is False
+    assert await orchestrator.complete_success("Update completed successfully") is False
 
     assert tracker.status.state == UpdateState.failed
 
@@ -155,7 +171,7 @@ async def test_cleanup_restore_orchestration_restores_hotspot_when_needed(tmp_pa
     tracker.start_job(_wifi_request())
     tracker.transition(UpdatePhase.installing)
 
-    await orchestrator.maybe_restore_hotspot_during_cleanup()
+    await orchestrator.cleanup_after_update()
 
     assert tracker.status.phase == UpdatePhase.restoring_hotspot
     assert any("Restoring hotspot..." in line for line in tracker.status.log_tail)
@@ -169,7 +185,7 @@ async def test_cleanup_restore_orchestration_skips_restore_when_no_longer_needed
     tracker.start_job(_wifi_request())
     tracker.mark_success("done")
 
-    await orchestrator.maybe_restore_hotspot_during_cleanup()
+    await orchestrator.cleanup_after_update()
 
     commands = [" ".join(call[0]) for call in runner.calls]
     assert not any("connection up VibeSensor-AP" in command for command in commands)

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -8,8 +8,12 @@ Module topology
 - **Facade**: ``manager.py`` — public ``UpdateManager`` API for routes and
   runtime lifecycle. Delegates update sequencing to ``workflow.py``.
 - **Workflow**: ``workflow.py`` — ``UpdateWorkflow`` runs the full update
-  sequence as named phase handlers with centralized cancellation. Also owns
-  ``schedule_service_restart()``.
+  sequence over validation, transport preparation, and release application.
+- **Transport sessions**: ``transport_sessions.py`` — canonical Wi-Fi and USB
+  transport-session boundary used by workflow, cleanup, and startup recovery.
+- **Release application**: ``release_application.py`` — release discovery,
+  download, install, firmware refresh, and restart scheduling after transport
+  preparation succeeds.
 - **Recovery**: ``recovery.py`` — ``InterruptedUpdateRecovery`` collaborator
   for interrupted-job detection, cleanup, and persistence on startup.
 - **Validation**: ``validation.py`` — runtime prerequisite checks for tools,

--- a/apps/server/vibesensor/use_cases/updates/job_lifecycle.py
+++ b/apps/server/vibesensor/use_cases/updates/job_lifecycle.py
@@ -7,27 +7,27 @@ from pathlib import Path
 
 from vibesensor.use_cases.updates.models import UpdateRequest
 from vibesensor.use_cases.updates.status import UpdateStatusTracker, collect_runtime_details
-from vibesensor.use_cases.updates.wifi import UpdateWifiOrchestrator
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
 
-WifiFactory = Callable[[], UpdateWifiOrchestrator]
+TransportSessionsFactory = Callable[[], UpdateTransportSessions]
 
 
 class UpdateJobLifecycleHandler:
     """Own stateful update job lifecycle callbacks and cleanup sequencing."""
 
-    __slots__ = ("_logger", "_repo", "_tracker", "_wifi_factory")
+    __slots__ = ("_logger", "_repo", "_tracker", "_transport_sessions_factory")
 
     def __init__(
         self,
         *,
         tracker: UpdateStatusTracker,
         repo: Path,
-        wifi_factory: WifiFactory,
+        transport_sessions_factory: TransportSessionsFactory,
         logger: logging.Logger,
     ) -> None:
         self._tracker = tracker
         self._repo = repo
-        self._wifi_factory = wifi_factory
+        self._transport_sessions_factory = transport_sessions_factory
         self._logger = logger
 
     def prepare_start(self, request: UpdateRequest) -> None:
@@ -54,11 +54,12 @@ class UpdateJobLifecycleHandler:
 
     async def cleanup_after_update(self) -> None:
         tracker = self._tracker
-        wifi = self._wifi_factory()
+        transport_session = self._transport_sessions_factory().for_transport(
+            tracker.status.transport,
+        )
         try:
-            await wifi.maybe_restore_hotspot_during_cleanup()
+            await transport_session.cleanup_after_update()
             tracker.set_runtime(await asyncio.to_thread(collect_runtime_details, self._repo))
-            tracker.extend_issues(await wifi.collect_cleanup_diagnostics())
         finally:
             tracker.clear_secrets()
             tracker.finish_cleanup()

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -21,12 +21,14 @@ from vibesensor.use_cases.updates.models import (
     validate_update_request,
 )
 from vibesensor.use_cases.updates.recovery import InterruptedUpdateRecovery
+from vibesensor.use_cases.updates.release_application import UpdateReleaseApplication
 from vibesensor.use_cases.updates.runner import CommandRunner, UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import (
     UpdateStateStore,
     UpdateStatusTracker,
     collect_runtime_details,
 )
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
 from vibesensor.use_cases.updates.usb_internet import (
     UpdateUsbInternetOrchestrator,
     UsbInternetStatusService,
@@ -169,12 +171,12 @@ class UpdateManager:
         self._lifecycle = UpdateJobLifecycleHandler(
             tracker=self._tracker,
             repo=self._repo,
-            wifi_factory=self._build_wifi_orchestrator,
+            transport_sessions_factory=lambda: self._build_transport_sessions(),
             logger=LOGGER,
         )
         self._recovery = InterruptedUpdateRecovery(
             tracker=self._tracker,
-            wifi_factory=self._build_wifi_orchestrator,
+            transport_sessions_factory=lambda: self._build_transport_sessions(),
         )
 
         # Build config objects once — shared by workflow, snapshot, and rollback.
@@ -255,15 +257,10 @@ class UpdateManager:
         workflow = UpdateWorkflow(
             tracker=self._tracker,
             commands=commands,
-            wifi=self._build_wifi_orchestrator(commands=commands),
-            usb_internet=self._build_usb_internet_orchestrator(commands=commands),
-            installer=self._build_installer(commands),
-            firmware_refresher=self._build_firmware_refresher(commands=commands),
+            transport_sessions=self._build_transport_sessions(commands=commands),
+            release_application=self._build_release_application(commands),
             cancel_requested=self._executor.cancel_requested,
             validation_config=self._validation_config,
-            rollback_dir=self._rollback_dir,
-            service_name=UPDATE_SERVICE_NAME,
-            restart_unit=UPDATE_RESTART_UNIT,
         )
         await workflow.execute(request)
 
@@ -300,6 +297,17 @@ class UpdateManager:
             self._build_wifi_config(),
         )
 
+    def _build_transport_sessions(
+        self,
+        *,
+        commands: UpdateCommandExecutor | None = None,
+    ) -> UpdateTransportSessions:
+        active_commands = commands or self._build_command_executor()
+        return UpdateTransportSessions(
+            wifi=self._build_wifi_orchestrator(commands=active_commands),
+            usb_internet=self._build_usb_internet_orchestrator(commands=active_commands),
+        )
+
     def _build_installer(
         self,
         commands: UpdateCommandExecutor,
@@ -316,6 +324,21 @@ class UpdateManager:
             self._tracker,
             self._repo,
             self._installer_config.firmware_refresh_timeout_s,
+        )
+
+    def _build_release_application(
+        self,
+        commands: UpdateCommandExecutor,
+    ) -> UpdateReleaseApplication:
+        return UpdateReleaseApplication(
+            tracker=self._tracker,
+            commands=commands,
+            installer=self._build_installer(commands),
+            firmware_refresher=self._build_firmware_refresher(commands=commands),
+            cancel_requested=self._executor.cancel_requested,
+            rollback_dir=self._rollback_dir,
+            service_name=UPDATE_SERVICE_NAME,
+            restart_unit=UPDATE_RESTART_UNIT,
         )
 
     async def _snapshot_for_rollback(self) -> bool:

--- a/apps/server/vibesensor/use_cases/updates/recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/recovery.py
@@ -11,9 +11,9 @@ from collections.abc import Callable
 
 from vibesensor.use_cases.updates.models import UpdateState
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.wifi import UpdateWifiOrchestrator
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
 
-WifiFactory = Callable[[], UpdateWifiOrchestrator]
+TransportSessionsFactory = Callable[[], UpdateTransportSessions]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -21,16 +21,16 @@ LOGGER = logging.getLogger(__name__)
 class InterruptedUpdateRecovery:
     """Detect and recover from an update job interrupted by a server restart."""
 
-    __slots__ = ("_tracker", "_wifi_factory")
+    __slots__ = ("_tracker", "_transport_sessions_factory")
 
     def __init__(
         self,
         *,
         tracker: UpdateStatusTracker,
-        wifi_factory: WifiFactory,
+        transport_sessions_factory: TransportSessionsFactory,
     ) -> None:
         self._tracker = tracker
-        self._wifi_factory = wifi_factory
+        self._transport_sessions_factory = transport_sessions_factory
 
     def needs_recovery(self) -> bool:
         """Return True when the persisted status indicates an interrupted job."""
@@ -38,9 +38,11 @@ class InterruptedUpdateRecovery:
         return status.state == UpdateState.running and status.finished_at is None
 
     async def recover(self) -> None:
-        """Mark the interrupted job as failed, run Wi-Fi cleanup, and persist."""
+        """Mark the interrupted job as failed, run transport cleanup, and persist."""
         LOGGER.warning("Detected interrupted update job; marking as failed and cleaning up")
         self._tracker.mark_interrupted("Update interrupted by server restart")
-        wifi = self._wifi_factory()
-        await wifi.recover_interrupted_update()
+        transport_session = self._transport_sessions_factory().for_transport(
+            self._tracker.status.transport,
+        )
+        await transport_session.recover_interrupted_update()
         self._tracker.persist()

--- a/apps/server/vibesensor/use_cases/updates/release_application.py
+++ b/apps/server/vibesensor/use_cases/updates/release_application.py
@@ -1,0 +1,201 @@
+"""Release discovery, install orchestration, and restart scheduling for updates."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from vibesensor.use_cases.updates.firmware import FirmwareRefresher
+from vibesensor.use_cases.updates.installer import UpdateInstaller
+from vibesensor.use_cases.updates.models import UpdatePhase
+from vibesensor.use_cases.updates.releases import (
+    UpdateReleaseCheck,
+    check_for_update,
+    download_release,
+    verify_download,
+)
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSession
+
+
+class UpdateReleaseApplication:
+    """Own the non-transport portion of an update run once uplink is ready."""
+
+    __slots__ = (
+        "_cancel_requested",
+        "_commands",
+        "_firmware_refresher",
+        "_installer",
+        "_restart_unit",
+        "_rollback_dir",
+        "_service_name",
+        "_tracker",
+    )
+
+    def __init__(
+        self,
+        *,
+        tracker: UpdateStatusTracker,
+        commands: UpdateCommandExecutor,
+        installer: UpdateInstaller,
+        firmware_refresher: FirmwareRefresher,
+        cancel_requested: Callable[[], bool],
+        rollback_dir: Path,
+        service_name: str,
+        restart_unit: str,
+    ) -> None:
+        self._tracker = tracker
+        self._commands = commands
+        self._installer = installer
+        self._firmware_refresher = firmware_refresher
+        self._cancel_requested = cancel_requested
+        self._rollback_dir = rollback_dir
+        self._service_name = service_name
+        self._restart_unit = restart_unit
+
+    async def execute(self, transport_session: UpdateTransportSession) -> None:
+        """Check for updates and apply them after transport preparation succeeds."""
+
+        self._tracker.transition(UpdatePhase.checking)
+        self._tracker.log("Checking for available updates...")
+        from vibesensor import __version__ as current_version
+
+        release_check = await check_for_update(
+            self._tracker,
+            self._rollback_dir,
+            current_version,
+        )
+        if release_check.failed:
+            return
+        if release_check.release is None:
+            await self._handle_already_up_to_date(
+                transport_session,
+                current_version=current_version,
+                latest_tag=release_check.latest_tag,
+            )
+            return
+
+        self._tracker.log(
+            f"Update available: {current_version} → {release_check.release.version}",
+        )
+        if self._cancelled():
+            return
+        await self._download_and_install(transport_session, release_check)
+
+    async def _handle_already_up_to_date(
+        self,
+        transport_session: UpdateTransportSession,
+        *,
+        current_version: str,
+        latest_tag: str,
+    ) -> None:
+        self._tracker.log(f"Already up-to-date (version={current_version})")
+        await self._firmware_refresher.refresh_esp_firmware(pinned_tag=latest_tag)
+        if self._cancelled():
+            return
+        await transport_session.complete_success("No server update needed; ESP firmware checked")
+
+    async def _download_and_install(
+        self,
+        transport_session: UpdateTransportSession,
+        release_check: UpdateReleaseCheck,
+    ) -> None:
+        release = release_check.release
+        assert release is not None  # noqa: S101
+        self._tracker.transition(UpdatePhase.downloading)
+        self._tracker.log(f"Downloading release {release.tag}...")
+        staging_dir = Path(tempfile.mkdtemp(prefix="vibesensor-update-"))
+        try:
+            wheel_path = await download_release(
+                self._tracker,
+                self._rollback_dir,
+                release,
+                staging_dir,
+            )
+            if wheel_path is None:
+                return
+            self._tracker.log(
+                f"Downloaded {wheel_path.name} (sha256={getattr(release, 'sha256', '')})",
+            )
+            if not await verify_download(self._tracker, release, wheel_path):
+                return
+            await self._firmware_refresher.refresh_esp_firmware(pinned_tag=release.tag)
+            if self._cancelled():
+                return
+            if not await self._install(wheel_path, str(release.version)):
+                return
+        finally:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+        if self._cancelled():
+            return
+        await self._finalize(transport_session)
+
+    async def _install(self, wheel_path: Path, version: str) -> bool:
+        self._tracker.transition(UpdatePhase.installing)
+        self._tracker.log("Installing update...")
+        if not await self._installer.snapshot_for_rollback():
+            self._tracker.fail(
+                UpdatePhase.installing,
+                "Rollback snapshot could not be created",
+                "Install aborted before mutating the live environment",
+            )
+            return False
+        return await self._installer.install_release(wheel_path, version)
+
+    async def _finalize(self, transport_session: UpdateTransportSession) -> None:
+        if not await transport_session.complete_success("Update completed successfully"):
+            return
+        if await schedule_service_restart(
+            commands=self._commands,
+            tracker=self._tracker,
+            service_name=self._service_name,
+            restart_unit=self._restart_unit,
+        ):
+            return
+        self._tracker.add_issue(
+            "done",
+            "Backend restart was not scheduled automatically",
+            "Run 'sudo systemctl restart vibesensor.service' manually",
+        )
+        self._tracker.log("Automatic backend restart scheduling failed")
+
+    def _cancelled(self) -> bool:
+        return self._cancel_requested()
+
+
+async def schedule_service_restart(
+    *,
+    commands: UpdateCommandExecutor,
+    tracker: UpdateStatusTracker,
+    service_name: str,
+    restart_unit: str,
+) -> bool:
+    """Schedule a systemd restart of the backend service."""
+
+    restart_attempts = [
+        [
+            "systemd-run",
+            "--unit",
+            restart_unit,
+            "--on-active=2s",
+            "systemctl",
+            "restart",
+            service_name,
+        ],
+        ["systemctl", "restart", service_name],
+    ]
+    for command in restart_attempts:
+        rc, _, _ = await commands.run(
+            command,
+            phase="done",
+            timeout=30,
+            sudo=True,
+        )
+        if rc == 0:
+            tracker.log("Scheduled backend service restart")
+            return True
+    return False

--- a/apps/server/vibesensor/use_cases/updates/transport_sessions.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_sessions.py
@@ -1,0 +1,52 @@
+"""Canonical transport-session boundary for update job control flow."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from vibesensor.use_cases.updates.models import UpdateRequest, UpdateTransport
+
+
+class UpdateTransportSession(Protocol):
+    """One transport-specific update session with a uniform lifecycle."""
+
+    transport: UpdateTransport
+
+    async def prepare(self, request: UpdateRequest) -> bool:
+        """Prepare this transport for an update run before release work starts."""
+        ...
+
+    async def complete_success(self, message: str) -> bool:
+        """Finalize a successful update for this transport."""
+        ...
+
+    async def cleanup_after_update(self) -> None:
+        """Run transport-specific cleanup after the update task exits."""
+        ...
+
+    async def recover_interrupted_update(self) -> None:
+        """Recover transport-owned state after an interrupted update job."""
+        ...
+
+
+class UpdateTransportSessions:
+    """Resolve canonical transport sessions from requests or persisted state."""
+
+    __slots__ = ("_sessions",)
+
+    def __init__(
+        self,
+        *,
+        wifi: UpdateTransportSession,
+        usb_internet: UpdateTransportSession,
+    ) -> None:
+        self._sessions: dict[UpdateTransport, UpdateTransportSession] = {
+            UpdateTransport.wifi: wifi,
+            UpdateTransport.usb_internet: usb_internet,
+        }
+
+    def for_request(self, request: UpdateRequest) -> UpdateTransportSession:
+        return self.for_transport(request.transport)
+
+    def for_transport(self, transport: UpdateTransport) -> UpdateTransportSession:
+        return self._sessions[transport]

--- a/apps/server/vibesensor/use_cases/updates/usb_internet.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_internet.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from vibesensor.use_cases.updates.models import UpdatePhase, UsbInternetStatus
+from vibesensor.use_cases.updates.models import (
+    UpdatePhase,
+    UpdateRequest,
+    UpdateTransport,
+    UsbInternetStatus,
+)
 from vibesensor.use_cases.updates.runner import (
     CommandRunner,
     UpdateCommandExecutor,
@@ -363,6 +368,7 @@ class UpdateUsbInternetOrchestrator:
     """Validate and reuse an already-present USB internet uplink for updates."""
 
     __slots__ = ("_readiness", "_status_service", "_tracker")
+    transport = UpdateTransport.usb_internet
 
     def __init__(
         self,
@@ -379,6 +385,13 @@ class UpdateUsbInternetOrchestrator:
             tracker=tracker,
             config=config,
         )
+
+    async def prepare(self, request: UpdateRequest) -> bool:
+        """Prepare USB internet transport before release work begins."""
+
+        del request
+        self._tracker.transition(UpdatePhase.connecting_usb_internet)
+        return await self.ensure_uplink_ready()
 
     async def ensure_uplink_ready(self) -> bool:
         if isinstance(self._status_service, UsbInternetStatusService):
@@ -412,3 +425,13 @@ class UpdateUsbInternetOrchestrator:
             readiness_subject="USB internet",
             failure_message="USB internet detected, but internet/DNS is not ready",
         )
+
+    async def complete_success(self, message: str) -> bool:
+        self._tracker.mark_success(message)
+        return True
+
+    async def cleanup_after_update(self) -> None:
+        return None
+
+    async def recover_interrupted_update(self) -> None:
+        return None

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_orchestrator.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 
 from vibesensor.use_cases.updates.models import (
-    UpdateIssue,
     UpdatePhase,
+    UpdateRequest,
     UpdateState,
     UpdateTransport,
 )
@@ -15,7 +14,6 @@ from vibesensor.use_cases.updates.wifi.wifi import UpdateWifiController
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 from vibesensor.use_cases.updates.wifi.wifi_diagnostics import parse_wifi_diagnostics
 
-LOGGER = logging.getLogger(__name__)
 _HOTSPOT_RESTORE_PHASES = frozenset(
     {
         UpdatePhase.stopping_hotspot,
@@ -29,9 +27,10 @@ _HOTSPOT_RESTORE_PHASES = frozenset(
 
 
 class UpdateWifiOrchestrator:
-    """Focused Wi-Fi transition helper for updater startup and cleanup paths."""
+    """Transport-specific Wi-Fi session for updater startup, success, and cleanup."""
 
     __slots__ = ("_controller", "_tracker")
+    transport = UpdateTransport.wifi
 
     def __init__(
         self,
@@ -57,6 +56,16 @@ class UpdateWifiOrchestrator:
 
         return await self._controller.connect_uplink(ssid, password)
 
+    async def prepare(self, request: UpdateRequest) -> bool:
+        """Prepare the updater's Wi-Fi transport before release work begins."""
+
+        self._tracker.transition(UpdatePhase.stopping_hotspot)
+        if not await self.stop_hotspot():
+            return False
+        self._tracker.transition(UpdatePhase.connecting_wifi)
+        assert request.ssid is not None  # noqa: S101
+        return await self.connect_uplink(request.ssid, request.password)
+
     async def restore_hotspot(self) -> bool:
         """Restore the hotspot after update work completes or is interrupted."""
 
@@ -66,59 +75,23 @@ class UpdateWifiOrchestrator:
         """Recover updater Wi-Fi state after a previously interrupted job."""
 
         if self._tracker.status.transport != UpdateTransport.wifi:
-            self._tracker.log("startup_recover: no Wi-Fi uplink cleanup required")
             return
         self._tracker.log("startup_recover: cleaning up uplink connection")
-        try:
-            await self._controller.cleanup_uplink()
-        except Exception as exc:
-            self._tracker.add_issue(
-                "startup",
-                "Failed to clean up uplink connection",
-                str(exc),
-            )
+        await self._controller.cleanup_uplink()
 
         self._tracker.log("startup_recover: restoring hotspot")
-        try:
-            restored = await self.restore_hotspot()
-            if restored:
-                self._tracker.log("startup_recover: hotspot restored successfully")
-            else:
-                self._tracker.add_issue(
-                    "startup",
-                    "Failed to restore hotspot after interrupted update",
-                )
-                self._tracker.log("startup_recover: hotspot restore failed")
-        except Exception as exc:
+        restored = await self.restore_hotspot()
+        if restored:
+            self._tracker.log("startup_recover: hotspot restored successfully")
+        else:
             self._tracker.add_issue(
                 "startup",
-                "Hotspot restore error during recovery",
-                str(exc),
+                "Failed to restore hotspot after interrupted update",
             )
+            self._tracker.log("startup_recover: hotspot restore failed")
 
-    async def cleanup_restore_hotspot(self) -> None:
-        """Restore the hotspot during cleanup without letting cancellation interrupt it."""
-
-        try:
-            restored = await asyncio.shield(self.restore_hotspot())
-            if not restored:
-                self._tracker.add_issue("cleanup", "Failed to restore hotspot during cleanup")
-                self._tracker.log("Cleanup hotspot restore failed")
-        except Exception as exc:
-            self._tracker.add_issue(
-                "cleanup",
-                "Hotspot restore error during cleanup",
-                str(exc),
-            )
-            LOGGER.warning("Cleanup hotspot restore failed", exc_info=True)
-
-    async def collect_cleanup_diagnostics(self) -> list[UpdateIssue]:
-        """Collect any hotspot diagnostics that should be attached to cleanup failures."""
-
-        return await asyncio.to_thread(parse_wifi_diagnostics)
-
-    async def complete_update_success(self, message: str) -> bool:
-        """Restore the hotspot and then finalize the job as successful."""
+    async def complete_success(self, message: str) -> bool:
+        """Restore the hotspot and then finalize the Wi-Fi update as successful."""
 
         if self._tracker.status.transport != UpdateTransport.wifi:
             self._tracker.mark_success(message)
@@ -133,8 +106,8 @@ class UpdateWifiOrchestrator:
         self._tracker.mark_success(message)
         return True
 
-    async def maybe_restore_hotspot_during_cleanup(self) -> None:
-        """Restore the hotspot if cleanup begins while the updater still owns Wi-Fi state."""
+    async def cleanup_after_update(self) -> None:
+        """Restore hotspot ownership and attach cleanup diagnostics after a run."""
 
         if self._tracker.status.transport != UpdateTransport.wifi:
             return
@@ -142,4 +115,8 @@ class UpdateWifiOrchestrator:
         if status.state == UpdateState.running or status.phase in _HOTSPOT_RESTORE_PHASES:
             self._tracker.transition(UpdatePhase.restoring_hotspot)
             self._tracker.log("Restoring hotspot...")
-            await self.cleanup_restore_hotspot()
+            restored = await asyncio.shield(self.restore_hotspot())
+            if not restored:
+                self._tracker.add_issue("cleanup", "Failed to restore hotspot during cleanup")
+                self._tracker.log("Cleanup hotspot restore failed")
+        self._tracker.extend_issues(await asyncio.to_thread(parse_wifi_diagnostics))

--- a/apps/server/vibesensor/use_cases/updates/workflow.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow.py
@@ -1,48 +1,27 @@
-"""Explicit step-based update workflow.
-
-Owns the sequencing and per-phase logic previously inlined in
-``UpdateManager._run_update_inner()``.  Cancellation checks are
-centralized in ``_cancelled()`` rather than repeated after every step.
-"""
+"""Explicit update workflow over transport and release/application collaborators."""
 
 from __future__ import annotations
 
-import shutil
-import tempfile
 from collections.abc import Callable
-from pathlib import Path
 
-from vibesensor.use_cases.updates.firmware import FirmwareRefresher
-from vibesensor.use_cases.updates.installer import UpdateInstaller
-from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
-from vibesensor.use_cases.updates.releases import (
-    UpdateReleaseCheck,
-    check_for_update,
-    download_release,
-    verify_download,
-)
+from vibesensor.use_cases.updates.models import UpdateRequest
+from vibesensor.use_cases.updates.release_application import UpdateReleaseApplication
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.usb_internet import UpdateUsbInternetOrchestrator
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
 from vibesensor.use_cases.updates.validation import UpdateValidationConfig, validate_prerequisites
-from vibesensor.use_cases.updates.wifi import UpdateWifiOrchestrator
 
 
 class UpdateWorkflow:
-    """Named-step update workflow with centralized cancellation."""
+    """Coordinate validation, transport preparation, and release application."""
 
     __slots__ = (
         "_cancel_requested",
         "_commands",
-        "_firmware_refresher",
-        "_installer",
-        "_restart_unit",
-        "_rollback_dir",
-        "_service_name",
+        "_release_application",
         "_tracker",
-        "_usb_internet",
+        "_transport_sessions",
         "_validation_config",
-        "_wifi",
     )
 
     def __init__(
@@ -50,53 +29,31 @@ class UpdateWorkflow:
         *,
         tracker: UpdateStatusTracker,
         commands: UpdateCommandExecutor,
-        wifi: UpdateWifiOrchestrator,
-        usb_internet: UpdateUsbInternetOrchestrator,
-        installer: UpdateInstaller,
-        firmware_refresher: FirmwareRefresher,
+        transport_sessions: UpdateTransportSessions,
+        release_application: UpdateReleaseApplication,
         cancel_requested: Callable[[], bool],
         validation_config: UpdateValidationConfig,
-        rollback_dir: Path,
-        service_name: str,
-        restart_unit: str,
     ) -> None:
         self._tracker = tracker
         self._commands = commands
-        self._wifi = wifi
-        self._usb_internet = usb_internet
-        self._installer = installer
-        self._firmware_refresher = firmware_refresher
+        self._transport_sessions = transport_sessions
+        self._release_application = release_application
         self._cancel_requested = cancel_requested
         self._validation_config = validation_config
-        self._rollback_dir = rollback_dir
-        self._service_name = service_name
-        self._restart_unit = restart_unit
-
-    # ------------------------------------------------------------------
-    # Public entry point
-    # ------------------------------------------------------------------
 
     async def execute(self, request: UpdateRequest) -> None:
         """Run the full update workflow."""
+
         if not await self._validate(request):
             return
-        if request.transport == UpdateTransport.wifi:
-            if not await self._stop_hotspot():
-                return
-            if not await self._connect_wifi(request):
-                return
-        else:
-            if not await self._connect_usb_internet():
-                return
-        await self._check_and_apply(request)
-
-    # ------------------------------------------------------------------
-    # Phase handlers
-    # ------------------------------------------------------------------
+        transport_session = self._transport_sessions.for_request(request)
+        if not await transport_session.prepare(request):
+            return
+        if self._cancelled():
+            return
+        await self._release_application.execute(transport_session)
 
     async def _validate(self, request: UpdateRequest) -> bool:
-        """Run prerequisite validation before any network or install mutation."""
-
         if not await validate_prerequisites(
             commands=self._commands,
             tracker=self._tracker,
@@ -106,190 +63,5 @@ class UpdateWorkflow:
             return False
         return not self._cancelled()
 
-    async def _stop_hotspot(self) -> bool:
-        self._tracker.transition(UpdatePhase.stopping_hotspot)
-        if not await self._wifi.stop_hotspot():
-            return False
-        return not self._cancelled()
-
-    async def _connect_wifi(self, request: UpdateRequest) -> bool:
-        self._tracker.transition(UpdatePhase.connecting_wifi)
-        assert request.ssid is not None  # noqa: S101
-        if not await self._wifi.connect_uplink(request.ssid, request.password):
-            return False
-        return not self._cancelled()
-
-    async def _connect_usb_internet(self) -> bool:
-        self._tracker.transition(UpdatePhase.connecting_usb_internet)
-        if not await self._usb_internet.ensure_uplink_ready():
-            return False
-        return not self._cancelled()
-
-    async def _check_and_apply(self, request: UpdateRequest) -> None:
-        self._tracker.transition(UpdatePhase.checking)
-        self._tracker.log("Checking for available updates...")
-        from vibesensor import __version__ as current_version
-
-        release_check = await check_for_update(
-            self._tracker,
-            self._rollback_dir,
-            current_version,
-        )
-        if release_check.failed:
-            return
-        if release_check.release is None:
-            await self._handle_already_up_to_date(
-                current_version,
-                release_check.latest_tag,
-                transport=request.transport,
-            )
-            return
-
-        self._tracker.log(
-            f"Update available: {current_version} → {release_check.release.version}",
-        )
-        if self._cancelled():
-            return
-        await self._download_and_install(release_check, transport=request.transport)
-
-    async def _handle_already_up_to_date(
-        self,
-        current_version: str,
-        latest_tag: str,
-        *,
-        transport: UpdateTransport,
-    ) -> None:
-        """Finish successfully when only the ESP firmware refresh still matters."""
-
-        self._tracker.log(f"Already up-to-date (version={current_version})")
-        await self._firmware_refresher.refresh_esp_firmware(pinned_tag=latest_tag)
-        if self._cancelled():
-            return
-        if transport == UpdateTransport.wifi:
-            await self._wifi.complete_update_success(
-                "No server update needed; ESP firmware checked",
-            )
-            return
-        self._tracker.mark_success("No server update needed; ESP firmware checked")
-
-    async def _download_and_install(
-        self,
-        release_check: UpdateReleaseCheck,
-        *,
-        transport: UpdateTransport,
-    ) -> None:
-        """Download, verify, and install a newly discovered server release."""
-
-        release = release_check.release
-        assert release is not None  # noqa: S101
-        self._tracker.transition(UpdatePhase.downloading)
-        self._tracker.log(f"Downloading release {release.tag}...")
-        staging_dir = Path(tempfile.mkdtemp(prefix="vibesensor-update-"))
-        try:
-            wheel_path = await download_release(
-                self._tracker,
-                self._rollback_dir,
-                release,
-                staging_dir,
-            )
-            if wheel_path is None:
-                return
-            self._tracker.log(
-                f"Downloaded {wheel_path.name} (sha256={getattr(release, 'sha256', '')})",
-            )
-            if not await verify_download(self._tracker, release, wheel_path):
-                return
-            await self._firmware_refresher.refresh_esp_firmware(pinned_tag=release.tag)
-            if self._cancelled():
-                return
-            if not await self._install(wheel_path, str(release.version)):
-                return
-        finally:
-            shutil.rmtree(staging_dir, ignore_errors=True)
-
-        if self._cancelled():
-            return
-        await self._finalize(transport=transport)
-
-    async def _install(self, wheel_path: Path, version: str) -> bool:
-        """Create rollback state before mutating the live server environment."""
-
-        self._tracker.transition(UpdatePhase.installing)
-        self._tracker.log("Installing update...")
-        if not await self._installer.snapshot_for_rollback():
-            self._tracker.fail(
-                UpdatePhase.installing,
-                "Rollback snapshot could not be created",
-                "Install aborted before mutating the live environment",
-            )
-            return False
-        return await self._installer.install_release(wheel_path, version)
-
-    async def _finalize(self, *, transport: UpdateTransport) -> None:
-        """Restore normal runtime state and schedule the backend restart."""
-
-        if transport == UpdateTransport.wifi:
-            if not await self._wifi.complete_update_success("Update completed successfully"):
-                return
-        else:
-            self._tracker.mark_success("Update completed successfully")
-        if await schedule_service_restart(
-            commands=self._commands,
-            tracker=self._tracker,
-            service_name=self._service_name,
-            restart_unit=self._restart_unit,
-        ):
-            return
-        self._tracker.add_issue(
-            "done",
-            "Backend restart was not scheduled automatically",
-            "Run 'sudo systemctl restart vibesensor.service' manually",
-        )
-        self._tracker.log("Automatic backend restart scheduling failed")
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
     def _cancelled(self) -> bool:
-        """Centralize the workflow's cancellation check for phase handlers."""
-
         return self._cancel_requested()
-
-
-# ---------------------------------------------------------------------------
-# Service control
-# ---------------------------------------------------------------------------
-
-
-async def schedule_service_restart(
-    *,
-    commands: UpdateCommandExecutor,
-    tracker: UpdateStatusTracker,
-    service_name: str,
-    restart_unit: str,
-) -> bool:
-    """Schedule a systemd restart of the backend service."""
-    restart_attempts = [
-        [
-            "systemd-run",
-            "--unit",
-            restart_unit,
-            "--on-active=2s",
-            "systemctl",
-            "restart",
-            service_name,
-        ],
-        ["systemctl", "restart", service_name],
-    ]
-    for command in restart_attempts:
-        rc, _, _ = await commands.run(
-            command,
-            phase="done",
-            timeout=30,
-            sudo=True,
-        )
-        if rc == 0:
-            tracker.log("Scheduled backend service restart")
-            return True
-    return False


### PR DESCRIPTION
## Summary
- split update transport lifecycle from release/install execution by introducing canonical transport sessions and a dedicated release application collaborator
- rewire update workflow, startup recovery, and cleanup through the transport-session boundary instead of branching over Wi-Fi-specific paths directly
- tighten Wi-Fi recovery/cleanup so broad catch-all handling no longer hides programmer faults, and add focused workflow/release-application tests

## Architecture issues addressed
- weak responsibility boundaries in the updates subsystem
- mixed policy/execution around transport preparation, cleanup, and recovery
- broad operational exception handling in Wi-Fi recovery paths

## Backward-incompatible changes
- internal update orchestration no longer exposes the old workflow-level transport branching
- `UpdateWifiOrchestrator` now uses the canonical `prepare` / `complete_success` / `cleanup_after_update` transport-session surface
- release checking moved out of `workflow.py` into `release_application.py`, so old patch points/tests targeting `workflow.check_for_update` were removed

## Deleted compatibility layers
- workflow-level transport-specific success/finalize branching
- Wi-Fi-specific cleanup/recovery wiring in lifecycle and interrupted-update recovery
- broad catch-all wrappers around Wi-Fi startup recovery and cleanup restore paths

## Local tests
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m ruff check vibesensor/use_cases/updates tests/use_cases/updates tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m pytest -q tests/use_cases/updates tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m mypy vibesensor`