### PR TITLE
Split processing-loop failure policy

### DIFF
--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -170,7 +170,8 @@ def _make_state(
 ) -> RuntimeState:
     from vibesensor.app.runtime_state import RuntimeState
     from vibesensor.infra.runtime import RuntimeHealthState
-    from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingLoopState
+    from vibesensor.infra.runtime.processing_loop import ProcessingLoop
+    from vibesensor.infra.runtime.processing_state import ProcessingLoopState
     from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 
     registry = _StubRegistry(clients)

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -9,15 +9,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibesensor.infra.runtime.processing_loop import (
+from vibesensor.infra.runtime.processing_failure_policy import (
     MAX_CONSECUTIVE_FAILURES,
     MAX_FATAL_BACKOFF_CYCLES,
-    ProcessingHealth,
-    ProcessingLoop,
-    ProcessingLoopError,
-    ProcessingLoopState,
 )
+from vibesensor.infra.runtime.processing_failures import (
+    ProcessingFailureCategory,
+    ProcessingTickFailure,
+)
+from vibesensor.infra.runtime.processing_loop import ProcessingLoop
+from vibesensor.infra.runtime.processing_state import ProcessingHealth, ProcessingLoopState
 from vibesensor.shared.exceptions import ProcessingError
+from vibesensor.shared.runtime_failures import ProcessingLoopFailure
 
 # ---------------------------------------------------------------------------
 # Minimal stubs
@@ -135,7 +138,7 @@ class TestProcessingLoopFailureTracking:
 
     @pytest.mark.asyncio
     async def test_single_failure_records_category_and_count(self) -> None:
-        """A single ProcessingLoopError records category and increments failure count."""
+        """A single processing tick failure records category and increments failure count."""
         processor = _StubProcessor(fail_count=1)
         loop, state = _make_loop(processor=processor)
 
@@ -172,7 +175,7 @@ class TestProcessingLoopFailureTracking:
         await _run_loop(loop, max_ticks=MAX_CONSECUTIVE_FAILURES + 2)
 
         assert state.processing_state == ProcessingHealth.OK
-        assert state.fatal_backoff_cycles == 0
+        assert state.tick_count == 1
         assert state.last_failure_category == "compute_all"
 
     @pytest.mark.asyncio
@@ -187,11 +190,10 @@ class TestProcessingLoopFailureTracking:
             await original_sleep(0)
 
         with patch("asyncio.sleep", _fast_sleep):
-            with pytest.raises(RuntimeError, match="persistent processing failure"):
+            with pytest.raises(ProcessingLoopFailure, match="Processing loop remained unhealthy"):
                 await loop.run()
 
         assert state.processing_state == ProcessingHealth.FATAL
-        assert state.fatal_backoff_cycles == MAX_FATAL_BACKOFF_CYCLES
 
     @pytest.mark.asyncio
     async def test_programmer_bug_propagates_from_ingress_state(self) -> None:
@@ -355,10 +357,10 @@ class TestProcessingLoopCleanup:
         processor = _StubProcessor(fail_count=1)
         loop, _state = _make_loop(processor=processor, registry=registry)
 
-        with pytest.raises(ProcessingLoopError, match="stub compute_all failure") as exc_info:
+        with pytest.raises(ProcessingTickFailure, match="stub compute_all failure") as exc_info:
             await loop._run_tick(sync_clock=False)
 
-        assert exc_info.value.category == "compute_all"
+        assert exc_info.value.category is ProcessingFailureCategory.COMPUTE_ALL
         assert processor.compute_call_args == [
             (
                 ["stay", "drop"],

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -122,10 +122,8 @@ def _make_runtime(**overrides: Any):
     import vibesensor.infra.runtime as runtime_module
     from vibesensor.app.runtime_state import RuntimeState
     from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
-    from vibesensor.infra.runtime.processing_loop import (
-        ProcessingLoop,
-        ProcessingLoopState,
-    )
+    from vibesensor.infra.runtime.processing_loop import ProcessingLoop
+    from vibesensor.infra.runtime.processing_state import ProcessingLoopState
     from vibesensor.infra.runtime.ws_broadcast import (
         WsBroadcastService,
     )

--- a/apps/server/tests/use_cases/test_system_health.py
+++ b/apps/server/tests/use_cases/test_system_health.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 from vibesensor.infra.runtime.health_snapshot import build_system_health_snapshot
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.processing_loop import ProcessingHealth, ProcessingLoopState
+from vibesensor.infra.runtime.processing_state import ProcessingHealth, ProcessingLoopState
 from vibesensor.shared.types.payload_types import IntakeStatsPayload, WorkerPoolStats
 
 

--- a/apps/server/vibesensor/adapters/http/dependencies.py
+++ b/apps/server/vibesensor/adapters/http/dependencies.py
@@ -14,7 +14,7 @@ from vibesensor.adapters.http.models import (
 from vibesensor.infra.config.settings_store import SettingsStore
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
+from vibesensor.infra.runtime.processing_state import ProcessingLoopState
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.use_cases.history.exports import HistoryExportDownload
 from vibesensor.use_cases.history.reports import HistoryReportPdf

--- a/apps/server/vibesensor/adapters/http/health.py
+++ b/apps/server/vibesensor/adapters/http/health.py
@@ -12,7 +12,7 @@ from vibesensor.infra.runtime.health_snapshot import build_system_health_snapsho
 if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
     from vibesensor.infra.runtime.health_state import RuntimeHealthState
-    from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
+    from vibesensor.infra.runtime.processing_state import ProcessingLoopState
     from vibesensor.infra.runtime.registry import ClientRegistry
     from vibesensor.use_cases.run import RunRecorder
 

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -34,7 +34,8 @@ from vibesensor.infra.config.speed_source_runtime import (
 )
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingLoopState
+from vibesensor.infra.runtime.processing_loop import ProcessingLoop
+from vibesensor.infra.runtime.processing_state import ProcessingLoopState
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.workers.worker_pool import WorkerPool

--- a/apps/server/vibesensor/app/runtime_state.py
+++ b/apps/server/vibesensor/app/runtime_state.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING
 
 from vibesensor.adapters.http.dependencies import RouterDeps
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.processing_loop import ProcessingLoop, ProcessingLoopState
+from vibesensor.infra.runtime.processing_loop import ProcessingLoop
+from vibesensor.infra.runtime.processing_state import ProcessingLoopState
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.workers.worker_pool import WorkerPool
 from vibesensor.shared.ports import ClientTracker, SettingsReader, SignalSource

--- a/apps/server/vibesensor/infra/runtime/__init__.py
+++ b/apps/server/vibesensor/infra/runtime/__init__.py
@@ -11,7 +11,10 @@ Submodules
 - ``health_snapshot``: runtime health snapshot assembly for HTTP/read-side consumers
 - ``health_state``: mutable startup and background-task health state
 - ``registry_updates``: DATA-message dedup/reset bookkeeping
-- ``processing_loop``: ProcessingLoop (async tick loop + failure tracking)
+- ``processing_failures``: typed per-tick runtime failure categories
+- ``processing_failure_policy``: retry/backoff/escalation policy for processing failures
+- ``processing_state``: observable processing-loop health and timing state
+- ``processing_loop``: ProcessingLoop (async tick scheduling over execution + failure policy)
 - ``task_supervisor``: TaskSupervisor (managed restart policy + backoff)
 - ``udp_transport_lifecycle``: UdpTransportLifecycle (UDP startup + cleanup seam)
 - ``ws_broadcast``: WsBroadcastService (payload assembly + cache)
@@ -20,7 +23,7 @@ Submodules
 """
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.processing_loop import ProcessingLoopState
+from vibesensor.infra.runtime.processing_state import ProcessingLoopState
 
 __all__ = [
     "ProcessingLoopState",

--- a/apps/server/vibesensor/infra/runtime/health_snapshot.py
+++ b/apps/server/vibesensor/infra/runtime/health_snapshot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Literal, Protocol
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
-from vibesensor.infra.runtime.processing_loop import ProcessingHealth, ProcessingLoopState
+from vibesensor.infra.runtime.processing_state import ProcessingHealth, ProcessingLoopState
 from vibesensor.shared.types.health_snapshot import HealthSnapshotData, RunRecorderHealthSnapshot
 from vibesensor.shared.types.payload_types import IntakeStatsPayload
 

--- a/apps/server/vibesensor/infra/runtime/processing_failure_policy.py
+++ b/apps/server/vibesensor/infra/runtime/processing_failure_policy.py
@@ -1,0 +1,146 @@
+"""Retry, backoff, and escalation policy for runtime processing failures."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from vibesensor.shared.failure_utils import bounded_failure_message
+from vibesensor.shared.runtime_failures import ProcessingLoopFailure
+
+from .processing_failures import ProcessingTickFailure
+from .processing_state import ProcessingHealth, ProcessingLoopState
+
+MAX_CONSECUTIVE_FAILURES = 25
+"""After this many consecutive processing failures, enter fatal backoff."""
+
+FAILURE_BACKOFF_S = 5
+"""Seconds to sleep on fatal failure threshold before retrying the loop."""
+
+MAX_FATAL_BACKOFF_CYCLES = 3
+"""After this many fatal backoff cycles, escalate to a managed task failure."""
+
+_MAX_FAILURE_MESSAGE_LEN = 240
+_MAX_RETRY_DELAY_S = 5.0
+_MAX_BACKOFF_EXPONENT = 6
+
+__all__ = [
+    "FAILURE_BACKOFF_S",
+    "MAX_CONSECUTIVE_FAILURES",
+    "MAX_FATAL_BACKOFF_CYCLES",
+    "ProcessingFailurePolicy",
+]
+
+
+class ProcessingFailurePolicy:
+    """Own categorized failure accounting, retry delay, and fatal escalation."""
+
+    __slots__ = (
+        "_consecutive_failures",
+        "_failure_backoff_s",
+        "_fatal_backoff_cycles",
+        "_logger",
+        "_max_consecutive_failures",
+        "_max_fatal_backoff_cycles",
+        "_max_retry_delay_s",
+    )
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger,
+        max_consecutive_failures: int = MAX_CONSECUTIVE_FAILURES,
+        failure_backoff_s: float = FAILURE_BACKOFF_S,
+        max_fatal_backoff_cycles: int = MAX_FATAL_BACKOFF_CYCLES,
+        max_retry_delay_s: float = _MAX_RETRY_DELAY_S,
+    ) -> None:
+        self._logger = logger
+        self._max_consecutive_failures = max_consecutive_failures
+        self._failure_backoff_s = failure_backoff_s
+        self._max_fatal_backoff_cycles = max_fatal_backoff_cycles
+        self._max_retry_delay_s = max_retry_delay_s
+        self._consecutive_failures = 0
+        self._fatal_backoff_cycles = 0
+
+    @property
+    def fatal_backoff_cycles(self) -> int:
+        return self._fatal_backoff_cycles
+
+    def record_success(self, state: ProcessingLoopState, *, tick_duration_s: float) -> None:
+        state.last_tick_duration_s = tick_duration_s
+        if tick_duration_s > state.max_tick_duration_s:
+            state.max_tick_duration_s = tick_duration_s
+        state.tick_count += 1
+        state.processing_state = ProcessingHealth.OK
+        self._consecutive_failures = 0
+        self._fatal_backoff_cycles = 0
+
+    async def record_failure(
+        self,
+        state: ProcessingLoopState,
+        failure: ProcessingTickFailure,
+        *,
+        interval_s: float,
+    ) -> float:
+        self._consecutive_failures += 1
+        category = failure.category.value
+        state.processing_failure_count += 1
+        state.last_failure_category = category
+        state.last_failure_message = bounded_failure_message(
+            failure.cause,
+            max_length=_MAX_FAILURE_MESSAGE_LEN,
+        )
+        state.processing_failure_categories[category] = (
+            state.processing_failure_categories.get(category, 0) + 1
+        )
+        is_fatal = self._consecutive_failures >= self._max_consecutive_failures
+        state.processing_state = ProcessingHealth.FATAL if is_fatal else ProcessingHealth.DEGRADED
+        self._logger.warning(
+            "Processing loop tick failed in %s; will retry.",
+            category,
+            exc_info=(type(failure.cause), failure.cause, failure.cause.__traceback__),
+        )
+        if is_fatal:
+            return await self._handle_fatal_backoff(state, failure, interval_s=interval_s)
+        retry_delay_s = interval_s * float(
+            2 ** min(_MAX_BACKOFF_EXPONENT, self._consecutive_failures)
+        )
+        return self._max_retry_delay_s if retry_delay_s > self._max_retry_delay_s else retry_delay_s
+
+    async def _handle_fatal_backoff(
+        self,
+        state: ProcessingLoopState,
+        failure: ProcessingTickFailure,
+        *,
+        interval_s: float,
+    ) -> float:
+        self._fatal_backoff_cycles += 1
+        if self._fatal_backoff_cycles >= self._max_fatal_backoff_cycles:
+            self._logger.error(
+                "Processing loop exceeded %d fatal backoff cycles; "
+                "escalating to a managed task failure.",
+                self._max_fatal_backoff_cycles,
+            )
+            raise ProcessingLoopFailure(
+                fatal_backoff_cycles=self._fatal_backoff_cycles,
+                failure_category=failure.category.value,
+                cause=failure.cause,
+            ) from failure.cause
+        self._logger.error(
+            "Processing loop hit %d failures; backing off %s s (fatal cycle %d/%d)",
+            self._max_consecutive_failures,
+            self._failure_backoff_s,
+            self._fatal_backoff_cycles,
+            self._max_fatal_backoff_cycles,
+        )
+        await asyncio.sleep(self._failure_backoff_s)
+        state.processing_state = ProcessingHealth.DEGRADED
+        self._logger.info(
+            "Processing loop resuming after fatal-backoff cycle %d/%d; "
+            "total failure count so far: %d",
+            self._fatal_backoff_cycles,
+            self._max_fatal_backoff_cycles,
+            state.processing_failure_count,
+        )
+        self._consecutive_failures = 0
+        return interval_s

--- a/apps/server/vibesensor/infra/runtime/processing_failures.py
+++ b/apps/server/vibesensor/infra/runtime/processing_failures.py
@@ -1,0 +1,26 @@
+"""Typed failure categories for one processing tick."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from vibesensor.shared.exceptions import ProcessingError
+
+__all__ = ["ProcessingFailureCategory", "ProcessingTickFailure"]
+
+
+class ProcessingFailureCategory(StrEnum):
+    """Stable categories for operational processing-tick failures."""
+
+    SYNC_CLOCK = "sync_clock"
+    COMPUTE_ALL = "compute_all"
+    EVICT_CLIENTS = "evict_clients"
+
+
+class ProcessingTickFailure(ProcessingError):
+    """Categorized operational processing-tick failure."""
+
+    def __init__(self, category: ProcessingFailureCategory, cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.category = category
+        self.cause = cause

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -1,23 +1,18 @@
-"""ProcessingLoop – async tick loop with failure tracking.
-
-Owns:
-- ``ProcessingLoopState`` dataclass (failure counters + mismatch guards)
-- The ~100 ms tick coroutine that evicts stale clients and computes metrics
-"""
+"""ProcessingLoop – async tick scheduling over tick execution and failure policy."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 import time
-from dataclasses import dataclass, field
-from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from vibesensor.shared.failure_utils import bounded_failure_message
 from vibesensor.shared.ports import ClockSyncBroadcaster
 
-from .processing_tick import ProcessingLoopError, ProcessingTickRunner
+from .processing_failure_policy import ProcessingFailurePolicy
+from .processing_failures import ProcessingTickFailure
+from .processing_state import ProcessingLoopState
+from .processing_tick import ProcessingTickRunner
 
 if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
@@ -25,51 +20,12 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-MAX_CONSECUTIVE_FAILURES = 25
-"""After this many consecutive processing failures, enter fatal backoff."""
-
-FAILURE_BACKOFF_S = 5
-"""Seconds to sleep on fatal failure threshold before resetting."""
-
-MAX_FATAL_BACKOFF_CYCLES = 3
-"""After this many fatal backoff cycles, escalate to a managed task failure."""
-
-_MAX_FAILURE_MESSAGE_LEN = 240
-
-
-class ProcessingHealth(StrEnum):
-    """Health status of the processing loop."""
-
-    OK = "ok"
-    DEGRADED = "degraded"
-    FATAL = "fatal"
-
-
-@dataclass(slots=True)
-class ProcessingLoopState:
-    """Mutable tracking state for the processing loop.
-
-    Failure counters and mismatch log-guards form a coherent,
-    narrowly-scoped unit.
-    """
-
-    processing_state: ProcessingHealth = ProcessingHealth.OK
-    processing_failure_count: int = 0
-    processing_failure_categories: dict[str, int] = field(default_factory=dict)
-    last_failure_category: str | None = None
-    last_failure_message: str | None = None
-    sample_rate_mismatch_logged: set[str] = field(default_factory=set)
-    frame_size_mismatch_logged: set[str] = field(default_factory=set)
-    last_tick_duration_s: float = 0.0
-    max_tick_duration_s: float = 0.0
-    tick_count: int = 0
-    fatal_backoff_cycles: int = 0
-
 
 class ProcessingLoop:
     """Async processing tick loop: evict stale clients, compute metrics, handle failures."""
 
     __slots__ = (
+        "_failure_policy",
         "_fft_update_hz",
         "_tick_runner",
         "state",
@@ -85,9 +41,11 @@ class ProcessingLoop:
         registry: ClientRegistry,
         processor: SignalProcessor,
         control_plane: ClockSyncBroadcaster | None = None,
+        failure_policy: ProcessingFailurePolicy | None = None,
     ) -> None:
         self.state = state
         self._fft_update_hz = fft_update_hz
+        self._failure_policy = failure_policy or ProcessingFailurePolicy(logger=LOGGER)
         self._tick_runner = ProcessingTickRunner(
             state=state,
             sample_rate_hz=sample_rate_hz,
@@ -97,61 +55,16 @@ class ProcessingLoop:
             control_plane=control_plane,
         )
 
-    @staticmethod
-    def _truncate_failure_message(exc: Exception) -> str:
-        return bounded_failure_message(exc, max_length=_MAX_FAILURE_MESSAGE_LEN)
-
-    def _record_failure(self, category: str, exc: Exception) -> None:
-        state = self.state
-        state.processing_failure_count += 1
-        state.last_failure_category = category
-        state.last_failure_message = self._truncate_failure_message(exc)
-        state.processing_failure_categories[category] = (
-            state.processing_failure_categories.get(category, 0) + 1
-        )
-
-    async def _handle_fatal_backoff(self) -> int:
-        state = self.state
-        state.fatal_backoff_cycles += 1
-        if state.fatal_backoff_cycles >= MAX_FATAL_BACKOFF_CYCLES:
-            message = (
-                "persistent processing failure after "
-                f"{state.fatal_backoff_cycles} fatal backoff cycles"
-            )
-            LOGGER.error(
-                "Processing loop exceeded %d fatal backoff cycles; escalating to a "
-                "managed task failure.",
-                MAX_FATAL_BACKOFF_CYCLES,
-            )
-            raise RuntimeError(message)
-        LOGGER.error(
-            "Processing loop hit %d failures; backing off %d s (fatal cycle %d/%d)",
-            MAX_CONSECUTIVE_FAILURES,
-            FAILURE_BACKOFF_S,
-            state.fatal_backoff_cycles,
-            MAX_FATAL_BACKOFF_CYCLES,
-        )
-        await asyncio.sleep(FAILURE_BACKOFF_S)
-        state.processing_state = ProcessingHealth.DEGRADED
-        LOGGER.info(
-            "Processing loop resuming after fatal-backoff cycle %d/%d; "
-            "total failure count so far: %d",
-            state.fatal_backoff_cycles,
-            MAX_FATAL_BACKOFF_CYCLES,
-            state.processing_failure_count,
-        )
-        return 0
-
     async def _run_tick(self, *, sync_clock: bool) -> None:
         await self._tick_runner.run(sync_clock=sync_clock)
 
     async def run(self) -> None:
         """~100 ms tick loop: evict stale clients, compute metrics, handle failures."""
         interval = 1.0 / max(1, self._fft_update_hz)
-        consecutive_failures = 0
         _sync_clock_tick = 0
         _SYNC_CLOCK_EVERY_N_TICKS = max(1, int(5.0 / interval))  # ~every 5 s
         while True:
+            delay = interval
             try:
                 _sync_clock_tick += 1
                 sync_clock = False
@@ -161,30 +74,11 @@ class ProcessingLoop:
                 tick_start = time.monotonic()
                 await self._run_tick(sync_clock=sync_clock)
                 tick_dur = time.monotonic() - tick_start
-                self.state.last_tick_duration_s = tick_dur
-                if tick_dur > self.state.max_tick_duration_s:
-                    self.state.max_tick_duration_s = tick_dur
-                self.state.tick_count += 1
-                consecutive_failures = 0
-                self.state.processing_state = ProcessingHealth.OK
-                self.state.fatal_backoff_cycles = 0
-            except ProcessingLoopError as exc:
-                consecutive_failures += 1
-                self._record_failure(exc.category, exc.cause)
-                is_fatal = consecutive_failures >= MAX_CONSECUTIVE_FAILURES
-                self.state.processing_state = (
-                    ProcessingHealth.FATAL if is_fatal else ProcessingHealth.DEGRADED
+                self._failure_policy.record_success(self.state, tick_duration_s=tick_dur)
+            except ProcessingTickFailure as failure:
+                delay = await self._failure_policy.record_failure(
+                    self.state,
+                    failure,
+                    interval_s=interval,
                 )
-                LOGGER.warning(
-                    "Processing loop tick failed in %s; will retry.",
-                    exc.category,
-                    exc_info=True,
-                )
-                if is_fatal:
-                    consecutive_failures = await self._handle_fatal_backoff()
-            delay = (
-                interval
-                if consecutive_failures == 0
-                else min(5.0, interval * (2 ** min(6, consecutive_failures)))
-            )
             await asyncio.sleep(delay)

--- a/apps/server/vibesensor/infra/runtime/processing_state.py
+++ b/apps/server/vibesensor/infra/runtime/processing_state.py
@@ -1,0 +1,30 @@
+"""Observable processing-loop state exposed to health reporting and runtime wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class ProcessingHealth(StrEnum):
+    """Health status of the processing loop."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    FATAL = "fatal"
+
+
+@dataclass(slots=True)
+class ProcessingLoopState:
+    """Mutable health and timing state for the runtime processing loop."""
+
+    processing_state: ProcessingHealth = ProcessingHealth.OK
+    processing_failure_count: int = 0
+    processing_failure_categories: dict[str, int] = field(default_factory=dict)
+    last_failure_category: str | None = None
+    last_failure_message: str | None = None
+    sample_rate_mismatch_logged: set[str] = field(default_factory=set)
+    frame_size_mismatch_logged: set[str] = field(default_factory=set)
+    last_tick_duration_s: float = 0.0
+    max_tick_duration_s: float = 0.0
+    tick_count: int = 0

--- a/apps/server/vibesensor/infra/runtime/processing_tick.py
+++ b/apps/server/vibesensor/infra/runtime/processing_tick.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Protocol
 from vibesensor.shared.exceptions import ProcessingError
 from vibesensor.shared.ports import ClockSyncBroadcaster
 
+from .processing_failures import ProcessingFailureCategory, ProcessingTickFailure
+
 if TYPE_CHECKING:
     from vibesensor.infra.processing import SignalProcessor
     from vibesensor.infra.runtime.registry import ClientRegistry
@@ -19,15 +21,6 @@ _OPERATIONAL_PROCESSING_EXCEPTIONS = (OSError, ProcessingError)
 
 STALE_DATA_AGE_S = 2.0
 """Clients without fresh UDP data within this window are excluded from spectrum output."""
-
-
-class ProcessingLoopError(ProcessingError):
-    """Categorized processing-loop failure with a stable health-reporting key."""
-
-    def __init__(self, category: str, cause: Exception) -> None:
-        super().__init__(str(cause))
-        self.category = category
-        self.cause = cause
 
 
 class ProcessingTickState(Protocol):
@@ -68,7 +61,7 @@ class ProcessingTickRunner:
         if sync_clock:
             await self._sync_clock()
         compute_client_ids, sample_rates = self._collect_compute_clients()
-        await self._compute_and_publish(
+        await self._compute_and_evict_clients(
             compute_client_ids=compute_client_ids,
             sample_rates=sample_rates,
         )
@@ -79,7 +72,7 @@ class ProcessingTickRunner:
         try:
             await asyncio.to_thread(self._control_plane.broadcast_sync_clock)
         except OSError as exc:
-            raise ProcessingLoopError("sync_clock", exc) from exc
+            raise ProcessingTickFailure(ProcessingFailureCategory.SYNC_CLOCK, exc) from exc
 
     def _collect_compute_clients(self) -> tuple[list[str], dict[str, int]]:
         self._registry.evict_stale()
@@ -131,13 +124,13 @@ class ProcessingTickRunner:
             self._fft_n,
         )
 
-    async def _compute_and_publish(
+    async def _compute_and_evict_clients(
         self,
         *,
         compute_client_ids: list[str],
         sample_rates: dict[str, int],
     ) -> None:
-        compute_error: Exception | None = None
+        compute_failure: ProcessingTickFailure | None = None
         try:
             await asyncio.to_thread(
                 self._processor.compute_all,
@@ -145,19 +138,22 @@ class ProcessingTickRunner:
                 sample_rates_hz=sample_rates,
             )
         except _OPERATIONAL_PROCESSING_EXCEPTIONS as exc:
-            compute_error = exc
+            compute_failure = ProcessingTickFailure(
+                ProcessingFailureCategory.COMPUTE_ALL,
+                exc,
+            )
 
         try:
             self._processor.evict_clients(set(self._registry.active_client_ids()))
         except _OPERATIONAL_PROCESSING_EXCEPTIONS as exc:
-            if compute_error is not None:
+            if compute_failure is not None:
                 LOGGER.warning(
                     "Processing loop cleanup also failed after compute_all failure; "
                     "reporting compute_all as the primary error.",
                     exc_info=True,
                 )
-                raise ProcessingLoopError("compute_all", compute_error) from compute_error
-            raise ProcessingLoopError("publish_metrics", exc) from exc
+                raise compute_failure from compute_failure.cause
+            raise ProcessingTickFailure(ProcessingFailureCategory.EVICT_CLIENTS, exc) from exc
 
-        if compute_error is not None:
-            raise ProcessingLoopError("compute_all", compute_error) from compute_error
+        if compute_failure is not None:
+            raise compute_failure from compute_failure.cause

--- a/apps/server/vibesensor/shared/runtime_failures.py
+++ b/apps/server/vibesensor/shared/runtime_failures.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from vibesensor.shared.failure_utils import bounded_failure_message
 
-__all__ = ["BroadcastTickLoopFailure"]
+__all__ = ["BroadcastTickLoopFailure", "ProcessingLoopFailure"]
 
 
 class BroadcastTickLoopFailure(RuntimeError):
@@ -16,4 +16,24 @@ class BroadcastTickLoopFailure(RuntimeError):
         super().__init__(
             "WebSocket broadcast tick failed "
             f"{consecutive_failures} consecutive times: {bounded_failure_message(cause)}"
+        )
+
+
+class ProcessingLoopFailure(RuntimeError):
+    """Persistent processing-loop failure escalated to outer runtime supervision."""
+
+    def __init__(
+        self,
+        *,
+        fatal_backoff_cycles: int,
+        failure_category: str,
+        cause: Exception,
+    ) -> None:
+        self.fatal_backoff_cycles = fatal_backoff_cycles
+        self.failure_category = failure_category
+        self.cause = cause
+        super().__init__(
+            "Processing loop remained unhealthy after "
+            f"{fatal_backoff_cycles} fatal backoff cycles "
+            f"({failure_category}): {bounded_failure_message(cause)}"
         )


### PR DESCRIPTION
## Summary
- split the runtime processing-loop seam so scheduling/orchestration, tick execution, observable state, and failure/backoff policy are no longer fused in `processing_loop.py`
- replace stringly processing-loop failures with typed tick-failure categories and an explicit managed fatal-escalation path
- update runtime, health, app wiring, and test imports to use the canonical processing state module instead of the old loop-owned state surface

## Structural changes
- add `infra/runtime/processing_state.py` as the canonical observable processing-loop state boundary
- add `infra/runtime/processing_failures.py` for typed tick failure categories and `ProcessingTickFailure`
- add `infra/runtime/processing_failure_policy.py` for retry delay, fatal backoff, and managed escalation policy
- slim `processing_loop.py` down to tick scheduling plus delegation to the failure policy
- slim `processing_tick.py` down to execution and typed failure emission
- keep health-snapshot consumers on the read-side state model while moving fatal backoff counters out of public runtime state

## Backward-incompatible changes
- `ProcessingLoopError` is removed in favor of `ProcessingTickFailure` and `ProcessingLoopFailure`
- fatal-backoff cycle counters are no longer exposed on `ProcessingLoopState`
- processing failure category names are now explicit enum-backed values; the old `publish_metrics` category is gone in favor of `evict_clients`
- runtime state imports should come from `processing_state.py`, not `processing_loop.py`

## Deleted compatibility layers
- removed loop-owned retry/backoff bookkeeping from `processing_loop.py`
- removed the old stringly loop-error surface instead of re-exporting it for compatibility
- removed public access to internal fatal-backoff counters from the runtime state object

## Local tests
- `pytest apps/server/tests/infra/runtime/test_processing_loop.py apps/server/tests/infra/runtime/test_runtime.py apps/server/tests/use_cases/test_system_health.py apps/server/tests/adapters/websocket/test_tick_controller.py apps/server/tests/adapters/websocket/test_build_ws_payload.py -q`
- `pytest apps/server/tests/infra/runtime apps/server/tests/use_cases/test_system_health.py apps/server/tests/adapters/http/test_health_endpoint.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/adapters/websocket/test_tick_controller.py -q`
- `make lint`
- `make typecheck-backend`
