### PR TITLE
refactor: isolate OBD connection execution

### DIFF
--- a/apps/server/tests/adapters/obd/test_connection_executor.py
+++ b/apps/server/tests/adapters/obd/test_connection_executor.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from test_support.obd_runtime import (
+    FakeClock,
+    build_connected_obd_runtime_parts,
+    build_obd_runtime_parts,
+)
+
+from vibesensor.adapters.obd.connection_executor import ObdConnectionLoopState
+from vibesensor.adapters.obd.connection_plan import ObdConnectionStep, ObdConnectionStepKind
+from vibesensor.adapters.obd.elm327 import ObdTransportError
+
+
+@pytest.mark.asyncio
+async def test_executor_closes_replaced_session_before_returning_to_planning() -> None:
+    clock = FakeClock()
+    parts = build_connected_obd_runtime_parts(clock=clock)
+
+    state = ObdConnectionLoopState(
+        session=parts.session,
+        session_device_mac="00043e5a4a4d",
+        reconnect_delay_s=4.0,
+    )
+    next_state = await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(
+            kind=ObdConnectionStepKind.REPLACE_SESSION,
+            close_session=True,
+        ),
+    )
+
+    parts.session.close.assert_called_once_with()
+    assert next_state.session is None
+    assert next_state.session_device_mac is None
+    assert next_state.reconnect_delay_s == pytest.approx(4.0)
+
+
+@pytest.mark.asyncio
+async def test_executor_marks_disconnected_and_backs_off_after_connect_failure() -> None:
+    clock = FakeClock()
+    admin_client = MagicMock()
+    admin_client.device_info.side_effect = OSError("rfcomm busy")
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    parts = build_obd_runtime_parts(
+        clock=clock,
+        admin_client=admin_client,
+        sleep=record_sleep,
+    )
+    next_state = await parts.executor.execute(
+        state=ObdConnectionLoopState(reconnect_delay_s=2.0),
+        step=ObdConnectionStep(
+            kind=ObdConnectionStepKind.CONNECT,
+            mac_address="00043e5a4a4d",
+            configured_name="OBDLink MX+",
+        ),
+    )
+
+    status = parts.observation.status_snapshot()
+    assert sleeps == [2.0]
+    assert status.connection_state == "disconnected"
+    assert status.last_error == "rfcomm busy"
+    assert next_state.session is None
+    assert next_state.session_device_mac is None
+    assert next_state.reconnect_delay_s == pytest.approx(4.0)
+
+
+@pytest.mark.asyncio
+async def test_executor_closes_session_and_backs_off_after_poll_connection_loss() -> None:
+    clock = FakeClock()
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    parts = build_connected_obd_runtime_parts(clock=clock, sleep=record_sleep)
+
+    def request(command: str, *, timeout_s: float | None = None) -> str:
+        del command, timeout_s
+        raise ObdTransportError("Session is not connected")
+
+    parts.session.request.side_effect = request
+
+    next_state = await parts.executor.execute(
+        state=ObdConnectionLoopState(
+            session=parts.session,
+            session_device_mac="00043e5a4a4d",
+            reconnect_delay_s=4.0,
+        ),
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
+
+    status = parts.observation.status_snapshot()
+    parts.session.close.assert_called_once_with()
+    assert sleeps == [4.0]
+    assert status.connection_state == "disconnected"
+    assert status.last_error == "PID 010C request failed: Session is not connected"
+    assert next_state.session is None
+    assert next_state.session_device_mac is None
+    assert next_state.reconnect_delay_s == pytest.approx(8.0)

--- a/apps/server/tests/adapters/obd/test_runtime_services.py
+++ b/apps/server/tests/adapters/obd/test_runtime_services.py
@@ -1,110 +1,24 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
+from test_support.obd_runtime import (
+    FakeClock as _FakeClock,
+)
+from test_support.obd_runtime import (
+    build_connected_obd_runtime_parts as _connected_runtime_parts,
+)
+from test_support.obd_runtime import (
+    build_obd_runtime_parts as _build_runtime_parts,
+)
 
 from vibesensor.adapters.http.obd_status_presentation import obd_debug_hint
-from vibesensor.adapters.obd.admin_runtime import ObdAdminRuntime
-from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
 from vibesensor.adapters.obd.elm327 import ObdTransportError
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.polling import ObdPidFailureKind, ObdPidPollResult, ObdPollResult
-from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
-from vibesensor.adapters.obd.runtime_observation import ObdRuntimeObservation
-from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
-from vibesensor.adapters.obd.runtime_store import ObdRuntimeStore
 from vibesensor.shared.operational_errors import ExternalCommandError
-
-
-class _FakeClock:
-    def __init__(self, now: float = 0.0) -> None:
-        self.now = now
-
-    def __call__(self) -> float:
-        return self.now
-
-    def advance(self, seconds: float) -> None:
-        self.now += seconds
-
-
-@dataclass(slots=True)
-class _RuntimeParts:
-    store: ObdRuntimeStore
-    observation: ObdRuntimeObservation
-    settings: ObdRuntimeSettings
-    connection_state: ObdRuntimeConnectionState
-    admin: ObdAdminRuntime
-    runner: ObdConnectionRuntime
-    session: MagicMock
-    admin_client: MagicMock
-
-
-def _build_runtime_parts(
-    *,
-    clock: Callable[[], float],
-    admin_client: MagicMock | None = None,
-    session: MagicMock | None = None,
-) -> _RuntimeParts:
-    admin = MagicMock() if admin_client is None else admin_client
-    if admin_client is None:
-        admin.device_info.return_value = ObdDeviceSnapshot(
-            mac_address="00043e5a4a4d",
-            name="OBDLink MX+",
-            paired=True,
-            trusted=True,
-            connected=False,
-            rfcomm_channel=1,
-        )
-    resolved_session = MagicMock() if session is None else session
-    store = ObdRuntimeStore(
-        monotonic=clock,
-        poll_interval_s=0.75,
-        initial_reconnect_delay_s=1.0,
-        engine_rpm_stale_timeout_s=2.0,
-    )
-    connection_state = ObdRuntimeConnectionState(store=store)
-    return _RuntimeParts(
-        store=store,
-        observation=ObdRuntimeObservation(store=store),
-        settings=ObdRuntimeSettings(store=store),
-        connection_state=connection_state,
-        admin=ObdAdminRuntime(
-            admin_client=admin,
-            connection_state=connection_state,
-        ),
-        runner=ObdConnectionRuntime(
-            admin_client=admin,
-            connection_state=connection_state,
-            session_factory=lambda: resolved_session,
-            monotonic=clock,
-        ),
-        session=resolved_session,
-        admin_client=admin,
-    )
-
-
-def _connected_runtime_parts(
-    *,
-    clock: Callable[[], float],
-    admin_client: MagicMock | None = None,
-    session: MagicMock | None = None,
-) -> _RuntimeParts:
-    parts = _build_runtime_parts(clock=clock, admin_client=admin_client, session=session)
-    parts.settings.apply_speed_source_settings(
-        effective_speed_kmh=None,
-        manual_source_selected=False,
-        stale_timeout_s=5.0,
-        selected_source="obd2",
-        obd_device_mac="00043e5a4a4d",
-        obd_device_name="OBDLink MX+",
-    )
-    _, device = parts.runner._connect_blocking("00043e5a4a4d", "OBDLink MX+")
-    parts.connection_state.mark_connected(device)
-    return parts
 
 
 def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -> None:
@@ -129,9 +43,9 @@ def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -
 
     parts.session.request.side_effect = request
 
-    parts.connection_state.apply_poll_cycle(parts.runner._poll_cycle_blocking(parts.session))
+    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
     clock.now = started_at + 0.05
-    parts.connection_state.apply_poll_cycle(parts.runner._poll_cycle_blocking(parts.session))
+    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.2)]
     assert parts.observation.resolve_speed().source == "obd2"
@@ -168,9 +82,9 @@ def test_obd_observation_keeps_last_good_rpm_until_the_reference_goes_stale() ->
 
     parts.session.request.side_effect = request
 
-    parts.connection_state.apply_poll_cycle(parts.runner._poll_cycle_blocking(parts.session))
+    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
     clock.now = 0.05
-    parts.connection_state.apply_poll_cycle(parts.runner._poll_cycle_blocking(parts.session))
+    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
 
     assert parts.observation.engine_rpm == pytest.approx(0x1AF8 / 4.0)
     clock.now = 1.99
@@ -202,8 +116,8 @@ def test_obd_connection_state_backs_off_and_stays_in_rpm_only_mode_when_speed_ti
 
     parts.session.request.side_effect = request
 
-    parts.connection_state.apply_poll_cycle(parts.runner._poll_cycle_blocking(parts.session))
-    parts.connection_state.apply_poll_cycle(parts.runner._poll_cycle_blocking(parts.session))
+    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.3)]
     status = parts.observation.status_snapshot()
@@ -314,7 +228,7 @@ def test_connect_blocking_closes_session_and_propagates_transport_error() -> Non
     parts = _build_runtime_parts(clock=clock, admin_client=admin_client, session=session)
 
     with pytest.raises(ObdTransportError, match="no prompt from adapter"):
-        parts.runner._connect_blocking("00043e5a4a4d", "OBDLink MX+")
+        parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
 
     session.close.assert_called_once_with()
 
@@ -345,6 +259,6 @@ def test_connect_blocking_closes_session_and_propagates_unexpected_runtime_error
     parts = _build_runtime_parts(clock=clock, admin_client=admin_client, session=session)
 
     with pytest.raises(RuntimeError, match="session bug"):
-        parts.runner._connect_blocking("00043e5a4a4d", "OBDLink MX+")
+        parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
 
     session.close.assert_called_once_with()

--- a/apps/server/tests/test_support/obd_runtime.py
+++ b/apps/server/tests/test_support/obd_runtime.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+from vibesensor.adapters.obd.admin_runtime import ObdAdminRuntime
+from vibesensor.adapters.obd.connection_executor import ObdConnectionExecutor
+from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
+from vibesensor.adapters.obd.models import ObdDeviceSnapshot
+from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
+from vibesensor.adapters.obd.runtime_observation import ObdRuntimeObservation
+from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
+from vibesensor.adapters.obd.runtime_store import ObdRuntimeStore
+
+
+class FakeClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@dataclass(slots=True)
+class ObdRuntimeParts:
+    store: ObdRuntimeStore
+    observation: ObdRuntimeObservation
+    settings: ObdRuntimeSettings
+    connection_state: ObdRuntimeConnectionState
+    admin: ObdAdminRuntime
+    executor: ObdConnectionExecutor
+    runner: ObdConnectionRuntime
+    session: MagicMock
+    admin_client: MagicMock
+
+
+def build_obd_runtime_parts(
+    *,
+    clock: Callable[[], float],
+    admin_client: MagicMock | None = None,
+    session: MagicMock | None = None,
+    sleep: Callable[[float], Awaitable[object]] | None = None,
+) -> ObdRuntimeParts:
+    admin = MagicMock() if admin_client is None else admin_client
+    if admin_client is None:
+        admin.device_info.return_value = ObdDeviceSnapshot(
+            mac_address="00043e5a4a4d",
+            name="OBDLink MX+",
+            paired=True,
+            trusted=True,
+            connected=False,
+            rfcomm_channel=1,
+        )
+    resolved_session = MagicMock() if session is None else session
+    store = ObdRuntimeStore(
+        monotonic=clock,
+        poll_interval_s=0.75,
+        initial_reconnect_delay_s=1.0,
+        engine_rpm_stale_timeout_s=2.0,
+    )
+    connection_state = ObdRuntimeConnectionState(store=store)
+    executor = ObdConnectionExecutor(
+        admin_client=admin,
+        connection_state=connection_state,
+        session_factory=lambda: resolved_session,
+        monotonic=clock,
+        **({} if sleep is None else {"sleep": sleep}),
+    )
+    runner = ObdConnectionRuntime(
+        admin_client=admin,
+        connection_state=connection_state,
+        session_factory=lambda: resolved_session,
+        monotonic=clock,
+    )
+    return ObdRuntimeParts(
+        store=store,
+        observation=ObdRuntimeObservation(store=store),
+        settings=ObdRuntimeSettings(store=store),
+        connection_state=connection_state,
+        admin=ObdAdminRuntime(
+            admin_client=admin,
+            connection_state=connection_state,
+        ),
+        executor=executor,
+        runner=runner,
+        session=resolved_session,
+        admin_client=admin,
+    )
+
+
+def build_connected_obd_runtime_parts(
+    *,
+    clock: Callable[[], float],
+    admin_client: MagicMock | None = None,
+    session: MagicMock | None = None,
+    sleep: Callable[[float], Awaitable[object]] | None = None,
+) -> ObdRuntimeParts:
+    parts = build_obd_runtime_parts(
+        clock=clock,
+        admin_client=admin_client,
+        session=session,
+        sleep=sleep,
+    )
+    parts.settings.apply_speed_source_settings(
+        effective_speed_kmh=None,
+        manual_source_selected=False,
+        stale_timeout_s=5.0,
+        selected_source="obd2",
+        obd_device_mac="00043e5a4a4d",
+        obd_device_name="OBDLink MX+",
+    )
+    _, device = parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
+    parts.connection_state.mark_connected(device)
+    return parts

--- a/apps/server/vibesensor/adapters/obd/connection_executor.py
+++ b/apps/server/vibesensor/adapters/obd/connection_executor.py
@@ -1,0 +1,222 @@
+"""Step execution and fault boundaries for Bluetooth OBD connection control."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+
+from vibesensor.adapters.obd.admin_client import ObdAdminClient
+from vibesensor.adapters.obd.connection_plan import ObdConnectionStep, ObdConnectionStepKind
+from vibesensor.adapters.obd.elm327 import Elm327Session, ObdTransportError
+from vibesensor.adapters.obd.models import ObdDeviceSnapshot
+from vibesensor.adapters.obd.polling import ObdPollResult, execute_poll_plan
+from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
+from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
+
+__all__ = ["ObdConnectionExecutor", "ObdConnectionLoopState"]
+
+_INITIAL_RECONNECT_DELAY_S = 1.0
+_MAX_RECONNECT_DELAY_S = 30.0
+
+SessionFactory = Callable[[], Elm327Session]
+MonotonicFn = Callable[[], float]
+SleepFn = Callable[[float], Awaitable[object]]
+
+
+@dataclass(frozen=True, slots=True)
+class ObdConnectionLoopState:
+    session: Elm327Session | None = None
+    session_device_mac: str | None = None
+    reconnect_delay_s: float = _INITIAL_RECONNECT_DELAY_S
+
+
+class ObdConnectionExecutor:
+    """Own step-specific connection behavior and its operational fault boundaries."""
+
+    __slots__ = (
+        "_admin_client",
+        "_connection_state",
+        "_monotonic",
+        "_session_factory",
+        "_sleep",
+    )
+
+    def __init__(
+        self,
+        *,
+        admin_client: ObdAdminClient,
+        connection_state: ObdRuntimeConnectionState,
+        session_factory: SessionFactory,
+        monotonic: MonotonicFn = time.monotonic,
+        sleep: SleepFn = asyncio.sleep,
+    ) -> None:
+        self._admin_client = admin_client
+        self._connection_state = connection_state
+        self._session_factory = session_factory
+        self._monotonic = monotonic
+        self._sleep = sleep
+
+    async def execute(
+        self,
+        *,
+        state: ObdConnectionLoopState,
+        step: ObdConnectionStep,
+    ) -> ObdConnectionLoopState:
+        resolved_state = await self._close_session_if_needed(
+            state=state,
+            close_session=step.close_session,
+        )
+        if step.kind is ObdConnectionStepKind.IDLE:
+            return await self._run_idle_step(state=resolved_state, sleep_s=step.sleep_s)
+        if step.kind is ObdConnectionStepKind.MISSING_CONFIG:
+            return await self._run_missing_config_step(
+                state=resolved_state,
+                error=step.error,
+                sleep_s=step.sleep_s,
+            )
+        if step.kind is ObdConnectionStepKind.REPLACE_SESSION:
+            return resolved_state
+        if step.kind is ObdConnectionStepKind.CONNECT:
+            if step.mac_address is None:
+                raise RuntimeError("CONNECT step requires a configured OBD adapter MAC address")
+            return await self._run_connect_step(
+                state=resolved_state,
+                mac_address=step.mac_address,
+                configured_name=step.configured_name,
+            )
+        if step.kind is ObdConnectionStepKind.WAIT:
+            return await self._run_wait_step(state=resolved_state, sleep_s=step.sleep_s)
+        if resolved_state.session is None:
+            raise RuntimeError("POLL step requires an active OBD session")
+        return await self._run_poll_step(state=resolved_state)
+
+    async def close(self, *, state: ObdConnectionLoopState) -> ObdConnectionLoopState:
+        return await self._close_session_if_needed(state=state, close_session=True)
+
+    async def _run_idle_step(
+        self,
+        *,
+        state: ObdConnectionLoopState,
+        sleep_s: float,
+    ) -> ObdConnectionLoopState:
+        await self._sleep(sleep_s)
+        return replace(state, reconnect_delay_s=_INITIAL_RECONNECT_DELAY_S)
+
+    async def _run_missing_config_step(
+        self,
+        *,
+        state: ObdConnectionLoopState,
+        error: str | None,
+        sleep_s: float,
+    ) -> ObdConnectionLoopState:
+        self._connection_state.mark_disconnected(error=error)
+        await self._sleep(sleep_s)
+        return replace(state, reconnect_delay_s=_INITIAL_RECONNECT_DELAY_S)
+
+    async def _run_connect_step(
+        self,
+        *,
+        state: ObdConnectionLoopState,
+        mac_address: str,
+        configured_name: str | None,
+    ) -> ObdConnectionLoopState:
+        self._connection_state.mark_connecting()
+        try:
+            session, device = await asyncio.to_thread(
+                self._connect_blocking,
+                mac_address,
+                configured_name,
+            )
+        except (OperationalError, OSError, ObdTransportError) as exc:
+            self._connection_state.mark_disconnected(
+                error=str(exc),
+                reconnect_delay_s=state.reconnect_delay_s,
+            )
+            await self._sleep(state.reconnect_delay_s)
+            return replace(
+                state,
+                reconnect_delay_s=self._next_reconnect_delay(state.reconnect_delay_s),
+            )
+        self._connection_state.mark_connected(device)
+        return ObdConnectionLoopState(
+            session=session,
+            session_device_mac=device.mac_address,
+            reconnect_delay_s=_INITIAL_RECONNECT_DELAY_S,
+        )
+
+    async def _run_wait_step(
+        self,
+        *,
+        state: ObdConnectionLoopState,
+        sleep_s: float,
+    ) -> ObdConnectionLoopState:
+        await self._sleep(sleep_s)
+        return state
+
+    async def _run_poll_step(self, *, state: ObdConnectionLoopState) -> ObdConnectionLoopState:
+        assert state.session is not None
+        poll_result = await asyncio.to_thread(self._poll_cycle_blocking, state.session)
+        connection_lost = self._connection_state.apply_poll_cycle(
+            poll_result,
+            reconnect_delay_s=state.reconnect_delay_s,
+        )
+        if not connection_lost:
+            return state
+        closed_state = await self._close_session_if_needed(state=state, close_session=True)
+        await self._sleep(state.reconnect_delay_s)
+        return replace(
+            closed_state,
+            reconnect_delay_s=self._next_reconnect_delay(state.reconnect_delay_s),
+        )
+
+    def _connect_blocking(
+        self,
+        mac_address: str,
+        configured_name: str | None,
+    ) -> tuple[Elm327Session, ObdDeviceSnapshot]:
+        info = self._admin_client.device_info(mac_address)
+        if not info.paired:
+            raise ServiceUnavailableError("Configured OBD adapter is not paired")
+        if not info.trusted:
+            raise ServiceUnavailableError("Configured OBD adapter is not trusted")
+        if info.rfcomm_channel is None:
+            raise ServiceUnavailableError("Bluetooth OBD adapter exposes no RFCOMM serial channel")
+        session = self._session_factory()
+        session.connect(mac_address, info.rfcomm_channel)
+        self._initialize_session(session)
+        device = replace(
+            info,
+            name=info.name or configured_name,
+            connected=True,
+        )
+        return session, device
+
+    def _initialize_session(self, session: Elm327Session) -> None:
+        initialized = False
+        try:
+            session.initialize()
+            initialized = True
+        finally:
+            if not initialized:
+                session.close()
+
+    def _poll_cycle_blocking(self, session: Elm327Session) -> ObdPollResult:
+        plan = self._connection_state.prepare_poll()
+        return execute_poll_plan(session, plan=plan, monotonic=self._monotonic)
+
+    async def _close_session_if_needed(
+        self,
+        *,
+        state: ObdConnectionLoopState,
+        close_session: bool,
+    ) -> ObdConnectionLoopState:
+        if close_session and state.session is not None:
+            await asyncio.to_thread(state.session.close)
+            return replace(state, session=None, session_device_mac=None)
+        return state
+
+    @staticmethod
+    def _next_reconnect_delay(reconnect_delay_s: float) -> float:
+        return min(reconnect_delay_s * 2.0, _MAX_RECONNECT_DELAY_S)

--- a/apps/server/vibesensor/adapters/obd/connection_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/connection_runtime.py
@@ -5,25 +5,22 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
-from dataclasses import replace
 
 from vibesensor.adapters.obd.admin_client import ObdAdminClient
+from vibesensor.adapters.obd.connection_executor import (
+    ObdConnectionExecutor,
+    ObdConnectionLoopState,
+)
 from vibesensor.adapters.obd.connection_plan import (
     ObdConnectionLoopSnapshot,
     ObdConnectionStep,
-    ObdConnectionStepKind,
     plan_connection_step,
 )
-from vibesensor.adapters.obd.elm327 import Elm327Session, ObdTransportError
-from vibesensor.adapters.obd.models import ObdDeviceSnapshot
-from vibesensor.adapters.obd.polling import ObdPollResult, execute_poll_plan
+from vibesensor.adapters.obd.elm327 import Elm327Session
 from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
-from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
 
 __all__ = ["ObdConnectionRuntime"]
 
-_INITIAL_RECONNECT_DELAY_S = 1.0
-_MAX_RECONNECT_DELAY_S = 30.0
 _IDLE_POLL_S = 1.0
 
 SessionFactory = Callable[[], Elm327Session]
@@ -34,10 +31,8 @@ class ObdConnectionRuntime:
     """Own session lifecycle, reconnect behavior, and blocking poll execution."""
 
     __slots__ = (
-        "_admin_client",
         "_connection_state",
-        "_monotonic",
-        "_session_factory",
+        "_executor",
     )
 
     def __init__(
@@ -48,78 +43,28 @@ class ObdConnectionRuntime:
         session_factory: SessionFactory,
         monotonic: MonotonicFn = time.monotonic,
     ) -> None:
-        self._admin_client = admin_client
         self._connection_state = connection_state
-        self._session_factory = session_factory
-        self._monotonic = monotonic
+        self._executor = ObdConnectionExecutor(
+            admin_client=admin_client,
+            connection_state=connection_state,
+            session_factory=session_factory,
+            monotonic=monotonic,
+        )
 
     async def run(self) -> None:
-        session: Elm327Session | None = None
-        session_device_mac: str | None = None
-        reconnect_delay = _INITIAL_RECONNECT_DELAY_S
+        state = ObdConnectionLoopState()
         try:
             while True:
                 step = self._plan_loop_step(
-                    session=session,
-                    session_device_mac=session_device_mac,
+                    session=state.session,
+                    session_device_mac=state.session_device_mac,
                 )
-                session, session_device_mac = await self._close_session_if_needed(
-                    session=session,
-                    session_device_mac=session_device_mac,
-                    close_session=step.close_session,
+                state = await self._executor.execute(
+                    state=state,
+                    step=step,
                 )
-                if step.kind is ObdConnectionStepKind.IDLE:
-                    reconnect_delay = _INITIAL_RECONNECT_DELAY_S
-                    await asyncio.sleep(step.sleep_s)
-                    continue
-                if step.kind is ObdConnectionStepKind.MISSING_CONFIG:
-                    self._connection_state.mark_disconnected(
-                        error=step.error,
-                    )
-                    reconnect_delay = _INITIAL_RECONNECT_DELAY_S
-                    await asyncio.sleep(step.sleep_s)
-                    continue
-                if step.kind is ObdConnectionStepKind.REPLACE_SESSION:
-                    continue
-                if step.kind is ObdConnectionStepKind.CONNECT:
-                    assert step.mac_address is not None
-                    self._connection_state.mark_connecting()
-                    try:
-                        session, device = await asyncio.to_thread(
-                            self._connect_blocking,
-                            step.mac_address,
-                            step.configured_name,
-                        )
-                    except (OperationalError, OSError, ObdTransportError) as exc:
-                        self._connection_state.mark_disconnected(
-                            error=str(exc),
-                            reconnect_delay_s=reconnect_delay,
-                        )
-                        await asyncio.sleep(reconnect_delay)
-                        reconnect_delay = min(reconnect_delay * 2.0, _MAX_RECONNECT_DELAY_S)
-                        continue
-                    session_device_mac = device.mac_address
-                    reconnect_delay = _INITIAL_RECONNECT_DELAY_S
-                    self._connection_state.mark_connected(device)
-                    continue
-                if step.kind is ObdConnectionStepKind.WAIT:
-                    await asyncio.sleep(step.sleep_s)
-                    continue
-                assert session is not None
-                poll_result = await asyncio.to_thread(self._poll_cycle_blocking, session)
-                connection_lost = self._connection_state.apply_poll_cycle(
-                    poll_result,
-                    reconnect_delay_s=reconnect_delay,
-                )
-                if connection_lost:
-                    await asyncio.to_thread(session.close)
-                    session = None
-                    session_device_mac = None
-                    await asyncio.sleep(reconnect_delay)
-                    reconnect_delay = min(reconnect_delay * 2.0, _MAX_RECONNECT_DELAY_S)
         except asyncio.CancelledError:
-            if session is not None:
-                await asyncio.to_thread(session.close)
+            await self._executor.close(state=state)
             raise
 
     def _plan_loop_step(
@@ -144,50 +89,3 @@ class ObdConnectionRuntime:
             ),
             idle_poll_s=_IDLE_POLL_S,
         )
-
-    def _connect_blocking(
-        self,
-        mac_address: str,
-        configured_name: str | None,
-    ) -> tuple[Elm327Session, ObdDeviceSnapshot]:
-        info = self._admin_client.device_info(mac_address)
-        if not info.paired:
-            raise ServiceUnavailableError("Configured OBD adapter is not paired")
-        if not info.trusted:
-            raise ServiceUnavailableError("Configured OBD adapter is not trusted")
-        if info.rfcomm_channel is None:
-            raise ServiceUnavailableError("Bluetooth OBD adapter exposes no RFCOMM serial channel")
-        session = self._session_factory()
-        session.connect(mac_address, info.rfcomm_channel)
-        self._initialize_session(session)
-        device = replace(
-            info,
-            name=info.name or configured_name,
-            connected=True,
-        )
-        return session, device
-
-    def _initialize_session(self, session: Elm327Session) -> None:
-        initialized = False
-        try:
-            session.initialize()
-            initialized = True
-        finally:
-            if not initialized:
-                session.close()
-
-    def _poll_cycle_blocking(self, session: Elm327Session) -> ObdPollResult:
-        plan = self._connection_state.prepare_poll()
-        return execute_poll_plan(session, plan=plan, monotonic=self._monotonic)
-
-    async def _close_session_if_needed(
-        self,
-        *,
-        session: Elm327Session | None,
-        session_device_mac: str | None,
-        close_session: bool,
-    ) -> tuple[Elm327Session | None, str | None]:
-        if close_session and session is not None:
-            await asyncio.to_thread(session.close)
-            return None, None
-        return session, session_device_mac


### PR DESCRIPTION
## Summary
- addresses issue ledger item 6: OBD connection runtime still owns too much loop control and fault handling
- adds `connection_executor.py` so connect, poll, close, and backoff execution no longer live inline in `connection_runtime.run()`
- narrows `connection_runtime.py` to loop planning plus executor dispatch
- adds focused connection-executor tests and shared OBD test support for the new seam

## Architectural simplifications
- planning remains in `connection_plan.py` and `connection_runtime.py`; step execution now lives in `connection_executor.py`
- connect-step and poll-step fault handling now have explicit per-step boundaries instead of one branching loop body
- cancellation cleanup flows through the same executor close path as session replacement and poll-loss cleanup

## Intentional breaking changes
- internal OBD loop execution helpers move off `ObdConnectionRuntime` and onto the executor boundary used by tests

## Local validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/obd/test_runtime_services.py apps/server/tests/adapters/obd/test_connection_executor.py apps/server/tests/adapters/obd/test_connection_plan.py`
- `make lint && make typecheck-backend && .venv/bin/python -m pytest -q apps/server/tests/adapters/obd apps/server/tests/adapters/speed apps/server/tests/adapters/http/test_settings_obd_endpoints.py apps/server/tests/adapters/websocket/test_build_ws_payload.py apps/server/tests/infra/runtime`
