### PR TITLE
Wave 3: clarify OBD runtime connection events

### DIFF
--- a/apps/server/tests/adapters/obd/test_monitor.py
+++ b/apps/server/tests/adapters/obd/test_monitor.py
@@ -11,6 +11,7 @@ from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
 from vibesensor.adapters.obd.elm327 import ObdTransportError
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.monitor import OBDSpeedMonitor
+from vibesensor.adapters.obd.polling import ObdPidFailureKind, ObdPidPollResult, ObdPollResult
 from vibesensor.adapters.obd.runtime_controller import ObdRuntimeController
 from vibesensor.shared.operational_errors import ExternalCommandError
 
@@ -63,9 +64,7 @@ def _connected_runtime(
         monotonic=clock,
     )
     connected_session, device = connection_runtime._connect_blocking("00043e5a4a4d", "OBDLink MX+")
-    runtime.apply_device_snapshot(device)
-    runtime.reset_poll_schedule()
-    runtime.set_connection_state("connected", error=None)
+    runtime.mark_connected(device)
     return runtime, connection_runtime, connected_session
 
 
@@ -92,9 +91,9 @@ def test_obd_monitor_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -> No
 
     session.request.side_effect = request
 
-    runtime.apply_poll_result(connection_runtime._poll_cycle_blocking(session))
+    runtime.apply_poll_cycle(connection_runtime._poll_cycle_blocking(session))
     clock.now = started_at + 0.05
-    runtime.apply_poll_result(connection_runtime._poll_cycle_blocking(session))
+    runtime.apply_poll_cycle(connection_runtime._poll_cycle_blocking(session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.2)]
     assert runtime.resolve_speed().source == "obd2"
@@ -131,9 +130,9 @@ def test_obd_monitor_keeps_last_good_rpm_until_the_rpm_reference_goes_stale() ->
 
     session.request.side_effect = request
 
-    runtime.apply_poll_result(connection_runtime._poll_cycle_blocking(session))
+    runtime.apply_poll_cycle(connection_runtime._poll_cycle_blocking(session))
     clock.now = 0.05
-    runtime.apply_poll_result(connection_runtime._poll_cycle_blocking(session))
+    runtime.apply_poll_cycle(connection_runtime._poll_cycle_blocking(session))
 
     assert runtime.engine_rpm == pytest.approx(0x1AF8 / 4.0)
     clock.now = 1.99
@@ -165,8 +164,8 @@ def test_obd_monitor_backs_off_and_stays_in_rpm_only_mode_when_speed_times_out()
 
     session.request.side_effect = request
 
-    runtime.apply_poll_result(connection_runtime._poll_cycle_blocking(session))
-    runtime.apply_poll_result(connection_runtime._poll_cycle_blocking(session))
+    runtime.apply_poll_cycle(connection_runtime._poll_cycle_blocking(session))
+    runtime.apply_poll_cycle(connection_runtime._poll_cycle_blocking(session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.3)]
     status = runtime.status_snapshot()
@@ -194,7 +193,7 @@ def test_obd_runtime_resolves_stale_speed_to_manual_fallback() -> None:
         obd_device_name="OBDLink MX+",
     )
     runtime.speed_snapshot = (10.0, 90.0)
-    runtime.set_connection_state("connected", error=None)
+    runtime.mark_connected()
 
     resolution = runtime.resolve_speed()
 
@@ -246,6 +245,32 @@ def test_obd_status_reports_sudo_helper_hint_when_admin_refresh_fails() -> None:
 
     assert "sudo" in str(status.last_error).lower()
     assert "sudo helper" in str(obd_debug_hint(status)).lower()
+
+
+def test_obd_runtime_marks_disconnected_after_fatal_poll_cycle() -> None:
+    clock = _FakeClock()
+    runtime, _, _ = _connected_runtime(clock=clock)
+
+    connection_lost = runtime.apply_poll_cycle(
+        ObdPollResult(
+            rpm=ObdPidPollResult(
+                value=None,
+                raw_response=None,
+                error="PID 010C request failed: Session is not connected",
+                duration_s=0.05,
+                executed=True,
+                failure_kind=ObdPidFailureKind.FATAL_TRANSPORT,
+            ),
+            speed=ObdPidPollResult.skipped(),
+        ),
+        reconnect_delay_s=4.0,
+    )
+
+    assert connection_lost is True
+    status = runtime.status_snapshot()
+    assert status.connection_state == "disconnected"
+    assert status.last_error == "PID 010C request failed: Session is not connected"
+    assert status.reconnect_delay_s == 4.0
 
 
 def test_connect_blocking_closes_session_and_propagates_transport_error() -> None:

--- a/apps/server/vibesensor/adapters/obd/connection_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/connection_runtime.py
@@ -73,8 +73,7 @@ class ObdConnectionRuntime:
                     await asyncio.sleep(step.sleep_s)
                     continue
                 if step.kind is ObdConnectionStepKind.MISSING_CONFIG:
-                    self._runtime.set_connection_state(
-                        "disconnected",
+                    self._runtime.mark_disconnected(
                         error=step.error,
                     )
                     reconnect_delay = _INITIAL_RECONNECT_DELAY_S
@@ -84,7 +83,7 @@ class ObdConnectionRuntime:
                     continue
                 if step.kind is ObdConnectionStepKind.CONNECT:
                     assert step.mac_address is not None
-                    self._runtime.set_connection_state("connecting", error=None)
+                    self._runtime.mark_connecting()
                     try:
                         session, device = await asyncio.to_thread(
                             self._connect_blocking,
@@ -92,8 +91,7 @@ class ObdConnectionRuntime:
                             step.configured_name,
                         )
                     except (OperationalError, OSError, ObdTransportError) as exc:
-                        self._runtime.set_connection_state(
-                            "disconnected",
+                        self._runtime.mark_disconnected(
                             error=str(exc),
                             reconnect_delay_s=reconnect_delay,
                         )
@@ -102,25 +100,21 @@ class ObdConnectionRuntime:
                         continue
                     session_device_mac = device.mac_address
                     reconnect_delay = _INITIAL_RECONNECT_DELAY_S
-                    self._runtime.apply_device_snapshot(device)
-                    self._runtime.reset_poll_schedule()
-                    self._runtime.set_connection_state("connected", error=None)
+                    self._runtime.mark_connected(device)
                     continue
                 if step.kind is ObdConnectionStepKind.WAIT:
                     await asyncio.sleep(step.sleep_s)
                     continue
                 assert session is not None
                 poll_result = await asyncio.to_thread(self._poll_cycle_blocking, session)
-                self._runtime.apply_poll_result(poll_result)
-                if poll_result.connection_lost:
+                connection_lost = self._runtime.apply_poll_cycle(
+                    poll_result,
+                    reconnect_delay_s=reconnect_delay,
+                )
+                if connection_lost:
                     await asyncio.to_thread(session.close)
                     session = None
                     session_device_mac = None
-                    self._runtime.set_connection_state(
-                        "disconnected",
-                        error=self._runtime.status_snapshot().last_error,
-                        reconnect_delay_s=reconnect_delay,
-                    )
                     await asyncio.sleep(reconnect_delay)
                     reconnect_delay = min(reconnect_delay * 2.0, _MAX_RECONNECT_DELAY_S)
         except asyncio.CancelledError:

--- a/apps/server/vibesensor/adapters/obd/runtime_controller.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_controller.py
@@ -158,14 +158,23 @@ class ObdRuntimeController:
         with self._lock:
             return self._polling.prepare_poll(now=self._monotonic())
 
-    def apply_poll_result(self, result: ObdPollResult) -> None:
+    def apply_poll_cycle(
+        self,
+        result: ObdPollResult,
+        *,
+        reconnect_delay_s: float | None = None,
+    ) -> bool:
         now = self._monotonic()
         with self._lock:
             self._runtime_state.apply_poll_result(result, now=now, polling=self._polling)
-
-    def apply_device_snapshot(self, snapshot: ObdDeviceSnapshot) -> None:
-        with self._lock:
-            self._runtime_state.apply_device_snapshot(snapshot)
+            if not result.connection_lost:
+                return False
+            self._runtime_state.set_connection_state(
+                "disconnected",
+                error=self._runtime_state.last_error,
+                reconnect_delay_s=reconnect_delay_s,
+            )
+            return True
 
     def apply_admin_observation(
         self,
@@ -179,20 +188,29 @@ class ObdRuntimeController:
                 observation=observation,
             )
 
-    def set_connection_state(
+    def mark_connecting(self) -> None:
+        with self._lock:
+            self._runtime_state.set_connection_state(
+                "connecting",
+                error=None,
+            )
+
+    def mark_connected(self, snapshot: ObdDeviceSnapshot | None = None) -> None:
+        with self._lock:
+            if snapshot is not None:
+                self._runtime_state.apply_device_snapshot(snapshot)
+            self._polling.reset(now=self._monotonic())
+            self._runtime_state.set_connection_state("connected", error=None)
+
+    def mark_disconnected(
         self,
-        state: str,
         *,
         error: str | None,
         reconnect_delay_s: float | None = None,
     ) -> None:
         with self._lock:
             self._runtime_state.set_connection_state(
-                state,
+                "disconnected",
                 error=error,
                 reconnect_delay_s=reconnect_delay_s,
             )
-
-    def reset_poll_schedule(self) -> None:
-        with self._lock:
-            self._polling.reset(now=self._monotonic())

--- a/apps/server/vibesensor/adapters/obd/runtime_state.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_state.py
@@ -112,6 +112,8 @@ class ObdRuntimeState:
             self._engine_rpm = float(result.rpm.value)
             self._engine_rpm_ts = rpm_sample_time
         self._last_error = result.rpm.error or result.speed.error
+        if result.connection_lost:
+            return
         self._device_connected = True
         self._connection_state = "connected"
         self._current_reconnect_delay = self._initial_reconnect_delay_s


### PR DESCRIPTION
## Summary
- replace connection_runtime's low-level runtime-state choreography with event-style controller methods
- move poll-cycle disconnect handling into ObdRuntimeController and keep fatal transport polls from transiently marking the runtime as connected
- update focused OBD monitor coverage for the new controller surface and disconnect behavior

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/adapters/obd
- make lint && make typecheck-backend
- VIBESENSOR_TEST_BASE_URL=http://127.0.0.1:8000 .venv/bin/pytest -q -m 'e2e and long_sim' apps/server/tests/integration/test_sim_ingestion.py