### PR TITLE
Clarify updater staging cleanup

### DIFF
--- a/apps/server/tests/use_cases/updates/test_release_staging.py
+++ b/apps/server/tests/use_cases/updates/test_release_staging.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from test_support.update_status import build_update_status_harness
 
-from vibesensor.shared.exceptions import UpdateReleaseError
+from vibesensor.shared.exceptions import UpdateCleanupError, UpdateReleaseError
 from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
@@ -100,3 +100,88 @@ async def test_stage_returns_none_when_verification_fails(tmp_path: Path) -> Non
 
     assert staged_dir is not None
     assert staged_dir.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_stage_raises_cleanup_error_when_cleanup_fails_without_prior_error(
+    tmp_path: Path,
+) -> None:
+    tracker = build_update_status_harness(tmp_path / "state.json")
+    _seed_release_ready_state(tracker)
+    stager = ServerReleaseStager(
+        status=tracker,
+        rollback_dir=tmp_path / "rollback",
+    )
+    release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="")
+    staged_dir: Path | None = None
+
+    async def _download_release(_release: object, staging_dir: Path) -> Path:
+        nonlocal staged_dir
+        staged_dir = staging_dir
+        wheel_path = staging_dir / "release.whl"
+        wheel_path.write_text("wheel", encoding="utf-8")
+        return wheel_path
+
+    with (
+        patch.object(
+            ServerReleaseStager,
+            "_download_release",
+            new=AsyncMock(side_effect=_download_release),
+        ),
+        patch.object(
+            ServerReleaseStager,
+            "_verify_download",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "vibesensor.use_cases.updates.release_staging.shutil.rmtree",
+            side_effect=OSError("busy"),
+        ),
+        pytest.raises(
+            UpdateCleanupError,
+            match="Failed to remove staged release directory: busy",
+        ),
+    ):
+        async with stager.stage(release):
+            pass
+
+    assert staged_dir is not None
+    assert staged_dir.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_stage_keeps_prior_error_and_adds_cleanup_note(tmp_path: Path) -> None:
+    tracker = build_update_status_harness(tmp_path / "state.json")
+    _seed_release_ready_state(tracker)
+    stager = ServerReleaseStager(
+        status=tracker,
+        rollback_dir=tmp_path / "rollback",
+    )
+    release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4", sha256="")
+
+    async def _download_release(_release: object, staging_dir: Path) -> Path:
+        wheel_path = staging_dir / "release.whl"
+        wheel_path.write_text("wheel", encoding="utf-8")
+        return wheel_path
+
+    with (
+        patch.object(
+            ServerReleaseStager,
+            "_download_release",
+            new=AsyncMock(side_effect=_download_release),
+        ),
+        patch.object(
+            ServerReleaseStager,
+            "_verify_download",
+            new=AsyncMock(side_effect=UpdateReleaseError("checksum mismatch")),
+        ),
+        patch(
+            "vibesensor.use_cases.updates.release_staging.shutil.rmtree",
+            side_effect=OSError("busy"),
+        ),
+        pytest.raises(UpdateReleaseError, match="checksum mismatch") as exc_info,
+    ):
+        async with stager.stage(release):
+            pytest.fail("stage() should not yield when verification fails")
+
+    assert exc_info.value.__notes__ == ["Failed to remove staged release directory: busy"]

--- a/apps/server/vibesensor/use_cases/updates/release_staging.py
+++ b/apps/server/vibesensor/use_cases/updates/release_staging.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import shutil
-import sys
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -49,25 +48,37 @@ class ServerReleaseStager:
         self._status.transition(UpdatePhase.downloading)
         self._status.log(f"Downloading release {release.tag}...")
         staging_dir = Path(tempfile.mkdtemp(prefix="vibesensor-update-"))
+        prior_error: BaseException | None = None
         try:
-            wheel_path = await self._download_release(release, staging_dir)
-            self._status.log(
-                f"Downloaded {wheel_path.name} (sha256={getattr(release, 'sha256', '')})",
-            )
-            await self._verify_download(release, wheel_path)
-            yield StagedServerRelease(release=release, wheel_path=wheel_path)
-        finally:
-            active_error = sys.exc_info()[1]
             try:
-                shutil.rmtree(staging_dir)
-            except OSError as exc:
-                cleanup_error = UpdateCleanupError(
-                    f"Failed to remove staged release directory: {exc}",
+                wheel_path = await self._download_release(release, staging_dir)
+                self._status.log(
+                    f"Downloaded {wheel_path.name} (sha256={getattr(release, 'sha256', '')})",
                 )
-                if active_error is not None:
-                    active_error.add_note(str(cleanup_error))
-                else:
-                    raise cleanup_error from exc
+                await self._verify_download(release, wheel_path)
+                yield StagedServerRelease(release=release, wheel_path=wheel_path)
+            except BaseException as exc:
+                prior_error = exc
+                raise
+        finally:
+            self._cleanup_staging_dir(staging_dir, prior_error=prior_error)
+
+    def _cleanup_staging_dir(
+        self,
+        staging_dir: Path,
+        *,
+        prior_error: BaseException | None,
+    ) -> None:
+        try:
+            shutil.rmtree(staging_dir)
+        except OSError as exc:
+            cleanup_error = UpdateCleanupError(
+                f"Failed to remove staged release directory: {exc}",
+            )
+            if prior_error is not None:
+                prior_error.add_note(str(cleanup_error))
+                return
+            raise cleanup_error from exc
 
     async def _download_release(self, release: ReleaseInfo, staging_dir: Path) -> Path:
         """Download a release wheel to *staging_dir*."""


### PR DESCRIPTION
Summary:
- replace the remaining sys.exc_info()-based staging cleanup flow with explicit prior-error tracking in release_staging.py
- keep cleanup failures attached to the triggering exception when staging already failed, and raise UpdateCleanupError when cleanup fails on its own
- add regression coverage for both cleanup-only failures and cleanup failures layered on top of release verification errors

Testing:
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/updates
- make lint && make typecheck-backend
- make test-changed

Notes:
- Local Docker stack validation is still blocked in this environment because docker compose lacks the compose plugin and docker-compose cannot reach a Docker daemon socket.