### PR TITLE
Collapse history report preparation handoff

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -19,7 +19,6 @@ from vibesensor.adapters.history import (
     project_history_insights,
 )
 from vibesensor.domain import CarSnapshot, RunStatus
-from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
 from vibesensor.shared.boundaries.run_metadata_codec import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frame_decoder import sensor_frame_from_mapping
 from vibesensor.shared.exceptions import AnalysisNotReadyError
@@ -171,7 +170,7 @@ async def test_report_service_load_report_request_uses_persisted_language() -> N
 
     assert request.filename == "run-1_report.pdf"
     assert request.cache_key[1] == "nl"
-    assert request.analysis.language == "nl"
+    assert request.prepared.language == "nl"
 
 
 @pytest.mark.asyncio
@@ -212,13 +211,7 @@ async def test_report_service_load_report_request_keeps_persisted_summary_immuta
     )
 
     request = await loader.load_report_request("run-1", "en")
-    prepared = prepare_persisted_report_input(
-        request.analysis,
-        warnings=request.warnings,
-        filename=request.filename,
-        language=request.language,
-        cache_key=request.cache_key,
-    )
+    prepared = request.prepared
 
     stored_analysis = loader._history_db.get_run("run-1")
     assert stored_analysis is not None

--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -161,7 +161,7 @@ async def test_report_loader_uses_requested_lang_when_persisted_lang_is_blank() 
 
     request = await loader.load_report_request("run/1 sample", " NL ")
 
-    assert request.language == "nl"
+    assert request.prepared.language == "nl"
     assert request.cache_key[1] == "nl"
     assert request.filename == "run_1_sample_report.pdf"
 

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -1,4 +1,4 @@
-"""Persisted history-report loading and request shaping."""
+"""Persisted history-report loading and canonical prepared-report handoff."""
 
 from __future__ import annotations
 
@@ -6,14 +6,16 @@ import json
 from dataclasses import dataclass
 
 from vibesensor.domain import RunStatus
+from vibesensor.shared.boundaries.reporting import (
+    PreparedReportInput,
+    prepare_persisted_report_input,
+)
 from vibesensor.shared.boundaries.run_metadata_codec import run_metadata_to_json_object
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.filenames import safe_filename
 from vibesensor.shared.ports import RunPersistence
-from vibesensor.shared.run_context_warning import RunContextWarningsInput
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import is_json_array
-from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.report_cache import ReportPdfCacheKey
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.history.helpers import (
@@ -26,17 +28,24 @@ _PERSISTED_REPORT_MODE_TOKEN = "none"
 
 @dataclass(frozen=True)
 class HistoryReportRequest:
-    """Resolved persisted report context ready for cache lookup and preparation."""
+    """Resolved persisted report request with a canonical prepared report input."""
 
-    cache_key: ReportPdfCacheKey
-    filename: str
-    language: str
-    analysis: PersistedAnalysis
-    warnings: RunContextWarningsInput
+    prepared: PreparedReportInput
+
+    @property
+    def cache_key(self) -> ReportPdfCacheKey:
+        cache_key = self.prepared.cache_key
+        if cache_key is None:
+            raise RuntimeError("Persisted history report requests must carry a cache key")
+        return cache_key
+
+    @property
+    def filename(self) -> str:
+        return self.prepared.filename
 
 
 class HistoryReportRequestLoader:
-    """Load persisted report data and shape it for PDF generation."""
+    """Load persisted report data and prepare the canonical report input."""
 
     __slots__ = ("_history_db",)
 
@@ -70,12 +79,15 @@ class HistoryReportRequestLoader:
             run_id,
             report_language,
         )
+        filename = f"{safe_filename(run_id)}_report.pdf"
         return HistoryReportRequest(
-            cache_key=cache_key,
-            filename=f"{safe_filename(run_id)}_report.pdf",
-            language=report_language,
-            analysis=analysis,
-            warnings=warnings,
+            prepared=prepare_persisted_report_input(
+                analysis,
+                warnings=warnings,
+                filename=filename,
+                language=report_language,
+                cache_key=cache_key,
+            ),
         )
 
     @staticmethod

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -10,10 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from vibesensor.shared.boundaries.reporting import (
-    PreparedReportInput,
-    prepare_persisted_report_input,
-)
+from vibesensor.shared.boundaries.reporting import PreparedReportInput
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
 from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
@@ -57,14 +54,6 @@ class HistoryReportService:
 
         pdf = await self._pdf_cache.get_or_build(
             request.cache_key,
-            lambda: self._pdf_renderer(
-                prepare_persisted_report_input(
-                    request.analysis,
-                    warnings=request.warnings,
-                    filename=request.filename,
-                    language=request.language,
-                    cache_key=request.cache_key,
-                )
-            ),
+            lambda: self._pdf_renderer(request.prepared),
         )
         return HistoryReportPdf(content=pdf, filename=request.filename)


### PR DESCRIPTION
## Summary
- move persisted report preparation into `HistoryReportRequestLoader`
- make `HistoryReportService` consume the prepared request directly for cache and render flow
- update history request tests to assert through the new prepared-report handoff

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history
- .venv/bin/python -m pytest -q apps/server/tests/adapters/pdf
- make lint && make typecheck-backend