### PR TITLE
Wave 4: compose full report document context

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
@@ -51,11 +51,7 @@ def _prepared_report_input() -> PreparedReportInput:
 
 def test_prepare_report_input_returns_mapping_ready_boundary_types() -> None:
     prepared = _prepared_report_input()
-    composition = report_document.compose_report_document(
-        aggregate=prepared.domain_test_run,
-        report_facts=prepared.report_facts,
-        lang=prepared.language,
-    )
+    context = report_document.compose_report_document_context(prepared)
 
     assert isinstance(prepared, shared_reporting.PreparedReportInput)
     assert isinstance(prepared.report_facts, shared_reporting.PreparedReportFacts)
@@ -63,7 +59,7 @@ def test_prepare_report_input_returns_mapping_ready_boundary_types() -> None:
         prepared.report_facts.decision.primary_candidate,
         shared_report_projection.PrimaryReportFacts,
     )
-    assert isinstance(composition, report_document.ReportDocumentComposition)
+    assert isinstance(context, shared_report_document.ReportDocumentContext)
     assert not hasattr(prepared, "renderer_payload")
     assert not hasattr(prepared, "presentation")
 

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -214,7 +214,7 @@ def test_report_facts_hold_canonical_document_sections_without_builder_shims() -
         PreparedReportFacts,
         PreparedReportInput,
     )
-    from vibesensor.use_cases.history.report_document import ReportDocumentComposition
+    from vibesensor.shared.boundaries.reporting.document import ReportDocumentContext
 
     fact_fields = {field.name for field in fields(PreparedReportFacts)}
     assert "verdict_page" not in fact_fields
@@ -226,8 +226,16 @@ def test_report_facts_hold_canonical_document_sections_without_builder_shims() -
     assert "summary" not in input_fields
     assert "presentation" not in input_fields
 
-    composition_fields = {field.name for field in fields(ReportDocumentComposition)}
-    assert composition_fields == {"verdict_page", "appendix_a", "appendix_b"}
+    context_fields = {field.name for field in fields(ReportDocumentContext)}
+    assert {
+        "verdict_page",
+        "appendix_a",
+        "appendix_b",
+        "appendix_c",
+        "appendix_d",
+    } <= context_fields
+    assert not hasattr(mapping, "ReportDocumentComposition")
+    assert not hasattr(mapping, "compose_report_document")
 
     assert not hasattr(mapping, "_build_verdict_page_data")
     assert not hasattr(mapping, "_build_appendix_a_data")

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -10,7 +10,10 @@ from vibesensor.shared.boundaries.test_run_reconstruction import (
     test_run_from_summary as build_test_run_from_summary,
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
-from vibesensor.use_cases.history.report_document import compose_report_document
+from vibesensor.use_cases.history.report_document import (
+    compose_report_document_context,
+    prepare_report_input,
+)
 
 
 def _summary() -> dict[str, object]:
@@ -116,18 +119,8 @@ def _prepare_facts(summary: dict[str, object], **kwargs: object):
     )
 
 
-def _prepare_composition(summary: dict[str, object]):
-    test_run = build_test_run_from_summary(summary)
-    assert test_run is not None
-    return compose_report_document(
-        aggregate=test_run,
-        report_facts=prepare_report_facts(
-            summary,
-            summary=report_summary_from_mapping(summary),
-            test_run=test_run,
-        ),
-        lang=str(summary["lang"]),
-    )
+def _prepare_context(summary: dict[str, object]):
+    return compose_report_document_context(prepare_report_input(summary))
 
 
 def test_prepare_report_facts_filters_to_active_sensor_locations() -> None:
@@ -188,16 +181,16 @@ def test_prepare_report_facts_keeps_phase_timeline_intervals() -> None:
     assert facts.run.timeline_intervals[1].has_fault_evidence is True
 
 
-def test_compose_report_document_builds_workflow_document_sections() -> None:
+def test_compose_report_document_context_builds_workflow_document_sections() -> None:
     summary = _summary()
-    composition = _prepare_composition(summary)
+    context = _prepare_context(summary)
 
-    assert composition.verdict_page.action_status
-    assert composition.verdict_page.suspected_source
-    assert composition.appendix_a.mode == "workflow"
-    assert len(composition.appendix_a.ranked_candidates) == 1
-    assert composition.appendix_b.coverage_label == composition.verdict_page.coverage_label
-    assert len(composition.verdict_page.footer_routes) == 4
+    assert context.verdict_page.action_status
+    assert context.verdict_page.suspected_source
+    assert context.appendix_a.mode == "workflow"
+    assert len(context.appendix_a.ranked_candidates) == 1
+    assert context.appendix_b.coverage_label == context.verdict_page.coverage_label
+    assert len(context.verdict_page.footer_routes) == 4
 
 
 @pytest.mark.parametrize(
@@ -232,11 +225,11 @@ def test_prepare_report_facts_keeps_weak_spatial_wheel_findings_on_recapture_pat
 
 def test_compose_report_document_builds_recapture_document_guidance() -> None:
     summary = _weak_spatial_order_summary(source="wheel/tire", order_label="1x wheel order")
-    composition = _prepare_composition(summary)
+    context = _prepare_context(summary)
 
-    assert composition.appendix_a.mode == "recapture"
-    assert composition.appendix_a.capture_issues
-    assert composition.appendix_a.capture_changes
-    assert composition.appendix_a.capture_conditions
-    assert composition.verdict_page.reason_sentence == composition.appendix_a.capture_issues[0]
-    assert len(composition.verdict_page.footer_routes) == 1
+    assert context.appendix_a.mode == "recapture"
+    assert context.appendix_a.capture_issues
+    assert context.appendix_a.capture_changes
+    assert context.appendix_a.capture_conditions
+    assert context.verdict_page.reason_sentence == context.appendix_a.capture_issues[0]
+    assert len(context.verdict_page.footer_routes) == 1

--- a/apps/server/vibesensor/use_cases/history/report_document/__init__.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/__init__.py
@@ -19,21 +19,20 @@ from ._candidate_resolver import (
 )
 from ._card_builder import build_system_cards, humanize_signatures
 from .builder import ReportDocumentBuilder, build_report_document, build_report_document_data
-from .composition import ReportDocumentComposition, compose_report_document
+from .composition import compose_report_document_context
 
 __all__ = [
     "PreparedReportInput",
     "PrimaryCandidateContext",
     "Report",
     "ReportDocumentBuilder",
-    "ReportDocumentComposition",
     "ReportDocument",
     "ReportDocumentContext",
     "build_system_cards",
     "humanize_signatures",
     "build_report_document",
     "build_report_document_data",
-    "compose_report_document",
+    "compose_report_document_context",
     "prepare_persisted_report_input",
     "prepare_report_input",
     "resolve_primary_report_candidate",

--- a/apps/server/vibesensor/use_cases/history/report_document/builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/builder.py
@@ -1,229 +1,28 @@
-"""Canonical report-document builder from prepared report inputs."""
+"""Canonical context-to-document mapping for report rendering."""
 
 from __future__ import annotations
 
-from dataclasses import replace
-
-from vibesensor.report_i18n import normalize_lang
-from vibesensor.report_i18n import tr as _tr
-from vibesensor.shared.boundaries.reporting import PreparedReportFacts, PreparedReportInput
+from vibesensor.shared.boundaries.reporting import PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import (
-    NextStep,
-    PatternEvidence,
     ReportDocument,
     ReportDocumentContext,
 )
-from vibesensor.shared.boundaries.reporting.facts import ReportRunFacts
-from vibesensor.shared.report_presentation import display_location
-from vibesensor.shared.time_utils import (
-    format_timestamp_in_recorded_timezone,
-    format_utc_timestamp,
-    utc_now_iso,
-)
-from vibesensor.shared.types.json_types import JsonValue
 
-from ._candidate_resolver import PrimaryCandidateContext, resolve_primary_report_candidate
-from ._card_builder import build_system_cards
-from .composition import ReportDocumentComposition, compose_report_document
-from .measurements import _measurement_rows
-from .narrative_summaries import _proof_summary_text
-from .pattern_evidence import build_pattern_evidence
-from .peak_table import build_peak_rows
-from .report_sections import build_data_trust, build_next_steps
-from .sections import (
-    _build_appendix_c_data,
-    _build_appendix_d_data,
-    _build_timeline_graph_data,
-)
+from .composition import compose_report_document_context
 
 __all__ = ["ReportDocumentBuilder", "build_report_document", "build_report_document_data"]
 
 
 class ReportDocumentBuilder:
-    """Build the canonical report document through one immutable assembly context."""
+    """Build the canonical report document from one precomposed immutable context."""
 
-    __slots__ = ("_lang", "_prepared")
+    __slots__ = ("_prepared",)
 
     def __init__(self, prepared: PreparedReportInput) -> None:
         self._prepared = prepared
-        self._lang = str(normalize_lang(prepared.language))
 
     def build(self) -> ReportDocument:
-        context = self._build_context()
-        return build_report_document_data(context)
-
-    def _build_context(self) -> ReportDocumentContext:
-        prepared = self._prepared
-        test_run = prepared.domain_test_run
-        report_facts = prepared.report_facts
-        run_facts = report_facts.run
-        sensor_facts = report_facts.sensor
-        decision_facts = report_facts.decision
-        prepared_findings = report_facts.findings
-        tr = self._tr
-        composition = compose_report_document(
-            aggregate=test_run,
-            report_facts=report_facts,
-            lang=self._lang,
-        )
-        primary = resolve_primary_report_candidate(
-            aggregate=test_run,
-            facts=decision_facts.primary_candidate,
-            tr=tr,
-            lang=self._lang,
-        )
-        observed = self._observed_signature(primary)
-        observed.strongest_location = display_location(primary.primary_location, tr=tr)
-        data_trust = tuple(
-            build_data_trust(
-                suitability_checks=decision_facts.suitability_checks,
-                warnings=decision_facts.warnings,
-                lang=self._lang,
-                tr=tr,
-            )
-        )
-        pattern_evidence = build_pattern_evidence(
-            aggregate=test_run,
-            origin=run_facts.origin,
-            primary=primary,
-            lang=self._lang,
-            tr=tr,
-        )
-        peak_rows = tuple(
-            build_peak_rows(
-                run_facts.peak_table_rows,
-                findings=list(prepared_findings.all_findings),
-                lang=self._lang,
-                tr=tr,
-            )
-        )
-        proof_summary = _proof_summary_text(
-            test_run,
-            primary,
-            report_facts,
-            composition,
-            tr=tr,
-        )
-        return ReportDocumentContext(
-            title=tr("REPORT_FOOTER_TITLE"),
-            run_datetime=self._report_date_text(run_facts),
-            run_id=run_facts.run_id,
-            duration_text=run_facts.duration_text,
-            start_time_utc=format_utc_timestamp(run_facts.start_time_utc),
-            end_time_utc=format_utc_timestamp(run_facts.end_time_utc),
-            sample_rate_hz=run_facts.sample_rate_hz,
-            tire_spec_text=run_facts.tire_spec_text,
-            sample_count=run_facts.sample_count,
-            sensor_count=primary.sensor_count,
-            sensor_locations=tuple(sensor_facts.active_locations),
-            sensor_model=run_facts.sensor_model,
-            firmware_version=run_facts.firmware_version,
-            car_name=run_facts.car_name,
-            car_type=run_facts.car_type,
-            observed=observed,
-            system_cards=tuple(
-                build_system_cards(
-                    test_run,
-                    primary,
-                    self._lang,
-                    tr,
-                )
-            ),
-            next_steps=self._resolve_next_steps(
-                primary=primary,
-                report_facts=report_facts,
-                composition=composition,
-            ),
-            data_trust=data_trust,
-            pattern_evidence=pattern_evidence,
-            peak_rows=peak_rows,
-            language=self._lang,
-            certainty_tier_key=primary.tier,
-            findings=prepared_findings.all_findings,
-            top_causes=prepared_findings.top_causes,
-            sensor_intensity_by_location=tuple(sensor_facts.active_intensity),
-            location_hotspot_rows=tuple(sensor_facts.location_hotspot_rows),
-            verdict_page=replace(
-                composition.verdict_page,
-                proof_summary=proof_summary,
-                timeline_graph=_build_timeline_graph_data(
-                    report_facts,
-                    duration_s=run_facts.duration_s,
-                ),
-            ),
-            appendix_a=composition.appendix_a,
-            appendix_b=composition.appendix_b,
-            appendix_c=_build_appendix_c_data(
-                primary=primary,
-                aggregate=test_run,
-                measurements=_measurement_rows(
-                    run_facts,
-                    aggregate=test_run,
-                    tr=tr,
-                ),
-                report_facts=report_facts,
-                composition=composition,
-                data_trust=list(data_trust),
-                tr=tr,
-            ),
-            appendix_d=_build_appendix_d_data(
-                date_str=self._report_date_text(run_facts),
-                run_id=run_facts.run_id,
-                tire_spec_text=run_facts.tire_spec_text,
-                sensor_model=run_facts.sensor_model,
-                firmware_version=run_facts.firmware_version,
-                sample_count=run_facts.sample_count,
-                sample_rate_hz=run_facts.sample_rate_hz,
-                tr=tr,
-            ),
-        )
-
-    def _resolve_next_steps(
-        self,
-        *,
-        primary: PrimaryCandidateContext,
-        report_facts: PreparedReportFacts,
-        composition: ReportDocumentComposition,
-    ) -> tuple[NextStep, ...]:
-        recapture_mode = report_facts.decision.action_status_key == "recapture_before_acting"
-        if recapture_mode:
-            return tuple(
-                NextStep(action=action) for action in composition.appendix_a.capture_changes
-            )
-        return tuple(
-            build_next_steps(
-                recommended_actions=report_facts.decision.recommended_actions,
-                primary_source=primary.primary_source,
-                primary_location=primary.primary_location,
-                tier=primary.tier,
-                cert_reason=primary.certainty_reason or self._tr("REPORT_CAPTURE_ISSUE_GENERIC"),
-                recapture_mode=recapture_mode,
-                lang=self._lang,
-                tr=self._tr,
-            )
-        )
-
-    def _observed_signature(self, primary: PrimaryCandidateContext) -> PatternEvidence:
-        return PatternEvidence(
-            primary_system=primary.primary_system,
-            strongest_location=primary.primary_location,
-            speed_band=primary.primary_speed,
-            strength_label=primary.strength_text,
-            strength_peak_db=primary.strength_db,
-            certainty_label=primary.certainty_label_text,
-            certainty_pct=primary.certainty_pct,
-            certainty_reason=primary.certainty_reason,
-        )
-
-    def _report_date_text(self, run_facts: ReportRunFacts) -> str:
-        report_date = run_facts.report_date or utc_now_iso()
-        return format_timestamp_in_recorded_timezone(
-            report_date,
-            run_facts.recorded_utc_offset_seconds,
-        ) or str(report_date)
-
-    def _tr(self, key: str, **kw: JsonValue) -> str:
-        return str(_tr(self._lang, key, **kw))
+        return build_report_document_data(compose_report_document_context(self._prepared))
 
 
 def build_report_document_data(context: ReportDocumentContext) -> ReportDocument:

--- a/apps/server/vibesensor/use_cases/history/report_document/composition.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/composition.py
@@ -1,21 +1,25 @@
-"""Report-document composition from semantic report facts."""
+"""Canonical report-document context composition from prepared report facts."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from vibesensor.domain import Finding, LocationIntensitySummary, SuitabilityCheck, TestRun
-from vibesensor.report_i18n import human_source
+from vibesensor.report_i18n import human_source, normalize_lang
 from vibesensor.report_i18n import tr as _tr
-from vibesensor.shared.boundaries.reporting import PreparedReportFacts
+from vibesensor.shared.boundaries.reporting import PreparedReportFacts, PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
     AppendixBData,
+    NextStep,
+    PatternEvidence,
     RankedCandidateRow,
+    ReportDocumentContext,
     TopologyIntensityRow,
     VerdictPageData,
 )
+from vibesensor.shared.boundaries.reporting.facts import ReportRunFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.shared.report_diagnostics import (
     check_state,
@@ -42,29 +46,174 @@ from vibesensor.shared.report_presentation import (
     uses_shared_overlap_wording,
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
+from vibesensor.shared.time_utils import (
+    format_timestamp_in_recorded_timezone,
+    format_utc_timestamp,
+    utc_now_iso,
+)
 from vibesensor.shared.types.json_types import JsonValue
 from vibesensor.use_cases.history.report_observation_matrix import (
     build_sensor_observation_matrix_rows,
 )
 
-__all__ = ["ReportDocumentComposition", "compose_report_document"]
+from ._candidate_resolver import PrimaryCandidateContext, resolve_primary_report_candidate
+from ._card_builder import build_system_cards
+from .measurements import _measurement_rows
+from .narrative_summaries import _proof_summary_text
+from .pattern_evidence import build_pattern_evidence
+from .peak_table import build_peak_rows
+from .report_sections import build_data_trust, build_next_steps
+from .sections import _build_appendix_c_data, _build_appendix_d_data, _build_timeline_graph_data
+
+__all__ = ["compose_report_document_context"]
 
 
 @dataclass(frozen=True, slots=True)
-class ReportDocumentComposition:
-    """Document-facing verdict and appendix content composed from report facts."""
+class _ReportDocumentSections:
+    """Document-facing sections composed before final ReportDocument mapping."""
 
     verdict_page: VerdictPageData
     appendix_a: AppendixAData
     appendix_b: AppendixBData
 
 
-def compose_report_document(
+def compose_report_document_context(prepared: PreparedReportInput) -> ReportDocumentContext:
+    """Compose the full immutable ReportDocumentContext from prepared report input."""
+
+    lang = str(normalize_lang(prepared.language))
+
+    def tr(key: str, **kw: JsonValue) -> str:
+        return str(_tr(lang, key, **kw))
+
+    test_run = prepared.domain_test_run
+    report_facts = prepared.report_facts
+    run_facts = report_facts.run
+    sensor_facts = report_facts.sensor
+    decision_facts = report_facts.decision
+    prepared_findings = report_facts.findings
+    sections = _compose_report_document_sections(
+        aggregate=test_run,
+        report_facts=report_facts,
+        lang=lang,
+    )
+    primary = resolve_primary_report_candidate(
+        aggregate=test_run,
+        facts=decision_facts.primary_candidate,
+        tr=tr,
+        lang=lang,
+    )
+    data_trust = tuple(
+        build_data_trust(
+            suitability_checks=decision_facts.suitability_checks,
+            warnings=decision_facts.warnings,
+            lang=lang,
+            tr=tr,
+        )
+    )
+    proof_summary = _proof_summary_text(
+        test_run,
+        primary,
+        report_facts,
+        runner_up_corner=sections.appendix_b.runner_up_corner,
+        tr=tr,
+    )
+    return ReportDocumentContext(
+        title=tr("REPORT_FOOTER_TITLE"),
+        run_datetime=_report_date_text(run_facts),
+        run_id=run_facts.run_id,
+        duration_text=run_facts.duration_text,
+        start_time_utc=format_utc_timestamp(run_facts.start_time_utc),
+        end_time_utc=format_utc_timestamp(run_facts.end_time_utc),
+        sample_rate_hz=run_facts.sample_rate_hz,
+        tire_spec_text=run_facts.tire_spec_text,
+        sample_count=run_facts.sample_count,
+        sensor_count=primary.sensor_count,
+        sensor_locations=tuple(sensor_facts.active_locations),
+        sensor_model=run_facts.sensor_model,
+        firmware_version=run_facts.firmware_version,
+        car_name=run_facts.car_name,
+        car_type=run_facts.car_type,
+        observed=_observed_signature(primary, tr=tr),
+        system_cards=tuple(
+            build_system_cards(
+                test_run,
+                primary,
+                lang,
+                tr,
+            )
+        ),
+        next_steps=_resolve_next_steps(
+            primary=primary,
+            report_facts=report_facts,
+            appendix_a=sections.appendix_a,
+            lang=lang,
+            tr=tr,
+        ),
+        data_trust=data_trust,
+        pattern_evidence=build_pattern_evidence(
+            aggregate=test_run,
+            origin=run_facts.origin,
+            primary=primary,
+            lang=lang,
+            tr=tr,
+        ),
+        peak_rows=tuple(
+            build_peak_rows(
+                run_facts.peak_table_rows,
+                findings=list(prepared_findings.all_findings),
+                lang=lang,
+                tr=tr,
+            )
+        ),
+        language=lang,
+        certainty_tier_key=primary.tier,
+        findings=prepared_findings.all_findings,
+        top_causes=prepared_findings.top_causes,
+        sensor_intensity_by_location=tuple(sensor_facts.active_intensity),
+        location_hotspot_rows=tuple(sensor_facts.location_hotspot_rows),
+        verdict_page=replace(
+            sections.verdict_page,
+            proof_summary=proof_summary,
+            timeline_graph=_build_timeline_graph_data(
+                report_facts,
+                duration_s=run_facts.duration_s,
+            ),
+        ),
+        appendix_a=sections.appendix_a,
+        appendix_b=sections.appendix_b,
+        appendix_c=_build_appendix_c_data(
+            primary=primary,
+            aggregate=test_run,
+            measurements=_measurement_rows(
+                run_facts,
+                aggregate=test_run,
+                tr=tr,
+            ),
+            report_facts=report_facts,
+            speed_window_label=sections.verdict_page.speed_window_label,
+            proof_caveat=sections.verdict_page.proof_caveat,
+            data_trust=list(data_trust),
+            tr=tr,
+        ),
+        appendix_d=_build_appendix_d_data(
+            date_str=_report_date_text(run_facts),
+            run_id=run_facts.run_id,
+            tire_spec_text=run_facts.tire_spec_text,
+            sensor_model=run_facts.sensor_model,
+            firmware_version=run_facts.firmware_version,
+            sample_count=run_facts.sample_count,
+            sample_rate_hz=run_facts.sample_rate_hz,
+            tr=tr,
+        ),
+    )
+
+
+def _compose_report_document_sections(
     *,
     aggregate: TestRun,
     report_facts: PreparedReportFacts,
     lang: str,
-) -> ReportDocumentComposition:
+) -> _ReportDocumentSections:
     """Build presentation-specific report sections from prepared semantic facts."""
 
     def tr(key: str, **kw: JsonValue) -> str:
@@ -126,7 +275,7 @@ def compose_report_document(
         warnings=decision_facts.warnings,
         tr=tr,
     )
-    return ReportDocumentComposition(
+    return _ReportDocumentSections(
         verdict_page=_build_verdict_page_data(
             aggregate=aggregate,
             primary_candidate_facts=decision_facts.primary_candidate,
@@ -167,6 +316,56 @@ def compose_report_document(
             tr=tr,
         ),
     )
+
+
+def _resolve_next_steps(
+    *,
+    primary: PrimaryCandidateContext,
+    report_facts: PreparedReportFacts,
+    appendix_a: AppendixAData,
+    lang: str,
+    tr: Callable[..., str],
+) -> tuple[NextStep, ...]:
+    recapture_mode = report_facts.decision.action_status_key == "recapture_before_acting"
+    if recapture_mode:
+        return tuple(NextStep(action=action) for action in appendix_a.capture_changes)
+    return tuple(
+        build_next_steps(
+            recommended_actions=report_facts.decision.recommended_actions,
+            primary_source=primary.primary_source,
+            primary_location=primary.primary_location,
+            tier=primary.tier,
+            cert_reason=primary.certainty_reason or tr("REPORT_CAPTURE_ISSUE_GENERIC"),
+            recapture_mode=recapture_mode,
+            lang=lang,
+            tr=tr,
+        )
+    )
+
+
+def _observed_signature(
+    primary: PrimaryCandidateContext,
+    *,
+    tr: Callable[..., str],
+) -> PatternEvidence:
+    return PatternEvidence(
+        primary_system=primary.primary_system,
+        strongest_location=display_location(primary.primary_location, tr=tr),
+        speed_band=primary.primary_speed,
+        strength_label=primary.strength_text,
+        strength_peak_db=primary.strength_db,
+        certainty_label=primary.certainty_label_text,
+        certainty_pct=primary.certainty_pct,
+        certainty_reason=primary.certainty_reason,
+    )
+
+
+def _report_date_text(run_facts: ReportRunFacts) -> str:
+    report_date = run_facts.report_date or utc_now_iso()
+    return format_timestamp_in_recorded_timezone(
+        report_date,
+        run_facts.recorded_utc_offset_seconds,
+    ) or str(report_date)
 
 
 def _build_verdict_page_data(

--- a/apps/server/vibesensor/use_cases/history/report_document/narrative_summaries.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/narrative_summaries.py
@@ -14,7 +14,6 @@ from vibesensor.shared.report_presentation import (
 )
 from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext
 
-from .composition import ReportDocumentComposition
 from .phase_analysis import (
     _finding_phase_label,
     _same_source_temporal_pair,
@@ -34,8 +33,8 @@ def _proof_summary_text(
     aggregate: TestRun,
     primary: PrimaryCandidateContext,
     report_facts: PreparedReportFacts,
-    composition: ReportDocumentComposition,
     *,
+    runner_up_corner: str | None,
     tr: Callable[..., str],
 ) -> str:
     sequence_summary = _same_source_temporal_proof_summary(
@@ -47,7 +46,7 @@ def _proof_summary_text(
         return sequence_summary
     ratio = report_facts.decision.primary_candidate.dominance_ratio
     location = display_location(primary.primary_location, tr=tr)
-    runner_up = composition.appendix_b.runner_up_corner
+    runner_up = runner_up_corner
     if ratio is not None:
         if runner_up is not None:
             return tr(
@@ -66,18 +65,18 @@ def _proof_summary_text(
 
 def _run_limits_summary_text(
     report_facts: PreparedReportFacts,
-    composition: ReportDocumentComposition,
     *,
+    speed_window_label: str | None,
+    proof_caveat: str | None,
     tr: Callable[..., str],
 ) -> str:
-    speed_window = str(composition.verdict_page.speed_window_label or "").strip() or tr("UNKNOWN")
+    speed_window = str(speed_window_label or "").strip() or tr("UNKNOWN")
     if (
         report_facts.decision.action_status_key == "action_ready_caution"
         and report_facts.decision.alternative_source_visible
     ):
         return tr("REPORT_RUN_LIMITS_RECAPTURE_RECIPE", speed=speed_window)
-    note = composition.verdict_page.proof_caveat
-    return note or tr("REPORT_CAPTURE_ISSUE_GENERIC")
+    return proof_caveat or tr("REPORT_CAPTURE_ISSUE_GENERIC")
 
 
 def _evidence_summary_text(

--- a/apps/server/vibesensor/use_cases/history/report_document/sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/sections.py
@@ -17,7 +17,6 @@ from vibesensor.shared.boundaries.reporting.document import (
 )
 from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext
 
-from .composition import ReportDocumentComposition
 from .measurements import _evidence_chain_rows
 from .narrative_summaries import (
     _context_summary_text,
@@ -94,7 +93,8 @@ def _build_appendix_c_data(
     aggregate: TestRun,
     measurements: list[MeasurementRow],
     report_facts: PreparedReportFacts,
-    composition: ReportDocumentComposition,
+    speed_window_label: str | None,
+    proof_caveat: str | None,
     data_trust: list[DataTrustItem],
     tr: Callable[..., str],
 ) -> AppendixCData:
@@ -113,7 +113,8 @@ def _build_appendix_c_data(
         context_summary=_context_summary_text(primary, report_facts, tr=tr),
         limits_summary=_run_limits_summary_text(
             report_facts,
-            composition,
+            speed_window_label=speed_window_label,
+            proof_caveat=proof_caveat,
             tr=tr,
         ),
         speed_band_summary=speed_summary,


### PR DESCRIPTION
## Summary
- move full `ReportDocumentContext` assembly into `report_document/composition.py` so report content is composed before the final document mapping step
- remove the public `ReportDocumentComposition` / `compose_report_document` seam and thread only explicit section facts into narrative/appendix helpers
- update report mapping tests and hygiene guardrails to validate the new context-composition boundary

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/adapters/pdf/test_template_builder.py
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf
- make lint && make typecheck-backend
- VIBESENSOR_TEST_BASE_URL=http://127.0.0.1:8000 .venv/bin/pytest -q -m 'e2e and long_sim' apps/server/tests/integration/test_sim_ingestion.py