### PR TITLE
Refactor updater completion boundaries

### DIFF
--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -177,8 +177,7 @@ class TestUpdateManagerCancelledError:
             ),
             release_planner=SimpleNamespace(plan=AsyncMock(side_effect=asyncio.CancelledError())),
             workflow_executor=MagicMock(),
-            transport_coordinator=SimpleNamespace(cleanup_after_update=AsyncMock()),
-            runtime_details_refresher=SimpleNamespace(refresh=AsyncMock()),
+            finalizer=SimpleNamespace(finalize=AsyncMock()),
         )
 
         with pytest.raises(asyncio.CancelledError):

--- a/apps/server/tests/use_cases/updates/test_update_completion.py
+++ b/apps/server/tests/use_cases/updates/test_update_completion.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
+
+
+@pytest.mark.asyncio
+async def test_completion_finishes_transport_then_schedules_restart() -> None:
+    restart_scheduler = MagicMock()
+    restart_scheduler.schedule = AsyncMock(return_value=True)
+    status = MagicMock()
+    prepared_transport = MagicMock()
+    prepared_transport.complete_success = AsyncMock()
+    coordinator = UpdateCompletionCoordinator(
+        restart_scheduler=restart_scheduler,
+        status=status,
+    )
+
+    await coordinator.complete_success(
+        prepared_transport,
+        message="Update completed successfully",
+    )
+
+    prepared_transport.complete_success.assert_awaited_once_with(
+        "Update completed successfully",
+    )
+    restart_scheduler.schedule.assert_awaited_once_with()
+    status.add_issue.assert_not_called()
+    status.log.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_completion_records_issue_when_restart_scheduling_fails() -> None:
+    restart_scheduler = MagicMock()
+    restart_scheduler.schedule = AsyncMock(return_value=False)
+    status = MagicMock()
+    prepared_transport = MagicMock()
+    prepared_transport.complete_success = AsyncMock()
+    coordinator = UpdateCompletionCoordinator(
+        restart_scheduler=restart_scheduler,
+        status=status,
+    )
+
+    await coordinator.complete_success(
+        prepared_transport,
+        message="No server update needed; ESP firmware checked",
+    )
+
+    prepared_transport.complete_success.assert_awaited_once_with(
+        "No server update needed; ESP firmware checked",
+    )
+    status.add_issue.assert_called_once_with(
+        "done",
+        "Backend restart was not scheduled automatically",
+        "Run 'sudo systemctl restart vibesensor.service' manually",
+    )
+    status.log.assert_called_once_with("Automatic backend restart scheduling failed")

--- a/apps/server/tests/use_cases/updates/test_update_finalization.py
+++ b/apps/server/tests/use_cases/updates/test_update_finalization.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vibesensor.shared.exceptions import UpdateCleanupError
+from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
+
+
+@pytest.mark.asyncio
+async def test_finalizer_cleans_up_transport_then_refreshes_runtime() -> None:
+    transport_coordinator = MagicMock()
+    transport_coordinator.cleanup_after_update = AsyncMock()
+    runtime_details_refresher = MagicMock()
+    runtime_details_refresher.refresh = AsyncMock()
+    prepared_transport = MagicMock()
+    finalizer = UpdateWorkflowFinalizer(
+        transport_coordinator=transport_coordinator,
+        runtime_details_refresher=runtime_details_refresher,
+    )
+
+    await finalizer.finalize(prepared_transport)
+
+    transport_coordinator.cleanup_after_update.assert_awaited_once_with(prepared_transport)
+    runtime_details_refresher.refresh.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_finalizer_adds_cleanup_note_to_active_failure() -> None:
+    transport_coordinator = MagicMock()
+    transport_coordinator.cleanup_after_update = AsyncMock(
+        side_effect=UpdateCleanupError("transport cleanup failed"),
+    )
+    runtime_details_refresher = MagicMock()
+    runtime_details_refresher.refresh = AsyncMock()
+    finalizer = UpdateWorkflowFinalizer(
+        transport_coordinator=transport_coordinator,
+        runtime_details_refresher=runtime_details_refresher,
+    )
+
+    with pytest.raises(RuntimeError, match="workflow bug") as exc_info:
+        try:
+            raise RuntimeError("workflow bug")
+        except RuntimeError:
+            await finalizer.finalize(MagicMock())
+            raise
+
+    assert exc_info.value.__notes__ == ["Cleanup also failed: transport cleanup failed"]
+    runtime_details_refresher.refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finalizer_raises_cleanup_error_when_cleanup_fails_after_cancellation() -> None:
+    transport_coordinator = MagicMock()
+    transport_coordinator.cleanup_after_update = AsyncMock(
+        side_effect=UpdateCleanupError("transport cleanup failed"),
+    )
+    runtime_details_refresher = MagicMock()
+    runtime_details_refresher.refresh = AsyncMock()
+    finalizer = UpdateWorkflowFinalizer(
+        transport_coordinator=transport_coordinator,
+        runtime_details_refresher=runtime_details_refresher,
+    )
+
+    with pytest.raises(
+        UpdateCleanupError,
+        match="Cleanup failed after cancellation: transport cleanup failed",
+    ):
+        try:
+            raise asyncio.CancelledError
+        except asyncio.CancelledError:
+            await finalizer.finalize(MagicMock())

--- a/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
@@ -6,10 +6,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vibesensor.shared.exceptions import (
-    UpdateCleanupError,
     UpdatePreparationError,
     UpdateReleaseError,
 )
+from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
@@ -35,7 +35,6 @@ def _build_workflow() -> tuple[
     AsyncMock,
     AsyncMock,
     AsyncMock,
-    AsyncMock,
 ]:
     preparation = MagicMock()
     preparation.prepare = AsyncMock()
@@ -43,23 +42,19 @@ def _build_workflow() -> tuple[
     release_planner.plan = AsyncMock()
     workflow_executor = MagicMock()
     workflow_executor.execute = AsyncMock()
-    transport_coordinator = MagicMock()
-    transport_coordinator.cleanup_after_update = AsyncMock()
-    runtime_details_refresher = MagicMock()
-    runtime_details_refresher.refresh = AsyncMock()
+    finalizer = MagicMock(spec=UpdateWorkflowFinalizer)
+    finalizer.finalize = AsyncMock()
     return (
         UpdateWorkflow(
             preparation=preparation,
             release_planner=release_planner,
             workflow_executor=workflow_executor,
-            transport_coordinator=transport_coordinator,
-            runtime_details_refresher=runtime_details_refresher,
+            finalizer=finalizer,
         ),
         preparation.prepare,
         release_planner.plan,
         workflow_executor.execute,
-        transport_coordinator.cleanup_after_update,
-        runtime_details_refresher.refresh,
+        finalizer.finalize,
     )
 
 
@@ -86,7 +81,7 @@ def _build_manager(
 
 @pytest.mark.asyncio
 async def test_workflow_stops_after_preparation_failure_and_finalizes_without_transport() -> None:
-    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
+    workflow, prepare, plan, execute, finalize = _build_workflow()
     prepare.side_effect = UpdatePreparationError("validation failed")
 
     with pytest.raises(UpdatePreparationError, match="validation failed"):
@@ -95,13 +90,12 @@ async def test_workflow_stops_after_preparation_failure_and_finalizes_without_tr
     prepare.assert_awaited_once()
     plan.assert_not_awaited()
     execute.assert_not_awaited()
-    cleanup.assert_awaited_once_with(None)
-    refresh.assert_awaited_once_with()
+    finalize.assert_awaited_once_with(None)
 
 
 @pytest.mark.asyncio
 async def test_workflow_finalizes_the_prepared_transport_handle() -> None:
-    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
+    workflow, prepare, plan, execute, finalize = _build_workflow()
     prepared_transport = AsyncMock()
     prepared = PreparedUpdateRun(
         current_version="2026.4.3",
@@ -116,13 +110,12 @@ async def test_workflow_finalizes_the_prepared_transport_handle() -> None:
     prepare.assert_awaited_once()
     plan.assert_awaited_once_with(prepared)
     execute.assert_awaited_once_with(planned)
-    cleanup.assert_awaited_once_with(prepared_transport)
-    refresh.assert_awaited_once_with()
+    finalize.assert_awaited_once_with(prepared_transport)
 
 
 @pytest.mark.asyncio
 async def test_workflow_stops_after_release_failure_and_finalizes_prepared_transport() -> None:
-    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
+    workflow, prepare, plan, execute, finalize = _build_workflow()
     prepared_transport = AsyncMock()
     prepare.return_value = PreparedUpdateRun(
         current_version="2026.4.3",
@@ -134,27 +127,7 @@ async def test_workflow_stops_after_release_failure_and_finalizes_prepared_trans
         await workflow.run(request=_wifi_request())
 
     execute.assert_not_awaited()
-    cleanup.assert_awaited_once_with(prepared_transport)
-    refresh.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_workflow_adds_cleanup_note_to_workflow_bug() -> None:
-    workflow, prepare, plan, execute, cleanup, refresh = _build_workflow()
-    prepared_transport = AsyncMock()
-    prepare.return_value = PreparedUpdateRun(
-        current_version="2026.4.3",
-        prepared_transport=prepared_transport,
-    )
-    plan.return_value = object()
-    execute.side_effect = RuntimeError("workflow bug")
-    cleanup.side_effect = UpdateCleanupError("transport cleanup failed")
-
-    with pytest.raises(RuntimeError, match="workflow bug") as exc_info:
-        await workflow.run(request=_wifi_request())
-
-    assert exc_info.value.__notes__ == ["Cleanup also failed: transport cleanup failed"]
-    refresh.assert_not_awaited()
+    finalize.assert_awaited_once_with(prepared_transport)
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
@@ -24,37 +24,27 @@ def _executor() -> tuple[
     MagicMock,
     MagicMock,
     MagicMock,
-    MagicMock,
 ]:
+    completion = MagicMock()
+    completion.complete_success = AsyncMock()
     stager = MagicMock()
     deployment = MagicMock()
     deployment.deploy = AsyncMock(return_value=True)
     firmware_refresher = MagicMock()
     firmware_refresher.refresh_esp_firmware = AsyncMock()
-    restart_scheduler = MagicMock()
-    restart_scheduler.schedule = AsyncMock(return_value=True)
-    status = MagicMock()
     executor = UpdateWorkflowExecutor(
+        completion=completion,
         stager=stager,
         deployment=deployment,
         firmware_refresher=firmware_refresher,
-        restart_scheduler=restart_scheduler,
-        status=status,
     )
     return (
         executor,
+        completion,
         stager,
         deployment,
         firmware_refresher,
-        restart_scheduler,
-        status,
     )
-
-
-def _prepared_transport() -> MagicMock:
-    prepared_transport = MagicMock()
-    prepared_transport.complete_success = AsyncMock()
-    return prepared_transport
 
 
 def _prepared_run(prepared_transport: object) -> PreparedUpdateRun:
@@ -65,16 +55,15 @@ def _prepared_run(prepared_transport: object) -> PreparedUpdateRun:
 
 
 @pytest.mark.asyncio
-async def test_execute_refresh_plan_refreshes_firmware_then_finalizes_transport() -> None:
+async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() -> None:
     (
         executor,
+        completion,
         stager,
         deployment,
         firmware_refresher,
-        restart_scheduler,
-        status,
     ) = _executor()
-    prepared_transport = _prepared_transport()
+    prepared_transport = MagicMock()
     workflow = PlannedUpdateRun(
         prepared=_prepared_run(prepared_transport),
         execution_plan=RefreshFirmwarePlan(
@@ -88,28 +77,26 @@ async def test_execute_refresh_plan_refreshes_firmware_then_finalizes_transport(
     firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
         pinned_tag="server-v2026.4.3",
     )
-    prepared_transport.complete_success.assert_awaited_once_with(
-        "No server update needed; ESP firmware checked",
+    completion.complete_success.assert_awaited_once_with(
+        prepared_transport,
+        message="No server update needed; ESP firmware checked",
     )
-    restart_scheduler.schedule.assert_awaited_once_with()
-    status.add_issue.assert_not_called()
     deployment.deploy.assert_not_awaited()
     assert not stager.stage.called
 
 
 @pytest.mark.asyncio
-async def test_execute_install_plan_stages_and_deploys_before_finalization(tmp_path: Path) -> None:
+async def test_execute_install_plan_stages_and_deploys_before_completion(tmp_path: Path) -> None:
     (
         executor,
+        completion,
         stager,
         deployment,
         firmware_refresher,
-        restart_scheduler,
-        status,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
-    prepared_transport = _prepared_transport()
+    prepared_transport = MagicMock()
 
     @asynccontextmanager
     async def stage(_release: object):
@@ -129,29 +116,27 @@ async def test_execute_install_plan_stages_and_deploys_before_finalization(tmp_p
     assert completed == UpdateExecutionOutcome.installed
     stager.stage.assert_called_once_with(release)
     deployment.deploy.assert_awaited_once_with(staged_release)
-    prepared_transport.complete_success.assert_awaited_once_with(
-        "Update completed successfully",
+    completion.complete_success.assert_awaited_once_with(
+        prepared_transport,
+        message="Update completed successfully",
     )
-    restart_scheduler.schedule.assert_awaited_once_with()
-    status.add_issue.assert_not_called()
     firmware_refresher.refresh_esp_firmware.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_execute_install_plan_propagates_deploy_failure_before_finalization(
+async def test_execute_install_plan_propagates_deploy_failure_before_completion(
     tmp_path: Path,
 ) -> None:
     (
         executor,
+        completion,
         stager,
         deployment,
         _firmware_refresher,
-        restart_scheduler,
-        _status,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
-    prepared_transport = _prepared_transport()
+    prepared_transport = MagicMock()
 
     @asynccontextmanager
     async def stage(_release: object):
@@ -171,42 +156,4 @@ async def test_execute_install_plan_propagates_deploy_failure_before_finalizatio
         )
 
     deployment.deploy.assert_awaited_once_with(staged_release)
-    prepared_transport.complete_success.assert_not_awaited()
-    restart_scheduler.schedule.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_execute_records_issue_when_restart_scheduling_fails() -> None:
-    (
-        executor,
-        _stager,
-        _deployment,
-        firmware_refresher,
-        restart_scheduler,
-        status,
-    ) = _executor()
-    restart_scheduler.schedule.return_value = False
-    prepared_transport = _prepared_transport()
-
-    completed = await executor.execute(
-        PlannedUpdateRun(
-            prepared=_prepared_run(prepared_transport),
-            execution_plan=RefreshFirmwarePlan(
-                latest_tag="server-v2026.4.3",
-            ),
-        ),
-    )
-
-    assert completed == UpdateExecutionOutcome.refresh_only
-    firmware_refresher.refresh_esp_firmware.assert_awaited_once_with(
-        pinned_tag="server-v2026.4.3",
-    )
-    prepared_transport.complete_success.assert_awaited_once_with(
-        "No server update needed; ESP firmware checked",
-    )
-    status.add_issue.assert_called_once_with(
-        "done",
-        "Backend restart was not scheduled automatically",
-        "Run 'sudo systemctl restart vibesensor.service' manually",
-    )
-    status.log.assert_called_once_with("Automatic backend restart scheduling failed")
+    completion.complete_success.assert_not_awaited()

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -9,15 +9,15 @@ The updater now has one explicit run-scoped workflow boundary per concern:
 - ``run_models.py`` holds the canonical prepared/planned run models shared
   across the workflow.
 - ``workflow.py`` owns request-scoped orchestration across preparation,
-  planning, execution, and explicit post-run finalization.
+  planning, execution, and explicit post-run finalization handoff.
 - ``preparation.py`` owns validation, transport preparation, and current-version
   observation for one run while returning the prepared transport lifecycle
   explicitly.
 - ``release_planner.py`` interprets discovered release state into one canonical
   execution plan tied to that prepared session.
-- ``workflow_executor.py`` owns plan execution plus success/restart finalization
-  against the explicit prepared transport handle.
-- ``runtime_refresh.py`` refreshes runtime/build metadata after workflow exit.
+- ``workflow_executor.py`` owns plan execution only.
+- ``completion.py`` owns post-success transport completion and restart follow-up.
+- ``finalization.py`` owns unconditional transport cleanup and runtime refresh.
 - ``transport_lifecycles.py`` defines the prepared-transport and lifecycle
   interfaces plus request/status-based transport resolution.
 - ``transport_coordinator.py`` owns lifecycle selection, prepare-time rollback,

--- a/apps/server/vibesensor/use_cases/updates/completion.py
+++ b/apps/server/vibesensor/use_cases/updates/completion.py
@@ -1,0 +1,40 @@
+"""Successful update completion boundary for updater workflows."""
+
+from __future__ import annotations
+
+from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.transport_lifecycles import PreparedUpdateTransport
+
+__all__ = ["UpdateCompletionCoordinator"]
+
+
+class UpdateCompletionCoordinator:
+    """Own post-success transport completion and restart follow-up."""
+
+    __slots__ = ("_restart_scheduler", "_status")
+
+    def __init__(
+        self,
+        *,
+        restart_scheduler: UpdateRestartScheduler,
+        status: UpdateStatusTracker,
+    ) -> None:
+        self._restart_scheduler = restart_scheduler
+        self._status = status
+
+    async def complete_success(
+        self,
+        prepared_transport: PreparedUpdateTransport,
+        *,
+        message: str,
+    ) -> None:
+        await prepared_transport.complete_success(message)
+        if await self._restart_scheduler.schedule():
+            return
+        self._status.add_issue(
+            "done",
+            "Backend restart was not scheduled automatically",
+            "Run 'sudo systemctl restart vibesensor.service' manually",
+        )
+        self._status.log("Automatic backend restart scheduling failed")

--- a/apps/server/vibesensor/use_cases/updates/finalization.py
+++ b/apps/server/vibesensor/use_cases/updates/finalization.py
@@ -1,0 +1,42 @@
+"""Always-run workflow finalization for updater runs."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from vibesensor.shared.exceptions import UpdateCleanupError
+from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
+from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
+from vibesensor.use_cases.updates.transport_lifecycles import PreparedUpdateTransport
+
+__all__ = ["UpdateWorkflowFinalizer"]
+
+
+class UpdateWorkflowFinalizer:
+    """Own unconditional transport cleanup and runtime refresh after one run."""
+
+    __slots__ = ("_runtime_details_refresher", "_transport_coordinator")
+
+    def __init__(
+        self,
+        *,
+        transport_coordinator: UpdateTransportCoordinator,
+        runtime_details_refresher: UpdateRuntimeDetailsRefresher,
+    ) -> None:
+        self._transport_coordinator = transport_coordinator
+        self._runtime_details_refresher = runtime_details_refresher
+
+    async def finalize(self, prepared_transport: PreparedUpdateTransport | None) -> None:
+        active_error = sys.exc_info()[1]
+        try:
+            await self._transport_coordinator.cleanup_after_update(prepared_transport)
+            await self._runtime_details_refresher.refresh()
+        except asyncio.CancelledError:
+            raise
+        except UpdateCleanupError as exc:
+            if active_error is None:
+                raise
+            if isinstance(active_error, asyncio.CancelledError):
+                raise UpdateCleanupError(f"Cleanup failed after cancellation: {exc}") from exc
+            active_error.add_note(f"Cleanup also failed: {exc}")

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -7,6 +7,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
+from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.manager import UpdateManager
@@ -283,16 +285,20 @@ def _build_update_workflow(
             resolver=resolver,
         ),
         workflow_executor=UpdateWorkflowExecutor(
+            completion=UpdateCompletionCoordinator(
+                restart_scheduler=restart_scheduler,
+                status=status,
+            ),
             stager=stager,
             deployment=deployment,
             firmware_refresher=firmware_refresher,
-            restart_scheduler=restart_scheduler,
-            status=status,
         ),
-        transport_coordinator=transport_coordinator,
-        runtime_details_refresher=UpdateRuntimeDetailsRefresher(
-            status=status,
-            repo=config.repo,
-            logger=LOGGER,
+        finalizer=UpdateWorkflowFinalizer(
+            transport_coordinator=transport_coordinator,
+            runtime_details_refresher=UpdateRuntimeDetailsRefresher(
+                status=status,
+                repo=config.repo,
+                logger=LOGGER,
+            ),
         ),
     )

--- a/apps/server/vibesensor/use_cases/updates/workflow.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
-import sys
 from dataclasses import dataclass
 
-from vibesensor.shared.exceptions import UpdateCleanupError
+from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.models import UpdateRequest
 from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
 from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
 from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
-from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
-from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
 from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
 
 __all__ = ["UpdateWorkflow"]
@@ -25,8 +21,7 @@ class UpdateWorkflow:
     preparation: UpdatePreparationCoordinator
     release_planner: UpdateReleasePlanner
     workflow_executor: UpdateWorkflowExecutor
-    transport_coordinator: UpdateTransportCoordinator
-    runtime_details_refresher: UpdateRuntimeDetailsRefresher
+    finalizer: UpdateWorkflowFinalizer
 
     async def run(
         self,
@@ -39,20 +34,6 @@ class UpdateWorkflow:
             planned = await self.release_planner.plan(prepared)
             await self.workflow_executor.execute(planned)
         finally:
-            await self._finalize(prepared)
-
-    async def _finalize(self, prepared: PreparedUpdateRun | None) -> None:
-        active_error = sys.exc_info()[1]
-        try:
-            await self.transport_coordinator.cleanup_after_update(
+            await self.finalizer.finalize(
                 None if prepared is None else prepared.prepared_transport,
             )
-            await self.runtime_details_refresher.refresh()
-        except asyncio.CancelledError:
-            raise
-        except UpdateCleanupError as exc:
-            if active_error is None:
-                raise
-            if isinstance(active_error, asyncio.CancelledError):
-                raise UpdateCleanupError(f"Cleanup failed after cancellation: {exc}") from exc
-            active_error.add_note(f"Cleanup also failed: {exc}")

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
 from vibesensor.use_cases.updates.release_deployment import (
     UpdateReleaseDeploymentCoordinator,
 )
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
-from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
 from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
     PlannedUpdateRun,
     RefreshFirmwarePlan,
 )
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.transport_lifecycles import PreparedUpdateTransport
 
 __all__ = ["UpdateWorkflowExecutor"]
 
@@ -24,27 +22,24 @@ class UpdateWorkflowExecutor:
     """Execute a prepared release plan while delegating side effects to focused collaborators."""
 
     __slots__ = (
+        "_completion",
         "_deployment",
         "_firmware_refresher",
-        "_restart_scheduler",
         "_stager",
-        "_status",
     )
 
     def __init__(
         self,
         *,
+        completion: UpdateCompletionCoordinator,
         stager: ServerReleaseStager,
         deployment: UpdateReleaseDeploymentCoordinator,
         firmware_refresher: FirmwareRefresher,
-        restart_scheduler: UpdateRestartScheduler,
-        status: UpdateStatusTracker,
     ) -> None:
+        self._completion = completion
         self._stager = stager
         self._deployment = deployment
         self._firmware_refresher = firmware_refresher
-        self._restart_scheduler = restart_scheduler
-        self._status = status
 
     async def execute(
         self,
@@ -68,7 +63,7 @@ class UpdateWorkflowExecutor:
         plan: RefreshFirmwarePlan,
     ) -> UpdateExecutionOutcome:
         await self._firmware_refresher.refresh_esp_firmware(pinned_tag=plan.latest_tag)
-        await self._complete_success(
+        await self._completion.complete_success(
             workflow.prepared.prepared_transport,
             message="No server update needed; ESP firmware checked",
         )
@@ -82,24 +77,8 @@ class UpdateWorkflowExecutor:
     ) -> UpdateExecutionOutcome:
         async with self._stager.stage(plan.release) as staged_release:
             await self._deployment.deploy(staged_release)
-        await self._complete_success(
+        await self._completion.complete_success(
             workflow.prepared.prepared_transport,
             message="Update completed successfully",
         )
         return UpdateExecutionOutcome.installed
-
-    async def _complete_success(
-        self,
-        prepared_transport: PreparedUpdateTransport,
-        *,
-        message: str,
-    ) -> None:
-        await prepared_transport.complete_success(message)
-        if await self._restart_scheduler.schedule():
-            return
-        self._status.add_issue(
-            "done",
-            "Backend restart was not scheduled automatically",
-            "Run 'sudo systemctl restart vibesensor.service' manually",
-        )
-        self._status.log("Automatic backend restart scheduling failed")


### PR DESCRIPTION
## Summary
- move successful update side effects into `UpdateCompletionCoordinator`
- move always-run cleanup and runtime refresh into `UpdateWorkflowFinalizer`
- retarget updater tests to the new canonical seams

## Issues addressed
- updates success completion and finalization are split across too many seams

## Architectural simplifications
- `UpdateWorkflowExecutor` no longer owns restart scheduling or status issue emission
- `UpdateWorkflow` no longer owns transport cleanup or runtime refresh details
- updater runtime wiring now makes success completion and finalization explicit collaborators

## Compatibility removals
- removed the old executor-owned success/restart finalization seam
- removed the old workflow-owned cleanup/runtime refresh seam

## Breaking changes
- internal-only updater constructor seams changed for `UpdateWorkflow` and `UpdateWorkflowExecutor`

## Local validation
- `pytest -q apps/server/tests/use_cases/updates apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `make lint && make typecheck-backend`