### PR TITLE
refactor: split OBD admin seams

### DIFF
--- a/apps/server/tests/adapters/speed/test_speed_services.py
+++ b/apps/server/tests/adapters/speed/test_speed_services.py
@@ -71,12 +71,14 @@ def test_observation_service_switches_to_obd_status_and_resolution() -> None:
     obd_observation.resolve_speed.return_value = SpeedResolution(12.0, False, "obd2")
     obd_observation.status_snapshot.return_value = _obd_status_snapshot()
     obd_observation.stale_timeout_s = 8.0
-    obd_admin = MagicMock()
+    obd_device_admin = MagicMock()
+    obd_status_refresher = MagicMock()
     obd_control = MagicMock()
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
         obd_observation=obd_observation,
-        obd_admin=obd_admin,
+        obd_device_admin=obd_device_admin,
+        obd_status_refresher=obd_status_refresher,
         obd_control=obd_control,
     )
 
@@ -96,7 +98,7 @@ def test_observation_service_switches_to_obd_status_and_resolution() -> None:
     assert status.device == "OBDLink MX+ (00043e5a4a4d)"
     assert status.raw_speed_kmh == pytest.approx(43.2)
     assert status.speed_source == "obd2"
-    obd_admin.refresh_configured_device.assert_not_called()
+    obd_status_refresher.refresh_configured_device.assert_not_called()
     obd_observation.status_snapshot.assert_called_once_with()
 
 
@@ -108,7 +110,8 @@ def test_observation_service_obd_status_is_side_effect_free() -> None:
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
         obd_observation=obd_observation,
-        obd_admin=MagicMock(),
+        obd_device_admin=MagicMock(),
+        obd_status_refresher=MagicMock(),
         obd_control=MagicMock(),
     )
 
@@ -129,22 +132,23 @@ def test_observation_service_obd_status_is_side_effect_free() -> None:
 
 def test_admin_service_refreshes_obd_status_explicitly() -> None:
     gps_monitor = MagicMock()
-    obd_admin = MagicMock()
+    obd_status_refresher = MagicMock()
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
         obd_observation=MagicMock(),
-        obd_admin=obd_admin,
+        obd_device_admin=MagicMock(),
+        obd_status_refresher=obd_status_refresher,
         obd_control=MagicMock(),
     )
 
     services.admin.refresh_obd_status()
 
-    obd_admin.refresh_configured_device.assert_called_once_with()
+    obd_status_refresher.refresh_configured_device.assert_called_once_with()
 
 
-def test_admin_service_delegates_scan_and_pair_to_obd_admin_runtime() -> None:
+def test_admin_service_delegates_scan_and_pair_to_obd_device_admin() -> None:
     gps_monitor = MagicMock()
-    obd_admin = MagicMock()
+    obd_device_admin = MagicMock()
     device = ObdDeviceSnapshot(
         mac_address="00043e5a4a4d",
         name="OBDLink MX+",
@@ -153,12 +157,13 @@ def test_admin_service_delegates_scan_and_pair_to_obd_admin_runtime() -> None:
         connected=False,
         rfcomm_channel=1,
     )
-    obd_admin.scan_devices.return_value = [device]
-    obd_admin.pair_device.return_value = device
+    obd_device_admin.scan_devices.return_value = [device]
+    obd_device_admin.pair_device.return_value = device
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
         obd_observation=MagicMock(),
-        obd_admin=obd_admin,
+        obd_device_admin=obd_device_admin,
+        obd_status_refresher=MagicMock(),
         obd_control=MagicMock(),
     )
 
@@ -167,5 +172,5 @@ def test_admin_service_delegates_scan_and_pair_to_obd_admin_runtime() -> None:
 
     assert scanned == [device]
     assert paired == device
-    obd_admin.scan_devices.assert_called_once_with(timeout_s=8)
-    obd_admin.pair_device.assert_called_once_with("00043e5a4a4d")
+    obd_device_admin.scan_devices.assert_called_once_with(timeout_s=8)
+    obd_device_admin.pair_device.assert_called_once_with("00043e5a4a4d")

--- a/apps/server/vibesensor/adapters/obd/admin_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/admin_runtime.py
@@ -1,17 +1,16 @@
-"""Admin-side observation and control for Bluetooth OBD monitoring."""
+"""Configured-device OBD admin observation over runtime state."""
 
 from __future__ import annotations
 
 from vibesensor.adapters.obd.admin_client import ObdAdminClient
 from vibesensor.adapters.obd.admin_state import observe_configured_obd_device
-from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
 
 __all__ = ["ObdAdminRuntime"]
 
 
 class ObdAdminRuntime:
-    """Own privileged OBD admin actions separately from live connection control."""
+    """Refresh configured-device admin state without exposing raw client actions."""
 
     __slots__ = ("_admin_client", "_runtime")
 
@@ -23,12 +22,6 @@ class ObdAdminRuntime:
     ) -> None:
         self._admin_client = admin_client
         self._runtime = connection_state
-
-    def scan_devices(self, *, timeout_s: int = 8) -> list[ObdDeviceSnapshot]:
-        return self._admin_client.scan_devices(timeout_s=timeout_s)
-
-    def pair_device(self, mac_address: str) -> ObdDeviceSnapshot:
-        return self._admin_client.pair_device(mac_address)
 
     def refresh_configured_device(self) -> None:
         configured_mac = self._runtime.configured_device_mac_snapshot()

--- a/apps/server/vibesensor/adapters/speed/source_coordinator.py
+++ b/apps/server/vibesensor/adapters/speed/source_coordinator.py
@@ -42,11 +42,13 @@ class ObdObservation(Protocol):
     def status_snapshot(self) -> ObdStatusSnapshot: ...
 
 
-class ObdAdmin(Protocol):
+class ObdDeviceAdmin(Protocol):
     def scan_devices(self, *, timeout_s: int = ...) -> list[ObdDeviceSnapshot]: ...
 
     def pair_device(self, mac_address: str) -> ObdDeviceSnapshot: ...
 
+
+class ObdConfiguredDeviceRefresher(Protocol):
     def refresh_configured_device(self) -> None: ...
 
 
@@ -153,19 +155,25 @@ class SpeedSourceObservationService:
 class SpeedSourceAdminService:
     """Admin-only Bluetooth OBD actions."""
 
-    __slots__ = ("_obd_admin",)
+    __slots__ = ("_obd_device_admin", "_obd_status_refresher")
 
-    def __init__(self, *, obd_admin: ObdAdmin) -> None:
-        self._obd_admin = obd_admin
+    def __init__(
+        self,
+        *,
+        obd_device_admin: ObdDeviceAdmin,
+        obd_status_refresher: ObdConfiguredDeviceRefresher,
+    ) -> None:
+        self._obd_device_admin = obd_device_admin
+        self._obd_status_refresher = obd_status_refresher
 
     def scan_obd_devices(self, *, timeout_s: int = 8) -> list[ObdDeviceSnapshot]:
-        return self._obd_admin.scan_devices(timeout_s=timeout_s)
+        return self._obd_device_admin.scan_devices(timeout_s=timeout_s)
 
     def pair_obd_device(self, mac_address: str) -> ObdDeviceSnapshot:
-        return self._obd_admin.pair_device(mac_address)
+        return self._obd_device_admin.pair_device(mac_address)
 
     def refresh_obd_status(self) -> None:
-        self._obd_admin.refresh_configured_device()
+        self._obd_status_refresher.refresh_configured_device()
 
 
 class SpeedSourceControlService:
@@ -244,7 +252,8 @@ def build_speed_source_services(
     *,
     gps_monitor: GPSSpeedMonitor,
     obd_observation: ObdObservation,
-    obd_admin: ObdAdmin,
+    obd_device_admin: ObdDeviceAdmin,
+    obd_status_refresher: ObdConfiguredDeviceRefresher,
     obd_control: SpeedSourceSync,
 ) -> SpeedSourceServices:
     selected_source = _SelectedSourceState()
@@ -254,7 +263,10 @@ def build_speed_source_services(
             obd_observation=obd_observation,
             selected_source=selected_source,
         ),
-        admin=SpeedSourceAdminService(obd_admin=obd_admin),
+        admin=SpeedSourceAdminService(
+            obd_device_admin=obd_device_admin,
+            obd_status_refresher=obd_status_refresher,
+        ),
         control=SpeedSourceControlService(
             gps_monitor=gps_monitor,
             obd_control=obd_control,

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -141,7 +141,8 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     speed_services = build_speed_source_services(
         gps_monitor=gps_monitor,
         obd_observation=obd_runtime.observation,
-        obd_admin=obd_runtime.admin,
+        obd_device_admin=obd_admin_client,
+        obd_status_refresher=obd_runtime.admin,
         obd_control=obd_runtime.control,
     )
     settings_store = SettingsStore(db=history.settings_snapshot_repository)


### PR DESCRIPTION
## Summary
- addresses issue 8 from the architecture ledger: `ObdAdminRuntime` still mixed configured-device refresh with raw client pass-throughs
- removes the pure-forwarding `scan_devices()` / `pair_device()` methods from `ObdAdminRuntime`
- splits `SpeedSourceAdminService` so raw device admin comes directly from `ObdAdminClient` while configured-device refresh stays on the runtime-owned admin seam
- rewires runtime assembly and speed-service tests to the narrower OBD admin contracts

## Removed / simplified
- raw scan/pair pass-through wrappers in `apps/server/vibesensor/adapters/obd/admin_runtime.py`
- the mixed single-dependency admin seam in `SpeedSourceAdminService`

## Backward-incompatible changes
- `build_speed_source_services(...)` now takes `obd_device_admin=` and `obd_status_refresher=` instead of one `obd_admin=` dependency

## Local validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/speed/test_speed_services.py apps/server/tests/adapters/obd/test_runtime_services.py apps/server/tests/infra/runtime/test_runtime.py`
- `make lint && make typecheck-backend`
