### PR TITLE
Split report section contexts

### DIFF
--- a/apps/server/vibesensor/use_cases/history/report_document/composition.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/composition.py
@@ -3,18 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import replace
 
-from vibesensor.domain import TestRun
 from vibesensor.report_i18n import normalize_lang
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts, PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
-    AppendixBData,
     NextStep,
     ReportDocument,
-    VerdictPageData,
 )
 from vibesensor.shared.boundaries.reporting.facts import ReportRunFacts
 from vibesensor.shared.report_presentation import (
@@ -38,7 +35,12 @@ from .narrative_summaries import _proof_summary_text
 from .pattern_evidence import build_pattern_evidence
 from .peak_table import build_peak_rows
 from .report_sections import build_data_trust, build_next_steps
-from .section_context import ReportSectionContext
+from .section_context import (
+    AppendixAContext,
+    AppendixBContext,
+    AppendixCContext,
+    VerdictPageContext,
+)
 from .sections import _build_appendix_c_data, _build_timeline_graph_data, _build_traceability_rows
 from .verdict_page import build_observed_signature, build_verdict_page_data
 from .workflow_appendix import (
@@ -48,16 +50,6 @@ from .workflow_appendix import (
 )
 
 __all__ = ["compose_report_document"]
-
-
-@dataclass(frozen=True, slots=True)
-class _ReportDocumentSections:
-    """Document-facing sections composed before final report assembly."""
-
-    section_context: ReportSectionContext
-    verdict_page: VerdictPageData
-    appendix_a: AppendixAData
-    appendix_b: AppendixBData
 
 
 def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
@@ -74,10 +66,91 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
     sensor_facts = report_facts.sensor
     decision_facts = report_facts.decision
     prepared_findings = report_facts.findings
-    sections = _compose_report_document_sections(
+    coverage = sensor_facts.coverage
+    active_locations = tuple(coverage.active_locations)
+    coverage_label_text = coverage_label(
+        expected_locations=coverage.expected_locations,
+        active_locations=coverage.active_locations,
+        missing_locations=coverage.missing_locations,
+        partial_locations=coverage.partial_locations,
+        tr=tr,
+    )
+    coverage_notes_items = tuple(
+        coverage_notes(
+            missing_locations=coverage.missing_locations,
+            partial_locations=coverage.partial_locations,
+            tr=tr,
+        )
+    )
+    proof_caveat = proof_caveat_text(
+        primary_candidate_facts=decision_facts.primary_candidate,
+        action_status_key=decision_facts.action_status_key,
+        location_confidence_key=decision_facts.location_confidence_key,
+        tr=tr,
+    )
+    runner_up = runner_up_corner(sensor_facts.active_intensity, tr=tr)
+    speed_window_label = str(decision_facts.primary_candidate.primary_speed or "").strip() or None
+    recapture = build_recapture_assessment(
         aggregate=test_run,
-        report_facts=report_facts,
+        primary_candidate_facts=decision_facts.primary_candidate,
+        location_confidence_key=decision_facts.location_confidence_key,
+        expected_locations=coverage.expected_locations,
+        active_locations=coverage.active_locations,
+        suitability_checks=decision_facts.suitability_checks,
+        warnings=decision_facts.warnings,
         lang=lang,
+        tr=tr,
+    )
+    verdict_context = VerdictPageContext(
+        action_status_key=decision_facts.action_status_key,
+        location_confidence_key=decision_facts.location_confidence_key,
+        alternative_source_visible=decision_facts.alternative_source_visible,
+        active_locations=active_locations,
+        coverage_label=coverage_label_text,
+        proof_caveat=proof_caveat,
+        runner_up_corner=runner_up,
+        speed_window_label=speed_window_label,
+        recapture=recapture,
+    )
+    appendix_a_context = AppendixAContext(
+        action_status_key=decision_facts.action_status_key,
+        alternative_source_visible=decision_facts.alternative_source_visible,
+        ranked_candidates=build_ranked_candidates(test_run, tr=tr),
+        recapture=recapture,
+    )
+    appendix_b_context = AppendixBContext(
+        action_status_key=decision_facts.action_status_key,
+        location_confidence_key=decision_facts.location_confidence_key,
+        active_locations=active_locations,
+        coverage_label=coverage_label_text,
+        coverage_notes=coverage_notes_items,
+        runner_up_corner=runner_up,
+    )
+    appendix_c_context = AppendixCContext(
+        speed_window_label=speed_window_label,
+        proof_caveat=proof_caveat,
+    )
+    verdict_page = build_verdict_page_data(
+        aggregate=test_run,
+        primary_candidate_facts=decision_facts.primary_candidate,
+        duration_text=run_facts.duration_text,
+        verdict_context=verdict_context,
+        suitability_checks=decision_facts.suitability_checks,
+        warnings=decision_facts.warnings,
+        lang=lang,
+        tr=tr,
+    )
+    appendix_a = build_appendix_a_data(
+        aggregate=test_run,
+        appendix_context=appendix_a_context,
+        tr=tr,
+    )
+    appendix_b = build_appendix_b_data(
+        aggregate=test_run,
+        primary_candidate_facts=decision_facts.primary_candidate,
+        active_sensor_intensity=sensor_facts.active_intensity,
+        appendix_context=appendix_b_context,
+        tr=tr,
     )
     primary = resolve_primary_report_candidate(
         aggregate=test_run,
@@ -95,13 +168,13 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
         test_run,
         primary,
         report_facts,
-        runner_up_corner=sections.section_context.runner_up_corner,
+        runner_up_corner=verdict_context.runner_up_corner,
         tr=tr,
     )
     run_datetime = _report_date_text(run_facts)
     findings = list(prepared_findings.all_findings)
     verdict_page = replace(
-        sections.verdict_page,
+        verdict_page,
         proof_summary=proof_summary,
         timeline_graph=_build_timeline_graph_data(
             report_facts,
@@ -135,7 +208,7 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
             _resolve_next_steps(
                 primary=primary,
                 report_facts=report_facts,
-                appendix_a=sections.appendix_a,
+                appendix_a=appendix_a,
                 lang=lang,
                 tr=tr,
             )
@@ -161,8 +234,8 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
         sensor_intensity_by_location=list(sensor_facts.active_intensity),
         location_hotspot_rows=list(sensor_facts.location_hotspot_rows),
         verdict_page=verdict_page,
-        appendix_a=sections.appendix_a,
-        appendix_b=sections.appendix_b,
+        appendix_a=appendix_a,
+        appendix_b=appendix_b,
         appendix_c=_build_appendix_c_data(
             primary=primary,
             aggregate=test_run,
@@ -172,7 +245,7 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
                 tr=tr,
             ),
             report_facts=report_facts,
-            section_context=sections.section_context,
+            appendix_context=appendix_c_context,
             data_trust=list(data_trust),
             tr=tr,
         ),
@@ -187,106 +260,6 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
                 sample_rate_hz=run_facts.sample_rate_hz,
                 tr=tr,
             )
-        ),
-    )
-
-
-def _compose_report_document_sections(
-    *,
-    aggregate: TestRun,
-    report_facts: PreparedReportFacts,
-    lang: str,
-) -> _ReportDocumentSections:
-    """Build presentation-specific report sections from prepared semantic facts."""
-
-    def tr(key: str, **kw: JsonValue) -> str:
-        return str(_tr(lang, key, **kw))
-
-    run_facts = report_facts.run
-    sensor_facts = report_facts.sensor
-    decision_facts = report_facts.decision
-    section_context = _build_report_section_context(
-        aggregate=aggregate,
-        report_facts=report_facts,
-        lang=lang,
-        tr=tr,
-    )
-    return _ReportDocumentSections(
-        section_context=section_context,
-        verdict_page=build_verdict_page_data(
-            aggregate=aggregate,
-            primary_candidate_facts=decision_facts.primary_candidate,
-            duration_text=run_facts.duration_text,
-            section_context=section_context,
-            suitability_checks=decision_facts.suitability_checks,
-            warnings=decision_facts.warnings,
-            lang=lang,
-            tr=tr,
-        ),
-        appendix_a=build_appendix_a_data(
-            aggregate=aggregate,
-            section_context=section_context,
-            tr=tr,
-        ),
-        appendix_b=build_appendix_b_data(
-            aggregate=aggregate,
-            primary_candidate_facts=decision_facts.primary_candidate,
-            active_sensor_intensity=sensor_facts.active_intensity,
-            section_context=section_context,
-            tr=tr,
-        ),
-    )
-
-
-def _build_report_section_context(
-    *,
-    aggregate: TestRun,
-    report_facts: PreparedReportFacts,
-    lang: str,
-    tr: Callable[..., str],
-) -> ReportSectionContext:
-    sensor_facts = report_facts.sensor
-    decision_facts = report_facts.decision
-    coverage = sensor_facts.coverage
-    return ReportSectionContext(
-        action_status_key=decision_facts.action_status_key,
-        location_confidence_key=decision_facts.location_confidence_key,
-        alternative_source_visible=decision_facts.alternative_source_visible,
-        active_locations=tuple(coverage.active_locations),
-        coverage_label=coverage_label(
-            expected_locations=coverage.expected_locations,
-            active_locations=coverage.active_locations,
-            missing_locations=coverage.missing_locations,
-            partial_locations=coverage.partial_locations,
-            tr=tr,
-        ),
-        coverage_notes=tuple(
-            coverage_notes(
-                missing_locations=coverage.missing_locations,
-                partial_locations=coverage.partial_locations,
-                tr=tr,
-            )
-        ),
-        proof_caveat=proof_caveat_text(
-            primary_candidate_facts=decision_facts.primary_candidate,
-            action_status_key=decision_facts.action_status_key,
-            location_confidence_key=decision_facts.location_confidence_key,
-            tr=tr,
-        ),
-        runner_up_corner=runner_up_corner(sensor_facts.active_intensity, tr=tr),
-        speed_window_label=str(decision_facts.primary_candidate.primary_speed or "").strip()
-        or None,
-        ranked_candidates=build_ranked_candidates(aggregate, tr=tr),
-        recapture=build_recapture_assessment(
-            aggregate=aggregate,
-            primary_candidate_facts=decision_facts.primary_candidate,
-            location_confidence_key=decision_facts.location_confidence_key,
-            expected_locations=coverage.expected_locations,
-            active_locations=coverage.active_locations,
-            suitability_checks=decision_facts.suitability_checks,
-            warnings=decision_facts.warnings,
-            lang=lang,
-            tr=tr,
         ),
     )
 

--- a/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
@@ -16,7 +16,7 @@ from vibesensor.use_cases.history.report_observation_matrix import (
     build_sensor_observation_matrix_rows,
 )
 
-from .section_context import ReportSectionContext
+from .section_context import AppendixBContext
 
 __all__ = ["build_appendix_b_data"]
 
@@ -26,7 +26,7 @@ def build_appendix_b_data(
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
     active_sensor_intensity: Sequence[LocationIntensitySummary],
-    section_context: ReportSectionContext,
+    appendix_context: AppendixBContext,
     tr: Callable[..., str],
 ) -> AppendixBData:
     dominance_ratio_text = (
@@ -58,21 +58,21 @@ def build_appendix_b_data(
     ]
     return AppendixBData(
         dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
-        runner_up_corner=section_context.runner_up_corner,
+        runner_up_corner=appendix_context.runner_up_corner,
         dominance_ratio_text=dominance_ratio_text,
         location_confidence=location_confidence_text(
             presented_location_confidence_key(
-                action_status_key=section_context.action_status_key,
-                location_confidence_key=section_context.location_confidence_key,
+                action_status_key=appendix_context.action_status_key,
+                location_confidence_key=appendix_context.location_confidence_key,
             ),
             tr=tr,
         ),
-        coverage_label=section_context.coverage_label,
-        coverage_notes=list(section_context.coverage_notes),
+        coverage_label=appendix_context.coverage_label,
+        coverage_notes=list(appendix_context.coverage_notes),
         intensity_rows=intensity_rows,
         sensor_observation_rows=build_sensor_observation_matrix_rows(
             aggregate,
-            sensor_locations=list(section_context.active_locations),
+            sensor_locations=list(appendix_context.active_locations),
             tr=tr,
         ),
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/section_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/section_context.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass
 
 from vibesensor.shared.boundaries.reporting.document import RankedCandidateRow
 
-__all__ = ["RecaptureAssessment", "ReportSectionContext"]
+__all__ = [
+    "AppendixAContext",
+    "AppendixBContext",
+    "AppendixCContext",
+    "RecaptureAssessment",
+    "VerdictPageContext",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,17 +25,45 @@ class RecaptureAssessment:
 
 
 @dataclass(frozen=True, slots=True)
-class ReportSectionContext:
-    """Common derived values reused by verdict and appendix builders."""
+class VerdictPageContext:
+    """Derived values used by the verdict-page builder."""
 
     action_status_key: str
     location_confidence_key: str
     alternative_source_visible: bool
     active_locations: tuple[str, ...]
     coverage_label: str
-    coverage_notes: tuple[str, ...]
     proof_caveat: str | None
     runner_up_corner: str | None
     speed_window_label: str | None
+    recapture: RecaptureAssessment
+
+
+@dataclass(frozen=True, slots=True)
+class AppendixAContext:
+    """Derived values used by the workflow appendix builder."""
+
+    action_status_key: str
+    alternative_source_visible: bool
     ranked_candidates: tuple[RankedCandidateRow, ...]
     recapture: RecaptureAssessment
+
+
+@dataclass(frozen=True, slots=True)
+class AppendixBContext:
+    """Derived values used by the location appendix builder."""
+
+    action_status_key: str
+    location_confidence_key: str
+    active_locations: tuple[str, ...]
+    coverage_label: str
+    coverage_notes: tuple[str, ...]
+    runner_up_corner: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AppendixCContext:
+    """Derived values used by the evidence appendix builder."""
+
+    speed_window_label: str | None
+    proof_caveat: str | None

--- a/apps/server/vibesensor/use_cases/history/report_document/sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/sections.py
@@ -24,7 +24,7 @@ from .narrative_summaries import (
     _phase_summary_text,
     _run_limits_summary_text,
 )
-from .section_context import ReportSectionContext
+from .section_context import AppendixCContext
 
 __all__ = [
     "_build_appendix_c_data",
@@ -93,7 +93,7 @@ def _build_appendix_c_data(
     aggregate: TestRun,
     measurements: list[MeasurementRow],
     report_facts: PreparedReportFacts,
-    section_context: ReportSectionContext,
+    appendix_context: AppendixCContext,
     data_trust: list[DataTrustItem],
     tr: Callable[..., str],
 ) -> AppendixCData:
@@ -112,8 +112,8 @@ def _build_appendix_c_data(
         context_summary=_context_summary_text(primary, report_facts, tr=tr),
         limits_summary=_run_limits_summary_text(
             report_facts,
-            speed_window_label=section_context.speed_window_label,
-            proof_caveat=section_context.proof_caveat,
+            speed_window_label=appendix_context.speed_window_label,
+            proof_caveat=appendix_context.proof_caveat,
             tr=tr,
         ),
         speed_band_summary=speed_summary,

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -22,7 +22,7 @@ from vibesensor.shared.report_presentation import (
 from vibesensor.shared.run_context_warning import RunContextWarning
 
 from ._candidate_resolver import PrimaryCandidateContext
-from .section_context import ReportSectionContext
+from .section_context import VerdictPageContext
 
 __all__ = ["build_observed_signature", "build_verdict_page_data"]
 
@@ -49,15 +49,15 @@ def build_verdict_page_data(
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
     duration_text: str | None,
-    section_context: ReportSectionContext,
+    verdict_context: VerdictPageContext,
     suitability_checks: Sequence[SuitabilityCheck],
     warnings: Sequence[RunContextWarning],
     lang: str,
     tr: Callable[..., str],
 ) -> VerdictPageData:
-    recapture_before_acting = section_context.action_status_key == "recapture_before_acting"
+    recapture_before_acting = verdict_context.action_status_key == "recapture_before_acting"
     return VerdictPageData(
-        speed_window_label=section_context.speed_window_label,
+        speed_window_label=verdict_context.speed_window_label,
         suspected_source=(
             tr("REPORT_INCONCLUSIVE_SOURCE")
             if recapture_before_acting
@@ -68,50 +68,50 @@ def build_verdict_page_data(
             if recapture_before_acting
             else display_location(primary_candidate_facts.primary_location, tr=tr)
         ),
-        action_status=action_status_text(section_context.action_status_key, tr=tr),
+        action_status=action_status_text(verdict_context.action_status_key, tr=tr),
         action_status_note=_action_status_note_text(
             aggregate=aggregate,
             primary_candidate_facts=primary_candidate_facts,
-            action_status_key=section_context.action_status_key,
-            location_confidence_key=section_context.location_confidence_key,
-            alternative_source_visible=section_context.alternative_source_visible,
+            action_status_key=verdict_context.action_status_key,
+            location_confidence_key=verdict_context.location_confidence_key,
+            alternative_source_visible=verdict_context.alternative_source_visible,
             suitability_checks=suitability_checks,
             warnings=warnings,
             lang=lang,
             tr=tr,
         ),
         reason_sentence=(
-            section_context.recapture.issues[0]
-            if recapture_before_acting and section_context.recapture.issues
+            verdict_context.recapture.issues[0]
+            if recapture_before_acting and verdict_context.recapture.issues
             else _build_primary_reason_sentence(
                 primary_candidate_facts=primary_candidate_facts,
-                active_locations=section_context.active_locations,
+                active_locations=verdict_context.active_locations,
                 duration_text=duration_text,
                 tr=tr,
             )
         ),
         dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
-        runner_up_corner=section_context.runner_up_corner,
+        runner_up_corner=verdict_context.runner_up_corner,
         location_confidence=_location_confidence_display_text(
             primary_candidate_facts=primary_candidate_facts,
-            action_status_key=section_context.action_status_key,
-            location_confidence_key=section_context.location_confidence_key,
-            alternative_source_visible=section_context.alternative_source_visible,
+            action_status_key=verdict_context.action_status_key,
+            location_confidence_key=verdict_context.location_confidence_key,
+            alternative_source_visible=verdict_context.alternative_source_visible,
             dominance_ratio=primary_candidate_facts.dominance_ratio,
             suitability_checks=suitability_checks,
             warnings=warnings,
             lang=lang,
             tr=tr,
         ),
-        coverage_label=section_context.coverage_label,
+        coverage_label=verdict_context.coverage_label,
         also_consider=(
             source_with_confidence(aggregate.effective_top_causes()[1], tr=tr)
             if not recapture_before_acting
-            and section_context.alternative_source_visible
+            and verdict_context.alternative_source_visible
             and len(aggregate.effective_top_causes()) > 1
             else None
         ),
-        proof_caveat=section_context.proof_caveat,
+        proof_caveat=verdict_context.proof_caveat,
         proof_panel_title=(
             tr("REPORT_PROOF_PANEL_TITLE_INCONCLUSIVE")
             if recapture_before_acting

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -21,7 +21,7 @@ from vibesensor.shared.report_presentation import (
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
 
-from .section_context import RecaptureAssessment, ReportSectionContext
+from .section_context import AppendixAContext, RecaptureAssessment
 
 __all__ = [
     "build_appendix_a_data",
@@ -33,11 +33,11 @@ __all__ = [
 def build_appendix_a_data(
     *,
     aggregate: TestRun,
-    section_context: ReportSectionContext,
+    appendix_context: AppendixAContext,
     tr: Callable[..., str],
 ) -> AppendixAData:
-    ranked_candidates = section_context.ranked_candidates
-    recapture_before_acting = section_context.action_status_key == "recapture_before_acting"
+    ranked_candidates = appendix_context.ranked_candidates
+    recapture_before_acting = appendix_context.action_status_key == "recapture_before_acting"
     if recapture_before_acting:
         return AppendixAData(
             mode="recapture",
@@ -47,9 +47,9 @@ def build_appendix_a_data(
             why_alternative_next=None,
             next_if_clean=None,
             ranked_candidates=[],
-            capture_issues=list(section_context.recapture.issues),
-            capture_changes=list(section_context.recapture.actions),
-            capture_conditions=list(section_context.recapture.conditions),
+            capture_issues=list(appendix_context.recapture.issues),
+            capture_changes=list(appendix_context.recapture.actions),
+            capture_conditions=list(appendix_context.recapture.conditions),
         )
 
     primary_source = (
@@ -69,11 +69,11 @@ def build_appendix_a_data(
             source=ranked_candidates[1].source_name,
             confidence=ranked_candidates[1].confidence_pct,
         )
-        if section_context.alternative_source_visible
+        if appendix_context.alternative_source_visible
         and len(ranked_candidates) > 1
         and ranked_candidates[1].confidence_pct
         else ranked_candidates[1].source_name
-        if section_context.alternative_source_visible and len(ranked_candidates) > 1
+        if appendix_context.alternative_source_visible and len(ranked_candidates) > 1
         else None
     )
     return AppendixAData(
@@ -83,7 +83,7 @@ def build_appendix_a_data(
         why_primary_first=ranked_candidates[0].reason if ranked_candidates else None,
         why_alternative_next=(
             ranked_candidates[1].reason
-            if section_context.alternative_source_visible and len(ranked_candidates) > 1
+            if appendix_context.alternative_source_visible and len(ranked_candidates) > 1
             else None
         ),
         next_if_clean=_next_if_primary_clean(aggregate, tr=tr),


### PR DESCRIPTION
## Summary
- remove the `_ReportDocumentSections` bundle so report composition wires section builders directly into the final document assembly
- replace the broad `ReportSectionContext` bag with focused verdict and appendix context types that match the builders that consume them
- keep the report flow flatter by passing each builder only the derived values it actually uses

## Testing
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history apps/server/tests/adapters/pdf apps/server/tests/integration/test_contract_analysis_report.py
- make lint
- make typecheck-backend
- make test-changed

## Notes
- Local Docker stack validation is still blocked in this environment because the Docker daemon is unavailable.