### PR TITLE
refactor: split updater transport lifecycle

### DIFF
--- a/apps/server/tests/use_cases/updates/test_transport_coordinator.py
+++ b/apps/server/tests/use_cases/updates/test_transport_coordinator.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from test_support.update_status import build_update_status_harness
+
+from vibesensor.shared.exceptions import UpdateTransportError
+from vibesensor.use_cases.updates.models import UpdateRequest, UpdateTransport
+from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
+from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
+
+
+def _request(transport: UpdateTransport) -> UpdateRequest:
+    if transport is UpdateTransport.wifi:
+        return UpdateRequest(
+            transport=transport,
+            ssid="TestNet",
+            password="pass123",
+        )
+    return UpdateRequest(
+        transport=transport,
+        ssid=None,
+        password="",
+    )
+
+
+@dataclass(slots=True)
+class _RecordingSetupTransport:
+    transport: UpdateTransport = UpdateTransport.wifi
+    fail_prepare: bool = False
+    calls: list[str] = field(default_factory=list)
+
+    async def prepare(self, request: UpdateRequest) -> None:
+        self.calls.append(f"prepare:{request.transport.value}")
+        if self.fail_prepare:
+            raise UpdateTransportError("setup failed")
+
+    async def abort_preparation(self) -> None:
+        self.calls.append("abort")
+
+    async def complete_success(self, message: str) -> None:
+        self.calls.append(f"success:{message}")
+
+    async def cleanup_after_update(self) -> None:
+        self.calls.append("cleanup")
+
+    async def recover_interrupted_update(self) -> None:
+        self.calls.append("recover")
+
+
+@dataclass(slots=True)
+class _RecordingValidatingTransport:
+    transport: UpdateTransport = UpdateTransport.usb_internet
+    fail_validate: bool = False
+    calls: list[str] = field(default_factory=list)
+
+    async def validate(self, request: UpdateRequest) -> None:
+        self.calls.append(f"validate:{request.transport.value}")
+        if self.fail_validate:
+            raise UpdateTransportError("validation failed")
+
+    async def complete_success(self, message: str) -> None:
+        self.calls.append(f"success:{message}")
+
+
+def _coordinator(
+    tmp_path: Path,
+    *,
+    setup: _RecordingSetupTransport | None = None,
+    validating: _RecordingValidatingTransport | None = None,
+) -> tuple[UpdateTransportCoordinator, object]:
+    status = build_update_status_harness(tmp_path / "state.json")
+    return UpdateTransportCoordinator(
+        sessions=UpdateTransportSessions(
+            wifi=setup or _RecordingSetupTransport(),
+            usb_internet=validating or _RecordingValidatingTransport(),
+        ),
+        status=status,
+        logger=MagicMock(),
+    ), status
+
+
+@pytest.mark.asyncio
+async def test_prepare_rolls_back_only_setup_transport_on_failure(tmp_path: Path) -> None:
+    setup = _RecordingSetupTransport(fail_prepare=True)
+    coordinator, _status = _coordinator(tmp_path, setup=setup)
+
+    with pytest.raises(UpdateTransportError, match="setup failed"):
+        await coordinator.prepare(_request(UpdateTransport.wifi))
+
+    assert setup.calls == ["prepare:wifi", "abort"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_validates_passive_transport_without_abort_path(tmp_path: Path) -> None:
+    validating = _RecordingValidatingTransport(fail_validate=True)
+    coordinator, _status = _coordinator(tmp_path, validating=validating)
+
+    with pytest.raises(UpdateTransportError, match="validation failed"):
+        await coordinator.prepare(_request(UpdateTransport.usb_internet))
+
+    assert validating.calls == ["validate:usb_internet"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_and_recovery_skip_passive_transport(tmp_path: Path) -> None:
+    validating = _RecordingValidatingTransport()
+    coordinator, status = _coordinator(tmp_path, validating=validating)
+
+    session = await coordinator.prepare(_request(UpdateTransport.usb_internet))
+    await coordinator.cleanup_after_update(session)
+    status.start_job(_request(UpdateTransport.usb_internet))
+    await coordinator.recover_interrupted(
+        status.status,
+    )
+
+    assert validating.calls == ["validate:usb_internet"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_and_recovery_run_for_setup_transport(tmp_path: Path) -> None:
+    setup = _RecordingSetupTransport()
+    coordinator, status = _coordinator(tmp_path, setup=setup)
+
+    session = await coordinator.prepare(_request(UpdateTransport.wifi))
+    await coordinator.cleanup_after_update(session)
+    status.start_job(_request(UpdateTransport.wifi))
+    await coordinator.recover_interrupted(status.status)
+
+    assert setup.calls == ["prepare:wifi", "cleanup", "recover"]

--- a/apps/server/tests/use_cases/updates/test_update_preparation.py
+++ b/apps/server/tests/use_cases/updates/test_update_preparation.py
@@ -16,7 +16,6 @@ from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinato
 from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
-from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSessions
 
 
 def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateRequest:
@@ -31,17 +30,11 @@ def _build_preparation(
     tmp_path: Path,
     *,
     current_version: str = "2026.4.3",
-) -> tuple[UpdatePreparationCoordinator, UpdateStatusTracker, AsyncMock]:
+) -> tuple[UpdatePreparationCoordinator, UpdateStatusTracker, AsyncMock, AsyncMock]:
     status = build_update_status_harness(tmp_path / "state.json")
     transport_session = AsyncMock()
-    transport_coordinator = UpdateTransportCoordinator(
-        sessions=MagicMock(
-            spec=UpdateTransportSessions,
-            for_request=MagicMock(return_value=transport_session),
-        ),
-        status=status,
-        logger=MagicMock(),
-    )
+    transport_coordinator = MagicMock(spec=UpdateTransportCoordinator)
+    transport_coordinator.prepare = AsyncMock(return_value=transport_session)
     preparation = UpdatePreparationCoordinator(
         status=status,
         commands=MagicMock(),
@@ -52,12 +45,12 @@ def _build_preparation(
         ),
         current_version_provider=lambda: current_version,
     )
-    return preparation, status, transport_session
+    return preparation, status, transport_session, transport_coordinator
 
 
 @pytest.mark.asyncio
 async def test_prepare_stops_after_validation_failure(tmp_path: Path) -> None:
-    preparation, _tracker, transport_session = _build_preparation(tmp_path)
+    preparation, _tracker, _transport_session, transport_coordinator = _build_preparation(tmp_path)
 
     with (
         patch(
@@ -68,14 +61,14 @@ async def test_prepare_stops_after_validation_failure(tmp_path: Path) -> None:
     ):
         await preparation.prepare(_wifi_request())
 
-    transport_session.prepare.assert_not_awaited()
+    transport_coordinator.prepare.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_prepare_stops_when_transport_cannot_prepare(tmp_path: Path) -> None:
-    preparation, _tracker, transport_session = _build_preparation(tmp_path)
+    preparation, _tracker, _transport_session, transport_coordinator = _build_preparation(tmp_path)
     request = _wifi_request()
-    transport_session.prepare.side_effect = UpdateTransportError("transport failed")
+    transport_coordinator.prepare.side_effect = UpdateTransportError("transport failed")
 
     with (
         patch(
@@ -86,18 +79,16 @@ async def test_prepare_stops_when_transport_cannot_prepare(tmp_path: Path) -> No
     ):
         await preparation.prepare(request)
 
-    transport_session.prepare.assert_awaited_once_with(request)
-    transport_session.abort_preparation.assert_awaited_once()
+    transport_coordinator.prepare.assert_awaited_once_with(request)
 
 
 @pytest.mark.asyncio
 async def test_prepare_returns_canonical_prepared_run(tmp_path: Path) -> None:
-    preparation, _tracker, transport_session = _build_preparation(
+    preparation, _tracker, transport_session, transport_coordinator = _build_preparation(
         tmp_path,
         current_version="2026.4.9",
     )
     request = _wifi_request()
-    transport_session.prepare.return_value = None
 
     with patch(
         "vibesensor.use_cases.updates.preparation.validate_prerequisites",
@@ -107,4 +98,5 @@ async def test_prepare_returns_canonical_prepared_run(tmp_path: Path) -> None:
 
     assert isinstance(prepared, PreparedUpdateRun)
     assert prepared.current_version == "2026.4.9"
+    transport_coordinator.prepare.assert_awaited_once_with(request)
     assert prepared.transport_session is transport_session

--- a/apps/server/vibesensor/use_cases/updates/run_models.py
+++ b/apps/server/vibesensor/use_cases/updates/run_models.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo
-    from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSession
+    from vibesensor.use_cases.updates.transport_sessions import ManagedUpdateTransportSession
 
 __all__ = [
     "InstallServerReleasePlan",
@@ -23,7 +23,7 @@ class PreparedUpdateRun:
     """Validated updater state with one prepared transport session."""
 
     current_version: str
-    transport_session: UpdateTransportSession
+    transport_session: ManagedUpdateTransportSession
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/use_cases/updates/transport_coordinator.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_coordinator.py
@@ -9,8 +9,10 @@ from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError, Update
 from vibesensor.use_cases.updates.models import UpdateJobStatus, UpdateRequest
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport_sessions import (
-    UpdateTransportSession,
+    ManagedUpdateTransportSession,
+    SetupUpdateTransportSession,
     UpdateTransportSessions,
+    ValidatingUpdateTransportSession,
 )
 
 __all__ = ["UpdateTransportCoordinator"]
@@ -32,18 +34,23 @@ class UpdateTransportCoordinator:
         self._status = status
         self._logger = logger
 
-    async def prepare(self, request: UpdateRequest) -> UpdateTransportSession:
+    async def prepare(self, request: UpdateRequest) -> ManagedUpdateTransportSession:
         session = self._sessions.for_request(request)
         try:
-            await session.prepare(request)
+            if isinstance(session, SetupUpdateTransportSession):
+                await session.prepare(request)
+            else:
+                assert isinstance(session, ValidatingUpdateTransportSession)  # noqa: S101
+                await session.validate(request)
         except UpdateTransportError:
-            await self._abort_preparation(session)
+            if isinstance(session, SetupUpdateTransportSession):
+                await self._abort_preparation(session)
             raise
         return session
 
     async def complete_success(
         self,
-        transport_session: UpdateTransportSession,
+        transport_session: ManagedUpdateTransportSession,
         *,
         message: str,
     ) -> None:
@@ -51,9 +58,12 @@ class UpdateTransportCoordinator:
 
     async def cleanup_after_update(
         self,
-        transport_session: UpdateTransportSession | None,
+        transport_session: ManagedUpdateTransportSession | None,
     ) -> None:
-        if transport_session is None:
+        if transport_session is None or not isinstance(
+            transport_session,
+            SetupUpdateTransportSession,
+        ):
             return
         try:
             await transport_session.cleanup_after_update()
@@ -63,9 +73,11 @@ class UpdateTransportCoordinator:
             raise UpdateCleanupError(f"Transport cleanup failed: {exc}") from exc
 
     async def recover_interrupted(self, status: UpdateJobStatus) -> None:
-        await self._sessions.for_status(status).recover_interrupted_update()
+        transport_session = self._sessions.for_status(status)
+        if isinstance(transport_session, SetupUpdateTransportSession):
+            await transport_session.recover_interrupted_update()
 
-    async def _abort_preparation(self, session: UpdateTransportSession) -> None:
+    async def _abort_preparation(self, session: SetupUpdateTransportSession) -> None:
         active_error = sys.exc_info()[1]
         try:
             await session.abort_preparation()

--- a/apps/server/vibesensor/use_cases/updates/transport_sessions.py
+++ b/apps/server/vibesensor/use_cases/updates/transport_sessions.py
@@ -1,27 +1,40 @@
-"""Canonical transport-session boundary for update job control flow."""
+"""Canonical updater transport boundaries for active setup and passive validation."""
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from vibesensor.use_cases.updates.models import UpdateJobStatus, UpdateRequest, UpdateTransport
 
+__all__ = [
+    "ManagedUpdateTransportSession",
+    "SetupUpdateTransportSession",
+    "UpdateTransportSessions",
+    "ValidatingUpdateTransportSession",
+]
 
-class UpdateTransportSession(Protocol):
-    """One transport-specific update session with a uniform lifecycle."""
+
+@runtime_checkable
+class ManagedUpdateTransportSession(Protocol):
+    """Post-prepare transport surface used by the main update workflow."""
 
     transport: UpdateTransport
 
+    async def complete_success(self, message: str) -> None:
+        """Finalize a successful update for this transport."""
+        ...
+
+
+@runtime_checkable
+class SetupUpdateTransportSession(ManagedUpdateTransportSession, Protocol):
+    """Transport that must actively set up and later unwind update-owned state."""
+
     async def prepare(self, request: UpdateRequest) -> None:
-        """Prepare this transport for an update run before release work starts."""
+        """Prepare this transport before release work starts."""
         ...
 
     async def abort_preparation(self) -> None:
         """Rollback any partial transport setup after prepare-time failure."""
-        ...
-
-    async def complete_success(self, message: str) -> None:
-        """Finalize a successful update for this transport."""
         ...
 
     async def cleanup_after_update(self) -> None:
@@ -33,27 +46,41 @@ class UpdateTransportSession(Protocol):
         ...
 
 
+@runtime_checkable
+class ValidatingUpdateTransportSession(ManagedUpdateTransportSession, Protocol):
+    """Transport that reuses an existing uplink and only validates readiness."""
+
+    async def validate(self, request: UpdateRequest) -> None:
+        """Validate an already-live transport before release work starts."""
+        ...
+
+
+type PreparingUpdateTransportSession = (
+    SetupUpdateTransportSession | ValidatingUpdateTransportSession
+)
+
+
 class UpdateTransportSessions:
-    """Resolve canonical transport sessions from requests or persisted state."""
+    """Resolve canonical updater transports from requests or persisted state."""
 
     __slots__ = ("_sessions",)
 
     def __init__(
         self,
         *,
-        wifi: UpdateTransportSession,
-        usb_internet: UpdateTransportSession,
+        wifi: SetupUpdateTransportSession,
+        usb_internet: ValidatingUpdateTransportSession,
     ) -> None:
-        self._sessions: dict[UpdateTransport, UpdateTransportSession] = {
+        self._sessions: dict[UpdateTransport, PreparingUpdateTransportSession] = {
             UpdateTransport.wifi: wifi,
             UpdateTransport.usb_internet: usb_internet,
         }
 
-    def for_request(self, request: UpdateRequest) -> UpdateTransportSession:
-        return self.for_transport(request.transport)
+    def for_request(self, request: UpdateRequest) -> PreparingUpdateTransportSession:
+        return self._sessions[request.transport]
 
-    def for_transport(self, transport: UpdateTransport) -> UpdateTransportSession:
+    def for_transport(self, transport: UpdateTransport) -> ManagedUpdateTransportSession:
         return self._sessions[transport]
 
-    def for_status(self, status: UpdateJobStatus) -> UpdateTransportSession:
+    def for_status(self, status: UpdateJobStatus) -> ManagedUpdateTransportSession:
         return self.for_transport(status.transport)

--- a/apps/server/vibesensor/use_cases/updates/usb_transport.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_transport.py
@@ -80,8 +80,7 @@ class UpdateUsbInternetSession:
             config=config,
         )
 
-    async def prepare(self, request: UpdateRequest) -> None:
-        del request
+    async def validate(self, _request: UpdateRequest) -> None:
         self._status.transition(UpdatePhase.connecting_usb_internet)
         try:
             await self.ensure_uplink_ready()
@@ -90,9 +89,6 @@ class UpdateUsbInternetSession:
             raise UpdateTransportError(
                 "Failed to prepare the USB internet uplink for update"
             ) from exc
-
-    async def abort_preparation(self) -> None:
-        return None
 
     async def ensure_uplink_ready(self) -> None:
         decision = _classify_usb_internet(await self._status_service.snapshot(activate=True))
@@ -113,9 +109,3 @@ class UpdateUsbInternetSession:
 
     async def complete_success(self, message: str) -> None:
         self._status.mark_success(message)
-
-    async def cleanup_after_update(self) -> None:
-        return None
-
-    async def recover_interrupted_update(self) -> None:
-        return None

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -14,7 +14,7 @@ from vibesensor.use_cases.updates.run_models import (
 )
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
-from vibesensor.use_cases.updates.transport_sessions import UpdateTransportSession
+from vibesensor.use_cases.updates.transport_sessions import ManagedUpdateTransportSession
 
 __all__ = ["UpdateWorkflowExecutor"]
 
@@ -92,7 +92,7 @@ class UpdateWorkflowExecutor:
 
     async def _complete_success(
         self,
-        transport_session: UpdateTransportSession,
+        transport_session: ManagedUpdateTransportSession,
         *,
         message: str,
     ) -> None:


### PR DESCRIPTION
## Summary
- address ledger issue #1 by splitting updater transports into setup vs passive validation roles
- remove the fake USB preparation rollback hook and stop treating USB as if it owned Wi-Fi-style cleanup/recovery state
- keep workflow/run models on the post-prepare managed transport surface and add focused coordinator coverage

## Architectural simplifications
- replace the one-size-fits-all `UpdateTransportSession` contract with explicit setup and validating transport protocols
- narrow `UpdateTransportCoordinator` so rollback/cleanup/recovery only run for setup transports
- simplify `UpdatePreparationCoordinator` tests so they target the coordinator seam instead of transport internals

## Transitional structures removed
- fake USB `abort_preparation()` implementation required only by the old shared protocol
- implicit assumption that every transport supports setup rollback

## Intentional internal contract changes
- USB transports now validate readiness through a passive validation interface instead of pretending to implement the setup lifecycle
- transport cleanup/recovery are now setup-transport capabilities, not universal transport requirements

## Local validation
- `make lint`
- `make typecheck-backend`
- `.venv/bin/python -m pytest -q apps/server/tests/use_cases/updates`
- `.venv/bin/python -m pytest -q apps/server/tests/use_cases/updates/test_update_preparation.py apps/server/tests/use_cases/updates/test_transport_coordinator.py apps/server/tests/use_cases/updates/wifi/test_wifi_session.py apps/server/tests/use_cases/updates/test_update_manager_async.py`

## Notes
- local Docker stack validation could not run in this environment because the Docker daemon socket is unavailable.