### PR TITLE
Wave 2: tighten OBD initialization fault boundary

### DIFF
--- a/apps/server/tests/adapters/obd/test_monitor.py
+++ b/apps/server/tests/adapters/obd/test_monitor.py
@@ -280,6 +280,16 @@ def test_connect_blocking_closes_session_and_propagates_transport_error() -> Non
     session.close.assert_called_once_with()
 
 
+def test_connect_blocking_keeps_initialized_session_open() -> None:
+    clock = _FakeClock()
+    runtime, connection_runtime, session = _connected_runtime(clock=clock)
+
+    assert connection_runtime is not None
+    assert runtime is not None
+    session.initialize.assert_called_once_with()
+    assert session.close.call_count == 0
+
+
 def test_connect_blocking_closes_session_and_propagates_unexpected_runtime_error() -> None:
     clock = _FakeClock()
     admin_client = MagicMock()

--- a/apps/server/vibesensor/adapters/obd/connection_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/connection_runtime.py
@@ -165,20 +165,22 @@ class ObdConnectionRuntime:
             raise ServiceUnavailableError("Bluetooth OBD adapter exposes no RFCOMM serial channel")
         session = self._session_factory()
         session.connect(mac_address, info.rfcomm_channel)
-        try:
-            session.initialize()
-        except (OSError, OperationalError, ObdTransportError):
-            session.close()
-            raise
-        except Exception:
-            session.close()
-            raise
+        self._initialize_session(session)
         device = replace(
             info,
             name=info.name or configured_name,
             connected=True,
         )
         return session, device
+
+    def _initialize_session(self, session: Elm327Session) -> None:
+        initialized = False
+        try:
+            session.initialize()
+            initialized = True
+        finally:
+            if not initialized:
+                session.close()
 
     def _poll_cycle_blocking(self, session: Elm327Session) -> ObdPollResult:
         plan = self._runtime.prepare_poll()


### PR DESCRIPTION
## Summary
- replace the OBD session initialization broad catch with an explicit cleanup boundary
- keep cleanup behavior for failed initialization without flattening unexpected faults into a catch-all path
- add focused OBD monitor coverage for the successful initialization path

## Initial five issues selected
1. Unify updater status public surface
2. Tighten OBD connection fault boundary
3. Separate OBD runtime observation, policy, and control more clearly
4. Decouple report composition from rendering-facing document building
5. Clarify shared boundary codec/reporting entrypoints

## Architectural problems addressed in this wave
- `_connect_blocking()` relied on a broad `except Exception` solely to guarantee cleanup during ELM327 session initialization
- the cleanup contract was implicit and fault categories were less clear than they needed to be at this operational boundary

## Main simplifications made
- moved session-initialization cleanup to a `try/finally` boundary that closes only when initialization does not complete
- preserved the existing transport-error and unexpected-bug behavior without a catch-all handler in the OBD runtime path
- added a focused success-path test to keep the session-lifecycle contract explicit

## Intentionally kept
- `use_cases/run/post_analysis.py` still uses a broad worker-boundary catch because it is the explicit hard-stop path for unexpected worker bugs, clears queued work, records the bug, and is covered by dedicated tests

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/obd`
- `make lint && make typecheck-backend`
