### PR TITLE
Refactor HTTP operational error boundaries

### DIFF
--- a/apps/server/tests/adapters/http/test_helpers_exception_handling.py
+++ b/apps/server/tests/adapters/http/test_helpers_exception_handling.py
@@ -1,37 +1,38 @@
-"""Tests for domain_errors_to_http() exception handling in _helpers.py."""
+"""Tests for the HTTP route error boundary."""
 
 from __future__ import annotations
 
 import pytest
 from fastapi import HTTPException
 
-from vibesensor.adapters.http._helpers import domain_errors_to_http
+from vibesensor.adapters.http.error_boundary import route_errors_to_http
 from vibesensor.shared.exceptions import (
     ConfigurationError,
     ProtocolError,
     UpdateError,
     VibeSensorError,
 )
+from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
 
 
 def test_configuration_error_caught_as_vibesensor_error() -> None:
     """ConfigurationError maps to HTTP 400."""
     with pytest.raises(HTTPException) as exc_info:
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             raise ConfigurationError("bad config")
     assert exc_info.value.status_code == 400
 
 
 def test_protocol_error_maps_to_400() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        with domain_errors_to_http():
+        with route_errors_to_http():
             raise ProtocolError("bad packet")
     assert exc_info.value.status_code == 400
 
 
 def test_update_error_conflict_maps_to_409() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        with domain_errors_to_http():
+        with route_errors_to_http():
             raise UpdateError("busy", status="conflict")
     assert exc_info.value.status_code == 409
 
@@ -39,22 +40,28 @@ def test_update_error_conflict_maps_to_409() -> None:
 def test_plain_value_error_still_caught() -> None:
     """A plain ValueError is still caught by the except ValueError fallback."""
     with pytest.raises(HTTPException) as exc_info:
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             raise ValueError("not a number")
     assert exc_info.value.status_code == 400
 
 
-def test_plain_runtime_error_still_caught() -> None:
-    """A plain RuntimeError is still caught by the except RuntimeError fallback."""
+def test_service_unavailable_error_maps_to_503() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        with domain_errors_to_http(catch_runtime_error=503):
-            raise RuntimeError("service down")
+        with route_errors_to_http():
+            raise ServiceUnavailableError("service down")
     assert exc_info.value.status_code == 503
 
 
 def test_vibesensor_error_base_caught() -> None:
     """VibeSensorError (base) is caught and mapped to HTTP 500."""
     with pytest.raises(HTTPException) as exc_info:
-        with domain_errors_to_http():
+        with route_errors_to_http():
             raise VibeSensorError("generic domain error")
+    assert exc_info.value.status_code == 500
+
+
+def test_operational_error_base_maps_to_500() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        with route_errors_to_http():
+            raise OperationalError("operational failure")
     assert exc_info.value.status_code == 500

--- a/apps/server/tests/adapters/http/test_middleware_exception_discipline.py
+++ b/apps/server/tests/adapters/http/test_middleware_exception_discipline.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from vibesensor.adapters.http.middleware import install_request_logging_middleware
+from vibesensor.shared.operational_errors import ServiceUnavailableError
 
 
 def _app_with_endpoint(endpoint):
@@ -46,3 +47,14 @@ def test_request_middleware_lets_programming_errors_propagate() -> None:
 
     assert response.status_code == 500
     assert response.text == "Internal Server Error"
+
+
+def test_request_middleware_maps_operational_errors_to_503() -> None:
+    async def failing_endpoint() -> None:
+        raise ServiceUnavailableError("dependency unavailable")
+
+    with TestClient(_app_with_endpoint(failing_endpoint), raise_server_exceptions=False) as client:
+        response = client.get("/")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "dependency unavailable"}

--- a/apps/server/tests/adapters/http/test_request_observability.py
+++ b/apps/server/tests/adapters/http/test_request_observability.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from vibesensor.adapters.http.middleware import install_request_logging_middleware
 from vibesensor.adapters.http.settings import create_settings_routes
 from vibesensor.infra.config.settings_store import SettingsStore
+from vibesensor.shared.operational_errors import ServiceUnavailableError
 from vibesensor.shared.structured_logging import REQUEST_ID_HEADER
 
 
@@ -86,6 +87,31 @@ def test_unhandled_errors_still_echo_request_id(caplog: pytest.LogCaptureFixture
     failure_log = _log_record(caplog, "http_request_failed")
     assert failure_log.request_id == "failing-request"
     assert failure_log.failure_kind == "programmer"
+
+
+def test_unhandled_operational_errors_return_503_and_log_operational_kind(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+
+    @app.get("/dependency-down")
+    async def dependency_down() -> dict[str, bool]:
+        raise ServiceUnavailableError("helper unavailable")
+
+    with caplog.at_level(logging.INFO):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get(
+                "/dependency-down",
+                headers={REQUEST_ID_HEADER: "operational-request"},
+            )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "helper unavailable"}
+    assert response.headers[REQUEST_ID_HEADER] == "operational-request"
+    failure_log = _log_record(caplog, "http_request_failed")
+    assert failure_log.request_id == "operational-request"
+    assert failure_log.failure_kind == "operational"
 
 
 def test_http_exception_keeps_status_code_and_request_id(caplog: pytest.LogCaptureFixture) -> None:

--- a/apps/server/tests/adapters/http/test_settings_obd_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_obd_endpoints.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
 from vibesensor.adapters.http.settings import create_settings_routes
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot, ObdStatusSnapshot
+from vibesensor.shared.operational_errors import ExternalCommandError
 
 
 def _build_client() -> tuple[TestClient, MagicMock, MagicMock, MagicMock]:
@@ -60,7 +61,7 @@ def test_scan_obd_devices_endpoint_returns_serialized_devices() -> None:
 
 def test_scan_obd_devices_endpoint_returns_structured_runtime_error_detail() -> None:
     client, _, _, speed_service = _build_client()
-    speed_service.scan_obd_devices.side_effect = RuntimeError(
+    speed_service.scan_obd_devices.side_effect = ExternalCommandError(
         "Bluetooth OBD scan requires the Pi sudo helper and NOPASSWD sudoers entry "
         "to run non-interactively."
     )
@@ -74,6 +75,19 @@ def test_scan_obd_devices_endpoint_returns_structured_runtime_error_detail() -> 
             "to run non-interactively."
         )
     }
+
+
+def test_pair_obd_device_endpoint_returns_503_for_operational_failure() -> None:
+    client, _, _, speed_service = _build_client()
+    speed_service.pair_obd_device.side_effect = ExternalCommandError("Bluetooth OBD helper failed")
+
+    response = client.post(
+        "/api/settings/obd/pair",
+        json={"mac_address": "00:04:3E:5A:4A:4D"},
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Bluetooth OBD helper failed"}
 
 
 def test_pair_obd_device_endpoint_normalizes_mac_and_persists_config() -> None:

--- a/apps/server/tests/adapters/obd/test_admin_client.py
+++ b/apps/server/tests/adapters/obd/test_admin_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from vibesensor.adapters.obd import admin_client as admin_client_module
 from vibesensor.adapters.obd.admin_client import CommandResult, ObdAdminClient
+from vibesensor.shared.operational_errors import ExternalCommandError
 
 
 def test_scan_devices_invokes_sudo_helper_and_parses_json(tmp_path: Path) -> None:
@@ -44,7 +45,7 @@ def test_scan_devices_invokes_sudo_helper_and_parses_json(tmp_path: Path) -> Non
     assert devices[0].rfcomm_channel == 1
 
 
-def test_pair_device_raises_runtime_error_from_helper_json(tmp_path: Path) -> None:
+def test_pair_device_raises_operational_error_from_helper_json(tmp_path: Path) -> None:
     helper_script = tmp_path / "vibesensor_obd_admin.py"
 
     def runner(argv: list[str], timeout_s: int) -> CommandResult:
@@ -57,7 +58,7 @@ def test_pair_device_raises_runtime_error_from_helper_json(tmp_path: Path) -> No
 
     client = ObdAdminClient(helper_script=helper_script, runner=runner)
 
-    with pytest.raises(RuntimeError, match="Bluetooth OBD pairing failed"):
+    with pytest.raises(ExternalCommandError, match="Bluetooth OBD pairing failed"):
         client.pair_device("00043e5a4a4d")
 
 
@@ -75,7 +76,7 @@ def test_scan_devices_reports_noninteractive_sudo_failure_cleanly(tmp_path: Path
     client = ObdAdminClient(helper_script=helper_script, runner=runner)
 
     with pytest.raises(
-        RuntimeError,
+        ExternalCommandError,
         match="Bluetooth OBD scan requires the Pi sudo helper and NOPASSWD sudoers entry",
     ):
         client.scan_devices()
@@ -94,7 +95,7 @@ def test_scan_devices_still_reports_invalid_json_when_stdout_is_malformed(tmp_pa
 
     client = ObdAdminClient(helper_script=helper_script, runner=runner)
 
-    with pytest.raises(RuntimeError, match="Bluetooth OBD helper returned invalid JSON"):
+    with pytest.raises(ExternalCommandError, match="Bluetooth OBD helper returned invalid JSON"):
         client.scan_devices()
 
 

--- a/apps/server/tests/adapters/obd/test_monitor.py
+++ b/apps/server/tests/adapters/obd/test_monitor.py
@@ -9,6 +9,7 @@ import pytest
 from vibesensor.adapters.obd.elm327 import ObdTransportError
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.monitor import OBDSpeedMonitor
+from vibesensor.shared.operational_errors import ExternalCommandError
 
 
 class _FakeClock:
@@ -193,7 +194,7 @@ def test_obd_monitor_resolves_stale_speed_to_manual_fallback() -> None:
 
 def test_obd_status_reports_sudo_helper_hint_when_admin_refresh_fails() -> None:
     admin_client = MagicMock()
-    admin_client.device_info.side_effect = RuntimeError("sudo: a password is required")
+    admin_client.device_info.side_effect = ExternalCommandError("sudo: a password is required")
     monitor = OBDSpeedMonitor(
         admin_client=admin_client,
         session_factory=lambda: MagicMock(),

--- a/apps/server/tests/hygiene/test_operational_errors.py
+++ b/apps/server/tests/hygiene/test_operational_errors.py
@@ -1,0 +1,48 @@
+"""Test the operational exception hierarchy."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.shared.exceptions import VibeSensorError
+from vibesensor.shared.operational_errors import (
+    ExternalCommandError,
+    OperationalError,
+    ServiceUnavailableError,
+)
+
+_ALL_OPERATIONAL_EXCEPTIONS = (
+    ServiceUnavailableError,
+    ExternalCommandError,
+)
+
+
+def test_operational_base_exception_is_exception() -> None:
+    assert issubclass(OperationalError, Exception)
+
+
+@pytest.mark.parametrize("exc_cls", _ALL_OPERATIONAL_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_operational_errors_catchable_by_base(exc_cls: type[OperationalError]) -> None:
+    try:
+        raise exc_cls("test")
+    except OperationalError:
+        pass
+    else:
+        raise AssertionError(f"{exc_cls.__name__} not catchable as OperationalError")
+
+
+def test_operational_error_base_is_direct_exception_subclass() -> None:
+    assert OperationalError.__bases__ == (Exception,)
+
+
+def test_service_unavailable_error_uses_operational_base() -> None:
+    assert ServiceUnavailableError.__bases__ == (OperationalError,)
+
+
+def test_external_command_error_uses_service_unavailable_base() -> None:
+    assert ExternalCommandError.__bases__ == (ServiceUnavailableError,)
+
+
+@pytest.mark.parametrize("exc_cls", _ALL_OPERATIONAL_EXCEPTIONS, ids=lambda cls: cls.__name__)
+def test_operational_errors_are_not_domain_errors(exc_cls: type[OperationalError]) -> None:
+    assert not issubclass(exc_cls, VibeSensorError)

--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -3,27 +3,16 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
-from contextlib import contextmanager
 from typing import Any
 
 from fastapi import HTTPException
 
 from vibesensor.domain import normalize_sensor_id
-from vibesensor.shared.exceptions import (
-    AnalysisNotReadyError,
-    ConfigurationError,
-    ProtocolError,
-    RunNotFoundError,
-    UpdateError,
-    VibeSensorError,
-)
 from vibesensor.use_cases.history.helpers import async_require_run, safe_filename
 
 __all__ = [
     "OpenAPIResponses",
     "async_require_run",
-    "domain_errors_to_http",
     "normalize_car_id_or_400",
     "normalize_client_id_or_400",
     "normalize_mac_or_400",
@@ -34,49 +23,6 @@ __all__ = [
 type OpenAPIResponses = dict[int | str, dict[str, Any]]
 _CAR_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 _RUN_ID_RE = re.compile(r"^[!-~]{1,128}$")
-
-
-@contextmanager
-def domain_errors_to_http(
-    *,
-    catch_value_error: int | None = None,
-    catch_runtime_error: int | None = None,
-) -> Iterator[None]:
-    """Translate domain exceptions to appropriate HTTP status codes.
-
-    This is the single place in the routes layer where domain exceptions
-    from the service layer are mapped to ``HTTPException`` responses.
-
-    Optional parameters allow catching ``ValueError`` / ``RuntimeError``
-    with a caller-specified HTTP status code.
-    """
-    try:
-        yield
-    except RunNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except AnalysisNotReadyError as exc:
-        status_map = {"in_progress": 409, "active": 409, "error": 422, "unavailable": 422}
-        raise HTTPException(
-            status_code=status_map.get(exc.status, 409),
-            detail=str(exc),
-        ) from exc
-    except ConfigurationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except ProtocolError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except UpdateError as exc:
-        status_code = 409 if exc.status == "conflict" else 500
-        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
-    except VibeSensorError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-    except ValueError as exc:
-        if catch_value_error is None:
-            raise
-        raise HTTPException(status_code=catch_value_error, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        if catch_runtime_error is None:
-            raise
-        raise HTTPException(status_code=catch_runtime_error, detail=str(exc)) from exc
 
 
 def normalize_client_id_or_400(client_id: str) -> str:

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -9,9 +9,9 @@ from fastapi import APIRouter, HTTPException
 
 from vibesensor.adapters.http._helpers import (
     OpenAPIResponses,
-    domain_errors_to_http,
     normalize_client_id_or_400,
 )
+from vibesensor.adapters.http.error_boundary import route_errors_to_http
 from vibesensor.adapters.http.models import (
     ClientLocationsResponse,
     ClientsResponse,
@@ -128,7 +128,7 @@ def create_client_routes(
 
         updated = registry.get(normalized_client_id)
         mac = client_id_mac(normalized_client_id)
-        with domain_errors_to_http(catch_value_error=409):
+        with route_errors_to_http(catch_value_error=409):
             stored = await asyncio.to_thread(sensor_settings_store.set_sensor, mac, payload)
             registry.set_location(normalized_client_id, code)
             if code:

--- a/apps/server/vibesensor/adapters/http/error_boundary.py
+++ b/apps/server/vibesensor/adapters/http/error_boundary.py
@@ -1,0 +1,72 @@
+"""HTTP error mapping for domain and operational exceptions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from fastapi import HTTPException
+
+from vibesensor.shared.exceptions import (
+    AnalysisNotReadyError,
+    ConfigurationError,
+    ProtocolError,
+    RunNotFoundError,
+    UpdateError,
+    VibeSensorError,
+)
+from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
+
+__all__ = [
+    "http_exception_for_operational_error",
+    "http_status_for_operational_error",
+    "route_errors_to_http",
+]
+
+
+def http_status_for_operational_error(exc: OperationalError) -> int:
+    """Return the HTTP status code for one operational failure."""
+
+    if isinstance(exc, ServiceUnavailableError):
+        return 503
+    return 500
+
+
+def http_exception_for_operational_error(exc: OperationalError) -> HTTPException:
+    """Convert one operational failure into an HTTPException."""
+
+    return HTTPException(
+        status_code=http_status_for_operational_error(exc),
+        detail=str(exc),
+    )
+
+
+@contextmanager
+def route_errors_to_http(*, catch_value_error: int | None = None) -> Iterator[None]:
+    """Translate route-facing domain and operational errors into HTTP responses."""
+
+    try:
+        yield
+    except RunNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except AnalysisNotReadyError as exc:
+        status_map = {"in_progress": 409, "active": 409, "error": 422, "unavailable": 422}
+        raise HTTPException(
+            status_code=status_map.get(exc.status, 409),
+            detail=str(exc),
+        ) from exc
+    except ConfigurationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ProtocolError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except UpdateError as exc:
+        status_code = 409 if exc.status == "conflict" else 500
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
+    except VibeSensorError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except OperationalError as exc:
+        raise http_exception_for_operational_error(exc) from exc
+    except ValueError as exc:
+        if catch_value_error is None:
+            raise
+        raise HTTPException(status_code=catch_value_error, detail=str(exc)) from exc

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -9,9 +9,9 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from vibesensor.adapters.http._helpers import (
     OpenAPIResponses,
-    domain_errors_to_http,
     normalize_run_id_or_400,
 )
+from vibesensor.adapters.http.error_boundary import route_errors_to_http
 from vibesensor.adapters.http.models import (
     DeleteHistoryRunResponse,
     HistoryInsightsAnalyzingResponse,
@@ -96,7 +96,7 @@ def create_history_routes(
     async def get_history_run(run_id: str) -> HistoryRunResponse:
         """Return full metadata and analysis payloads for a single recorded run."""
         run_id = normalize_run_id_or_400(run_id)
-        with domain_errors_to_http():
+        with route_errors_to_http():
             return await run_service.get_run(run_id)
 
     @router.get(
@@ -115,7 +115,7 @@ def create_history_routes(
     ) -> HistoryInsightsResponse | JSONResponse:
         """Return localized post-analysis findings, or a 202 while analysis is still running."""
         run_id = normalize_run_id_or_400(run_id)
-        with domain_errors_to_http():
+        with route_errors_to_http():
             result = await run_service.get_insights(run_id, requested_lang=lang)
         if result is None:
             analyzing_response = HistoryInsightsAnalyzingResponse(run_id=run_id, status="analyzing")
@@ -133,7 +133,7 @@ def create_history_routes(
     async def delete_history_run(run_id: str) -> DeleteHistoryRunResponse:
         """Delete a persisted run and its derived artifacts from history storage."""
         run_id = normalize_run_id_or_400(run_id)
-        with domain_errors_to_http():
+        with route_errors_to_http():
             return await run_service.delete_run(run_id)
 
     # -- report PDF ------------------------------------------------------------
@@ -155,7 +155,7 @@ def create_history_routes(
     ) -> Response:
         """Build and download the PDF diagnostic report for a persisted run."""
         run_id = normalize_run_id_or_400(run_id)
-        with domain_errors_to_http():
+        with route_errors_to_http():
             pdf = await report_service.build_pdf(run_id, lang)
         pdf_headers = {
             "Content-Disposition": f'attachment; filename="{pdf.filename}"',
@@ -176,7 +176,7 @@ def create_history_routes(
     async def export_history_run(run_id: str) -> StreamingResponse:
         """Build and stream the ZIP export bundle for a persisted run."""
         run_id = normalize_run_id_or_400(run_id)
-        with domain_errors_to_http():
+        with route_errors_to_http():
             export = await export_service.build_export(run_id)
         return StreamingResponse(
             content=export.iter_bytes(),

--- a/apps/server/vibesensor/adapters/http/middleware.py
+++ b/apps/server/vibesensor/adapters/http/middleware.py
@@ -6,9 +6,11 @@ from time import perf_counter
 
 from fastapi import FastAPI
 from starlette.datastructures import Headers, MutableHeaders
-from starlette.responses import PlainTextResponse
+from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from vibesensor.adapters.http.error_boundary import http_exception_for_operational_error
+from vibesensor.shared.operational_errors import OperationalError
 from vibesensor.shared.structured_logging import (
     REQUEST_ID_HEADER,
     bind_request_id,
@@ -18,12 +20,6 @@ from vibesensor.shared.structured_logging import (
 )
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _failure_kind(exc: Exception) -> str:
-    """Return the structured failure bucket for one unhandled request exception."""
-
-    return "operational" if isinstance(exc, (OSError, TimeoutError)) else "programmer"
 
 
 class RequestLoggingMiddleware:
@@ -66,13 +62,13 @@ class RequestLoggingMiddleware:
             await self.app(scope, receive, _send_with_request_id)
         except asyncio.CancelledError:
             raise
-        except Exception as exc:
+        except OperationalError as exc:
             request_failed = True
             LOGGER.exception(
                 "http_request_failed",
                 extra=log_extra(
                     event="http_request_failed",
-                    failure_kind=_failure_kind(exc),
+                    failure_kind="operational",
                     method=method,
                     path=path,
                     status_code=status_code,
@@ -81,8 +77,29 @@ class RequestLoggingMiddleware:
             )
             if response_started:
                 raise
-            response = PlainTextResponse("Internal Server Error", status_code=500)
-            await response(scope, receive, _send_with_request_id)
+            http_error = http_exception_for_operational_error(exc)
+            operational_response = JSONResponse(
+                status_code=http_error.status_code,
+                content={"detail": http_error.detail},
+            )
+            await operational_response(scope, receive, _send_with_request_id)
+        except Exception:
+            request_failed = True
+            LOGGER.exception(
+                "http_request_failed",
+                extra=log_extra(
+                    event="http_request_failed",
+                    failure_kind="programmer",
+                    method=method,
+                    path=path,
+                    status_code=status_code,
+                    duration_ms=round((perf_counter() - started_at) * 1000.0, 3),
+                ),
+            )
+            if response_started:
+                raise
+            failure_response = PlainTextResponse("Internal Server Error", status_code=500)
+            await failure_response(scope, receive, _send_with_request_id)
         finally:
             if not request_failed:
                 LOGGER.info(

--- a/apps/server/vibesensor/adapters/http/settings.py
+++ b/apps/server/vibesensor/adapters/http/settings.py
@@ -10,13 +10,13 @@ from fastapi import APIRouter, HTTPException
 
 from vibesensor.adapters.http._helpers import (
     OpenAPIResponses,
-    domain_errors_to_http,
     normalize_car_id_or_400,
     normalize_mac_or_400,
 )
 from vibesensor.adapters.http.analysis_settings_request_codec import (
     analysis_settings_payload_from_request,
 )
+from vibesensor.adapters.http.error_boundary import route_errors_to_http
 from vibesensor.adapters.http.models import (
     ActiveCarRequest,
     AnalysisSettingsRequest,
@@ -274,7 +274,7 @@ def create_settings_routes(
     async def set_active_car(req: ActiveCarRequest) -> CarsResponse:
         """Select which saved car profile should drive current analysis settings."""
         car_id = normalize_car_id_or_400(req.car_id)
-        with domain_errors_to_http(catch_value_error=404):
+        with route_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(settings_store.set_active_car, car_id)
         return _cars_response(result)
 
@@ -287,7 +287,7 @@ def create_settings_routes(
         """Update an existing car profile while preserving unspecified fields."""
         car_id = normalize_car_id_or_400(car_id)
         payload = _car_upsert_payload(req)
-        with domain_errors_to_http(catch_value_error=404):
+        with route_errors_to_http(catch_value_error=404):
             result = await asyncio.to_thread(
                 settings_store.update_car,
                 car_id,
@@ -308,7 +308,7 @@ def create_settings_routes(
         cars_snapshot = await asyncio.to_thread(settings_store.get_cars)
         if not any(car["id"] == car_id for car in cars_snapshot.cars):
             raise HTTPException(status_code=404, detail=f"Car {car_id!r} not found")
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             result = await asyncio.to_thread(settings_store.delete_car, car_id)
         return _cars_response(result)
 
@@ -327,7 +327,7 @@ def create_settings_routes(
     async def update_speed_source(req: SpeedSourceRequest) -> SpeedSourceResponse:
         """Update the preferred speed source, manual fallback speed, and staleness timeout."""
         payload = _speed_source_update_payload(req)
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             result = await asyncio.to_thread(
                 speed_source_service.update_speed_source,
                 payload,
@@ -346,10 +346,8 @@ def create_settings_routes(
     )
     async def scan_obd_devices() -> ObdScanResponse:
         """Scan nearby Bluetooth OBD adapters using the privileged helper."""
-        try:
+        with route_errors_to_http():
             devices = await asyncio.to_thread(gps_monitor.scan_obd_devices)
-        except RuntimeError as exc:
-            raise HTTPException(status_code=503, detail=str(exc)) from exc
         return ObdScanResponse(devices=[_obd_device_response(device) for device in devices])
 
     @router.post(
@@ -360,17 +358,15 @@ def create_settings_routes(
     async def pair_obd_device(req: ObdPairRequest) -> ObdPairResponse:
         """Pair, trust, connect, and persist the selected Bluetooth OBD adapter."""
         normalized_mac = normalize_mac_or_400(req.mac_address)
-        try:
+        with route_errors_to_http():
             device = await asyncio.to_thread(gps_monitor.pair_obd_device, normalized_mac)
-        except RuntimeError as exc:
-            raise HTTPException(status_code=503, detail=str(exc)) from exc
-        persisted = await asyncio.to_thread(
-            speed_source_service.update_speed_source,
-            {
-                "obdDeviceMac": device.mac_address,
-                "obdDeviceName": device.name,
-            },
-        )
+            persisted = await asyncio.to_thread(
+                speed_source_service.update_speed_source,
+                {
+                    "obdDeviceMac": device.mac_address,
+                    "obdDeviceName": device.name,
+                },
+            )
         return _obd_pair_response(
             configured_device_mac=str(persisted.get("obdDeviceMac") or device.mac_address),
             configured_device_name=(
@@ -405,7 +401,7 @@ def create_settings_routes(
         """Create or update persisted sensor metadata for a specific MAC address."""
         normalized_mac = normalize_mac_or_400(mac)
         payload = _sensor_update_payload(req)
-        with domain_errors_to_http(catch_value_error=409):
+        with route_errors_to_http(catch_value_error=409):
             await asyncio.to_thread(
                 settings_store.set_sensor,
                 normalized_mac,
@@ -421,7 +417,7 @@ def create_settings_routes(
     async def delete_sensor(mac: str) -> SensorsResponse:
         """Delete persisted sensor metadata for a specific MAC address."""
         normalized_mac = normalize_mac_or_400(mac)
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             removed = await asyncio.to_thread(settings_store.remove_sensor, normalized_mac)
         if not removed:
             raise HTTPException(status_code=404, detail="Unknown sensor MAC")
@@ -441,7 +437,7 @@ def create_settings_routes(
     )
     async def set_language(req: LanguageRequest) -> LanguageResponse:
         """Update the dashboard language used by the local UI."""
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             language = await asyncio.to_thread(settings_store.set_language, req.language)
         return LanguageResponse(language=language)
 
@@ -457,7 +453,7 @@ def create_settings_routes(
     )
     async def set_speed_unit(req: SpeedUnitRequest) -> SpeedUnitResponse:
         """Update the speed unit used for UI display and manual speed entry."""
-        with domain_errors_to_http(catch_value_error=400):
+        with route_errors_to_http(catch_value_error=400):
             unit = await asyncio.to_thread(settings_store.set_speed_unit, req.speed_unit)
         return SpeedUnitResponse(speed_unit=unit)
 
@@ -477,7 +473,7 @@ def create_settings_routes(
         """Update analysis-specific car aspects such as tire geometry and drivetrain ratios."""
         changes = analysis_settings_payload_from_request(req)
         if changes:
-            with domain_errors_to_http(catch_value_error=400):
+            with route_errors_to_http(catch_value_error=400):
                 await asyncio.to_thread(settings_store.update_active_car_aspects, changes)
         return _analysis_settings_response()
 

--- a/apps/server/vibesensor/adapters/http/updates.py
+++ b/apps/server/vibesensor/adapters/http/updates.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Query
 
-from vibesensor.adapters.http._helpers import OpenAPIResponses, domain_errors_to_http
+from vibesensor.adapters.http._helpers import OpenAPIResponses
+from vibesensor.adapters.http.error_boundary import route_errors_to_http
 from vibesensor.adapters.http.models import (
     EspFlashCancelResponse,
     EspFlashHistoryResponse,
@@ -80,7 +81,7 @@ def create_update_routes(
     )
     async def start_update(req: UpdateStartRequest) -> UpdateStartResponse:
         """Start an OTA software update using the supplied uplink Wi-Fi credentials."""
-        with domain_errors_to_http():
+        with route_errors_to_http():
             update_manager.start(
                 ssid=req.ssid,
                 password=req.password,
@@ -112,7 +113,7 @@ def create_update_routes(
     )
     async def start_esp_flash(req: EspFlashStartRequest) -> EspFlashStartResponse:
         """Start a new ESP32 firmware flash job with either auto-detect or an explicit port."""
-        with domain_errors_to_http():
+        with route_errors_to_http():
             job_id = esp_flash_manager.start(port=req.port, auto_detect=req.auto_detect)
         return EspFlashStartResponse(status="started", job_id=job_id)
 

--- a/apps/server/vibesensor/adapters/obd/admin_client.py
+++ b/apps/server/vibesensor/adapters/obd/admin_client.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
+from vibesensor.shared.operational_errors import ExternalCommandError
 
 __all__ = ["CommandResult", "ObdAdminClient"]
 
@@ -53,11 +54,11 @@ def _default_runner(argv: list[str], timeout_s: int) -> CommandResult:
             timeout=timeout_s,
         )
     except FileNotFoundError as exc:
-        raise RuntimeError(f"Required command is unavailable: {argv[0]}") from exc
+        raise ExternalCommandError(f"Required command is unavailable: {argv[0]}") from exc
     except subprocess.TimeoutExpired as exc:
         stdout = str(exc.stdout or "").strip()
         stderr = str(exc.stderr or "").strip()
-        raise RuntimeError(
+        raise ExternalCommandError(
             f"OBD helper timed out after {timeout_s}s"
             + (f": {stderr}" if stderr else "")
             + (f" ({stdout})" if stdout else "")
@@ -92,17 +93,17 @@ class ObdAdminClient:
         result = self._runner(argv, timeout_s)
         launch_error = self._pre_json_failure(result)
         if launch_error is not None:
-            raise RuntimeError(launch_error)
+            raise ExternalCommandError(launch_error)
         raw_output = result.stdout or result.stderr or ""
         try:
             payload_raw = json.loads(raw_output or "{}")
         except json.JSONDecodeError as exc:
-            raise RuntimeError(
+            raise ExternalCommandError(
                 "Bluetooth OBD helper returned invalid JSON"
                 + (f": {raw_output}" if raw_output else "")
             ) from exc
         if not isinstance(payload_raw, dict):
-            raise RuntimeError("Bluetooth OBD helper returned a non-object JSON payload")
+            raise ExternalCommandError("Bluetooth OBD helper returned a non-object JSON payload")
         payload = cast(dict[str, Any], payload_raw)
         if result.returncode != 0:
             error = str(
@@ -111,7 +112,7 @@ class ObdAdminClient:
                 or result.stdout
                 or "Bluetooth OBD helper failed"
             )
-            raise RuntimeError(error)
+            raise ExternalCommandError(error)
         return payload
 
     @staticmethod
@@ -134,7 +135,7 @@ class ObdAdminClient:
     @staticmethod
     def _device_from_payload(raw: object) -> ObdDeviceSnapshot:
         if not isinstance(raw, dict):
-            raise RuntimeError("Bluetooth OBD helper returned an invalid device payload")
+            raise ExternalCommandError("Bluetooth OBD helper returned an invalid device payload")
         channel_raw = raw.get("rfcomm_channel")
         channel = int(channel_raw) if isinstance(channel_raw, int) else None
         return ObdDeviceSnapshot(
@@ -153,7 +154,7 @@ class ObdAdminClient:
         )
         devices_raw = payload.get("devices")
         if not isinstance(devices_raw, list):
-            raise RuntimeError("Bluetooth OBD helper did not return a device list")
+            raise ExternalCommandError("Bluetooth OBD helper did not return a device list")
         return [self._device_from_payload(item) for item in devices_raw]
 
     def pair_device(self, mac_address: str) -> ObdDeviceSnapshot:

--- a/apps/server/vibesensor/adapters/obd/monitor.py
+++ b/apps/server/vibesensor/adapters/obd/monitor.py
@@ -22,6 +22,7 @@ from vibesensor.adapters.obd.status import ObdMonitorStatusState, build_obd_stat
 from vibesensor.domain import SpeedSourceKind
 from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.constants.units import KMH_TO_MPS
+from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
 
 __all__ = ["OBDSpeedMonitor"]
 
@@ -185,7 +186,7 @@ class OBDSpeedMonitor:
         if refresh_admin and configured_mac is not None:
             try:
                 helper_device = self._admin_client.device_info(configured_mac)
-            except RuntimeError as exc:
+            except OperationalError as exc:
                 helper_error = str(exc)
             else:
                 self._apply_device_snapshot(helper_device)
@@ -248,7 +249,7 @@ class OBDSpeedMonitor:
                             configured_mac,
                             configured_name,
                         )
-                    except RuntimeError as exc:
+                    except (OperationalError, RuntimeError) as exc:
                         self._set_connection_state(
                             "disconnected",
                             error=str(exc),
@@ -293,16 +294,16 @@ class OBDSpeedMonitor:
     ) -> tuple[Elm327Session, ObdDeviceSnapshot]:
         info = self._admin_client.device_info(mac_address)
         if not info.paired:
-            raise RuntimeError("Configured OBD adapter is not paired")
+            raise ServiceUnavailableError("Configured OBD adapter is not paired")
         if not info.trusted:
-            raise RuntimeError("Configured OBD adapter is not trusted")
+            raise ServiceUnavailableError("Configured OBD adapter is not trusted")
         if info.rfcomm_channel is None:
-            raise RuntimeError("Bluetooth OBD adapter exposes no RFCOMM serial channel")
+            raise ServiceUnavailableError("Bluetooth OBD adapter exposes no RFCOMM serial channel")
         session = self._session_factory()
         session.connect(mac_address, info.rfcomm_channel)
         try:
             session.initialize()
-        except (OSError, RuntimeError):
+        except (OSError, OperationalError, RuntimeError):
             session.close()
             raise
         device = replace(

--- a/apps/server/vibesensor/shared/operational_errors.py
+++ b/apps/server/vibesensor/shared/operational_errors.py
@@ -1,0 +1,27 @@
+"""Operational exception hierarchy for runtime and external-dependency failures.
+
+These exceptions represent failures caused by environment state, external
+commands, or service availability rather than domain invariants. They are kept
+separate from ``vibesensor.shared.exceptions`` so HTTP and runtime boundaries
+can distinguish operational recovery cases from programmer/domain faults.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ExternalCommandError",
+    "OperationalError",
+    "ServiceUnavailableError",
+]
+
+
+class OperationalError(Exception):
+    """Base exception for non-domain operational failures."""
+
+
+class ServiceUnavailableError(OperationalError):
+    """An external dependency or runtime capability is currently unavailable."""
+
+
+class ExternalCommandError(ServiceUnavailableError):
+    """A subprocess or privileged helper command could not complete successfully."""


### PR DESCRIPTION
## Summary
- replace the diffuse route-level error translation seam with one dedicated HTTP error boundary and a canonical operational-error hierarchy
- remove route-local `RuntimeError`/`503` translation in the OBD admin path and push typed operational failures from the helper through the monitor and route boundary
- narrow request middleware failure classification so operational vs programmer failures are based on explicit error types rather than raw stdlib heuristics

## Structural changes
- add `shared/operational_errors.py` as the canonical operational error taxonomy
- add `adapters/http/error_boundary.py` for domain/operational-to-HTTP mapping via `route_errors_to_http`
- delete `domain_errors_to_http` from `adapters/http/_helpers.py` so `_helpers.py` only keeps shared normalization/helper concerns
- rewire `history.py`, `clients.py`, `settings.py`, and `updates.py` to use the new HTTP error boundary
- convert the OBD admin helper and monitor paths to raise/catch typed operational errors instead of raw `RuntimeError`
- update request middleware to return mapped operational responses and keep programmer faults on the generic 500 path

## Backward-incompatible changes
- `domain_errors_to_http` has been removed from `adapters/http/_helpers.py`
- the route error boundary no longer supports the old `catch_runtime_error` fallback; route-facing operational failures must now use typed operational exceptions
- OBD admin/helper failures now raise `ExternalCommandError` / `OperationalError` instead of raw `RuntimeError`
- unhandled operational exceptions that reach middleware now return structured JSON `{ "detail": ... }` with mapped status codes instead of falling through the generic plain-text 500 path

## Deleted compatibility layers
- removed route-local `RuntimeError` -> `HTTPException(status_code=503)` translation from the OBD settings endpoints
- removed middleware heuristics that inferred `failure_kind="operational"` from raw `OSError`/`TimeoutError`
- removed the old mixed error translation helper from `_helpers.py` instead of re-exporting it for compatibility

## Local tests
- `pytest apps/server/tests/adapters/http apps/server/tests/adapters/obd/test_admin_client.py apps/server/tests/adapters/obd/test_monitor.py apps/server/tests/hygiene/test_domain_exceptions.py apps/server/tests/hygiene/test_operational_errors.py -q`
- `pytest apps/server/tests/adapters/obd -q`
- `make lint`
- `make typecheck-backend`
