### PR TITLE
Refactor update workflow boundaries

### DIFF
--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -21,10 +21,8 @@ from vibesensor.use_cases.diagnostics.math_utils import _corr_abs_clamped
 from vibesensor.use_cases.updates.firmware.firmware_bundle import dir_sha256
 from vibesensor.use_cases.updates.firmware.firmware_release_fetcher import GitHubReleaseFetcher
 from vibesensor.use_cases.updates.firmware.firmware_types import FirmwareCacheConfig
-from vibesensor.use_cases.updates.preparation import PreparedUpdateWorkflow
-from vibesensor.use_cases.updates.transport_coordinator import PreparedUpdateTransport
+from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.workflow import UpdateWorkflow
-from vibesensor.use_cases.updates.workflow_runner import UpdateWorkflowContext
 
 # ── 2. _corr_abs_clamped returns at most 1.0 ─────────────────────────────
 
@@ -171,21 +169,20 @@ class TestUpdateManagerCancelledError:
         workflow = UpdateWorkflow(
             preparation=SimpleNamespace(
                 prepare=AsyncMock(
-                    return_value=PreparedUpdateWorkflow(
+                    return_value=PreparedUpdateRun(
                         current_version="2026.4.3",
-                        transport=PreparedUpdateTransport(
-                            request=MagicMock(),
-                            session=AsyncMock(),
-                        ),
+                        transport_session=AsyncMock(),
                     )
                 )
             ),
             release_planner=SimpleNamespace(plan=AsyncMock(side_effect=asyncio.CancelledError())),
             workflow_executor=MagicMock(),
+            transport_cleanup=SimpleNamespace(run=AsyncMock()),
+            runtime_details_refresher=SimpleNamespace(refresh=AsyncMock()),
         )
 
         with pytest.raises(asyncio.CancelledError):
-            await workflow.run(context=UpdateWorkflowContext(), request=MagicMock())
+            await workflow.run(request=MagicMock())
 
 
 # ── 7. dir_sha256 uses separators ────────────────────────────────────────

--- a/apps/server/tests/use_cases/updates/test_release_resolution.py
+++ b/apps/server/tests/use_cases/updates/test_release_resolution.py
@@ -2,20 +2,17 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from test_support.update_status import build_update_status_harness
 
 from vibesensor.shared.exceptions import UpdateReleaseError
-from vibesensor.use_cases.updates.release_resolution import (
-    ServerReleaseResolver,
-    UpdateReleaseCheck,
-)
+from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
 
 
 @pytest.mark.asyncio
-async def test_resolve_maps_update_check_fields(tmp_path: Path) -> None:
+async def test_resolve_returns_release_without_latest_tag_lookup(tmp_path: Path) -> None:
     status = build_update_status_harness(tmp_path / "state.json")
     resolver = ServerReleaseResolver(
         status_controller=status.controller,
@@ -23,22 +20,44 @@ async def test_resolve_maps_update_check_fields(tmp_path: Path) -> None:
         rollback_dir=tmp_path / "rollback",
     )
     release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4")
+    fetcher = MagicMock()
+    fetcher.check_update_available.return_value = release
 
     with patch(
-        "vibesensor.use_cases.updates.release_resolution.check_for_update",
-        new=AsyncMock(
-            return_value=UpdateReleaseCheck(
-                release=release,
-                latest_tag="server-v2026.4.4",
-            ),
-        ),
+        "vibesensor.use_cases.updates.release_resolution.release_fetcher_factory.build_server_release_fetcher",
+        return_value=fetcher,
     ):
         resolution = await resolver.resolve("2026.4.3")
 
     assert resolution.current_version == "2026.4.3"
     assert resolution.release is release
-    assert resolution.latest_tag == "server-v2026.4.4"
+    assert resolution.latest_tag == ""
     assert resolution.update_available is True
+    fetcher.find_latest_release.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_latest_tag_when_no_update_is_available(tmp_path: Path) -> None:
+    status = build_update_status_harness(tmp_path / "state.json")
+    resolver = ServerReleaseResolver(
+        status_controller=status.controller,
+        status_recorder=status.recorder,
+        rollback_dir=tmp_path / "rollback",
+    )
+    fetcher = MagicMock()
+    fetcher.check_update_available.return_value = None
+    fetcher.find_latest_release.return_value = SimpleNamespace(tag="server-v2026.4.4")
+
+    with patch(
+        "vibesensor.use_cases.updates.release_resolution.release_fetcher_factory.build_server_release_fetcher",
+        return_value=fetcher,
+    ):
+        resolution = await resolver.resolve("2026.4.3")
+
+    assert resolution.current_version == "2026.4.3"
+    assert resolution.release is None
+    assert resolution.latest_tag == "server-v2026.4.4"
+    assert resolution.update_available is False
 
 
 @pytest.mark.asyncio
@@ -49,10 +68,12 @@ async def test_resolve_propagates_release_check_failure(tmp_path: Path) -> None:
         status_recorder=status.recorder,
         rollback_dir=tmp_path / "rollback",
     )
+    fetcher = MagicMock()
+    fetcher.check_update_available.side_effect = OSError("rate limited")
 
     with patch(
-        "vibesensor.use_cases.updates.release_resolution.check_for_update",
-        new=AsyncMock(side_effect=UpdateReleaseError("rate limited")),
+        "vibesensor.use_cases.updates.release_resolution.release_fetcher_factory.build_server_release_fetcher",
+        return_value=fetcher,
     ):
         with pytest.raises(UpdateReleaseError, match="rate limited"):
             await resolver.resolve("2026.4.3")

--- a/apps/server/tests/use_cases/updates/test_release_staging.py
+++ b/apps/server/tests/use_cases/updates/test_release_staging.py
@@ -37,26 +37,22 @@ async def test_stage_yields_staged_release_and_cleans_temp_dir(tmp_path: Path) -
     release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="")
     staged_path: Path | None = None
 
-    async def _download_release(
-        _controller,
-        _recorder,
-        _rollback_dir,
-        _release,
-        staging_dir: Path,
-    ) -> Path:
+    async def _download_release(_release: object, staging_dir: Path) -> Path:
         nonlocal staged_path
         staged_path = staging_dir / "release.whl"
         staged_path.write_text("wheel", encoding="utf-8")
         return staged_path
 
     with (
-        patch(
-            "vibesensor.use_cases.updates.release_staging.download_release",
-            new=_download_release,
+        patch.object(
+            ServerReleaseStager,
+            "_download_release",
+            new=AsyncMock(side_effect=_download_release),
         ),
-        patch(
-            "vibesensor.use_cases.updates.release_staging.verify_download",
-            new=AsyncMock(return_value=True),
+        patch.object(
+            ServerReleaseStager,
+            "_verify_download",
+            new=AsyncMock(return_value=None),
         ),
     ):
         async with stager.stage(release) as staged:
@@ -82,13 +78,7 @@ async def test_stage_returns_none_when_verification_fails(tmp_path: Path) -> Non
     release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="bad")
     staged_dir: Path | None = None
 
-    async def _download_release(
-        _controller,
-        _recorder,
-        _rollback_dir,
-        _release,
-        staging_dir: Path,
-    ) -> Path:
+    async def _download_release(_release: object, staging_dir: Path) -> Path:
         nonlocal staged_dir
         staged_dir = staging_dir
         wheel_path = staging_dir / "release.whl"
@@ -96,12 +86,14 @@ async def test_stage_returns_none_when_verification_fails(tmp_path: Path) -> Non
         return wheel_path
 
     with (
-        patch(
-            "vibesensor.use_cases.updates.release_staging.download_release",
-            new=_download_release,
+        patch.object(
+            ServerReleaseStager,
+            "_download_release",
+            new=AsyncMock(side_effect=_download_release),
         ),
-        patch(
-            "vibesensor.use_cases.updates.release_staging.verify_download",
+        patch.object(
+            ServerReleaseStager,
+            "_verify_download",
             new=AsyncMock(side_effect=UpdateReleaseError("checksum mismatch")),
         ),
         pytest.raises(UpdateReleaseError, match="checksum mismatch"),

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -102,8 +102,8 @@ class TestUpdateManagerAsync:
             patch("shutil.which", mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
             patch(
-                "vibesensor.use_cases.updates.release_resolution.check_for_update",
-                side_effect=AssertionError("check_for_update should not run without privileges"),
+                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver._check_for_update",
+                side_effect=AssertionError("release resolution should not run without privileges"),
             ),
         ):
             await run_update(manager, "TestNet", "pass")
@@ -431,16 +431,26 @@ class TestUpdateManagerAsync:
 
         with (
             patch(
-                "vibesensor.use_cases.updates.cleanup.collect_runtime_details",
+                "vibesensor.use_cases.updates.runtime_refresh.collect_runtime_details",
                 side_effect=OSError("runtime unavailable"),
+            ),
+            patch.object(
+                type(manager._runtime.workflow.preparation),
+                "prepare",
+                new=AsyncMock(
+                    return_value=SimpleNamespace(
+                        current_version="2026.4.3",
+                        transport_session=AsyncMock(),
+                    )
+                ),
+            ),
+            patch.object(
+                type(manager._runtime.workflow.release_planner),
+                "plan",
+                new=AsyncMock(side_effect=asyncio.CancelledError()),
             ),
             caplog.at_level("ERROR"),
         ):
-            object.__setattr__(
-                manager._runtime,
-                "workflow",
-                SimpleNamespace(run=AsyncMock(side_effect=asyncio.CancelledError())),
-            )
             manager.start("TestNet", "pass123")
             assert manager.job_task is not None
             with pytest.raises(
@@ -467,15 +477,27 @@ class TestUpdateManagerAsync:
     ) -> None:
         manager, _runner, _ = setup_update_env(tmp_path)
 
-        with patch(
-            "vibesensor.use_cases.updates.cleanup.collect_runtime_details",
-            side_effect=TypeError("runtime bug"),
+        with (
+            patch(
+                "vibesensor.use_cases.updates.runtime_refresh.collect_runtime_details",
+                side_effect=TypeError("runtime bug"),
+            ),
+            patch.object(
+                type(manager._runtime.workflow.preparation),
+                "prepare",
+                new=AsyncMock(
+                    return_value=SimpleNamespace(
+                        current_version="2026.4.3",
+                        transport_session=AsyncMock(),
+                    )
+                ),
+            ),
+            patch.object(
+                type(manager._runtime.workflow.release_planner),
+                "plan",
+                new=AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
         ):
-            object.__setattr__(
-                manager._runtime,
-                "workflow",
-                SimpleNamespace(run=AsyncMock(side_effect=asyncio.CancelledError())),
-            )
             manager.start("TestNet", "pass123")
             assert manager.job_task is not None
             with pytest.raises(TypeError, match="runtime bug"):

--- a/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from vibesensor.shared.exceptions import UpdatePreparationError, UpdateReleaseError
+from vibesensor.shared.exceptions import (
+    UpdateCleanupError,
+    UpdatePreparationError,
+    UpdateReleaseError,
+)
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
@@ -13,10 +17,8 @@ from vibesensor.use_cases.updates.models import (
     UpdateState,
     UpdateTransport,
 )
-from vibesensor.use_cases.updates.preparation import PreparedUpdateWorkflow
-from vibesensor.use_cases.updates.transport_coordinator import PreparedUpdateTransport
+from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.workflow import UpdateWorkflow
-from vibesensor.use_cases.updates.workflow_runner import UpdateWorkflowContext
 
 
 def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateRequest:
@@ -27,22 +29,37 @@ def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateReq
     )
 
 
-def _build_workflow() -> tuple[UpdateWorkflow, AsyncMock, AsyncMock, AsyncMock]:
+def _build_workflow() -> tuple[
+    UpdateWorkflow,
+    AsyncMock,
+    AsyncMock,
+    AsyncMock,
+    AsyncMock,
+    AsyncMock,
+]:
     preparation = MagicMock()
     preparation.prepare = AsyncMock()
     release_planner = MagicMock()
     release_planner.plan = AsyncMock()
     workflow_executor = MagicMock()
     workflow_executor.execute = AsyncMock()
+    transport_cleanup = MagicMock()
+    transport_cleanup.run = AsyncMock()
+    runtime_details_refresher = MagicMock()
+    runtime_details_refresher.refresh = AsyncMock()
     return (
         UpdateWorkflow(
             preparation=preparation,
             release_planner=release_planner,
             workflow_executor=workflow_executor,
+            transport_cleanup=transport_cleanup,
+            runtime_details_refresher=runtime_details_refresher,
         ),
         preparation.prepare,
         release_planner.plan,
         workflow_executor.execute,
+        transport_cleanup.run,
+        runtime_details_refresher.refresh,
     )
 
 
@@ -52,12 +69,8 @@ def _build_manager(
 ) -> tuple[UpdateManager, AsyncMock]:
     status_services = MagicMock()
     status_services.status = status or UpdateJobStatus()
-    recorder = MagicMock()
-    status_controller = MagicMock()
     runtime = SimpleNamespace(
         status_services=status_services,
-        recorder=recorder,
-        status_controller=status_controller,
         workflow=MagicMock(),
         startup_recovery=SimpleNamespace(recover=AsyncMock()),
         workflow_runner=SimpleNamespace(
@@ -70,59 +83,76 @@ def _build_manager(
 
 
 @pytest.mark.asyncio
-async def test_workflow_stops_after_preparation_failure() -> None:
-    workflow, prepare, plan, execute = _build_workflow()
+async def test_workflow_stops_after_preparation_failure_and_finalizes_without_transport() -> None:
+    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
     prepare.side_effect = UpdatePreparationError("validation failed")
 
     with pytest.raises(UpdatePreparationError, match="validation failed"):
-        await workflow.run(context=UpdateWorkflowContext(), request=_wifi_request())
+        await workflow.run(request=_wifi_request())
 
     prepare.assert_awaited_once()
     plan.assert_not_awaited()
     execute.assert_not_awaited()
+    cleanup.assert_awaited_once_with(None)
+    refresh.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_workflow_carries_resolved_transport_session_through_context() -> None:
-    workflow, prepare, plan, execute = _build_workflow()
+async def test_workflow_finalizes_the_prepared_transport_session() -> None:
+    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
     transport_session = AsyncMock()
-    prepared = PreparedUpdateWorkflow(
+    prepared = PreparedUpdateRun(
         current_version="2026.4.3",
-        transport=PreparedUpdateTransport(
-            request=_wifi_request(),
-            session=transport_session,
-        ),
+        transport_session=transport_session,
     )
     planned = object()
     prepare.return_value = prepared
     plan.return_value = planned
-    context = UpdateWorkflowContext()
 
-    await workflow.run(context=context, request=_wifi_request())
+    await workflow.run(request=_wifi_request())
 
     prepare.assert_awaited_once()
     plan.assert_awaited_once_with(prepared)
     execute.assert_awaited_once_with(planned)
-    assert context.transport is prepared.transport
+    cleanup.assert_awaited_once_with(transport_session)
+    refresh.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
-async def test_workflow_stops_after_release_failure() -> None:
-    workflow, prepare, plan, execute = _build_workflow()
+async def test_workflow_stops_after_release_failure_and_finalizes_prepared_transport() -> None:
+    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
     transport_session = AsyncMock()
-    prepare.return_value = PreparedUpdateWorkflow(
+    prepare.return_value = PreparedUpdateRun(
         current_version="2026.4.3",
-        transport=PreparedUpdateTransport(
-            request=_wifi_request(),
-            session=transport_session,
-        ),
+        transport_session=transport_session,
     )
     plan.side_effect = UpdateReleaseError("release check failed")
 
     with pytest.raises(UpdateReleaseError, match="release check failed"):
-        await workflow.run(context=UpdateWorkflowContext(), request=_wifi_request())
+        await workflow.run(request=_wifi_request())
 
     execute.assert_not_awaited()
+    cleanup.assert_awaited_once_with(transport_session)
+    refresh.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_workflow_adds_cleanup_note_to_workflow_bug() -> None:
+    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
+    transport_session = AsyncMock()
+    prepare.return_value = PreparedUpdateRun(
+        current_version="2026.4.3",
+        transport_session=transport_session,
+    )
+    plan.return_value = object()
+    execute.side_effect = RuntimeError("workflow bug")
+    cleanup.side_effect = UpdateCleanupError("transport cleanup failed")
+
+    with pytest.raises(RuntimeError, match="workflow bug") as exc_info:
+        await workflow.run(request=_wifi_request())
+
+    assert exc_info.value.__notes__ == ["Cleanup also failed: transport cleanup failed"]
+    refresh.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/test_update_preparation.py
+++ b/apps/server/tests/use_cases/updates/test_update_preparation.py
@@ -12,10 +12,8 @@ from vibesensor.use_cases.updates.models import (
     UpdateTransport,
     UpdateValidationConfig,
 )
-from vibesensor.use_cases.updates.preparation import (
-    PreparedUpdateWorkflow,
-    UpdatePreparationCoordinator,
-)
+from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
+from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
 from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
 
@@ -91,7 +89,7 @@ async def test_prepare_stops_when_transport_cannot_prepare(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_prepare_returns_canonical_prepared_workflow(tmp_path: Path) -> None:
+async def test_prepare_returns_canonical_prepared_run(tmp_path: Path) -> None:
     preparation, _tracker, transport_session = _build_preparation(
         tmp_path,
         current_version="2026.4.9",
@@ -105,6 +103,6 @@ async def test_prepare_returns_canonical_prepared_workflow(tmp_path: Path) -> No
     ):
         prepared = await preparation.prepare(request)
 
-    assert isinstance(prepared, PreparedUpdateWorkflow)
+    assert isinstance(prepared, PreparedUpdateRun)
     assert prepared.current_version == "2026.4.9"
-    assert prepared.transport.session is transport_session
+    assert prepared.transport_session is transport_session

--- a/apps/server/tests/use_cases/updates/test_update_release_planner.py
+++ b/apps/server/tests/use_cases/updates/test_update_release_planner.py
@@ -13,14 +13,13 @@ from vibesensor.use_cases.updates.models import (
     UpdateRequest,
     UpdateTransport,
 )
-from vibesensor.use_cases.updates.preparation import PreparedUpdateWorkflow
-from vibesensor.use_cases.updates.release_planner import (
+from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
+from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
-    PlannedUpdateWorkflow,
+    PlannedUpdateRun,
+    PreparedUpdateRun,
     RefreshFirmwarePlan,
-    UpdateReleasePlanner,
 )
-from vibesensor.use_cases.updates.transport_coordinator import PreparedUpdateTransport
 
 
 def _planner(tmp_path: Path) -> tuple[UpdateReleasePlanner, UpdateStatusHarness, MagicMock]:
@@ -47,17 +46,10 @@ def _planner(tmp_path: Path) -> tuple[UpdateReleasePlanner, UpdateStatusHarness,
     )
 
 
-def _prepared_workflow() -> PreparedUpdateWorkflow:
-    return PreparedUpdateWorkflow(
+def _prepared_run() -> PreparedUpdateRun:
+    return PreparedUpdateRun(
         current_version="2026.4.3",
-        transport=PreparedUpdateTransport(
-            request=UpdateRequest(
-                transport=UpdateTransport.wifi,
-                ssid="TestNet",
-                password="secret",
-            ),
-            session=object(),
-        ),
+        transport_session=object(),
     )
 
 
@@ -71,11 +63,11 @@ async def test_plan_returns_refresh_only_plan_when_no_server_update_is_needed(
         latest_tag="server-v2026.4.3",
     )
 
-    planned = await planner.plan(_prepared_workflow())
+    planned = await planner.plan(_prepared_run())
 
-    assert isinstance(planned, PlannedUpdateWorkflow)
+    assert isinstance(planned, PlannedUpdateRun)
     assert isinstance(planned.execution_plan, RefreshFirmwarePlan)
-    assert planned.execution_plan.current_version == "2026.4.3"
+    assert planned.prepared.current_version == "2026.4.3"
     assert planned.execution_plan.latest_tag == "server-v2026.4.3"
     assert tracker.status.phase.value == "checking"
     assert any("Already up-to-date" in line for line in tracker.status.log_tail)
@@ -90,10 +82,10 @@ async def test_plan_returns_install_plan_when_server_update_is_available(tmp_pat
         latest_tag="server-v2026.4.4",
     )
 
-    planned = await planner.plan(_prepared_workflow())
+    planned = await planner.plan(_prepared_run())
 
     assert isinstance(planned.execution_plan, InstallServerReleasePlan)
-    assert planned.execution_plan.current_version == "2026.4.3"
+    assert planned.prepared.current_version == "2026.4.3"
     assert planned.execution_plan.release is release
     assert tracker.status.phase.value == "checking"
     assert any("Update available: 2026.4.3 → 2026.4.4" in line for line in tracker.status.log_tail)
@@ -105,6 +97,6 @@ async def test_plan_propagates_release_resolution_failure(tmp_path: Path) -> Non
     resolver.resolve.side_effect = UpdateReleaseError("release check failed")
 
     with pytest.raises(UpdateReleaseError, match="release check failed"):
-        await planner.plan(_prepared_workflow())
+        await planner.plan(_prepared_run())
 
     assert tracker.status.phase.value == "checking"

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -516,8 +516,8 @@ class TestPersistenceDuringLifecycle:
             patch("shutil.which", _mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
             patch(
-                "vibesensor.use_cases.updates.release_resolution.check_for_update",
-                side_effect=AssertionError("check_for_update should not run without privileges"),
+                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver._check_for_update",
+                side_effect=AssertionError("release resolution should not run without privileges"),
             ),
         ):
             mgr.start("TestNet", "")

--- a/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
@@ -8,17 +8,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vibesensor.shared.exceptions import UpdateReleaseError
-from vibesensor.use_cases.updates.models import (
-    UpdateExecutionOutcome,
-    UpdateRequest,
-    UpdateTransport,
-)
-from vibesensor.use_cases.updates.release_planner import (
+from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
+from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
-    PlannedUpdateWorkflow,
+    PlannedUpdateRun,
+    PreparedUpdateRun,
     RefreshFirmwarePlan,
 )
-from vibesensor.use_cases.updates.transport_coordinator import PreparedUpdateTransport
 from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
 
 
@@ -39,14 +35,10 @@ def _executor() -> tuple[UpdateWorkflowExecutor, MagicMock, MagicMock, MagicMock
     return executor, stager, deployer, firmware_refresher, completion
 
 
-def _prepared_transport(session: object) -> PreparedUpdateTransport:
-    return PreparedUpdateTransport(
-        request=UpdateRequest(
-            transport=UpdateTransport.usb_internet,
-            ssid=None,
-            password="",
-        ),
-        session=session,
+def _prepared_run(session: object) -> PreparedUpdateRun:
+    return PreparedUpdateRun(
+        current_version="2026.4.3",
+        transport_session=session,
     )
 
 
@@ -54,10 +46,9 @@ def _prepared_transport(session: object) -> PreparedUpdateTransport:
 async def test_execute_refresh_plan_refreshes_firmware_then_finalizes_transport() -> None:
     executor, stager, deployer, firmware_refresher, completion = _executor()
     transport_session = object()
-    workflow = PlannedUpdateWorkflow(
-        transport=_prepared_transport(transport_session),
+    workflow = PlannedUpdateRun(
+        prepared=_prepared_run(transport_session),
         execution_plan=RefreshFirmwarePlan(
-            current_version="2026.4.3",
             latest_tag="server-v2026.4.3",
         ),
     )
@@ -69,7 +60,7 @@ async def test_execute_refresh_plan_refreshes_firmware_then_finalizes_transport(
         pinned_tag="server-v2026.4.3",
     )
     completion.complete.assert_awaited_once_with(
-        workflow.transport,
+        transport_session,
         message="No server update needed; ESP firmware checked",
     )
     deployer.deploy.assert_not_awaited()
@@ -90,10 +81,9 @@ async def test_execute_install_plan_stages_and_deploys_before_finalization(tmp_p
     stager.stage.side_effect = stage
 
     completed = await executor.execute(
-        workflow := PlannedUpdateWorkflow(
-            transport=_prepared_transport(transport_session),
+        workflow := PlannedUpdateRun(
+            prepared=_prepared_run(transport_session),
             execution_plan=InstallServerReleasePlan(
-                current_version="2026.4.3",
                 release=release,
             ),
         ),
@@ -103,7 +93,7 @@ async def test_execute_install_plan_stages_and_deploys_before_finalization(tmp_p
     stager.stage.assert_called_once_with(release)
     deployer.deploy.assert_awaited_once_with(staged_release)
     completion.complete.assert_awaited_once_with(
-        workflow.transport,
+        workflow.prepared.transport_session,
         message="Update completed successfully",
     )
     firmware_refresher.refresh_esp_firmware.assert_not_awaited()
@@ -127,10 +117,9 @@ async def test_execute_install_plan_propagates_deploy_failure_before_finalizatio
 
     with pytest.raises(UpdateReleaseError, match="install failed"):
         await executor.execute(
-            PlannedUpdateWorkflow(
-                transport=_prepared_transport(transport_session),
+            PlannedUpdateRun(
+                prepared=_prepared_run(transport_session),
                 execution_plan=InstallServerReleasePlan(
-                    current_version="2026.4.3",
                     release=release,
                 ),
             ),

--- a/apps/server/tests/use_cases/updates/test_update_workflow_runner.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_runner.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
-from vibesensor.use_cases.updates.models import UpdateRequest, UpdateTransport
-from vibesensor.use_cases.updates.workflow_runner import UpdateWorkflowContext, UpdateWorkflowRunner
+from vibesensor.use_cases.updates.models import UpdateRequest, UpdateState, UpdateTransport
+from vibesensor.use_cases.updates.workflow_runner import UpdateWorkflowRunner
 
 
 def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateRequest:
@@ -23,18 +23,16 @@ def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateReq
 async def test_start_rejects_concurrent_job() -> None:
     controller = MagicMock()
     recorder = MagicMock()
-    cleanup = AsyncMock()
     runner = UpdateWorkflowRunner(
         status_controller=controller,
         status_recorder=recorder,
-        cleanup=cleanup,
         timeout_s=10.0,
     )
     request = _wifi_request()
     started = asyncio.Event()
     release = asyncio.Event()
 
-    async def running_workflow(_context: UpdateWorkflowContext) -> None:
+    async def running_workflow() -> None:
         started.set()
         await release.wait()
 
@@ -54,18 +52,16 @@ async def test_start_rejects_concurrent_job() -> None:
 
 
 @pytest.mark.asyncio
-async def test_timeout_marks_failure_and_runs_cleanup() -> None:
+async def test_timeout_marks_failure_and_finishes_lifecycle() -> None:
     controller = MagicMock()
     recorder = MagicMock()
-    cleanup = AsyncMock()
     runner = UpdateWorkflowRunner(
         status_controller=controller,
         status_recorder=recorder,
-        cleanup=cleanup,
         timeout_s=0.01,
     )
 
-    async def slow_workflow(_context: UpdateWorkflowContext) -> None:
+    async def slow_workflow() -> None:
         await asyncio.sleep(1.0)
 
     runner.start(request=_wifi_request(), workflow=slow_workflow)
@@ -76,60 +72,53 @@ async def test_timeout_marks_failure_and_runs_cleanup() -> None:
     recorder.add_issue.assert_any_call("timeout", "Update timed out after 0.01s")
     recorder.log.assert_any_call("Update timed out after 0.01s")
     controller.mark_failed.assert_called_once_with()
-    cleanup.run.assert_awaited_once_with(None)
     recorder.clear_secrets.assert_called_once_with()
     controller.finish_cleanup.assert_called_once_with()
 
 
 @pytest.mark.asyncio
-async def test_operational_cleanup_failure_adds_note_to_workflow_error() -> None:
+async def test_update_error_marks_failure_without_propagating() -> None:
     controller = MagicMock()
+    controller.status.state = UpdateState.running
     recorder = MagicMock()
-    cleanup = AsyncMock()
-    cleanup.run.side_effect = UpdateCleanupError("transport cleanup failed")
     runner = UpdateWorkflowRunner(
         status_controller=controller,
         status_recorder=recorder,
-        cleanup=cleanup,
         timeout_s=10.0,
     )
 
-    async def broken_workflow(_context: UpdateWorkflowContext) -> None:
-        raise RuntimeError("workflow bug")
+    async def broken_workflow() -> None:
+        raise UpdateError("transport failed")
 
     runner.start(request=_wifi_request(), workflow=broken_workflow)
     task = runner.job_task
     assert task is not None
+    await task
 
-    with pytest.raises(RuntimeError, match="workflow bug") as exc_info:
-        await task
-
-    assert exc_info.value.__notes__ == ["Cleanup also failed: transport cleanup failed"]
+    recorder.add_issue.assert_any_call("workflow", "transport failed")
+    controller.mark_failed.assert_called_once_with()
     recorder.clear_secrets.assert_called_once_with()
     controller.finish_cleanup.assert_called_once_with()
 
 
 @pytest.mark.asyncio
-async def test_unexpected_cleanup_bug_propagates_instead_of_being_hidden() -> None:
+async def test_cleanup_error_propagates_explicitly() -> None:
     controller = MagicMock()
     recorder = MagicMock()
-    cleanup = AsyncMock()
-    cleanup.run.side_effect = TypeError("cleanup bug")
     runner = UpdateWorkflowRunner(
         status_controller=controller,
         status_recorder=recorder,
-        cleanup=cleanup,
         timeout_s=10.0,
     )
 
-    async def broken_workflow(_context: UpdateWorkflowContext) -> None:
-        raise RuntimeError("workflow bug")
+    async def broken_workflow() -> None:
+        raise UpdateCleanupError("transport cleanup failed")
 
     runner.start(request=_wifi_request(), workflow=broken_workflow)
     task = runner.job_task
     assert task is not None
 
-    with pytest.raises(TypeError, match="cleanup bug"):
+    with pytest.raises(UpdateCleanupError, match="transport cleanup failed"):
         await task
 
     recorder.clear_secrets.assert_called_once_with()

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
-from test_support.update_status import UpdateStatusHarness, build_update_status_harness
+from test_support.update_status import build_update_status_harness
 from use_cases.updates._update_manager_test_helpers import FakeRunner
 
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.transport_failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.wifi.wifi_config import build_default_wifi_config
 from vibesensor.use_cases.updates.wifi.wifi_readiness import UpdateWifiReadiness
 
@@ -18,7 +19,7 @@ def _build_readiness(
     *,
     dns_ready_min_wait_s: float = 0.05,
     dns_retry_interval_s: float = 0.01,
-) -> tuple[UpdateWifiReadiness, FakeRunner, UpdateStatusHarness]:
+) -> tuple[UpdateWifiReadiness, FakeRunner]:
     runner = FakeRunner()
     status = build_update_status_harness(tmp_path / "state.json")
     config = replace(
@@ -29,11 +30,10 @@ def _build_readiness(
     commands = UpdateCommandExecutor(runner=runner, recorder=status.recorder)
     readiness = UpdateWifiReadiness(
         commands=commands,
-        status_controller=status.controller,
         status_recorder=status.recorder,
         config=config,
     )
-    return readiness, runner, status.tracker
+    return readiness, runner
 
 
 @pytest.mark.asyncio
@@ -41,7 +41,7 @@ async def test_bring_uplink_up_retries_ssid_not_found_then_succeeds(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    readiness, runner, tracker = _build_readiness(tmp_path)
+    readiness, runner = _build_readiness(tmp_path)
     original_run = runner.run
     connect_calls = {"count": 0}
 
@@ -57,21 +57,19 @@ async def test_bring_uplink_up_retries_ssid_not_found_then_succeeds(
     sleep = AsyncMock(return_value=None)
     monkeypatch.setattr("vibesensor.use_cases.updates.wifi.wifi_readiness.asyncio.sleep", sleep)
 
-    assert await readiness.bring_uplink_up("TestNet")
+    await readiness.bring_uplink_up("TestNet")
     assert connect_calls["count"] == 2
     assert sleep.await_count == 1
-    assert not tracker.status.issues
     assert any("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_dns_ready_reports_clear_failure(tmp_path: Path) -> None:
-    readiness, runner, tracker = _build_readiness(tmp_path)
+async def test_wait_for_dns_ready_raises_clear_failure(tmp_path: Path) -> None:
+    readiness, runner = _build_readiness(tmp_path)
     runner.set_response("socket.getaddrinfo", 1, "", "Temporary failure in name resolution")
 
-    assert not await readiness.wait_for_dns_ready()
-    assert any(
-        issue.message == "Connected to Wi-Fi, but internet/DNS is not ready"
-        and "Temporary failure in name resolution" in (issue.detail or "")
-        for issue in tracker.status.issues
-    )
+    with pytest.raises(UpdateTransportStepError) as exc_info:
+        await readiness.wait_for_dns_ready()
+
+    assert str(exc_info.value) == "Connected to Wi-Fi, but internet/DNS is not ready"
+    assert "Temporary failure in name resolution" in exc_info.value.detail

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from test_support.update_status import UpdateStatusHarness, build_update_status_harness
+from test_support.update_status import build_update_status_harness
 from use_cases.updates._update_manager_test_helpers import FakeRunner
 
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.transport_failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.wifi.wifi_config import build_default_wifi_config
 from vibesensor.use_cases.updates.wifi.wifi_uplink_setup import (
     UpdateUplinkProvisioner,
@@ -14,19 +15,15 @@ from vibesensor.use_cases.updates.wifi.wifi_uplink_setup import (
 )
 
 
-def _build_uplink_provisioner(
-    tmp_path: Path,
-) -> tuple[UpdateUplinkProvisioner, FakeRunner, UpdateStatusHarness]:
+def _build_uplink_provisioner(tmp_path: Path) -> tuple[UpdateUplinkProvisioner, FakeRunner]:
     runner = FakeRunner()
     status = build_update_status_harness(tmp_path / "state.json")
     commands = UpdateCommandExecutor(runner=runner, recorder=status.recorder)
     provisioner = UpdateUplinkProvisioner(
         commands=commands,
-        status_controller=status.controller,
-        status_recorder=status.recorder,
         config=build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
     )
-    return provisioner, runner, status.tracker
+    return provisioner, runner
 
 
 def test_ssid_security_modes_handles_escaped_ssids() -> None:
@@ -40,22 +37,21 @@ def test_ssid_security_modes_handles_escaped_ssids() -> None:
 async def test_prepare_uplink_connection_requires_password_for_secured_network(
     tmp_path: Path,
 ) -> None:
-    provisioner, runner, tracker = _build_uplink_provisioner(tmp_path)
+    provisioner, runner = _build_uplink_provisioner(tmp_path)
     runner.set_response("dev wifi list", 0, "Pim:WPA2 WPA3\n")
 
-    assert not await provisioner.prepare_uplink_connection("Pim", "")
-    assert any(
-        issue.message == "Wi-Fi password required for secured network"
-        for issue in tracker.status.issues
-    )
+    with pytest.raises(
+        UpdateTransportStepError,
+        match="Wi-Fi password required for secured network",
+    ):
+        await provisioner.prepare_uplink_connection("Pim", "")
 
 
 @pytest.mark.asyncio
 async def test_prepare_uplink_connection_applies_password(tmp_path: Path) -> None:
-    provisioner, runner, tracker = _build_uplink_provisioner(tmp_path)
+    provisioner, runner = _build_uplink_provisioner(tmp_path)
 
-    assert await provisioner.prepare_uplink_connection("Pim", "tomaat123")
-    assert not tracker.status.issues
+    await provisioner.prepare_uplink_connection("Pim", "tomaat123")
     assert any(
         "connection modify VibeSensor-Uplink wifi-sec.key-mgmt wpa-psk wifi-sec.psk tomaat123"
         in " ".join(call[0])

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -5,8 +5,10 @@ The updater now has one explicit run-scoped workflow boundary per concern:
 - ``manager.py`` exposes the public API only.
 - ``runtime.py`` composes one canonical runtime graph with explicit status
   services, transport lifecycle coordination, and workflow collaborators.
+- ``run_models.py`` holds the canonical prepared/planned run models shared
+  across the workflow.
 - ``workflow.py`` owns request-scoped orchestration across preparation,
-  planning, and execution.
+  planning, execution, and explicit post-run finalization.
 - ``preparation.py`` owns validation, transport preparation, and current-version
   observation for one run while returning the prepared transport lifecycle
   explicitly.
@@ -14,6 +16,8 @@ The updater now has one explicit run-scoped workflow boundary per concern:
   execution plan tied to that prepared session.
 - ``workflow_executor.py`` owns plan execution while ``completion.py`` owns
   success/restart finalization against the explicit prepared transport.
+- ``cleanup.py`` owns transport cleanup only, while ``runtime_refresh.py``
+  refreshes runtime/build metadata after workflow exit.
 - ``transport_sessions.py`` defines the transport-session interface and request/
   status-based resolution boundary.
 - ``transport_coordinator.py`` owns prepare/cleanup/recovery/success transport

--- a/apps/server/vibesensor/use_cases/updates/cleanup.py
+++ b/apps/server/vibesensor/use_cases/updates/cleanup.py
@@ -1,29 +1,22 @@
-"""Post-run update cleanup separated from lifecycle state callbacks."""
+"""Transport cleanup boundary for updater workflows."""
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from pathlib import Path
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
-from vibesensor.use_cases.updates.status import (
-    UpdateStatusController,
-    UpdateStatusRecorder,
-    collect_runtime_details,
-)
-from vibesensor.use_cases.updates.transport_coordinator import (
-    PreparedUpdateTransport,
-    UpdateTransportCoordinator,
-)
+from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
+from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSession
+
+__all__ = ["UpdateTransportCleanupCoordinator"]
 
 
-class UpdateCleanupCoordinator:
-    """Run explicit post-update cleanup steps without owning lifecycle state transitions."""
+class UpdateTransportCleanupCoordinator:
+    """Run transport-owned cleanup steps after the workflow exits."""
 
     __slots__ = (
         "_logger",
-        "_repo",
         "_status_controller",
         "_status_recorder",
         "_transport_coordinator",
@@ -35,41 +28,21 @@ class UpdateCleanupCoordinator:
         status_controller: UpdateStatusController,
         status_recorder: UpdateStatusRecorder,
         transport_coordinator: UpdateTransportCoordinator,
-        repo: Path,
         logger: logging.Logger,
     ) -> None:
         self._status_controller = status_controller
         self._status_recorder = status_recorder
         self._transport_coordinator = transport_coordinator
-        self._repo = repo
         self._logger = logger
 
-    async def run(self, transport: PreparedUpdateTransport | None) -> None:
-        await self._cleanup_transport_session(transport)
-        await self._refresh_runtime_details()
-
-    async def _cleanup_transport_session(
+    async def run(
         self,
-        transport: PreparedUpdateTransport | None,
+        transport_session: UpdateTransportSession | None,
     ) -> None:
         try:
-            await self._transport_coordinator.cleanup_after_update(transport)
+            await self._transport_coordinator.cleanup_after_update(transport_session)
         except (OSError, UpdateError) as exc:
             self._status_recorder.add_issue("cleanup", "Transport cleanup failed", str(exc))
             self._status_controller.mark_failed()
             self._logger.exception("update: transport cleanup error")
             raise UpdateCleanupError(f"Transport cleanup failed: {exc}") from exc
-
-    async def _refresh_runtime_details(self) -> None:
-        try:
-            runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
-        except (OSError, UpdateError) as exc:
-            self._status_recorder.add_issue(
-                "cleanup",
-                "Runtime details refresh failed",
-                str(exc),
-            )
-            self._status_controller.mark_failed()
-            self._logger.exception("update: runtime details refresh error")
-            raise UpdateCleanupError(f"Runtime details refresh failed: {exc}") from exc
-        self._status_recorder.set_runtime(runtime_details)

--- a/apps/server/vibesensor/use_cases/updates/completion.py
+++ b/apps/server/vibesensor/use_cases/updates/completion.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
 from vibesensor.use_cases.updates.status import UpdateStatusRecorder
-from vibesensor.use_cases.updates.transport_coordinator import (
-    PreparedUpdateTransport,
-    UpdateTransportCoordinator,
-)
+from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSession
 
 __all__ = ["UpdateCompletionCoordinator"]
 
@@ -30,11 +28,14 @@ class UpdateCompletionCoordinator:
 
     async def complete(
         self,
-        transport: PreparedUpdateTransport,
+        transport_session: UpdateTransportSession,
         *,
         message: str,
     ) -> None:
-        await self._transport_coordinator.complete_success(transport, message=message)
+        await self._transport_coordinator.complete_success(
+            transport_session,
+            message=message,
+        )
         if await self._restart_scheduler.schedule():
             return
         self._status_recorder.add_issue(

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -44,10 +44,7 @@ class UpdateManager:
         request = validate_update_request(ssid, password, transport=transport)
         self._runtime.workflow_runner.start(
             request=request,
-            workflow=lambda context: self._runtime.workflow.run(
-                context=context,
-                request=request,
-            ),
+            workflow=lambda: self._runtime.workflow.run(request=request),
         )
 
     def cancel(self) -> bool:

--- a/apps/server/vibesensor/use_cases/updates/preparation.py
+++ b/apps/server/vibesensor/use_cases/updates/preparation.py
@@ -3,32 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
 
 from vibesensor.use_cases.updates.models import UpdateRequest, UpdateValidationConfig
+from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
-from vibesensor.use_cases.updates.transport_coordinator import (
-    PreparedUpdateTransport,
-    UpdateTransportCoordinator,
-)
+from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
 from vibesensor.use_cases.updates.validation import validate_prerequisites
 
-__all__ = [
-    "CurrentVersionProvider",
-    "PreparedUpdateWorkflow",
-    "UpdatePreparationCoordinator",
-]
+__all__ = ["CurrentVersionProvider", "UpdatePreparationCoordinator"]
 
 CurrentVersionProvider = Callable[[], str]
-
-
-@dataclass(frozen=True, slots=True)
-class PreparedUpdateWorkflow:
-    """Validated update workflow state with one prepared transport lifecycle."""
-
-    current_version: str
-    transport: PreparedUpdateTransport
 
 
 class UpdatePreparationCoordinator:
@@ -60,7 +45,7 @@ class UpdatePreparationCoordinator:
         self._validation_config = validation_config
         self._current_version_provider = current_version_provider
 
-    async def prepare(self, request: UpdateRequest) -> PreparedUpdateWorkflow:
+    async def prepare(self, request: UpdateRequest) -> PreparedUpdateRun:
         await validate_prerequisites(
             commands=self._commands,
             controller=self._status_controller,
@@ -68,7 +53,7 @@ class UpdatePreparationCoordinator:
             config=self._validation_config,
             request=request,
         )
-        return PreparedUpdateWorkflow(
+        return PreparedUpdateRun(
             current_version=self._current_version_provider(),
-            transport=await self._transport_coordinator.prepare(request),
+            transport_session=await self._transport_coordinator.prepare(request),
         )

--- a/apps/server/vibesensor/use_cases/updates/release_planner.py
+++ b/apps/server/vibesensor/use_cases/updates/release_planner.py
@@ -2,52 +2,21 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.use_cases.updates.models import UpdatePhase
-from vibesensor.use_cases.updates.preparation import PreparedUpdateWorkflow
 from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
-from vibesensor.use_cases.updates.transport_coordinator import PreparedUpdateTransport
+from vibesensor.use_cases.updates.run_models import (
+    InstallServerReleasePlan,
+    PlannedUpdateRun,
+    PreparedUpdateRun,
+    RefreshFirmwarePlan,
+)
 
 if TYPE_CHECKING:
-    from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
     from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
 
-__all__ = [
-    "InstallServerReleasePlan",
-    "PlannedUpdateWorkflow",
-    "RefreshFirmwarePlan",
-    "ReleaseExecutionPlan",
-    "UpdateReleasePlanner",
-]
-
-
-@dataclass(frozen=True, slots=True)
-class RefreshFirmwarePlan:
-    """Execution plan for runs that only need firmware refresh and transport success."""
-
-    current_version: str
-    latest_tag: str
-
-
-@dataclass(frozen=True, slots=True)
-class InstallServerReleasePlan:
-    """Execution plan for runs that must stage and install a new server release."""
-
-    current_version: str
-    release: ReleaseInfo
-
-
-type ReleaseExecutionPlan = RefreshFirmwarePlan | InstallServerReleasePlan
-
-
-@dataclass(frozen=True, slots=True)
-class PlannedUpdateWorkflow:
-    """Release plan coupled to the already-prepared transport session."""
-
-    transport: PreparedUpdateTransport
-    execution_plan: ReleaseExecutionPlan
+__all__ = ["UpdateReleasePlanner"]
 
 
 class UpdateReleasePlanner:
@@ -66,7 +35,7 @@ class UpdateReleasePlanner:
         self._status_recorder = status_recorder
         self._resolver = resolver
 
-    async def plan(self, prepared: PreparedUpdateWorkflow) -> PlannedUpdateWorkflow:
+    async def plan(self, prepared: PreparedUpdateRun) -> PlannedUpdateRun:
         current_version = prepared.current_version
         self._status_controller.transition(UpdatePhase.checking)
         self._status_recorder.log("Checking for available updates...")
@@ -74,10 +43,9 @@ class UpdateReleasePlanner:
         resolution = await self._resolver.resolve(current_version)
         if resolution.release is None:
             self._status_recorder.log(f"Already up-to-date (version={current_version})")
-            return PlannedUpdateWorkflow(
-                transport=prepared.transport,
+            return PlannedUpdateRun(
+                prepared=prepared,
                 execution_plan=RefreshFirmwarePlan(
-                    current_version=current_version,
                     latest_tag=resolution.latest_tag,
                 ),
             )
@@ -85,10 +53,9 @@ class UpdateReleasePlanner:
         self._status_recorder.log(
             f"Update available: {current_version} → {resolution.release.version}",
         )
-        return PlannedUpdateWorkflow(
-            transport=prepared.transport,
+        return PlannedUpdateRun(
+            prepared=prepared,
             execution_plan=InstallServerReleasePlan(
-                current_version=current_version,
                 release=resolution.release,
             ),
         )

--- a/apps/server/vibesensor/use_cases/updates/release_resolution.py
+++ b/apps/server/vibesensor/use_cases/updates/release_resolution.py
@@ -11,23 +11,13 @@ from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.releases import factory as release_fetcher_factory
 
 if TYPE_CHECKING:
-    from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
+    from vibesensor.use_cases.updates.releases.release_fetcher import (
+        ReleaseInfo,
+        ServerReleaseFetcher,
+    )
     from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
 
-__all__ = [
-    "ServerReleaseResolver",
-    "UpdateReleaseCheck",
-    "UpdateReleaseResolution",
-    "check_for_update",
-]
-
-
-@dataclass(frozen=True, slots=True)
-class UpdateReleaseCheck:
-    """Outcome of checking for a newer server release during updater execution."""
-
-    release: ReleaseInfo | None
-    latest_tag: str = ""
+__all__ = ["ServerReleaseResolver", "UpdateReleaseResolution"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,43 +50,39 @@ class ServerReleaseResolver:
         self._rollback_dir = rollback_dir
 
     async def resolve(self, current_version: str) -> UpdateReleaseResolution:
-        release_check = await check_for_update(
-            self._status_controller,
-            self._status_recorder,
-            self._rollback_dir,
-            current_version,
+        fetcher = release_fetcher_factory.build_server_release_fetcher(
+            rollback_dir=self._rollback_dir,
         )
+        release = await self._check_for_update(fetcher, current_version)
+        if release is None:
+            return UpdateReleaseResolution(
+                current_version=current_version,
+                release=None,
+                latest_tag=await self._latest_tag(fetcher),
+            )
         return UpdateReleaseResolution(
             current_version=current_version,
-            release=release_check.release,
-            latest_tag=release_check.latest_tag,
+            release=release,
         )
 
+    async def _check_for_update(
+        self,
+        fetcher: ServerReleaseFetcher,
+        current_version: str,
+    ) -> ReleaseInfo | None:
+        try:
+            return await asyncio.to_thread(fetcher.check_update_available, current_version)
+        except (OSError, ValueError) as exc:
+            self._status_recorder.add_issue("checking", f"Failed to check for updates: {exc}")
+            self._status_controller.mark_failed()
+            raise UpdateReleaseError(f"Failed to check for updates: {exc}") from exc
 
-async def check_for_update(
-    status_controller: UpdateStatusController,
-    status_recorder: UpdateStatusRecorder,
-    rollback_dir: Path,
-    current_version: str,
-) -> UpdateReleaseCheck:
-    """Check GitHub releases for an available update."""
-
-    fetcher = release_fetcher_factory.build_server_release_fetcher(rollback_dir=rollback_dir)
-    try:
-        release = await asyncio.to_thread(fetcher.check_update_available, current_version)
-    except (OSError, ValueError) as exc:
-        status_recorder.add_issue("checking", f"Failed to check for updates: {exc}")
-        status_controller.mark_failed()
-        raise UpdateReleaseError(f"Failed to check for updates: {exc}") from exc
-    if release is not None:
-        return UpdateReleaseCheck(release=release)
-    latest_tag = ""
-    try:
-        latest_release = await asyncio.to_thread(fetcher.find_latest_release)
-        if isinstance(latest_release.tag, str):
-            latest_tag = latest_release.tag
-    except (OSError, ValueError) as exc:
-        status_recorder.log(
-            f"Could not resolve the latest release tag for ESP firmware sync: {exc}",
-        )
-    return UpdateReleaseCheck(release=None, latest_tag=latest_tag)
+    async def _latest_tag(self, fetcher: ServerReleaseFetcher) -> str:
+        try:
+            latest_release = await asyncio.to_thread(fetcher.find_latest_release)
+        except (OSError, ValueError) as exc:
+            self._status_recorder.log(
+                f"Could not resolve the latest release tag for ESP firmware sync: {exc}",
+            )
+            return ""
+        return latest_release.tag if isinstance(latest_release.tag, str) else ""

--- a/apps/server/vibesensor/use_cases/updates/release_staging.py
+++ b/apps/server/vibesensor/use_cases/updates/release_staging.py
@@ -52,22 +52,11 @@ class ServerReleaseStager:
         self._status_recorder.log(f"Downloading release {release.tag}...")
         staging_dir = Path(tempfile.mkdtemp(prefix="vibesensor-update-"))
         try:
-            wheel_path = await download_release(
-                self._status_controller,
-                self._status_recorder,
-                self._rollback_dir,
-                release,
-                staging_dir,
-            )
+            wheel_path = await self._download_release(release, staging_dir)
             self._status_recorder.log(
                 f"Downloaded {wheel_path.name} (sha256={getattr(release, 'sha256', '')})",
             )
-            await verify_download(
-                self._status_controller,
-                self._status_recorder,
-                release,
-                wheel_path,
-            )
+            await self._verify_download(release, wheel_path)
             yield StagedServerRelease(release=release, wheel_path=wheel_path)
         finally:
             active_error = sys.exc_info()[1]
@@ -82,45 +71,36 @@ class ServerReleaseStager:
                 else:
                     raise cleanup_error from exc
 
+    async def _download_release(self, release: ReleaseInfo, staging_dir: Path) -> Path:
+        """Download a release wheel to *staging_dir*."""
 
-async def download_release(
-    status_controller: UpdateStatusController,
-    status_recorder: UpdateStatusRecorder,
-    rollback_dir: Path,
-    release: ReleaseInfo,
-    staging_dir: Path,
-) -> Path:
-    """Download a release wheel to *staging_dir*."""
+        fetcher = release_fetcher_factory.build_server_release_fetcher(
+            rollback_dir=self._rollback_dir,
+        )
+        try:
+            return await asyncio.to_thread(fetcher.download_wheel, release, staging_dir)
+        except (OSError, ValueError) as exc:
+            self._status_recorder.add_issue("downloading", f"Failed to download release: {exc}")
+            self._status_controller.mark_failed()
+            raise UpdateReleaseError(f"Failed to download release: {exc}") from exc
 
-    fetcher = release_fetcher_factory.build_server_release_fetcher(rollback_dir=rollback_dir)
-    try:
-        return await asyncio.to_thread(fetcher.download_wheel, release, staging_dir)
-    except (OSError, ValueError) as exc:
-        status_recorder.add_issue("downloading", f"Failed to download release: {exc}")
-        status_controller.mark_failed()
-        raise UpdateReleaseError(f"Failed to download release: {exc}") from exc
+    async def _verify_download(self, release: ReleaseInfo, wheel_path: Path) -> None:
+        """Verify SHA-256 digest of a downloaded wheel."""
 
-
-async def verify_download(
-    status_controller: UpdateStatusController,
-    status_recorder: UpdateStatusRecorder,
-    release: ReleaseInfo,
-    wheel_path: Path,
-) -> None:
-    """Verify SHA-256 digest of a downloaded wheel."""
-
-    if not release.sha256:
-        return
-    actual_sha256 = await asyncio.to_thread(sha256_file, wheel_path)
-    expected_sha256 = release.sha256.lower()
-    if actual_sha256 == expected_sha256:
-        status_recorder.log(f"SHA-256 verified: {actual_sha256}")
-        return
-    status_recorder.add_issue(
-        "downloading",
-        "Downloaded wheel SHA-256 mismatch",
-        f"expected={release.sha256} actual={actual_sha256}",
-    )
-    status_controller.mark_failed()
-    status_recorder.log(f"SHA-256 mismatch: expected {release.sha256} but got {actual_sha256}")
-    raise UpdateReleaseError("Downloaded wheel SHA-256 mismatch")
+        if not release.sha256:
+            return
+        actual_sha256 = await asyncio.to_thread(sha256_file, wheel_path)
+        expected_sha256 = release.sha256.lower()
+        if actual_sha256 == expected_sha256:
+            self._status_recorder.log(f"SHA-256 verified: {actual_sha256}")
+            return
+        self._status_recorder.add_issue(
+            "downloading",
+            "Downloaded wheel SHA-256 mismatch",
+            f"expected={release.sha256} actual={actual_sha256}",
+        )
+        self._status_controller.mark_failed()
+        self._status_recorder.log(
+            f"SHA-256 mismatch: expected {release.sha256} but got {actual_sha256}",
+        )
+        raise UpdateReleaseError("Downloaded wheel SHA-256 mismatch")

--- a/apps/server/vibesensor/use_cases/updates/run_models.py
+++ b/apps/server/vibesensor/use_cases/updates/run_models.py
@@ -1,0 +1,51 @@
+"""Canonical run-scoped updater models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
+    from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSession
+
+__all__ = [
+    "InstallServerReleasePlan",
+    "PlannedUpdateRun",
+    "PreparedUpdateRun",
+    "RefreshFirmwarePlan",
+    "ReleaseExecutionPlan",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedUpdateRun:
+    """Validated updater state with one prepared transport session."""
+
+    current_version: str
+    transport_session: UpdateTransportSession
+
+
+@dataclass(frozen=True, slots=True)
+class RefreshFirmwarePlan:
+    """Execution plan for runs that only need firmware refresh and success finalization."""
+
+    latest_tag: str
+
+
+@dataclass(frozen=True, slots=True)
+class InstallServerReleasePlan:
+    """Execution plan for runs that must stage and install a server release."""
+
+    release: ReleaseInfo
+
+
+type ReleaseExecutionPlan = RefreshFirmwarePlan | InstallServerReleasePlan
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedUpdateRun:
+    """Prepared updater run paired with the release work chosen for execution."""
+
+    prepared: PreparedUpdateRun
+    execution_plan: ReleaseExecutionPlan

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from vibesensor.use_cases.updates.cleanup import UpdateCleanupCoordinator
+from vibesensor.use_cases.updates.cleanup import UpdateTransportCleanupCoordinator
 from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
@@ -25,6 +25,7 @@ from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolve
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
 from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
 from vibesensor.use_cases.updates.runner import CommandRunner, UpdateCommandExecutor
+from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
 from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
 from vibesensor.use_cases.updates.status import (
     UpdateStateStore,
@@ -123,13 +124,6 @@ def build_update_manager_runtime(
         workflow_runner=UpdateWorkflowRunner(
             status_controller=status_services.controller,
             status_recorder=status_services.recorder,
-            cleanup=UpdateCleanupCoordinator(
-                status_controller=status_services.controller,
-                status_recorder=status_services.recorder,
-                transport_coordinator=transport_coordinator,
-                repo=config.repo,
-                logger=LOGGER,
-            ),
             timeout_s=UPDATE_TIMEOUT_S,
         ),
         usb_status_service=status_service,
@@ -324,5 +318,17 @@ def _build_update_workflow(
                 status_recorder=recorder,
                 restart_scheduler=restart_scheduler,
             ),
+        ),
+        transport_cleanup=UpdateTransportCleanupCoordinator(
+            status_controller=status_controller,
+            status_recorder=recorder,
+            transport_coordinator=transport_coordinator,
+            logger=LOGGER,
+        ),
+        runtime_details_refresher=UpdateRuntimeDetailsRefresher(
+            status_controller=status_controller,
+            status_recorder=recorder,
+            repo=config.repo,
+            logger=LOGGER,
         ),
     )

--- a/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
@@ -1,0 +1,49 @@
+"""Runtime-details refresh boundary for updater workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
+from vibesensor.use_cases.updates.status import (
+    UpdateStatusController,
+    UpdateStatusRecorder,
+    collect_runtime_details,
+)
+
+__all__ = ["UpdateRuntimeDetailsRefresher"]
+
+
+class UpdateRuntimeDetailsRefresher:
+    """Refresh runtime/build metadata after a workflow finishes mutating the system."""
+
+    __slots__ = ("_logger", "_repo", "_status_controller", "_status_recorder")
+
+    def __init__(
+        self,
+        *,
+        status_controller: UpdateStatusController,
+        status_recorder: UpdateStatusRecorder,
+        repo: Path,
+        logger: logging.Logger,
+    ) -> None:
+        self._status_controller = status_controller
+        self._status_recorder = status_recorder
+        self._repo = repo
+        self._logger = logger
+
+    async def refresh(self) -> None:
+        try:
+            runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
+        except (OSError, UpdateError) as exc:
+            self._status_recorder.add_issue(
+                "cleanup",
+                "Runtime details refresh failed",
+                str(exc),
+            )
+            self._status_controller.mark_failed()
+            self._logger.exception("update: runtime details refresh error")
+            raise UpdateCleanupError(f"Runtime details refresh failed: {exc}") from exc
+        self._status_recorder.set_runtime(runtime_details)

--- a/apps/server/vibesensor/use_cases/updates/transport_coordinator.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError, UpdateTransportError
 from vibesensor.use_cases.updates.models import UpdateJobStatus, UpdateRequest
@@ -12,15 +11,7 @@ from vibesensor.use_cases.updates.transport_sessions import (
     UpdateTransportSessions,
 )
 
-__all__ = ["PreparedUpdateTransport", "UpdateTransportCoordinator"]
-
-
-@dataclass(frozen=True, slots=True)
-class PreparedUpdateTransport:
-    """Prepared transport state shared across updater workflow phases."""
-
-    request: UpdateRequest
-    session: UpdateTransportSession
+__all__ = ["UpdateTransportCoordinator"]
 
 
 class UpdateTransportCoordinator:
@@ -31,27 +22,30 @@ class UpdateTransportCoordinator:
     def __init__(self, *, sessions: UpdateTransportSessions) -> None:
         self._sessions = sessions
 
-    async def prepare(self, request: UpdateRequest) -> PreparedUpdateTransport:
+    async def prepare(self, request: UpdateRequest) -> UpdateTransportSession:
         session = self._sessions.for_request(request)
         try:
             await session.prepare(request)
         except UpdateTransportError:
             await self._abort_preparation(session)
             raise
-        return PreparedUpdateTransport(request=request, session=session)
+        return session
 
     async def complete_success(
         self,
-        transport: PreparedUpdateTransport,
+        transport_session: UpdateTransportSession,
         *,
         message: str,
     ) -> None:
-        await transport.session.complete_success(message)
+        await transport_session.complete_success(message)
 
-    async def cleanup_after_update(self, transport: PreparedUpdateTransport | None) -> None:
-        if transport is None:
+    async def cleanup_after_update(
+        self,
+        transport_session: UpdateTransportSession | None,
+    ) -> None:
+        if transport_session is None:
             return
-        await transport.session.cleanup_after_update()
+        await transport_session.cleanup_after_update()
 
     async def recover_interrupted(self, status: UpdateJobStatus) -> None:
         await self._sessions.for_status(status).recover_interrupted_update()

--- a/apps/server/vibesensor/use_cases/updates/transport_failures.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_failures.py
@@ -1,0 +1,25 @@
+"""Typed transport-step failures emitted below the transport session boundary."""
+
+from __future__ import annotations
+
+from vibesensor.shared.exceptions import UpdateTransportError
+from vibesensor.use_cases.updates.models import UpdatePhase
+
+__all__ = ["UpdateTransportStepError"]
+
+
+class UpdateTransportStepError(UpdateTransportError):
+    """Transport-step failure carrying the issue details for session-level handling."""
+
+    __slots__ = ("detail", "phase")
+
+    def __init__(
+        self,
+        *,
+        phase: UpdatePhase | str,
+        message: str,
+        detail: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.phase = phase.value if isinstance(phase, UpdatePhase) else phase
+        self.detail = detail

--- a/apps/server/vibesensor/use_cases/updates/usb_transport.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_transport.py
@@ -11,6 +11,7 @@ from vibesensor.use_cases.updates.models import (
 )
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
+from vibesensor.use_cases.updates.transport_failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.usb_status import UsbInternetStatusReader
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 from vibesensor.use_cases.updates.wifi.wifi_readiness import UpdateWifiReadiness
@@ -77,7 +78,6 @@ class UpdateUsbInternetSession:
         self._status_recorder = status_recorder
         self._readiness = UpdateWifiReadiness(
             commands=commands,
-            status_controller=status_controller,
             status_recorder=status_recorder,
             config=config,
         )
@@ -85,26 +85,30 @@ class UpdateUsbInternetSession:
     async def prepare(self, request: UpdateRequest) -> None:
         del request
         self._status_controller.transition(UpdatePhase.connecting_usb_internet)
-        if not await self.ensure_uplink_ready():
-            raise UpdateTransportError("Failed to prepare the USB internet uplink for update")
+        try:
+            await self.ensure_uplink_ready()
+        except UpdateTransportStepError as exc:
+            self._status_recorder.add_issue(exc.phase, str(exc), exc.detail)
+            self._status_controller.mark_failed()
+            raise UpdateTransportError(
+                "Failed to prepare the USB internet uplink for update"
+            ) from exc
 
     async def abort_preparation(self) -> None:
         return None
 
-    async def ensure_uplink_ready(self) -> bool:
+    async def ensure_uplink_ready(self) -> None:
         decision = _classify_usb_internet(await self._status_service.snapshot(activate=True))
         if not decision.usable:
-            self._status_recorder.add_issue(
-                UpdatePhase.connecting_usb_internet.value,
-                str(decision.issue_message),
-                decision.detail,
+            raise UpdateTransportStepError(
+                phase=UpdatePhase.connecting_usb_internet,
+                message=str(decision.issue_message),
+                detail=decision.detail,
             )
-            self._status_controller.mark_failed()
-            return False
         self._status_controller.set_uplink_interface(decision.interface_name)
         if decision.log_message is not None:
             self._status_recorder.log(decision.log_message)
-        return await self._readiness.wait_for_dns_ready(
+        await self._readiness.wait_for_dns_ready(
             phase=UpdatePhase.connecting_usb_internet,
             readiness_subject="USB internet",
             failure_message="USB internet detected, but internet/DNS is not ready",

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_readiness.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_readiness.py
@@ -5,29 +5,28 @@ import time
 
 from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
-from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
+from vibesensor.use_cases.updates.status import UpdateStatusRecorder
+from vibesensor.use_cases.updates.transport_failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 
 class UpdateWifiReadiness:
     """Wait for the transient uplink connection to become usable for updates."""
 
-    __slots__ = ("_commands", "_config", "_status_controller", "_status_recorder")
+    __slots__ = ("_commands", "_config", "_status_recorder")
 
     def __init__(
         self,
         *,
         commands: UpdateCommandExecutor,
-        status_controller: UpdateStatusController,
         status_recorder: UpdateStatusRecorder,
         config: UpdateWifiConfig,
     ) -> None:
         self._commands = commands
-        self._status_controller = status_controller
         self._status_recorder = status_recorder
         self._config = config
 
-    async def bring_uplink_up(self, ssid: str) -> bool:
+    async def bring_uplink_up(self, ssid: str) -> None:
         """Bring the prepared uplink connection up, retrying on scan lag."""
 
         rc = 1
@@ -47,7 +46,7 @@ class UpdateWifiReadiness:
                 sudo=True,
             )
             if rc == 0:
-                return True
+                return
             if "No network with SSID" not in (stderr or ""):
                 break
             self._status_recorder.log(
@@ -72,13 +71,11 @@ class UpdateWifiReadiness:
                 sudo=True,
             )
             await asyncio.sleep(2.0)
-        self._status_recorder.add_issue(
-            "connecting_wifi",
-            f"Failed to connect to Wi-Fi '{ssid}'",
-            stderr,
+        raise UpdateTransportStepError(
+            phase=UpdatePhase.connecting_wifi,
+            message=f"Failed to connect to Wi-Fi '{ssid}'",
+            detail=stderr,
         )
-        self._status_controller.mark_failed()
-        return False
 
     async def wait_for_dns_ready(
         self,
@@ -86,7 +83,7 @@ class UpdateWifiReadiness:
         phase: UpdatePhase | str = UpdatePhase.connecting_wifi,
         readiness_subject: str = "uplink",
         failure_message: str = "Connected to Wi-Fi, but internet/DNS is not ready",
-    ) -> bool:
+    ) -> None:
         """Wait for DNS resolution to succeed before download work begins."""
 
         self._status_recorder.log(
@@ -115,20 +112,18 @@ class UpdateWifiReadiness:
             )
             if rc == 0:
                 self._status_recorder.log(f"DNS probe succeeded on attempt {attempt}")
-                return True
+                return
             last_error = (stderr or stdout or f"exit {rc}").strip()
             if time.monotonic() >= deadline:
                 break
             await asyncio.sleep(self._config.dns_retry_interval_s)
-        self._status_recorder.add_issue(
-            phase.value if isinstance(phase, UpdatePhase) else phase,
-            failure_message,
-            (
+        raise UpdateTransportStepError(
+            phase=phase,
+            message=failure_message,
+            detail=(
                 "Waited at least "
                 f"{int(self._config.dns_ready_min_wait_s)} seconds for DNS resolution "
                 f"({self._config.dns_probe_host}) before starting the updater. "
                 f"Last probe error: {last_error or 'unknown'}"
             ),
         )
-        self._status_controller.mark_failed()
-        return False

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
@@ -13,6 +13,7 @@ from vibesensor.use_cases.updates.models import (
 )
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
+from vibesensor.use_cases.updates.transport_failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 from vibesensor.use_cases.updates.wifi.wifi_diagnostics import parse_wifi_diagnostics
 from vibesensor.use_cases.updates.wifi.wifi_hotspot_recovery import UpdateHotspotRecovery
@@ -79,14 +80,11 @@ class UpdateWifiSession:
         )
         self._readiness = UpdateWifiReadiness(
             commands=commands,
-            status_controller=status_controller,
             status_recorder=status_recorder,
             config=config,
         )
         self._uplink = UpdateUplinkProvisioner(
             commands=commands,
-            status_controller=status_controller,
-            status_recorder=status_recorder,
             config=config,
         )
 
@@ -95,19 +93,21 @@ class UpdateWifiSession:
 
         return await self._hotspot.stop_hotspot()
 
-    async def _connect_uplink(self, ssid: str, password: str) -> bool:
+    async def _connect_uplink(self, ssid: str, password: str) -> None:
         """Create and connect the transient uplink profile for this update run."""
 
         self._status_recorder.log(f"Connecting to Wi-Fi network: {ssid}")
-        if not await self._uplink.prepare_uplink_connection(ssid, password):
-            return False
-        if not await self._readiness.bring_uplink_up(ssid):
-            return False
+        await self._uplink.prepare_uplink_connection(ssid, password)
+        await self._readiness.bring_uplink_up(ssid)
         fallback = self._config.uplink_fallback_dns
         self._status_recorder.log(
             f"Wi-Fi connected successfully (client DNS fallback={fallback})",
         )
-        return await self._readiness.wait_for_dns_ready()
+        await self._readiness.wait_for_dns_ready()
+
+    def _record_transport_failure(self, exc: UpdateTransportStepError) -> None:
+        self._status_recorder.add_issue(exc.phase, str(exc), exc.detail)
+        self._status_controller.mark_failed()
 
     async def prepare(self, request: UpdateRequest) -> None:
         """Prepare the updater's Wi-Fi transport before release work begins."""
@@ -117,8 +117,11 @@ class UpdateWifiSession:
             raise UpdateTransportError("Failed to stop the hotspot before Wi-Fi update setup")
         self._status_controller.transition(UpdatePhase.connecting_wifi)
         assert request.ssid is not None  # noqa: S101
-        if not await self._connect_uplink(request.ssid, request.password):
-            raise UpdateTransportError("Failed to prepare the Wi-Fi uplink for update")
+        try:
+            await self._connect_uplink(request.ssid, request.password)
+        except UpdateTransportStepError as exc:
+            self._record_transport_failure(exc)
+            raise UpdateTransportError("Failed to prepare the Wi-Fi uplink for update") from exc
 
     async def abort_preparation(self) -> None:
         """Rollback partial Wi-Fi setup after transport preparation fails."""

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import re
 
+from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
-from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
+from vibesensor.use_cases.updates.transport_failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 _UNESCAPED_COLON_RE = re.compile(r"(?<!\\):")
@@ -35,36 +36,29 @@ def ssid_security_modes(scan_output: str, ssid: str) -> set[str]:
 class UpdateUplinkProvisioner:
     """Create and configure the temporary Wi-Fi uplink connection for updates."""
 
-    __slots__ = ("_commands", "_config", "_status_controller", "_status_recorder")
+    __slots__ = ("_commands", "_config")
 
     def __init__(
         self,
         *,
         commands: UpdateCommandExecutor,
-        status_controller: UpdateStatusController,
-        status_recorder: UpdateStatusRecorder,
         config: UpdateWifiConfig,
     ) -> None:
         self._commands = commands
-        self._status_controller = status_controller
-        self._status_recorder = status_recorder
         self._config = config
 
-    async def prepare_uplink_connection(self, ssid: str, password: str) -> bool:
+    async def prepare_uplink_connection(self, ssid: str, password: str) -> None:
         """Create the transient uplink profile and apply any required credentials."""
 
-        if not password and not await self._validate_open_network(ssid):
-            return False
+        if not password:
+            await self._validate_open_network(ssid)
         await self._delete_existing_uplink_connections()
-        if not await self._create_uplink_connection(ssid):
-            return False
-        if not await self._configure_uplink_connection():
-            return False
-        if password and not await self._apply_wifi_password(password):
-            return False
-        return True
+        await self._create_uplink_connection(ssid)
+        await self._configure_uplink_connection()
+        if password:
+            await self._apply_wifi_password(password)
 
-    async def _validate_open_network(self, ssid: str) -> bool:
+    async def _validate_open_network(self, ssid: str) -> None:
         """Reject blank-password attempts when the scanned SSID is secured."""
 
         rc, stdout, _ = await self._commands.run(
@@ -86,17 +80,15 @@ class UpdateUplinkProvisioner:
             sudo=True,
         )
         if rc != 0:
-            return True
+            return
         security_modes = ssid_security_modes(stdout, ssid)
         if not security_modes:
-            return True
-        self._status_recorder.add_issue(
-            "connecting_wifi",
-            "Wi-Fi password required for secured network",
-            f"SSID '{ssid}' advertises security: {', '.join(sorted(security_modes))}",
+            return
+        raise UpdateTransportStepError(
+            phase=UpdatePhase.connecting_wifi,
+            message="Wi-Fi password required for secured network",
+            detail=f"SSID '{ssid}' advertises security: {', '.join(sorted(security_modes))}",
         )
-        self._status_controller.mark_failed()
-        return False
 
     async def _delete_existing_uplink_connections(self) -> None:
         """Remove any stale transient uplink profiles before recreating them."""
@@ -122,7 +114,7 @@ class UpdateUplinkProvisioner:
                 sudo=True,
             )
 
-    async def _create_uplink_connection(self, ssid: str) -> bool:
+    async def _create_uplink_connection(self, ssid: str) -> None:
         """Create a new transient uplink profile for the requested SSID."""
 
         rc, _, stderr = await self._commands.run(
@@ -146,16 +138,14 @@ class UpdateUplinkProvisioner:
             sudo=True,
         )
         if rc == 0:
-            return True
-        self._status_recorder.add_issue(
-            "connecting_wifi",
-            "Failed to create uplink connection",
-            stderr,
+            return
+        raise UpdateTransportStepError(
+            phase=UpdatePhase.connecting_wifi,
+            message="Failed to create uplink connection",
+            detail=stderr,
         )
-        self._status_controller.mark_failed()
-        return False
 
-    async def _configure_uplink_connection(self) -> bool:
+    async def _configure_uplink_connection(self) -> None:
         """Apply the non-secret updater defaults to the uplink profile."""
 
         rc, _, stderr = await self._commands.run(
@@ -180,13 +170,15 @@ class UpdateUplinkProvisioner:
             sudo=True,
         )
         if rc == 0:
-            return True
-        self._status_recorder.add_issue("connecting_wifi", "Failed to configure uplink", stderr)
-        self._status_controller.mark_failed()
+            return
         await self._delete_uplink_connection()
-        return False
+        raise UpdateTransportStepError(
+            phase=UpdatePhase.connecting_wifi,
+            message="Failed to configure uplink",
+            detail=stderr,
+        )
 
-    async def _apply_wifi_password(self, password: str) -> bool:
+    async def _apply_wifi_password(self, password: str) -> None:
         """Apply WPA-PSK credentials to the transient uplink profile."""
 
         rc, _, stderr = await self._commands.run(
@@ -205,15 +197,13 @@ class UpdateUplinkProvisioner:
             sudo=True,
         )
         if rc == 0:
-            return True
-        self._status_recorder.add_issue(
-            "connecting_wifi",
-            "Failed to set Wi-Fi credentials",
-            stderr,
-        )
-        self._status_controller.mark_failed()
+            return
         await self._delete_uplink_connection()
-        return False
+        raise UpdateTransportStepError(
+            phase=UpdatePhase.connecting_wifi,
+            message="Failed to set Wi-Fi credentials",
+            detail=stderr,
+        )
 
     async def _delete_uplink_connection(self) -> None:
         """Delete the transient uplink profile after a partial setup failure."""

--- a/apps/server/vibesensor/use_cases/updates/workflow.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow.py
@@ -2,32 +2,57 @@
 
 from __future__ import annotations
 
+import asyncio
+import sys
 from dataclasses import dataclass
 
+from vibesensor.shared.exceptions import UpdateCleanupError
+from vibesensor.use_cases.updates.cleanup import UpdateTransportCleanupCoordinator
 from vibesensor.use_cases.updates.models import UpdateRequest
 from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
 from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
+from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
+from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
 from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
-from vibesensor.use_cases.updates.workflow_runner import UpdateWorkflowContext
 
 __all__ = ["UpdateWorkflow"]
 
 
 @dataclass(frozen=True, slots=True)
 class UpdateWorkflow:
-    """Run one canonical update request through preparation, planning, and execution."""
+    """Run one update request through the canonical workflow lifecycle."""
 
     preparation: UpdatePreparationCoordinator
     release_planner: UpdateReleasePlanner
     workflow_executor: UpdateWorkflowExecutor
+    transport_cleanup: UpdateTransportCleanupCoordinator
+    runtime_details_refresher: UpdateRuntimeDetailsRefresher
 
     async def run(
         self,
         *,
-        context: UpdateWorkflowContext,
         request: UpdateRequest,
     ) -> None:
-        prepared = await self.preparation.prepare(request)
-        context.transport = prepared.transport
-        planned = await self.release_planner.plan(prepared)
-        await self.workflow_executor.execute(planned)
+        prepared: PreparedUpdateRun | None = None
+        try:
+            prepared = await self.preparation.prepare(request)
+            planned = await self.release_planner.plan(prepared)
+            await self.workflow_executor.execute(planned)
+        finally:
+            await self._finalize(prepared)
+
+    async def _finalize(self, prepared: PreparedUpdateRun | None) -> None:
+        active_error = sys.exc_info()[1]
+        try:
+            await self.transport_cleanup.run(
+                None if prepared is None else prepared.transport_session,
+            )
+            await self.runtime_details_refresher.refresh()
+        except asyncio.CancelledError:
+            raise
+        except UpdateCleanupError as exc:
+            if active_error is None:
+                raise
+            if isinstance(active_error, asyncio.CancelledError):
+                raise UpdateCleanupError(f"Cleanup failed after cancellation: {exc}") from exc
+            active_error.add_note(f"Cleanup also failed: {exc}")

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -6,12 +6,12 @@ from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.release_deployment import UpdateReleaseDeployer
-from vibesensor.use_cases.updates.release_planner import (
+from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
+from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
-    PlannedUpdateWorkflow,
+    PlannedUpdateRun,
     RefreshFirmwarePlan,
 )
-from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
 
 __all__ = ["UpdateWorkflowExecutor"]
 
@@ -36,7 +36,7 @@ class UpdateWorkflowExecutor:
 
     async def execute(
         self,
-        workflow: PlannedUpdateWorkflow,
+        workflow: PlannedUpdateRun,
     ) -> UpdateExecutionOutcome:
         plan = workflow.execution_plan
         if isinstance(plan, RefreshFirmwarePlan):
@@ -52,12 +52,12 @@ class UpdateWorkflowExecutor:
     async def _execute_refresh_only(
         self,
         *,
-        workflow: PlannedUpdateWorkflow,
+        workflow: PlannedUpdateRun,
         plan: RefreshFirmwarePlan,
     ) -> UpdateExecutionOutcome:
         await self._firmware_refresher.refresh_esp_firmware(pinned_tag=plan.latest_tag)
         await self._completion.complete(
-            workflow.transport,
+            workflow.prepared.transport_session,
             message="No server update needed; ESP firmware checked",
         )
         return UpdateExecutionOutcome.refresh_only
@@ -65,13 +65,13 @@ class UpdateWorkflowExecutor:
     async def _execute_install(
         self,
         *,
-        workflow: PlannedUpdateWorkflow,
+        workflow: PlannedUpdateRun,
         plan: InstallServerReleasePlan,
     ) -> UpdateExecutionOutcome:
         async with self._stager.stage(plan.release) as staged_release:
             await self._deployer.deploy(staged_release)
         await self._completion.complete(
-            workflow.transport,
+            workflow.prepared.transport_session,
             message="Update completed successfully",
         )
         return UpdateExecutionOutcome.installed

--- a/apps/server/vibesensor/use_cases/updates/workflow_runner.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_runner.py
@@ -3,33 +3,21 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
-from vibesensor.use_cases.updates.cleanup import UpdateCleanupCoordinator
 from vibesensor.use_cases.updates.models import UpdateRequest, UpdateState
 from vibesensor.use_cases.updates.status import UpdateStatusController, UpdateStatusRecorder
-from vibesensor.use_cases.updates.transport_coordinator import PreparedUpdateTransport
 
-__all__ = ["UpdateWorkflowContext", "UpdateWorkflowRunner"]
+__all__ = ["UpdateWorkflowRunner"]
 
-ManagedUpdateWorkflow = Callable[["UpdateWorkflowContext"], Awaitable[None]]
-
-
-@dataclass(slots=True)
-class UpdateWorkflowContext:
-    """Mutable run-scoped workflow state shared with cleanup sequencing."""
-
-    transport: PreparedUpdateTransport | None = None
+ManagedUpdateWorkflow = Callable[[], Awaitable[None]]
 
 
 class UpdateWorkflowRunner:
-    """Own update task creation, timeout/cancel handling, and cleanup sequencing."""
+    """Own update task creation, timeout handling, and cancellation lifecycle."""
 
     __slots__ = (
-        "_cleanup",
         "_status_controller",
         "_status_recorder",
         "_task",
@@ -42,13 +30,11 @@ class UpdateWorkflowRunner:
         *,
         status_controller: UpdateStatusController,
         status_recorder: UpdateStatusRecorder,
-        cleanup: UpdateCleanupCoordinator,
         timeout_s: float,
         task_name: str = "system-update",
     ) -> None:
         self._status_controller = status_controller
         self._status_recorder = status_recorder
-        self._cleanup = cleanup
         self._timeout_s = timeout_s
         self._task_name = task_name
         self._task: asyncio.Task[None] | None = None
@@ -67,12 +53,8 @@ class UpdateWorkflowRunner:
             raise UpdateError("Update already in progress", status="conflict")
         self._status_controller.start_job(request)
         self._status_recorder.track_secret(request.password)
-        context = UpdateWorkflowContext()
         self._task = asyncio.get_running_loop().create_task(
-            self._run_managed_workflow(
-                context=context,
-                workflow=workflow,
-            ),
+            self._run_managed_workflow(workflow=workflow),
             name=self._task_name,
         )
 
@@ -85,11 +67,12 @@ class UpdateWorkflowRunner:
     async def _run_managed_workflow(
         self,
         *,
-        context: UpdateWorkflowContext,
         workflow: ManagedUpdateWorkflow,
     ) -> None:
         try:
-            await asyncio.wait_for(workflow(context), timeout=self._timeout_s)
+            await asyncio.wait_for(workflow(), timeout=self._timeout_s)
+        except UpdateCleanupError:
+            raise
         except UpdateError as exc:
             if self._status_controller.status.state is UpdateState.running:
                 self._status_recorder.add_issue("workflow", str(exc))
@@ -107,24 +90,6 @@ class UpdateWorkflowRunner:
             self._status_controller.mark_failed()
             self._status_recorder.log("Update cancelled")
             raise
-        finally:
-            await self._cleanup_after_workflow(context.transport)
-
-    async def _cleanup_after_workflow(
-        self,
-        transport: PreparedUpdateTransport | None,
-    ) -> None:
-        active_error = sys.exc_info()[1]
-        try:
-            await self._cleanup.run(transport)
-        except asyncio.CancelledError:
-            raise
-        except UpdateCleanupError as exc:
-            if active_error is None:
-                raise
-            if isinstance(active_error, asyncio.CancelledError):
-                raise UpdateCleanupError(f"Cleanup failed after cancellation: {exc}") from exc
-            active_error.add_note(f"Cleanup also failed: {exc}")
         finally:
             self._status_recorder.clear_secrets()
             self._status_controller.finish_cleanup()


### PR DESCRIPTION
## Summary
- collapse updater run preparation and planning onto one canonical run model
- move workflow finalization into the workflow so runner lifecycle only handles task, timeout, and cancellation policy
- split transport cleanup, runtime refresh, and low-level transport-step failures into explicit boundaries

## Architecture issues addressed
- Issue 1: stronger internal updater responsibility boundaries
- Issue 2: narrower operational fault handling at updater transport/finalization boundaries
- Issue 4: clearer updater boundary organization around run-scoped models and side effects

## Backward-incompatible cleanup
- delete `UpdateWorkflowContext`, `PreparedUpdateTransport`, `PreparedUpdateWorkflow`, and `PlannedUpdateWorkflow`
- delete module-level release-resolution and release-staging helper flows that only forwarded collaborator state
- remove inline status mutation from low-level Wi-Fi/USB transport helpers in favor of typed step failures handled at the session boundary

## Local validation
- `make lint`
- `make typecheck-backend`
- `.venv/bin/python -m pytest -q apps/server/tests/use_cases/updates apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- native server + `vibesensor-sim` runtime validation against `/api/recording/status` (Docker daemon unavailable in this environment)