### PR TITLE
refactor: narrow report document API

### DIFF
--- a/apps/server/tests/adapters/pdf/test_i18n_separation.py
+++ b/apps/server/tests/adapters/pdf/test_i18n_separation.py
@@ -17,7 +17,8 @@ import pytest
 from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.report_i18n import is_i18n_ref, tr
 from vibesensor.report_i18n import resolve_i18n as resolve_i18n_impl
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 _TRANSLATED_MARKERS = [
     # Dutch markers

--- a/apps/server/tests/adapters/pdf/test_report_content_coverage.py
+++ b/apps/server/tests/adapters/pdf/test_report_content_coverage.py
@@ -23,6 +23,7 @@ from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.domain import Finding
 from vibesensor.shared.boundaries.finding import finding_from_payload
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
     AppendixCData,
@@ -37,7 +38,7 @@ from vibesensor.shared.boundaries.reporting.document import (
 )
 from vibesensor.shared.constants.units import KMH_TO_MPS
 from vibesensor.use_cases.diagnostics.top_cause_selection import select_top_causes
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 _I18N_JSON = SERVER_ROOT / "data" / "report_i18n.json"
 

--- a/apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py
+++ b/apps/server/tests/adapters/pdf/test_report_data_strength_db_source.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from test_support.report_helpers import minimal_summary
 
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 _ORDER_TOP_CAUSE: dict[str, object] = {
     "finding_id": "F_ORDER",

--- a/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
+++ b/apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py
@@ -107,5 +107,5 @@ def test_prepare_persisted_report_input_rejects_non_projectable_payload() -> Non
 
 
 def test_report_document_reexports_boundary_types() -> None:
-    assert report_document.PreparedReportInput is shared_reporting.PreparedReportInput
-    assert report_document.Report is shared_report_document.Report
+    assert not hasattr(report_document, "PreparedReportInput")
+    assert not hasattr(report_document, "Report")

--- a/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
+++ b/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
@@ -35,8 +35,9 @@ from test_support.sample_scenarios import (
 )
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 # ---------------------------------------------------------------------------
 # Type alias

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_mapping.py
@@ -21,12 +21,13 @@ from test_support.report_helpers import report_sample as _base_sample
 from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.domain import VibrationOrigin
 from vibesensor.shared.boundaries.finding import finding_from_payload
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.boundaries.vibration_origin import build_origin_explanation
 from vibesensor.use_cases.diagnostics.run_analysis import (
     summarize_origin,
 )
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 
 def _sample(

--- a/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
+++ b/apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py
@@ -31,12 +31,13 @@ from vibesensor.adapters.pdf.pdf_style import (
     build_page1_layout,
     observed_signature_row_count,
 )
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import (
     NextStep,
     ReportDocument,
     VerdictPageData,
 )
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 
 def _sample(

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -472,10 +472,8 @@ def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> No
     from test_support.report_helpers import minimal_summary
 
     from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-    from vibesensor.use_cases.history.report_document import (
-        build_report_document,
-        prepare_report_input,
-    )
+    from vibesensor.shared.boundaries.reporting import prepare_report_input
+    from vibesensor.use_cases.history.report_document import build_report_document
 
     summary = minimal_summary(
         lang="en",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
@@ -13,7 +13,8 @@ from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.pdf_diagram_render import car_location_diagram
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 pdfium = pytest.importorskip("pypdfium2")
 

--- a/apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
@@ -13,7 +13,8 @@ from test_support.report_helpers import write_jsonl
 
 from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 pdfium = pytest.importorskip("pypdfium2")
 RapidOCR = pytest.importorskip("rapidocr_onnxruntime").RapidOCR

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -25,9 +25,10 @@ from test_support.report_helpers import (
 from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.adapters.pdf.pdf_diagram_render import car_location_diagram
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.constants.units import KMH_TO_MPS
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 
 def test_report_pdf_uses_a4_portrait_media_box(tmp_path: Path) -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py
@@ -11,7 +11,8 @@ from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 pdfium = pytest.importorskip("pypdfium2")
 

--- a/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pipeline_audit.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from vibesensor.report_i18n import tr
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 from vibesensor.use_cases.history.report_document.presentation import (
     peak_classification_text as _peak_classification_text,
 )

--- a/apps/server/tests/adapters/pdf/test_report_scenario_output_regression.py
+++ b/apps/server/tests/adapters/pdf/test_report_scenario_output_regression.py
@@ -7,10 +7,11 @@ from test_support.sample_scenarios import build_speed_sweep_samples, make_sample
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.shared.boundaries.finding import finding_from_payload
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.constants.units import KMH_TO_MPS
 from vibesensor.use_cases.diagnostics._reference_findings import _reference_missing_finding
 from vibesensor.use_cases.diagnostics.top_cause_selection import select_top_causes
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 
 class TestPlotDataKeyFix:

--- a/apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py
+++ b/apps/server/tests/adapters/pdf/test_report_strength_label_peak_amp.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.adapters.pdf.pdf_drawing import _strength_with_peak
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 from vibesensor.use_cases.history.report_document.presentation import strength_text
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/adapters/pdf/test_report_summary_basics.py
+++ b/apps/server/tests/adapters/pdf/test_report_summary_basics.py
@@ -16,8 +16,9 @@ from test_support.report_helpers import (
 
 from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.constants.units import KMH_TO_MPS
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 
 def test_complete_run_has_speed_bins_findings_and_plots(tmp_path: Path) -> None:

--- a/apps/server/tests/adapters/pdf/test_report_tier_gating.py
+++ b/apps/server/tests/adapters/pdf/test_report_tier_gating.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import pytest
 
 from vibesensor.domain import ConfidenceAssessment
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 # ---------------------------------------------------------------------------
 # Unit tests: ConfidenceAssessment.assess().tier domain thresholds

--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -14,13 +14,13 @@ from vibesensor.domain import (
     TestPlan as DomainTestPlan,
 )
 from vibesensor.shared.boundaries.analysis_summary_projection import project_analysis_summary
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.projection import resolve_report_origin
 from vibesensor.shared.boundaries.test_plan_projection import step_payloads_from_plan
 from vibesensor.shared.boundaries.test_run_reconstruction import (
     test_run_from_summary as _test_run_from_summary,
 )
 from vibesensor.shared.boundaries.vibration_origin import origin_payload_from_finding
-from vibesensor.use_cases.history.report_document import prepare_report_input
 
 
 def _minimal_summary(**overrides: object) -> dict[str, object]:

--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -19,7 +19,7 @@ from vibesensor.domain import (
     SpeedSourceKind,
 )
 from vibesensor.shared.boundaries.finding import finding_from_payload
-from vibesensor.use_cases.history.report_document import Report
+from vibesensor.shared.boundaries.reporting.document import Report
 
 # ---------------------------------------------------------------------------
 # Phase 1: SpeedSource

--- a/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
+++ b/apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
@@ -8,7 +8,7 @@ def test_prepared_report_input_has_domain_aggregate() -> None:
     from test_support.findings import make_finding_payload
 
     from vibesensor.domain import TestRun
-    from vibesensor.use_cases.history.report_document import prepare_report_input
+    from vibesensor.shared.boundaries.reporting import prepare_report_input
 
     summary = {
         "run_id": "test-context",
@@ -80,10 +80,8 @@ def test_build_report_document_produces_report_with_domain_findings() -> None:
     """build_report_document must produce report data using domain-first pipeline."""
     from test_support.findings import make_finding_payload
 
-    from vibesensor.use_cases.history.report_document import (
-        build_report_document,
-        prepare_report_input,
-    )
+    from vibesensor.shared.boundaries.reporting import prepare_report_input
+    from vibesensor.use_cases.history.report_document import build_report_document
 
     summary = {
         "run_id": "test-map",
@@ -118,8 +116,8 @@ def test_report_mapping_business_functions_use_domain_objects() -> None:
 
     from vibesensor.domain import VibrationSource
     from vibesensor.report_i18n import tr
+    from vibesensor.shared.boundaries.reporting import prepare_report_input
     from vibesensor.use_cases.history.report_document import (
-        prepare_report_input,
         resolve_primary_report_candidate,
     )
 
@@ -162,7 +160,7 @@ def test_prepared_report_input_exposes_canonical_summary_boundary() -> None:
     """Prepared report inputs must expose explicit typed fields instead of raw dict state."""
     from test_support.findings import make_finding_payload
 
-    from vibesensor.use_cases.history.report_document import prepare_report_input
+    from vibesensor.shared.boundaries.reporting import prepare_report_input
 
     prepared = prepare_report_input(
         {

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -20,6 +20,7 @@ from vibesensor.adapters.analysis_summary import (
     analysis_result_to_summary,
     summarize_run_data,
 )
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.boundaries.run_metadata_codec import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frame_decoder import sensor_frames_from_mappings
@@ -27,7 +28,6 @@ from vibesensor.use_cases.diagnostics._run_input import build_diagnostics_run_in
 from vibesensor.use_cases.diagnostics.run_analysis import RunAnalysis
 from vibesensor.use_cases.history.report_document import (
     build_report_document,
-    prepare_report_input,
     resolve_primary_report_candidate,
 )
 

--- a/apps/server/tests/integration/test_decode_project_roundtrip.py
+++ b/apps/server/tests/integration/test_decode_project_roundtrip.py
@@ -27,13 +27,14 @@ from vibesensor.shared.boundaries.analysis_summary_projection import project_ana
 from vibesensor.shared.boundaries.persisted_analysis_codec import (
     persisted_analysis_to_json_object,
 )
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.boundaries.run_metadata_codec import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frame_decoder import sensor_frames_from_mappings
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.use_cases.diagnostics._run_input import build_diagnostics_run_input
 from vibesensor.use_cases.diagnostics.run_analysis import AnalysisResult, RunAnalysis
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 # -- helpers ---------------------------------------------------------------
 

--- a/apps/server/tests/integration/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/integration/test_io_and_time_guard_regressions.py
@@ -20,7 +20,8 @@ from test_support.gps import set_gps_snapshot_age
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.cli.report import main as report_cli_main
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 from vibesensor.use_cases.updates.firmware.firmware_cache import FirmwareCache
 from vibesensor.use_cases.updates.firmware.firmware_release_fetcher import GitHubReleaseFetcher
 from vibesensor.use_cases.updates.firmware.firmware_types import FirmwareCacheConfig

--- a/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
+++ b/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
@@ -20,8 +20,9 @@ from vibesensor.domain import TireSpec
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.registry import ClientRegistry
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.constants.units import KMH_TO_MPS
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
 _FRAME_N = 256

--- a/apps/server/tests/integration/test_report_pipeline.py
+++ b/apps/server/tests/integration/test_report_pipeline.py
@@ -41,7 +41,8 @@ from test_support import (
 )
 
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
@@ -17,12 +17,13 @@ from vibesensor.adapters.persistence.history_db import HistoryDB
 from vibesensor.shared.boundaries.persisted_analysis_codec import (
     persisted_analysis_to_json_object,
 )
+from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.run_log import normalize_sample_record
 from vibesensor.shared.boundaries.run_metadata_codec import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frame_encoder import sensor_frame_to_json_object
 from vibesensor.shared.sampling import bounded_sample
 from vibesensor.shared.types.run_schema import RunMetadata
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_report_pdf.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_report_pdf.py
@@ -13,7 +13,8 @@ from test_support import (
 )
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
-from vibesensor.use_cases.history.report_document import build_report_document, prepare_report_input
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
 
 
 class TestPdfContentForDiagnosedScenario:

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -4,7 +4,7 @@ import pytest
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
-from vibesensor.shared.boundaries.reporting import prepare_report_facts
+from vibesensor.shared.boundaries.reporting import prepare_report_facts, prepare_report_input
 from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
 from vibesensor.shared.boundaries.test_run_reconstruction import (
     test_run_from_summary as build_test_run_from_summary,
@@ -12,7 +12,6 @@ from vibesensor.shared.boundaries.test_run_reconstruction import (
 from vibesensor.shared.run_context_warning import RunContextWarning
 from vibesensor.use_cases.history.report_document import (
     compose_report_document_context,
-    prepare_report_input,
 )
 
 

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -5,9 +5,11 @@ import pytest
 from vibesensor.shared.boundaries.persisted_analysis_codec import (
     persisted_analysis_from_json_object,
 )
-from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
-from vibesensor.use_cases.history.report_document import (
+from vibesensor.shared.boundaries.reporting import (
+    prepare_persisted_report_input,
     prepare_report_input,
+)
+from vibesensor.use_cases.history.report_document import (
     resolve_primary_report_candidate,
 )
 

--- a/apps/server/vibesensor/use_cases/history/report_document/__init__.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/__init__.py
@@ -2,38 +2,20 @@
 
 from __future__ import annotations
 
-from vibesensor.shared.boundaries.reporting import (
-    PreparedReportInput,
-    prepare_persisted_report_input,
-    prepare_report_input,
-)
-from vibesensor.shared.boundaries.reporting.document import (
-    Report,
-    ReportDocument,
-    ReportDocumentContext,
-)
-
 from ._candidate_resolver import (
     PrimaryCandidateContext,
     resolve_primary_report_candidate,
 )
 from ._card_builder import build_system_cards, humanize_signatures
-from .builder import ReportDocumentBuilder, build_report_document, build_report_document_data
+from .builder import build_report_document, build_report_document_data
 from .composition import compose_report_document_context
 
 __all__ = [
-    "PreparedReportInput",
     "PrimaryCandidateContext",
-    "Report",
-    "ReportDocumentBuilder",
-    "ReportDocument",
-    "ReportDocumentContext",
     "build_system_cards",
     "humanize_signatures",
     "build_report_document",
     "build_report_document_data",
     "compose_report_document_context",
-    "prepare_persisted_report_input",
-    "prepare_report_input",
     "resolve_primary_report_candidate",
 ]

--- a/apps/server/vibesensor/use_cases/history/report_document/builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/builder.py
@@ -10,19 +10,7 @@ from vibesensor.shared.boundaries.reporting.document import (
 
 from .composition import compose_report_document_context
 
-__all__ = ["ReportDocumentBuilder", "build_report_document", "build_report_document_data"]
-
-
-class ReportDocumentBuilder:
-    """Build the canonical report document from one precomposed immutable context."""
-
-    __slots__ = ("_prepared",)
-
-    def __init__(self, prepared: PreparedReportInput) -> None:
-        self._prepared = prepared
-
-    def build(self) -> ReportDocument:
-        return build_report_document_data(compose_report_document_context(self._prepared))
+__all__ = ["build_report_document", "build_report_document_data"]
 
 
 def build_report_document_data(context: ReportDocumentContext) -> ReportDocument:
@@ -67,4 +55,4 @@ def build_report_document_data(context: ReportDocumentContext) -> ReportDocument
 def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
     """Build the canonical report document from prepared report input."""
 
-    return ReportDocumentBuilder(prepared).build()
+    return build_report_document_data(compose_report_document_context(prepared))


### PR DESCRIPTION
## Summary
- address issue 3 from the architecture ledger by narrowing `use_cases.history.report_document` to assembly-owned exports only
- remove report preparation and document-model re-exports so `shared.boundaries.reporting` is the sole preparation/model surface
- delete the `ReportDocumentBuilder` wrapper class and keep one direct build path from prepared input to document data

## Architectural simplifications
- `history.report_document` now owns composition/build helpers only instead of mixing boundary preparation and document models
- report preparation/model imports now come directly from `shared.boundaries.reporting` and `shared.boundaries.reporting.document`
- builder indirection is gone; `build_report_document()` maps directly through composition plus `build_report_document_data()`

## Removed transitional structures
- removed boundary prep/document-model aliases from `apps/server/vibesensor/use_cases/history/report_document/__init__.py`
- deleted the `ReportDocumentBuilder` class wrapper in `builder.py`

## Intentional incompatible changes
- internal report callers must import preparation/model types from the reporting boundary package instead of `use_cases.history.report_document`

## Local validation
- `.venv/bin/python -m pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf apps/server/tests/domain/test_domain_objects.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_report_pdf.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/integration/test_report_pipeline.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py`
- `make lint && make typecheck-backend && .venv/bin/python -m pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf apps/server/tests/domain/test_domain_objects.py apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_report_pdf.py apps/server/tests/integration/test_contract_analysis_report.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/integration/test_report_pipeline.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py`
