### PR TITLE
Refactor updates command telemetry boundary

### DIFF
--- a/apps/server/tests/use_cases/updates/test_restart_scheduler.py
+++ b/apps/server/tests/use_cases/updates/test_restart_scheduler.py
@@ -6,13 +6,16 @@ import pytest
 from test_support.update_status import build_update_status_harness
 
 from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
+from vibesensor.use_cases.updates.runner import CommandExecutionResult
 
 
 @pytest.mark.asyncio
 async def test_schedule_uses_systemd_run_when_available(tmp_path) -> None:
     status = build_update_status_harness(tmp_path / "state.json")
     commands = MagicMock()
-    commands.run = AsyncMock(return_value=(0, "", ""))
+    commands.run = AsyncMock(
+        return_value=CommandExecutionResult(returncode=0, stdout="", stderr=""),
+    )
     scheduler = UpdateRestartScheduler(
         commands=commands,
         status=status,
@@ -28,7 +31,12 @@ async def test_schedule_uses_systemd_run_when_available(tmp_path) -> None:
 async def test_schedule_falls_back_to_direct_systemctl_restart(tmp_path) -> None:
     status = build_update_status_harness(tmp_path / "state.json")
     commands = MagicMock()
-    commands.run = AsyncMock(side_effect=[(1, "", "boom"), (0, "", "")])
+    commands.run = AsyncMock(
+        side_effect=[
+            CommandExecutionResult(returncode=1, stdout="", stderr="boom"),
+            CommandExecutionResult(returncode=0, stdout="", stderr=""),
+        ],
+    )
     scheduler = UpdateRestartScheduler(
         commands=commands,
         status=status,

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -17,6 +17,7 @@ from vibesensor.use_cases.updates.artifact_validation import (
 from vibesensor.use_cases.updates.firmware.firmware_refresh import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
+from vibesensor.use_cases.updates.runner import CommandExecutionResult
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.wheel_installation import WheelInstallResult
 
@@ -24,12 +25,17 @@ from vibesensor.use_cases.updates.wheel_installation import WheelInstallResult
 class RecordingCommands:
     def __init__(self) -> None:
         self.calls: list[tuple[list[str], str]] = []
-        self.responses: list[tuple[str, tuple[int, str, str]]] = []
-        self.default_response: tuple[int, str, str] = (0, "", "")
+        self.responses: list[tuple[str, CommandExecutionResult]] = []
+        self.default_response = CommandExecutionResult(returncode=0, stdout="", stderr="")
         self.local_wheel_version: str = ""
 
     def set_response(self, match_substr: str, rc: int, stdout: str = "", stderr: str = "") -> None:
-        self.responses.append((match_substr, (rc, stdout, stderr)))
+        self.responses.append(
+            (
+                match_substr,
+                CommandExecutionResult(returncode=rc, stdout=stdout, stderr=stderr),
+            ),
+        )
 
     async def run(
         self,
@@ -39,7 +45,7 @@ class RecordingCommands:
         phase: str,
         sudo: bool = False,
         env: dict[str, str] | None = None,
-    ) -> tuple[int, str, str]:
+    ) -> CommandExecutionResult:
         del timeout, sudo, env
         self.calls.append((list(args), phase))
         joined = " ".join(args)

--- a/apps/server/tests/use_cases/updates/test_update_runner.py
+++ b/apps/server/tests/use_cases/updates/test_update_runner.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from test_support.update_status import build_update_status_harness
+
+from vibesensor.use_cases.updates.runner import (
+    CommandExecutionResult,
+    CommandRunner,
+    UpdateCommandExecutor,
+    UpdateStatusCommandReporter,
+)
+
+
+class _StaticRunner(CommandRunner):
+    def __init__(self, *, response: CommandExecutionResult) -> None:
+        self.calls: list[tuple[list[str], float, dict[str, str] | None]] = []
+        self._response = response
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        timeout: float = 30,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        self.calls.append((list(args), timeout, env))
+        return (self._response.returncode, self._response.stdout, self._response.stderr)
+
+
+@pytest.mark.asyncio
+async def test_update_command_executor_returns_structured_result_without_reporter() -> None:
+    runner = _StaticRunner(response=CommandExecutionResult(returncode=0, stdout="ok\n", stderr=""))
+    executor = UpdateCommandExecutor(runner=runner)
+
+    result = await executor.run(["echo", "ok"], phase="checking", timeout=5)
+
+    assert result == CommandExecutionResult(returncode=0, stdout="ok\n", stderr="")
+    assert runner.calls == [(["echo", "ok"], 5, None)]
+
+
+@pytest.mark.asyncio
+async def test_status_command_reporter_logs_redacted_command_output_and_exit_code(
+    tmp_path: Path,
+) -> None:
+    status = build_update_status_harness(tmp_path / "state.json")
+    runner = _StaticRunner(
+        response=CommandExecutionResult(
+            returncode=7,
+            stdout="stdout line\n",
+            stderr="psk=mysecretpassword\n",
+        ),
+    )
+    executor = UpdateCommandExecutor(
+        runner=runner,
+        reporter=UpdateStatusCommandReporter(status=status),
+    )
+
+    result = await executor.run(
+        [
+            "nmcli",
+            "connection",
+            "modify",
+            "VibeSensor-Uplink",
+            "wifi-sec.psk",
+            "supersecret",
+        ],
+        phase="connecting_wifi",
+        timeout=5,
+    )
+
+    assert result.returncode == 7
+    assert any(
+        line.endswith(
+            "[connecting_wifi] $ nmcli connection modify VibeSensor-Uplink wifi-sec.psk ***",
+        )
+        for line in status.status.log_tail
+    )
+    assert any("[connecting_wifi] stdout: stdout line" in line for line in status.status.log_tail)
+    assert any("[connecting_wifi] stderr: psk=***" in line for line in status.status.log_tail)
+    assert any("[connecting_wifi] exit code: 7" in line for line in status.status.log_tail)

--- a/apps/server/tests/use_cases/updates/test_update_validation.py
+++ b/apps/server/tests/use_cases/updates/test_update_validation.py
@@ -11,6 +11,7 @@ from vibesensor.use_cases.updates.models import (
     UpdateTransport,
     UpdateValidationConfig,
 )
+from vibesensor.use_cases.updates.runner import CommandExecutionResult
 from vibesensor.use_cases.updates.validation import validate_prerequisites
 
 
@@ -23,7 +24,7 @@ def _mock_which(name: str) -> str | None:
 class _Commands:
     async def run(self, args, *, timeout, phase, sudo=False, env=None):
         del args, timeout, phase, sudo, env
-        return (0, "", "")
+        return CommandExecutionResult(returncode=0, stdout="", stderr="")
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py
@@ -28,7 +28,7 @@ def _build_recovery(
         build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
         hotspot_restore_delay_s=delay_s,
     )
-    commands = UpdateCommandExecutor(runner=runner, status=status)
+    commands = UpdateCommandExecutor(runner=runner)
     recovery = UpdateHotspotRecovery(
         commands=commands,
         status=status,

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
@@ -27,7 +27,7 @@ def _build_readiness(
         dns_ready_min_wait_s=dns_ready_min_wait_s,
         dns_retry_interval_s=dns_retry_interval_s,
     )
-    commands = UpdateCommandExecutor(runner=runner, status=status)
+    commands = UpdateCommandExecutor(runner=runner)
     readiness = UpdateWifiReadiness(
         commands=commands,
         status=status,

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
@@ -34,7 +34,7 @@ def _build_session(
         hotspot_restore_retries=restore_retries,
         hotspot_restore_delay_s=restore_delay_s,
     )
-    commands = UpdateCommandExecutor(runner=runner, status=status)
+    commands = UpdateCommandExecutor(runner=runner)
     session = UpdateWifiSession(
         commands=commands,
         status=status,

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from test_support.update_status import build_update_status_harness
 from use_cases.updates._update_manager_test_helpers import FakeRunner
 
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
@@ -16,9 +15,9 @@ from vibesensor.use_cases.updates.wifi.wifi_uplink_setup import (
 
 
 def _build_uplink_provisioner(tmp_path: Path) -> tuple[UpdateUplinkProvisioner, FakeRunner]:
+    del tmp_path
     runner = FakeRunner()
-    status = build_update_status_harness(tmp_path / "state.json")
-    commands = UpdateCommandExecutor(runner=runner, status=status)
+    commands = UpdateCommandExecutor(runner=runner)
     provisioner = UpdateUplinkProvisioner(
         commands=commands,
         config=build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py
@@ -48,17 +48,17 @@ class FirmwareRefresher:
             if not Path(refresh_exe).is_file()
             else [refresh_exe, *refresh_args]
         )
-        rc, _, stderr = await self._commands.run(
+        result = await self._commands.run(
             refresh_cmd,
             phase="downloading",
             timeout=self._timeout_s,
             sudo=False,
         )
-        if rc != 0:
+        if result.returncode != 0:
             self._status.add_issue(
                 "downloading",
-                f"ESP firmware cache refresh failed (exit {rc})",
-                stderr,
+                f"ESP firmware cache refresh failed (exit {result.returncode})",
+                result.stderr,
             )
             self._status.log("ESP firmware refresh failed; continuing with existing cache")
             return

--- a/apps/server/vibesensor/use_cases/updates/restart_scheduler.py
+++ b/apps/server/vibesensor/use_cases/updates/restart_scheduler.py
@@ -38,13 +38,13 @@ class UpdateRestartScheduler:
             ["systemctl", "restart", self._service_name],
         ]
         for command in restart_attempts:
-            rc, _, _ = await self._commands.run(
+            result = await self._commands.run(
                 command,
                 phase="done",
                 timeout=30,
                 sudo=True,
             )
-            if rc == 0:
+            if result.returncode == 0:
                 self._status.log("Scheduled backend service restart")
                 return True
         return False

--- a/apps/server/vibesensor/use_cases/updates/rollback_snapshot_builder.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_snapshot_builder.py
@@ -97,7 +97,7 @@ class RollbackSnapshotBuilder:
                 f"Local rollback wheel build skipped: {package_dir / 'pyproject.toml'} not found",
             )
             return None
-        rc, _, stderr = await self._commands.run(
+        result = await self._commands.run(
             [
                 venv_python,
                 "-m",
@@ -113,10 +113,11 @@ class RollbackSnapshotBuilder:
             timeout=60,
             sudo=False,
         )
-        if rc != 0:
+        if result.returncode != 0:
             self._status.log(
                 "Local rollback wheel build failed "
-                f"(exit {rc}); falling back to package-index download: {stderr}",
+                f"(exit {result.returncode}); falling back to package-index download: "
+                f"{result.stderr}",
             )
             return None
         return self._select_staged_rollback_wheel(
@@ -132,7 +133,7 @@ class RollbackSnapshotBuilder:
         stage_dir: Path,
         venv_python: str,
     ) -> Path | None:
-        rc, _, stderr = await self._commands.run(
+        result = await self._commands.run(
             [
                 venv_python,
                 "-m",
@@ -148,9 +149,10 @@ class RollbackSnapshotBuilder:
             timeout=60,
             sudo=False,
         )
-        if rc != 0:
+        if result.returncode != 0:
             self._status.log(
-                f"Package-index rollback download failed (exit {rc}): {stderr}",
+                f"Package-index rollback download failed (exit {result.returncode}): "
+                f"{result.stderr}",
             )
             return None
         return self._select_staged_rollback_wheel(

--- a/apps/server/vibesensor/use_cases/updates/runner.py
+++ b/apps/server/vibesensor/use_cases/updates/runner.py
@@ -7,18 +7,19 @@ import contextlib
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from typing import Protocol
 
 LOGGER = logging.getLogger(__name__)
 
 __all__ = [
     "build_sudo_args",
+    "CommandExecutionReporter",
+    "CommandExecutionResult",
     "CommandRunner",
     "UpdateCommandExecutor",
+    "UpdateStatusCommandReporter",
     "build_privilege_probe_args",
     "sanitize_log_line",
 ]
@@ -94,6 +95,28 @@ def sanitize_log_line(line: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True, slots=True)
+class CommandExecutionResult:
+    """One completed updater command execution."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandExecutionReporter(Protocol):
+    """Observe one updater command before and after execution."""
+
+    def command_started(self, *, phase: str, args: list[str]) -> None: ...
+
+    def command_finished(
+        self,
+        *,
+        phase: str,
+        result: CommandExecutionResult,
+    ) -> None: ...
+
+
 class CommandRunner:
     """Execute shell commands.  Override for testing."""
 
@@ -143,7 +166,7 @@ class CommandRunner:
 
 
 # ---------------------------------------------------------------------------
-# Command executor (wraps runner with logging + sudo)
+# Command executor
 # ---------------------------------------------------------------------------
 
 _SENSITIVE_KEYS: frozenset[str] = frozenset(
@@ -152,19 +175,56 @@ _SENSITIVE_KEYS: frozenset[str] = frozenset(
         "psk",
         "secret",
         "key",
+        "wifi-sec.psk",
         "802-11-wireless-security.psk",
     },
 )
 
 
-class UpdateCommandExecutor:
-    """Execute commands and report logs through the canonical update status boundary."""
+class _UpdateCommandStatusSink(Protocol):
+    def log(self, message: str) -> None: ...
 
-    __slots__ = ("_runner", "_status")
+    def redacted_args(self, args: list[str], sensitive_keys: set[str]) -> list[str]: ...
 
-    def __init__(self, *, runner: CommandRunner, status: UpdateStatusTracker) -> None:
-        self._runner = runner
+
+class UpdateStatusCommandReporter:
+    """Render updater command telemetry through the canonical status sink."""
+
+    __slots__ = ("_status",)
+
+    def __init__(self, *, status: _UpdateCommandStatusSink) -> None:
         self._status = status
+
+    def command_started(self, *, phase: str, args: list[str]) -> None:
+        command = " ".join(self._status.redacted_args(args, set(_SENSITIVE_KEYS)))
+        if len(command) > 500:
+            command = f"{command[:497]}..."
+        self._status.log(f"[{phase}] $ {command or '<empty>'}")
+
+    def command_finished(self, *, phase: str, result: CommandExecutionResult) -> None:
+        stdout_s = result.stdout.strip()
+        stderr_s = result.stderr.strip()
+        if stdout_s:
+            self._status.log(f"[{phase}] stdout: {stdout_s[:500]}")
+        if stderr_s:
+            self._status.log(f"[{phase}] stderr: {stderr_s[:500]}")
+        if result.returncode != 0:
+            self._status.log(f"[{phase}] exit code: {result.returncode}")
+
+
+class UpdateCommandExecutor:
+    """Execute updater commands and optionally report telemetry through a separate reporter."""
+
+    __slots__ = ("_reporter", "_runner")
+
+    def __init__(
+        self,
+        *,
+        runner: CommandRunner,
+        reporter: CommandExecutionReporter | None = None,
+    ) -> None:
+        self._runner = runner
+        self._reporter = reporter
 
     async def run(
         self,
@@ -174,19 +234,12 @@ class UpdateCommandExecutor:
         phase: str,
         sudo: bool = False,
         env: dict[str, str] | None = None,
-    ) -> tuple[int, str, str]:
+    ) -> CommandExecutionResult:
         full_args = build_sudo_args(args) if sudo else list(args)
-        command = " ".join(self._status.redacted_args(full_args, set(_SENSITIVE_KEYS)))
-        if len(command) > 500:
-            command = f"{command[:497]}..."
-        self._status.log(f"[{phase}] $ {command or '<empty>'}")
+        if self._reporter is not None:
+            self._reporter.command_started(phase=phase, args=full_args)
         rc, stdout, stderr = await self._runner.run(full_args, timeout=timeout, env=env)
-        stdout_s = stdout.strip()
-        stderr_s = stderr.strip()
-        if stdout_s:
-            self._status.log(f"[{phase}] stdout: {stdout_s[:500]}")
-        if stderr_s:
-            self._status.log(f"[{phase}] stderr: {stderr_s[:500]}")
-        if rc != 0:
-            self._status.log(f"[{phase}] exit code: {rc}")
-        return rc, stdout, stderr
+        result = CommandExecutionResult(returncode=rc, stdout=stdout, stderr=stderr)
+        if self._reporter is not None:
+            self._reporter.command_finished(phase=phase, result=result)
+        return result

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -21,7 +21,11 @@ from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
 from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
 from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
-from vibesensor.use_cases.updates.runner import CommandRunner, UpdateCommandExecutor
+from vibesensor.use_cases.updates.runner import (
+    CommandRunner,
+    UpdateCommandExecutor,
+    UpdateStatusCommandReporter,
+)
 from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
 from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
 from vibesensor.use_cases.updates.status import (
@@ -168,7 +172,10 @@ def _build_command_executor(
     runner: CommandRunner,
     status: UpdateStatusTracker,
 ) -> UpdateCommandExecutor:
-    return UpdateCommandExecutor(runner=runner, status=status)
+    return UpdateCommandExecutor(
+        runner=runner,
+        reporter=UpdateStatusCommandReporter(status=status),
+    )
 
 
 def _build_transport_sessions(

--- a/apps/server/vibesensor/use_cases/updates/validation.py
+++ b/apps/server/vibesensor/use_cases/updates/validation.py
@@ -75,13 +75,13 @@ async def validate_prerequisites(
             raise _fail_validation(status, f"Required tool not found: {tool}")
 
     if os.geteuid() != 0:
-        rc, _, _ = await commands.run(
+        result = await commands.run(
             build_privilege_probe_args(),
             phase="validating",
             timeout=5,
             sudo=True,
         )
-        if rc != 0:
+        if result.returncode != 0:
             raise _fail_validation(
                 status,
                 "Insufficient privileges",

--- a/apps/server/vibesensor/use_cases/updates/wheel_installation.py
+++ b/apps/server/vibesensor/use_cases/updates/wheel_installation.py
@@ -93,7 +93,7 @@ class WheelInstallExecutor:
         if not await self._validate_dependency_compatibility(wheel_path, venv_python=venv_python):
             return WheelInstallResult(succeeded=False)
 
-        rc, _, stderr = await self._commands.run(
+        install_result = await self._commands.run(
             [
                 venv_python,
                 "-m",
@@ -107,11 +107,11 @@ class WheelInstallExecutor:
             timeout=self._reinstall_timeout_s,
             sudo=False,
         )
-        if rc != 0:
+        if install_result.returncode != 0:
             self._status.add_issue(
                 "installing",
-                f"Wheel install failed (exit {rc})",
-                stderr,
+                f"Wheel install failed (exit {install_result.returncode})",
+                install_result.stderr,
             )
             self._status.mark_failed()
             return WheelInstallResult(succeeded=False, rollback_required=True)
@@ -131,7 +131,7 @@ class WheelInstallExecutor:
         """Install a previously captured rollback wheel without recursive fallback."""
 
         venv_python = reinstall_python_executable(self._repo)
-        rc, _, stderr = await self._commands.run(
+        rollback_result = await self._commands.run(
             [
                 venv_python,
                 "-m",
@@ -145,11 +145,11 @@ class WheelInstallExecutor:
             timeout=self._reinstall_timeout_s,
             sudo=False,
         )
-        if rc != 0:
+        if rollback_result.returncode != 0:
             self._status.add_issue(
                 "installing",
-                f"Rollback install failed (exit {rc})",
-                stderr,
+                f"Rollback install failed (exit {rollback_result.returncode})",
+                rollback_result.stderr,
             )
             return False
 
@@ -196,7 +196,7 @@ class WheelInstallExecutor:
         if not metadata.requires_python and not requirement_names:
             return True
 
-        rc, stdout, stderr = await self._commands.run(
+        dependency_check = await self._commands.run(
             [
                 venv_python,
                 "-c",
@@ -207,21 +207,24 @@ class WheelInstallExecutor:
             timeout=30,
             sudo=False,
         )
-        if rc != 0:
+        if dependency_check.returncode != 0:
             self._status.add_issue(
                 "installing",
-                f"Could not validate wheel dependency compatibility (exit {rc})",
-                stderr or stdout,
+                (
+                    "Could not validate wheel dependency compatibility "
+                    f"(exit {dependency_check.returncode})"
+                ),
+                dependency_check.stderr or dependency_check.stdout,
             )
             self._status.mark_failed()
             return False
         try:
-            snapshot = json.loads(stdout or "{}")
+            snapshot = json.loads(dependency_check.stdout or "{}")
         except json.JSONDecodeError:
             self._status.add_issue(
                 "installing",
                 "Could not parse wheel dependency compatibility results",
-                stdout or stderr,
+                dependency_check.stdout or dependency_check.stderr,
             )
             self._status.mark_failed()
             return False
@@ -235,7 +238,7 @@ class WheelInstallExecutor:
             self._status.add_issue(
                 "installing",
                 "Could not parse wheel dependency compatibility results",
-                stdout or stderr,
+                dependency_check.stdout or dependency_check.stderr,
             )
             self._status.mark_failed()
             return False
@@ -273,18 +276,18 @@ class WheelInstallExecutor:
         fatal: bool,
     ) -> str | None:
         venv_python = reinstall_python_executable(self._repo)
-        rc, stdout, stderr = await self._commands.run(
+        version_check = await self._commands.run(
             [venv_python, "-c", "from vibesensor import __version__; print(__version__)"],
             phase="installing",
             timeout=30,
             sudo=False,
         )
-        if rc == 0:
-            return stdout.strip()
-        message = f"{failure_message_prefix} (exit {rc})"
+        if version_check.returncode == 0:
+            return version_check.stdout.strip()
+        message = f"{failure_message_prefix} (exit {version_check.returncode})"
         if fatal:
-            self._status.add_issue("installing", message, stderr)
+            self._status.add_issue("installing", message, version_check.stderr)
             self._status.mark_failed()
         else:
-            self._status.add_issue("installing", message, stderr)
+            self._status.add_issue("installing", message, version_check.stderr)
         return None

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
@@ -27,13 +27,13 @@ class UpdateHotspotRecovery:
         """Stop the hotspot before attempting an uplink connection."""
 
         self._status.log("Stopping hotspot...")
-        rc, _, _ = await self._commands.run(
+        result = await self._commands.run(
             ["nmcli", "connection", "down", self._config.ap_con_name],
             phase="stopping_hotspot",
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        if rc != 0:
+        if result.returncode != 0:
             self._status.log("Hotspot down returned non-zero; may already be inactive")
         return True
 
@@ -58,16 +58,18 @@ class UpdateHotspotRecovery:
 
         await self.cleanup_uplink()
         for attempt in range(1, self._config.hotspot_restore_retries + 1):
-            rc, _, _ = await self._commands.run(
+            result = await self._commands.run(
                 ["nmcli", "connection", "up", self._config.ap_con_name],
                 phase="restore",
                 timeout=self._config.nmcli_timeout_s,
                 sudo=True,
             )
-            if rc == 0:
+            if result.returncode == 0:
                 self._status.log(f"Hotspot restored on attempt {attempt}")
                 return True
-            self._status.log(f"Hotspot restore attempt {attempt} failed (rc={rc})")
+            self._status.log(
+                f"Hotspot restore attempt {attempt} failed (rc={result.returncode})",
+            )
             if attempt < self._config.hotspot_restore_retries:
                 await asyncio.sleep(self._config.hotspot_restore_delay_s)
         self._status.add_issue(

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_readiness.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_readiness.py
@@ -29,10 +29,9 @@ class UpdateWifiReadiness:
     async def bring_uplink_up(self, ssid: str) -> None:
         """Bring the prepared uplink connection up, retrying on scan lag."""
 
-        rc = 1
-        stderr = ""
+        connect_result = None
         for attempt in range(1, self._config.uplink_connect_retries + 1):
-            rc, _, stderr = await self._commands.run(
+            connect_result = await self._commands.run(
                 [
                     "nmcli",
                     "--wait",
@@ -45,9 +44,9 @@ class UpdateWifiReadiness:
                 timeout=float(self._config.uplink_connect_wait_s + 10),
                 sudo=True,
             )
-            if rc == 0:
+            if connect_result.returncode == 0:
                 return
-            if "No network with SSID" not in (stderr or ""):
+            if "No network with SSID" not in (connect_result.stderr or ""):
                 break
             self._status.log(
                 f"SSID '{ssid}' not found on connect attempt {attempt}; rescanning and retrying",
@@ -74,7 +73,7 @@ class UpdateWifiReadiness:
         raise UpdateTransportStepError(
             phase=UpdatePhase.connecting_wifi,
             message=f"Failed to connect to Wi-Fi '{ssid}'",
-            detail=stderr,
+            detail="" if connect_result is None else connect_result.stderr,
         )
 
     async def wait_for_dns_ready(
@@ -104,16 +103,18 @@ class UpdateWifiReadiness:
         ]
         while True:
             attempt += 1
-            rc, stdout, stderr = await self._commands.run(
+            probe_result = await self._commands.run(
                 probe_cmd,
                 phase=str(phase),
                 timeout=5,
                 sudo=False,
             )
-            if rc == 0:
+            if probe_result.returncode == 0:
                 self._status.log(f"DNS probe succeeded on attempt {attempt}")
                 return
-            last_error = (stderr or stdout or f"exit {rc}").strip()
+            last_error = (
+                probe_result.stderr or probe_result.stdout or f"exit {probe_result.returncode}"
+            ).strip()
             if time.monotonic() >= deadline:
                 break
             await asyncio.sleep(self._config.dns_retry_interval_s)

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
@@ -61,7 +61,7 @@ class UpdateUplinkProvisioner:
     async def _validate_open_network(self, ssid: str) -> None:
         """Reject blank-password attempts when the scanned SSID is secured."""
 
-        rc, stdout, _ = await self._commands.run(
+        scan_result = await self._commands.run(
             [
                 "nmcli",
                 "-t",
@@ -79,9 +79,9 @@ class UpdateUplinkProvisioner:
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        if rc != 0:
+        if scan_result.returncode != 0:
             return
-        security_modes = ssid_security_modes(stdout, ssid)
+        security_modes = ssid_security_modes(scan_result.stdout, ssid)
         if not security_modes:
             return
         raise UpdateTransportStepError(
@@ -93,15 +93,15 @@ class UpdateUplinkProvisioner:
     async def _delete_existing_uplink_connections(self) -> None:
         """Remove any stale transient uplink profiles before recreating them."""
 
-        rc, stdout, _ = await self._commands.run(
+        connection_list = await self._commands.run(
             ["nmcli", "-t", "-f", "UUID,NAME", "connection", "show"],
             phase="connecting_wifi",
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        if rc != 0:
+        if connection_list.returncode != 0:
             return
-        for line in stdout.splitlines():
+        for line in connection_list.stdout.splitlines():
             if not line:
                 continue
             uuid, _, name = line.partition(":")
@@ -117,7 +117,7 @@ class UpdateUplinkProvisioner:
     async def _create_uplink_connection(self, ssid: str) -> None:
         """Create a new transient uplink profile for the requested SSID."""
 
-        rc, _, stderr = await self._commands.run(
+        create_result = await self._commands.run(
             [
                 "nmcli",
                 "connection",
@@ -137,18 +137,18 @@ class UpdateUplinkProvisioner:
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        if rc == 0:
+        if create_result.returncode == 0:
             return
         raise UpdateTransportStepError(
             phase=UpdatePhase.connecting_wifi,
             message="Failed to create uplink connection",
-            detail=stderr,
+            detail=create_result.stderr,
         )
 
     async def _configure_uplink_connection(self) -> None:
         """Apply the non-secret updater defaults to the uplink profile."""
 
-        rc, _, stderr = await self._commands.run(
+        configure_result = await self._commands.run(
             [
                 "nmcli",
                 "connection",
@@ -169,19 +169,19 @@ class UpdateUplinkProvisioner:
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        if rc == 0:
+        if configure_result.returncode == 0:
             return
         await self._delete_uplink_connection()
         raise UpdateTransportStepError(
             phase=UpdatePhase.connecting_wifi,
             message="Failed to configure uplink",
-            detail=stderr,
+            detail=configure_result.stderr,
         )
 
     async def _apply_wifi_password(self, password: str) -> None:
         """Apply WPA-PSK credentials to the transient uplink profile."""
 
-        rc, _, stderr = await self._commands.run(
+        password_result = await self._commands.run(
             [
                 "nmcli",
                 "connection",
@@ -196,13 +196,13 @@ class UpdateUplinkProvisioner:
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        if rc == 0:
+        if password_result.returncode == 0:
             return
         await self._delete_uplink_connection()
         raise UpdateTransportStepError(
             phase=UpdatePhase.connecting_wifi,
             message="Failed to set Wi-Fi credentials",
-            detail=stderr,
+            detail=password_result.stderr,
         )
 
     async def _delete_uplink_connection(self) -> None:


### PR DESCRIPTION
## Summary
- address Wave 1 issue 1 from the architecture refactor ledger: updates command execution is coupled to status mutation
- split updater command execution into `CommandExecutionResult` plus an optional `UpdateStatusCommandReporter`
- update updater command consumers and focused tests to use structured command results
- tighten updater log redaction so `wifi-sec.psk` values are masked

## Architectural simplifications
- `UpdateCommandExecutor` no longer depends directly on `UpdateStatusTracker`
- command telemetry now hangs off an explicit reporter boundary configured in runtime composition
- updater command consumers now read named result fields instead of raw tuple slots

## Removed or simplified
- removed direct status logging from the executor implementation
- removed focused test-time status coupling when constructing `UpdateCommandExecutor`

## Backward-incompatible changes
- internal-only: `UpdateCommandExecutor.__init__` now takes `reporter=` instead of `status=`
- internal-only: `UpdateCommandExecutor.run()` now returns `CommandExecutionResult`

## Local validation
- `make lint`
- `make typecheck-backend`
- `pytest -q apps/server/tests/use_cases/updates`
- `pytest -q apps/server/tests/use_cases/updates/test_update_runner.py apps/server/tests/use_cases/updates/test_update_installer_verification.py apps/server/tests/use_cases/updates/test_update_validation.py apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py apps/server/tests/use_cases/updates/wifi/test_wifi_session.py`

## Environment note
- Docker runtime smoke could not run here because the Docker daemon/socket is unavailable in this environment.