### PR TITLE
Clarify OBD runtime role surfaces

### DIFF
--- a/apps/server/tests/adapters/obd/test_runtime_facets.py
+++ b/apps/server/tests/adapters/obd/test_runtime_facets.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+from vibesensor.adapters.obd.runtime_services import (
+    ObdRuntime,
+    ObdRuntimeConnection,
+    ObdRuntimeControl,
+    ObdRuntimeObservation,
+    build_obd_runtime,
+)
+
+
+def test_build_obd_runtime_groups_services_by_role() -> None:
+    runtime = build_obd_runtime(
+        admin_client=MagicMock(),
+        session_factory=MagicMock(),
+    )
+
+    assert isinstance(runtime, ObdRuntime)
+    assert isinstance(runtime.observation, ObdRuntimeObservation)
+    assert isinstance(runtime.control, ObdRuntimeControl)
+    assert isinstance(runtime.connection, ObdRuntimeConnection)
+    assert runtime.observation.facts is not None
+    assert runtime.observation.projection is not None
+    assert runtime.control.settings is not None
+    assert runtime.control.admin is not None
+    assert runtime.connection.runner is not None

--- a/apps/server/vibesensor/adapters/obd/__init__.py
+++ b/apps/server/vibesensor/adapters/obd/__init__.py
@@ -2,12 +2,21 @@
 
 from .admin_client import ObdAdminClient
 from .models import ObdDeviceSnapshot, ObdStatusSnapshot
-from .runtime_services import ObdRuntimeServices, build_obd_runtime
+from .runtime_services import (
+    ObdRuntime,
+    ObdRuntimeConnection,
+    ObdRuntimeControl,
+    ObdRuntimeObservation,
+    build_obd_runtime,
+)
 
 __all__ = [
     "ObdAdminClient",
     "ObdDeviceSnapshot",
-    "ObdRuntimeServices",
+    "ObdRuntime",
+    "ObdRuntimeConnection",
+    "ObdRuntimeControl",
+    "ObdRuntimeObservation",
     "ObdStatusSnapshot",
     "build_obd_runtime",
 ]

--- a/apps/server/vibesensor/adapters/obd/runtime_services.py
+++ b/apps/server/vibesensor/adapters/obd/runtime_services.py
@@ -1,4 +1,4 @@
-"""Focused Bluetooth OBD runtime services over shared runtime state."""
+"""Focused Bluetooth OBD runtime role builders over shared runtime state."""
 
 from __future__ import annotations
 
@@ -19,7 +19,13 @@ from vibesensor.adapters.obd.runtime_projection import ObdRuntimeProjection
 from vibesensor.adapters.obd.runtime_settings import ObdRuntimeSettings
 from vibesensor.adapters.obd.runtime_store import MonotonicFn, ObdRuntimeStore
 
-__all__ = ["ObdRuntimeServices", "build_obd_runtime"]
+__all__ = [
+    "ObdRuntime",
+    "ObdRuntimeConnection",
+    "ObdRuntimeControl",
+    "ObdRuntimeObservation",
+    "build_obd_runtime",
+]
 
 _DEFAULT_POLL_INTERVAL_S = 0.75
 _RPM_STALE_TIMEOUT_S = 2.0
@@ -29,15 +35,35 @@ SessionFactory = Callable[[], Elm327Session]
 
 
 @dataclass(frozen=True, slots=True)
-class ObdRuntimeServices:
-    """Focused OBD services exposed to the rest of the application."""
+class ObdRuntimeObservation:
+    """Read-only OBD observation surface."""
 
     facts: ObdRuntimeFacts
     projection: ObdRuntimeProjection
-    control: ObdRuntimeSettings
+
+
+@dataclass(frozen=True, slots=True)
+class ObdRuntimeControl:
+    """Configuration and admin-control surface."""
+
+    settings: ObdRuntimeSettings
     admin: ObdAdminRuntime
-    connection_control: ObdRuntimeConnectionControl
+
+
+@dataclass(frozen=True, slots=True)
+class ObdRuntimeConnection:
+    """Connection execution surface."""
+
     runner: ObdConnectionRuntime
+
+
+@dataclass(frozen=True, slots=True)
+class ObdRuntime:
+    """Role-grouped OBD runtime surfaces for callers."""
+
+    observation: ObdRuntimeObservation
+    control: ObdRuntimeControl
+    connection: ObdRuntimeConnection
 
 
 def build_obd_runtime(
@@ -46,8 +72,8 @@ def build_obd_runtime(
     session_factory: SessionFactory | None = None,
     monotonic: MonotonicFn = time.monotonic,
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
-) -> ObdRuntimeServices:
-    """Build focused OBD services over one shared runtime store."""
+) -> ObdRuntime:
+    """Build role-grouped OBD runtime surfaces over one shared runtime store."""
 
     resolved_admin_client = ObdAdminClient() if admin_client is None else admin_client
     resolved_session_factory = Elm327Session if session_factory is None else session_factory
@@ -59,20 +85,25 @@ def build_obd_runtime(
     )
     connection_control = ObdRuntimeConnectionControl(store=store)
     connection_observation = ObdRuntimeConnectionObservation(store=store)
-    return ObdRuntimeServices(
-        facts=ObdRuntimeFacts(store=store),
-        projection=ObdRuntimeProjection(store=store),
-        control=ObdRuntimeSettings(store=store),
-        admin=ObdAdminRuntime(
-            admin_client=resolved_admin_client,
-            store=store,
+    return ObdRuntime(
+        observation=ObdRuntimeObservation(
+            facts=ObdRuntimeFacts(store=store),
+            projection=ObdRuntimeProjection(store=store),
         ),
-        connection_control=connection_control,
-        runner=ObdConnectionRuntime(
-            admin_client=resolved_admin_client,
-            connection_observation=connection_observation,
-            connection_control=connection_control,
-            session_factory=resolved_session_factory,
-            monotonic=monotonic,
+        control=ObdRuntimeControl(
+            settings=ObdRuntimeSettings(store=store),
+            admin=ObdAdminRuntime(
+                admin_client=resolved_admin_client,
+                store=store,
+            ),
+        ),
+        connection=ObdRuntimeConnection(
+            runner=ObdConnectionRuntime(
+                admin_client=resolved_admin_client,
+                connection_observation=connection_observation,
+                connection_control=connection_control,
+                session_factory=resolved_session_factory,
+                monotonic=monotonic,
+            ),
         ),
     )

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -140,11 +140,11 @@ def build_runtime(config: AppConfig) -> AppRuntime:
     obd_runtime = build_obd_runtime(admin_client=obd_admin_client)
     speed_services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_facts=obd_runtime.facts,
-        obd_projection=obd_runtime.projection,
+        obd_facts=obd_runtime.observation.facts,
+        obd_projection=obd_runtime.observation.projection,
         obd_device_admin=obd_admin_client,
-        obd_status_refresher=obd_runtime.admin,
-        obd_control=obd_runtime.control,
+        obd_status_refresher=obd_runtime.control.admin,
+        obd_control=obd_runtime.control.settings,
     )
     settings_store = SettingsStore(db=history.settings_snapshot_repository)
     settings_reader = SettingsDerivationService(
@@ -269,7 +269,7 @@ def build_runtime(config: AppConfig) -> AppRuntime:
         worker_pool=worker_pool,
         settings_store=settings_reader,
         gps_monitor=gps_monitor,
-        obd_runner=obd_runtime.runner,
+        obd_runner=obd_runtime.connection.runner,
         history_db=history_lifecycle,
         processing_loop_state=processing_loop_state,
         health_state=health_state,


### PR DESCRIPTION
## Summary
- replace the flat OBD runtime service bag with grouped observation, control, and connection role surfaces
- update the app container to consume the grouped runtime roles explicitly
- add a focused runtime-facets contract test for the new builder shape

## Validation
- .venv/bin/python -m pytest -q apps/server/tests/adapters/obd apps/server/tests/adapters/speed/test_speed_services.py
- make lint && make typecheck-backend
- make test-changed

## Notes
- local Docker stack exercise is still blocked in this environment because Docker Compose/daemon access is unavailable