### PR TITLE
Refactor report section context assembly

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_section_context.py
+++ b/apps/server/tests/use_cases/history/test_report_section_context.py
@@ -1,0 +1,25 @@
+from test_support.report_helpers import recapture_guidance_summary
+
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def _report_document_for_mode(mode: str):
+    return build_report_document(prepare_report_input(recapture_guidance_summary(mode)))
+
+
+def test_recapture_assessment_aligns_verdict_and_appendix_a() -> None:
+    document = _report_document_for_mode("overlap")
+
+    assert document.appendix_a.mode == "recapture"
+    assert document.appendix_a.capture_issues
+    assert document.verdict_page.reason_sentence == document.appendix_a.capture_issues[0]
+    assert document.appendix_a.capture_changes
+    assert document.appendix_a.capture_conditions
+
+
+def test_shared_section_context_aligns_verdict_and_appendix_b() -> None:
+    document = _report_document_for_mode("steady")
+
+    assert document.appendix_b.coverage_label == document.verdict_page.coverage_label
+    assert document.appendix_b.runner_up_corner == document.verdict_page.runner_up_corner

--- a/apps/server/vibesensor/use_cases/history/report_document/composition.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/composition.py
@@ -44,20 +44,13 @@ from .narrative_summaries import _proof_summary_text
 from .pattern_evidence import build_pattern_evidence
 from .peak_table import build_peak_rows
 from .report_sections import build_data_trust, build_next_steps
+from .section_context import ReportSectionContext
 from .sections import _build_appendix_c_data, _build_timeline_graph_data, _build_traceability_rows
 from .verdict_page import build_observed_signature, build_verdict_page_data
 from .workflow_appendix import (
     build_appendix_a_data,
     build_ranked_candidates,
-)
-from .workflow_appendix import (
-    recapture_actions as build_recapture_actions,
-)
-from .workflow_appendix import (
-    recapture_condition_lines as build_recapture_condition_lines,
-)
-from .workflow_appendix import (
-    recapture_issue_lines as build_recapture_issue_lines,
+    build_recapture_assessment,
 )
 
 __all__ = ["ReportDocumentContext", "compose_report_document_context"]
@@ -67,6 +60,7 @@ __all__ = ["ReportDocumentContext", "compose_report_document_context"]
 class _ReportDocumentSections:
     """Document-facing sections composed before final report assembly."""
 
+    section_context: ReportSectionContext
     verdict_page: VerdictPageData
     appendix_a: AppendixAData
     appendix_b: AppendixBData
@@ -147,7 +141,7 @@ def compose_report_document_context(prepared: PreparedReportInput) -> ReportDocu
         test_run,
         primary,
         report_facts,
-        runner_up_corner=sections.appendix_b.runner_up_corner,
+        runner_up_corner=sections.section_context.runner_up_corner,
         tr=tr,
     )
     run_datetime = _report_date_text(run_facts)
@@ -226,8 +220,7 @@ def compose_report_document_context(prepared: PreparedReportInput) -> ReportDocu
                 tr=tr,
             ),
             report_facts=report_facts,
-            speed_window_label=sections.verdict_page.speed_window_label,
-            proof_caveat=sections.verdict_page.proof_caveat,
+            section_context=sections.section_context,
             data_trust=list(data_trust),
             tr=tr,
         ),
@@ -260,72 +253,19 @@ def _compose_report_document_sections(
     run_facts = report_facts.run
     sensor_facts = report_facts.sensor
     decision_facts = report_facts.decision
-    coverage = sensor_facts.coverage
-    resolved_coverage_label = coverage_label(
-        expected_locations=coverage.expected_locations,
-        active_locations=coverage.active_locations,
-        missing_locations=coverage.missing_locations,
-        partial_locations=coverage.partial_locations,
-        tr=tr,
-    )
-    resolved_coverage_notes = coverage_notes(
-        missing_locations=coverage.missing_locations,
-        partial_locations=coverage.partial_locations,
-        tr=tr,
-    )
-    resolved_runner_up_corner = runner_up_corner(
-        sensor_facts.active_intensity,
-        tr=tr,
-    )
-    proof_caveat = proof_caveat_text(
-        primary_candidate_facts=decision_facts.primary_candidate,
-        action_status_key=decision_facts.action_status_key,
-        location_confidence_key=decision_facts.location_confidence_key,
-        tr=tr,
-    )
-    ranked_candidates = build_ranked_candidates(aggregate, tr=tr)
-    recapture_issues = build_recapture_issue_lines(
+    section_context = _build_report_section_context(
         aggregate=aggregate,
-        primary_candidate_facts=decision_facts.primary_candidate,
-        location_confidence_key=decision_facts.location_confidence_key,
-        suitability_checks=decision_facts.suitability_checks,
-        warnings=decision_facts.warnings,
+        report_facts=report_facts,
         lang=lang,
         tr=tr,
     )
-    recapture_actions = build_recapture_actions(
-        aggregate=aggregate,
-        primary_candidate_facts=decision_facts.primary_candidate,
-        location_confidence_key=decision_facts.location_confidence_key,
-        expected_locations=coverage.expected_locations,
-        active_locations=coverage.active_locations,
-        suitability_checks=decision_facts.suitability_checks,
-        warnings=decision_facts.warnings,
-        tr=tr,
-    )
-    recapture_conditions = build_recapture_condition_lines(
-        aggregate=aggregate,
-        primary_candidate_facts=decision_facts.primary_candidate,
-        location_confidence_key=decision_facts.location_confidence_key,
-        expected_locations=coverage.expected_locations,
-        active_locations=coverage.active_locations,
-        suitability_checks=decision_facts.suitability_checks,
-        warnings=decision_facts.warnings,
-        tr=tr,
-    )
     return _ReportDocumentSections(
+        section_context=section_context,
         verdict_page=build_verdict_page_data(
             aggregate=aggregate,
             primary_candidate_facts=decision_facts.primary_candidate,
             duration_text=run_facts.duration_text,
-            action_status_key=decision_facts.action_status_key,
-            location_confidence_key=decision_facts.location_confidence_key,
-            alternative_source_visible=decision_facts.alternative_source_visible,
-            active_locations=coverage.active_locations,
-            coverage_label=resolved_coverage_label,
-            runner_up_corner=resolved_runner_up_corner,
-            proof_caveat=proof_caveat,
-            recapture_issues=recapture_issues,
+            section_context=section_context,
             suitability_checks=decision_facts.suitability_checks,
             warnings=decision_facts.warnings,
             lang=lang,
@@ -333,24 +273,67 @@ def _compose_report_document_sections(
         ),
         appendix_a=build_appendix_a_data(
             aggregate=aggregate,
-            action_status_key=decision_facts.action_status_key,
-            alternative_source_visible=decision_facts.alternative_source_visible,
-            ranked_candidates=ranked_candidates,
-            recapture_issues=recapture_issues,
-            recapture_actions=recapture_actions,
-            recapture_conditions=recapture_conditions,
+            section_context=section_context,
             tr=tr,
         ),
         appendix_b=build_appendix_b_data(
             aggregate=aggregate,
             primary_candidate_facts=decision_facts.primary_candidate,
             active_sensor_intensity=sensor_facts.active_intensity,
+            section_context=section_context,
+            tr=tr,
+        ),
+    )
+
+
+def _build_report_section_context(
+    *,
+    aggregate: TestRun,
+    report_facts: PreparedReportFacts,
+    lang: str,
+    tr: Callable[..., str],
+) -> ReportSectionContext:
+    sensor_facts = report_facts.sensor
+    decision_facts = report_facts.decision
+    coverage = sensor_facts.coverage
+    return ReportSectionContext(
+        action_status_key=decision_facts.action_status_key,
+        location_confidence_key=decision_facts.location_confidence_key,
+        alternative_source_visible=decision_facts.alternative_source_visible,
+        active_locations=tuple(coverage.active_locations),
+        coverage_label=coverage_label(
+            expected_locations=coverage.expected_locations,
+            active_locations=coverage.active_locations,
+            missing_locations=coverage.missing_locations,
+            partial_locations=coverage.partial_locations,
+            tr=tr,
+        ),
+        coverage_notes=tuple(
+            coverage_notes(
+                missing_locations=coverage.missing_locations,
+                partial_locations=coverage.partial_locations,
+                tr=tr,
+            )
+        ),
+        proof_caveat=proof_caveat_text(
+            primary_candidate_facts=decision_facts.primary_candidate,
             action_status_key=decision_facts.action_status_key,
             location_confidence_key=decision_facts.location_confidence_key,
+            tr=tr,
+        ),
+        runner_up_corner=runner_up_corner(sensor_facts.active_intensity, tr=tr),
+        speed_window_label=str(decision_facts.primary_candidate.primary_speed or "").strip()
+        or None,
+        ranked_candidates=build_ranked_candidates(aggregate, tr=tr),
+        recapture=build_recapture_assessment(
+            aggregate=aggregate,
+            primary_candidate_facts=decision_facts.primary_candidate,
+            location_confidence_key=decision_facts.location_confidence_key,
+            expected_locations=coverage.expected_locations,
             active_locations=coverage.active_locations,
-            runner_up_corner=resolved_runner_up_corner,
-            coverage_label=resolved_coverage_label,
-            coverage_notes=resolved_coverage_notes,
+            suitability_checks=decision_facts.suitability_checks,
+            warnings=decision_facts.warnings,
+            lang=lang,
             tr=tr,
         ),
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
@@ -16,6 +16,8 @@ from vibesensor.use_cases.history.report_observation_matrix import (
     build_sensor_observation_matrix_rows,
 )
 
+from .section_context import ReportSectionContext
+
 __all__ = ["build_appendix_b_data"]
 
 
@@ -24,12 +26,7 @@ def build_appendix_b_data(
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
     active_sensor_intensity: Sequence[LocationIntensitySummary],
-    action_status_key: str,
-    location_confidence_key: str,
-    active_locations: Sequence[str],
-    runner_up_corner: str | None,
-    coverage_label: str,
-    coverage_notes: Sequence[str],
+    section_context: ReportSectionContext,
     tr: Callable[..., str],
 ) -> AppendixBData:
     dominance_ratio_text = (
@@ -61,21 +58,21 @@ def build_appendix_b_data(
     ]
     return AppendixBData(
         dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
-        runner_up_corner=runner_up_corner,
+        runner_up_corner=section_context.runner_up_corner,
         dominance_ratio_text=dominance_ratio_text,
         location_confidence=location_confidence_text(
             presented_location_confidence_key(
-                action_status_key=action_status_key,
-                location_confidence_key=location_confidence_key,
+                action_status_key=section_context.action_status_key,
+                location_confidence_key=section_context.location_confidence_key,
             ),
             tr=tr,
         ),
-        coverage_label=coverage_label,
-        coverage_notes=list(coverage_notes),
+        coverage_label=section_context.coverage_label,
+        coverage_notes=list(section_context.coverage_notes),
         intensity_rows=intensity_rows,
         sensor_observation_rows=build_sensor_observation_matrix_rows(
             aggregate,
-            sensor_locations=list(active_locations),
+            sensor_locations=list(section_context.active_locations),
             tr=tr,
         ),
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/section_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/section_context.py
@@ -1,0 +1,35 @@
+"""Shared verdict/appendix context for report-document composition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.reporting.document import RankedCandidateRow
+
+__all__ = ["RecaptureAssessment", "ReportSectionContext"]
+
+
+@dataclass(frozen=True, slots=True)
+class RecaptureAssessment:
+    """Shared recapture guidance derived from one report-decision pass."""
+
+    issues: tuple[str, ...]
+    actions: tuple[str, ...]
+    conditions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportSectionContext:
+    """Common derived values reused by verdict and appendix builders."""
+
+    action_status_key: str
+    location_confidence_key: str
+    alternative_source_visible: bool
+    active_locations: tuple[str, ...]
+    coverage_label: str
+    coverage_notes: tuple[str, ...]
+    proof_caveat: str | None
+    runner_up_corner: str | None
+    speed_window_label: str | None
+    ranked_candidates: tuple[RankedCandidateRow, ...]
+    recapture: RecaptureAssessment

--- a/apps/server/vibesensor/use_cases/history/report_document/sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/sections.py
@@ -24,6 +24,7 @@ from .narrative_summaries import (
     _phase_summary_text,
     _run_limits_summary_text,
 )
+from .section_context import ReportSectionContext
 
 __all__ = [
     "_build_appendix_c_data",
@@ -92,8 +93,7 @@ def _build_appendix_c_data(
     aggregate: TestRun,
     measurements: list[MeasurementRow],
     report_facts: PreparedReportFacts,
-    speed_window_label: str | None,
-    proof_caveat: str | None,
+    section_context: ReportSectionContext,
     data_trust: list[DataTrustItem],
     tr: Callable[..., str],
 ) -> AppendixCData:
@@ -112,8 +112,8 @@ def _build_appendix_c_data(
         context_summary=_context_summary_text(primary, report_facts, tr=tr),
         limits_summary=_run_limits_summary_text(
             report_facts,
-            speed_window_label=speed_window_label,
-            proof_caveat=proof_caveat,
+            speed_window_label=section_context.speed_window_label,
+            proof_caveat=section_context.proof_caveat,
             tr=tr,
         ),
         speed_band_summary=speed_summary,

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -22,6 +22,7 @@ from vibesensor.shared.report_presentation import (
 from vibesensor.shared.run_context_warning import RunContextWarning
 
 from ._candidate_resolver import PrimaryCandidateContext
+from .section_context import ReportSectionContext
 
 __all__ = ["build_observed_signature", "build_verdict_page_data"]
 
@@ -48,22 +49,15 @@ def build_verdict_page_data(
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
     duration_text: str | None,
-    action_status_key: str,
-    location_confidence_key: str,
-    alternative_source_visible: bool,
-    active_locations: Sequence[str],
-    coverage_label: str,
-    runner_up_corner: str | None,
-    proof_caveat: str | None,
-    recapture_issues: Sequence[str],
+    section_context: ReportSectionContext,
     suitability_checks: Sequence[SuitabilityCheck],
     warnings: Sequence[RunContextWarning],
     lang: str,
     tr: Callable[..., str],
 ) -> VerdictPageData:
-    recapture_before_acting = action_status_key == "recapture_before_acting"
+    recapture_before_acting = section_context.action_status_key == "recapture_before_acting"
     return VerdictPageData(
-        speed_window_label=str(primary_candidate_facts.primary_speed or "").strip() or None,
+        speed_window_label=section_context.speed_window_label,
         suspected_source=(
             tr("REPORT_INCONCLUSIVE_SOURCE")
             if recapture_before_acting
@@ -74,50 +68,50 @@ def build_verdict_page_data(
             if recapture_before_acting
             else display_location(primary_candidate_facts.primary_location, tr=tr)
         ),
-        action_status=action_status_text(action_status_key, tr=tr),
+        action_status=action_status_text(section_context.action_status_key, tr=tr),
         action_status_note=_action_status_note_text(
             aggregate=aggregate,
             primary_candidate_facts=primary_candidate_facts,
-            action_status_key=action_status_key,
-            location_confidence_key=location_confidence_key,
-            alternative_source_visible=alternative_source_visible,
+            action_status_key=section_context.action_status_key,
+            location_confidence_key=section_context.location_confidence_key,
+            alternative_source_visible=section_context.alternative_source_visible,
             suitability_checks=suitability_checks,
             warnings=warnings,
             lang=lang,
             tr=tr,
         ),
         reason_sentence=(
-            recapture_issues[0]
-            if recapture_before_acting and recapture_issues
+            section_context.recapture.issues[0]
+            if recapture_before_acting and section_context.recapture.issues
             else _build_primary_reason_sentence(
                 primary_candidate_facts=primary_candidate_facts,
-                active_locations=active_locations,
+                active_locations=section_context.active_locations,
                 duration_text=duration_text,
                 tr=tr,
             )
         ),
         dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
-        runner_up_corner=runner_up_corner,
+        runner_up_corner=section_context.runner_up_corner,
         location_confidence=_location_confidence_display_text(
             primary_candidate_facts=primary_candidate_facts,
-            action_status_key=action_status_key,
-            location_confidence_key=location_confidence_key,
-            alternative_source_visible=alternative_source_visible,
+            action_status_key=section_context.action_status_key,
+            location_confidence_key=section_context.location_confidence_key,
+            alternative_source_visible=section_context.alternative_source_visible,
             dominance_ratio=primary_candidate_facts.dominance_ratio,
             suitability_checks=suitability_checks,
             warnings=warnings,
             lang=lang,
             tr=tr,
         ),
-        coverage_label=coverage_label,
+        coverage_label=section_context.coverage_label,
         also_consider=(
             source_with_confidence(aggregate.effective_top_causes()[1], tr=tr)
             if not recapture_before_acting
-            and alternative_source_visible
+            and section_context.alternative_source_visible
             and len(aggregate.effective_top_causes()) > 1
             else None
         ),
-        proof_caveat=proof_caveat,
+        proof_caveat=section_context.proof_caveat,
         proof_panel_title=(
             tr("REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE")
             if recapture_before_acting

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -21,27 +21,23 @@ from vibesensor.shared.report_presentation import (
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
 
+from .section_context import RecaptureAssessment, ReportSectionContext
+
 __all__ = [
     "build_appendix_a_data",
     "build_ranked_candidates",
-    "recapture_actions",
-    "recapture_condition_lines",
-    "recapture_issue_lines",
+    "build_recapture_assessment",
 ]
 
 
 def build_appendix_a_data(
     *,
     aggregate: TestRun,
-    action_status_key: str,
-    alternative_source_visible: bool,
-    ranked_candidates: Sequence[RankedCandidateRow],
-    recapture_issues: Sequence[str],
-    recapture_actions: Sequence[str],
-    recapture_conditions: Sequence[str],
+    section_context: ReportSectionContext,
     tr: Callable[..., str],
 ) -> AppendixAData:
-    recapture_before_acting = action_status_key == "recapture_before_acting"
+    ranked_candidates = section_context.ranked_candidates
+    recapture_before_acting = section_context.action_status_key == "recapture_before_acting"
     if recapture_before_acting:
         return AppendixAData(
             mode="recapture",
@@ -51,9 +47,9 @@ def build_appendix_a_data(
             why_alternative_next=None,
             next_if_clean=None,
             ranked_candidates=[],
-            capture_issues=list(recapture_issues),
-            capture_changes=list(recapture_actions),
-            capture_conditions=list(recapture_conditions),
+            capture_issues=list(section_context.recapture.issues),
+            capture_changes=list(section_context.recapture.actions),
+            capture_conditions=list(section_context.recapture.conditions),
         )
 
     primary_source = (
@@ -73,11 +69,11 @@ def build_appendix_a_data(
             source=ranked_candidates[1].source_name,
             confidence=ranked_candidates[1].confidence_pct,
         )
-        if alternative_source_visible
+        if section_context.alternative_source_visible
         and len(ranked_candidates) > 1
         and ranked_candidates[1].confidence_pct
         else ranked_candidates[1].source_name
-        if alternative_source_visible and len(ranked_candidates) > 1
+        if section_context.alternative_source_visible and len(ranked_candidates) > 1
         else None
     )
     return AppendixAData(
@@ -87,7 +83,7 @@ def build_appendix_a_data(
         why_primary_first=ranked_candidates[0].reason if ranked_candidates else None,
         why_alternative_next=(
             ranked_candidates[1].reason
-            if alternative_source_visible and len(ranked_candidates) > 1
+            if section_context.alternative_source_visible and len(ranked_candidates) > 1
             else None
         ),
         next_if_clean=_next_if_primary_clean(aggregate, tr=tr),
@@ -128,18 +124,47 @@ def build_ranked_candidates(
     return tuple(rows)
 
 
-def recapture_issue_lines(
+def build_recapture_assessment(
     *,
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
     location_confidence_key: str,
+    expected_locations: Sequence[str],
+    active_locations: Sequence[str],
     suitability_checks: Sequence[SuitabilityCheck],
     warnings: Sequence[RunContextWarning],
     lang: str,
     tr: Callable[..., str],
-) -> tuple[str, ...]:
+) -> RecaptureAssessment:
+    expected = len(expected_locations) or len(active_locations)
+    source_overlap = has_source_overlap(aggregate, tr=tr)
+    weak_location = location_confidence_key == "weak"
+    mixed_location = location_confidence_key == "mixed"
+    transient_primary = is_transient_primary(primary_candidate_facts)
+    speed_variation_nonpass = (
+        check_state(suitability_checks, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass"
+    )
+    sensor_coverage_nonpass = (
+        weak_location
+        or mixed_location
+        or check_state(suitability_checks, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
+    )
+    reference_incomplete = (
+        primary_candidate_facts.has_reference_gaps
+        or check_state(suitability_checks, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
+        or has_warning_code(warnings, "reference_context_incomplete")
+    )
+    diagnostic_details = tuple(
+        nonpass_detail_lines(
+            suitability_checks=suitability_checks,
+            warnings=warnings,
+            lang=lang,
+            tr=tr,
+        )
+    )
+
     issues: list[str] = []
-    if has_source_overlap(aggregate, tr=tr):
+    if source_overlap:
         ranked = list(aggregate.effective_top_causes()[:2])
         if len(ranked) > 1:
             append_unique_line(
@@ -150,18 +175,13 @@ def recapture_issue_lines(
                     alternative=human_source(ranked[1].suspected_source, tr=tr),
                 ),
             )
-    if location_confidence_key == "weak":
+    if weak_location:
         append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_WEAK_LOCATION"))
-    elif location_confidence_key == "mixed":
+    elif mixed_location:
         append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_MIXED_LOCATION"))
-    if is_transient_primary(primary_candidate_facts):
+    if transient_primary:
         append_unique_line(issues, tr("REPORT_RECAPTURE_ISSUE_TRANSIENT"))
-    for detail in nonpass_detail_lines(
-        suitability_checks=suitability_checks,
-        warnings=warnings,
-        lang=lang,
-        tr=tr,
-    ):
+    for detail in diagnostic_details:
         append_unique_line(issues, detail)
     if not issues:
         note = proof_caveat_text(
@@ -171,38 +191,17 @@ def recapture_issue_lines(
             tr=tr,
         )
         append_unique_line(issues, note or tr("REPORT_CAPTURE_ISSUE_GENERIC"))
-    return tuple(issues[:4])
 
-
-def recapture_actions(
-    *,
-    aggregate: TestRun,
-    primary_candidate_facts: PrimaryReportFacts,
-    location_confidence_key: str,
-    expected_locations: Sequence[str],
-    active_locations: Sequence[str],
-    suitability_checks: Sequence[SuitabilityCheck],
-    warnings: Sequence[RunContextWarning],
-    tr: Callable[..., str],
-) -> tuple[str, ...]:
-    expected = len(expected_locations) or len(active_locations)
     actions: list[str] = []
-    if has_source_overlap(aggregate, tr=tr):
+    if source_overlap:
         append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_COMPARE_PATHS"))
-    if check_state(suitability_checks, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
+    if speed_variation_nonpass:
         append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_STEADY_HOLD"))
-    if is_transient_primary(primary_candidate_facts):
+    if transient_primary:
         append_unique_line(actions, tr("REPORT_RECAPTURE_ACTION_REPEAT_EVENT"))
-    if (
-        location_confidence_key in {"weak", "mixed"}
-        or check_state(suitability_checks, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
-    ):
+    if sensor_coverage_nonpass:
         append_unique_line(actions, tr("TIER_A_CAPTURE_MORE_SENSORS"))
-    if (
-        primary_candidate_facts.has_reference_gaps
-        or check_state(suitability_checks, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
-        or has_warning_code(warnings, "reference_context_incomplete")
-    ):
+    if reference_incomplete:
         append_unique_line(actions, tr("TIER_A_CAPTURE_REFERENCE_DATA"))
     if not actions:
         append_unique_line(actions, tr("TIER_A_CAPTURE_WIDER_SPEED"))
@@ -210,47 +209,34 @@ def recapture_actions(
             actions,
             tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
         )
-    return tuple(actions[:4])
 
-
-def recapture_condition_lines(
-    *,
-    aggregate: TestRun,
-    primary_candidate_facts: PrimaryReportFacts,
-    location_confidence_key: str,
-    expected_locations: Sequence[str],
-    active_locations: Sequence[str],
-    suitability_checks: Sequence[SuitabilityCheck],
-    warnings: Sequence[RunContextWarning],
-    tr: Callable[..., str],
-) -> tuple[str, ...]:
-    expected = len(expected_locations) or len(active_locations)
-    lines: list[str] = []
-    if check_state(suitability_checks, "SUITABILITY_CHECK_SPEED_VARIATION") != "pass":
-        append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_STEADY_HOLD"))
-    if has_source_overlap(aggregate, tr=tr):
-        append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_COMPARE_PATHS"))
-    if is_transient_primary(primary_candidate_facts):
-        append_unique_line(lines, tr("REPORT_RECAPTURE_CONDITION_REPEAT_EVENT"))
-    if (
-        location_confidence_key in {"weak", "mixed"}
-        or check_state(suitability_checks, "SUITABILITY_CHECK_SENSOR_COVERAGE") != "pass"
-    ):
+    conditions: list[str] = []
+    if speed_variation_nonpass:
+        append_unique_line(conditions, tr("REPORT_RECAPTURE_CONDITION_STEADY_HOLD"))
+    if source_overlap:
+        append_unique_line(conditions, tr("REPORT_RECAPTURE_CONDITION_COMPARE_PATHS"))
+    if transient_primary:
+        append_unique_line(conditions, tr("REPORT_RECAPTURE_CONDITION_REPEAT_EVENT"))
+    if sensor_coverage_nonpass:
         append_unique_line(
-            lines,
+            conditions,
             tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
         )
-    if (
-        primary_candidate_facts.has_reference_gaps
-        or check_state(suitability_checks, "SUITABILITY_CHECK_REFERENCE_COMPLETENESS") != "pass"
-        or has_warning_code(warnings, "reference_context_incomplete")
-    ):
-        append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
-    if not lines:
-        append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_STEADY"))
-        append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected))
-        append_unique_line(lines, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
-    return tuple(lines[:4])
+    if reference_incomplete:
+        append_unique_line(conditions, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
+    if not conditions:
+        append_unique_line(conditions, tr("REPORT_CAPTURE_CONDITION_STEADY"))
+        append_unique_line(
+            conditions,
+            tr("REPORT_CAPTURE_CONDITION_FULL_COVERAGE", expected=expected),
+        )
+        append_unique_line(conditions, tr("REPORT_CAPTURE_CONDITION_REFERENCE"))
+
+    return RecaptureAssessment(
+        issues=tuple(issues[:4]),
+        actions=tuple(actions[:4]),
+        conditions=tuple(conditions[:4]),
+    )
 
 
 def _next_if_primary_clean(


### PR DESCRIPTION
## Summary
- add a shared report-section context for verdict and appendix builders
- collapse recapture issues, actions, and conditions into one assessment path
- add focused report-document regression coverage for the shared context wiring

## Validation
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py
- make lint && make typecheck-backend
- make test-changed

## Notes
- local Docker stack exercise is still blocked in this environment because Docker Compose/daemon access is unavailable