### PR TITLE
Make firmware refresh outcomes explicit

### DIFF
--- a/apps/server/tests/use_cases/updates/test_release_deployment.py
+++ b/apps/server/tests/use_cases/updates/test_release_deployment.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vibesensor.shared.exceptions import UpdateReleaseError
+from vibesensor.use_cases.updates.firmware import FirmwareRefreshResult
 from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.release_deployment import (
     UpdateReleaseDeploymentCoordinator,
@@ -32,7 +33,9 @@ def _make_coordinator() -> tuple[
     installer.install_release = AsyncMock()
     installer.rollback = AsyncMock()
     firmware_refresher = MagicMock()
-    firmware_refresher.refresh_esp_firmware = AsyncMock()
+    firmware_refresher.refresh_esp_firmware = AsyncMock(
+        return_value=FirmwareRefreshResult.success(),
+    )
     status = MagicMock()
     return (
         UpdateReleaseDeploymentCoordinator(
@@ -78,8 +81,9 @@ async def test_deploy_snapshots_before_firmware_refresh(tmp_path: Path) -> None:
         events.append("snapshot")
         return True
 
-    async def refresh_esp_firmware(*, pinned_tag: str) -> None:
+    async def refresh_esp_firmware(*, pinned_tag: str) -> FirmwareRefreshResult:
         events.append(f"firmware:{pinned_tag}")
+        return FirmwareRefreshResult.success()
 
     async def install_release(wheel_path: Path, expected_version: str) -> WheelInstallResult:
         events.append(f"install:{wheel_path.name}:{expected_version}")
@@ -114,6 +118,33 @@ async def test_deploy_raises_plain_failure_without_rollback_for_non_mutating_rej
     installer.rollback.assert_not_awaited()
     status.fail.assert_not_called()
     status.log.assert_any_call("Installing update...")
+
+
+@pytest.mark.asyncio
+async def test_deploy_continues_install_when_cache_refresh_fails() -> None:
+    coordinator, installer, _firmware_refresher, status = _make_coordinator()
+    installer.snapshot_for_rollback.return_value = True
+    installer.install_release.return_value = WheelInstallResult(
+        succeeded=True,
+        rollback_required=False,
+    )
+    _firmware_refresher.refresh_esp_firmware.return_value = FirmwareRefreshResult.failure(
+        message="ESP firmware cache refresh failed (exit 1)",
+        detail="cache unavailable",
+    )
+
+    await coordinator.deploy(_staged_release())
+
+    status.add_issue.assert_called_once_with(
+        UpdatePhase.downloading,
+        "ESP firmware cache refresh failed (exit 1)",
+        "cache unavailable",
+    )
+    status.log.assert_any_call("ESP firmware refresh failed; continuing with existing cache")
+    installer.install_release.assert_awaited_once_with(
+        Path("/tmp/vibesensor.whl"),
+        "2025.6.15",
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -14,7 +14,7 @@ from vibesensor.use_cases.updates.artifact_validation import (
     sha256_file,
     wheel_dependency_issues,
 )
-from vibesensor.use_cases.updates.firmware.firmware_refresh import FirmwareRefresher
+from vibesensor.use_cases.updates.firmware import FirmwareRefresher, FirmwareRefreshResult
 from vibesensor.use_cases.updates.installer import UpdateInstaller, UpdateInstallerConfig
 from vibesensor.use_cases.updates.rollback_snapshot import RollbackSnapshotStore
 from vibesensor.use_cases.updates.runner import CommandExecutionResult
@@ -531,7 +531,7 @@ async def test_firmware_refresher_uses_module_fallback_without_installer(tmp_pat
         timeout_s=30,
     )
 
-    await refresher.refresh_esp_firmware("server-v2025.6.15")
+    result = await refresher.refresh_esp_firmware("server-v2025.6.15")
 
     assert any(
         call[0][:3]
@@ -543,3 +543,4 @@ async def test_firmware_refresher_uses_module_fallback_without_installer(tmp_pat
         and call[0][-2:] == ["--tag", "server-v2025.6.15"]
         for call in commands.calls
     )
+    assert result == FirmwareRefreshResult.success()

--- a/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
@@ -8,7 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vibesensor.shared.exceptions import UpdateReleaseError
-from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
+from vibesensor.use_cases.updates.firmware import FirmwareRefreshResult
+from vibesensor.use_cases.updates.models import UpdateExecutionOutcome, UpdatePhase
 from vibesensor.use_cases.updates.run_models import (
     InstallServerReleasePlan,
     PlannedUpdateRun,
@@ -24,6 +25,7 @@ def _executor() -> tuple[
     MagicMock,
     MagicMock,
     MagicMock,
+    MagicMock,
 ]:
     completion = MagicMock()
     completion.complete_success = AsyncMock()
@@ -31,12 +33,16 @@ def _executor() -> tuple[
     deployment = MagicMock()
     deployment.deploy = AsyncMock(return_value=True)
     firmware_refresher = MagicMock()
-    firmware_refresher.refresh_esp_firmware = AsyncMock()
+    firmware_refresher.refresh_esp_firmware = AsyncMock(
+        return_value=FirmwareRefreshResult.success(),
+    )
+    status = MagicMock()
     executor = UpdateWorkflowExecutor(
         completion=completion,
         stager=stager,
         deployment=deployment,
         firmware_refresher=firmware_refresher,
+        status=status,
     )
     return (
         executor,
@@ -44,6 +50,7 @@ def _executor() -> tuple[
         stager,
         deployment,
         firmware_refresher,
+        status,
     )
 
 
@@ -62,6 +69,7 @@ async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() 
         stager,
         deployment,
         firmware_refresher,
+        status,
     ) = _executor()
     prepared_transport = MagicMock()
     workflow = PlannedUpdateRun(
@@ -83,6 +91,43 @@ async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() 
     )
     deployment.deploy.assert_not_awaited()
     assert not stager.stage.called
+    status.fail.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
+    (
+        executor,
+        completion,
+        stager,
+        deployment,
+        firmware_refresher,
+        status,
+    ) = _executor()
+    prepared_transport = MagicMock()
+    workflow = PlannedUpdateRun(
+        prepared=_prepared_run(prepared_transport),
+        execution_plan=RefreshFirmwarePlan(
+            latest_tag="server-v2026.4.3",
+        ),
+    )
+    firmware_refresher.refresh_esp_firmware.return_value = FirmwareRefreshResult.failure(
+        message="ESP firmware cache refresh failed (exit 1)",
+        detail="cache unavailable",
+    )
+
+    with pytest.raises(UpdateReleaseError, match="ESP firmware cache refresh failed"):
+        await executor.execute(workflow)
+
+    status.fail.assert_called_once_with(
+        UpdatePhase.downloading,
+        "ESP firmware cache refresh failed (exit 1)",
+        "cache unavailable",
+        log_message="ESP firmware refresh failed; refresh-only update did not complete",
+    )
+    completion.complete_success.assert_not_awaited()
+    deployment.deploy.assert_not_awaited()
+    assert not stager.stage.called
 
 
 @pytest.mark.asyncio
@@ -93,6 +138,7 @@ async def test_execute_install_plan_stages_and_deploys_before_completion(tmp_pat
         stager,
         deployment,
         firmware_refresher,
+        status,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
@@ -121,6 +167,7 @@ async def test_execute_install_plan_stages_and_deploys_before_completion(tmp_pat
         message="Update completed successfully",
     )
     firmware_refresher.refresh_esp_firmware.assert_not_awaited()
+    status.fail.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -133,6 +180,7 @@ async def test_execute_install_plan_propagates_deploy_failure_before_completion(
         stager,
         deployment,
         _firmware_refresher,
+        status,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
@@ -157,3 +205,4 @@ async def test_execute_install_plan_propagates_deploy_failure_before_completion(
 
     deployment.deploy.assert_awaited_once_with(staged_release)
     completion.complete_success.assert_not_awaited()
+    status.fail.assert_not_called()

--- a/apps/server/vibesensor/use_cases/updates/firmware/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/__init__.py
@@ -2,6 +2,9 @@
 
 from vibesensor.use_cases.updates.firmware.esp_flash_manager import EspFlashManager
 from vibesensor.use_cases.updates.firmware.firmware_cache import FirmwareCache
-from vibesensor.use_cases.updates.firmware.firmware_refresh import FirmwareRefresher
+from vibesensor.use_cases.updates.firmware.firmware_refresh import (
+    FirmwareRefresher,
+    FirmwareRefreshResult,
+)
 
-__all__ = ["EspFlashManager", "FirmwareCache", "FirmwareRefresher"]
+__all__ = ["EspFlashManager", "FirmwareCache", "FirmwareRefreshResult", "FirmwareRefresher"]

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_refresh.py
@@ -2,17 +2,48 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
+from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
 
-__all__ = ["FirmwareRefresher"]
+__all__ = ["FirmwareRefreshResult", "FirmwareRefresher"]
+
+
+@dataclass(frozen=True, slots=True)
+class FirmwareRefreshResult:
+    """Explicit firmware-cache refresh outcome returned to workflow callers."""
+
+    succeeded: bool
+    phase: UpdatePhase = UpdatePhase.downloading
+    message: str = ""
+    detail: str = ""
+
+    @classmethod
+    def success(cls) -> FirmwareRefreshResult:
+        return cls(succeeded=True)
+
+    @classmethod
+    def failure(
+        cls,
+        *,
+        message: str,
+        detail: str = "",
+        phase: UpdatePhase = UpdatePhase.downloading,
+    ) -> FirmwareRefreshResult:
+        return cls(
+            succeeded=False,
+            phase=phase,
+            message=message,
+            detail=detail,
+        )
 
 
 class FirmwareRefresher:
-    """Refresh the updater firmware cache independently from install orchestration."""
+    """Run one firmware-cache refresh command and return an explicit outcome."""
 
     __slots__ = ("_commands", "_repo", "_status", "_timeout_s")
 
@@ -29,8 +60,8 @@ class FirmwareRefresher:
         self._repo = repo
         self._timeout_s = timeout_s
 
-    async def refresh_esp_firmware(self, pinned_tag: str = "") -> None:
-        """Refresh the firmware cache, falling back to the current cache on failure."""
+    async def refresh_esp_firmware(self, pinned_tag: str = "") -> FirmwareRefreshResult:
+        """Refresh the firmware cache and return the explicit outcome."""
 
         self._status.log("Refreshing ESP firmware cache...")
         venv_python = reinstall_python_executable(self._repo)
@@ -55,11 +86,9 @@ class FirmwareRefresher:
             sudo=False,
         )
         if result.returncode != 0:
-            self._status.add_issue(
-                "downloading",
-                f"ESP firmware cache refresh failed (exit {result.returncode})",
-                result.stderr,
+            return FirmwareRefreshResult.failure(
+                message=f"ESP firmware cache refresh failed (exit {result.returncode})",
+                detail=result.stderr,
             )
-            self._status.log("ESP firmware refresh failed; continuing with existing cache")
-            return
         self._status.log("ESP firmware cache refresh completed successfully")
+        return FirmwareRefreshResult.success()

--- a/apps/server/vibesensor/use_cases/updates/release_deployment.py
+++ b/apps/server/vibesensor/use_cases/updates/release_deployment.py
@@ -38,7 +38,16 @@ class UpdateReleaseDeploymentCoordinator:
                 "Install aborted before mutating the live environment",
             )
             raise UpdateReleaseError("Rollback snapshot could not be created")
-        await self._firmware_refresher.refresh_esp_firmware(pinned_tag=staged_release.release.tag)
+        refresh_result = await self._firmware_refresher.refresh_esp_firmware(
+            pinned_tag=staged_release.release.tag,
+        )
+        if not refresh_result.succeeded:
+            self._status.add_issue(
+                refresh_result.phase,
+                refresh_result.message,
+                refresh_result.detail,
+            )
+            self._status.log("ESP firmware refresh failed; continuing with existing cache")
         install_result = await self._installer.install_release(
             staged_release.wheel_path,
             str(staged_release.release.version),

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.models import UpdateExecutionOutcome
@@ -14,6 +15,7 @@ from vibesensor.use_cases.updates.run_models import (
     PlannedUpdateRun,
     RefreshFirmwarePlan,
 )
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 __all__ = ["UpdateWorkflowExecutor"]
 
@@ -26,6 +28,7 @@ class UpdateWorkflowExecutor:
         "_deployment",
         "_firmware_refresher",
         "_stager",
+        "_status",
     )
 
     def __init__(
@@ -35,11 +38,13 @@ class UpdateWorkflowExecutor:
         stager: ServerReleaseStager,
         deployment: UpdateReleaseDeploymentCoordinator,
         firmware_refresher: FirmwareRefresher,
+        status: UpdateStatusTracker,
     ) -> None:
         self._completion = completion
         self._stager = stager
         self._deployment = deployment
         self._firmware_refresher = firmware_refresher
+        self._status = status
 
     async def execute(
         self,
@@ -62,7 +67,17 @@ class UpdateWorkflowExecutor:
         workflow: PlannedUpdateRun,
         plan: RefreshFirmwarePlan,
     ) -> UpdateExecutionOutcome:
-        await self._firmware_refresher.refresh_esp_firmware(pinned_tag=plan.latest_tag)
+        refresh_result = await self._firmware_refresher.refresh_esp_firmware(
+            pinned_tag=plan.latest_tag,
+        )
+        if not refresh_result.succeeded:
+            self._status.fail(
+                refresh_result.phase,
+                refresh_result.message,
+                refresh_result.detail,
+                log_message="ESP firmware refresh failed; refresh-only update did not complete",
+            )
+            raise UpdateReleaseError(refresh_result.message)
         await self._completion.complete_success(
             workflow.prepared.prepared_transport,
             message="No server update needed; ESP firmware checked",

--- a/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
@@ -48,6 +48,7 @@ def build_update_workflow(
             stager=release.stager,
             deployment=release.deployment,
             firmware_refresher=release.firmware_refresher,
+            status=core.status,
         ),
         finalizer=UpdateWorkflowFinalizer(
             transport_coordinator=transport.coordinator,


### PR DESCRIPTION
## Summary
- return an explicit firmware refresh result instead of burying refresh outcome policy inside `FirmwareRefresher`
- let deployment continue with a recorded issue when cache refresh fails, while refresh-only workflows now fail instead of marking success
- cover the new outcome handling in deployment, workflow executor, and refresher tests

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/updates/test_release_deployment.py apps/server/tests/use_cases/updates/test_update_workflow_executor.py apps/server/tests/use_cases/updates/test_update_installer_verification.py
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/updates
- make lint
- make typecheck-backend
- make test-changed