### PR TITLE
Refactor OBD runtime boundaries

### DIFF
--- a/apps/server/tests/adapters/obd/test_connection_executor.py
+++ b/apps/server/tests/adapters/obd/test_connection_executor.py
@@ -62,7 +62,7 @@ async def test_executor_marks_disconnected_and_backs_off_after_connect_failure()
         ),
     )
 
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
     assert sleeps == [2.0]
     assert status.connection_state == "disconnected"
     assert status.last_error == "rfcomm busy"
@@ -96,7 +96,7 @@ async def test_executor_closes_session_and_backs_off_after_poll_connection_loss(
         step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
     )
 
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
     parts.session.close.assert_called_once_with()
     assert sleeps == [4.0]
     assert status.connection_state == "disconnected"

--- a/apps/server/tests/adapters/obd/test_runtime_services.py
+++ b/apps/server/tests/adapters/obd/test_runtime_services.py
@@ -43,14 +43,14 @@ def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -
 
     parts.session.request.side_effect = request
 
-    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
     clock.now = started_at + 0.05
-    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.2)]
-    assert parts.observation.resolve_speed().source == "obd2"
-    assert parts.observation.resolve_speed().speed_mps == pytest.approx(40.0 / 3.6)
-    status = parts.observation.status_snapshot()
+    assert parts.projection.resolve_speed().source == "obd2"
+    assert parts.projection.resolve_speed().speed_mps == pytest.approx(40.0 / 3.6)
+    status = parts.projection.status_snapshot()
     assert status.last_speed_kmh == pytest.approx(40.0)
     assert status.last_rpm == pytest.approx(0x1AF8 / 4.0)
     assert status.rpm_target_interval_ms == 50
@@ -82,17 +82,17 @@ def test_obd_observation_keeps_last_good_rpm_until_the_reference_goes_stale() ->
 
     parts.session.request.side_effect = request
 
-    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
     clock.now = 0.05
-    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
 
-    assert parts.observation.engine_rpm == pytest.approx(0x1AF8 / 4.0)
+    assert parts.facts.engine_rpm == pytest.approx(0x1AF8 / 4.0)
     clock.now = 1.99
-    assert parts.observation.engine_rpm == pytest.approx(0x1AF8 / 4.0)
+    assert parts.facts.engine_rpm == pytest.approx(0x1AF8 / 4.0)
     clock.now = 2.11
-    assert parts.observation.engine_rpm is None
+    assert parts.facts.engine_rpm is None
 
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
     assert status.timeout_count == 1
     assert status.backoff_active is True
 
@@ -116,11 +116,11 @@ def test_obd_connection_state_backs_off_and_stays_in_rpm_only_mode_when_speed_ti
 
     parts.session.request.side_effect = request
 
-    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
-    parts.connection_state.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.3)]
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
     assert status.poll_mode == "rpm_only_backoff"
     assert status.backoff_active is True
     assert status.timeout_count == 1
@@ -129,7 +129,7 @@ def test_obd_connection_state_backs_off_and_stays_in_rpm_only_mode_when_speed_ti
     assert status.request_rtt_ms is not None
 
 
-def test_obd_runtime_observation_resolves_stale_speed_to_manual_fallback() -> None:
+def test_obd_runtime_projection_resolves_stale_speed_to_manual_fallback() -> None:
     parts = _build_runtime_parts(clock=lambda: 100.0)
     parts.settings.apply_speed_source_settings(
         effective_speed_kmh=54.0,
@@ -140,9 +140,9 @@ def test_obd_runtime_observation_resolves_stale_speed_to_manual_fallback() -> No
         obd_device_name="OBDLink MX+",
     )
     parts.store.state.speed_snapshot = (10.0, 90.0)
-    parts.connection_state.mark_connected()
+    parts.connection_control.mark_connected()
 
-    resolution = parts.observation.resolve_speed()
+    resolution = parts.projection.resolve_speed()
 
     assert resolution.source == "fallback_manual"
     assert resolution.speed_mps == pytest.approx(54.0 / 3.6)
@@ -160,7 +160,7 @@ def test_obd_status_snapshot_does_not_refresh_admin_state_implicitly() -> None:
         obd_device_name="OBDLink MX+",
     )
 
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
 
     admin_client.device_info.assert_not_called()
     assert status.device_mac == "00043e5a4a4d"
@@ -180,7 +180,7 @@ def test_obd_status_reports_sudo_helper_hint_when_admin_refresh_fails() -> None:
     )
 
     parts.admin.refresh_configured_device()
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
 
     assert "sudo" in str(status.last_error).lower()
     assert "sudo helper" in str(obd_debug_hint(status)).lower()
@@ -190,7 +190,7 @@ def test_obd_connection_state_marks_disconnected_after_fatal_poll_cycle() -> Non
     clock = _FakeClock()
     parts = _connected_runtime_parts(clock=clock)
 
-    connection_lost = parts.connection_state.apply_poll_cycle(
+    connection_lost = parts.connection_control.apply_poll_cycle(
         ObdPollResult(
             rpm=ObdPidPollResult(
                 value=None,
@@ -206,7 +206,7 @@ def test_obd_connection_state_marks_disconnected_after_fatal_poll_cycle() -> Non
     )
 
     assert connection_lost is True
-    status = parts.observation.status_snapshot()
+    status = parts.projection.status_snapshot()
     assert status.connection_state == "disconnected"
     assert status.last_error == "PID 010C request failed: Session is not connected"
     assert status.reconnect_delay_s == 4.0
@@ -238,7 +238,8 @@ def test_connect_blocking_keeps_initialized_session_open() -> None:
     parts = _connected_runtime_parts(clock=clock)
 
     assert parts.runner is not None
-    assert parts.observation is not None
+    assert parts.facts is not None
+    assert parts.projection is not None
     parts.session.initialize.assert_called_once_with()
     assert parts.session.close.call_count == 0
 

--- a/apps/server/tests/adapters/obd/test_status.py
+++ b/apps/server/tests/adapters/obd/test_status.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from vibesensor.adapters.http.obd_status_presentation import obd_debug_hint
 from vibesensor.adapters.obd.polling import ObdPollingSnapshot
-from vibesensor.adapters.obd.status import ObdMonitorStatusState, build_obd_status_snapshot
+from vibesensor.adapters.obd.status import ObdRuntimeStatusFacts, build_obd_status_snapshot
 
 
 def _polling_snapshot(*, backoff_active: bool = True) -> ObdPollingSnapshot:
@@ -20,11 +20,8 @@ def _polling_snapshot(*, backoff_active: bool = True) -> ObdPollingSnapshot:
 
 def test_build_obd_status_snapshot_keeps_runtime_facts_and_http_hint_separate() -> None:
     status = build_obd_status_snapshot(
-        ObdMonitorStatusState(
-            effective_connection_state="disconnected",
+        ObdRuntimeStatusFacts(
             transport_connection_state="disconnected",
-            configured_device_mac="00043e5a4a4d",
-            configured_device_name="OBDLink MX+",
             device_mac=None,
             device_name=None,
             paired=True,
@@ -34,12 +31,15 @@ def test_build_obd_status_snapshot_keeps_runtime_facts_and_http_hint_separate() 
             speed_snapshot=(10.0, 90.0),
             engine_rpm=1726.0,
             engine_rpm_ts=99.0,
-            obd_selected=True,
-            last_error="link down",
+            last_runtime_error="link down",
             helper_error=None,
             reconnect_delay_s=4.0,
             polling=_polling_snapshot(),
         ),
+        configured_device_mac="00043e5a4a4d",
+        configured_device_name="OBDLink MX+",
+        effective_connection_state="disconnected",
+        obd_selected=True,
         now_mono=100.0,
     )
 
@@ -58,11 +58,8 @@ def test_build_obd_status_snapshot_keeps_runtime_facts_and_http_hint_separate() 
 
 def test_build_obd_status_snapshot_hides_obd_only_fields_when_not_selected() -> None:
     status = build_obd_status_snapshot(
-        ObdMonitorStatusState(
-            effective_connection_state="connected",
+        ObdRuntimeStatusFacts(
             transport_connection_state="connected",
-            configured_device_mac="00043e5a4a4d",
-            configured_device_name="OBDLink MX+",
             device_mac="00043e5a4a4d",
             device_name="OBDLink MX+",
             paired=True,
@@ -72,12 +69,15 @@ def test_build_obd_status_snapshot_hides_obd_only_fields_when_not_selected() -> 
             speed_snapshot=(10.0, 90.0),
             engine_rpm=1726.0,
             engine_rpm_ts=99.0,
-            obd_selected=False,
-            last_error=None,
+            last_runtime_error=None,
             helper_error=None,
             reconnect_delay_s=1.0,
             polling=_polling_snapshot(),
         ),
+        configured_device_mac="00043e5a4a4d",
+        configured_device_name="OBDLink MX+",
+        effective_connection_state="connected",
+        obd_selected=False,
         now_mono=100.0,
     )
 

--- a/apps/server/tests/adapters/speed/test_speed_services.py
+++ b/apps/server/tests/adapters/speed/test_speed_services.py
@@ -67,16 +67,18 @@ def test_observation_service_switches_to_obd_status_and_resolution() -> None:
     gps_monitor.status_snapshot.return_value = _gps_status_snapshot()
     gps_monitor.apply_speed_source_settings.return_value = None
 
-    obd_observation = MagicMock()
-    obd_observation.resolve_speed.return_value = SpeedResolution(12.0, False, "obd2")
-    obd_observation.status_snapshot.return_value = _obd_status_snapshot()
-    obd_observation.stale_timeout_s = 8.0
+    obd_facts = MagicMock()
+    obd_projection = MagicMock()
+    obd_projection.resolve_speed.return_value = SpeedResolution(12.0, False, "obd2")
+    obd_projection.status_snapshot.return_value = _obd_status_snapshot()
+    obd_projection.stale_timeout_s = 8.0
     obd_device_admin = MagicMock()
     obd_status_refresher = MagicMock()
     obd_control = MagicMock()
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_observation=obd_observation,
+        obd_facts=obd_facts,
+        obd_projection=obd_projection,
         obd_device_admin=obd_device_admin,
         obd_status_refresher=obd_status_refresher,
         obd_control=obd_control,
@@ -99,17 +101,19 @@ def test_observation_service_switches_to_obd_status_and_resolution() -> None:
     assert status.raw_speed_kmh == pytest.approx(43.2)
     assert status.speed_source == "obd2"
     obd_status_refresher.refresh_configured_device.assert_not_called()
-    obd_observation.status_snapshot.assert_called_once_with()
+    obd_projection.status_snapshot.assert_called_once_with()
 
 
 def test_observation_service_obd_status_is_side_effect_free() -> None:
     gps_monitor = MagicMock()
-    obd_observation = MagicMock()
+    obd_facts = MagicMock()
+    obd_projection = MagicMock()
     expected_status = _obd_status_snapshot()
-    obd_observation.status_snapshot.return_value = expected_status
+    obd_projection.status_snapshot.return_value = expected_status
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_observation=obd_observation,
+        obd_facts=obd_facts,
+        obd_projection=obd_projection,
         obd_device_admin=MagicMock(),
         obd_status_refresher=MagicMock(),
         obd_control=MagicMock(),
@@ -127,7 +131,7 @@ def test_observation_service_obd_status_is_side_effect_free() -> None:
     status = services.observation.obd_status()
 
     assert status == expected_status
-    obd_observation.status_snapshot.assert_called_once_with()
+    obd_projection.status_snapshot.assert_called_once_with()
 
 
 def test_admin_service_refreshes_obd_status_explicitly() -> None:
@@ -135,7 +139,8 @@ def test_admin_service_refreshes_obd_status_explicitly() -> None:
     obd_status_refresher = MagicMock()
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_observation=MagicMock(),
+        obd_facts=MagicMock(),
+        obd_projection=MagicMock(),
         obd_device_admin=MagicMock(),
         obd_status_refresher=obd_status_refresher,
         obd_control=MagicMock(),
@@ -161,7 +166,8 @@ def test_admin_service_delegates_scan_and_pair_to_obd_device_admin() -> None:
     obd_device_admin.pair_device.return_value = device
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_observation=MagicMock(),
+        obd_facts=MagicMock(),
+        obd_projection=MagicMock(),
         obd_device_admin=obd_device_admin,
         obd_status_refresher=MagicMock(),
         obd_control=MagicMock(),

--- a/apps/server/tests/test_support/obd_runtime.py
+++ b/apps/server/tests/test_support/obd_runtime.py
@@ -8,8 +8,10 @@ from vibesensor.adapters.obd.admin_runtime import ObdAdminRuntime
 from vibesensor.adapters.obd.connection_executor import ObdConnectionExecutor
 from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
-from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
-from vibesensor.adapters.obd.runtime_observation import ObdRuntimeObservation
+from vibesensor.adapters.obd.runtime_admin_state import ObdRuntimeAdminState
+from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
+from vibesensor.adapters.obd.runtime_facts import ObdRuntimeFacts
+from vibesensor.adapters.obd.runtime_projection import ObdRuntimeProjection
 from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
 from vibesensor.adapters.obd.runtime_store import ObdRuntimeStore
 
@@ -28,9 +30,10 @@ class FakeClock:
 @dataclass(slots=True)
 class ObdRuntimeParts:
     store: ObdRuntimeStore
-    observation: ObdRuntimeObservation
+    facts: ObdRuntimeFacts
+    projection: ObdRuntimeProjection
     settings: ObdRuntimeSettings
-    connection_state: ObdRuntimeConnectionState
+    connection_control: ObdRuntimeConnectionControl
     admin: ObdAdminRuntime
     executor: ObdConnectionExecutor
     runner: ObdConnectionRuntime
@@ -62,28 +65,30 @@ def build_obd_runtime_parts(
         initial_reconnect_delay_s=1.0,
         engine_rpm_stale_timeout_s=2.0,
     )
-    connection_state = ObdRuntimeConnectionState(store=store)
+    connection_control = ObdRuntimeConnectionControl(store=store)
+    admin_state = ObdRuntimeAdminState(store=store)
     executor = ObdConnectionExecutor(
         admin_client=admin,
-        connection_state=connection_state,
+        connection_control=connection_control,
         session_factory=lambda: resolved_session,
         monotonic=clock,
         **({} if sleep is None else {"sleep": sleep}),
     )
     runner = ObdConnectionRuntime(
         admin_client=admin,
-        connection_state=connection_state,
+        connection_control=connection_control,
         session_factory=lambda: resolved_session,
         monotonic=clock,
     )
     return ObdRuntimeParts(
         store=store,
-        observation=ObdRuntimeObservation(store=store),
+        facts=ObdRuntimeFacts(store=store),
+        projection=ObdRuntimeProjection(store=store),
         settings=ObdRuntimeSettings(store=store),
-        connection_state=connection_state,
+        connection_control=connection_control,
         admin=ObdAdminRuntime(
             admin_client=admin,
-            connection_state=connection_state,
+            admin_state=admin_state,
         ),
         executor=executor,
         runner=runner,
@@ -114,5 +119,5 @@ def build_connected_obd_runtime_parts(
         obd_device_name="OBDLink MX+",
     )
     _, device = parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
-    parts.connection_state.mark_connected(device)
+    parts.connection_control.mark_connected(device)
     return parts

--- a/apps/server/vibesensor/adapters/obd/admin_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/admin_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from vibesensor.adapters.obd.admin_client import ObdAdminClient
 from vibesensor.adapters.obd.admin_state import observe_configured_obd_device
-from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
+from vibesensor.adapters.obd.runtime_admin_state import ObdRuntimeAdminState
 
 __all__ = ["ObdAdminRuntime"]
 
@@ -18,10 +18,10 @@ class ObdAdminRuntime:
         self,
         *,
         admin_client: ObdAdminClient,
-        connection_state: ObdRuntimeConnectionState,
+        admin_state: ObdRuntimeAdminState,
     ) -> None:
         self._admin_client = admin_client
-        self._runtime = connection_state
+        self._runtime = admin_state
 
     def refresh_configured_device(self) -> None:
         configured_mac = self._runtime.configured_device_mac_snapshot()

--- a/apps/server/vibesensor/adapters/obd/connection_executor.py
+++ b/apps/server/vibesensor/adapters/obd/connection_executor.py
@@ -12,7 +12,7 @@ from vibesensor.adapters.obd.connection_plan import ObdConnectionStep, ObdConnec
 from vibesensor.adapters.obd.elm327 import Elm327Session, ObdTransportError
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.polling import ObdPollResult, execute_poll_plan
-from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
+from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
 from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
 
 __all__ = ["ObdConnectionExecutor", "ObdConnectionLoopState"]
@@ -37,7 +37,7 @@ class ObdConnectionExecutor:
 
     __slots__ = (
         "_admin_client",
-        "_connection_state",
+        "_connection_control",
         "_monotonic",
         "_session_factory",
         "_sleep",
@@ -47,13 +47,13 @@ class ObdConnectionExecutor:
         self,
         *,
         admin_client: ObdAdminClient,
-        connection_state: ObdRuntimeConnectionState,
+        connection_control: ObdRuntimeConnectionControl,
         session_factory: SessionFactory,
         monotonic: MonotonicFn = time.monotonic,
         sleep: SleepFn = asyncio.sleep,
     ) -> None:
         self._admin_client = admin_client
-        self._connection_state = connection_state
+        self._connection_control = connection_control
         self._session_factory = session_factory
         self._monotonic = monotonic
         self._sleep = sleep
@@ -111,7 +111,7 @@ class ObdConnectionExecutor:
         error: str | None,
         sleep_s: float,
     ) -> ObdConnectionLoopState:
-        self._connection_state.mark_disconnected(error=error)
+        self._connection_control.mark_disconnected(error=error)
         await self._sleep(sleep_s)
         return replace(state, reconnect_delay_s=_INITIAL_RECONNECT_DELAY_S)
 
@@ -122,7 +122,7 @@ class ObdConnectionExecutor:
         mac_address: str,
         configured_name: str | None,
     ) -> ObdConnectionLoopState:
-        self._connection_state.mark_connecting()
+        self._connection_control.mark_connecting()
         try:
             session, device = await asyncio.to_thread(
                 self._connect_blocking,
@@ -130,7 +130,7 @@ class ObdConnectionExecutor:
                 configured_name,
             )
         except (OperationalError, OSError, ObdTransportError) as exc:
-            self._connection_state.mark_disconnected(
+            self._connection_control.mark_disconnected(
                 error=str(exc),
                 reconnect_delay_s=state.reconnect_delay_s,
             )
@@ -139,7 +139,7 @@ class ObdConnectionExecutor:
                 state,
                 reconnect_delay_s=self._next_reconnect_delay(state.reconnect_delay_s),
             )
-        self._connection_state.mark_connected(device)
+        self._connection_control.mark_connected(device)
         return ObdConnectionLoopState(
             session=session,
             session_device_mac=device.mac_address,
@@ -158,7 +158,7 @@ class ObdConnectionExecutor:
     async def _run_poll_step(self, *, state: ObdConnectionLoopState) -> ObdConnectionLoopState:
         assert state.session is not None
         poll_result = await asyncio.to_thread(self._poll_cycle_blocking, state.session)
-        connection_lost = self._connection_state.apply_poll_cycle(
+        connection_lost = self._connection_control.apply_poll_cycle(
             poll_result,
             reconnect_delay_s=state.reconnect_delay_s,
         )
@@ -203,7 +203,7 @@ class ObdConnectionExecutor:
                 session.close()
 
     def _poll_cycle_blocking(self, session: Elm327Session) -> ObdPollResult:
-        plan = self._connection_state.prepare_poll()
+        plan = self._connection_control.prepare_poll()
         return execute_poll_plan(session, plan=plan, monotonic=self._monotonic)
 
     async def _close_session_if_needed(

--- a/apps/server/vibesensor/adapters/obd/connection_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/connection_runtime.py
@@ -17,7 +17,7 @@ from vibesensor.adapters.obd.connection_plan import (
     plan_connection_step,
 )
 from vibesensor.adapters.obd.elm327 import Elm327Session
-from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
+from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
 
 __all__ = ["ObdConnectionRuntime"]
 
@@ -31,7 +31,7 @@ class ObdConnectionRuntime:
     """Own session lifecycle, reconnect behavior, and blocking poll execution."""
 
     __slots__ = (
-        "_connection_state",
+        "_connection_control",
         "_executor",
     )
 
@@ -39,14 +39,14 @@ class ObdConnectionRuntime:
         self,
         *,
         admin_client: ObdAdminClient,
-        connection_state: ObdRuntimeConnectionState,
+        connection_control: ObdRuntimeConnectionControl,
         session_factory: SessionFactory,
         monotonic: MonotonicFn = time.monotonic,
     ) -> None:
-        self._connection_state = connection_state
+        self._connection_control = connection_control
         self._executor = ObdConnectionExecutor(
             admin_client=admin_client,
-            connection_state=connection_state,
+            connection_control=connection_control,
             session_factory=session_factory,
             monotonic=monotonic,
         )
@@ -77,7 +77,7 @@ class ObdConnectionRuntime:
             selected_source,
             configured_mac,
             configured_name,
-        ) = self._connection_state.configured_device_snapshot()
+        ) = self._connection_control.configured_device_snapshot()
         return plan_connection_step(
             ObdConnectionLoopSnapshot(
                 selected_source=selected_source,
@@ -85,7 +85,9 @@ class ObdConnectionRuntime:
                 configured_name=configured_name,
                 has_session=session is not None,
                 session_device_mac=session_device_mac,
-                poll_wait_s=(self._connection_state.next_wait_s() if session is not None else None),
+                poll_wait_s=(
+                    self._connection_control.next_wait_s() if session is not None else None
+                ),
             ),
             idle_poll_s=_IDLE_POLL_S,
         )

--- a/apps/server/vibesensor/adapters/obd/runtime_admin_state.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_admin_state.py
@@ -1,0 +1,34 @@
+"""Admin-refresh mutation surface over shared Bluetooth OBD runtime state."""
+
+from __future__ import annotations
+
+from vibesensor.adapters.obd.admin_state import ObdAdminObservation
+
+from .runtime_store import ObdRuntimeStore
+
+__all__ = ["ObdRuntimeAdminState"]
+
+
+class ObdRuntimeAdminState:
+    """Apply configured-device admin observations without exposing connection-loop controls."""
+
+    __slots__ = ("_store",)
+
+    def __init__(self, *, store: ObdRuntimeStore) -> None:
+        self._store = store
+
+    def configured_device_mac_snapshot(self) -> str | None:
+        with self._store._lock:
+            return self._store.policy.configured_device_mac
+
+    def apply_admin_observation(
+        self,
+        configured_mac: str | None,
+        observation: ObdAdminObservation,
+    ) -> None:
+        with self._store._lock:
+            self._store.state.apply_admin_observation(
+                observed_configured_mac=configured_mac,
+                current_configured_mac=self._store.policy.configured_device_mac,
+                observation=observation,
+            )

--- a/apps/server/vibesensor/adapters/obd/runtime_connection_control.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_connection_control.py
@@ -1,19 +1,18 @@
-"""Connection/admin mutation surface over shared Bluetooth OBD runtime state."""
+"""Connection-loop mutation and planning surface over shared Bluetooth OBD state."""
 
 from __future__ import annotations
 
-from vibesensor.adapters.obd.admin_state import ObdAdminObservation
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.polling import ObdPollPlan, ObdPollResult
 from vibesensor.domain import SpeedSourceKind
 
 from .runtime_store import ObdRuntimeStore
 
-__all__ = ["ObdRuntimeConnectionState"]
+__all__ = ["ObdRuntimeConnectionControl"]
 
 
-class ObdRuntimeConnectionState:
-    """Own connection-loop/admin mutation over shared policy, polling, and observed state."""
+class ObdRuntimeConnectionControl:
+    """Own connection-loop planning and mutation over shared policy, polling, and state."""
 
     __slots__ = ("_store",)
 
@@ -23,10 +22,6 @@ class ObdRuntimeConnectionState:
     def configured_device_snapshot(self) -> tuple[SpeedSourceKind, str | None, str | None]:
         with self._store._lock:
             return self._store.policy.config_snapshot()
-
-    def configured_device_mac_snapshot(self) -> str | None:
-        with self._store._lock:
-            return self._store.policy.configured_device_mac
 
     def next_wait_s(self) -> float:
         with self._store._lock:
@@ -57,18 +52,6 @@ class ObdRuntimeConnectionState:
                 reconnect_delay_s=reconnect_delay_s,
             )
             return True
-
-    def apply_admin_observation(
-        self,
-        configured_mac: str | None,
-        observation: ObdAdminObservation,
-    ) -> None:
-        with self._store._lock:
-            self._store.state.apply_admin_observation(
-                observed_configured_mac=configured_mac,
-                current_configured_mac=self._store.policy.configured_device_mac,
-                observation=observation,
-            )
 
     def mark_connecting(self) -> None:
         with self._store._lock:

--- a/apps/server/vibesensor/adapters/obd/runtime_facts.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_facts.py
@@ -1,0 +1,31 @@
+"""Raw observed Bluetooth OBD facts over shared runtime state."""
+
+from __future__ import annotations
+
+from .runtime_store import ObdRuntimeStore
+
+__all__ = ["ObdRuntimeFacts"]
+
+
+class ObdRuntimeFacts:
+    """Read live OBD facts without applying selected-source policy."""
+
+    __slots__ = ("_store",)
+
+    def __init__(self, *, store: ObdRuntimeStore) -> None:
+        self._store = store
+
+    @property
+    def speed_mps(self) -> float | None:
+        with self._store._lock:
+            return self._store.state.speed_mps
+
+    @property
+    def engine_rpm(self) -> float | None:
+        now = self._store.monotonic()
+        with self._store._lock:
+            return self._store.state.engine_rpm(now=now)
+
+    @property
+    def engine_rpm_source(self) -> str | None:
+        return "obd2" if self.engine_rpm is not None else None

--- a/apps/server/vibesensor/adapters/obd/runtime_projection.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_projection.py
@@ -1,17 +1,18 @@
-"""Read-side observation and status projection for Bluetooth OBD runtime state."""
+"""Policy-derived Bluetooth OBD status and speed projection over runtime facts."""
 
 from __future__ import annotations
 
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution
 from vibesensor.adapters.obd.models import ObdStatusSnapshot
+from vibesensor.adapters.obd.status import build_obd_status_snapshot
 
 from .runtime_store import ObdRuntimeStore
 
-__all__ = ["ObdRuntimeObservation"]
+__all__ = ["ObdRuntimeProjection"]
 
 
-class ObdRuntimeObservation:
-    """Read-only view over live OBD speed, RPM, and status facts."""
+class ObdRuntimeProjection:
+    """Project effective OBD status and speed from raw facts plus policy."""
 
     __slots__ = ("_store",)
 
@@ -19,27 +20,9 @@ class ObdRuntimeObservation:
         self._store = store
 
     @property
-    def speed_mps(self) -> float | None:
-        with self._store._lock:
-            return self._store.state.speed_mps
-
-    @property
     def stale_timeout_s(self) -> float:
         with self._store._lock:
             return self._store.policy.stale_timeout_s
-
-    @property
-    def engine_rpm(self) -> float | None:
-        now = self._store.monotonic()
-        with self._store._lock:
-            return self._store.state.engine_rpm(
-                now=now,
-                obd_selected=self._store.policy.obd_selected,
-            )
-
-    @property
-    def engine_rpm_source(self) -> str | None:
-        return "obd2" if self.engine_rpm is not None else None
 
     def resolve_speed(self) -> SpeedResolution:
         with self._store._lock:
@@ -49,9 +32,13 @@ class ObdRuntimeObservation:
             )
 
     def status_snapshot(self) -> ObdStatusSnapshot:
+        now = self._store.monotonic()
         with self._store._lock:
-            now = self._store.monotonic()
-            return self._store.state.status_snapshot(
+            return build_obd_status_snapshot(
+                self._store.state.status_facts(
+                    engine_rpm=self._store.state.engine_rpm(now=now),
+                    polling=self._store.polling,
+                ),
                 configured_device_mac=self._store.policy.configured_device_mac,
                 configured_device_name=self._store.policy.configured_device_name,
                 effective_connection_state=self._store.policy.effective_connection_state(
@@ -59,6 +46,5 @@ class ObdRuntimeObservation:
                     speed_snapshot=self._store.state.speed_snapshot,
                 ),
                 obd_selected=self._store.policy.obd_selected,
-                now=now,
-                polling=self._store.polling,
+                now_mono=now,
             )

--- a/apps/server/vibesensor/adapters/obd/runtime_services.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_services.py
@@ -10,8 +10,10 @@ from vibesensor.adapters.obd.admin_client import ObdAdminClient
 from vibesensor.adapters.obd.admin_runtime import ObdAdminRuntime
 from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
 from vibesensor.adapters.obd.elm327 import Elm327Session
-from vibesensor.adapters.obd.runtime_connection_state import ObdRuntimeConnectionState
-from vibesensor.adapters.obd.runtime_observation import ObdRuntimeObservation
+from vibesensor.adapters.obd.runtime_admin_state import ObdRuntimeAdminState
+from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
+from vibesensor.adapters.obd.runtime_facts import ObdRuntimeFacts
+from vibesensor.adapters.obd.runtime_projection import ObdRuntimeProjection
 from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
 from vibesensor.adapters.obd.runtime_store import MonotonicFn, ObdRuntimeStore
 
@@ -28,10 +30,11 @@ SessionFactory = Callable[[], Elm327Session]
 class ObdRuntimeServices:
     """Focused OBD services exposed to the rest of the application."""
 
-    observation: ObdRuntimeObservation
+    facts: ObdRuntimeFacts
+    projection: ObdRuntimeProjection
     control: ObdRuntimeSettings
     admin: ObdAdminRuntime
-    connection_state: ObdRuntimeConnectionState
+    connection_control: ObdRuntimeConnectionControl
     runner: ObdConnectionRuntime
 
 
@@ -52,18 +55,20 @@ def build_obd_runtime(
         initial_reconnect_delay_s=_INITIAL_RECONNECT_DELAY_S,
         engine_rpm_stale_timeout_s=_RPM_STALE_TIMEOUT_S,
     )
-    connection_state = ObdRuntimeConnectionState(store=store)
+    connection_control = ObdRuntimeConnectionControl(store=store)
+    admin_state = ObdRuntimeAdminState(store=store)
     return ObdRuntimeServices(
-        observation=ObdRuntimeObservation(store=store),
+        facts=ObdRuntimeFacts(store=store),
+        projection=ObdRuntimeProjection(store=store),
         control=ObdRuntimeSettings(store=store),
         admin=ObdAdminRuntime(
             admin_client=resolved_admin_client,
-            connection_state=connection_state,
+            admin_state=admin_state,
         ),
-        connection_state=connection_state,
+        connection_control=connection_control,
         runner=ObdConnectionRuntime(
             admin_client=resolved_admin_client,
-            connection_state=connection_state,
+            connection_control=connection_control,
             session_factory=resolved_session_factory,
             monotonic=monotonic,
         ),

--- a/apps/server/vibesensor/adapters/obd/runtime_state.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_state.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from vibesensor.adapters.obd.admin_state import ObdAdminObservation
-from vibesensor.adapters.obd.models import ObdDeviceSnapshot, ObdStatusSnapshot
+from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.polling import ObdPidPollResult, ObdPollingCadence, ObdPollResult
-from vibesensor.adapters.obd.status import ObdMonitorStatusState, build_obd_status_snapshot
+from vibesensor.adapters.obd.status import ObdRuntimeStatusFacts
 from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.constants.units import KMH_TO_MPS
 
@@ -75,9 +75,7 @@ class ObdRuntimeState:
     def last_error(self) -> str | None:
         return self._last_error
 
-    def engine_rpm(self, *, now: float, obd_selected: bool) -> float | None:
-        if not obd_selected:
-            return None
+    def engine_rpm(self, *, now: float) -> float | None:
         if (
             not isinstance(self._engine_rpm, NUMERIC_TYPES)
             or isinstance(self._engine_rpm, bool)
@@ -166,38 +164,27 @@ class ObdRuntimeState:
         if clear_runtime_error:
             self._last_error = None
 
-    def status_snapshot(
+    def status_facts(
         self,
         *,
-        configured_device_mac: str | None,
-        configured_device_name: str | None,
-        effective_connection_state: str,
-        obd_selected: bool,
-        now: float,
+        engine_rpm: float | None,
         polling: ObdPollingCadence,
-    ) -> ObdStatusSnapshot:
-        return build_obd_status_snapshot(
-            ObdMonitorStatusState(
-                effective_connection_state=effective_connection_state,
-                transport_connection_state=self._connection_state,
-                configured_device_mac=configured_device_mac,
-                configured_device_name=configured_device_name,
-                device_mac=self._device_mac,
-                device_name=self._device_name,
-                paired=self._paired,
-                trusted=self._trusted,
-                connected=self._device_connected,
-                rfcomm_channel=self._rfcomm_channel,
-                speed_snapshot=self._speed_snapshot,
-                engine_rpm=self.engine_rpm(now=now, obd_selected=obd_selected),
-                engine_rpm_ts=self._engine_rpm_ts,
-                obd_selected=obd_selected,
-                last_error=self._last_error or self._last_admin_error,
-                helper_error=self._last_admin_error,
-                reconnect_delay_s=self._current_reconnect_delay,
-                polling=polling.snapshot(),
-            ),
-            now_mono=now,
+    ) -> ObdRuntimeStatusFacts:
+        return ObdRuntimeStatusFacts(
+            transport_connection_state=self._connection_state,
+            device_mac=self._device_mac,
+            device_name=self._device_name,
+            paired=self._paired,
+            trusted=self._trusted,
+            connected=self._device_connected,
+            rfcomm_channel=self._rfcomm_channel,
+            speed_snapshot=self._speed_snapshot,
+            engine_rpm=engine_rpm,
+            engine_rpm_ts=self._engine_rpm_ts,
+            last_runtime_error=self._last_error,
+            helper_error=self._last_admin_error,
+            reconnect_delay_s=self._current_reconnect_delay,
+            polling=polling.snapshot(),
         )
 
     @staticmethod

--- a/apps/server/vibesensor/adapters/obd/status.py
+++ b/apps/server/vibesensor/adapters/obd/status.py
@@ -1,4 +1,4 @@
-"""Pure OBD runtime-fact projection helpers."""
+"""Pure OBD status projection over raw runtime facts and explicit policy inputs."""
 
 from __future__ import annotations
 
@@ -10,17 +10,14 @@ from vibesensor.adapters.obd.polling import ObdPollingSnapshot
 from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.constants.units import MPS_TO_KMH
 
-__all__ = ["ObdMonitorStatusState", "build_obd_status_snapshot"]
+__all__ = ["ObdRuntimeStatusFacts", "build_obd_status_snapshot"]
 
 
 @dataclass(frozen=True, slots=True)
-class ObdMonitorStatusState:
-    """Immutable OBD runtime/admin snapshot for outward status presentation."""
+class ObdRuntimeStatusFacts:
+    """Immutable raw runtime/admin facts for outward OBD status projection."""
 
-    effective_connection_state: str
     transport_connection_state: str
-    configured_device_mac: str | None
-    configured_device_name: str | None
     device_mac: str | None
     device_name: str | None
     paired: bool
@@ -30,63 +27,66 @@ class ObdMonitorStatusState:
     speed_snapshot: tuple[float | None, float | None]
     engine_rpm: float | None
     engine_rpm_ts: float | None
-    obd_selected: bool
-    last_error: str | None
+    last_runtime_error: str | None
     helper_error: str | None
     reconnect_delay_s: float
     polling: ObdPollingSnapshot
 
 
 def build_obd_status_snapshot(
-    state: ObdMonitorStatusState,
+    facts: ObdRuntimeStatusFacts,
     *,
+    configured_device_mac: str | None,
+    configured_device_name: str | None,
+    effective_connection_state: str,
+    obd_selected: bool,
     now_mono: float | None = None,
 ) -> ObdStatusSnapshot:
     now = time.monotonic() if now_mono is None else now_mono
 
-    speed_mps, last_speed_ts = state.speed_snapshot
+    speed_mps, last_speed_ts = facts.speed_snapshot
     last_speed_age_s = None if last_speed_ts is None else round(now - last_speed_ts, 2)
     last_speed_kmh = None
     if isinstance(speed_mps, NUMERIC_TYPES) and not isinstance(speed_mps, bool):
         last_speed_kmh = round(float(speed_mps) * MPS_TO_KMH, 2)
 
     rpm_sample_age_s = None
-    if state.obd_selected and state.engine_rpm_ts is not None:
-        rpm_sample_age_s = round(now - state.engine_rpm_ts, 2)
+    if obd_selected and facts.engine_rpm_ts is not None:
+        rpm_sample_age_s = round(now - facts.engine_rpm_ts, 2)
 
     poll_mode = (
-        state.polling.poll_mode
-        if state.obd_selected and state.transport_connection_state == "connected"
+        facts.polling.poll_mode
+        if obd_selected and facts.transport_connection_state == "connected"
         else None
     )
 
     return ObdStatusSnapshot(
-        configured_device_mac=state.configured_device_mac,
-        configured_device_name=state.configured_device_name,
-        connection_state=state.effective_connection_state,
-        device_mac=state.device_mac or state.configured_device_mac,
-        device_name=state.device_name or state.configured_device_name,
-        paired=state.paired,
-        trusted=state.trusted,
-        connected=state.connected,
-        rfcomm_channel=state.rfcomm_channel,
+        configured_device_mac=configured_device_mac,
+        configured_device_name=configured_device_name,
+        connection_state=effective_connection_state,
+        device_mac=facts.device_mac or configured_device_mac,
+        device_name=facts.device_name or configured_device_name,
+        paired=facts.paired,
+        trusted=facts.trusted,
+        connected=facts.connected,
+        rfcomm_channel=facts.rfcomm_channel,
         last_sample_age_s=last_speed_age_s,
         last_speed_kmh=last_speed_kmh,
-        last_rpm=state.engine_rpm,
+        last_rpm=facts.engine_rpm,
         rpm_sample_age_s=rpm_sample_age_s,
-        rpm_target_interval_ms=state.polling.rpm_target_interval_ms if state.obd_selected else None,
-        rpm_effective_hz=state.polling.rpm_effective_hz if state.obd_selected else None,
-        request_rtt_ms=state.polling.request_rtt_ms if state.obd_selected else None,
-        timeout_count=state.polling.timeout_count,
-        error_count=state.polling.error_count,
+        rpm_target_interval_ms=facts.polling.rpm_target_interval_ms if obd_selected else None,
+        rpm_effective_hz=facts.polling.rpm_effective_hz if obd_selected else None,
+        request_rtt_ms=facts.polling.request_rtt_ms if obd_selected else None,
+        timeout_count=facts.polling.timeout_count,
+        error_count=facts.polling.error_count,
         poll_mode=poll_mode,
-        backoff_active=state.obd_selected and state.polling.backoff_active,
-        last_error=state.last_error,
-        last_raw_response=state.polling.last_raw_response,
+        backoff_active=obd_selected and facts.polling.backoff_active,
+        last_error=facts.last_runtime_error or facts.helper_error,
+        last_raw_response=facts.polling.last_raw_response,
         reconnect_delay_s=(
-            round(state.reconnect_delay_s, 1)
-            if state.transport_connection_state == "disconnected"
+            round(facts.reconnect_delay_s, 1)
+            if facts.transport_connection_state == "disconnected"
             else None
         ),
-        helper_error=state.helper_error,
+        helper_error=facts.helper_error,
     )

--- a/apps/server/vibesensor/adapters/speed/source_coordinator.py
+++ b/apps/server/vibesensor/adapters/speed/source_coordinator.py
@@ -24,18 +24,20 @@ __all__ = [
 ]
 
 
-class ObdObservation(Protocol):
+class ObdFacts(Protocol):
     @property
     def speed_mps(self) -> float | None: ...
-
-    @property
-    def stale_timeout_s(self) -> float: ...
 
     @property
     def engine_rpm(self) -> float | None: ...
 
     @property
     def engine_rpm_source(self) -> str | None: ...
+
+
+class ObdProjection(Protocol):
+    @property
+    def stale_timeout_s(self) -> float: ...
 
     def resolve_speed(self) -> SpeedResolution: ...
 
@@ -71,23 +73,25 @@ class _SelectedSourceState:
 class SpeedSourceObservationService:
     """Read-side view over the selected live speed source."""
 
-    __slots__ = ("_gps_monitor", "_obd_observation", "_selected_source")
+    __slots__ = ("_gps_monitor", "_obd_facts", "_obd_projection", "_selected_source")
 
     def __init__(
         self,
         *,
         gps_monitor: GPSSpeedMonitor,
-        obd_observation: ObdObservation,
+        obd_facts: ObdFacts,
+        obd_projection: ObdProjection,
         selected_source: _SelectedSourceState,
     ) -> None:
         self._gps_monitor = gps_monitor
-        self._obd_observation = obd_observation
+        self._obd_facts = obd_facts
+        self._obd_projection = obd_projection
         self._selected_source = selected_source
 
     @property
     def speed_mps(self) -> float | None:
         if self._selected_source.get() is SpeedSourceKind.OBD2:
-            return self._obd_observation.speed_mps
+            return self._obd_facts.speed_mps
         return self._gps_monitor.speed_mps
 
     @property
@@ -98,24 +102,24 @@ class SpeedSourceObservationService:
     def engine_rpm(self) -> float | None:
         if self._selected_source.get() is not SpeedSourceKind.OBD2:
             return None
-        return self._obd_observation.engine_rpm
+        return self._obd_facts.engine_rpm
 
     @property
     def engine_rpm_source(self) -> str | None:
         if self._selected_source.get() is not SpeedSourceKind.OBD2:
             return None
-        return self._obd_observation.engine_rpm_source
+        return self._obd_facts.engine_rpm_source
 
     def resolve_speed(self) -> SpeedResolution:
         if self._selected_source.get() is SpeedSourceKind.OBD2:
-            return self._obd_observation.resolve_speed()
+            return self._obd_projection.resolve_speed()
         return self._gps_monitor.resolve_speed()
 
     def status_snapshot(self) -> SpeedSourceStatusSnapshot:
         if self._selected_source.get() is not SpeedSourceKind.OBD2:
             return self._gps_monitor.status_snapshot()
-        resolution = self._obd_observation.resolve_speed()
-        obd_status = self._obd_observation.status_snapshot()
+        resolution = self._obd_projection.resolve_speed()
+        obd_status = self._obd_projection.status_snapshot()
         return SpeedSourceStatusSnapshot(
             gps_enabled=self._gps_monitor.gps_enabled,
             connection_state=obd_status.connection_state,
@@ -133,11 +137,11 @@ class SpeedSourceObservationService:
             reconnect_delay_s=obd_status.reconnect_delay_s,
             fallback_active=resolution.fallback_active,
             speed_source=resolution.source,
-            stale_timeout_s=self._obd_observation.stale_timeout_s,
+            stale_timeout_s=self._obd_projection.stale_timeout_s,
         )
 
     def obd_status(self) -> ObdStatusSnapshot:
-        return self._obd_observation.status_snapshot()
+        return self._obd_projection.status_snapshot()
 
     @staticmethod
     def _format_device(snapshot: ObdStatusSnapshot) -> str | None:
@@ -251,7 +255,8 @@ class SpeedSourceServices:
 def build_speed_source_services(
     *,
     gps_monitor: GPSSpeedMonitor,
-    obd_observation: ObdObservation,
+    obd_facts: ObdFacts,
+    obd_projection: ObdProjection,
     obd_device_admin: ObdDeviceAdmin,
     obd_status_refresher: ObdConfiguredDeviceRefresher,
     obd_control: SpeedSourceSync,
@@ -260,7 +265,8 @@ def build_speed_source_services(
     return SpeedSourceServices(
         observation=SpeedSourceObservationService(
             gps_monitor=gps_monitor,
-            obd_observation=obd_observation,
+            obd_facts=obd_facts,
+            obd_projection=obd_projection,
             selected_source=selected_source,
         ),
         admin=SpeedSourceAdminService(

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -140,7 +140,8 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     obd_runtime = build_obd_runtime(admin_client=obd_admin_client)
     speed_services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_observation=obd_runtime.observation,
+        obd_facts=obd_runtime.facts,
+        obd_projection=obd_runtime.projection,
         obd_device_admin=obd_admin_client,
         obd_status_refresher=obd_runtime.admin,
         obd_control=obd_runtime.control,


### PR DESCRIPTION
## Summary
- split raw OBD facts from policy-derived OBD projection inside the runtime services
- separate admin refresh state from connection-loop control instead of routing both through one shared runtime surface
- update speed-service wiring, container composition, and OBD/speed/http tests to the focused runtime boundaries

## Validation
- make lint
- make typecheck-backend
- .venv/bin/python -m pytest -q apps/server/tests/adapters/obd apps/server/tests/adapters/speed apps/server/tests/adapters/http/test_settings_endpoints.py apps/server/tests/adapters/http/test_settings_obd_endpoints.py