### PR TITLE
Split OBD connection observation from control

### DIFF
--- a/apps/server/tests/test_support/obd_runtime.py
+++ b/apps/server/tests/test_support/obd_runtime.py
@@ -10,6 +10,9 @@ from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.runtime_admin_state import ObdRuntimeAdminState
 from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
+from vibesensor.adapters.obd.runtime_connection_observation import (
+    ObdRuntimeConnectionObservation,
+)
 from vibesensor.adapters.obd.runtime_facts import ObdRuntimeFacts
 from vibesensor.adapters.obd.runtime_projection import ObdRuntimeProjection
 from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
@@ -66,9 +69,11 @@ def build_obd_runtime_parts(
         engine_rpm_stale_timeout_s=2.0,
     )
     connection_control = ObdRuntimeConnectionControl(store=store)
+    connection_observation = ObdRuntimeConnectionObservation(store=store)
     admin_state = ObdRuntimeAdminState(store=store)
     executor = ObdConnectionExecutor(
         admin_client=admin,
+        connection_observation=connection_observation,
         connection_control=connection_control,
         session_factory=lambda: resolved_session,
         monotonic=clock,
@@ -76,6 +81,7 @@ def build_obd_runtime_parts(
     )
     runner = ObdConnectionRuntime(
         admin_client=admin,
+        connection_observation=connection_observation,
         connection_control=connection_control,
         session_factory=lambda: resolved_session,
         monotonic=clock,

--- a/apps/server/vibesensor/adapters/obd/connection_executor.py
+++ b/apps/server/vibesensor/adapters/obd/connection_executor.py
@@ -13,6 +13,9 @@ from vibesensor.adapters.obd.elm327 import Elm327Session, ObdTransportError
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.polling import ObdPollResult, execute_poll_plan
 from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
+from vibesensor.adapters.obd.runtime_connection_observation import (
+    ObdRuntimeConnectionObservation,
+)
 from vibesensor.shared.operational_errors import OperationalError, ServiceUnavailableError
 
 __all__ = ["ObdConnectionExecutor", "ObdConnectionLoopState"]
@@ -37,6 +40,7 @@ class ObdConnectionExecutor:
 
     __slots__ = (
         "_admin_client",
+        "_connection_observation",
         "_connection_control",
         "_monotonic",
         "_session_factory",
@@ -47,12 +51,14 @@ class ObdConnectionExecutor:
         self,
         *,
         admin_client: ObdAdminClient,
+        connection_observation: ObdRuntimeConnectionObservation,
         connection_control: ObdRuntimeConnectionControl,
         session_factory: SessionFactory,
         monotonic: MonotonicFn = time.monotonic,
         sleep: SleepFn = asyncio.sleep,
     ) -> None:
         self._admin_client = admin_client
+        self._connection_observation = connection_observation
         self._connection_control = connection_control
         self._session_factory = session_factory
         self._monotonic = monotonic
@@ -203,7 +209,7 @@ class ObdConnectionExecutor:
                 session.close()
 
     def _poll_cycle_blocking(self, session: Elm327Session) -> ObdPollResult:
-        plan = self._connection_control.prepare_poll()
+        plan = self._connection_observation.prepare_poll()
         return execute_poll_plan(session, plan=plan, monotonic=self._monotonic)
 
     async def _close_session_if_needed(

--- a/apps/server/vibesensor/adapters/obd/connection_runtime.py
+++ b/apps/server/vibesensor/adapters/obd/connection_runtime.py
@@ -18,6 +18,9 @@ from vibesensor.adapters.obd.connection_plan import (
 )
 from vibesensor.adapters.obd.elm327 import Elm327Session
 from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
+from vibesensor.adapters.obd.runtime_connection_observation import (
+    ObdRuntimeConnectionObservation,
+)
 
 __all__ = ["ObdConnectionRuntime"]
 
@@ -31,7 +34,7 @@ class ObdConnectionRuntime:
     """Own session lifecycle, reconnect behavior, and blocking poll execution."""
 
     __slots__ = (
-        "_connection_control",
+        "_connection_observation",
         "_executor",
     )
 
@@ -39,13 +42,15 @@ class ObdConnectionRuntime:
         self,
         *,
         admin_client: ObdAdminClient,
+        connection_observation: ObdRuntimeConnectionObservation,
         connection_control: ObdRuntimeConnectionControl,
         session_factory: SessionFactory,
         monotonic: MonotonicFn = time.monotonic,
     ) -> None:
-        self._connection_control = connection_control
+        self._connection_observation = connection_observation
         self._executor = ObdConnectionExecutor(
             admin_client=admin_client,
+            connection_observation=connection_observation,
             connection_control=connection_control,
             session_factory=session_factory,
             monotonic=monotonic,
@@ -77,7 +82,7 @@ class ObdConnectionRuntime:
             selected_source,
             configured_mac,
             configured_name,
-        ) = self._connection_control.configured_device_snapshot()
+        ) = self._connection_observation.configured_device_snapshot()
         return plan_connection_step(
             ObdConnectionLoopSnapshot(
                 selected_source=selected_source,
@@ -86,7 +91,7 @@ class ObdConnectionRuntime:
                 has_session=session is not None,
                 session_device_mac=session_device_mac,
                 poll_wait_s=(
-                    self._connection_control.next_wait_s() if session is not None else None
+                    self._connection_observation.next_wait_s() if session is not None else None
                 ),
             ),
             idle_poll_s=_IDLE_POLL_S,

--- a/apps/server/vibesensor/adapters/obd/runtime_connection_control.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_connection_control.py
@@ -1,10 +1,9 @@
-"""Connection-loop mutation and planning surface over shared Bluetooth OBD state."""
+"""Connection-loop mutation surface over shared Bluetooth OBD state."""
 
 from __future__ import annotations
 
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
-from vibesensor.adapters.obd.polling import ObdPollPlan, ObdPollResult
-from vibesensor.domain import SpeedSourceKind
+from vibesensor.adapters.obd.polling import ObdPollResult
 
 from .runtime_store import ObdRuntimeStore
 
@@ -12,24 +11,12 @@ __all__ = ["ObdRuntimeConnectionControl"]
 
 
 class ObdRuntimeConnectionControl:
-    """Own connection-loop planning and mutation over shared policy, polling, and state."""
+    """Own connection-loop state mutation over shared policy, polling, and state."""
 
     __slots__ = ("_store",)
 
     def __init__(self, *, store: ObdRuntimeStore) -> None:
         self._store = store
-
-    def configured_device_snapshot(self) -> tuple[SpeedSourceKind, str | None, str | None]:
-        with self._store._lock:
-            return self._store.policy.config_snapshot()
-
-    def next_wait_s(self) -> float:
-        with self._store._lock:
-            return self._store.polling.next_wait_s(now=self._store.monotonic())
-
-    def prepare_poll(self) -> ObdPollPlan:
-        with self._store._lock:
-            return self._store.polling.prepare_poll(now=self._store.monotonic())
 
     def apply_poll_cycle(
         self,

--- a/apps/server/vibesensor/adapters/obd/runtime_connection_observation.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_connection_observation.py
@@ -1,0 +1,31 @@
+"""Connection-loop observation surface over shared Bluetooth OBD runtime state."""
+
+from __future__ import annotations
+
+from vibesensor.adapters.obd.polling import ObdPollPlan
+from vibesensor.domain import SpeedSourceKind
+
+from .runtime_store import ObdRuntimeStore
+
+__all__ = ["ObdRuntimeConnectionObservation"]
+
+
+class ObdRuntimeConnectionObservation:
+    """Read connection-loop planning inputs without mutating runtime state."""
+
+    __slots__ = ("_store",)
+
+    def __init__(self, *, store: ObdRuntimeStore) -> None:
+        self._store = store
+
+    def configured_device_snapshot(self) -> tuple[SpeedSourceKind, str | None, str | None]:
+        with self._store._lock:
+            return self._store.policy.config_snapshot()
+
+    def next_wait_s(self) -> float:
+        with self._store._lock:
+            return self._store.polling.next_wait_s(now=self._store.monotonic())
+
+    def prepare_poll(self) -> ObdPollPlan:
+        with self._store._lock:
+            return self._store.polling.prepare_poll(now=self._store.monotonic())

--- a/apps/server/vibesensor/adapters/obd/runtime_services.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_services.py
@@ -12,6 +12,9 @@ from vibesensor.adapters.obd.connection_runtime import ObdConnectionRuntime
 from vibesensor.adapters.obd.elm327 import Elm327Session
 from vibesensor.adapters.obd.runtime_admin_state import ObdRuntimeAdminState
 from vibesensor.adapters.obd.runtime_connection_control import ObdRuntimeConnectionControl
+from vibesensor.adapters.obd.runtime_connection_observation import (
+    ObdRuntimeConnectionObservation,
+)
 from vibesensor.adapters.obd.runtime_facts import ObdRuntimeFacts
 from vibesensor.adapters.obd.runtime_projection import ObdRuntimeProjection
 from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
@@ -56,6 +59,7 @@ def build_obd_runtime(
         engine_rpm_stale_timeout_s=_RPM_STALE_TIMEOUT_S,
     )
     connection_control = ObdRuntimeConnectionControl(store=store)
+    connection_observation = ObdRuntimeConnectionObservation(store=store)
     admin_state = ObdRuntimeAdminState(store=store)
     return ObdRuntimeServices(
         facts=ObdRuntimeFacts(store=store),
@@ -68,6 +72,7 @@ def build_obd_runtime(
         connection_control=connection_control,
         runner=ObdConnectionRuntime(
             admin_client=resolved_admin_client,
+            connection_observation=connection_observation,
             connection_control=connection_control,
             session_factory=resolved_session_factory,
             monotonic=monotonic,


### PR DESCRIPTION
## Summary
- add a dedicated OBD connection observation surface for planning reads and poll-plan reads
- keep `ObdRuntimeConnectionControl` mutation-only for apply/mark operations
- update the OBD runner, executor, runtime wiring, and shared test support to use the new split

## Issues addressed
- OBD connection planning still reads via a mutation/control surface

## Architectural simplifications
- connection-loop planning now reads through `runtime_connection_observation.py`
- mutation-only connection control is easier to reason about and scan for side effects
- the executor no longer treats poll-plan reads as control behavior

## Compatibility removals
- removed planning/read methods from `ObdRuntimeConnectionControl`

## Breaking changes
- internal-only constructor seams changed for OBD runtime/executor test support

## Local validation
- `pytest -q apps/server/tests/adapters/obd`
- `make lint && make typecheck-backend`