### PR TITLE
Tighten firmware cache metadata fault handling

### DIFF
--- a/apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py
@@ -262,6 +262,17 @@ def test_cache_info_no_firmware(tmp_path: Path) -> None:
     assert _firmware_cache(cache_dir).info()["status"] == "no_firmware"
 
 
+def test_cache_info_reports_corrupt_metadata_explicitly(tmp_path: Path) -> None:
+    cache_dir = _make_cache(tmp_path, with_current=True)
+    (cache_dir / "current" / "_meta.json").write_text("{not-json", encoding="utf-8")
+
+    info = _firmware_cache(cache_dir).info()
+
+    assert info["status"] == "metadata_invalid"
+    assert info["source"] == "downloaded"
+    assert "metadata is corrupt" in info["message"]
+
+
 # ── Flash Manager Tests (using cached bundles) ──
 
 
@@ -336,6 +347,22 @@ async def test_flash_fails_fast_when_no_firmware_available(tmp_path: Path) -> No
     assert mgr.status.state.value == "failed"
     assert "No firmware bundle available" in str(mgr.status.error)
     assert any("updater" in line.lower() for line in mgr.logs_since(after=0)["lines"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_patch_esptool_which")
+async def test_flash_fails_when_bundle_metadata_is_corrupt(tmp_path: Path) -> None:
+    cache_dir = _make_cache(tmp_path, with_current=True)
+    (cache_dir / "current" / "_meta.json").write_text("{not-json", encoding="utf-8")
+    mgr, runner = _build_manager(cache_dir)
+
+    mgr.start(port=None, auto_detect=True)
+    assert mgr._task is not None
+    await mgr._task
+
+    assert mgr.status.state.value == "failed"
+    assert "metadata is corrupt" in str(mgr.status.error)
+    assert not any("erase_flash" in call for call in runner.calls)
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_bundle.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_bundle.py
@@ -143,8 +143,8 @@ def read_meta(bundle_dir: Path) -> BundleMeta | None:
         return None
     try:
         data = _read_json_file(meta_path)
-    except (json.JSONDecodeError, OSError):
-        return None
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Firmware bundle metadata is corrupt in {bundle_dir}: {exc}") from exc
     return BundleMeta(
         tag=str(data.get("tag", "")),
         asset=str(data.get("asset", "")),

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_cache.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_cache.py
@@ -100,7 +100,15 @@ class FirmwareCache:
         tag = release.get("tag_name", "")
         LOGGER.info("Selected release: %s", tag)
 
-        current_meta = read_meta(self.current_dir) if self.current_dir.is_dir() else None
+        current_meta: BundleMeta | None = None
+        if self.current_dir.is_dir():
+            try:
+                current_meta = read_meta(self.current_dir)
+            except ValueError:
+                LOGGER.warning(
+                    "Current firmware cache metadata is invalid; continuing with refresh",
+                    exc_info=True,
+                )
         if current_meta and current_meta.tag == tag:
             LOGGER.info("Cache is already current (tag=%s). No download needed.", tag)
             return current_meta
@@ -166,14 +174,25 @@ class FirmwareCache:
                     "Run the updater while online or reinstall Pi image."
                 ),
             }
-        meta = read_meta(bundle) or BundleMeta()
+        source = "downloaded" if bundle == self.current_dir else "baseline"
+        try:
+            meta = read_meta(bundle)
+        except ValueError as exc:
+            return {
+                "status": "metadata_invalid",
+                "message": str(exc),
+                "source": source,
+                "cache_dir": str(self._cache_dir),
+                "bundle_path": str(bundle),
+            }
+        resolved_meta = meta or BundleMeta(source=source)
         return {
             "status": "ok",
-            "source": meta.source or ("downloaded" if bundle == self.current_dir else "baseline"),
-            "tag": meta.tag,
-            "asset": meta.asset,
-            "timestamp": meta.timestamp,
-            "sha256": meta.sha256,
+            "source": resolved_meta.source or source,
+            "tag": resolved_meta.tag,
+            "asset": resolved_meta.asset,
+            "timestamp": resolved_meta.timestamp,
+            "sha256": resolved_meta.sha256,
             "cache_dir": str(self._cache_dir),
             "bundle_path": str(bundle),
         }


### PR DESCRIPTION
## Summary
- make corrupt firmware bundle metadata raise an explicit error instead of degrading to missing metadata
- return explicit cache-info status for corrupt metadata and keep refresh on a clear warning path
- add firmware cache and flash-manager regressions so corrupt `_meta.json` fails before flashing

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/updates apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
- make lint && make typecheck-backend