### PR TITLE
Split report document context composition

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_document_context.py
+++ b/apps/server/tests/use_cases/history/test_report_document_context.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from test_support.findings import make_finding_payload
+
+from vibesensor.shared.boundaries.reporting import PreparedReportInput, prepare_report_input
+from vibesensor.use_cases.history import report_document
+from vibesensor.use_cases.history.report_document.builder import build_report_document_data
+from vibesensor.use_cases.history.report_document.composition import (
+    ReportDocumentContext,
+    compose_report_document_context,
+)
+
+
+def _prepared_report_input() -> PreparedReportInput:
+    finding = make_finding_payload(finding_id="F001")
+    return prepare_report_input(
+        {
+            "run_id": "report-context",
+            "file_name": "report-context.csv",
+            "rows": 32,
+            "duration_s": 12.5,
+            "sensor_count_used": 2,
+            "lang": "en",
+            "metadata": {},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "warnings": [],
+            "sensor_locations": ["front-left", "rear-right"],
+            "sensor_locations_connected_throughout": ["rear-right"],
+            "sensor_intensity_by_location": [],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "plots": {},
+            "test_plan": [],
+            "findings": [finding],
+            "top_causes": [finding],
+        }
+    )
+
+
+def test_report_document_context_is_canonical_pre_render_state() -> None:
+    prepared = _prepared_report_input()
+
+    context = compose_report_document_context(prepared)
+    rebuilt_document = build_report_document_data(context)
+
+    assert isinstance(context, ReportDocumentContext)
+    assert context.sensor_locations == ("rear-right",)
+    assert rebuilt_document == report_document.build_report_document(prepared)

--- a/apps/server/vibesensor/use_cases/history/report_document/__init__.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/__init__.py
@@ -7,7 +7,7 @@ from ._candidate_resolver import (
     resolve_primary_report_candidate,
 )
 from ._card_builder import build_system_cards, humanize_signatures
-from .composition import build_report_document
+from .builder import build_report_document
 
 __all__ = [
     "PrimaryCandidateContext",

--- a/apps/server/vibesensor/use_cases/history/report_document/builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/builder.py
@@ -1,0 +1,55 @@
+"""Map composed report context to the PDF-facing report document model."""
+
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.reporting import PreparedReportInput
+from vibesensor.shared.boundaries.reporting.document import ReportDocument
+
+from .composition import ReportDocumentContext, compose_report_document_context
+
+__all__ = ["build_report_document"]
+
+
+def build_report_document_data(context: ReportDocumentContext) -> ReportDocument:
+    """Build the final PDF-facing report document from composed report context."""
+
+    return ReportDocument(
+        title=context.title,
+        run_datetime=context.run_datetime,
+        run_id=context.run_id,
+        duration_text=context.duration_text,
+        start_time_utc=context.start_time_utc,
+        end_time_utc=context.end_time_utc,
+        sample_rate_hz=context.sample_rate_hz,
+        tire_spec_text=context.tire_spec_text,
+        sample_count=context.sample_count,
+        sensor_count=context.sensor_count,
+        sensor_locations=list(context.sensor_locations),
+        sensor_model=context.sensor_model,
+        firmware_version=context.firmware_version,
+        car_name=context.car_name,
+        car_type=context.car_type,
+        observed=context.observed,
+        system_cards=list(context.system_cards),
+        next_steps=list(context.next_steps),
+        data_trust=list(context.data_trust),
+        pattern_evidence=context.pattern_evidence,
+        peak_rows=list(context.peak_rows),
+        lang=context.lang,
+        certainty_tier_key=context.certainty_tier_key,
+        findings=list(context.findings),
+        top_causes=list(context.top_causes),
+        sensor_intensity_by_location=list(context.sensor_intensity_by_location),
+        location_hotspot_rows=list(context.location_hotspot_rows),
+        verdict_page=context.verdict_page,
+        appendix_a=context.appendix_a,
+        appendix_b=context.appendix_b,
+        appendix_c=context.appendix_c,
+        traceability_rows=list(context.traceability_rows),
+    )
+
+
+def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
+    """Build the final PDF-facing report document from prepared report input."""
+
+    return build_report_document_data(compose_report_document_context(prepared))

--- a/apps/server/vibesensor/use_cases/history/report_document/composition.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/composition.py
@@ -1,22 +1,28 @@
-"""Canonical report-document composition from prepared report facts."""
+"""Compose canonical pre-render report state from prepared report input."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 
-from vibesensor.domain import TestRun
+from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary, TestRun
 from vibesensor.report_i18n import normalize_lang
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts, PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
     AppendixBData,
+    AppendixCData,
+    DataTrustItem,
     NextStep,
-    ReportDocument,
+    PatternEvidence,
+    PeakRow,
+    ReportLabelValueRow,
+    SystemFindingCard,
     VerdictPageData,
 )
 from vibesensor.shared.boundaries.reporting.facts import ReportRunFacts
+from vibesensor.shared.boundaries.reporting.findings import FindingPresentation
 from vibesensor.shared.report_presentation import (
     coverage_label,
     coverage_notes,
@@ -54,7 +60,7 @@ from .workflow_appendix import (
     recapture_issue_lines as build_recapture_issue_lines,
 )
 
-__all__ = ["build_report_document"]
+__all__ = ["ReportDocumentContext", "compose_report_document_context"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,8 +72,46 @@ class _ReportDocumentSections:
     appendix_b: AppendixBData
 
 
-def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
-    """Compose the canonical report document directly from prepared report input."""
+@dataclass(frozen=True, slots=True)
+class ReportDocumentContext:
+    """Canonical pre-render report state composed before PDF document mapping."""
+
+    title: str
+    run_datetime: str
+    run_id: str
+    duration_text: str | None
+    start_time_utc: str | None
+    end_time_utc: str | None
+    sample_rate_hz: str | None
+    tire_spec_text: str | None
+    sample_count: int
+    sensor_count: int
+    sensor_locations: tuple[str, ...]
+    sensor_model: str | None
+    firmware_version: str | None
+    car_name: str | None
+    car_type: str | None
+    observed: PatternEvidence
+    system_cards: tuple[SystemFindingCard, ...]
+    next_steps: tuple[NextStep, ...]
+    data_trust: tuple[DataTrustItem, ...]
+    pattern_evidence: PatternEvidence
+    peak_rows: tuple[PeakRow, ...]
+    lang: str
+    certainty_tier_key: str
+    findings: tuple[FindingPresentation, ...]
+    top_causes: tuple[FindingPresentation, ...]
+    sensor_intensity_by_location: tuple[LocationIntensitySummary, ...]
+    location_hotspot_rows: tuple[LocationHotspotRow, ...]
+    verdict_page: VerdictPageData
+    appendix_a: AppendixAData
+    appendix_b: AppendixBData
+    appendix_c: AppendixCData
+    traceability_rows: tuple[ReportLabelValueRow, ...]
+
+
+def compose_report_document_context(prepared: PreparedReportInput) -> ReportDocumentContext:
+    """Compose the canonical pre-render report context from prepared report input."""
 
     lang = str(normalize_lang(prepared.language))
 
@@ -106,9 +150,19 @@ def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
         runner_up_corner=sections.appendix_b.runner_up_corner,
         tr=tr,
     )
-    return ReportDocument(
+    run_datetime = _report_date_text(run_facts)
+    findings = tuple(prepared_findings.all_findings)
+    verdict_page = replace(
+        sections.verdict_page,
+        proof_summary=proof_summary,
+        timeline_graph=_build_timeline_graph_data(
+            report_facts,
+            duration_s=run_facts.duration_s,
+        ),
+    )
+    return ReportDocumentContext(
         title=tr("REPORT_FOOTER_TITLE"),
-        run_datetime=_report_date_text(run_facts),
+        run_datetime=run_datetime,
         run_id=run_facts.run_id,
         duration_text=run_facts.duration_text,
         start_time_utc=format_utc_timestamp(run_facts.start_time_utc),
@@ -117,13 +171,13 @@ def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
         tire_spec_text=run_facts.tire_spec_text,
         sample_count=run_facts.sample_count,
         sensor_count=primary.sensor_count,
-        sensor_locations=list(sensor_facts.active_locations),
+        sensor_locations=tuple(sensor_facts.active_locations),
         sensor_model=run_facts.sensor_model,
         firmware_version=run_facts.firmware_version,
         car_name=run_facts.car_name,
         car_type=run_facts.car_type,
         observed=build_observed_signature(primary, tr=tr),
-        system_cards=list(
+        system_cards=tuple(
             build_system_cards(
                 test_run,
                 primary,
@@ -131,16 +185,14 @@ def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
                 tr,
             )
         ),
-        next_steps=list(
-            _resolve_next_steps(
-                primary=primary,
-                report_facts=report_facts,
-                appendix_a=sections.appendix_a,
-                lang=lang,
-                tr=tr,
-            )
+        next_steps=_resolve_next_steps(
+            primary=primary,
+            report_facts=report_facts,
+            appendix_a=sections.appendix_a,
+            lang=lang,
+            tr=tr,
         ),
-        data_trust=list(data_trust),
+        data_trust=data_trust,
         pattern_evidence=build_pattern_evidence(
             aggregate=test_run,
             origin=run_facts.origin,
@@ -148,28 +200,21 @@ def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
             lang=lang,
             tr=tr,
         ),
-        peak_rows=list(
+        peak_rows=tuple(
             build_peak_rows(
                 run_facts.peak_table_rows,
-                findings=list(prepared_findings.all_findings),
+                findings=list(findings),
                 lang=lang,
                 tr=tr,
             )
         ),
         lang=lang,
         certainty_tier_key=primary.tier,
-        findings=list(prepared_findings.all_findings),
-        top_causes=list(prepared_findings.top_causes),
-        sensor_intensity_by_location=list(sensor_facts.active_intensity),
-        location_hotspot_rows=list(sensor_facts.location_hotspot_rows),
-        verdict_page=replace(
-            sections.verdict_page,
-            proof_summary=proof_summary,
-            timeline_graph=_build_timeline_graph_data(
-                report_facts,
-                duration_s=run_facts.duration_s,
-            ),
-        ),
+        findings=findings,
+        top_causes=tuple(prepared_findings.top_causes),
+        sensor_intensity_by_location=tuple(sensor_facts.active_intensity),
+        location_hotspot_rows=tuple(sensor_facts.location_hotspot_rows),
+        verdict_page=verdict_page,
         appendix_a=sections.appendix_a,
         appendix_b=sections.appendix_b,
         appendix_c=_build_appendix_c_data(
@@ -186,15 +231,17 @@ def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
             data_trust=list(data_trust),
             tr=tr,
         ),
-        traceability_rows=_build_traceability_rows(
-            date_str=_report_date_text(run_facts),
-            run_id=run_facts.run_id,
-            tire_spec_text=run_facts.tire_spec_text,
-            sensor_model=run_facts.sensor_model,
-            firmware_version=run_facts.firmware_version,
-            sample_count=run_facts.sample_count,
-            sample_rate_hz=run_facts.sample_rate_hz,
-            tr=tr,
+        traceability_rows=tuple(
+            _build_traceability_rows(
+                date_str=run_datetime,
+                run_id=run_facts.run_id,
+                tire_spec_text=run_facts.tire_spec_text,
+                sensor_model=run_facts.sensor_model,
+                firmware_version=run_facts.firmware_version,
+                sample_count=run_facts.sample_count,
+                sample_rate_hz=run_facts.sample_rate_hz,
+                tr=tr,
+            )
         ),
     )
 


### PR DESCRIPTION
## Summary
- compose immutable pre-render report state in `report_document/composition.py`
- move final `ReportDocument` mapping into a thin `report_document/builder.py` layer
- add a focused report-context test while keeping the public `build_report_document()` API stable

## Issues addressed
- report document composition is still a monolithic change surface

## Architectural simplifications
- report presentation logic now composes one canonical `ReportDocumentContext`
- final PDF-facing `ReportDocument` assembly is now a thin mapping layer
- the package surface stays small: internal composition/builder helpers are not re-exported

## Compatibility removals
- removed the old direct composition-to-`ReportDocument` assembly seam from `composition.py`

## Breaking changes
- none at the public package boundary; internal report-document module seams changed

## Local validation
- `pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py apps/server/tests/integration/test_decode_project_roundtrip.py apps/server/tests/integration/test_contract_analysis_report.py`
- `make lint && make typecheck-backend`