### PR TITLE
Split updater runtime service builders

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -4,8 +4,10 @@ The updater now has one explicit run-scoped workflow boundary per concern:
 
 - ``manager.py`` owns the public update-job runtime lifecycle: start, cancel,
   task supervision, timeout handling, and startup recovery.
-- ``runtime.py`` composes one canonical manager instance with explicit status
-  services, transport lifecycle coordination, and workflow collaborators.
+- ``runtime.py`` is the public updater-runtime facade that returns one canonical
+  manager instance.
+- ``runtime_services.py`` owns focused config resolution plus the status,
+  transport, release, and workflow builder clusters used by that facade.
 - ``run_models.py`` holds the canonical prepared/planned run models shared
   across the workflow.
 - ``workflow.py`` owns request-scoped orchestration across preparation,

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -3,69 +3,20 @@
 from __future__ import annotations
 
 import logging
-import os
-from dataclasses import dataclass
-from pathlib import Path
 
-from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
-from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
-from vibesensor.use_cases.updates.firmware import FirmwareRefresher
-from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.manager import UpdateManager
-from vibesensor.use_cases.updates.models import (
-    UpdateValidationConfig,
+from vibesensor.use_cases.updates.runner import CommandRunner
+from vibesensor.use_cases.updates.runtime_services import (
+    build_update_runtime_services,
+    build_update_workflow,
+    resolve_update_runtime_config,
 )
-from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
-from vibesensor.use_cases.updates.release_deployment import (
-    UpdateReleaseDeploymentCoordinator,
-)
-from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
-from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
-from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
-from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
-from vibesensor.use_cases.updates.runner import (
-    CommandRunner,
-    UpdateCommandExecutor,
-    UpdateStatusCommandReporter,
-)
-from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
-from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
-from vibesensor.use_cases.updates.status import (
-    UpdateStateStore,
-    UpdateStatusTracker,
-    build_update_status_tracker,
-    collect_runtime_details,
-)
-from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
-from vibesensor.use_cases.updates.transport_lifecycles import UpdateTransportLifecycles
-from vibesensor.use_cases.updates.usb_status import (
-    UsbInternetStatusReader,
-    UsbInternetStatusService,
-)
-from vibesensor.use_cases.updates.usb_transport import UpdateUsbInternetSession
-from vibesensor.use_cases.updates.validation import MIN_FREE_DISK_BYTES
-from vibesensor.use_cases.updates.wifi import UpdateWifiSession, build_default_wifi_config
-from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
-from vibesensor.use_cases.updates.workflow import UpdateWorkflow
-from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
+from vibesensor.use_cases.updates.status import UpdateStateStore
+from vibesensor.use_cases.updates.usb_status import UsbInternetStatusReader
 
 LOGGER = logging.getLogger(__name__)
 
 UPDATE_TIMEOUT_S = 600
-REINSTALL_OP_TIMEOUT_S = 180
-ESP_FIRMWARE_REFRESH_TIMEOUT_S = 240
-DEFAULT_ROLLBACK_DIR = "/var/lib/vibesensor/rollback"
-UPDATE_RESTART_UNIT = "vibesensor-post-update-restart"
-UPDATE_SERVICE_NAME = "vibesensor.service"
-
-
-@dataclass(frozen=True, slots=True)
-class UpdateRuntimeConfig:
-    repo: Path
-    rollback_dir: Path
-    wifi_config: UpdateWifiConfig
-    installer_config: UpdateInstallerConfig
-    validation_config: UpdateValidationConfig
 
 
 def build_update_manager(
@@ -79,226 +30,31 @@ def build_update_manager(
     usb_internet_service: UsbInternetStatusReader | None = None,
 ) -> UpdateManager:
     active_runner = runner or CommandRunner()
-    config = _resolve_runtime_config(
+    config = resolve_update_runtime_config(
         repo_path=repo_path,
         rollback_dir=rollback_dir,
         ap_con_name=ap_con_name,
         wifi_ifname=wifi_ifname,
     )
     active_state_store = state_store or UpdateStateStore()
-    status = _build_status_tracker(
-        repo=config.repo,
-        state_store=active_state_store,
-    )
-    commands = _build_command_executor(
+    services = build_update_runtime_services(
         runner=active_runner,
-        status=status,
-    )
-    status_service = usb_internet_service or UsbInternetStatusService(runner=active_runner)
-    transport_lifecycles = _build_transport_lifecycles(
-        commands=commands,
-        status=status,
-        wifi_config=config.wifi_config,
-        status_service=status_service,
-    )
-    transport_coordinator = UpdateTransportCoordinator(
-        lifecycles=transport_lifecycles,
-        status=status,
+        config=config,
+        state_store=active_state_store,
+        usb_internet_service=usb_internet_service,
         logger=LOGGER,
     )
-    workflow = _build_update_workflow(
-        commands=commands,
-        status=status,
+    workflow = build_update_workflow(
+        commands=services.commands,
+        status=services.status,
         config=config,
-        transport_coordinator=transport_coordinator,
+        transport_coordinator=services.transport_coordinator,
+        logger=LOGGER,
     )
     return UpdateManager(
-        status=status,
-        usb_status_service=status_service,
-        startup_recovery=UpdateStartupRecoveryCoordinator(
-            status=status,
-            transport_coordinator=transport_coordinator,
-        ),
+        status=services.status,
+        usb_status_service=services.usb_status_service,
+        startup_recovery=services.startup_recovery,
         workflow=workflow,
         timeout_s=UPDATE_TIMEOUT_S,
-    )
-
-
-def _resolve_runtime_config(
-    *,
-    repo_path: str | None,
-    rollback_dir: str | None,
-    ap_con_name: str,
-    wifi_ifname: str,
-) -> UpdateRuntimeConfig:
-    repo = Path(repo_path or os.environ.get("VIBESENSOR_REPO_PATH", "/opt/VibeSensor"))
-    resolved_rollback_dir = Path(
-        rollback_dir or os.environ.get("VIBESENSOR_ROLLBACK_DIR", DEFAULT_ROLLBACK_DIR),
-    )
-    wifi_config = build_default_wifi_config(
-        ap_con_name=ap_con_name,
-        wifi_ifname=wifi_ifname,
-    )
-    return UpdateRuntimeConfig(
-        repo=repo,
-        rollback_dir=resolved_rollback_dir,
-        wifi_config=wifi_config,
-        installer_config=UpdateInstallerConfig(
-            repo=repo,
-            rollback_dir=resolved_rollback_dir,
-            reinstall_timeout_s=REINSTALL_OP_TIMEOUT_S,
-        ),
-        validation_config=UpdateValidationConfig(
-            rollback_dir=resolved_rollback_dir,
-            min_free_disk_bytes=MIN_FREE_DISK_BYTES,
-        ),
-    )
-
-
-def _build_status_tracker(
-    *,
-    repo: Path,
-    state_store: UpdateStateStore,
-) -> UpdateStatusTracker:
-    loaded = state_store.load()
-    status = build_update_status_tracker(
-        state_store=state_store,
-        status=loaded,
-    )
-    status.set_runtime(collect_runtime_details(repo))
-    return status
-
-
-def _build_command_executor(
-    *,
-    runner: CommandRunner,
-    status: UpdateStatusTracker,
-) -> UpdateCommandExecutor:
-    return UpdateCommandExecutor(
-        runner=runner,
-        reporter=UpdateStatusCommandReporter(status=status),
-    )
-
-
-def _build_transport_lifecycles(
-    *,
-    commands: UpdateCommandExecutor,
-    status: UpdateStatusTracker,
-    wifi_config: UpdateWifiConfig,
-    status_service: UsbInternetStatusReader,
-) -> UpdateTransportLifecycles:
-    return UpdateTransportLifecycles(
-        wifi=UpdateWifiSession(
-            commands=commands,
-            status=status,
-            config=wifi_config,
-        ),
-        usb_internet=UpdateUsbInternetSession(
-            status_service=status_service,
-            commands=commands,
-            status=status,
-            config=wifi_config,
-        ),
-    )
-
-
-def _build_release_components(
-    *,
-    commands: UpdateCommandExecutor,
-    status: UpdateStatusTracker,
-    config: UpdateRuntimeConfig,
-) -> tuple[
-    ServerReleaseResolver,
-    ServerReleaseStager,
-    UpdateReleaseDeploymentCoordinator,
-    FirmwareRefresher,
-    UpdateRestartScheduler,
-]:
-    firmware_refresher = FirmwareRefresher(
-        commands=commands,
-        status=status,
-        repo=config.repo,
-        timeout_s=ESP_FIRMWARE_REFRESH_TIMEOUT_S,
-    )
-    installer = UpdateInstaller(
-        commands=commands,
-        status=status,
-        config=config.installer_config,
-    )
-    return (
-        ServerReleaseResolver(
-            status=status,
-            rollback_dir=config.rollback_dir,
-        ),
-        ServerReleaseStager(
-            status=status,
-            rollback_dir=config.rollback_dir,
-        ),
-        UpdateReleaseDeploymentCoordinator(
-            installer=installer,
-            firmware_refresher=firmware_refresher,
-            status=status,
-        ),
-        firmware_refresher,
-        UpdateRestartScheduler(
-            commands=commands,
-            status=status,
-            service_name=UPDATE_SERVICE_NAME,
-            restart_unit=UPDATE_RESTART_UNIT,
-        ),
-    )
-
-
-def _build_update_workflow(
-    *,
-    commands: UpdateCommandExecutor,
-    status: UpdateStatusTracker,
-    config: UpdateRuntimeConfig,
-    transport_coordinator: UpdateTransportCoordinator,
-) -> UpdateWorkflow:
-    def current_version_provider() -> str:
-        from vibesensor import __version__ as current_version
-
-        return current_version
-
-    (
-        resolver,
-        stager,
-        deployment,
-        firmware_refresher,
-        restart_scheduler,
-    ) = _build_release_components(
-        commands=commands,
-        status=status,
-        config=config,
-    )
-    return UpdateWorkflow(
-        preparation=UpdatePreparationCoordinator(
-            status=status,
-            commands=commands,
-            transport_coordinator=transport_coordinator,
-            validation_config=config.validation_config,
-            current_version_provider=current_version_provider,
-        ),
-        release_planner=UpdateReleasePlanner(
-            status=status,
-            resolver=resolver,
-        ),
-        workflow_executor=UpdateWorkflowExecutor(
-            completion=UpdateCompletionCoordinator(
-                restart_scheduler=restart_scheduler,
-                status=status,
-            ),
-            stager=stager,
-            deployment=deployment,
-            firmware_refresher=firmware_refresher,
-        ),
-        finalizer=UpdateWorkflowFinalizer(
-            transport_coordinator=transport_coordinator,
-            runtime_details_refresher=UpdateRuntimeDetailsRefresher(
-                status=status,
-                repo=config.repo,
-                logger=LOGGER,
-            ),
-        ),
     )

--- a/apps/server/vibesensor/use_cases/updates/runtime_services.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime_services.py
@@ -1,0 +1,292 @@
+"""Focused service bundles used by updater runtime composition."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
+from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
+from vibesensor.use_cases.updates.firmware import FirmwareRefresher
+from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
+from vibesensor.use_cases.updates.models import UpdateValidationConfig
+from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
+from vibesensor.use_cases.updates.release_deployment import (
+    UpdateReleaseDeploymentCoordinator,
+)
+from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
+from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
+from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
+from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
+from vibesensor.use_cases.updates.runner import (
+    CommandRunner,
+    UpdateCommandExecutor,
+    UpdateStatusCommandReporter,
+)
+from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
+from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
+from vibesensor.use_cases.updates.status import (
+    UpdateStateStore,
+    UpdateStatusTracker,
+    build_update_status_tracker,
+    collect_runtime_details,
+)
+from vibesensor.use_cases.updates.transport_coordinator import UpdateTransportCoordinator
+from vibesensor.use_cases.updates.transport_lifecycles import UpdateTransportLifecycles
+from vibesensor.use_cases.updates.usb_status import (
+    UsbInternetStatusReader,
+    UsbInternetStatusService,
+)
+from vibesensor.use_cases.updates.usb_transport import UpdateUsbInternetSession
+from vibesensor.use_cases.updates.validation import MIN_FREE_DISK_BYTES
+from vibesensor.use_cases.updates.wifi import UpdateWifiSession, build_default_wifi_config
+from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
+from vibesensor.use_cases.updates.workflow import UpdateWorkflow
+from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
+
+REINSTALL_OP_TIMEOUT_S = 180
+ESP_FIRMWARE_REFRESH_TIMEOUT_S = 240
+DEFAULT_ROLLBACK_DIR = "/var/lib/vibesensor/rollback"
+UPDATE_RESTART_UNIT = "vibesensor-post-update-restart"
+UPDATE_SERVICE_NAME = "vibesensor.service"
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateRuntimeConfig:
+    repo: Path
+    rollback_dir: Path
+    wifi_config: UpdateWifiConfig
+    installer_config: UpdateInstallerConfig
+    validation_config: UpdateValidationConfig
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateRuntimeServices:
+    status: UpdateStatusTracker
+    commands: UpdateCommandExecutor
+    usb_status_service: UsbInternetStatusReader
+    transport_coordinator: UpdateTransportCoordinator
+    startup_recovery: UpdateStartupRecoveryCoordinator
+
+
+def resolve_update_runtime_config(
+    *,
+    repo_path: str | None,
+    rollback_dir: str | None,
+    ap_con_name: str,
+    wifi_ifname: str,
+) -> UpdateRuntimeConfig:
+    repo = Path(repo_path or os.environ.get("VIBESENSOR_REPO_PATH", "/opt/VibeSensor"))
+    resolved_rollback_dir = Path(
+        rollback_dir or os.environ.get("VIBESENSOR_ROLLBACK_DIR", DEFAULT_ROLLBACK_DIR),
+    )
+    wifi_config = build_default_wifi_config(
+        ap_con_name=ap_con_name,
+        wifi_ifname=wifi_ifname,
+    )
+    return UpdateRuntimeConfig(
+        repo=repo,
+        rollback_dir=resolved_rollback_dir,
+        wifi_config=wifi_config,
+        installer_config=UpdateInstallerConfig(
+            repo=repo,
+            rollback_dir=resolved_rollback_dir,
+            reinstall_timeout_s=REINSTALL_OP_TIMEOUT_S,
+        ),
+        validation_config=UpdateValidationConfig(
+            rollback_dir=resolved_rollback_dir,
+            min_free_disk_bytes=MIN_FREE_DISK_BYTES,
+        ),
+    )
+
+
+def build_update_runtime_services(
+    *,
+    runner: CommandRunner,
+    config: UpdateRuntimeConfig,
+    state_store: UpdateStateStore,
+    usb_internet_service: UsbInternetStatusReader | None,
+    logger: logging.Logger,
+) -> UpdateRuntimeServices:
+    status = _build_status_tracker(
+        repo=config.repo,
+        state_store=state_store,
+    )
+    commands = _build_command_executor(
+        runner=runner,
+        status=status,
+    )
+    status_service = usb_internet_service or UsbInternetStatusService(runner=runner)
+    transport_coordinator = UpdateTransportCoordinator(
+        lifecycles=_build_transport_lifecycles(
+            commands=commands,
+            status=status,
+            wifi_config=config.wifi_config,
+            status_service=status_service,
+        ),
+        status=status,
+        logger=logger,
+    )
+    return UpdateRuntimeServices(
+        status=status,
+        commands=commands,
+        usb_status_service=status_service,
+        transport_coordinator=transport_coordinator,
+        startup_recovery=UpdateStartupRecoveryCoordinator(
+            status=status,
+            transport_coordinator=transport_coordinator,
+        ),
+    )
+
+
+def build_update_workflow(
+    *,
+    commands: UpdateCommandExecutor,
+    status: UpdateStatusTracker,
+    config: UpdateRuntimeConfig,
+    transport_coordinator: UpdateTransportCoordinator,
+    logger: logging.Logger,
+) -> UpdateWorkflow:
+    (
+        resolver,
+        stager,
+        deployment,
+        firmware_refresher,
+        restart_scheduler,
+    ) = _build_release_components(
+        commands=commands,
+        status=status,
+        config=config,
+    )
+    return UpdateWorkflow(
+        preparation=UpdatePreparationCoordinator(
+            status=status,
+            commands=commands,
+            transport_coordinator=transport_coordinator,
+            validation_config=config.validation_config,
+            current_version_provider=_current_version_provider,
+        ),
+        release_planner=UpdateReleasePlanner(
+            status=status,
+            resolver=resolver,
+        ),
+        workflow_executor=UpdateWorkflowExecutor(
+            completion=UpdateCompletionCoordinator(
+                restart_scheduler=restart_scheduler,
+                status=status,
+            ),
+            stager=stager,
+            deployment=deployment,
+            firmware_refresher=firmware_refresher,
+        ),
+        finalizer=UpdateWorkflowFinalizer(
+            transport_coordinator=transport_coordinator,
+            runtime_details_refresher=UpdateRuntimeDetailsRefresher(
+                status=status,
+                repo=config.repo,
+                logger=logger,
+            ),
+        ),
+    )
+
+
+def _build_status_tracker(
+    *,
+    repo: Path,
+    state_store: UpdateStateStore,
+) -> UpdateStatusTracker:
+    loaded = state_store.load()
+    status = build_update_status_tracker(
+        state_store=state_store,
+        status=loaded,
+    )
+    status.set_runtime(collect_runtime_details(repo))
+    return status
+
+
+def _build_command_executor(
+    *,
+    runner: CommandRunner,
+    status: UpdateStatusTracker,
+) -> UpdateCommandExecutor:
+    return UpdateCommandExecutor(
+        runner=runner,
+        reporter=UpdateStatusCommandReporter(status=status),
+    )
+
+
+def _build_transport_lifecycles(
+    *,
+    commands: UpdateCommandExecutor,
+    status: UpdateStatusTracker,
+    wifi_config: UpdateWifiConfig,
+    status_service: UsbInternetStatusReader,
+) -> UpdateTransportLifecycles:
+    return UpdateTransportLifecycles(
+        wifi=UpdateWifiSession(
+            commands=commands,
+            status=status,
+            config=wifi_config,
+        ),
+        usb_internet=UpdateUsbInternetSession(
+            status_service=status_service,
+            commands=commands,
+            status=status,
+            config=wifi_config,
+        ),
+    )
+
+
+def _build_release_components(
+    *,
+    commands: UpdateCommandExecutor,
+    status: UpdateStatusTracker,
+    config: UpdateRuntimeConfig,
+) -> tuple[
+    ServerReleaseResolver,
+    ServerReleaseStager,
+    UpdateReleaseDeploymentCoordinator,
+    FirmwareRefresher,
+    UpdateRestartScheduler,
+]:
+    firmware_refresher = FirmwareRefresher(
+        commands=commands,
+        status=status,
+        repo=config.repo,
+        timeout_s=ESP_FIRMWARE_REFRESH_TIMEOUT_S,
+    )
+    installer = UpdateInstaller(
+        commands=commands,
+        status=status,
+        config=config.installer_config,
+    )
+    return (
+        ServerReleaseResolver(
+            status=status,
+            rollback_dir=config.rollback_dir,
+        ),
+        ServerReleaseStager(
+            status=status,
+            rollback_dir=config.rollback_dir,
+        ),
+        UpdateReleaseDeploymentCoordinator(
+            installer=installer,
+            firmware_refresher=firmware_refresher,
+            status=status,
+        ),
+        firmware_refresher,
+        UpdateRestartScheduler(
+            commands=commands,
+            status=status,
+            service_name=UPDATE_SERVICE_NAME,
+            restart_unit=UPDATE_RESTART_UNIT,
+        ),
+    )
+
+
+def _current_version_provider() -> str:
+    from vibesensor import __version__ as current_version
+
+    return current_version


### PR DESCRIPTION
## Summary
- move updater runtime config resolution and focused service/workflow builder clusters into `runtime_services.py`
- keep `build_update_manager()` as the thin public facade that wires the runtime bundle into `UpdateManager`
- update updater package guidance to point at the new runtime service ownership

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/updates apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
- make lint && make typecheck-backend