### PR TITLE
Clarify reporting boundary entrypoints

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_labels.py
@@ -6,7 +6,7 @@ import pytest
 
 import vibesensor.use_cases.history.report_document.peak_table as peak_table
 from vibesensor.domain.confidence_assessment import ConfidenceAssessment
-from vibesensor.shared.boundaries.reporting.document import FindingPresentation
+from vibesensor.shared.boundaries.reporting import FindingPresentation
 from vibesensor.use_cases.history.report_document.pattern_parts import (
     parts_for_pattern,
     why_parts_listed,

--- a/apps/server/tests/adapters/pdf/test_template_builder.py
+++ b/apps/server/tests/adapters/pdf/test_template_builder.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
+from vibesensor.shared.boundaries.reporting import FindingPresentation
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
     AppendixBData,
     AppendixCData,
     AppendixDData,
     DataTrustItem,
-    FindingPresentation,
     NextStep,
     PatternEvidence,
     PeakRow,

--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -282,63 +282,6 @@ class TestReport:
         with pytest.raises(AttributeError):
             r.title = "new"
 
-    def test_from_summary(self) -> None:
-        from vibesensor.shared.boundaries.reporting.document import build_report_from_summary
-        from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
-
-        summary: dict[str, object] = {
-            "run_id": "run-123",
-            "lang": "de",
-            "rows": 500,
-            "duration_s": 125.0,
-            "report_date": "2025-01-15",
-            "sensor_count_used": 3,
-            "findings": [
-                {"finding_id": "F001", "suspected_source": "bearing"},
-                {"finding_id": "F002", "suspected_source": "tire"},
-            ],
-            "metadata": {
-                "run_id": "run-123",
-                "active_car_snapshot": {"name": "BMW 3", "type": "sedan"},
-            },
-        }
-        r = build_report_from_summary(
-            report_summary_from_mapping(summary),
-            language=str(summary["lang"]),
-        )
-        assert r.run_id == "run-123"
-        assert r.lang == "de"
-        assert r.sample_count == 500
-        assert r.sensor_count == 3
-        assert r.car_name == "BMW 3"
-        assert r.car_type == "sedan"
-        assert r.report_date == "2025-01-15"
-        assert r.duration_s == 125.0
-
-    def test_from_summary_minimal(self) -> None:
-        from vibesensor.shared.boundaries.reporting.document import build_report_from_summary
-        from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
-
-        summary = {"run_id": "r1", "findings": [], "top_causes": []}
-        r = build_report_from_summary(
-            report_summary_from_mapping(summary),
-            language="en",
-        )
-        assert r.run_id == "r1"
-        assert r.sample_count == 0
-        assert r.car_name is None
-
-    def test_from_summary_short_duration(self) -> None:
-        from vibesensor.shared.boundaries.reporting.document import build_report_from_summary
-        from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
-
-        summary = {"run_id": "r1", "duration_s": 45.0, "findings": [], "top_causes": []}
-        r = build_report_from_summary(
-            report_summary_from_mapping(summary),
-            language="en",
-        )
-        assert r.duration_s == 45.0
-
 
 # ---------------------------------------------------------------------------
 # Package-level imports
@@ -528,38 +471,6 @@ class TestReportValidation:
     def test_zero_duration_allowed(self) -> None:
         r = Report(run_id="r1", duration_s=0.0)
         assert r.duration_s == 0.0
-
-    def test_from_summary_empty_run_id_gets_fallback(self) -> None:
-        from vibesensor.shared.boundaries.reporting.document import build_report_from_summary
-        from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
-
-        summary = {"run_id": "", "findings": [], "top_causes": []}
-        r = build_report_from_summary(
-            report_summary_from_mapping(summary),
-            language="en",
-        )
-        assert r.run_id == "unknown"
-
-    def test_from_summary_creates_metadata(self) -> None:
-        from vibesensor.shared.boundaries.reporting.document import build_report_from_summary
-        from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
-
-        summary: dict[str, object] = {
-            "run_id": "run-1",
-            "findings": [
-                {
-                    "finding_id": "F001",
-                    "suspected_source": "bearing",
-                    "confidence": 0.8,
-                },
-            ],
-        }
-        r = build_report_from_summary(
-            report_summary_from_mapping(summary),
-            language="en",
-        )
-        assert r.run_id == "run-1"
-        assert r.lang == "en"
 
 
 class TestRunEnrichments:

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -206,6 +206,15 @@ def test_mapping_module_no_longer_reexports_raw_summary_report_builder() -> None
     assert not hasattr(mapping, "build_report_from_summary")
 
 
+def test_reporting_document_boundary_exposes_document_models_only() -> None:
+    from vibesensor.shared.boundaries.reporting import FindingPresentation
+    from vibesensor.shared.boundaries.reporting import document as document_boundary
+
+    assert not hasattr(document_boundary, "build_report_from_summary")
+    assert not hasattr(document_boundary, "FindingPresentation")
+    assert FindingPresentation is not None
+
+
 def test_report_facts_hold_canonical_document_sections_without_builder_shims() -> None:
     from dataclasses import fields
 

--- a/apps/server/vibesensor/adapters/pdf/report_types.py
+++ b/apps/server/vibesensor/adapters/pdf/report_types.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
+from vibesensor.shared.boundaries.reporting import FindingPresentation
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
     AppendixBData,
     AppendixCData,
-    FindingPresentation,
     NextStep,
     ReportDocument,
     ReportLabelValueRow,

--- a/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
@@ -1,6 +1,8 @@
 """Canonical reporting boundary package."""
 
-from .decision_facts import ReportDecisionFacts
+# Summary normalization and projectable-payload gates.
+# Fact projections and prepared fact groups.
+from .decision_facts import ReportDecisionFacts, build_report_decision_facts
 from .facts import (
     ActionStatusKey,
     LocationConfidenceKey,
@@ -10,6 +12,8 @@ from .facts import (
 )
 from .findings import FindingPresentation, PreparedReportFindings
 from .input import PreparedReportInput
+
+# Reconstructed prepared-input entrypoints.
 from .preparation import prepare_persisted_report_input, prepare_report_input
 from .projection import (
     PrimaryReportFacts,
@@ -28,6 +32,7 @@ from .summary import (
 
 __all__ = [
     "ActionStatusKey",
+    "build_report_decision_facts",
     "FindingPresentation",
     "LocationConfidenceKey",
     "NormalizedReportSummary",

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/__init__.py
@@ -14,10 +14,9 @@ from .appendices import (
     TopologyIntensityRow,
 )
 from .context import ReportDocumentContext
-from .document import Report, ReportDocument, build_report_from_summary
+from .document import Report, ReportDocument
 from .panels import DataTrustItem, NextStep, PartSuggestion, PatternEvidence, SystemFindingCard
 from .sections import (
-    FindingPresentation,
     PeakRow,
     TimelineGraphData,
     TimelineGraphInterval,
@@ -31,7 +30,6 @@ __all__ = [
     "AppendixDData",
     "DataTrustItem",
     "EvidenceChainRow",
-    "FindingPresentation",
     "MeasurementRow",
     "NextStep",
     "PartSuggestion",
@@ -49,5 +47,4 @@ __all__ = [
     "TimelineGraphInterval",
     "TopologyIntensityRow",
     "VerdictPageData",
-    "build_report_from_summary",
 ]

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/context.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/context.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
 
+from ..findings import FindingPresentation
 from .appendices import AppendixAData, AppendixBData, AppendixCData, AppendixDData
 from .panels import DataTrustItem, NextStep, PatternEvidence, SystemFindingCard
-from .sections import FindingPresentation, PeakRow, VerdictPageData
+from .sections import PeakRow, VerdictPageData
 
 __all__ = ["ReportDocumentContext"]
 

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/document.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/document.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary
-from vibesensor.shared.boundaries.reporting.summary import NormalizedReportSummary
 
+from ..findings import FindingPresentation
 from .appendices import AppendixAData, AppendixBData, AppendixCData, AppendixDData
 from .panels import DataTrustItem, NextStep, PatternEvidence, SystemFindingCard
-from .sections import FindingPresentation, PeakRow, VerdictPageData
+from .sections import PeakRow, VerdictPageData
 
 __all__ = [
     "Report",
     "ReportDocument",
-    "build_report_from_summary",
 ]
 
 
@@ -75,22 +74,3 @@ class ReportDocument:
     appendix_b: AppendixBData = field(default_factory=AppendixBData)
     appendix_c: AppendixCData = field(default_factory=AppendixCData)
     appendix_d: AppendixDData = field(default_factory=AppendixDData)
-
-
-def build_report_from_summary(
-    summary: NormalizedReportSummary,
-    *,
-    language: str,
-) -> Report:
-    """Create a ``Report`` metadata object from the canonical report summary."""
-    metadata = summary.metadata
-    return Report(
-        run_id=summary.run_id or "unknown",
-        lang=language,
-        car_name=metadata.car_name if metadata is not None else None,
-        car_type=metadata.car_type if metadata is not None else None,
-        report_date=summary.report_date,
-        duration_s=summary.duration_s,
-        sample_count=summary.sample_count,
-        sensor_count=summary.sensor_count,
-    )

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/sections.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/sections.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from vibesensor.shared.boundaries.reporting.findings import FindingPresentation
-
 __all__ = [
-    "FindingPresentation",
     "PeakRow",
     "TimelineGraphData",
     "TimelineGraphInterval",

--- a/apps/server/vibesensor/use_cases/history/report_document/peak_table.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/peak_table.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 
 from vibesensor.domain import VibrationSource
-from vibesensor.shared.boundaries.reporting.document import FindingPresentation, PeakRow
+from vibesensor.shared.boundaries.reporting import FindingPresentation
+from vibesensor.shared.boundaries.reporting.document import PeakRow
 from vibesensor.shared.json_utils import as_float_or_none as _as_float
 from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.use_cases.history.report_document.presentation import (


### PR DESCRIPTION
## Summary
- remove stale document-package reporting exports so `reporting.document` exposes document models only
- make `FindingPresentation` imports come from the canonical root reporting boundary
- add hygiene coverage for the tightened reporting/document package surface

## Validation
- .venv/bin/python -m pytest -q apps/server/tests/domain/test_domain_objects.py apps/server/tests/adapters/pdf/test_template_builder.py apps/server/tests/adapters/pdf/test_report_new_modules_labels.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf apps/server/tests/domain/test_domain_objects.py apps/server/tests/shared/boundaries
- make lint && make typecheck-backend
- VIBESENSOR_TEST_BASE_URL=http://127.0.0.1:8000 .venv/bin/pytest -q -m 'e2e and long_sim' apps/server/tests/integration/test_sim_ingestion.py