### PR TITLE
Split updater artifact lifecycle

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -16,6 +16,7 @@ from vibesensor.use_cases.updates.firmware.firmware_refresh import FirmwareRefre
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
 from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
+from vibesensor.use_cases.updates.wheel_installation import WheelInstallResult
 
 
 class RecordingCommands:
@@ -119,7 +120,6 @@ def _make_installer(
             repo=repo,
             rollback_dir=tmp_path / "rollback",
             reinstall_timeout_s=30,
-            firmware_refresh_timeout_s=30,
         ),
     )
     return installer, commands, tracker
@@ -442,6 +442,47 @@ async def test_install_release_rejects_incompatible_environment_before_pip_insta
     assert not any(
         "pip install --force-reinstall --no-deps" in " ".join(call[0]) for call in commands.calls
     )
+
+
+@pytest.mark.asyncio
+async def test_wheel_install_executor_only_requests_rollback_after_mutating_failure(
+    tmp_path: Path,
+) -> None:
+    installer, commands, _tracker = _make_installer(tmp_path)
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_dist=("missingdep>=1",),
+    )
+    commands.set_response(
+        "missingdep",
+        0,
+        (
+            '{"python_full_version":"3.14.3","marker_environment":{"python_full_version":"3.14.3",'
+            '"python_version":"3.14","sys_platform":"linux"},"installed_versions":{"missingdep":""}}\n'
+        ),
+        "",
+    )
+
+    compatibility_result = await installer._wheel_install_executor.install_release(
+        wheel_path,
+        "2025.6.15",
+    )
+
+    assert compatibility_result == WheelInstallResult(succeeded=False, rollback_required=False)
+
+    second_installer, second_commands, _second_tracker = _make_installer(tmp_path / "second")
+    second_wheel = tmp_path / "second" / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_wheel(second_wheel, version="2025.6.15")
+    second_commands.set_response("pip install --force-reinstall --no-deps", 1, "", "install failed")
+
+    install_result = await second_installer._wheel_install_executor.install_release(
+        second_wheel,
+        "2025.6.15",
+    )
+
+    assert install_result == WheelInstallResult(succeeded=False, rollback_required=True)
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -26,7 +26,10 @@ Module topology
   diagnostics parsing, and the thin Wi-Fi workflow coordinator.
 - **Releases**: ``releases/`` — GitHub release discovery, validation, and
   updater-facing download helpers.
-- **Operations**: ``installer.py`` (install/rollback orchestration),
+- **Operations**: ``installer.py`` (install policy facade),
+  ``wheel_installation.py`` (wheel install + verification execution),
+  ``rollback_snapshot_builder.py`` (rollback snapshot capture),
+  ``rollback_executor.py`` (rollback candidate selection + execution),
   ``artifact_validation.py`` (wheel validation + checksums),
   ``rollback_snapshot.py`` (rollback metadata + stored wheels),
   ``runner.py`` (process execution and command helpers), and

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
@@ -92,6 +92,7 @@ class GitHubReleaseFetcher(GitHubAPIClient):
             # firmware binary in memory (Pi 3A+ has only 512 MB RAM).
             tmp_fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), suffix=".dl_tmp")
             fdopen_ok = False
+            downloaded = False
             try:
                 total = 0
                 with os.fdopen(tmp_fd, "wb") as tmp_f:
@@ -108,16 +109,14 @@ class GitHubReleaseFetcher(GitHubAPIClient):
                             )
                         tmp_f.write(chunk)
                 Path(tmp_path).replace(dest)
-            except BaseException:
-                # If os.fdopen() failed, the raw fd is still open; close it.
-                # Once os.fdopen() succeeds it owns the fd (closed by `with`).
+                downloaded = True
+            finally:
                 if not fdopen_ok:
                     with contextlib.suppress(OSError):
                         os.close(tmp_fd)
-                # Clean up partial temp file on any failure
-                with contextlib.suppress(OSError):
-                    Path(tmp_path).unlink()
-                raise
+                if not downloaded:
+                    with contextlib.suppress(OSError):
+                        Path(tmp_path).unlink()
 
     def find_release(self) -> GitHubReleasePayload:
         """Find the target release based on config (pinned tag, channel)."""

--- a/apps/server/vibesensor/use_cases/updates/installer.py
+++ b/apps/server/vibesensor/use_cases/updates/installer.py
@@ -1,29 +1,17 @@
-"""Local install and rollback orchestration for updater runs."""
+"""Public installer facade over focused updater artifact collaborators."""
 
 from __future__ import annotations
 
-import json
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
-
-from vibesensor.use_cases.updates.artifact_validation import (
-    WheelArtifactValidator,
-    read_wheel_metadata,
-    sha256_file,
-    wheel_dependency_issues,
-    wheel_metadata_validation_errors,
-)
-from vibesensor.use_cases.updates.rollback_snapshot import (
-    RollbackSnapshotMetadata,
-    RollbackSnapshotStore,
-)
+from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator
+from vibesensor.use_cases.updates.rollback_executor import RollbackExecutor
+from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
+from vibesensor.use_cases.updates.rollback_snapshot_builder import RollbackSnapshotBuilder
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
+from vibesensor.use_cases.updates.wheel_installation import WheelInstallExecutor
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,47 +19,18 @@ class UpdateInstallerConfig:
     repo: Path
     rollback_dir: Path
     reinstall_timeout_s: float
-    firmware_refresh_timeout_s: float
-
-
-_TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
-    [
-        "import importlib.metadata as metadata",
-        "import json",
-        "import sys",
-        "from packaging.markers import default_environment",
-        "from packaging.utils import canonicalize_name",
-        "payload = json.loads(sys.argv[1])",
-        "distribution_names = [",
-        "    canonicalize_name(str(name))",
-        "    for name in payload.get('distribution_names', [])",
-        "]",
-        "installed_versions = {}",
-        "for distribution_name in distribution_names:",
-        "    try:",
-        "        installed_versions[distribution_name] = metadata.version(distribution_name)",
-        "    except metadata.PackageNotFoundError:",
-        "        installed_versions[distribution_name] = ''",
-        "marker_environment = default_environment()",
-        "print(json.dumps({",
-        "    'python_full_version': marker_environment.get('python_full_version', ''),",
-        "    'marker_environment': marker_environment,",
-        "    'installed_versions': installed_versions,",
-        "}))",
-    ],
-)
-
-
-def _rollback_wheel_version(wheel_path: Path) -> str:
-    """Extract the version token from a rollback wheel filename when present."""
-    wheel_parts = wheel_path.stem.split("-")
-    return wheel_parts[1] if len(wheel_parts) >= 2 else ""
 
 
 class UpdateInstaller:
-    """Owns install, rollback snapshot orchestration, and rollback execution."""
+    """Own install policy while delegating execution to focused collaborators."""
 
-    __slots__ = ("_commands", "_config", "_rollback_snapshots", "_tracker", "_wheel_validator")
+    __slots__ = (
+        "_config",
+        "_rollback_executor",
+        "_rollback_snapshot_builder",
+        "_tracker",
+        "_wheel_install_executor",
+    )
 
     def __init__(
         self,
@@ -80,442 +39,46 @@ class UpdateInstaller:
         tracker: UpdateStatusTracker,
         config: UpdateInstallerConfig,
     ) -> None:
-        self._commands = commands
-        self._tracker = tracker
         self._config = config
-        self._rollback_snapshots = RollbackSnapshotStore(config.rollback_dir, tracker)
-        self._wheel_validator = WheelArtifactValidator(tracker)
-
-    def _existing_local_rollback_wheel(self, *, current_version: str) -> Path | None:
-        candidates = sorted(
-            self._config.rollback_dir.glob(f"vibesensor-{current_version}-*.whl"),
-            reverse=True,
+        self._tracker = tracker
+        rollback_snapshots = RollbackSnapshotStore(config.rollback_dir, tracker)
+        wheel_validator = WheelArtifactValidator(tracker)
+        self._wheel_install_executor = WheelInstallExecutor(
+            commands=commands,
+            tracker=tracker,
+            repo=config.repo,
+            reinstall_timeout_s=config.reinstall_timeout_s,
+            wheel_validator=wheel_validator,
         )
-        for candidate in candidates:
-            errors = wheel_metadata_validation_errors(
-                candidate,
-                expected_name="vibesensor",
-                expected_version=current_version,
-            )
-            if not errors:
-                self._tracker.log(
-                    f"Reusing existing local rollback wheel {candidate.name}",
-                )
-                return candidate
-            self._tracker.log(
-                f"Ignoring existing rollback wheel {candidate.name}: {'; '.join(errors)}",
-            )
-        return None
-
-    def _select_staged_rollback_wheel(
-        self,
-        *,
-        stage_dir: Path,
-        current_version: str,
-        source_label: str,
-    ) -> Path | None:
-        staged_wheels = sorted(stage_dir.glob("vibesensor-*.whl"), reverse=True)
-        for rollback_wheel in staged_wheels:
-            errors = wheel_metadata_validation_errors(
-                rollback_wheel,
-                expected_name="vibesensor",
-                expected_version=current_version,
-            )
-            if not errors:
-                return rollback_wheel
-            self._tracker.log(
-                f"{source_label} produced unusable wheel {rollback_wheel.name}: "
-                f"{'; '.join(errors)}",
-            )
-        self._tracker.log(
-            f"{source_label} did not produce a usable wheel for {current_version}",
+        self._rollback_snapshot_builder = RollbackSnapshotBuilder(
+            commands=commands,
+            tracker=tracker,
+            repo=config.repo,
+            rollback_dir=config.rollback_dir,
+            rollback_snapshots=rollback_snapshots,
         )
-        return None
-
-    async def _build_local_rollback_wheel(
-        self,
-        *,
-        current_version: str,
-        stage_dir: Path,
-        venv_python: str,
-    ) -> Path | None:
-        package_dir = self._config.repo / "apps" / "server"
-        if not (package_dir / "pyproject.toml").is_file():
-            self._tracker.log(
-                f"Local rollback wheel build skipped: {package_dir / 'pyproject.toml'} not found",
-            )
-            return None
-        rc, _, stderr = await self._commands.run(
-            [
-                venv_python,
-                "-m",
-                "pip",
-                "wheel",
-                "--no-deps",
-                "--no-build-isolation",
-                "-w",
-                str(stage_dir),
-                str(package_dir),
-            ],
-            phase="installing",
-            timeout=60,
-            sudo=False,
+        self._rollback_executor = RollbackExecutor(
+            tracker=tracker,
+            rollback_dir=config.rollback_dir,
+            rollback_snapshots=rollback_snapshots,
+            wheel_validator=wheel_validator,
+            wheel_install_executor=self._wheel_install_executor,
         )
-        if rc != 0:
-            self._tracker.log(
-                "Local rollback wheel build failed "
-                f"(exit {rc}); falling back to package-index download: {stderr}",
-            )
-            return None
-        return self._select_staged_rollback_wheel(
-            stage_dir=stage_dir,
-            current_version=current_version,
-            source_label="Local rollback wheel build",
-        )
-
-    async def _download_rollback_wheel(
-        self,
-        *,
-        current_version: str,
-        stage_dir: Path,
-        venv_python: str,
-    ) -> Path | None:
-        rc, _, stderr = await self._commands.run(
-            [
-                venv_python,
-                "-m",
-                "pip",
-                "download",
-                "--no-deps",
-                "--no-build-isolation",
-                "-d",
-                str(stage_dir),
-                f"vibesensor=={current_version}",
-            ],
-            phase="installing",
-            timeout=60,
-            sudo=False,
-        )
-        if rc != 0:
-            self._tracker.log(
-                f"Package-index rollback download failed (exit {rc}): {stderr}",
-            )
-            return None
-        return self._select_staged_rollback_wheel(
-            stage_dir=stage_dir,
-            current_version=current_version,
-            source_label="Package-index rollback download",
-        )
-
-    def _write_rollback_snapshot(
-        self,
-        *,
-        rollback_wheel: Path,
-        current_version: str,
-    ) -> bool:
-        rollback_sha256 = sha256_file(rollback_wheel)
-        promoted_wheel = self._config.rollback_dir / rollback_wheel.name
-        if rollback_wheel != promoted_wheel:
-            rollback_wheel.replace(promoted_wheel)
-        try:
-            self._rollback_snapshots.write_metadata(
-                RollbackSnapshotMetadata(
-                    version=current_version,
-                    wheel_name=promoted_wheel.name,
-                    sha256=rollback_sha256,
-                ),
-            )
-        except OSError as exc:
-            self._tracker.add_issue(
-                "installing",
-                "Rollback metadata could not be written",
-                str(exc),
-            )
-            return False
-        self._rollback_snapshots.prune_wheels(keep_name=promoted_wheel.name)
-        self._tracker.log(
-            "Rollback snapshot created successfully "
-            f"(wheel={promoted_wheel.name}, sha256={rollback_sha256})",
-        )
-        return True
 
     async def snapshot_for_rollback(self) -> bool:
-        self._config.rollback_dir.mkdir(parents=True, exist_ok=True)
-        venv_python = reinstall_python_executable(self._config.repo)
-        from vibesensor import __version__ as current_version
-
-        self._tracker.log(f"Creating rollback snapshot (version={current_version})")
-        if existing_wheel := self._existing_local_rollback_wheel(current_version=current_version):
-            return self._write_rollback_snapshot(
-                rollback_wheel=existing_wheel,
-                current_version=current_version,
-            )
-        with tempfile.TemporaryDirectory(
-            prefix="vibesensor-rollback-stage-",
-            dir=self._config.rollback_dir.parent,
-        ) as stage_dir_text:
-            stage_dir = Path(stage_dir_text)
-            rollback_wheel = await self._build_local_rollback_wheel(
-                current_version=current_version,
-                stage_dir=stage_dir,
-                venv_python=venv_python,
-            )
-            if rollback_wheel is None:
-                rollback_wheel = await self._download_rollback_wheel(
-                    current_version=current_version,
-                    stage_dir=stage_dir,
-                    venv_python=venv_python,
-                )
-            if rollback_wheel is None:
-                (self._config.rollback_dir / "rollback_version.txt").write_text(
-                    current_version,
-                    encoding="utf-8",
-                )
-                return False
-            return self._write_rollback_snapshot(
-                rollback_wheel=rollback_wheel,
-                current_version=current_version,
-            )
+        return await self._rollback_snapshot_builder.snapshot_for_rollback()
 
     async def install_release(self, wheel_path: Path, expected_version: str) -> bool:
-        if not self._wheel_validator.validate_wheel(
+        install_result = await self._wheel_install_executor.install_release(
             wheel_path,
-            phase="installing",
-            context="Downloaded wheel",
-            fatal=True,
-        ):
-            return False
-        venv_python = reinstall_python_executable(self._config.repo)
-        if not await self._validate_dependency_compatibility(wheel_path, venv_python=venv_python):
-            return False
-        rc, _, stderr = await self._commands.run(
-            [
-                venv_python,
-                "-m",
-                "pip",
-                "install",
-                "--force-reinstall",
-                "--no-deps",
-                str(wheel_path),
-            ],
-            phase="installing",
-            timeout=self._config.reinstall_timeout_s,
-            sudo=False,
+            expected_version,
         )
-        if rc != 0:
-            self._tracker.fail("installing", f"Wheel install failed (exit {rc})", stderr)
-            self._tracker.log("Attempting rollback...")
-            await self.rollback()
-            return False
-
-        installed_version = await self._verify_installed_version(phase="installing")
-        if installed_version is None:
-            self._tracker.log("Attempting rollback...")
-            await self.rollback()
-            return False
-
-        self._tracker.log(f"Installed vibesensor {expected_version}")
-        self._tracker.log(f"Verified installed version: {installed_version}")
-        return True
-
-    async def _validate_dependency_compatibility(
-        self,
-        wheel_path: Path,
-        *,
-        venv_python: str,
-    ) -> bool:
-        metadata = read_wheel_metadata(wheel_path)
-        requirement_names = sorted(
-            {
-                canonicalize_name(Requirement(raw_requirement).name)
-                for raw_requirement in metadata.requires_dist
-            },
-        )
-        if not metadata.requires_python and not requirement_names:
+        if install_result.succeeded:
             return True
-
-        rc, stdout, stderr = await self._commands.run(
-            [
-                venv_python,
-                "-c",
-                _TARGET_ENV_SNAPSHOT_SCRIPT,
-                json.dumps({"distribution_names": requirement_names}),
-            ],
-            phase="installing",
-            timeout=30,
-            sudo=False,
-        )
-        if rc != 0:
-            self._tracker.fail(
-                "installing",
-                f"Could not validate wheel dependency compatibility (exit {rc})",
-                stderr or stdout,
-            )
-            return False
-        try:
-            snapshot = json.loads(stdout or "{}")
-        except json.JSONDecodeError:
-            self._tracker.fail(
-                "installing",
-                "Could not parse wheel dependency compatibility results",
-                stdout or stderr,
-            )
-            return False
-
-        marker_environment_raw = snapshot.get("marker_environment", {})
-        installed_versions_raw = snapshot.get("installed_versions", {})
-        if not isinstance(marker_environment_raw, dict) or not isinstance(
-            installed_versions_raw,
-            dict,
-        ):
-            self._tracker.fail(
-                "installing",
-                "Could not parse wheel dependency compatibility results",
-                stdout or stderr,
-            )
-            return False
-        issues = wheel_dependency_issues(
-            metadata,
-            python_full_version=str(snapshot.get("python_full_version") or ""),
-            marker_environment={
-                str(key): str(value)
-                for key, value in marker_environment_raw.items()
-                if isinstance(key, str)
-            },
-            installed_versions={
-                str(key): str(value)
-                for key, value in installed_versions_raw.items()
-                if isinstance(key, str)
-            },
-        )
-        if issues:
-            self._tracker.fail(
-                "installing",
-                "Downloaded wheel is incompatible with the current environment",
-                "; ".join(issues),
-            )
-            return False
-        self._tracker.log("Validated wheel dependency compatibility against target environment")
-        return True
+        if install_result.rollback_required:
+            self._tracker.log("Attempting rollback...")
+            await self.rollback()
+        return False
 
     async def rollback(self) -> bool:
-        self._tracker.log("Rolling back to previous version...")
-        metadata = self._rollback_snapshots.load_metadata()
-        rollback_wheels = self._rollback_snapshots.rollback_wheels()
-        if not rollback_wheels:
-            self._tracker.add_issue("installing", "No rollback wheel available")
-            return False
-
-        wheel: Path | None = None
-        expected_version = ""
-        candidates: list[tuple[Path, str, str | None]] = []
-        if metadata is not None:
-            primary_wheel = self._config.rollback_dir / metadata.wheel_name
-            candidates.append((primary_wheel, metadata.version, metadata.sha256))
-            for fallback_wheel in rollback_wheels:
-                if fallback_wheel.name == metadata.wheel_name:
-                    continue
-                candidates.append((fallback_wheel, _rollback_wheel_version(fallback_wheel), None))
-        else:
-            self._tracker.log(
-                "Rollback metadata missing; falling back to newest "
-                "rollback wheel without checksum pin",
-            )
-            for fallback_wheel in rollback_wheels:
-                candidates.append((fallback_wheel, _rollback_wheel_version(fallback_wheel), None))
-
-        for idx, (candidate_wheel, candidate_version, candidate_sha256) in enumerate(candidates):
-            if not candidate_wheel.is_file():
-                if idx == 0 and metadata is not None:
-                    self._tracker.add_issue(
-                        "installing",
-                        "Rollback snapshot wheel is missing",
-                        f"metadata expected {candidate_wheel}",
-                    )
-                continue
-            context = "Rollback wheel" if idx == 0 else "Fallback rollback wheel"
-            if not self._wheel_validator.validate_wheel(
-                candidate_wheel,
-                phase="installing",
-                context=context,
-                fatal=False,
-                expected_sha256=candidate_sha256,
-            ):
-                if idx == 0 and len(candidates) > 1:
-                    self._tracker.log(
-                        "Primary rollback snapshot could not be used; trying older rollback wheel"
-                    )
-                continue
-            if idx > 0:
-                self._tracker.log(f"Using fallback rollback wheel {candidate_wheel.name}")
-            wheel = candidate_wheel
-            expected_version = candidate_version
-            break
-        if wheel is None:
-            return False
-
-        venv_python = reinstall_python_executable(self._config.repo)
-        rc, _, stderr = await self._commands.run(
-            [
-                venv_python,
-                "-m",
-                "pip",
-                "install",
-                "--force-reinstall",
-                "--no-deps",
-                str(wheel),
-            ],
-            phase="installing",
-            timeout=self._config.reinstall_timeout_s,
-            sudo=False,
-        )
-        if rc != 0:
-            self._tracker.add_issue(
-                "installing",
-                f"Rollback install failed (exit {rc})",
-                stderr,
-            )
-            return False
-
-        rolled_back_version = await self._verify_installed_version(phase="installing")
-        if rolled_back_version is None:
-            return False
-
-        if expected_version and rolled_back_version != expected_version:
-            self._tracker.add_issue(
-                "installing",
-                "Rolled-back version label mismatch",
-                (
-                    "wheel filename version="
-                    f"{expected_version} but import reports version="
-                    f"{rolled_back_version}; "
-                    "possible wheel naming issue or pip normalisation difference"
-                ),
-            )
-            self._tracker.log(
-                "WARNING: rolled-back version mismatch "
-                f"(wheel={expected_version}, import={rolled_back_version})",
-            )
-        self._tracker.log(f"Rolled back to {wheel.name} (verified version={rolled_back_version})")
-        return True
-
-    async def _verify_installed_version(self, *, phase: str) -> str | None:
-        venv_python = reinstall_python_executable(self._config.repo)
-        rc, stdout, stderr = await self._commands.run(
-            [venv_python, "-c", "from vibesensor import __version__; print(__version__)"],
-            phase=phase,
-            timeout=30,
-            sudo=False,
-        )
-        if rc == 0:
-            return stdout.strip()
-        message = (
-            f"Post-install verification failed (exit {rc})"
-            if phase == "installing"
-            else f"Post-rollback verification failed (exit {rc})"
-        )
-        if phase == "installing":
-            self._tracker.fail(phase, message, stderr)
-        else:
-            self._tracker.add_issue(phase, message, stderr)
-        return None
+        return await self._rollback_executor.rollback()

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -184,7 +184,6 @@ class UpdateManager:
             repo=self._repo,
             rollback_dir=self._rollback_dir,
             reinstall_timeout_s=REINSTALL_OP_TIMEOUT_S,
-            firmware_refresh_timeout_s=ESP_FIRMWARE_REFRESH_TIMEOUT_S,
         )
         self._validation_config = UpdateValidationConfig(
             rollback_dir=self._rollback_dir,
@@ -323,7 +322,7 @@ class UpdateManager:
             commands or self._build_command_executor(),
             self._tracker,
             self._repo,
-            self._installer_config.firmware_refresh_timeout_s,
+            ESP_FIRMWARE_REFRESH_TIMEOUT_S,
         )
 
     def _build_release_application(

--- a/apps/server/vibesensor/use_cases/updates/rollback_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_executor.py
@@ -1,0 +1,148 @@
+"""Rollback candidate selection and execution for updater-managed server wheels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator
+from vibesensor.use_cases.updates.rollback_snapshot import (
+    RollbackSnapshotMetadata,
+    RollbackSnapshotStore,
+)
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.wheel_installation import WheelInstallExecutor
+
+
+def _rollback_wheel_version(wheel_path: Path) -> str:
+    """Extract the version token from a rollback wheel filename when present."""
+
+    wheel_parts = wheel_path.stem.split("-")
+    return wheel_parts[1] if len(wheel_parts) >= 2 else ""
+
+
+@dataclass(frozen=True, slots=True)
+class RollbackCandidate:
+    wheel_path: Path
+    expected_version: str
+    expected_sha256: str | None
+    primary: bool
+
+
+class RollbackExecutor:
+    """Select a rollback candidate and reinstall it after update failure."""
+
+    __slots__ = (
+        "_rollback_dir",
+        "_rollback_snapshots",
+        "_tracker",
+        "_wheel_install_executor",
+        "_wheel_validator",
+    )
+
+    def __init__(
+        self,
+        *,
+        tracker: UpdateStatusTracker,
+        rollback_dir: Path,
+        rollback_snapshots: RollbackSnapshotStore,
+        wheel_validator: WheelArtifactValidator,
+        wheel_install_executor: WheelInstallExecutor,
+    ) -> None:
+        self._tracker = tracker
+        self._rollback_dir = rollback_dir
+        self._rollback_snapshots = rollback_snapshots
+        self._wheel_validator = wheel_validator
+        self._wheel_install_executor = wheel_install_executor
+
+    async def rollback(self) -> bool:
+        self._tracker.log("Rolling back to previous version...")
+        candidate = self._select_candidate()
+        if candidate is None:
+            return False
+        return await self._wheel_install_executor.install_rollback_wheel(
+            candidate.wheel_path,
+            expected_version=candidate.expected_version,
+        )
+
+    def _select_candidate(self) -> RollbackCandidate | None:
+        candidates = self._candidate_list()
+        for index, candidate in enumerate(candidates):
+            if not candidate.wheel_path.is_file():
+                if index == 0 and candidate.primary:
+                    self._tracker.add_issue(
+                        "installing",
+                        "Rollback snapshot wheel is missing",
+                        f"metadata expected {candidate.wheel_path}",
+                    )
+                continue
+            context = "Rollback wheel" if candidate.primary else "Fallback rollback wheel"
+            if not self._wheel_validator.validate_wheel(
+                candidate.wheel_path,
+                phase="installing",
+                context=context,
+                fatal=False,
+                expected_sha256=candidate.expected_sha256,
+            ):
+                if candidate.primary and len(candidates) > 1:
+                    self._tracker.log(
+                        "Primary rollback snapshot could not be used; trying older rollback wheel",
+                    )
+                continue
+            if not candidate.primary:
+                self._tracker.log(f"Using fallback rollback wheel {candidate.wheel_path.name}")
+            return candidate
+        return None
+
+    def _candidate_list(self) -> list[RollbackCandidate]:
+        metadata = self._rollback_snapshots.load_metadata()
+        rollback_wheels = self._rollback_snapshots.rollback_wheels()
+        if not rollback_wheels:
+            self._tracker.add_issue("installing", "No rollback wheel available")
+            return []
+
+        candidates: list[RollbackCandidate] = []
+        if metadata is not None:
+            candidates.extend(self._metadata_candidates(metadata, rollback_wheels=rollback_wheels))
+            return candidates
+
+        self._tracker.log(
+            "Rollback metadata missing; falling back to newest rollback wheel without checksum pin",
+        )
+        for fallback_wheel in rollback_wheels:
+            candidates.append(
+                RollbackCandidate(
+                    wheel_path=fallback_wheel,
+                    expected_version=_rollback_wheel_version(fallback_wheel),
+                    expected_sha256=None,
+                    primary=False,
+                ),
+            )
+        return candidates
+
+    def _metadata_candidates(
+        self,
+        metadata: RollbackSnapshotMetadata,
+        *,
+        rollback_wheels: list[Path],
+    ) -> list[RollbackCandidate]:
+        candidates = [
+            RollbackCandidate(
+                wheel_path=self._rollback_dir / metadata.wheel_name,
+                expected_version=metadata.version,
+                expected_sha256=metadata.sha256,
+                primary=True,
+            ),
+        ]
+        for fallback_wheel in rollback_wheels:
+            if fallback_wheel.name == metadata.wheel_name:
+                continue
+            candidates.append(
+                RollbackCandidate(
+                    wheel_path=fallback_wheel,
+                    expected_version=_rollback_wheel_version(fallback_wheel),
+                    expected_sha256=None,
+                    primary=False,
+                ),
+            )
+        return candidates

--- a/apps/server/vibesensor/use_cases/updates/rollback_snapshot_builder.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_snapshot_builder.py
@@ -1,0 +1,229 @@
+"""Rollback snapshot creation for updater-managed server wheels."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_validation_errors
+from vibesensor.use_cases.updates.rollback_snapshot import (
+    RollbackSnapshotMetadata,
+    RollbackSnapshotStore,
+)
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
+
+
+class RollbackSnapshotBuilder:
+    """Capture the current server wheel into rollback storage before mutation."""
+
+    __slots__ = ("_commands", "_repo", "_rollback_dir", "_rollback_snapshots", "_tracker")
+
+    def __init__(
+        self,
+        *,
+        commands: UpdateCommandExecutor,
+        tracker: UpdateStatusTracker,
+        repo: Path,
+        rollback_dir: Path,
+        rollback_snapshots: RollbackSnapshotStore,
+    ) -> None:
+        self._commands = commands
+        self._tracker = tracker
+        self._repo = repo
+        self._rollback_dir = rollback_dir
+        self._rollback_snapshots = rollback_snapshots
+
+    def _existing_local_rollback_wheel(self, *, current_version: str) -> Path | None:
+        candidates = sorted(
+            self._rollback_dir.glob(f"vibesensor-{current_version}-*.whl"),
+            reverse=True,
+        )
+        for candidate in candidates:
+            errors = wheel_metadata_validation_errors(
+                candidate,
+                expected_name="vibesensor",
+                expected_version=current_version,
+            )
+            if not errors:
+                self._tracker.log(
+                    f"Reusing existing local rollback wheel {candidate.name}",
+                )
+                return candidate
+            self._tracker.log(
+                f"Ignoring existing rollback wheel {candidate.name}: {'; '.join(errors)}",
+            )
+        return None
+
+    def _select_staged_rollback_wheel(
+        self,
+        *,
+        stage_dir: Path,
+        current_version: str,
+        source_label: str,
+    ) -> Path | None:
+        staged_wheels = sorted(stage_dir.glob("vibesensor-*.whl"), reverse=True)
+        for rollback_wheel in staged_wheels:
+            errors = wheel_metadata_validation_errors(
+                rollback_wheel,
+                expected_name="vibesensor",
+                expected_version=current_version,
+            )
+            if not errors:
+                return rollback_wheel
+            self._tracker.log(
+                f"{source_label} produced unusable wheel {rollback_wheel.name}: "
+                f"{'; '.join(errors)}",
+            )
+        self._tracker.log(
+            f"{source_label} did not produce a usable wheel for {current_version}",
+        )
+        return None
+
+    async def _build_local_rollback_wheel(
+        self,
+        *,
+        current_version: str,
+        stage_dir: Path,
+        venv_python: str,
+    ) -> Path | None:
+        package_dir = self._repo / "apps" / "server"
+        if not (package_dir / "pyproject.toml").is_file():
+            self._tracker.log(
+                f"Local rollback wheel build skipped: {package_dir / 'pyproject.toml'} not found",
+            )
+            return None
+        rc, _, stderr = await self._commands.run(
+            [
+                venv_python,
+                "-m",
+                "pip",
+                "wheel",
+                "--no-deps",
+                "--no-build-isolation",
+                "-w",
+                str(stage_dir),
+                str(package_dir),
+            ],
+            phase="installing",
+            timeout=60,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.log(
+                "Local rollback wheel build failed "
+                f"(exit {rc}); falling back to package-index download: {stderr}",
+            )
+            return None
+        return self._select_staged_rollback_wheel(
+            stage_dir=stage_dir,
+            current_version=current_version,
+            source_label="Local rollback wheel build",
+        )
+
+    async def _download_rollback_wheel(
+        self,
+        *,
+        current_version: str,
+        stage_dir: Path,
+        venv_python: str,
+    ) -> Path | None:
+        rc, _, stderr = await self._commands.run(
+            [
+                venv_python,
+                "-m",
+                "pip",
+                "download",
+                "--no-deps",
+                "--no-build-isolation",
+                "-d",
+                str(stage_dir),
+                f"vibesensor=={current_version}",
+            ],
+            phase="installing",
+            timeout=60,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.log(
+                f"Package-index rollback download failed (exit {rc}): {stderr}",
+            )
+            return None
+        return self._select_staged_rollback_wheel(
+            stage_dir=stage_dir,
+            current_version=current_version,
+            source_label="Package-index rollback download",
+        )
+
+    def _write_rollback_snapshot(
+        self,
+        *,
+        rollback_wheel: Path,
+        current_version: str,
+    ) -> bool:
+        from vibesensor.use_cases.updates.artifact_validation import sha256_file
+
+        rollback_sha256 = sha256_file(rollback_wheel)
+        promoted_wheel = self._rollback_dir / rollback_wheel.name
+        if rollback_wheel != promoted_wheel:
+            rollback_wheel.replace(promoted_wheel)
+        try:
+            self._rollback_snapshots.write_metadata(
+                RollbackSnapshotMetadata(
+                    version=current_version,
+                    wheel_name=promoted_wheel.name,
+                    sha256=rollback_sha256,
+                ),
+            )
+        except OSError as exc:
+            self._tracker.add_issue(
+                "installing",
+                "Rollback metadata could not be written",
+                str(exc),
+            )
+            return False
+        self._rollback_snapshots.prune_wheels(keep_name=promoted_wheel.name)
+        self._tracker.log(
+            "Rollback snapshot created successfully "
+            f"(wheel={promoted_wheel.name}, sha256={rollback_sha256})",
+        )
+        return True
+
+    async def snapshot_for_rollback(self) -> bool:
+        self._rollback_dir.mkdir(parents=True, exist_ok=True)
+        venv_python = reinstall_python_executable(self._repo)
+        from vibesensor import __version__ as current_version
+
+        self._tracker.log(f"Creating rollback snapshot (version={current_version})")
+        if existing_wheel := self._existing_local_rollback_wheel(current_version=current_version):
+            return self._write_rollback_snapshot(
+                rollback_wheel=existing_wheel,
+                current_version=current_version,
+            )
+        with tempfile.TemporaryDirectory(
+            prefix="vibesensor-rollback-stage-",
+            dir=self._rollback_dir.parent,
+        ) as stage_dir_text:
+            stage_dir = Path(stage_dir_text)
+            rollback_wheel = await self._build_local_rollback_wheel(
+                current_version=current_version,
+                stage_dir=stage_dir,
+                venv_python=venv_python,
+            )
+            if rollback_wheel is None:
+                rollback_wheel = await self._download_rollback_wheel(
+                    current_version=current_version,
+                    stage_dir=stage_dir,
+                    venv_python=venv_python,
+                )
+            if rollback_wheel is None:
+                (self._rollback_dir / "rollback_version.txt").write_text(
+                    current_version,
+                    encoding="utf-8",
+                )
+                return False
+            return self._write_rollback_snapshot(
+                rollback_wheel=rollback_wheel,
+                current_version=current_version,
+            )

--- a/apps/server/vibesensor/use_cases/updates/wheel_installation.py
+++ b/apps/server/vibesensor/use_cases/updates/wheel_installation.py
@@ -1,0 +1,272 @@
+"""Wheel installation and verification for updater-managed server packages."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+from vibesensor.use_cases.updates.artifact_validation import (
+    WheelArtifactValidator,
+    read_wheel_metadata,
+    wheel_dependency_issues,
+)
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
+
+_TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
+    [
+        "import importlib.metadata as metadata",
+        "import json",
+        "import sys",
+        "from packaging.markers import default_environment",
+        "from packaging.utils import canonicalize_name",
+        "payload = json.loads(sys.argv[1])",
+        "distribution_names = [",
+        "    canonicalize_name(str(name))",
+        "    for name in payload.get('distribution_names', [])",
+        "]",
+        "installed_versions = {}",
+        "for distribution_name in distribution_names:",
+        "    try:",
+        "        installed_versions[distribution_name] = metadata.version(distribution_name)",
+        "    except metadata.PackageNotFoundError:",
+        "        installed_versions[distribution_name] = ''",
+        "marker_environment = default_environment()",
+        "print(json.dumps({",
+        "    'python_full_version': marker_environment.get('python_full_version', ''),",
+        "    'marker_environment': marker_environment,",
+        "    'installed_versions': installed_versions,",
+        "}))",
+    ],
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WheelInstallResult:
+    succeeded: bool
+    rollback_required: bool = False
+
+
+class WheelInstallExecutor:
+    """Install and verify server wheels after updater policy chooses an action."""
+
+    __slots__ = ("_commands", "_reinstall_timeout_s", "_repo", "_tracker", "_wheel_validator")
+
+    def __init__(
+        self,
+        *,
+        commands: UpdateCommandExecutor,
+        tracker: UpdateStatusTracker,
+        repo: Path,
+        reinstall_timeout_s: float,
+        wheel_validator: WheelArtifactValidator,
+    ) -> None:
+        self._commands = commands
+        self._tracker = tracker
+        self._repo = repo
+        self._reinstall_timeout_s = reinstall_timeout_s
+        self._wheel_validator = wheel_validator
+
+    async def install_release(self, wheel_path: Path, expected_version: str) -> WheelInstallResult:
+        """Install a newly downloaded release wheel and report rollback policy needs."""
+
+        if not self._wheel_validator.validate_wheel(
+            wheel_path,
+            phase="installing",
+            context="Downloaded wheel",
+            fatal=True,
+        ):
+            return WheelInstallResult(succeeded=False)
+
+        venv_python = reinstall_python_executable(self._repo)
+        if not await self._validate_dependency_compatibility(wheel_path, venv_python=venv_python):
+            return WheelInstallResult(succeeded=False)
+
+        rc, _, stderr = await self._commands.run(
+            [
+                venv_python,
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "--no-deps",
+                str(wheel_path),
+            ],
+            phase="installing",
+            timeout=self._reinstall_timeout_s,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.fail("installing", f"Wheel install failed (exit {rc})", stderr)
+            return WheelInstallResult(succeeded=False, rollback_required=True)
+
+        installed_version = await self._verify_installed_version(
+            failure_message_prefix="Post-install verification failed",
+            fatal=True,
+        )
+        if installed_version is None:
+            return WheelInstallResult(succeeded=False, rollback_required=True)
+
+        self._tracker.log(f"Installed vibesensor {expected_version}")
+        self._tracker.log(f"Verified installed version: {installed_version}")
+        return WheelInstallResult(succeeded=True)
+
+    async def install_rollback_wheel(self, wheel_path: Path, *, expected_version: str) -> bool:
+        """Install a previously captured rollback wheel without recursive fallback."""
+
+        venv_python = reinstall_python_executable(self._repo)
+        rc, _, stderr = await self._commands.run(
+            [
+                venv_python,
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "--no-deps",
+                str(wheel_path),
+            ],
+            phase="installing",
+            timeout=self._reinstall_timeout_s,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.add_issue(
+                "installing",
+                f"Rollback install failed (exit {rc})",
+                stderr,
+            )
+            return False
+
+        rolled_back_version = await self._verify_installed_version(
+            failure_message_prefix="Post-rollback verification failed",
+            fatal=False,
+        )
+        if rolled_back_version is None:
+            return False
+
+        if expected_version and rolled_back_version != expected_version:
+            self._tracker.add_issue(
+                "installing",
+                "Rolled-back version label mismatch",
+                (
+                    "wheel filename version="
+                    f"{expected_version} but import reports version="
+                    f"{rolled_back_version}; "
+                    "possible wheel naming issue or pip normalisation difference"
+                ),
+            )
+            self._tracker.log(
+                "WARNING: rolled-back version mismatch "
+                f"(wheel={expected_version}, import={rolled_back_version})",
+            )
+        self._tracker.log(
+            f"Rolled back to {wheel_path.name} (verified version={rolled_back_version})",
+        )
+        return True
+
+    async def _validate_dependency_compatibility(
+        self,
+        wheel_path: Path,
+        *,
+        venv_python: str,
+    ) -> bool:
+        metadata = read_wheel_metadata(wheel_path)
+        requirement_names = sorted(
+            {
+                canonicalize_name(Requirement(raw_requirement).name)
+                for raw_requirement in metadata.requires_dist
+            },
+        )
+        if not metadata.requires_python and not requirement_names:
+            return True
+
+        rc, stdout, stderr = await self._commands.run(
+            [
+                venv_python,
+                "-c",
+                _TARGET_ENV_SNAPSHOT_SCRIPT,
+                json.dumps({"distribution_names": requirement_names}),
+            ],
+            phase="installing",
+            timeout=30,
+            sudo=False,
+        )
+        if rc != 0:
+            self._tracker.fail(
+                "installing",
+                f"Could not validate wheel dependency compatibility (exit {rc})",
+                stderr or stdout,
+            )
+            return False
+        try:
+            snapshot = json.loads(stdout or "{}")
+        except json.JSONDecodeError:
+            self._tracker.fail(
+                "installing",
+                "Could not parse wheel dependency compatibility results",
+                stdout or stderr,
+            )
+            return False
+
+        marker_environment_raw = snapshot.get("marker_environment", {})
+        installed_versions_raw = snapshot.get("installed_versions", {})
+        if not isinstance(marker_environment_raw, dict) or not isinstance(
+            installed_versions_raw,
+            dict,
+        ):
+            self._tracker.fail(
+                "installing",
+                "Could not parse wheel dependency compatibility results",
+                stdout or stderr,
+            )
+            return False
+        issues = wheel_dependency_issues(
+            metadata,
+            python_full_version=str(snapshot.get("python_full_version") or ""),
+            marker_environment={
+                str(key): str(value)
+                for key, value in marker_environment_raw.items()
+                if isinstance(key, str)
+            },
+            installed_versions={
+                str(key): str(value)
+                for key, value in installed_versions_raw.items()
+                if isinstance(key, str)
+            },
+        )
+        if issues:
+            self._tracker.fail(
+                "installing",
+                "Downloaded wheel is incompatible with the current environment",
+                "; ".join(issues),
+            )
+            return False
+        self._tracker.log("Validated wheel dependency compatibility against target environment")
+        return True
+
+    async def _verify_installed_version(
+        self,
+        *,
+        failure_message_prefix: str,
+        fatal: bool,
+    ) -> str | None:
+        venv_python = reinstall_python_executable(self._repo)
+        rc, stdout, stderr = await self._commands.run(
+            [venv_python, "-c", "from vibesensor import __version__; print(__version__)"],
+            phase="installing",
+            timeout=30,
+            sudo=False,
+        )
+        if rc == 0:
+            return stdout.strip()
+        message = f"{failure_message_prefix} (exit {rc})"
+        if fatal:
+            self._tracker.fail("installing", message, stderr)
+        else:
+            self._tracker.add_issue("installing", message, stderr)
+        return None


### PR DESCRIPTION
## Summary
- split the updater artifact lifecycle so `UpdateInstaller` is now a small policy facade over `WheelInstallExecutor`, `RollbackSnapshotBuilder`, and `RollbackExecutor`
- remove firmware-refresh configuration leakage from `UpdateInstallerConfig`; firmware refresh timeout is now owned at the manager/firmware boundary instead of installer wiring
- tighten firmware asset download cleanup so temporary-file/fd cleanup happens in `finally` without a broad `BaseException` catch

## Architecture issues addressed
- update install/rollback logic no longer mixes snapshot capture, wheel installation, rollback candidate selection, and rollback execution in one class
- install execution now reports whether rollback is required, keeping rollback policy out of low-level pip/install code
- installer configuration no longer carries unrelated firmware refresh settings

## Backward-incompatible changes
- `UpdateInstallerConfig` no longer accepts `firmware_refresh_timeout_s`
- the old monolithic `UpdateInstaller` internals were deleted and replaced by focused collaborators (`wheel_installation.py`, `rollback_snapshot_builder.py`, `rollback_executor.py`)

## Deleted compatibility / obsolete paths
- deleted the mixed install/rollback/snapshot implementation that lived directly inside `installer.py`
- removed the firmware timeout field from installer config instead of preserving cross-subsystem config coupling
- removed the broad cleanup catch in `firmware_release_fetcher._download_asset()`

## Local tests
- `python -m pytest -q tests/use_cases/updates tests/integration/test_io_and_time_guard_regressions.py tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `python -m ruff check vibesensor/use_cases/updates tests/use_cases/updates/test_update_installer_verification.py tests/integration/test_io_and_time_guard_regressions.py tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `python -m mypy vibesensor`
