### PR TITLE
Refactor update, OBD, and report boundaries

### DIFF
--- a/apps/server/tests/adapters/obd/test_admin_state.py
+++ b/apps/server/tests/adapters/obd/test_admin_state.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vibesensor.adapters.obd.admin_state import observe_configured_obd_device
+from vibesensor.adapters.obd.models import ObdDeviceSnapshot
+from vibesensor.shared.operational_errors import ExternalCommandError
+
+
+def test_observe_configured_obd_device_skips_lookup_without_configured_mac() -> None:
+    admin_client = MagicMock()
+
+    observation = observe_configured_obd_device(
+        admin_client=admin_client,
+        configured_mac=None,
+    )
+
+    assert observation.snapshot is None
+    assert observation.helper_error is None
+    admin_client.device_info.assert_not_called()
+
+
+def test_observe_configured_obd_device_returns_helper_error_for_operational_failure() -> None:
+    admin_client = MagicMock()
+    admin_client.device_info.side_effect = ExternalCommandError("sudo helper missing")
+
+    observation = observe_configured_obd_device(
+        admin_client=admin_client,
+        configured_mac="00043e5a4a4d",
+    )
+
+    assert observation.snapshot is None
+    assert observation.helper_error == "sudo helper missing"
+
+
+def test_observe_configured_obd_device_returns_snapshot() -> None:
+    admin_client = MagicMock()
+    admin_client.device_info.return_value = ObdDeviceSnapshot(
+        mac_address="00043e5a4a4d",
+        name="OBDLink MX+",
+        paired=True,
+        trusted=True,
+        connected=True,
+        rfcomm_channel=1,
+    )
+
+    observation = observe_configured_obd_device(
+        admin_client=admin_client,
+        configured_mac="00043e5a4a4d",
+    )
+
+    assert observation.snapshot == admin_client.device_info.return_value
+    assert observation.helper_error is None

--- a/apps/server/tests/adapters/obd/test_monitor.py
+++ b/apps/server/tests/adapters/obd/test_monitor.py
@@ -89,7 +89,7 @@ def test_obd_monitor_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -> No
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.2)]
     assert monitor.resolve_speed().source == "obd2"
     assert monitor.resolve_speed().speed_mps == pytest.approx(40.0 / 3.6)
-    status = monitor.status_snapshot(refresh_admin=False)
+    status = monitor.status_snapshot()
     assert status.last_speed_kmh == pytest.approx(40.0)
     assert status.last_rpm == pytest.approx(0x1AF8 / 4.0)
     assert status.rpm_target_interval_ms == 50
@@ -131,7 +131,7 @@ def test_obd_monitor_keeps_last_good_rpm_until_the_rpm_reference_goes_stale() ->
     clock.now = 2.11
     assert monitor.engine_rpm is None
 
-    status = monitor.status_snapshot(refresh_admin=False)
+    status = monitor.status_snapshot()
     assert status.timeout_count == 1
     assert status.backoff_active is True
 
@@ -159,7 +159,7 @@ def test_obd_monitor_backs_off_and_stays_in_rpm_only_mode_when_speed_times_out()
     monitor._apply_poll_result(monitor._poll_cycle_blocking(session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.3)]
-    status = monitor.status_snapshot(refresh_admin=False)
+    status = monitor.status_snapshot()
     assert status.poll_mode == "rpm_only_backoff"
     assert status.backoff_active is True
     assert status.timeout_count == 1
@@ -192,6 +192,28 @@ def test_obd_monitor_resolves_stale_speed_to_manual_fallback() -> None:
     assert resolution.fallback_active is True
 
 
+def test_obd_status_snapshot_does_not_refresh_admin_state_implicitly() -> None:
+    admin_client = MagicMock()
+    monitor = OBDSpeedMonitor(
+        admin_client=admin_client,
+        session_factory=lambda: MagicMock(),
+        monotonic=lambda: 100.0,
+    )
+    monitor.apply_speed_source_settings(
+        effective_speed_kmh=None,
+        manual_source_selected=False,
+        selected_source="obd2",
+        obd_device_mac="00043e5a4a4d",
+        obd_device_name="OBDLink MX+",
+    )
+
+    status = monitor.status_snapshot()
+
+    admin_client.device_info.assert_not_called()
+    assert status.device_mac == "00043e5a4a4d"
+    assert status.paired is False
+
+
 def test_obd_status_reports_sudo_helper_hint_when_admin_refresh_fails() -> None:
     admin_client = MagicMock()
     admin_client.device_info.side_effect = ExternalCommandError("sudo: a password is required")
@@ -208,7 +230,8 @@ def test_obd_status_reports_sudo_helper_hint_when_admin_refresh_fails() -> None:
         obd_device_name="OBDLink MX+",
     )
 
-    status = monitor.status_snapshot(refresh_admin=True)
+    monitor.refresh_admin_state()
+    status = monitor.status_snapshot()
 
     assert "sudo" in str(status.last_error).lower()
     assert "sudo helper" in str(status.debug_hint).lower()

--- a/apps/server/tests/adapters/pdf/test_render_planner.py
+++ b/apps/server/tests/adapters/pdf/test_render_planner.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from vibesensor.adapters.pdf.render_planner import build_report_render_plan
+from vibesensor.shared.boundaries.reporting.document import (
+    AppendixAData,
+    AppendixBData,
+    AppendixCData,
+    AppendixDData,
+    NextStep,
+    ReportDocument,
+    ReportLabelValueRow,
+)
+
+
+def _document(**overrides: object) -> ReportDocument:
+    defaults: dict[str, object] = {
+        "title": "VibeSensor Diagnostic Report",
+        "lang": "en",
+        "next_steps": [NextStep(action="Inspect wheel/tire condition")],
+        "appendix_a": AppendixAData(mode="workflow"),
+        "appendix_b": AppendixBData(dominant_corner="Front Left"),
+        "appendix_c": AppendixCData(),
+        "appendix_d": AppendixDData(rows=[ReportLabelValueRow(label="Run ID", value="run-001")]),
+    }
+    defaults.update(overrides)
+    return ReportDocument(**defaults)
+
+
+def test_build_report_render_plan_counts_workflow_pages_from_page_sequence() -> None:
+    plan = build_report_render_plan(_document())
+
+    assert plan.recapture_mode is False
+    assert plan.appendix_b is not None
+    assert len(plan.appendix_a_pages) == 1
+    assert plan.total_pages == 4
+
+
+def test_build_report_render_plan_omits_empty_appendix_b() -> None:
+    plan = build_report_render_plan(_document(appendix_b=AppendixBData()))
+
+    assert plan.appendix_b is None
+    assert plan.total_pages == 3
+
+
+def test_build_report_render_plan_uses_recapture_sequence_without_appendix_c_page_count() -> None:
+    plan = build_report_render_plan(
+        _document(
+            next_steps=[],
+            appendix_a=AppendixAData(mode="recapture", capture_issues=["Speed was unstable"]),
+            appendix_b=AppendixBData(),
+        )
+    )
+
+    assert plan.recapture_mode is True
+    assert plan.appendix_b is None
+    assert len(plan.appendix_a_pages) == 1
+    assert plan.total_pages == 2

--- a/apps/server/tests/adapters/pdf/test_template_builder.py
+++ b/apps/server/tests/adapters/pdf/test_template_builder.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
 from vibesensor.shared.boundaries.reporting.document import (
+    AppendixAData,
+    AppendixBData,
+    AppendixCData,
+    AppendixDData,
     DataTrustItem,
     FindingPresentation,
     NextStep,
@@ -13,10 +17,14 @@ from vibesensor.shared.boundaries.reporting.document import (
     PeakRow,
     Report,
     SystemFindingCard,
+    VerdictPageData,
 )
 from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext
 from vibesensor.use_cases.history.report_document.document_builder import (
     build_report_document_data,
+)
+from vibesensor.use_cases.history.report_document.resolved_sections import (
+    ResolvedReportDocumentSections,
 )
 
 
@@ -92,26 +100,62 @@ def _make_primary(**overrides: object) -> PrimaryCandidateContext:
     return PrimaryCandidateContext(**defaults)
 
 
-def _build(**overrides: object):
-    """Build a ReportDocument with sensible defaults, allowing overrides."""
+def _make_sections(**overrides: object) -> ResolvedReportDocumentSections:
     defaults: dict[str, object] = {
-        "prepared": _make_prepared(),
-        "report": _make_report(),
         "report_date_text": "2026-01-01 12:00:00 UTC",
         "report_start_time_utc": "2026-01-01T12:00:00Z",
         "report_end_time_utc": "2026-01-01T12:01:00Z",
-        "primary": _make_primary(),
         "title": "Test Report",
+        "primary": _make_primary(),
         "observed": PatternEvidence(),
-        "system_cards": [],
-        "next_steps": [],
-        "data_trust": [],
+        "system_cards": (),
+        "next_steps": (),
+        "data_trust": (),
         "pattern_evidence": PatternEvidence(),
-        "peak_rows": [],
-        "findings": [],
-        "top_causes": [],
-        "sensor_intensity": [],
-        "hotspot_rows": [],
+        "peak_rows": (),
+        "findings": (),
+        "top_causes": (),
+        "sensor_intensity": (),
+        "hotspot_rows": (),
+        "verdict_page": VerdictPageData(),
+        "appendix_a": AppendixAData(),
+        "appendix_b": AppendixBData(),
+        "appendix_c": AppendixCData(),
+        "appendix_d": AppendixDData(),
+    }
+    defaults.update(overrides)
+    return ResolvedReportDocumentSections(**defaults)
+
+
+def _build(**overrides: object):
+    """Build a ReportDocument with sensible defaults, allowing overrides."""
+    section_keys = {
+        "report_date_text",
+        "report_start_time_utc",
+        "report_end_time_utc",
+        "title",
+        "primary",
+        "observed",
+        "system_cards",
+        "next_steps",
+        "data_trust",
+        "pattern_evidence",
+        "peak_rows",
+        "findings",
+        "top_causes",
+        "sensor_intensity",
+        "hotspot_rows",
+        "verdict_page",
+        "appendix_a",
+        "appendix_b",
+        "appendix_c",
+        "appendix_d",
+    }
+    section_overrides = {key: overrides.pop(key) for key in tuple(overrides) if key in section_keys}
+    defaults: dict[str, object] = {
+        "prepared": _make_prepared(),
+        "report": _make_report(),
+        "sections": _make_sections(**section_overrides),
     }
     defaults.update(overrides)
     return build_report_document_data(**defaults)
@@ -132,9 +176,11 @@ def test_prepared_metadata_maps_to_template() -> None:
     )
     result = _build(
         prepared=prepared,
-        report_date_text="2026-03-25 10:00:00 UTC",
-        report_start_time_utc="2026-03-25T10:00:00Z",
-        report_end_time_utc="2026-03-25T10:01:30Z",
+        sections=_make_sections(
+            report_date_text="2026-03-25 10:00:00 UTC",
+            report_start_time_utc="2026-03-25T10:00:00Z",
+            report_end_time_utc="2026-03-25T10:01:30Z",
+        ),
     )
 
     assert result.run_datetime == "2026-03-25 10:00:00 UTC"

--- a/apps/server/tests/adapters/speed/test_source_coordinator.py
+++ b/apps/server/tests/adapters/speed/test_source_coordinator.py
@@ -86,3 +86,53 @@ def test_speed_source_coordinator_switches_to_obd_status_and_resolution() -> Non
     assert status.device == "OBDLink MX+ (00043e5a4a4d)"
     assert status.raw_speed_kmh == pytest.approx(43.2)
     assert status.speed_source == "obd2"
+    obd_monitor.refresh_admin_state.assert_not_called()
+    obd_monitor.status_snapshot.assert_called_once_with()
+
+
+def test_speed_source_coordinator_refreshes_admin_state_for_obd_status() -> None:
+    gps_monitor = MagicMock()
+    obd_monitor = MagicMock()
+    expected_status = ObdStatusSnapshot(
+        configured_device_mac="00043e5a4a4d",
+        configured_device_name="OBDLink MX+",
+        connection_state="connected",
+        device_mac="00043e5a4a4d",
+        device_name="OBDLink MX+",
+        paired=True,
+        trusted=True,
+        connected=True,
+        rfcomm_channel=1,
+        last_sample_age_s=0.2,
+        last_speed_kmh=43.2,
+        last_rpm=2100.0,
+        rpm_sample_age_s=0.1,
+        rpm_target_interval_ms=50,
+        rpm_effective_hz=20.0,
+        request_rtt_ms=48.0,
+        timeout_count=0,
+        error_count=0,
+        poll_mode="rpm_priority",
+        backoff_active=False,
+        last_error=None,
+        last_raw_response="410D0C",
+        reconnect_delay_s=None,
+        debug_hint=None,
+    )
+    obd_monitor.status_snapshot.return_value = expected_status
+    coordinator = SpeedSourceCoordinator(gps_monitor=gps_monitor, obd_monitor=obd_monitor)
+
+    coordinator.apply_speed_source_settings(
+        effective_speed_kmh=None,
+        manual_source_selected=False,
+        stale_timeout_s=8.0,
+        selected_source="obd2",
+        obd_device_mac="00043e5a4a4d",
+        obd_device_name="OBDLink MX+",
+    )
+
+    status = coordinator.obd_status()
+
+    assert status == expected_status
+    obd_monitor.refresh_admin_state.assert_called_once_with()
+    obd_monitor.status_snapshot.assert_called_once_with()

--- a/apps/server/tests/use_cases/updates/test_release_resolution.py
+++ b/apps/server/tests/use_cases/updates/test_release_resolution.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.release_resolution import (
     ServerReleaseResolver,
     UpdateReleaseCheck,
@@ -33,21 +34,17 @@ async def test_resolve_maps_update_check_fields(tmp_path: Path) -> None:
     assert resolution.current_version == "2026.4.3"
     assert resolution.release is release
     assert resolution.latest_tag == "server-v2026.4.4"
-    assert resolution.failed is False
     assert resolution.update_available is True
 
 
 @pytest.mark.asyncio
-async def test_resolve_preserves_failed_check_without_release(tmp_path: Path) -> None:
+async def test_resolve_propagates_release_check_failure(tmp_path: Path) -> None:
     tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "state.json"))
     resolver = ServerReleaseResolver(tracker=tracker, rollback_dir=tmp_path / "rollback")
 
     with patch(
         "vibesensor.use_cases.updates.release_resolution.check_for_update",
-        new=AsyncMock(return_value=UpdateReleaseCheck(release=None, failed=True)),
+        new=AsyncMock(side_effect=UpdateReleaseError("rate limited")),
     ):
-        resolution = await resolver.resolve("2026.4.3")
-
-    assert resolution.release is None
-    assert resolution.failed is True
-    assert resolution.update_available is False
+        with pytest.raises(UpdateReleaseError, match="rate limited"):
+            await resolver.resolve("2026.4.3")

--- a/apps/server/tests/use_cases/updates/test_release_staging.py
+++ b/apps/server/tests/use_cases/updates/test_release_staging.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
 from vibesensor.use_cases.updates.status import UpdateStateStore, UpdateStatusTracker
@@ -63,8 +64,11 @@ async def test_stage_returns_none_when_verification_fails(tmp_path: Path) -> Non
     _seed_release_ready_state(tracker)
     stager = ServerReleaseStager(tracker=tracker, rollback_dir=tmp_path / "rollback")
     release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="bad")
+    staged_dir: Path | None = None
 
     async def _download_release(_tracker, _rollback_dir, _release, staging_dir: Path) -> Path:
+        nonlocal staged_dir
+        staged_dir = staging_dir
         wheel_path = staging_dir / "release.whl"
         wheel_path.write_text("wheel", encoding="utf-8")
         return wheel_path
@@ -76,8 +80,12 @@ async def test_stage_returns_none_when_verification_fails(tmp_path: Path) -> Non
         ),
         patch(
             "vibesensor.use_cases.updates.release_staging.verify_download",
-            new=AsyncMock(return_value=False),
+            new=AsyncMock(side_effect=UpdateReleaseError("checksum mismatch")),
         ),
+        pytest.raises(UpdateReleaseError, match="checksum mismatch"),
     ):
-        async with stager.stage(release) as staged:
-            assert staged is None
+        async with stager.stage(release):
+            pytest.fail("stage() should not yield when verification fails")
+
+    assert staged_dir is not None
+    assert staged_dir.exists() is False

--- a/apps/server/tests/use_cases/updates/test_update_coordinator.py
+++ b/apps/server/tests/use_cases/updates/test_update_coordinator.py
@@ -5,6 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from vibesensor.shared.exceptions import (
+    UpdatePreparationError,
+    UpdateReleaseError,
+    UpdateTransportError,
+)
 from vibesensor.use_cases.updates.coordinator import UpdateCoordinator
 from vibesensor.use_cases.updates.models import (
     UpdateExecutionOutcome,
@@ -24,8 +29,6 @@ def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateReq
 
 def _build_coordinator(
     tmp_path: Path,
-    *,
-    cancel_requested=lambda: False,
 ) -> tuple[
     UpdateCoordinator,
     MagicMock,
@@ -42,7 +45,6 @@ def _build_coordinator(
         preparation=preparation,
         release_planner=release_planner,
         workflow_executor=workflow_executor,
-        cancel_requested=cancel_requested,
     )
     return coordinator, preparation, release_planner, workflow_executor
 
@@ -57,10 +59,10 @@ async def test_execute_stops_after_validation_failure(tmp_path: Path) -> None:
     ) = _build_coordinator(tmp_path)
     request = _wifi_request()
 
-    preparation.prepare.return_value = None
-    outcome = await coordinator.execute(request)
+    preparation.prepare.side_effect = UpdatePreparationError("validation failed")
 
-    assert outcome == UpdateExecutionOutcome.aborted
+    with pytest.raises(UpdatePreparationError, match="validation failed"):
+        await coordinator.execute(request)
     preparation.prepare.assert_awaited_once_with(request)
     release_planner.plan.assert_not_awaited()
     workflow_executor.execute.assert_not_awaited()
@@ -75,37 +77,11 @@ async def test_execute_stops_when_transport_cannot_prepare(tmp_path: Path) -> No
         workflow_executor,
     ) = _build_coordinator(tmp_path)
     request = _wifi_request()
-    preparation.prepare.return_value = None
+    preparation.prepare.side_effect = UpdateTransportError("transport failed")
 
-    outcome = await coordinator.execute(request)
+    with pytest.raises(UpdateTransportError, match="transport failed"):
+        await coordinator.execute(request)
 
-    assert outcome == UpdateExecutionOutcome.aborted
-    preparation.prepare.assert_awaited_once_with(request)
-    release_planner.plan.assert_not_awaited()
-    workflow_executor.execute.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_execute_honors_cancellation_after_transport_prepare(tmp_path: Path) -> None:
-    (
-        coordinator,
-        preparation,
-        release_planner,
-        workflow_executor,
-    ) = _build_coordinator(
-        tmp_path,
-        cancel_requested=lambda: True,
-    )
-    request = _wifi_request()
-    preparation.prepare.return_value = PreparedUpdateSession(
-        request=request,
-        current_version="2026.4.3",
-        transport_session=object(),
-    )
-
-    outcome = await coordinator.execute(request)
-
-    assert outcome == UpdateExecutionOutcome.aborted
     preparation.prepare.assert_awaited_once_with(request)
     release_planner.plan.assert_not_awaited()
     workflow_executor.execute.assert_not_awaited()
@@ -142,7 +118,7 @@ async def test_execute_delegates_release_plan_and_execution(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_execute_stops_when_release_planner_returns_none(tmp_path: Path) -> None:
+async def test_execute_propagates_release_plan_failure(tmp_path: Path) -> None:
     (
         coordinator,
         preparation,
@@ -155,10 +131,10 @@ async def test_execute_stops_when_release_planner_returns_none(tmp_path: Path) -
         current_version="2026.4.3",
         transport_session=object(),
     )
-    release_planner.plan.return_value = None
+    release_planner.plan.side_effect = UpdateReleaseError("release check failed")
 
-    outcome = await coordinator.execute(request)
-
-    assert outcome == UpdateExecutionOutcome.aborted
+    with pytest.raises(UpdateReleaseError, match="release check failed"):
+        await coordinator.execute(request)
+    preparation.prepare.assert_awaited_once_with(request)
     release_planner.plan.assert_awaited_once_with("2026.4.3")
     workflow_executor.execute.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.artifact_validation import (
     WheelArtifactValidator,
     read_wheel_metadata,
@@ -234,7 +235,8 @@ async def test_install_release_rejects_corrupt_downloaded_wheel(tmp_path: Path) 
     broken_wheel = tmp_path / "broken.whl"
     broken_wheel.write_text("not a wheel", encoding="utf-8")
 
-    assert await installer.install_release(broken_wheel, "2025.6.15") is False
+    with pytest.raises(UpdateReleaseError, match="Update install failed"):
+        await installer.install_release(broken_wheel, "2025.6.15")
     assert tracker.status.state.value == "failed"
     assert not commands.calls
     assert any(issue.message == "Downloaded wheel is corrupt" for issue in tracker.status.issues)
@@ -433,7 +435,8 @@ async def test_install_release_rejects_incompatible_environment_before_pip_insta
         "",
     )
 
-    assert await installer.install_release(wheel_path, "2025.6.15") is False
+    with pytest.raises(UpdateReleaseError, match="Update install failed"):
+        await installer.install_release(wheel_path, "2025.6.15")
     assert tracker.status.state.value == "failed"
     assert any(
         issue.message == "Downloaded wheel is incompatible with the current environment"

--- a/apps/server/tests/use_cases/updates/test_update_job_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_job_executor.py
@@ -33,7 +33,7 @@ async def test_start_rejects_concurrent_job() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_sets_event_and_cancels_running_task() -> None:
+async def test_cancel_cancels_running_task() -> None:
     executor = UpdateJobExecutor()
     started = asyncio.Event()
 
@@ -46,9 +46,7 @@ async def test_cancel_sets_event_and_cancels_running_task() -> None:
     assert task is not None
     await asyncio.wait_for(started.wait(), timeout=1)
 
-    assert executor.cancel_requested() is False
     assert executor.cancel() is True
-    assert executor.cancel_requested() is True
     with pytest.raises(asyncio.CancelledError):
         await task
 
@@ -85,9 +83,12 @@ async def test_run_surfaces_cancelled_cleanup_error() -> None:
 
     async def cleanup() -> None:
         events.append("cleanup")
-        raise RuntimeError("cleanup bug")
+        raise OSError("cleanup bug")
 
-    with pytest.raises(UpdateCleanupError, match="Cleanup failed: cleanup bug"):
+    with pytest.raises(
+        UpdateCleanupError,
+        match="Cleanup failed after cancellation: cleanup bug",
+    ):
         await executor.run(
             workflow_factory=lambda: cancelled_workflow(),
             timeout_s=1.0,
@@ -134,7 +135,7 @@ async def test_run_preserves_workflow_error_when_cleanup_also_fails() -> None:
         events.append("cleanup")
         raise RuntimeError("cleanup bug")
 
-    with pytest.raises(RuntimeError, match="workflow bug"):
+    with pytest.raises(RuntimeError, match="workflow bug") as exc_info:
         await executor.run(
             workflow_factory=lambda: broken_workflow(),
             timeout_s=1.0,
@@ -144,3 +145,4 @@ async def test_run_preserves_workflow_error_when_cleanup_also_fails() -> None:
         )
 
     assert events == ["cleanup"]
+    assert exc_info.value.__notes__ == ["Cleanup also failed: cleanup bug"]

--- a/apps/server/tests/use_cases/updates/test_update_job_lifecycle.py
+++ b/apps/server/tests/use_cases/updates/test_update_job_lifecycle.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from _update_manager_test_helpers import setup_update_env
 
+from vibesensor.shared.exceptions import UpdateCleanupError
 from vibesensor.use_cases.updates.models import (
     UpdatePhase,
     UpdateRequest,
@@ -69,7 +70,7 @@ async def test_cleanup_re_raises_runtime_details_bug_after_finishing_cleanup(tmp
     manager.status.phase = UpdatePhase.installing
 
     with patch(
-        "vibesensor.use_cases.updates.job_lifecycle.collect_runtime_details",
+        "vibesensor.use_cases.updates.cleanup.collect_runtime_details",
         side_effect=TypeError("runtime bug"),
     ):
         with pytest.raises(TypeError, match="runtime bug"):
@@ -97,24 +98,32 @@ async def test_cleanup_re_raises_wifi_diagnostics_bug_after_finishing_cleanup(tm
 
 
 @pytest.mark.asyncio
-async def test_cleanup_logs_and_marks_failed_before_reraising(tmp_path, caplog) -> None:
+async def test_cleanup_wraps_operational_runtime_refresh_failure(tmp_path, caplog) -> None:
     manager, _runner, _repo = setup_update_env(tmp_path)
     manager.status.state = UpdateState.running
     manager.status.phase = UpdatePhase.installing
 
     with (
         patch(
-            "vibesensor.use_cases.updates.job_lifecycle.collect_runtime_details",
-            side_effect=RuntimeError("cleanup bug"),
+            "vibesensor.use_cases.updates.cleanup.collect_runtime_details",
+            side_effect=OSError("runtime unavailable"),
         ),
         caplog.at_level("ERROR"),
-        pytest.raises(RuntimeError, match="cleanup bug"),
+        pytest.raises(
+            UpdateCleanupError,
+            match="Runtime details refresh failed: runtime unavailable",
+        ),
     ):
         await manager._runtime.lifecycle.cleanup_after_update()
 
     assert manager.status.state == UpdateState.failed
-    assert any(issue.message == "Cleanup failed: cleanup bug" for issue in manager.status.issues)
-    assert any(record.message == "update: cleanup error" for record in caplog.records)
+    assert any(
+        issue.message == "Runtime details refresh failed" and issue.detail == "runtime unavailable"
+        for issue in manager.status.issues
+    )
+    assert any(
+        record.message == "update: runtime details refresh error" for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -16,7 +16,6 @@ from _update_manager_test_helpers import (
     setup_update_env,
 )
 
-from vibesensor.shared.exceptions import UpdateCleanupError
 from vibesensor.use_cases.updates.models import UpdateState, UpdateTransport, UsbInternetStatus
 from vibesensor.use_cases.updates.status import collect_runtime_details
 
@@ -421,7 +420,7 @@ class TestUpdateManagerAsync:
             await asyncio.wait_for(task, timeout=3)
         assert manager.status.state == UpdateState.failed
 
-    async def test_run_update_surfaces_cleanup_bug_when_cancellation_cleanup_fails(
+    async def test_run_update_marks_failed_when_cancellation_cleanup_reports_operational_error(
         self,
         tmp_path,
         caplog: pytest.LogCaptureFixture,
@@ -432,23 +431,45 @@ class TestUpdateManagerAsync:
 
         with (
             patch(
-                "vibesensor.use_cases.updates.job_lifecycle.collect_runtime_details",
-                side_effect=TypeError("runtime bug"),
+                "vibesensor.use_cases.updates.cleanup.collect_runtime_details",
+                side_effect=OSError("runtime unavailable"),
             ),
             caplog.at_level("ERROR"),
         ):
             object.__setattr__(manager._runtime, "coordinator_factory", lambda: mock_coordinator)
             manager.start("TestNet", "pass123")
             assert manager.job_task is not None
-            with pytest.raises(UpdateCleanupError, match="Cleanup failed: runtime bug"):
+            await manager.job_task
+
+        assert manager.status.finished_at is not None
+        assert manager.status.state == UpdateState.failed
+        assert any(
+            issue.message == "Runtime details refresh failed"
+            and issue.detail == "runtime unavailable"
+            for issue in manager.status.issues
+        )
+        assert any(rec.message == "update: runtime details refresh error" for rec in caplog.records)
+
+    async def test_run_update_surfaces_programmer_bug_from_cancellation_cleanup(
+        self,
+        tmp_path,
+    ) -> None:
+        manager, _runner, _ = setup_update_env(tmp_path)
+        mock_coordinator = MagicMock()
+        mock_coordinator.execute = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with patch(
+            "vibesensor.use_cases.updates.cleanup.collect_runtime_details",
+            side_effect=TypeError("runtime bug"),
+        ):
+            object.__setattr__(manager._runtime, "coordinator_factory", lambda: mock_coordinator)
+            manager.start("TestNet", "pass123")
+            assert manager.job_task is not None
+            with pytest.raises(TypeError, match="runtime bug"):
                 await manager.job_task
 
         assert manager.status.finished_at is not None
         assert manager.status.state == UpdateState.failed
-        assert any(rec.message == "update: cleanup error" for rec in caplog.records)
-        assert any(
-            issue.message == "Cleanup failed: runtime bug" for issue in manager.status.issues
-        )
 
     async def test_check_update_failure_fails_update(self, tmp_path) -> None:
         manager, _runner, _ = setup_update_env(tmp_path)

--- a/apps/server/tests/use_cases/updates/test_update_preparation.py
+++ b/apps/server/tests/use_cases/updates/test_update_preparation.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdatePreparationError, UpdateTransportError
 from vibesensor.use_cases.updates.models import (
     UpdateRequest,
     UpdateTransport,
@@ -28,7 +29,6 @@ def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateReq
 def _build_preparation(
     tmp_path: Path,
     *,
-    cancel_requested=lambda: False,
     current_version: str = "2026.4.3",
 ) -> tuple[UpdatePreparationCoordinator, UpdateStatusTracker, MagicMock]:
     tracker = UpdateStatusTracker(state_store=UpdateStateStore(tmp_path / "state.json"))
@@ -43,7 +43,6 @@ def _build_preparation(
             min_free_disk_bytes=1,
         ),
         current_version_provider=lambda: current_version,
-        cancel_requested=cancel_requested,
     )
     return preparation, tracker, transport_controller
 
@@ -52,13 +51,15 @@ def _build_preparation(
 async def test_prepare_stops_after_validation_failure(tmp_path: Path) -> None:
     preparation, _tracker, transport_controller = _build_preparation(tmp_path)
 
-    with patch(
-        "vibesensor.use_cases.updates.preparation.validate_prerequisites",
-        new=AsyncMock(return_value=False),
+    with (
+        patch(
+            "vibesensor.use_cases.updates.preparation.validate_prerequisites",
+            new=AsyncMock(side_effect=UpdatePreparationError("validation failed")),
+        ),
+        pytest.raises(UpdatePreparationError, match="validation failed"),
     ):
-        prepared = await preparation.prepare(_wifi_request())
+        await preparation.prepare(_wifi_request())
 
-    assert prepared is None
     transport_controller.prepare.assert_not_awaited()
 
 
@@ -66,36 +67,17 @@ async def test_prepare_stops_after_validation_failure(tmp_path: Path) -> None:
 async def test_prepare_stops_when_transport_cannot_prepare(tmp_path: Path) -> None:
     preparation, _tracker, transport_controller = _build_preparation(tmp_path)
     request = _wifi_request()
-    transport_controller.prepare.return_value = None
+    transport_controller.prepare.side_effect = UpdateTransportError("transport failed")
 
-    with patch(
-        "vibesensor.use_cases.updates.preparation.validate_prerequisites",
-        new=AsyncMock(return_value=True),
+    with (
+        patch(
+            "vibesensor.use_cases.updates.preparation.validate_prerequisites",
+            new=AsyncMock(return_value=None),
+        ),
+        pytest.raises(UpdateTransportError, match="transport failed"),
     ):
-        prepared = await preparation.prepare(request)
+        await preparation.prepare(request)
 
-    assert prepared is None
-    transport_controller.prepare.assert_awaited_once_with(request)
-
-
-@pytest.mark.asyncio
-async def test_prepare_honors_cancellation_after_transport_prepare(tmp_path: Path) -> None:
-    cancel_results = iter((False, True))
-    preparation, _tracker, transport_controller = _build_preparation(
-        tmp_path,
-        cancel_requested=lambda: next(cancel_results),
-    )
-    request = _wifi_request()
-    transport_session = object()
-    transport_controller.prepare.return_value = transport_session
-
-    with patch(
-        "vibesensor.use_cases.updates.preparation.validate_prerequisites",
-        new=AsyncMock(return_value=True),
-    ):
-        prepared = await preparation.prepare(request)
-
-    assert prepared is None
     transport_controller.prepare.assert_awaited_once_with(request)
 
 
@@ -111,7 +93,7 @@ async def test_prepare_returns_canonical_prepared_session(tmp_path: Path) -> Non
 
     with patch(
         "vibesensor.use_cases.updates.preparation.validate_prerequisites",
-        new=AsyncMock(return_value=True),
+        new=AsyncMock(return_value=None),
     ):
         prepared = await preparation.prepare(request)
 

--- a/apps/server/tests/use_cases/updates/test_update_release_planner.py
+++ b/apps/server/tests/use_cases/updates/test_update_release_planner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.models import (
     UpdatePhase,
     UpdateRequest,
@@ -40,7 +41,6 @@ async def test_plan_returns_refresh_only_plan_when_no_server_update_is_needed(
 ) -> None:
     planner, tracker, resolver = _planner(tmp_path)
     resolver.resolve.return_value = SimpleNamespace(
-        failed=False,
         release=None,
         latest_tag="server-v2026.4.3",
     )
@@ -59,7 +59,6 @@ async def test_plan_returns_install_plan_when_server_update_is_available(tmp_pat
     planner, tracker, resolver = _planner(tmp_path)
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4")
     resolver.resolve.return_value = SimpleNamespace(
-        failed=False,
         release=release,
         latest_tag="server-v2026.4.4",
     )
@@ -74,15 +73,11 @@ async def test_plan_returns_install_plan_when_server_update_is_available(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_plan_returns_none_when_release_resolution_failed(tmp_path: Path) -> None:
+async def test_plan_propagates_release_resolution_failure(tmp_path: Path) -> None:
     planner, tracker, resolver = _planner(tmp_path)
-    resolver.resolve.return_value = SimpleNamespace(
-        failed=True,
-        release=None,
-        latest_tag="server-v2026.4.3",
-    )
+    resolver.resolve.side_effect = UpdateReleaseError("release check failed")
 
-    plan = await planner.plan("2026.4.3")
+    with pytest.raises(UpdateReleaseError, match="release check failed"):
+        await planner.plan("2026.4.3")
 
-    assert plan is None
     assert tracker.status.phase.value == "checking"

--- a/apps/server/tests/use_cases/updates/test_update_validation.py
+++ b/apps/server/tests/use_cases/updates/test_update_validation.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdatePreparationError
 from vibesensor.use_cases.updates.models import (
     UpdateRequest,
     UpdateTransport,
@@ -38,21 +39,21 @@ async def test_validation_fails_when_rollback_dir_probe_fails(monkeypatch, tmp_p
         _raise_probe,
     )
 
-    result = await validate_prerequisites(
-        commands=_Commands(),
-        tracker=tracker,
-        config=UpdateValidationConfig(
-            rollback_dir=tmp_path / "rollback",
-            min_free_disk_bytes=1,
-        ),
-        request=UpdateRequest(
-            transport=UpdateTransport.wifi,
-            ssid="TestNet",
-            password="",
-        ),
-    )
+    with pytest.raises(UpdatePreparationError, match="Rollback directory is not writable"):
+        await validate_prerequisites(
+            commands=_Commands(),
+            tracker=tracker,
+            config=UpdateValidationConfig(
+                rollback_dir=tmp_path / "rollback",
+                min_free_disk_bytes=1,
+            ),
+            request=UpdateRequest(
+                transport=UpdateTransport.wifi,
+                ssid="TestNet",
+                password="",
+            ),
+        )
 
-    assert result is False
     assert tracker.status.state.value == "failed"
     assert any(
         issue.message == "Rollback directory is not writable" for issue in tracker.status.issues

--- a/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.release_planner import (
     InstallServerReleasePlan,
@@ -15,10 +16,7 @@ from vibesensor.use_cases.updates.release_planner import (
 from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
 
 
-def _executor(
-    *,
-    cancel_requested=lambda: False,
-) -> tuple[UpdateWorkflowExecutor, MagicMock, MagicMock, MagicMock, MagicMock]:
+def _executor() -> tuple[UpdateWorkflowExecutor, MagicMock, MagicMock, MagicMock, MagicMock]:
     stager = MagicMock()
     deployer = MagicMock()
     deployer.deploy = AsyncMock(return_value=True)
@@ -31,7 +29,6 @@ def _executor(
         deployer=deployer,
         firmware_refresher=firmware_refresher,
         finalizer=finalizer,
-        cancel_requested=cancel_requested,
     )
     return executor, stager, deployer, firmware_refresher, finalizer
 
@@ -88,13 +85,10 @@ async def test_execute_install_plan_stages_and_deploys_before_finalization(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_execute_install_plan_stops_before_finalization_when_cancelled(
+async def test_execute_install_plan_propagates_deploy_failure_before_finalization(
     tmp_path: Path,
 ) -> None:
-    cancel_results = iter((False, True))
-    executor, stager, deployer, _firmware_refresher, finalizer = _executor(
-        cancel_requested=lambda: next(cancel_results),
-    )
+    executor, stager, deployer, _firmware_refresher, finalizer = _executor()
     transport_session = object()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
@@ -104,12 +98,13 @@ async def test_execute_install_plan_stops_before_finalization_when_cancelled(
         yield staged_release
 
     stager.stage.side_effect = stage
+    deployer.deploy.side_effect = UpdateReleaseError("install failed")
 
-    completed = await executor.execute(
-        InstallServerReleasePlan(current_version="2026.4.3", release=release),
-        transport_session=transport_session,
-    )
+    with pytest.raises(UpdateReleaseError, match="install failed"):
+        await executor.execute(
+            InstallServerReleasePlan(current_version="2026.4.3", release=release),
+            transport_session=transport_session,
+        )
 
-    assert completed == UpdateExecutionOutcome.aborted
     deployer.deploy.assert_awaited_once_with(staged_release)
     finalizer.complete.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from use_cases.updates._update_manager_test_helpers import FakeRunner
 
+from vibesensor.shared.exceptions import UpdateTransportError
 from vibesensor.use_cases.updates.models import (
     UpdateIssue,
     UpdatePhase,
@@ -84,7 +85,7 @@ async def test_prepare_stops_hotspot_and_connects_uplink(tmp_path: Path) -> None
     session, runner, tracker = _build_session(tmp_path)
     tracker.start_job(_wifi_request(password="pass123"))
 
-    assert await session.prepare(_wifi_request(password="pass123")) is True
+    await session.prepare(_wifi_request(password="pass123"))
 
     commands = [" ".join(call[0]) for call in runner.calls]
     assert any("connection down VibeSensor-AP" in command for command in commands)
@@ -156,7 +157,7 @@ async def test_complete_success_restores_hotspot_and_marks_success(tmp_path: Pat
     session, _runner, tracker = _build_session(tmp_path)
     _seed_checked_phase(tracker)
 
-    assert await session.complete_success("Update completed successfully") is True
+    await session.complete_success("Update completed successfully")
 
     assert tracker.status.state == UpdateState.success
     assert tracker.status.phase == UpdatePhase.done
@@ -173,7 +174,8 @@ async def test_complete_success_marks_failed_when_restore_fails(tmp_path: Path) 
     _seed_checked_phase(tracker)
     runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
 
-    assert await session.complete_success("Update completed successfully") is False
+    with pytest.raises(UpdateTransportError, match="Failed to restore hotspot after update"):
+        await session.complete_success("Update completed successfully")
 
     assert tracker.status.state == UpdateState.failed
     assert any(

--- a/apps/server/vibesensor/adapters/obd/admin_state.py
+++ b/apps/server/vibesensor/adapters/obd/admin_state.py
@@ -1,0 +1,35 @@
+"""Observation helpers for configured Bluetooth OBD admin state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.adapters.obd.admin_client import ObdAdminClient
+from vibesensor.adapters.obd.models import ObdDeviceSnapshot
+from vibesensor.shared.operational_errors import OperationalError
+
+__all__ = ["ObdAdminObservation", "observe_configured_obd_device"]
+
+
+@dataclass(frozen=True, slots=True)
+class ObdAdminObservation:
+    """Latest configured-device admin observation, separated from monitor mutation."""
+
+    snapshot: ObdDeviceSnapshot | None
+    helper_error: str | None
+
+
+def observe_configured_obd_device(
+    *,
+    admin_client: ObdAdminClient,
+    configured_mac: str | None,
+) -> ObdAdminObservation:
+    """Fetch admin/device state for the configured adapter without mutating monitor state."""
+
+    if configured_mac is None:
+        return ObdAdminObservation(snapshot=None, helper_error=None)
+    try:
+        snapshot = admin_client.device_info(configured_mac)
+    except OperationalError as exc:
+        return ObdAdminObservation(snapshot=None, helper_error=str(exc))
+    return ObdAdminObservation(snapshot=snapshot, helper_error=None)

--- a/apps/server/vibesensor/adapters/obd/monitor.py
+++ b/apps/server/vibesensor/adapters/obd/monitor.py
@@ -10,6 +10,10 @@ from threading import RLock
 
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution, SpeedResolutionPolicy
 from vibesensor.adapters.obd.admin_client import ObdAdminClient
+from vibesensor.adapters.obd.admin_state import (
+    ObdAdminObservation,
+    observe_configured_obd_device,
+)
 from vibesensor.adapters.obd.elm327 import Elm327Session
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot, ObdStatusSnapshot
 from vibesensor.adapters.obd.polling import (
@@ -51,6 +55,7 @@ class OBDSpeedMonitor:
         "_device_name",
         "_engine_rpm",
         "_engine_rpm_ts",
+        "_last_admin_error",
         "_last_error",
         "_lock",
         "_monotonic",
@@ -94,6 +99,7 @@ class OBDSpeedMonitor:
         self._speed_snapshot: tuple[float | None, float | None] = (None, None)
         self._engine_rpm: float | None = None
         self._engine_rpm_ts: float | None = None
+        self._last_admin_error: str | None = None
         self._last_error: str | None = None
         self._current_reconnect_delay = _INITIAL_RECONNECT_DELAY_S
 
@@ -146,17 +152,22 @@ class OBDSpeedMonitor:
             stale_timeout_s=stale_timeout_s,
         )
         with self._lock:
+            previous_configured_mac = self._configured_device_mac
             if selected_source is not None:
                 self._selected_source = SpeedSourceKind(selected_source)
             self._configured_device_mac = obd_device_mac
             self._configured_device_name = obd_device_name
+            if self._configured_device_mac != previous_configured_mac:
+                self._reset_observed_device_state_unlocked(clear_runtime_error=True)
             if (
                 self._selected_source is SpeedSourceKind.OBD2
                 and self._configured_device_mac is None
             ):
                 self._connection_state = "disconnected"
+                self._reset_observed_device_state_unlocked(clear_runtime_error=True)
             elif self._selected_source is not SpeedSourceKind.OBD2:
                 self._connection_state = "idle"
+                self._reset_observed_device_state_unlocked(clear_runtime_error=True)
         return applied_speed
 
     def scan_devices(self, *, timeout_s: int = 8) -> list[ObdDeviceSnapshot]:
@@ -178,18 +189,15 @@ class OBDSpeedMonitor:
     ) -> None:
         self._policy.set_fallback_settings(stale_timeout_s=stale_timeout_s, **kwargs)
 
-    def status_snapshot(self, *, refresh_admin: bool = False) -> ObdStatusSnapshot:
-        helper_error: str | None = None
-        configured_mac: str | None
-        with self._lock:
-            configured_mac = self._configured_device_mac
-        if refresh_admin and configured_mac is not None:
-            try:
-                helper_device = self._admin_client.device_info(configured_mac)
-            except OperationalError as exc:
-                helper_error = str(exc)
-            else:
-                self._apply_device_snapshot(helper_device)
+    def refresh_admin_state(self) -> None:
+        configured_mac = self._configured_device_mac_snapshot()
+        observation = observe_configured_obd_device(
+            admin_client=self._admin_client,
+            configured_mac=configured_mac,
+        )
+        self._apply_admin_observation(configured_mac, observation)
+
+    def status_snapshot(self) -> ObdStatusSnapshot:
         with self._lock:
             now = self._monotonic()
             return build_obd_status_snapshot(
@@ -208,8 +216,8 @@ class OBDSpeedMonitor:
                     engine_rpm=self._engine_rpm_unlocked(now),
                     engine_rpm_ts=self._engine_rpm_ts,
                     obd_selected=self._selected_source is SpeedSourceKind.OBD2,
-                    last_error=self._last_error or helper_error,
-                    helper_error=helper_error,
+                    last_error=self._last_error or self._last_admin_error,
+                    helper_error=self._last_admin_error,
                     reconnect_delay_s=self._current_reconnect_delay,
                     polling=self._polling.snapshot(),
                 ),
@@ -344,12 +352,7 @@ class OBDSpeedMonitor:
 
     def _apply_device_snapshot(self, snapshot: ObdDeviceSnapshot) -> None:
         with self._lock:
-            self._device_mac = snapshot.mac_address
-            self._device_name = snapshot.name
-            self._paired = snapshot.paired
-            self._trusted = snapshot.trusted
-            self._device_connected = snapshot.connected
-            self._rfcomm_channel = snapshot.rfcomm_channel
+            self._apply_device_snapshot_unlocked(snapshot)
 
     async def _idle(
         self,
@@ -363,6 +366,22 @@ class OBDSpeedMonitor:
     def _config_snapshot(self) -> tuple[SpeedSourceKind, str | None, str | None]:
         with self._lock:
             return self._selected_source, self._configured_device_mac, self._configured_device_name
+
+    def _configured_device_mac_snapshot(self) -> str | None:
+        with self._lock:
+            return self._configured_device_mac
+
+    def _apply_admin_observation(
+        self,
+        configured_mac: str | None,
+        observation: ObdAdminObservation,
+    ) -> None:
+        with self._lock:
+            if configured_mac != self._configured_device_mac:
+                return
+            self._last_admin_error = observation.helper_error
+            if observation.snapshot is not None:
+                self._apply_device_snapshot_unlocked(observation.snapshot)
 
     def _set_connection_state(
         self,
@@ -379,6 +398,26 @@ class OBDSpeedMonitor:
                 self._current_reconnect_delay = float(reconnect_delay_s)
             elif state == "connected":
                 self._current_reconnect_delay = _INITIAL_RECONNECT_DELAY_S
+
+    def _apply_device_snapshot_unlocked(self, snapshot: ObdDeviceSnapshot) -> None:
+        self._device_mac = snapshot.mac_address
+        self._device_name = snapshot.name
+        self._paired = snapshot.paired
+        self._trusted = snapshot.trusted
+        self._device_connected = snapshot.connected
+        self._rfcomm_channel = snapshot.rfcomm_channel
+        self._last_admin_error = None
+
+    def _reset_observed_device_state_unlocked(self, *, clear_runtime_error: bool) -> None:
+        self._device_mac = None
+        self._device_name = None
+        self._paired = False
+        self._trusted = False
+        self._device_connected = False
+        self._rfcomm_channel = None
+        self._last_admin_error = None
+        if clear_runtime_error:
+            self._last_error = None
 
     def _engine_rpm_unlocked(self, now: float) -> float | None:
         if self._selected_source is not SpeedSourceKind.OBD2:

--- a/apps/server/vibesensor/adapters/pdf/pdf_engine.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_engine.py
@@ -15,7 +15,7 @@ from vibesensor.adapters.pdf.pdf_appendices import (
 from vibesensor.adapters.pdf.pdf_drawing import _draw_footer
 from vibesensor.adapters.pdf.pdf_page1 import _page1
 from vibesensor.adapters.pdf.pdf_style import PAGE_SIZE
-from vibesensor.adapters.pdf.report_types import build_report_render_plan
+from vibesensor.adapters.pdf.render_planner import build_report_render_plan
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 
 LOGGER = logging.getLogger(__name__)

--- a/apps/server/vibesensor/adapters/pdf/render_planner.py
+++ b/apps/server/vibesensor/adapters/pdf/render_planner.py
@@ -1,0 +1,100 @@
+"""PDF page-sequencing planner over the canonical report document."""
+
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.reporting.document import ReportDocument
+
+from .pdf_appendices.action_matrix import worksheet_step_pages
+from .report_types import (
+    AppendixAPageRenderPlan,
+    AppendixBRenderPlan,
+    ReportPdfRenderPlan,
+    build_appendix_b_render_plan,
+    build_appendix_c_render_plan,
+    build_page1_render_plan,
+)
+
+__all__ = ["build_report_render_plan"]
+
+
+def build_report_render_plan(data: ReportDocument) -> ReportPdfRenderPlan:
+    """Build the complete adapter-side render plan for the shipped PDF flow."""
+
+    recapture_mode = data.appendix_a.mode == "recapture"
+    appendix_a_pages = _appendix_a_page_plans(data)
+    appendix_b = _appendix_b_render_plan(data, recapture_mode=recapture_mode)
+    total_pages = (
+        1 + len(appendix_a_pages)
+        if recapture_mode
+        else len(appendix_a_pages) + 2 + (1 if appendix_b is not None else 0)
+    )
+    return ReportPdfRenderPlan(
+        document_title=data.title or "VibeSensor Diagnostic Report",
+        page1=build_page1_render_plan(data),
+        appendix_a_pages=appendix_a_pages,
+        appendix_b=appendix_b,
+        appendix_c=build_appendix_c_render_plan(data),
+        recapture_mode=recapture_mode,
+        total_pages=total_pages,
+    )
+
+
+def _appendix_a_page_plans(data: ReportDocument) -> tuple[AppendixAPageRenderPlan, ...]:
+    trace_rows = tuple(data.appendix_d.rows)
+    if data.appendix_a.mode == "recapture":
+        return (
+            AppendixAPageRenderPlan(
+                lang=data.lang,
+                appendix=data.appendix_a,
+                trace_rows=trace_rows,
+                steps=(),
+                start_number=1,
+                continued=False,
+            ),
+        )
+
+    step_pages = worksheet_step_pages(data.appendix_a, list(data.next_steps), lang=data.lang)
+    page_plans: list[AppendixAPageRenderPlan] = []
+    start_number = 1
+    for index, page_steps in enumerate(step_pages):
+        page_plans.append(
+            AppendixAPageRenderPlan(
+                lang=data.lang,
+                appendix=data.appendix_a,
+                trace_rows=trace_rows,
+                steps=tuple(page_steps),
+                start_number=start_number,
+                continued=index > 0,
+            )
+        )
+        start_number += len(page_steps)
+    return tuple(page_plans)
+
+
+def _appendix_b_render_plan(
+    data: ReportDocument,
+    *,
+    recapture_mode: bool,
+) -> AppendixBRenderPlan | None:
+    if recapture_mode:
+        return None
+    appendix_b = build_appendix_b_render_plan(data)
+    if not _has_appendix_b_content(appendix_b):
+        return None
+    return appendix_b
+
+
+def _has_appendix_b_content(plan: AppendixBRenderPlan) -> bool:
+    appendix = plan.appendix
+    return any(
+        (
+            appendix.dominant_corner,
+            appendix.runner_up_corner,
+            appendix.dominance_ratio_text,
+            appendix.location_confidence,
+            appendix.coverage_label,
+            appendix.coverage_notes,
+            appendix.intensity_rows,
+            appendix.sensor_observation_rows,
+        )
+    )

--- a/apps/server/vibesensor/adapters/pdf/report_types.py
+++ b/apps/server/vibesensor/adapters/pdf/report_types.py
@@ -17,8 +17,6 @@ from vibesensor.shared.boundaries.reporting.document import (
 )
 from vibesensor.shared.types.analysis_views import PeakTableRow
 
-from .pdf_appendices.action_matrix import worksheet_step_pages
-
 __all__ = [
     "AppendixAPageRenderPlan",
     "AppendixBRenderPlan",
@@ -29,7 +27,6 @@ __all__ = [
     "build_appendix_b_render_plan",
     "build_appendix_c_render_plan",
     "build_page1_render_plan",
-    "build_report_render_plan",
 ]
 
 
@@ -144,71 +141,4 @@ def build_appendix_c_render_plan(data: ReportDocument) -> AppendixCRenderPlan:
         appendix=data.appendix_c,
         trace_rows=tuple(data.appendix_d.rows),
         action_status_note=data.verdict_page.action_status_note,
-    )
-
-
-def build_report_render_plan(data: ReportDocument) -> ReportPdfRenderPlan:
-    """Build the complete adapter-side render plan for the shipped PDF flow."""
-
-    recapture_mode = data.appendix_a.mode == "recapture"
-    appendix_a_pages = _appendix_a_page_plans(data)
-    appendix_b = None if recapture_mode else build_appendix_b_render_plan(data)
-    render_appendix_b = appendix_b is not None and _has_appendix_b_content(appendix_b)
-    total_pages = len(appendix_a_pages) + 2 + (1 if render_appendix_b else 0)
-    return ReportPdfRenderPlan(
-        document_title=data.title or "VibeSensor Diagnostic Report",
-        page1=build_page1_render_plan(data),
-        appendix_a_pages=appendix_a_pages,
-        appendix_b=appendix_b if render_appendix_b else None,
-        appendix_c=build_appendix_c_render_plan(data),
-        recapture_mode=recapture_mode,
-        total_pages=total_pages,
-    )
-
-
-def _appendix_a_page_plans(data: ReportDocument) -> tuple[AppendixAPageRenderPlan, ...]:
-    trace_rows = tuple(data.appendix_d.rows)
-    if data.appendix_a.mode == "recapture":
-        return (
-            AppendixAPageRenderPlan(
-                lang=data.lang,
-                appendix=data.appendix_a,
-                trace_rows=trace_rows,
-                steps=(),
-                start_number=1,
-                continued=False,
-            ),
-        )
-
-    step_pages = worksheet_step_pages(data.appendix_a, list(data.next_steps), lang=data.lang)
-    page_plans: list[AppendixAPageRenderPlan] = []
-    start_number = 1
-    for index, page_steps in enumerate(step_pages):
-        page_plans.append(
-            AppendixAPageRenderPlan(
-                lang=data.lang,
-                appendix=data.appendix_a,
-                trace_rows=trace_rows,
-                steps=tuple(page_steps),
-                start_number=start_number,
-                continued=index > 0,
-            )
-        )
-        start_number += len(page_steps)
-    return tuple(page_plans)
-
-
-def _has_appendix_b_content(plan: AppendixBRenderPlan) -> bool:
-    appendix = plan.appendix
-    return any(
-        (
-            appendix.dominant_corner,
-            appendix.runner_up_corner,
-            appendix.dominance_ratio_text,
-            appendix.location_confidence,
-            appendix.coverage_label,
-            appendix.coverage_notes,
-            appendix.intensity_rows,
-            appendix.sensor_observation_rows,
-        )
     )

--- a/apps/server/vibesensor/adapters/speed/source_coordinator.py
+++ b/apps/server/vibesensor/adapters/speed/source_coordinator.py
@@ -95,7 +95,7 @@ class SpeedSourceCoordinator:
         if self._selected_source_kind() is not SpeedSourceKind.OBD2:
             return self._gps_monitor.status_snapshot()
         resolution = self._obd_monitor.resolve_speed()
-        obd_status = self._obd_monitor.status_snapshot(refresh_admin=False)
+        obd_status = self._obd_monitor.status_snapshot()
         return SpeedSourceStatusSnapshot(
             gps_enabled=self._gps_monitor.gps_enabled,
             connection_state=obd_status.connection_state,
@@ -123,7 +123,8 @@ class SpeedSourceCoordinator:
         return self._obd_monitor.pair_device(mac_address)
 
     def obd_status(self) -> ObdStatusSnapshot:
-        return self._obd_monitor.status_snapshot(refresh_admin=True)
+        self._obd_monitor.refresh_admin_state()
+        return self._obd_monitor.status_snapshot()
 
     def set_manual_source_selected(self, selected: bool) -> None:
         self._gps_monitor.set_manual_source_selected(selected)

--- a/apps/server/vibesensor/shared/boundaries/_codec_helpers.py
+++ b/apps/server/vibesensor/shared/boundaries/_codec_helpers.py
@@ -1,0 +1,32 @@
+"""Shared scalar coercion helpers for boundary codecs."""
+
+from __future__ import annotations
+
+from vibesensor.domain import coerce_float, coerce_int
+
+__all__ = ["coerce_count", "optional_float", "text_or_none"]
+
+
+def text_or_none(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return coerce_float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def coerce_count(value: object) -> int:
+    if value is None:
+        return 0
+    try:
+        return coerce_int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/apps/server/vibesensor/shared/boundaries/reporting/payload.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/payload.py
@@ -6,7 +6,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import cast
 
-from vibesensor.domain import LocationIntensitySummary, coerce_float, coerce_int
+from vibesensor.domain import LocationIntensitySummary
+from vibesensor.shared.boundaries._codec_helpers import (
+    coerce_count,
+    optional_float,
+    text_or_none,
+)
 from vibesensor.shared.boundaries.location_hotspot_codec import (
     location_intensity_summaries_from_rows,
 )
@@ -79,12 +84,12 @@ def report_summary_from_mapping(payload: Mapping[str, object]) -> NormalizedRepo
         run_id=_summary_run_id(payload, typed_metadata),
         metadata=typed_metadata,
         report_date=_summary_report_date(payload, typed_metadata),
-        duration_s=_optional_float(payload.get("duration_s")),
-        record_length=_normalized_text(payload.get("record_length")),
-        start_time_utc=_normalized_text(payload.get("start_time_utc")),
-        end_time_utc=_normalized_text(payload.get("end_time_utc")),
-        sample_count=_coerce_count(payload.get("rows")),
-        sensor_count=_coerce_count(payload.get("sensor_count_used")),
+        duration_s=optional_float(payload.get("duration_s")),
+        record_length=text_or_none(payload.get("record_length")),
+        start_time_utc=text_or_none(payload.get("start_time_utc")),
+        end_time_utc=text_or_none(payload.get("end_time_utc")),
+        sample_count=coerce_count(payload.get("rows")),
+        sensor_count=coerce_count(payload.get("sensor_count_used")),
         active_sensor_locations=_active_sensor_locations(payload),
         sensor_intensity_rows=_sensor_intensity_rows(payload),
         peak_table_rows=_peak_table_rows(payload),
@@ -98,8 +103,8 @@ def _summary_run_metadata(payload: Mapping[str, object]) -> RunMetadata | None:
         return None
     if not metadata_payload:
         return None
-    top_level_run_id = _normalized_text(payload.get("run_id"))
-    metadata_run_id = _normalized_text(metadata_payload.get("run_id"))
+    top_level_run_id = text_or_none(payload.get("run_id"))
+    metadata_run_id = text_or_none(metadata_payload.get("run_id"))
     if metadata_run_id is None:
         raise ValueError("report summary metadata must include canonical nested run_id")
     if top_level_run_id is not None and metadata_run_id != top_level_run_id:
@@ -108,7 +113,7 @@ def _summary_run_metadata(payload: Mapping[str, object]) -> RunMetadata | None:
 
 
 def _summary_run_id(payload: Mapping[str, object], metadata: RunMetadata | None) -> str:
-    raw_run_id = _normalized_text(payload.get("run_id"))
+    raw_run_id = text_or_none(payload.get("run_id"))
     if raw_run_id is not None:
         return raw_run_id
     if metadata is not None and metadata.run_id:
@@ -117,8 +122,8 @@ def _summary_run_id(payload: Mapping[str, object], metadata: RunMetadata | None)
 
 
 def _summary_report_date(payload: Mapping[str, object], metadata: RunMetadata | None) -> str | None:
-    return _normalized_text(payload.get("report_date")) or (
-        _normalized_text(metadata.report_date) if metadata is not None else None
+    return text_or_none(payload.get("report_date")) or (
+        text_or_none(metadata.report_date) if metadata is not None else None
     )
 
 
@@ -157,42 +162,17 @@ def _timeline_intervals(payload: Mapping[str, object]) -> tuple[ReportTimelineIn
     for row in raw_timeline:
         if not isinstance(row, Mapping):
             continue
-        phase = _normalized_text(row.get("phase"))
+        phase = text_or_none(row.get("phase"))
         if phase is None:
             continue
         intervals.append(
             ReportTimelineInterval(
                 phase=phase,
-                start_t_s=_optional_float(row.get("start_t_s")),
-                end_t_s=_optional_float(row.get("end_t_s")),
-                speed_min_kmh=_optional_float(row.get("speed_min_kmh")),
-                speed_max_kmh=_optional_float(row.get("speed_max_kmh")),
+                start_t_s=optional_float(row.get("start_t_s")),
+                end_t_s=optional_float(row.get("end_t_s")),
+                speed_min_kmh=optional_float(row.get("speed_min_kmh")),
+                speed_max_kmh=optional_float(row.get("speed_max_kmh")),
                 has_fault_evidence=bool(row.get("has_fault_evidence")),
             )
         )
     return tuple(intervals)
-
-
-def _normalized_text(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    return text or None
-
-
-def _optional_float(value: object) -> float | None:
-    if value is None:
-        return None
-    try:
-        return coerce_float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _coerce_count(value: object) -> int:
-    if value is None:
-        return 0
-    try:
-        return coerce_int(value)
-    except (TypeError, ValueError):
-        return 0

--- a/apps/server/vibesensor/shared/boundaries/run_car_codec.py
+++ b/apps/server/vibesensor/shared/boundaries/run_car_codec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from vibesensor.shared.boundaries._codec_helpers import text_or_none
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.run_schema import RunCarMetadata
 
@@ -19,10 +20,10 @@ def run_car_metadata_from_mapping(payload: object) -> RunCarMetadata | None:
     if not isinstance(payload, Mapping):
         return None
     run_car = RunCarMetadata(
-        car_id=_text_or_none(payload.get("id")),
-        name=_text_or_none(payload.get("name")),
-        car_type=_text_or_none(payload.get("type")),
-        variant=_text_or_none(payload.get("variant")),
+        car_id=text_or_none(payload.get("id")),
+        name=text_or_none(payload.get("name")),
+        car_type=text_or_none(payload.get("type")),
+        variant=text_or_none(payload.get("variant")),
     )
     if (
         run_car.car_id is None
@@ -45,10 +46,3 @@ def run_car_metadata_to_json_object(run_car: RunCarMetadata | None) -> JsonObjec
         "type": run_car.car_type,
         "variant": run_car.variant,
     }
-
-
-def _text_or_none(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    return text or None

--- a/apps/server/vibesensor/shared/boundaries/run_metadata_codec.py
+++ b/apps/server/vibesensor/shared/boundaries/run_metadata_codec.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Mapping
 
 from vibesensor.domain import Symptom
+from vibesensor.shared.boundaries._codec_helpers import text_or_none
 from vibesensor.shared.boundaries.analysis_settings_snapshot_codec import (
     analysis_settings_snapshot_from_mapping,
     analysis_settings_snapshot_to_metadata,
@@ -35,32 +36,32 @@ _LOGGER = logging.getLogger(__name__)
 def run_metadata_from_mapping(data: Mapping[str, object]) -> RunMetadata:
     """Normalize a raw persisted metadata mapping into the canonical typed object."""
 
-    run_id = _text_or_none(data.get("run_id")) or ""
+    run_id = text_or_none(data.get("run_id")) or ""
     if not run_id:
         _LOGGER.warning("run_metadata_from_mapping: missing or empty run_id in record %r", data)
     return RunMetadata(
-        record_type=_text_or_none(data.get("record_type")) or RUN_METADATA_TYPE,
-        schema_version=_text_or_none(data.get("schema_version")) or RUN_SCHEMA_VERSION,
+        record_type=text_or_none(data.get("record_type")) or RUN_METADATA_TYPE,
+        schema_version=text_or_none(data.get("schema_version")) or RUN_SCHEMA_VERSION,
         run_id=run_id,
-        start_time_utc=_text_or_none(data.get("start_time_utc")) or "",
-        end_time_utc=_text_or_none(data.get("end_time_utc")),
-        sensor_model=_text_or_none(data.get("sensor_model")) or "unknown",
-        firmware_version=_text_or_none(data.get("firmware_version")),
+        start_time_utc=text_or_none(data.get("start_time_utc")) or "",
+        end_time_utc=text_or_none(data.get("end_time_utc")),
+        sensor_model=text_or_none(data.get("sensor_model")) or "unknown",
+        firmware_version=text_or_none(data.get("firmware_version")),
         raw_sample_rate_hz=as_int_or_none(data.get("raw_sample_rate_hz")),
         feature_interval_s=as_float_or_none(data.get("feature_interval_s")),
         fft_window_size_samples=as_int_or_none(data.get("fft_window_size_samples")),
-        fft_window_type=_text_or_none(data.get("fft_window_type")),
-        peak_picker_method=_text_or_none(data.get("peak_picker_method")) or PEAK_PICKER_METHOD,
+        fft_window_type=text_or_none(data.get("fft_window_type")),
+        peak_picker_method=text_or_none(data.get("peak_picker_method")) or PEAK_PICKER_METHOD,
         accel_scale_g_per_lsb=as_float_or_none(data.get("accel_scale_g_per_lsb")),
         incomplete_for_order_analysis=bool(data.get("incomplete_for_order_analysis", False)),
         analysis_settings=analysis_settings_snapshot_from_mapping(
             data.get("analysis_settings_snapshot"),
         ),
         car=run_car_metadata_from_mapping(data.get("active_car_snapshot")),
-        case_id=_text_or_none(data.get("case_id")) or "",
-        sensor_mac=_text_or_none(data.get("sensor_mac")),
+        case_id=text_or_none(data.get("case_id")) or "",
+        sensor_mac=text_or_none(data.get("sensor_mac")),
         symptom=_symptom_from_payload(data.get("symptom")),
-        report_date=_text_or_none(data.get("report_date")),
+        report_date=text_or_none(data.get("report_date")),
         language=_normalized_language(data.get("language")),
         wheel_circumference_m=_reference_tire_circumference(data.get("reference_context")),
         recorded_utc_offset_seconds=coerce_utc_offset_seconds(
@@ -106,28 +107,21 @@ def run_metadata_to_json_object(metadata: RunMetadata) -> JsonObject:
     return payload
 
 
-def _text_or_none(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    return text or None
-
-
 def _normalized_language(value: object) -> str:
-    text = _text_or_none(value)
+    text = text_or_none(value)
     return text.lower() if text is not None else "en"
 
 
 def _symptom_from_payload(payload: object) -> Symptom | None:
     if not isinstance(payload, Mapping):
         return None
-    description = _text_or_none(payload.get("description"))
+    description = text_or_none(payload.get("description"))
     if description is None:
         return None
     return Symptom(
         description=description,
-        onset=_text_or_none(payload.get("onset")) or "",
-        context=_text_or_none(payload.get("context")) or "",
+        onset=text_or_none(payload.get("onset")) or "",
+        context=text_or_none(payload.get("context")) or "",
     )
 
 

--- a/apps/server/vibesensor/shared/exceptions.py
+++ b/apps/server/vibesensor/shared/exceptions.py
@@ -30,7 +30,11 @@ __all__ = [
     "PersistenceError",
     "ProcessingError",
     "ProtocolError",
+    "UpdateCancelledError",
     "UpdateCleanupError",
+    "UpdatePreparationError",
+    "UpdateReleaseError",
+    "UpdateTransportError",
     "RunNotFoundError",
     "UpdateError",
     "VibeSensorError",
@@ -67,6 +71,25 @@ class UpdateError(VibeSensorError):
 
 class UpdateCleanupError(UpdateError):
     """Updater cleanup failed after the main workflow had already exited."""
+
+
+class UpdatePreparationError(UpdateError):
+    """Update preflight or transport preparation failed."""
+
+
+class UpdateTransportError(UpdateError):
+    """Transport-specific update setup or finalization failed."""
+
+
+class UpdateReleaseError(UpdateError):
+    """Release discovery, staging, or installation failed."""
+
+
+class UpdateCancelledError(UpdateError):
+    """Update execution was cancelled intentionally."""
+
+    def __init__(self, message: str = "Update was cancelled") -> None:
+        super().__init__(message, status="cancelled")
 
 
 class RunNotFoundError(VibeSensorError):

--- a/apps/server/vibesensor/use_cases/history/report_document/builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/builder.py
@@ -8,44 +8,16 @@ from vibesensor.report_i18n import normalize_lang
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.reporting.contracts import PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import (
-    NextStep,
-    PatternEvidence,
     Report,
     ReportDocument,
     build_report_from_summary,
 )
-from vibesensor.shared.report_presentation import display_location
-from vibesensor.shared.time_utils import (
-    format_timestamp_in_recorded_timezone,
-    format_utc_timestamp,
-    utc_now_iso,
-)
 from vibesensor.shared.types.json_types import JsonValue
-from vibesensor.use_cases.history.report_document._candidate_resolver import (
-    PrimaryCandidateContext,
-    resolve_primary_report_candidate,
-)
-from vibesensor.use_cases.history.report_document._card_builder import build_system_cards
 from vibesensor.use_cases.history.report_document.document_builder import (
     build_report_document_data,
 )
-from vibesensor.use_cases.history.report_document.peak_table import build_peak_rows
-from vibesensor.use_cases.history.report_document.report_sections import (
-    build_data_trust,
-    build_next_steps,
-)
-
-from .measurements import _measurement_rows
-from .narrative_summaries import _proof_summary_text
-from .pattern_evidence import build_pattern_evidence
-from .sections import (
-    _build_appendix_a_data,
-    _build_appendix_b_data,
-    _build_appendix_c_data,
-    _build_appendix_d_data,
-    _build_timeline_graph_data,
-    _build_verdict_page_data,
-    _finding_to_presentation,
+from vibesensor.use_cases.history.report_document.resolved_sections import (
+    resolve_report_document_sections,
 )
 
 __all__ = ["build_report_document"]
@@ -78,152 +50,15 @@ def _build_report_document(
     tr: Callable[..., str],
 ) -> ReportDocument:
     """Resolve report sections, then assemble the canonical report document."""
-    test_run = prepared.domain_test_run
-    report_facts = prepared.report_facts
-    report_date_text = _report_date_text(prepared)
-    report_start_time_utc = format_utc_timestamp(report_facts.start_time_utc)
-    report_end_time_utc = format_utc_timestamp(report_facts.end_time_utc)
-    raw_sensor_intensity = list(report_facts.active_sensor_intensity)
-
-    primary = resolve_primary_report_candidate(
-        aggregate=test_run,
-        facts=report_facts.primary_candidate_facts,
-        tr=tr,
+    sections = resolve_report_document_sections(
+        prepared,
+        report=report,
         lang=lang,
-    )
-    observed = _observed_signature(primary)
-    observed.strongest_location = display_location(primary.primary_location, tr=tr)
-    system_cards = build_system_cards(
-        test_run,
-        primary,
-        lang,
-        tr,
-    )
-    recapture_mode = report_facts.action_status_key == "recapture_before_acting"
-    data_trust = build_data_trust(
-        suitability_checks=report_facts.suitability_checks,
-        warnings=report_facts.warnings,
-        lang=lang,
-        tr=tr,
-    )
-    next_steps = (
-        [NextStep(action=action) for action in report_facts.display.appendix_a.capture_changes]
-        if recapture_mode
-        else build_next_steps(
-            recommended_actions=report_facts.recommended_actions,
-            primary_source=primary.primary_source,
-            primary_location=primary.primary_location,
-            tier=primary.tier,
-            cert_reason=primary.certainty_reason or tr("REPORT_CAPTURE_ISSUE_GENERIC"),
-            recapture_mode=recapture_mode,
-            lang=lang,
-            tr=tr,
-        )
-    )
-    pattern_evidence = build_pattern_evidence(
-        aggregate=test_run,
-        origin=report_facts.origin,
-        primary=primary,
-        lang=lang,
-        tr=tr,
-    )
-    findings = [_finding_to_presentation(f) for f in test_run.findings]
-    top_causes = [_finding_to_presentation(f) for f in test_run.effective_top_causes()]
-    peak_rows = build_peak_rows(
-        prepared.summary.peak_table_rows,
-        findings=findings,
-        lang=lang,
-        tr=tr,
-    )
-    measurements = _measurement_rows(
-        prepared.summary,
-        aggregate=test_run,
-        tr=tr,
-    )
-    proof_summary = _proof_summary_text(test_run, primary, report_facts, tr=tr)
-    timeline_graph = _build_timeline_graph_data(report_facts, duration_s=report.duration_s)
-    verdict_page = _build_verdict_page_data(
-        verdict=report_facts.display.verdict,
-        proof_summary=proof_summary,
-        timeline_graph=timeline_graph,
-    )
-    appendix_a = _build_appendix_a_data(
-        appendix=report_facts.display.appendix_a,
-        next_steps=next_steps,
-    )
-    appendix_b = _build_appendix_b_data(
-        aggregate=test_run,
-        appendix=report_facts.display.appendix_b,
-        sensor_locations=list(report_facts.sensor_locations_active),
-        sensor_intensity=raw_sensor_intensity,
-        tr=tr,
-    )
-    appendix_c = _build_appendix_c_data(
-        primary=primary,
-        aggregate=test_run,
-        measurements=measurements,
-        report_facts=report_facts,
-        data_trust=data_trust,
-        tr=tr,
-    )
-    appendix_d = _build_appendix_d_data(
-        date_str=report_date_text,
-        run_id=report.run_id,
-        tire_spec_text=report_facts.tire_spec_text,
-        sensor_model=report_facts.sensor_model,
-        firmware_version=report_facts.firmware_version,
-        sample_count=report_facts.sample_count,
-        sample_rate_hz=report_facts.sample_rate_hz,
         tr=tr,
     )
 
     return build_report_document_data(
         prepared=prepared,
         report=report,
-        report_date_text=report_date_text,
-        report_start_time_utc=report_start_time_utc,
-        report_end_time_utc=report_end_time_utc,
-        primary=primary,
-        title=tr("REPORT_FOOTER_TITLE"),
-        observed=observed,
-        system_cards=system_cards,
-        next_steps=next_steps,
-        data_trust=data_trust,
-        pattern_evidence=pattern_evidence,
-        peak_rows=peak_rows,
-        findings=findings,
-        top_causes=top_causes,
-        sensor_intensity=raw_sensor_intensity,
-        hotspot_rows=list(report_facts.location_hotspot_rows),
-        verdict_page=verdict_page,
-        appendix_a=appendix_a,
-        appendix_b=appendix_b,
-        appendix_c=appendix_c,
-        appendix_d=appendix_d,
+        sections=sections,
     )
-
-
-def _observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
-    return PatternEvidence(
-        primary_system=primary.primary_system,
-        strongest_location=primary.primary_location,
-        speed_band=primary.primary_speed,
-        strength_label=primary.strength_text,
-        strength_peak_db=primary.strength_db,
-        certainty_label=primary.certainty_label_text,
-        certainty_pct=primary.certainty_pct,
-        certainty_reason=primary.certainty_reason,
-    )
-
-
-def _report_date_text(prepared: PreparedReportInput) -> str:
-    report_date = prepared.summary.report_date or utc_now_iso()
-    recorded_offset_seconds = (
-        prepared.summary.metadata.recorded_utc_offset_seconds
-        if prepared.summary.metadata is not None
-        else None
-    )
-    return format_timestamp_in_recorded_timezone(
-        report_date,
-        recorded_offset_seconds,
-    ) or str(report_date)

--- a/apps/server/vibesensor/use_cases/history/report_document/document_builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_builder.py
@@ -7,50 +7,20 @@ the orchestration layer handles section resolution.
 
 from __future__ import annotations
 
-from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
 from vibesensor.shared.boundaries.reporting.contracts import PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import (
-    AppendixAData,
-    AppendixBData,
-    AppendixCData,
-    AppendixDData,
-    DataTrustItem,
-    FindingPresentation,
-    NextStep,
-    PatternEvidence,
-    PeakRow,
     Report,
     ReportDocument,
-    SystemFindingCard,
-    VerdictPageData,
 )
-from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext
+
+from .resolved_sections import ResolvedReportDocumentSections
 
 
 def build_report_document_data(
     *,
     prepared: PreparedReportInput,
     report: Report,
-    report_date_text: str,
-    report_start_time_utc: str | None,
-    report_end_time_utc: str | None,
-    primary: PrimaryCandidateContext,
-    title: str,
-    observed: PatternEvidence,
-    system_cards: list[SystemFindingCard],
-    next_steps: list[NextStep],
-    data_trust: list[DataTrustItem],
-    pattern_evidence: PatternEvidence,
-    peak_rows: list[PeakRow],
-    findings: list[FindingPresentation],
-    top_causes: list[FindingPresentation],
-    sensor_intensity: list[LocationIntensitySummary],
-    hotspot_rows: list[LocationHotspotRow],
-    verdict_page: VerdictPageData | None = None,
-    appendix_a: AppendixAData | None = None,
-    appendix_b: AppendixBData | None = None,
-    appendix_c: AppendixCData | None = None,
-    appendix_d: AppendixDData | None = None,
+    sections: ResolvedReportDocumentSections,
 ) -> ReportDocument:
     """Map resolved report sections into ``ReportDocument``.
 
@@ -61,16 +31,16 @@ def build_report_document_data(
     report_facts = prepared.report_facts
     summary_metadata = prepared.summary.metadata
     return ReportDocument(
-        title=title,
-        run_datetime=report_date_text,
+        title=sections.title,
+        run_datetime=sections.report_date_text,
         run_id=report.run_id,
         duration_text=report_facts.duration_text,
-        start_time_utc=report_start_time_utc,
-        end_time_utc=report_end_time_utc,
+        start_time_utc=sections.report_start_time_utc,
+        end_time_utc=sections.report_end_time_utc,
         sample_rate_hz=report_facts.sample_rate_hz,
         tire_spec_text=report_facts.tire_spec_text,
         sample_count=report_facts.sample_count,
-        sensor_count=primary.sensor_count,
+        sensor_count=sections.primary.sensor_count,
         sensor_locations=list(report_facts.sensor_locations_active),
         sensor_model=report_facts.sensor_model,
         firmware_version=report_facts.firmware_version,
@@ -78,21 +48,21 @@ def build_report_document_data(
         or (summary_metadata.car_name if summary_metadata is not None else None),
         car_type=report.car_type
         or (summary_metadata.car_type if summary_metadata is not None else None),
-        observed=observed,
-        system_cards=system_cards,
-        next_steps=next_steps,
-        data_trust=data_trust,
-        pattern_evidence=pattern_evidence,
-        peak_rows=peak_rows,
+        observed=sections.observed,
+        system_cards=list(sections.system_cards),
+        next_steps=list(sections.next_steps),
+        data_trust=list(sections.data_trust),
+        pattern_evidence=sections.pattern_evidence,
+        peak_rows=list(sections.peak_rows),
         lang=report.lang,
-        certainty_tier_key=primary.tier,
-        findings=findings,
-        top_causes=top_causes,
-        sensor_intensity_by_location=sensor_intensity,
-        location_hotspot_rows=hotspot_rows,
-        verdict_page=verdict_page or VerdictPageData(),
-        appendix_a=appendix_a or AppendixAData(),
-        appendix_b=appendix_b or AppendixBData(),
-        appendix_c=appendix_c or AppendixCData(),
-        appendix_d=appendix_d or AppendixDData(),
+        certainty_tier_key=sections.primary.tier,
+        findings=list(sections.findings),
+        top_causes=list(sections.top_causes),
+        sensor_intensity_by_location=list(sections.sensor_intensity),
+        location_hotspot_rows=list(sections.hotspot_rows),
+        verdict_page=sections.verdict_page,
+        appendix_a=sections.appendix_a,
+        appendix_b=sections.appendix_b,
+        appendix_c=sections.appendix_c,
+        appendix_d=sections.appendix_d,
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/resolved_sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/resolved_sections.py
@@ -1,0 +1,260 @@
+"""Resolved report sections and section-assembly orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
+from vibesensor.shared.boundaries.reporting.contracts import (
+    PreparedReportFacts,
+    PreparedReportInput,
+)
+from vibesensor.shared.boundaries.reporting.document import (
+    AppendixAData,
+    AppendixBData,
+    AppendixCData,
+    AppendixDData,
+    DataTrustItem,
+    FindingPresentation,
+    NextStep,
+    PatternEvidence,
+    PeakRow,
+    Report,
+    SystemFindingCard,
+    VerdictPageData,
+)
+from vibesensor.shared.report_presentation import display_location
+from vibesensor.shared.time_utils import (
+    format_timestamp_in_recorded_timezone,
+    format_utc_timestamp,
+    utc_now_iso,
+)
+from vibesensor.use_cases.history.report_document._candidate_resolver import (
+    PrimaryCandidateContext,
+    resolve_primary_report_candidate,
+)
+from vibesensor.use_cases.history.report_document._card_builder import build_system_cards
+from vibesensor.use_cases.history.report_document.peak_table import build_peak_rows
+from vibesensor.use_cases.history.report_document.report_sections import (
+    build_data_trust,
+    build_next_steps,
+)
+
+from .measurements import _measurement_rows
+from .narrative_summaries import _proof_summary_text
+from .pattern_evidence import build_pattern_evidence
+from .sections import (
+    _build_appendix_a_data,
+    _build_appendix_b_data,
+    _build_appendix_c_data,
+    _build_appendix_d_data,
+    _build_timeline_graph_data,
+    _build_verdict_page_data,
+    _finding_to_presentation,
+)
+
+__all__ = ["ResolvedReportDocumentSections", "resolve_report_document_sections"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedReportDocumentSections:
+    """Canonical resolved report sections prior to document field mapping."""
+
+    report_date_text: str
+    report_start_time_utc: str | None
+    report_end_time_utc: str | None
+    title: str
+    primary: PrimaryCandidateContext
+    observed: PatternEvidence
+    system_cards: tuple[SystemFindingCard, ...]
+    next_steps: tuple[NextStep, ...]
+    data_trust: tuple[DataTrustItem, ...]
+    pattern_evidence: PatternEvidence
+    peak_rows: tuple[PeakRow, ...]
+    findings: tuple[FindingPresentation, ...]
+    top_causes: tuple[FindingPresentation, ...]
+    sensor_intensity: tuple[LocationIntensitySummary, ...]
+    hotspot_rows: tuple[LocationHotspotRow, ...]
+    verdict_page: VerdictPageData
+    appendix_a: AppendixAData
+    appendix_b: AppendixBData
+    appendix_c: AppendixCData
+    appendix_d: AppendixDData
+
+
+def resolve_report_document_sections(
+    prepared: PreparedReportInput,
+    *,
+    report: Report,
+    lang: str,
+    tr: Callable[..., str],
+) -> ResolvedReportDocumentSections:
+    """Resolve report-facing sections before mapping them into ``ReportDocument``."""
+
+    test_run = prepared.domain_test_run
+    report_facts = prepared.report_facts
+    report_date_text = _report_date_text(prepared)
+    primary = resolve_primary_report_candidate(
+        aggregate=test_run,
+        facts=report_facts.primary_candidate_facts,
+        tr=tr,
+        lang=lang,
+    )
+    observed = _observed_signature(primary)
+    observed.strongest_location = display_location(primary.primary_location, tr=tr)
+    system_cards = tuple(
+        build_system_cards(
+            test_run,
+            primary,
+            lang,
+            tr,
+        )
+    )
+    recapture_mode = report_facts.action_status_key == "recapture_before_acting"
+    data_trust = tuple(
+        build_data_trust(
+            suitability_checks=report_facts.suitability_checks,
+            warnings=report_facts.warnings,
+            lang=lang,
+            tr=tr,
+        )
+    )
+    next_steps = _resolve_next_steps(
+        primary=primary,
+        report_facts=report_facts,
+        recapture_mode=recapture_mode,
+        lang=lang,
+        tr=tr,
+    )
+    pattern_evidence = build_pattern_evidence(
+        aggregate=test_run,
+        origin=report_facts.origin,
+        primary=primary,
+        lang=lang,
+        tr=tr,
+    )
+    findings = tuple(_finding_to_presentation(finding) for finding in test_run.findings)
+    top_causes = tuple(
+        _finding_to_presentation(finding) for finding in test_run.effective_top_causes()
+    )
+    peak_rows = tuple(
+        build_peak_rows(
+            prepared.summary.peak_table_rows,
+            findings=list(findings),
+            lang=lang,
+            tr=tr,
+        )
+    )
+    measurements = _measurement_rows(
+        prepared.summary,
+        aggregate=test_run,
+        tr=tr,
+    )
+    proof_summary = _proof_summary_text(test_run, primary, report_facts, tr=tr)
+    timeline_graph = _build_timeline_graph_data(report_facts, duration_s=report.duration_s)
+    appendix_a = _build_appendix_a_data(
+        appendix=report_facts.display.appendix_a,
+        next_steps=list(next_steps),
+    )
+    sensor_intensity = tuple(report_facts.active_sensor_intensity)
+    return ResolvedReportDocumentSections(
+        report_date_text=report_date_text,
+        report_start_time_utc=format_utc_timestamp(report_facts.start_time_utc),
+        report_end_time_utc=format_utc_timestamp(report_facts.end_time_utc),
+        title=tr("REPORT_FOOTER_TITLE"),
+        primary=primary,
+        observed=observed,
+        system_cards=system_cards,
+        next_steps=next_steps,
+        data_trust=data_trust,
+        pattern_evidence=pattern_evidence,
+        peak_rows=peak_rows,
+        findings=findings,
+        top_causes=top_causes,
+        sensor_intensity=sensor_intensity,
+        hotspot_rows=tuple(report_facts.location_hotspot_rows),
+        verdict_page=_build_verdict_page_data(
+            verdict=report_facts.display.verdict,
+            proof_summary=proof_summary,
+            timeline_graph=timeline_graph,
+        ),
+        appendix_a=appendix_a,
+        appendix_b=_build_appendix_b_data(
+            aggregate=test_run,
+            appendix=report_facts.display.appendix_b,
+            sensor_locations=list(report_facts.sensor_locations_active),
+            sensor_intensity=list(sensor_intensity),
+            tr=tr,
+        ),
+        appendix_c=_build_appendix_c_data(
+            primary=primary,
+            aggregate=test_run,
+            measurements=measurements,
+            report_facts=report_facts,
+            data_trust=list(data_trust),
+            tr=tr,
+        ),
+        appendix_d=_build_appendix_d_data(
+            date_str=report_date_text,
+            run_id=report.run_id,
+            tire_spec_text=report_facts.tire_spec_text,
+            sensor_model=report_facts.sensor_model,
+            firmware_version=report_facts.firmware_version,
+            sample_count=report_facts.sample_count,
+            sample_rate_hz=report_facts.sample_rate_hz,
+            tr=tr,
+        ),
+    )
+
+
+def _resolve_next_steps(
+    *,
+    primary: PrimaryCandidateContext,
+    report_facts: PreparedReportFacts,
+    recapture_mode: bool,
+    lang: str,
+    tr: Callable[..., str],
+) -> tuple[NextStep, ...]:
+    if recapture_mode:
+        return tuple(
+            NextStep(action=action) for action in report_facts.display.appendix_a.capture_changes
+        )
+    return tuple(
+        build_next_steps(
+            recommended_actions=report_facts.recommended_actions,
+            primary_source=primary.primary_source,
+            primary_location=primary.primary_location,
+            tier=primary.tier,
+            cert_reason=primary.certainty_reason or tr("REPORT_CAPTURE_ISSUE_GENERIC"),
+            recapture_mode=recapture_mode,
+            lang=lang,
+            tr=tr,
+        )
+    )
+
+
+def _observed_signature(primary: PrimaryCandidateContext) -> PatternEvidence:
+    return PatternEvidence(
+        primary_system=primary.primary_system,
+        strongest_location=primary.primary_location,
+        speed_band=primary.primary_speed,
+        strength_label=primary.strength_text,
+        strength_peak_db=primary.strength_db,
+        certainty_label=primary.certainty_label_text,
+        certainty_pct=primary.certainty_pct,
+        certainty_reason=primary.certainty_reason,
+    )
+
+
+def _report_date_text(prepared: PreparedReportInput) -> str:
+    report_date = prepared.summary.report_date or utc_now_iso()
+    recorded_offset_seconds = (
+        prepared.summary.metadata.recorded_utc_offset_seconds
+        if prepared.summary.metadata is not None
+        else None
+    )
+    return format_timestamp_in_recorded_timezone(
+        report_date,
+        recorded_offset_seconds,
+    ) or str(report_date)

--- a/apps/server/vibesensor/use_cases/updates/cleanup.py
+++ b/apps/server/vibesensor/use_cases/updates/cleanup.py
@@ -1,0 +1,57 @@
+"""Post-run update cleanup separated from lifecycle state callbacks."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
+from vibesensor.use_cases.updates.status import UpdateStatusTracker, collect_runtime_details
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
+
+TransportSessionsFactory = Callable[[], UpdateTransportSessions]
+
+
+class UpdateCleanupCoordinator:
+    """Run explicit post-update cleanup steps without owning lifecycle state transitions."""
+
+    __slots__ = ("_logger", "_repo", "_tracker", "_transport_sessions_factory")
+
+    def __init__(
+        self,
+        *,
+        tracker: UpdateStatusTracker,
+        repo: Path,
+        transport_sessions_factory: TransportSessionsFactory,
+        logger: logging.Logger,
+    ) -> None:
+        self._tracker = tracker
+        self._repo = repo
+        self._transport_sessions_factory = transport_sessions_factory
+        self._logger = logger
+
+    async def run(self) -> None:
+        await self._cleanup_transport_session()
+        await self._refresh_runtime_details()
+
+    async def _cleanup_transport_session(self) -> None:
+        transport_session = self._transport_sessions_factory().for_transport(
+            self._tracker.status.transport,
+        )
+        try:
+            await transport_session.cleanup_after_update()
+        except (OSError, RuntimeError, UpdateError) as exc:
+            self._tracker.fail("cleanup", "Transport cleanup failed", str(exc))
+            self._logger.exception("update: transport cleanup error")
+            raise UpdateCleanupError(f"Transport cleanup failed: {exc}") from exc
+
+    async def _refresh_runtime_details(self) -> None:
+        try:
+            runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
+        except (OSError, RuntimeError, UpdateError) as exc:
+            self._tracker.fail("cleanup", "Runtime details refresh failed", str(exc))
+            self._logger.exception("update: runtime details refresh error")
+            raise UpdateCleanupError(f"Runtime details refresh failed: {exc}") from exc
+        self._tracker.set_runtime(runtime_details)

--- a/apps/server/vibesensor/use_cases/updates/coordinator.py
+++ b/apps/server/vibesensor/use_cases/updates/coordinator.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome, UpdateRequest
 from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
 from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
@@ -13,12 +11,7 @@ from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecuto
 class UpdateCoordinator:
     """Own top-level sequencing while delegating planning and execution elsewhere."""
 
-    __slots__ = (
-        "_cancel_requested",
-        "_preparation",
-        "_release_planner",
-        "_workflow_executor",
-    )
+    __slots__ = ("_preparation", "_release_planner", "_workflow_executor")
 
     def __init__(
         self,
@@ -26,26 +19,15 @@ class UpdateCoordinator:
         preparation: UpdatePreparationCoordinator,
         release_planner: UpdateReleasePlanner,
         workflow_executor: UpdateWorkflowExecutor,
-        cancel_requested: Callable[[], bool],
     ) -> None:
         self._preparation = preparation
         self._release_planner = release_planner
         self._workflow_executor = workflow_executor
-        self._cancel_requested = cancel_requested
 
     async def execute(self, request: UpdateRequest) -> UpdateExecutionOutcome:
         prepared = await self._preparation.prepare(request)
-        if prepared is None:
-            return UpdateExecutionOutcome.aborted
-        if self._cancelled():
-            return UpdateExecutionOutcome.aborted
         plan = await self._release_planner.plan(prepared.current_version)
-        if plan is None or self._cancelled():
-            return UpdateExecutionOutcome.aborted
         return await self._workflow_executor.execute(
             plan,
             transport_session=prepared.transport_session,
         )
-
-    def _cancelled(self) -> bool:
-        return self._cancel_requested()

--- a/apps/server/vibesensor/use_cases/updates/installer.py
+++ b/apps/server/vibesensor/use_cases/updates/installer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.artifact_validation import WheelArtifactValidator
 from vibesensor.use_cases.updates.rollback_executor import RollbackExecutor
 from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
@@ -68,17 +69,24 @@ class UpdateInstaller:
     async def snapshot_for_rollback(self) -> bool:
         return await self._rollback_snapshot_builder.snapshot_for_rollback()
 
-    async def install_release(self, wheel_path: Path, expected_version: str) -> bool:
+    async def install_release(self, wheel_path: Path, expected_version: str) -> None:
         install_result = await self._wheel_install_executor.install_release(
             wheel_path,
             expected_version,
         )
         if install_result.succeeded:
-            return True
+            return
+        rollback_succeeded = False
         if install_result.rollback_required:
             self._tracker.log("Attempting rollback...")
-            await self.rollback()
-        return False
+            rollback_succeeded = await self.rollback()
+        if rollback_succeeded:
+            raise UpdateReleaseError(
+                "Update install failed; rollback restored the previous version"
+            )
+        if install_result.rollback_required:
+            raise UpdateReleaseError("Update install failed and rollback did not complete")
+        raise UpdateReleaseError("Update install failed")
 
     async def rollback(self) -> bool:
         return await self._rollback_executor.rollback()

--- a/apps/server/vibesensor/use_cases/updates/job_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/job_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from collections.abc import Awaitable, Callable, Coroutine
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
@@ -15,20 +16,15 @@ TaskCoroutineFactory = Callable[[], Coroutine[object, object, None]]
 class UpdateJobExecutor:
     """Own update task lifecycle mechanics apart from the update workflow itself."""
 
-    __slots__ = ("_cancel_event", "_task", "_task_name")
+    __slots__ = ("_task", "_task_name")
 
     def __init__(self, *, task_name: str = "system-update") -> None:
         self._task_name = task_name
         self._task: asyncio.Task[None] | None = None
-        self._cancel_event = asyncio.Event()
 
     @property
     def job_task(self) -> asyncio.Task[None] | None:
         return self._task
-
-    def cancel_requested(self) -> bool:
-        """Return whether cancellation has been requested for the active job."""
-        return self._cancel_event.is_set()
 
     def start(
         self,
@@ -39,7 +35,6 @@ class UpdateJobExecutor:
         """Start a new update task after running any synchronous pre-start hook."""
         if self._task is not None and not self._task.done():
             raise UpdateError("Update already in progress", status="conflict")
-        self._cancel_event.clear()
         if before_start is not None:
             before_start()
         self._task = asyncio.get_running_loop().create_task(
@@ -48,10 +43,9 @@ class UpdateJobExecutor:
         )
 
     def cancel(self) -> bool:
-        """Request cancellation for the active task and signal the cancel event."""
+        """Request cancellation for the active task."""
         if self._task is None or self._task.done():
             return False
-        self._cancel_event.set()
         self._task.cancel()
         return True
 
@@ -65,30 +59,26 @@ class UpdateJobExecutor:
         cleanup: CleanupCallback,
     ) -> None:
         """Run the workflow with timeout/cancel handling and guaranteed cleanup."""
-        primary_error: BaseException | None = None
-        cancelled = False
         try:
             await asyncio.wait_for(workflow_factory(), timeout=timeout_s)
         except TimeoutError:
             on_timeout()
-        except asyncio.CancelledError as exc:
-            cancelled = True
+        except asyncio.CancelledError:
             on_cancelled()
-            primary_error = exc
-        except Exception as exc:
-            primary_error = exc
+            raise
+        finally:
+            await self._cleanup_after_workflow(cleanup)
 
-        cleanup_error: Exception | None = None
+    async def _cleanup_after_workflow(self, cleanup: CleanupCallback) -> None:
+        active_error = sys.exc_info()[1]
         try:
             await cleanup()
         except asyncio.CancelledError:
             raise
-        except Exception as exc:
-            cleanup_error = exc
-
-        if cancelled and cleanup_error is not None:
-            raise UpdateCleanupError(f"Cleanup failed: {cleanup_error}") from cleanup_error
-        if primary_error is not None:
-            raise primary_error
-        if cleanup_error is not None:
-            raise UpdateCleanupError(f"Cleanup failed: {cleanup_error}") from cleanup_error
+        except (OSError, RuntimeError, UpdateError) as exc:
+            if isinstance(active_error, asyncio.CancelledError):
+                raise UpdateCleanupError(f"Cleanup failed after cancellation: {exc}") from exc
+            if active_error is not None:
+                active_error.add_note(f"Cleanup also failed: {exc}")
+                return
+            raise UpdateCleanupError(f"Cleanup failed: {exc}") from exc

--- a/apps/server/vibesensor/use_cases/updates/job_lifecycle.py
+++ b/apps/server/vibesensor/use_cases/updates/job_lifecycle.py
@@ -1,34 +1,23 @@
 from __future__ import annotations
 
-import asyncio
-import logging
-from collections.abc import Callable
-from pathlib import Path
-
+from vibesensor.use_cases.updates.cleanup import UpdateCleanupCoordinator
 from vibesensor.use_cases.updates.models import UpdateRequest
-from vibesensor.use_cases.updates.status import UpdateStatusTracker, collect_runtime_details
-from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
-
-TransportSessionsFactory = Callable[[], UpdateTransportSessions]
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 
 class UpdateJobLifecycleHandler:
     """Own stateful update job lifecycle callbacks and cleanup sequencing."""
 
-    __slots__ = ("_logger", "_repo", "_tracker", "_transport_sessions_factory")
+    __slots__ = ("_cleanup", "_tracker")
 
     def __init__(
         self,
         *,
         tracker: UpdateStatusTracker,
-        repo: Path,
-        transport_sessions_factory: TransportSessionsFactory,
-        logger: logging.Logger,
+        cleanup: UpdateCleanupCoordinator,
     ) -> None:
         self._tracker = tracker
-        self._repo = repo
-        self._transport_sessions_factory = transport_sessions_factory
-        self._logger = logger
+        self._cleanup = cleanup
 
     def prepare_start(self, request: UpdateRequest) -> None:
         self._tracker.start_job(request)
@@ -43,22 +32,8 @@ class UpdateJobLifecycleHandler:
         self._tracker.log("Update cancelled")
 
     async def cleanup_after_update(self) -> None:
-        tracker = self._tracker
-        transport_session = self._transport_sessions_factory().for_transport(
-            tracker.status.transport,
-        )
-        cleanup_error: Exception | None = None
         try:
-            await transport_session.cleanup_after_update()
-            tracker.set_runtime(await asyncio.to_thread(collect_runtime_details, self._repo))
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            tracker.fail("cleanup", f"Cleanup failed: {exc}")
-            self._logger.exception("update: cleanup error")
-            cleanup_error = exc
+            await self._cleanup.run()
         finally:
-            tracker.clear_secrets()
-            tracker.finish_cleanup()
-        if cleanup_error is not None:
-            raise cleanup_error
+            self._tracker.clear_secrets()
+            self._tracker.finish_cleanup()

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
+from vibesensor.shared.exceptions import UpdateError
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
     UpdateRequest,
@@ -78,10 +79,13 @@ class UpdateManager:
         self,
         request: UpdateRequest,
     ) -> None:
-        await self._runtime.executor.run(
-            workflow_factory=lambda: self._runtime.coordinator_factory().execute(request),
-            timeout_s=UPDATE_TIMEOUT_S,
-            on_timeout=lambda: self._runtime.lifecycle.handle_timeout(UPDATE_TIMEOUT_S),
-            on_cancelled=self._runtime.lifecycle.handle_cancelled,
-            cleanup=self._runtime.lifecycle.cleanup_after_update,
-        )
+        try:
+            await self._runtime.executor.run(
+                workflow_factory=lambda: self._runtime.coordinator_factory().execute(request),
+                timeout_s=UPDATE_TIMEOUT_S,
+                on_timeout=lambda: self._runtime.lifecycle.handle_timeout(UPDATE_TIMEOUT_S),
+                on_cancelled=self._runtime.lifecycle.handle_cancelled,
+                cleanup=self._runtime.lifecycle.cleanup_after_update,
+            )
+        except UpdateError:
+            return

--- a/apps/server/vibesensor/use_cases/updates/preparation.py
+++ b/apps/server/vibesensor/use_cases/updates/preparation.py
@@ -34,7 +34,6 @@ class UpdatePreparationCoordinator:
     """Own validation, transport setup, and version resolution before release work."""
 
     __slots__ = (
-        "_cancel_requested",
         "_commands",
         "_current_version_provider",
         "_tracker",
@@ -50,28 +49,21 @@ class UpdatePreparationCoordinator:
         transport_controller: UpdateTransportController,
         validation_config: UpdateValidationConfig,
         current_version_provider: CurrentVersionProvider,
-        cancel_requested: Callable[[], bool],
     ) -> None:
         self._tracker = tracker
         self._commands = commands
         self._transport_controller = transport_controller
         self._validation_config = validation_config
         self._current_version_provider = current_version_provider
-        self._cancel_requested = cancel_requested
 
-    async def prepare(self, request: UpdateRequest) -> PreparedUpdateSession | None:
-        if not await validate_prerequisites(
+    async def prepare(self, request: UpdateRequest) -> PreparedUpdateSession:
+        await validate_prerequisites(
             commands=self._commands,
             tracker=self._tracker,
             config=self._validation_config,
             request=request,
-        ):
-            return None
-        if self._cancel_requested():
-            return None
+        )
         transport_session = await self._transport_controller.prepare(request)
-        if transport_session is None or self._cancel_requested():
-            return None
         return PreparedUpdateSession(
             request=request,
             current_version=self._current_version_provider(),

--- a/apps/server/vibesensor/use_cases/updates/release_deployment.py
+++ b/apps/server/vibesensor/use_cases/updates/release_deployment.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller
 from vibesensor.use_cases.updates.models import UpdatePhase
@@ -14,7 +13,7 @@ from vibesensor.use_cases.updates.status import UpdateStatusTracker
 class UpdateReleaseDeployer:
     """Own the system-mutating part of an update after staging succeeds."""
 
-    __slots__ = ("_cancel_requested", "_firmware_refresher", "_installer", "_tracker")
+    __slots__ = ("_firmware_refresher", "_installer", "_tracker")
 
     def __init__(
         self,
@@ -22,17 +21,13 @@ class UpdateReleaseDeployer:
         tracker: UpdateStatusTracker,
         installer: UpdateInstaller,
         firmware_refresher: FirmwareRefresher,
-        cancel_requested: Callable[[], bool],
     ) -> None:
         self._tracker = tracker
         self._installer = installer
         self._firmware_refresher = firmware_refresher
-        self._cancel_requested = cancel_requested
 
-    async def deploy(self, staged_release: StagedServerRelease) -> bool:
+    async def deploy(self, staged_release: StagedServerRelease) -> None:
         await self._firmware_refresher.refresh_esp_firmware(pinned_tag=staged_release.release.tag)
-        if self._cancel_requested():
-            return False
         self._tracker.transition(UpdatePhase.installing)
         self._tracker.log("Installing update...")
         if not await self._installer.snapshot_for_rollback():
@@ -41,8 +36,8 @@ class UpdateReleaseDeployer:
                 "Rollback snapshot could not be created",
                 "Install aborted before mutating the live environment",
             )
-            return False
-        return await self._installer.install_release(
+            raise UpdateReleaseError("Rollback snapshot could not be created")
+        await self._installer.install_release(
             staged_release.wheel_path,
             str(staged_release.release.version),
         )

--- a/apps/server/vibesensor/use_cases/updates/release_planner.py
+++ b/apps/server/vibesensor/use_cases/updates/release_planner.py
@@ -53,13 +53,11 @@ class UpdateReleasePlanner:
         self._tracker = tracker
         self._resolver = resolver
 
-    async def plan(self, current_version: str) -> ReleaseExecutionPlan | None:
+    async def plan(self, current_version: str) -> ReleaseExecutionPlan:
         self._tracker.transition(UpdatePhase.checking)
         self._tracker.log("Checking for available updates...")
 
         resolution = await self._resolver.resolve(current_version)
-        if resolution.failed:
-            return None
         if resolution.release is None:
             self._tracker.log(f"Already up-to-date (version={current_version})")
             return RefreshFirmwarePlan(

--- a/apps/server/vibesensor/use_cases/updates/release_resolution.py
+++ b/apps/server/vibesensor/use_cases/updates/release_resolution.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.releases import factory as release_fetcher_factory
 
 if TYPE_CHECKING:
@@ -27,7 +28,6 @@ class UpdateReleaseCheck:
 
     release: ReleaseInfo | None
     latest_tag: str = ""
-    failed: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,11 +37,10 @@ class UpdateReleaseResolution:
     current_version: str
     release: ReleaseInfo | None
     latest_tag: str = ""
-    failed: bool = False
 
     @property
     def update_available(self) -> bool:
-        return self.release is not None and not self.failed
+        return self.release is not None
 
 
 class ServerReleaseResolver:
@@ -63,7 +62,6 @@ class ServerReleaseResolver:
             current_version=current_version,
             release=release_check.release,
             latest_tag=release_check.latest_tag,
-            failed=release_check.failed,
         )
 
 
@@ -79,7 +77,7 @@ async def check_for_update(
         release = await asyncio.to_thread(fetcher.check_update_available, current_version)
     except (OSError, ValueError) as exc:
         tracker.fail("checking", f"Failed to check for updates: {exc}")
-        return UpdateReleaseCheck(release=None, failed=True)
+        raise UpdateReleaseError(f"Failed to check for updates: {exc}") from exc
     if release is not None:
         return UpdateReleaseCheck(release=release)
     latest_tag = ""

--- a/apps/server/vibesensor/use_cases/updates/release_staging.py
+++ b/apps/server/vibesensor/use_cases/updates/release_staging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+import sys
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -11,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vibesensor.shared.exceptions import UpdateCleanupError, UpdateReleaseError
 from vibesensor.use_cases.updates.artifact_validation import sha256_file
 from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.releases import factory as release_fetcher_factory
@@ -38,7 +40,7 @@ class ServerReleaseStager:
         self._rollback_dir = rollback_dir
 
     @asynccontextmanager
-    async def stage(self, release: ReleaseInfo) -> AsyncIterator[StagedServerRelease | None]:
+    async def stage(self, release: ReleaseInfo) -> AsyncIterator[StagedServerRelease]:
         self._tracker.transition(UpdatePhase.downloading)
         self._tracker.log(f"Downloading release {release.tag}...")
         staging_dir = Path(tempfile.mkdtemp(prefix="vibesensor-update-"))
@@ -49,18 +51,23 @@ class ServerReleaseStager:
                 release,
                 staging_dir,
             )
-            if wheel_path is None:
-                yield None
-                return
             self._tracker.log(
                 f"Downloaded {wheel_path.name} (sha256={getattr(release, 'sha256', '')})",
             )
-            if not await verify_download(self._tracker, release, wheel_path):
-                yield None
-                return
+            await verify_download(self._tracker, release, wheel_path)
             yield StagedServerRelease(release=release, wheel_path=wheel_path)
         finally:
-            shutil.rmtree(staging_dir, ignore_errors=True)
+            active_error = sys.exc_info()[1]
+            try:
+                shutil.rmtree(staging_dir)
+            except OSError as exc:
+                cleanup_error = UpdateCleanupError(
+                    f"Failed to remove staged release directory: {exc}",
+                )
+                if active_error is not None:
+                    active_error.add_note(str(cleanup_error))
+                else:
+                    raise cleanup_error from exc
 
 
 async def download_release(
@@ -68,7 +75,7 @@ async def download_release(
     rollback_dir: Path,
     release: ReleaseInfo,
     staging_dir: Path,
-) -> Path | None:
+) -> Path:
     """Download a release wheel to *staging_dir*."""
 
     fetcher = release_fetcher_factory.build_server_release_fetcher(rollback_dir=rollback_dir)
@@ -76,27 +83,27 @@ async def download_release(
         return await asyncio.to_thread(fetcher.download_wheel, release, staging_dir)
     except (OSError, ValueError) as exc:
         tracker.fail("downloading", f"Failed to download release: {exc}")
-        return None
+        raise UpdateReleaseError(f"Failed to download release: {exc}") from exc
 
 
 async def verify_download(
     tracker: UpdateStatusTracker,
     release: ReleaseInfo,
     wheel_path: Path,
-) -> bool:
+) -> None:
     """Verify SHA-256 digest of a downloaded wheel."""
 
     if not release.sha256:
-        return True
+        return
     actual_sha256 = await asyncio.to_thread(sha256_file, wheel_path)
     expected_sha256 = release.sha256.lower()
     if actual_sha256 == expected_sha256:
         tracker.log(f"SHA-256 verified: {actual_sha256}")
-        return True
+        return
     tracker.fail(
         "downloading",
         "Downloaded wheel SHA-256 mismatch",
         f"expected={release.sha256} actual={actual_sha256}",
     )
     tracker.log(f"SHA-256 mismatch: expected {release.sha256} but got {actual_sha256}")
-    return False
+    raise UpdateReleaseError("Downloaded wheel SHA-256 mismatch")

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from vibesensor.use_cases.updates.cleanup import UpdateCleanupCoordinator
 from vibesensor.use_cases.updates.coordinator import UpdateCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
@@ -157,7 +158,6 @@ def build_update_manager_runtime(
                 tracker=tracker,
                 installer=installer,
                 firmware_refresher=firmware_refresher,
-                cancel_requested=executor.cancel_requested,
             ),
             firmware_refresher,
             UpdateRestartScheduler(
@@ -191,7 +191,6 @@ def build_update_manager_runtime(
                 transport_controller=UpdateTransportController(sessions=transport_sessions),
                 validation_config=validation_config,
                 current_version_provider=current_version_provider,
-                cancel_requested=executor.cancel_requested,
             ),
             release_planner=UpdateReleasePlanner(
                 tracker=tracker,
@@ -205,16 +204,17 @@ def build_update_manager_runtime(
                     tracker=tracker,
                     restart_scheduler=restart_scheduler,
                 ),
-                cancel_requested=executor.cancel_requested,
             ),
-            cancel_requested=executor.cancel_requested,
         )
 
     lifecycle = UpdateJobLifecycleHandler(
         tracker=tracker,
-        repo=repo,
-        transport_sessions_factory=lambda: build_transport_sessions(),
-        logger=LOGGER,
+        cleanup=UpdateCleanupCoordinator(
+            tracker=tracker,
+            repo=repo,
+            transport_sessions_factory=lambda: build_transport_sessions(),
+            logger=LOGGER,
+        ),
     )
     recovery = InterruptedUpdateRecovery(
         tracker=tracker,

--- a/apps/server/vibesensor/use_cases/updates/success_finalizer.py
+++ b/apps/server/vibesensor/use_cases/updates/success_finalizer.py
@@ -23,15 +23,13 @@ class UpdateSuccessFinalizer:
         self._tracker = tracker
         self._restart_scheduler = restart_scheduler
 
-    async def complete(self, transport_session: UpdateTransportSession, *, message: str) -> bool:
-        if not await transport_session.complete_success(message):
-            return False
+    async def complete(self, transport_session: UpdateTransportSession, *, message: str) -> None:
+        await transport_session.complete_success(message)
         if await self._restart_scheduler.schedule():
-            return True
+            return
         self._tracker.add_issue(
             "done",
             "Backend restart was not scheduled automatically",
             "Run 'sudo systemctl restart vibesensor.service' manually",
         )
         self._tracker.log("Automatic backend restart scheduling failed")
-        return True

--- a/apps/server/vibesensor/use_cases/updates/transport_controller.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_controller.py
@@ -19,8 +19,7 @@ class UpdateTransportController:
     def __init__(self, *, sessions: UpdateTransportSessions) -> None:
         self._sessions = sessions
 
-    async def prepare(self, request: UpdateRequest) -> UpdateTransportSession | None:
+    async def prepare(self, request: UpdateRequest) -> UpdateTransportSession:
         transport_session = self._sessions.for_request(request)
-        if not await transport_session.prepare(request):
-            return None
+        await transport_session.prepare(request)
         return transport_session

--- a/apps/server/vibesensor/use_cases/updates/transport_sessions.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_sessions.py
@@ -12,11 +12,11 @@ class UpdateTransportSession(Protocol):
 
     transport: UpdateTransport
 
-    async def prepare(self, request: UpdateRequest) -> bool:
+    async def prepare(self, request: UpdateRequest) -> None:
         """Prepare this transport for an update run before release work starts."""
         ...
 
-    async def complete_success(self, message: str) -> bool:
+    async def complete_success(self, message: str) -> None:
         """Finalize a successful update for this transport."""
         ...
 

--- a/apps/server/vibesensor/use_cases/updates/usb_transport.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_transport.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from vibesensor.shared.exceptions import UpdateTransportError
 from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
@@ -30,10 +31,11 @@ class UpdateUsbInternetSession:
             config=config,
         )
 
-    async def prepare(self, request: UpdateRequest) -> bool:
+    async def prepare(self, request: UpdateRequest) -> None:
         del request
         self._tracker.transition(UpdatePhase.connecting_usb_internet)
-        return await self.ensure_uplink_ready()
+        if not await self.ensure_uplink_ready():
+            raise UpdateTransportError("Failed to prepare the USB internet uplink for update")
 
     async def ensure_uplink_ready(self) -> bool:
         status = await self._status_service.snapshot(activate=True)
@@ -65,9 +67,8 @@ class UpdateUsbInternetSession:
             failure_message="USB internet detected, but internet/DNS is not ready",
         )
 
-    async def complete_success(self, message: str) -> bool:
+    async def complete_success(self, message: str) -> None:
         self._tracker.mark_success(message)
-        return True
 
     async def cleanup_after_update(self) -> None:
         return None

--- a/apps/server/vibesensor/use_cases/updates/validation.py
+++ b/apps/server/vibesensor/use_cases/updates/validation.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from vibesensor.shared.exceptions import UpdatePreparationError
 from vibesensor.use_cases.updates.models import (
     UpdateRequest,
     UpdateTransport,
@@ -19,6 +20,15 @@ from vibesensor.use_cases.updates.runner import (
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 MIN_FREE_DISK_BYTES = 200 * 1024 * 1024
+
+
+def _fail_validation(
+    tracker: UpdateStatusTracker,
+    message: str,
+    detail: str = "",
+) -> UpdatePreparationError:
+    tracker.fail("validating", message, detail)
+    return UpdatePreparationError(message)
 
 
 def _probe_rollback_dir(rollback_dir: Path) -> None:
@@ -54,7 +64,7 @@ async def validate_prerequisites(
     tracker: UpdateStatusTracker,
     config: UpdateValidationConfig,
     request: UpdateRequest,
-) -> bool:
+) -> None:
     """Validate tool availability, privilege access, and disk space."""
     if request.transport == UpdateTransport.wifi:
         tracker.log(f"Starting update with SSID: {request.ssid}")
@@ -62,8 +72,7 @@ async def validate_prerequisites(
         tracker.log("Starting update using existing USB internet")
     for tool in ("nmcli", "python3"):
         if not shutil.which(tool):
-            tracker.fail("validating", f"Required tool not found: {tool}")
-            return False
+            raise _fail_validation(tracker, f"Required tool not found: {tool}")
 
     if os.geteuid() != 0:
         rc, _, _ = await commands.run(
@@ -73,23 +82,23 @@ async def validate_prerequisites(
             sudo=True,
         )
         if rc != 0:
-            tracker.fail(
-                "validating",
+            raise _fail_validation(
+                tracker,
                 "Insufficient privileges",
-                "Cannot run updater privileged commands non-interactively. "
-                "In dev/Docker environments, hotspot management is not available.",
+                (
+                    "Cannot run updater privileged commands non-interactively. "
+                    "In dev/Docker environments, hotspot management is not available."
+                ),
             )
-            return False
 
     try:
         _probe_rollback_dir(config.rollback_dir)
     except OSError as exc:
-        tracker.fail(
-            "validating",
+        raise _fail_validation(
+            tracker,
             "Rollback directory is not writable",
             f"{config.rollback_dir}: {exc}",
-        )
-        return False
+        ) from exc
 
     try:
         disk_check_path = _disk_check_path(config.rollback_dir)
@@ -97,17 +106,13 @@ async def validate_prerequisites(
         if free_bytes < config.min_free_disk_bytes:
             free_mb = free_bytes // (1024 * 1024)
             min_mb = config.min_free_disk_bytes // (1024 * 1024)
-            tracker.fail(
-                "validating",
+            raise _fail_validation(
+                tracker,
                 f"Insufficient disk space: {free_mb} MiB free, {min_mb} MiB required",
             )
-            return False
     except OSError as exc:
-        tracker.fail(
-            "validating",
+        raise _fail_validation(
+            tracker,
             "Could not verify free disk space",
             str(exc),
-        )
-        return False
-
-    return True
+        ) from exc

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
+from vibesensor.shared.exceptions import UpdateTransportError
 from vibesensor.use_cases.updates.models import (
     UpdatePhase,
     UpdateRequest,
@@ -64,15 +65,16 @@ class UpdateWifiSession:
         self._tracker.log(f"Wi-Fi connected successfully (client DNS fallback={fallback})")
         return await self._readiness.wait_for_dns_ready()
 
-    async def prepare(self, request: UpdateRequest) -> bool:
+    async def prepare(self, request: UpdateRequest) -> None:
         """Prepare the updater's Wi-Fi transport before release work begins."""
 
         self._tracker.transition(UpdatePhase.stopping_hotspot)
         if not await self.stop_hotspot():
-            return False
+            raise UpdateTransportError("Failed to stop the hotspot before Wi-Fi update setup")
         self._tracker.transition(UpdatePhase.connecting_wifi)
         assert request.ssid is not None  # noqa: S101
-        return await self.connect_uplink(request.ssid, request.password)
+        if not await self.connect_uplink(request.ssid, request.password):
+            raise UpdateTransportError("Failed to prepare the Wi-Fi uplink for update")
 
     async def restore_hotspot(self) -> bool:
         """Restore the hotspot after update work completes or is interrupted."""
@@ -98,12 +100,12 @@ class UpdateWifiSession:
             )
             self._tracker.log("startup_recover: hotspot restore failed")
 
-    async def complete_success(self, message: str) -> bool:
+    async def complete_success(self, message: str) -> None:
         """Restore the hotspot and then finalize the Wi-Fi update as successful."""
 
         if self._tracker.status.transport != UpdateTransport.wifi:
             self._tracker.mark_success(message)
-            return True
+            return
         self._tracker.transition(UpdatePhase.restoring_hotspot)
         self._tracker.log("Restoring hotspot...")
         restored = await self.restore_hotspot()
@@ -112,9 +114,8 @@ class UpdateWifiSession:
                 UpdatePhase.restoring_hotspot,
                 "Failed to restore hotspot after update",
             )
-            return False
+            raise UpdateTransportError("Failed to restore hotspot after update")
         self._tracker.mark_success(message)
-        return True
 
     async def cleanup_after_update(self) -> None:
         """Restore hotspot ownership and attach cleanup diagnostics after a run."""

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.release_deployment import UpdateReleaseDeployer
@@ -22,13 +20,7 @@ __all__ = ["UpdateWorkflowExecutor"]
 class UpdateWorkflowExecutor:
     """Execute a prepared release plan while delegating side effects to focused collaborators."""
 
-    __slots__ = (
-        "_cancel_requested",
-        "_deployer",
-        "_firmware_refresher",
-        "_finalizer",
-        "_stager",
-    )
+    __slots__ = ("_deployer", "_firmware_refresher", "_finalizer", "_stager")
 
     def __init__(
         self,
@@ -37,13 +29,11 @@ class UpdateWorkflowExecutor:
         deployer: UpdateReleaseDeployer,
         firmware_refresher: FirmwareRefresher,
         finalizer: UpdateSuccessFinalizer,
-        cancel_requested: Callable[[], bool],
     ) -> None:
         self._stager = stager
         self._deployer = deployer
         self._firmware_refresher = firmware_refresher
         self._finalizer = finalizer
-        self._cancel_requested = cancel_requested
 
     async def execute(
         self,
@@ -62,13 +52,11 @@ class UpdateWorkflowExecutor:
         transport_session: UpdateTransportSession,
     ) -> UpdateExecutionOutcome:
         await self._firmware_refresher.refresh_esp_firmware(pinned_tag=plan.latest_tag)
-        if self._cancelled():
-            return UpdateExecutionOutcome.aborted
-        completed = await self._finalizer.complete(
+        await self._finalizer.complete(
             transport_session,
             message="No server update needed; ESP firmware checked",
         )
-        return UpdateExecutionOutcome.refresh_only if completed else UpdateExecutionOutcome.aborted
+        return UpdateExecutionOutcome.refresh_only
 
     async def _execute_install(
         self,
@@ -77,17 +65,9 @@ class UpdateWorkflowExecutor:
         transport_session: UpdateTransportSession,
     ) -> UpdateExecutionOutcome:
         async with self._stager.stage(plan.release) as staged_release:
-            if staged_release is None or self._cancelled():
-                return UpdateExecutionOutcome.aborted
-            if not await self._deployer.deploy(staged_release):
-                return UpdateExecutionOutcome.aborted
-        if self._cancelled():
-            return UpdateExecutionOutcome.aborted
-        completed = await self._finalizer.complete(
+            await self._deployer.deploy(staged_release)
+        await self._finalizer.complete(
             transport_session,
             message="Update completed successfully",
         )
-        return UpdateExecutionOutcome.installed if completed else UpdateExecutionOutcome.aborted
-
-    def _cancelled(self) -> bool:
-        return self._cancel_requested()
+        return UpdateExecutionOutcome.installed


### PR DESCRIPTION
## Summary
- split update preparation, execution, and cleanup into explicit boundaries and replaced boolean/None/cancel flag control flow with typed update failures
- split OBD admin observation from status projection so status reads are pure and refresh is explicit
- centralized report boundary coercion, introduced resolved report sections and a PDF render planner, and reduced report/PDF cross-coupling

## Architecture issues addressed
- stronger update subsystem responsibility boundaries
- narrower operational error handling outside runtime loops
- cleaner separation of policy, state interpretation, and execution in OBD status flows
- more coherent boundary/codec organization for report metadata and payload shaping
- lower change surface in reporting/PDF planning and assembly

## Breaking changes / deleted compatibility
- removed update-flow compatibility based on False/None returns and cancel_requested plumbing
- removed side-effectful OBD status reads via status_snapshot(refresh_admin=...)
- removed scattered report codec coercion helpers and old whole-report PDF sequencing from report_types.py

## Local validation
- pytest -q apps/server/tests/use_cases/updates apps/server/tests/adapters/obd apps/server/tests/adapters/speed
- .venv/bin/python -m pytest -q apps/server/tests/adapters/pdf
- make lint && make typecheck-backend
- VIBESENSOR_TEST_BASE_URL=http://127.0.0.1:8000 .venv/bin/pytest -q -m 'e2e and long_sim' apps/server/tests/integration/test_sim_ingestion.py