### PR TITLE
Wave 1: refactor updater status, release, and USB seams

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -49,7 +49,7 @@ vibesensor-ws-smoke = "vibesensor.adapters.simulator.ws_smoke:main"
 vibesensor-config-preflight = "vibesensor.cli.preflight:main"
 vibesensor-fw-refresh = "vibesensor.use_cases.updates.firmware.firmware_cache:refresh_cache_cli"
 vibesensor-fw-info = "vibesensor.use_cases.updates.firmware.firmware_cache:cache_info_cli"
-vibesensor-release-fetch = "vibesensor.use_cases.updates.releases.release_fetcher:fetch_latest_wheel_cli"
+vibesensor-release-fetch = "vibesensor.use_cases.updates.releases.cli:fetch_latest_wheel_cli"
 
 [tool.setuptools.dynamic]
 version = {attr = "vibesensor._version.__version__"}

--- a/apps/server/tests/hygiene/test_ai_smoke.py
+++ b/apps/server/tests/hygiene/test_ai_smoke.py
@@ -233,7 +233,7 @@ def test_smoke_server_pyproject_includes_esptool_for_esp_flash() -> None:
     assert "vibesensor.use_cases.updates.firmware.firmware_cache:cache_info_cli" in text, (
         "Firmware cache info CLI entry point must target the firmware package module"
     )
-    assert "vibesensor.use_cases.updates.releases.release_fetcher:fetch_latest_wheel_cli" in text, (
+    assert "vibesensor.use_cases.updates.releases.cli:fetch_latest_wheel_cli" in text, (
         "Server release fetch CLI entry point must target the releases package module"
     )
 

--- a/apps/server/tests/integration/test_multi_domain_regressions.py
+++ b/apps/server/tests/integration/test_multi_domain_regressions.py
@@ -7,7 +7,6 @@ condition and asserting the corrected behavior.
 from __future__ import annotations
 
 from datetime import UTC
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -24,7 +23,8 @@ from vibesensor.use_cases.diagnostics.location_scoring import weighted_speed_win
 from vibesensor.use_cases.diagnostics.phase_segmentation import segment_run_phases
 from vibesensor.use_cases.diagnostics.signal_aggregation import _sensor_intensity_by_location
 from vibesensor.use_cases.diagnostics.statistics import compute_run_timing
-from vibesensor.use_cases.updates.releases.release_fetcher import ReleaseInfo, ServerReleaseFetcher
+from vibesensor.use_cases.updates.releases.models import ReleaseInfo
+from vibesensor.use_cases.updates.releases.version_policy import select_update_release
 
 
 def _make_release_info(version: str) -> ReleaseInfo:
@@ -107,21 +107,23 @@ class TestBug04SpeedBinLabelNonFinite:
 
 
 # ---------------------------------------------------------------------------
-# Bug 5: check_update_available suggests downgrades as updates
+# Bug 5: version policy suggests downgrades as updates
 # ---------------------------------------------------------------------------
 
 
 class TestBug05ReleaseVersionComparison:
     def test_downgrade_returns_none(self) -> None:
-        fetcher = ServerReleaseFetcher.__new__(ServerReleaseFetcher)
-        fetcher.find_latest_release = MagicMock(return_value=_make_release_info("2024.1.0"))
-        result = fetcher.check_update_available("2025.6.0")
+        result = select_update_release(
+            current_version="2025.6.0",
+            latest_release=_make_release_info("2024.1.0"),
+        )
         assert result is None
 
     def test_upgrade_returns_release(self) -> None:
-        fetcher = ServerReleaseFetcher.__new__(ServerReleaseFetcher)
-        fetcher.find_latest_release = MagicMock(return_value=_make_release_info("2026.1.0"))
-        result = fetcher.check_update_available("2025.6.0")
+        result = select_update_release(
+            current_version="2025.6.0",
+            latest_release=_make_release_info("2026.1.0"),
+        )
         assert result is not None
         assert result.version == "2026.1.0"
 

--- a/apps/server/tests/integration/test_refactor_contract_regressions.py
+++ b/apps/server/tests/integration/test_refactor_contract_regressions.py
@@ -26,12 +26,10 @@ from vibesensor.shared.boundaries.run_metadata_codec import run_metadata_from_ma
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.updates.firmware.firmware_release_fetcher import GitHubReleaseFetcher
 from vibesensor.use_cases.updates.firmware.firmware_types import FirmwareCacheConfig
-from vibesensor.use_cases.updates.releases.release_fetcher import (
-    GitHubAPIClient,
-    ReleaseFetcherConfig,
-    ReleaseInfo,
-    ServerReleaseFetcher,
-)
+from vibesensor.use_cases.updates.releases.github_api import GitHubApiClient
+from vibesensor.use_cases.updates.releases.models import ReleaseFetcherConfig, ReleaseInfo
+from vibesensor.use_cases.updates.releases.release_fetcher import ServerReleaseFetcher
+from vibesensor.use_cases.updates.releases.version_policy import select_update_release
 
 # ---------------------------------------------------------------------------
 # Shared constants / fixtures
@@ -187,43 +185,44 @@ class TestRunStatus:
 
 
 # ---------------------------------------------------------------------------
-# Fix 4+5: GitHubAPIClient base class
+# Fix 4+5: shared GitHub API client composition
 # ---------------------------------------------------------------------------
 
 
-class TestGitHubAPIClient:
-    """Verify shared base class works for both fetcher types."""
+class TestGitHubApiClient:
+    """Verify both updater fetchers share the same GitHub API client surface."""
 
     def test_api_headers_no_token(self) -> None:
-        client = GitHubAPIClient()
-        headers = client._api_headers()
+        client = GitHubApiClient()
+        headers = client.api_headers()
         assert "Accept" in headers
         assert "Authorization" not in headers
 
     def test_api_headers_with_token(self) -> None:
-        client = GitHubAPIClient()
-        client._github_token = "gh-token-123"
-        headers = client._api_headers()
+        client = GitHubApiClient(token="gh-token-123")
+        headers = client.api_headers()
         assert headers["Authorization"] == "Bearer gh-token-123"
 
-    def test_server_fetcher_inherits(self) -> None:
-        assert issubclass(ServerReleaseFetcher, GitHubAPIClient)
-
-    def test_firmware_fetcher_inherits(self) -> None:
-        assert issubclass(GitHubReleaseFetcher, GitHubAPIClient)
-
-    def test_api_get_validates_https(self) -> None:
-        client = GitHubAPIClient()
+    def test_build_request_validates_https(self) -> None:
+        client = GitHubApiClient()
         with pytest.raises(ValueError, match="non-HTTPS"):
-            client._api_get("http://insecure.example.com/api")
+            client.build_request("http://insecure.example.com/api")
 
     def test_server_fetcher_context(self) -> None:
-        fetcher = ServerReleaseFetcher(ReleaseFetcherConfig(server_repo="owner/repo"))
-        assert fetcher._api_context == "release"
+        client = GitHubApiClient(context="release")
+        fetcher = ServerReleaseFetcher(
+            ReleaseFetcherConfig(server_repo="owner/repo"),
+            client=client,
+        )
+        assert fetcher._client.context == "release"
 
     def test_firmware_fetcher_context(self) -> None:
-        fetcher = GitHubReleaseFetcher(FirmwareCacheConfig(cache_dir="/tmp/test"))
-        assert fetcher._api_context == "firmware"
+        client = GitHubApiClient(context="firmware")
+        fetcher = GitHubReleaseFetcher(
+            FirmwareCacheConfig(cache_dir="/tmp/test"),
+            client=client,
+        )
+        assert fetcher._client.context == "firmware"
 
 
 # ---------------------------------------------------------------------------
@@ -321,9 +320,6 @@ class TestVersionComparisonWarning:
         """When packaging cannot parse versions, a warning should be logged
         instead of silently swallowing the exception.
         """
-        config = ReleaseFetcherConfig(server_repo="owner/repo")
-        fetcher = ServerReleaseFetcher(config)
-
         fake_release = ReleaseInfo(
             tag="server-v!!!INVALID!!!",
             version="!!!INVALID!!!",
@@ -331,11 +327,11 @@ class TestVersionComparisonWarning:
             asset_url="https://api.github.com/repos/owner/repo/releases/assets/1",
         )
 
-        with (
-            patch.object(fetcher, "find_latest_release", return_value=fake_release),
-            patch("vibesensor.use_cases.updates.releases.release_fetcher.LOGGER") as mock_logger,
-        ):
-            result = fetcher.check_update_available("1.0.0")
+        with patch("vibesensor.use_cases.updates.releases.version_policy.LOGGER") as mock_logger:
+            result = select_update_release(
+                current_version="1.0.0",
+                latest_release=fake_release,
+            )
 
         # Should still return the release (treating unparseable as update)
         assert result is not None

--- a/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
+++ b/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
@@ -134,8 +134,12 @@ def patch_release_fetcher(current_version: str = "2025.6.15") -> Iterator[MagicM
         patch(
             "vibesensor.use_cases.updates.releases.factory.build_server_release_fetcher",
         ) as mock_fetcher,
-        patch("vibesensor._version.__version__", current_version),
+        patch("vibesensor.__version__", current_version),
     ):
+        mock_fetcher.return_value.find_latest_release.return_value = make_mock_release(
+            version=current_version,
+            tag=f"server-v{current_version}",
+        )
         yield mock_fetcher
 
 

--- a/apps/server/tests/use_cases/updates/firmware/test_firmware_cache.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_firmware_cache.py
@@ -3,17 +3,23 @@ from __future__ import annotations
 import io
 import zipfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from vibesensor.use_cases.updates.firmware.firmware_bundle import safe_extractall
 from vibesensor.use_cases.updates.firmware.firmware_release_fetcher import GitHubReleaseFetcher
 from vibesensor.use_cases.updates.firmware.firmware_types import FirmwareCacheConfig
+from vibesensor.use_cases.updates.releases.github_api import GitHubApiClient
 
 
-def _make_fetcher(channel: str = "stable") -> GitHubReleaseFetcher:
+def _make_fetcher(
+    channel: str = "stable",
+    *,
+    client: GitHubApiClient | None = None,
+) -> GitHubReleaseFetcher:
     config = FirmwareCacheConfig(firmware_repo="Skamba/VibeSensor", channel=channel)
-    return GitHubReleaseFetcher(config)
+    return GitHubReleaseFetcher(config, client=client)
 
 
 def _make_zip(entries: dict[str, str | bytes]) -> io.BytesIO:
@@ -101,15 +107,14 @@ def test_find_release_prefers_combined_release_assets(
     expected_tag: str,
     releases: list[dict],
 ) -> None:
-    fetcher = _make_fetcher(channel)
-    fetcher._api_get = lambda _url: releases
+    client = MagicMock(spec=GitHubApiClient)
+    client.get_json.return_value = releases
+    fetcher = _make_fetcher(channel, client=client)
     selected = fetcher.find_release()
     assert selected["tag_name"] == expected_tag
 
 
 def test_find_release_raises_when_no_firmware_assets() -> None:
-    fetcher = _make_fetcher()
-
     releases = [
         {
             "tag_name": "server-v2026.2.27",
@@ -124,7 +129,9 @@ def test_find_release_raises_when_no_firmware_assets() -> None:
         },
     ]
 
-    fetcher._api_get = lambda _url: releases
+    client = MagicMock(spec=GitHubApiClient)
+    client.get_json.return_value = releases
+    fetcher = _make_fetcher(client=client)
 
     with pytest.raises(ValueError, match="No eligible firmware release found"):
         fetcher.find_release()

--- a/apps/server/tests/use_cases/updates/releases/test_release_fetcher.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_fetcher.py
@@ -1,24 +1,22 @@
-"""Tests for release_fetcher module."""
+"""Tests for updater server release helpers."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibesensor.use_cases.updates.releases.release_fetcher import (
+from vibesensor.use_cases.updates.releases.github_api import GitHubApiClient, validate_https_url
+from vibesensor.use_cases.updates.releases.models import (
     GitHubRelease,
     GitHubReleaseAsset,
     ReleaseFetcherConfig,
     ReleaseInfo,
-    ServerReleaseFetcher,
-    validate_https_url,
+    resolve_release_fetcher_config,
 )
-
-# ---------------------------------------------------------------------------
-# URL validation
-# ---------------------------------------------------------------------------
+from vibesensor.use_cases.updates.releases.release_fetcher import ServerReleaseFetcher
+from vibesensor.use_cases.updates.releases.version_policy import select_update_release
 
 
 class TestValidateUrl:
@@ -38,39 +36,30 @@ class TestValidateUrl:
             validate_https_url(url)
 
 
-# ---------------------------------------------------------------------------
-# Config
-# ---------------------------------------------------------------------------
-
-
 class TestReleaseFetcherConfig:
-    def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("VIBESENSOR_SERVER_REPO", raising=False)
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        monkeypatch.delenv("VIBESENSOR_ROLLBACK_DIR", raising=False)
+    def test_defaults(self) -> None:
         config = ReleaseFetcherConfig()
         assert config.server_repo == "Skamba/VibeSensor"
         assert config.github_token == ""
         assert config.rollback_dir == "/var/lib/vibesensor/rollback"
 
-    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_resolve_uses_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VIBESENSOR_SERVER_REPO", "test/repo")
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
         monkeypatch.setenv("VIBESENSOR_ROLLBACK_DIR", "/tmp/rollback")
-        config = ReleaseFetcherConfig()
+
+        config = resolve_release_fetcher_config()
+
         assert config.server_repo == "test/repo"
         assert config.github_token == "ghp_test123"
         assert config.rollback_dir == "/tmp/rollback"
 
-    def test_explicit_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_resolve_prefers_explicit_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VIBESENSOR_SERVER_REPO", "env/repo")
-        config = ReleaseFetcherConfig(server_repo="explicit/repo")
+
+        config = resolve_release_fetcher_config(server_repo="explicit/repo")
+
         assert config.server_repo == "explicit/repo"
-
-
-# ---------------------------------------------------------------------------
-# ReleaseInfo
-# ---------------------------------------------------------------------------
 
 
 class TestReleaseInfo:
@@ -83,10 +72,15 @@ class TestReleaseInfo:
             sha256="abc123",
             published_at="2025-06-15T02:00:00Z",
         )
-        d = info.to_dict()
-        assert d["tag"] == "server-v2025.6.15"
-        assert d["version"] == "2025.6.15"
-        assert d["sha256"] == "abc123"
+
+        assert info.to_dict() == {
+            "tag": "server-v2025.6.15",
+            "version": "2025.6.15",
+            "asset_name": "vibesensor-2025.6.15-py3-none-any.whl",
+            "asset_url": "https://api.github.com/repos/Skamba/VibeSensor/releases/assets/123",
+            "sha256": "abc123",
+            "published_at": "2025-06-15T02:00:00Z",
+        }
 
 
 class TestGitHubReleaseAsset:
@@ -147,9 +141,18 @@ class TestGitHubRelease:
         )
 
 
-# ---------------------------------------------------------------------------
-# ServerReleaseFetcher
-# ---------------------------------------------------------------------------
+class TestGitHubApiClient:
+    def test_api_headers_without_token(self) -> None:
+        headers = GitHubApiClient().api_headers()
+
+        assert "Authorization" not in headers
+        assert headers["Accept"] == "application/vnd.github+json"
+
+    def test_api_headers_with_token(self) -> None:
+        headers = GitHubApiClient(token="ghp_test").api_headers()
+
+        assert headers["Authorization"] == "Bearer ghp_test"
+
 
 MOCK_RELEASES = [
     {
@@ -189,14 +192,22 @@ MOCK_RELEASES = [
 
 
 class TestServerReleaseFetcher:
-    def _make_fetcher(self) -> ServerReleaseFetcher:
-        config = ReleaseFetcherConfig(server_repo="Skamba/VibeSensor")
-        return ServerReleaseFetcher(config)
+    def _make_fetcher(
+        self,
+        *,
+        client: GitHubApiClient | None = None,
+    ) -> ServerReleaseFetcher:
+        return ServerReleaseFetcher(
+            ReleaseFetcherConfig(server_repo="Skamba/VibeSensor"),
+            client=client,
+        )
 
     def test_find_latest_release(self) -> None:
-        fetcher = self._make_fetcher()
-        with patch.object(fetcher, "_api_get", return_value=MOCK_RELEASES):
-            release = fetcher.find_latest_release()
+        client = MagicMock(spec=GitHubApiClient)
+        client.get_json.return_value = MOCK_RELEASES
+        fetcher = self._make_fetcher(client=client)
+        release = fetcher.find_latest_release()
+
         assert release.tag == "server-v2025.6.15"
         assert release.version == "2025.6.15"
         assert release.asset_name == "vibesensor-2025.6.15-py3-none-any.whl"
@@ -213,9 +224,11 @@ class TestServerReleaseFetcher:
             },
             *MOCK_RELEASES,
         ]
-        fetcher = self._make_fetcher()
-        with patch.object(fetcher, "_api_get", return_value=releases):
-            release = fetcher.find_latest_release()
+        client = MagicMock(spec=GitHubApiClient)
+        client.get_json.return_value = releases
+        fetcher = self._make_fetcher(client=client)
+        release = fetcher.find_latest_release()
+
         assert release.tag == "server-v2025.6.15"
 
     def test_find_latest_rejects_malformed_release_rows(self) -> None:
@@ -228,11 +241,11 @@ class TestServerReleaseFetcher:
             },
             *MOCK_RELEASES,
         ]
-        fetcher = self._make_fetcher()
-        with (
-            patch.object(fetcher, "_api_get", return_value=releases),
-            pytest.raises(ValueError, match="Unexpected GitHub API response format"),
-        ):
+        client = MagicMock(spec=GitHubApiClient)
+        client.get_json.return_value = releases
+        fetcher = self._make_fetcher(client=client)
+
+        with pytest.raises(ValueError, match="Unexpected GitHub API response format"):
             fetcher.find_latest_release()
 
     @pytest.mark.parametrize(
@@ -252,37 +265,23 @@ class TestServerReleaseFetcher:
             pytest.param([], id="empty-releases"),
         ],
     )
-    def test_find_latest_no_server_release(self, releases: list[dict]) -> None:
-        fetcher = self._make_fetcher()
-        with (
-            patch.object(fetcher, "_api_get", return_value=releases),
-            pytest.raises(ValueError, match="No server release found"),
-        ):
+    def test_find_latest_no_server_release(self, releases: list[dict[str, object]]) -> None:
+        client = MagicMock(spec=GitHubApiClient)
+        client.get_json.return_value = releases
+        fetcher = self._make_fetcher(client=client)
+
+        with pytest.raises(ValueError, match="No server release found"):
             fetcher.find_latest_release()
 
     def test_find_latest_rejects_non_array_api_response(self) -> None:
-        fetcher = self._make_fetcher()
-        with (
-            patch.object(fetcher, "_api_get", return_value={"unexpected": "object"}),
-            pytest.raises(ValueError, match="Unexpected GitHub API response format"),
-        ):
+        client = MagicMock(spec=GitHubApiClient)
+        client.get_json.return_value = {"unexpected": "object"}
+        fetcher = self._make_fetcher(client=client)
+
+        with pytest.raises(ValueError, match="Unexpected GitHub API response format"):
             fetcher.find_latest_release()
 
-    def test_check_update_available_newer(self) -> None:
-        fetcher = self._make_fetcher()
-        with patch.object(fetcher, "_api_get", return_value=MOCK_RELEASES):
-            result = fetcher.check_update_available("2025.6.14")
-        assert result is not None
-        assert result.version == "2025.6.15"
-
-    def test_check_update_available_up_to_date(self) -> None:
-        fetcher = self._make_fetcher()
-        with patch.object(fetcher, "_api_get", return_value=MOCK_RELEASES):
-            result = fetcher.check_update_available("2025.6.15")
-        assert result is None
-
     def test_download_wheel(self, tmp_path: Path) -> None:
-        fetcher = self._make_fetcher()
         release = ReleaseInfo(
             tag="server-v2025.6.15",
             version="2025.6.15",
@@ -290,24 +289,68 @@ class TestServerReleaseFetcher:
             asset_url="https://api.github.com/assets/456",
         )
         wheel_content = b"fake-wheel-content"
-        with patch.object(fetcher, "_download_asset") as mock_dl:
-            mock_dl.side_effect = lambda url, dest: dest.write_bytes(wheel_content)
-            path = fetcher.download_wheel(release, dest_dir=tmp_path)
+
+        class _DownloadFetcher(ServerReleaseFetcher):
+            def _download_asset(self, url: str, dest: Path) -> None:
+                del url
+                dest.write_bytes(wheel_content)
+
+        fetcher = _DownloadFetcher(ReleaseFetcherConfig(server_repo="Skamba/VibeSensor"))
+        path = fetcher.download_wheel(release, dest_dir=tmp_path)
+
         assert path.exists()
         assert path.name == "vibesensor-2025.6.15-py3-none-any.whl"
         assert path.read_bytes() == wheel_content
-        assert release.sha256  # Should be populated after download
+        assert release.sha256
 
-    def test_api_headers_without_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        config = ReleaseFetcherConfig(server_repo="a/b", github_token="")
-        fetcher = ServerReleaseFetcher(config)
-        headers = fetcher._api_headers()
-        assert "Authorization" not in headers
-        assert headers["Accept"] == "application/vnd.github+json"
 
-    def test_api_headers_with_token(self) -> None:
-        config = ReleaseFetcherConfig(server_repo="a/b", github_token="ghp_test")
-        fetcher = ServerReleaseFetcher(config)
-        headers = fetcher._api_headers()
-        assert headers["Authorization"] == "Bearer ghp_test"
+class TestVersionPolicy:
+    def test_select_update_release_returns_newer_release(self) -> None:
+        release = ReleaseInfo(
+            tag="server-v2025.6.15",
+            version="2025.6.15",
+            asset_name="vibesensor-2025.6.15-py3-none-any.whl",
+            asset_url="https://api.github.com/assets/456",
+        )
+
+        assert (
+            select_update_release(
+                current_version="2025.6.14",
+                latest_release=release,
+            )
+            is release
+        )
+
+    def test_select_update_release_skips_matching_version(self) -> None:
+        release = ReleaseInfo(
+            tag="server-v2025.6.15",
+            version="2025.6.15",
+            asset_name="vibesensor-2025.6.15-py3-none-any.whl",
+            asset_url="https://api.github.com/assets/456",
+        )
+
+        assert (
+            select_update_release(
+                current_version="2025.6.15",
+                latest_release=release,
+            )
+            is None
+        )
+
+    def test_select_update_release_logs_warning_on_unparseable_version(self) -> None:
+        release = ReleaseInfo(
+            tag="server-v!!!INVALID!!!",
+            version="!!!INVALID!!!",
+            asset_name="vibesensor-0.0.0-py3-none-any.whl",
+            asset_url="https://api.github.com/repos/owner/repo/releases/assets/1",
+        )
+
+        with patch("vibesensor.use_cases.updates.releases.version_policy.LOGGER") as mock_logger:
+            result = select_update_release(
+                current_version="1.0.0",
+                latest_release=release,
+            )
+
+        assert result is release
+        mock_logger.warning.assert_called_once()
+        assert "Could not compare versions" in mock_logger.warning.call_args[0][0]

--- a/apps/server/tests/use_cases/updates/test_release_deployment.py
+++ b/apps/server/tests/use_cases/updates/test_release_deployment.py
@@ -54,15 +54,17 @@ async def test_deploy_aborts_before_live_mutation_when_snapshot_fails() -> None:
     coordinator, installer, firmware_refresher, status = _make_coordinator()
     installer.snapshot_for_rollback.return_value = False
 
-    with pytest.raises(UpdateReleaseError, match="Rollback snapshot could not be created"):
+    with pytest.raises(
+        UpdateReleaseError,
+        match="Rollback snapshot could not be created",
+    ) as excinfo:
         await coordinator.deploy(_staged_release())
 
     status.transition.assert_called_once_with(UpdatePhase.installing)
-    status.fail.assert_called_once_with(
-        UpdatePhase.installing.value,
-        "Rollback snapshot could not be created",
-        "Install aborted before mutating the live environment",
-    )
+    assert excinfo.value.phase == UpdatePhase.installing.value
+    assert excinfo.value.detail == "Install aborted before mutating the live environment"
+    status.fail.assert_not_called()
+    status.log.assert_called_once_with("Installing update...")
     installer.install_release.assert_not_awaited()
     installer.rollback.assert_not_awaited()
     firmware_refresher.refresh_esp_firmware.assert_not_awaited()

--- a/apps/server/tests/use_cases/updates/test_release_resolution.py
+++ b/apps/server/tests/use_cases/updates/test_release_resolution.py
@@ -5,22 +5,19 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from test_support.update_status import build_update_status_harness
 
 from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
 
 
 @pytest.mark.asyncio
-async def test_resolve_returns_release_without_latest_tag_lookup(tmp_path: Path) -> None:
-    status = build_update_status_harness(tmp_path / "state.json")
+async def test_resolve_returns_release_when_latest_version_is_newer(tmp_path: Path) -> None:
     resolver = ServerReleaseResolver(
-        status=status,
         rollback_dir=tmp_path / "rollback",
     )
     release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4")
     fetcher = MagicMock()
-    fetcher.check_update_available.return_value = release
+    fetcher.find_latest_release.return_value = release
 
     with patch(
         "vibesensor.use_cases.updates.release_resolution.release_fetcher_factory.build_server_release_fetcher",
@@ -32,19 +29,19 @@ async def test_resolve_returns_release_without_latest_tag_lookup(tmp_path: Path)
     assert resolution.release is release
     assert resolution.latest_tag == ""
     assert resolution.update_available is True
-    fetcher.find_latest_release.assert_not_called()
+    fetcher.find_latest_release.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_resolve_uses_latest_tag_when_no_update_is_available(tmp_path: Path) -> None:
-    status = build_update_status_harness(tmp_path / "state.json")
     resolver = ServerReleaseResolver(
-        status=status,
         rollback_dir=tmp_path / "rollback",
     )
     fetcher = MagicMock()
-    fetcher.check_update_available.return_value = None
-    fetcher.find_latest_release.return_value = SimpleNamespace(tag="server-v2026.4.4")
+    fetcher.find_latest_release.return_value = SimpleNamespace(
+        tag="server-v2026.4.4",
+        version="2026.4.3",
+    )
 
     with patch(
         "vibesensor.use_cases.updates.release_resolution.release_fetcher_factory.build_server_release_fetcher",
@@ -60,13 +57,11 @@ async def test_resolve_uses_latest_tag_when_no_update_is_available(tmp_path: Pat
 
 @pytest.mark.asyncio
 async def test_resolve_propagates_release_check_failure(tmp_path: Path) -> None:
-    status = build_update_status_harness(tmp_path / "state.json")
     resolver = ServerReleaseResolver(
-        status=status,
         rollback_dir=tmp_path / "rollback",
     )
     fetcher = MagicMock()
-    fetcher.check_update_available.side_effect = OSError("rate limited")
+    fetcher.find_latest_release.side_effect = OSError("rate limited")
 
     with patch(
         "vibesensor.use_cases.updates.release_resolution.release_fetcher_factory.build_server_release_fetcher",

--- a/apps/server/tests/use_cases/updates/test_startup_recovery.py
+++ b/apps/server/tests/use_cases/updates/test_startup_recovery.py
@@ -15,18 +15,22 @@ def _make_recovery(
     MagicMock,
     AsyncMock,
     MagicMock,
+    MagicMock,
 ]:
     status_tracker = MagicMock()
     status_tracker.status = status
+    reporter = MagicMock()
     transport_coordinator = MagicMock()
     transport_coordinator.recover_interrupted = AsyncMock()
     return (
         UpdateStartupRecoveryCoordinator(
             status=status_tracker,
+            reporter=reporter,
             transport_coordinator=transport_coordinator,
         ),
         transport_coordinator,
         transport_coordinator.recover_interrupted,
+        reporter,
         status_tracker,
     )
 
@@ -37,6 +41,7 @@ async def test_recover_skips_non_running_jobs() -> None:
         coordinator,
         transport_coordinator,
         recover,
+        reporter,
         status_tracker,
     ) = _make_recovery(UpdateJobStatus(state=UpdateState.idle))
 
@@ -44,7 +49,7 @@ async def test_recover_skips_non_running_jobs() -> None:
 
     transport_coordinator.recover_interrupted.assert_not_called()
     recover.assert_not_awaited()
-    status_tracker.mark_interrupted.assert_not_called()
+    reporter.mark_interrupted.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -53,6 +58,7 @@ async def test_recover_marks_interrupted_and_recovers_transport() -> None:
         coordinator,
         transport_coordinator,
         recover,
+        reporter,
         status_tracker,
     ) = _make_recovery(
         UpdateJobStatus(
@@ -69,4 +75,4 @@ async def test_recover_marks_interrupted_and_recovers_transport() -> None:
             transport=UpdateTransport.usb_internet,
         ),
     )
-    status_tracker.mark_interrupted.assert_called_once_with("Update interrupted by server restart")
+    reporter.mark_interrupted.assert_called_once_with("Update interrupted by server restart")

--- a/apps/server/tests/use_cases/updates/test_transport_coordinator.py
+++ b/apps/server/tests/use_cases/updates/test_transport_coordinator.py
@@ -42,8 +42,8 @@ class _RecordingTransportLifecycle:
     async def abort_preparation(self) -> None:
         self.calls.append("abort")
 
-    async def complete_success(self, message: str) -> None:
-        self.calls.append(f"success:{message}")
+    async def complete_success(self) -> None:
+        self.calls.append("success")
 
     async def cleanup_after_update(self) -> None:
         self.calls.append("cleanup")
@@ -66,7 +66,6 @@ def _coordinator(
             usb_internet=usb_internet
             or _RecordingTransportLifecycle(transport=UpdateTransport.usb_internet),
         ),
-        status=status,
         logger=MagicMock(),
     ), status
 

--- a/apps/server/tests/use_cases/updates/test_update_completion.py
+++ b/apps/server/tests/use_cases/updates/test_update_completion.py
@@ -11,11 +11,13 @@ from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 async def test_completion_finishes_transport_then_schedules_restart() -> None:
     restart_scheduler = MagicMock()
     restart_scheduler.schedule = AsyncMock(return_value=True)
+    reporter = MagicMock()
     status = MagicMock()
     prepared_transport = MagicMock()
     prepared_transport.complete_success = AsyncMock()
     coordinator = UpdateCompletionCoordinator(
         restart_scheduler=restart_scheduler,
+        reporter=reporter,
         status=status,
     )
 
@@ -24,9 +26,8 @@ async def test_completion_finishes_transport_then_schedules_restart() -> None:
         message="Update completed successfully",
     )
 
-    prepared_transport.complete_success.assert_awaited_once_with(
-        "Update completed successfully",
-    )
+    prepared_transport.complete_success.assert_awaited_once_with()
+    reporter.mark_success.assert_called_once_with("Update completed successfully")
     restart_scheduler.schedule.assert_awaited_once_with()
     status.add_issue.assert_not_called()
     status.log.assert_not_called()
@@ -36,11 +37,13 @@ async def test_completion_finishes_transport_then_schedules_restart() -> None:
 async def test_completion_records_issue_when_restart_scheduling_fails() -> None:
     restart_scheduler = MagicMock()
     restart_scheduler.schedule = AsyncMock(return_value=False)
+    reporter = MagicMock()
     status = MagicMock()
     prepared_transport = MagicMock()
     prepared_transport.complete_success = AsyncMock()
     coordinator = UpdateCompletionCoordinator(
         restart_scheduler=restart_scheduler,
+        reporter=reporter,
         status=status,
     )
 
@@ -49,7 +52,8 @@ async def test_completion_records_issue_when_restart_scheduling_fails() -> None:
         message="No server update needed; ESP firmware checked",
     )
 
-    prepared_transport.complete_success.assert_awaited_once_with(
+    prepared_transport.complete_success.assert_awaited_once_with()
+    reporter.mark_success.assert_called_once_with(
         "No server update needed; ESP firmware checked",
     )
     status.add_issue.assert_called_once_with(

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -56,7 +56,7 @@ class TestUpdateManagerAsync:
 
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:
             fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = mock_release
+            fetcher.find_latest_release.return_value = mock_release
             fetcher.download_wheel.return_value = mock_wheel_path
             runner.set_response("from vibesensor import __version__", 0, "2025.6.15", "")
             await run_update(manager)
@@ -80,11 +80,7 @@ class TestUpdateManagerAsync:
 
     async def test_already_up_to_date(self, tmp_path) -> None:
         manager, runner, _repo = setup_update_env(tmp_path, seed_artifacts=True)
-        with patch_release_fetcher() as mock_fetcher:
-            fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = None
-            latest_release = type("Latest", (), {"tag": "server-v2025.6.15"})()
-            fetcher.find_latest_release.return_value = latest_release
+        with patch_release_fetcher():
             await run_update(manager)
 
         assert manager.status.state == UpdateState.success
@@ -102,7 +98,7 @@ class TestUpdateManagerAsync:
             patch("shutil.which", mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
             patch(
-                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver._check_for_update",
+                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver.resolve",
                 side_effect=AssertionError("release resolution should not run without privileges"),
             ),
         ):
@@ -151,9 +147,9 @@ class TestUpdateManagerAsync:
             patch(
                 "vibesensor.use_cases.updates.releases.factory.build_server_release_fetcher",
             ) as mock_fetcher,
-            patch("vibesensor._version.__version__", "2025.6.15"),
+            patch("vibesensor.__version__", "2025.6.15"),
         ):
-            mock_fetcher.return_value.check_update_available.return_value = None
+            mock_fetcher.return_value.find_latest_release.return_value = make_mock_release()
             manager.start("TestNet", "pass123")
             task = manager.job_task
             assert task is not None
@@ -177,7 +173,7 @@ class TestUpdateManagerAsync:
     async def test_dns_probe_retries_then_update_continues(self, tmp_path) -> None:
         probe_attempts = {"count": 0}
         with (
-            patch_release_fetcher() as mock_fetcher,
+            patch_release_fetcher(),
             patch("vibesensor.use_cases.updates.wifi.wifi_config.DNS_READY_MIN_WAIT_S", 0.2),
             patch("vibesensor.use_cases.updates.wifi.wifi_config.DNS_RETRY_INTERVAL_S", 0.01),
         ):
@@ -192,7 +188,6 @@ class TestUpdateManagerAsync:
                 return await original_run(args, timeout=timeout, env=env)
 
             runner.run = run_with_dns_retry
-            mock_fetcher.return_value.check_update_available.return_value = None
             await run_update(manager)
 
         assert manager.status.state == UpdateState.success
@@ -207,8 +202,7 @@ class TestUpdateManagerAsync:
 
     async def test_password_is_applied_via_connection_modify(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path, seed_artifacts=True)
-        with patch_release_fetcher() as mock_fetcher:
-            mock_fetcher.return_value.check_update_available.return_value = None
+        with patch_release_fetcher():
             await run_update(manager, "Pim", "tomaat123")
         assert any(
             "connection modify VibeSensor-Uplink "
@@ -221,7 +215,7 @@ class TestUpdateManagerAsync:
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:
             mock_release = make_mock_release(sha256="abc")
             fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = mock_release
+            fetcher.find_latest_release.return_value = mock_release
             fetcher.download_wheel.side_effect = OSError("Network error")
             await run_update(manager, "TestNet", "pass")
         assert manager.status.state == UpdateState.failed
@@ -237,7 +231,7 @@ class TestUpdateManagerAsync:
 
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:
             fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = make_mock_release(sha256=wheel_sha256)
+            fetcher.find_latest_release.return_value = make_mock_release(sha256=wheel_sha256)
             fetcher.download_wheel.return_value = fake_wheel
             await run_update(manager, "TestNet", "pass")
         assert manager.status.state == UpdateState.failed
@@ -256,7 +250,7 @@ class TestUpdateManagerAsync:
             ),
         ):
             fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = make_mock_release(sha256=wheel_sha256)
+            fetcher.find_latest_release.return_value = make_mock_release(sha256=wheel_sha256)
             fetcher.download_wheel.return_value = fake_wheel
             await run_update(manager, "TestNet", "pass")
 
@@ -292,7 +286,7 @@ class TestUpdateManagerAsync:
 
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:
             fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = make_mock_release(sha256="0" * 64)
+            fetcher.find_latest_release.return_value = make_mock_release(sha256="0" * 64)
             fetcher.download_wheel.return_value = fake_wheel
             await run_update(manager, "TestNet", "pass")
         assert manager.status.state == UpdateState.failed
@@ -307,8 +301,7 @@ class TestUpdateManagerAsync:
     async def test_password_never_in_logs(self, tmp_path) -> None:
         secret = "SuperSecret!Password#2024"
         manager, _runner, _ = setup_update_env(tmp_path)
-        with patch_release_fetcher() as mock_fetcher:
-            mock_fetcher.return_value.check_update_available.return_value = None
+        with patch_release_fetcher():
             await run_update(manager, "TestNet", secret)
         serialized = str(manager.status.to_payload())
         assert secret not in serialized
@@ -352,11 +345,7 @@ class TestUpdateManagerAsync:
             seed_artifacts=True,
             usb_internet_service=usb_service,
         )
-        with patch_release_fetcher() as mock_fetcher:
-            fetcher = mock_fetcher.return_value
-            fetcher.check_update_available.return_value = None
-            latest_release = type("Latest", (), {"tag": "server-v2025.6.15"})()
-            fetcher.find_latest_release.return_value = latest_release
+        with patch_release_fetcher():
             await run_update(manager, transport=UpdateTransport.usb_internet)
 
         assert manager.status.state == UpdateState.success
@@ -455,18 +444,15 @@ class TestUpdateManagerAsync:
             assert manager.job_task is not None
             with pytest.raises(
                 UpdateCleanupError,
-                match=(
-                    "Cleanup failed after cancellation: "
-                    "Runtime details refresh failed: runtime unavailable"
-                ),
+                match="Cleanup failed after cancellation: Runtime details refresh failed",
             ):
                 await manager.job_task
 
         assert manager.status.finished_at is not None
         assert manager.status.state == UpdateState.failed
         assert any(
-            issue.message == "Runtime details refresh failed"
-            and issue.detail == "runtime unavailable"
+            issue.message == "Cleanup failed after cancellation: Runtime details refresh failed"
+            and issue.detail == ""
             for issue in manager.status.issues
         )
         assert any(rec.message == "update: runtime details refresh error" for rec in caplog.records)
@@ -509,7 +495,7 @@ class TestUpdateManagerAsync:
     async def test_check_update_failure_fails_update(self, tmp_path) -> None:
         manager, _runner, _ = setup_update_env(tmp_path)
         with patch_release_fetcher(current_version="2025.6.14") as mock_fetcher:
-            mock_fetcher.return_value.check_update_available.side_effect = OSError(
+            mock_fetcher.return_value.find_latest_release.side_effect = OSError(
                 "API rate limit exceeded",
             )
             await run_update(manager, "TestNet", "pass")

--- a/apps/server/tests/use_cases/updates/test_update_manager_lifecycle.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_lifecycle.py
@@ -23,24 +23,26 @@ def _wifi_request(ssid: str = "TestNet", password: str = "pass123") -> UpdateReq
 def _build_manager(
     *,
     timeout_s: float = 10.0,
-) -> tuple[UpdateManager, MagicMock, AsyncMock]:
+) -> tuple[UpdateManager, MagicMock, MagicMock, AsyncMock]:
     tracker = MagicMock()
     tracker.status = MagicMock()
     tracker.status.state = UpdateState.running
+    reporter = MagicMock()
     workflow_run = AsyncMock()
     manager = UpdateManager(
         status=tracker,
+        reporter=reporter,
         workflow=SimpleNamespace(run=workflow_run),
         startup_recovery=SimpleNamespace(recover=AsyncMock()),
         usb_status_service=MagicMock(),
         timeout_s=timeout_s,
     )
-    return manager, tracker, workflow_run
+    return manager, tracker, reporter, workflow_run
 
 
 @pytest.mark.asyncio
 async def test_start_rejects_concurrent_job() -> None:
-    manager, tracker, workflow_run = _build_manager()
+    manager, tracker, reporter, workflow_run = _build_manager()
     request = _wifi_request()
     started = asyncio.Event()
     release = asyncio.Event()
@@ -64,6 +66,7 @@ async def test_start_rejects_concurrent_job() -> None:
         await task
     tracker.start_job.assert_called_once_with(request)
     tracker.track_secret.assert_called_once_with(request.password)
+    reporter.fail_cancelled.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -72,7 +75,7 @@ async def test_timeout_marks_failure_and_finishes_lifecycle() -> None:
         assert request == _wifi_request()
         await asyncio.sleep(1.0)
 
-    manager, tracker, workflow_run = _build_manager(timeout_s=0.01)
+    manager, tracker, reporter, workflow_run = _build_manager(timeout_s=0.01)
     workflow_run.side_effect = slow_workflow
     request = _wifi_request()
     manager.start(request.ssid, request.password, transport=request.transport)
@@ -80,34 +83,32 @@ async def test_timeout_marks_failure_and_finishes_lifecycle() -> None:
     assert task is not None
     await task
 
-    tracker.fail.assert_called_once_with(
-        "timeout",
-        "Update timed out after 0.01s",
-        log_message="Update timed out after 0.01s",
-    )
+    reporter.fail_timeout.assert_called_once_with(timeout_s=0.01)
     tracker.clear_secrets.assert_called_once_with()
     tracker.finish_cleanup.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_update_error_marks_failure_without_propagating() -> None:
-    manager, tracker, workflow_run = _build_manager()
-    workflow_run.side_effect = UpdateError("transport failed")
+    manager, tracker, reporter, workflow_run = _build_manager()
+    error = UpdateError("transport failed")
+    workflow_run.side_effect = error
     request = _wifi_request()
     manager.start(request.ssid, request.password, transport=request.transport)
     task = manager.job_task
     assert task is not None
     await task
 
-    tracker.fail.assert_called_once_with("workflow", "transport failed")
+    reporter.fail.assert_called_once_with(error, default_phase="workflow")
     tracker.clear_secrets.assert_called_once_with()
     tracker.finish_cleanup.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_cleanup_error_propagates_explicitly() -> None:
-    manager, tracker, workflow_run = _build_manager()
-    workflow_run.side_effect = UpdateCleanupError("transport cleanup failed")
+    manager, tracker, reporter, workflow_run = _build_manager()
+    error = UpdateCleanupError("transport cleanup failed")
+    workflow_run.side_effect = error
     request = _wifi_request()
     manager.start(request.ssid, request.password, transport=request.transport)
     task = manager.job_task
@@ -116,5 +117,6 @@ async def test_cleanup_error_propagates_explicitly() -> None:
     with pytest.raises(UpdateCleanupError, match="transport cleanup failed"):
         await task
 
+    reporter.fail.assert_called_once_with(error, default_phase="cleanup")
     tracker.clear_secrets.assert_called_once_with()
     tracker.finish_cleanup.assert_called_once_with()

--- a/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
@@ -64,12 +64,14 @@ def _build_manager(
 ) -> tuple[UpdateManager, AsyncMock]:
     tracker = MagicMock()
     tracker.status = status or UpdateJobStatus()
+    reporter = MagicMock()
     runtime = SimpleNamespace(
         recover=AsyncMock(),
     )
     return (
         UpdateManager(
             status=tracker,
+            reporter=reporter,
             workflow=MagicMock(),
             startup_recovery=runtime,
             usb_status_service=MagicMock(),

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -498,7 +498,7 @@ class TestPersistenceDuringLifecycle:
             patch("shutil.which", _mock_which),
             patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
             patch(
-                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver._check_for_update",
+                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver.resolve",
                 side_effect=AssertionError("release resolution should not run without privileges"),
             ),
         ):

--- a/apps/server/tests/use_cases/updates/test_update_tool_cli_fault_boundaries.py
+++ b/apps/server/tests/use_cases/updates/test_update_tool_cli_fault_boundaries.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from vibesensor.use_cases.updates.firmware.firmware_cache import refresh_cache_cli
-from vibesensor.use_cases.updates.releases.release_fetcher import fetch_latest_wheel_cli
+from vibesensor.use_cases.updates.releases.cli import fetch_latest_wheel_cli
 
 
 def test_fetch_latest_wheel_cli_exits_for_operational_value_error(
@@ -22,7 +22,7 @@ def test_fetch_latest_wheel_cli_exits_for_operational_value_error(
             raise ValueError("bad release metadata")
 
     monkeypatch.setattr(
-        "vibesensor.use_cases.updates.releases.release_fetcher.ServerReleaseFetcher",
+        "vibesensor.use_cases.updates.releases.cli.ServerReleaseFetcher",
         _BrokenFetcher,
     )
 
@@ -46,7 +46,7 @@ def test_fetch_latest_wheel_cli_allows_programmer_errors_to_surface(
             raise AssertionError("programmer bug")
 
     monkeypatch.setattr(
-        "vibesensor.use_cases.updates.releases.release_fetcher.ServerReleaseFetcher",
+        "vibesensor.use_cases.updates.releases.cli.ServerReleaseFetcher",
         _BrokenFetcher,
     )
 

--- a/apps/server/tests/use_cases/updates/test_update_validation.py
+++ b/apps/server/tests/use_cases/updates/test_update_validation.py
@@ -40,7 +40,10 @@ async def test_validation_fails_when_rollback_dir_probe_fails(monkeypatch, tmp_p
         _raise_probe,
     )
 
-    with pytest.raises(UpdatePreparationError, match="Rollback directory is not writable"):
+    with pytest.raises(
+        UpdatePreparationError,
+        match="Rollback directory is not writable",
+    ) as excinfo:
         await validate_prerequisites(
             commands=_Commands(),
             status=tracker,
@@ -55,7 +58,7 @@ async def test_validation_fails_when_rollback_dir_probe_fails(monkeypatch, tmp_p
             ),
         )
 
-    assert tracker.status.state.value == "failed"
-    assert any(
-        issue.message == "Rollback directory is not writable" for issue in tracker.status.issues
-    )
+    assert excinfo.value.phase == "validating"
+    assert "readonly" in excinfo.value.detail
+    assert tracker.status.state.value == "idle"
+    assert tracker.status.issues == []

--- a/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
+++ b/apps/server/tests/use_cases/updates/test_update_workflow_executor.py
@@ -25,7 +25,6 @@ def _executor() -> tuple[
     MagicMock,
     MagicMock,
     MagicMock,
-    MagicMock,
 ]:
     completion = MagicMock()
     completion.complete_success = AsyncMock()
@@ -36,13 +35,11 @@ def _executor() -> tuple[
     firmware_refresher.refresh_esp_firmware = AsyncMock(
         return_value=FirmwareRefreshResult.success(),
     )
-    status = MagicMock()
     executor = UpdateWorkflowExecutor(
         completion=completion,
         stager=stager,
         deployment=deployment,
         firmware_refresher=firmware_refresher,
-        status=status,
     )
     return (
         executor,
@@ -50,7 +47,6 @@ def _executor() -> tuple[
         stager,
         deployment,
         firmware_refresher,
-        status,
     )
 
 
@@ -69,7 +65,6 @@ async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() 
         stager,
         deployment,
         firmware_refresher,
-        status,
     ) = _executor()
     prepared_transport = MagicMock()
     workflow = PlannedUpdateRun(
@@ -91,7 +86,6 @@ async def test_execute_refresh_plan_refreshes_firmware_then_completes_success() 
     )
     deployment.deploy.assert_not_awaited()
     assert not stager.stage.called
-    status.fail.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -102,7 +96,6 @@ async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
         stager,
         deployment,
         firmware_refresher,
-        status,
     ) = _executor()
     prepared_transport = MagicMock()
     workflow = PlannedUpdateRun(
@@ -116,14 +109,14 @@ async def test_execute_refresh_plan_fails_when_firmware_refresh_fails() -> None:
         detail="cache unavailable",
     )
 
-    with pytest.raises(UpdateReleaseError, match="ESP firmware cache refresh failed"):
+    with pytest.raises(UpdateReleaseError, match="ESP firmware cache refresh failed") as excinfo:
         await executor.execute(workflow)
 
-    status.fail.assert_called_once_with(
-        UpdatePhase.downloading,
-        "ESP firmware cache refresh failed (exit 1)",
-        "cache unavailable",
-        log_message="ESP firmware refresh failed; refresh-only update did not complete",
+    assert excinfo.value.phase == UpdatePhase.downloading.value
+    assert excinfo.value.detail == "cache unavailable"
+    assert (
+        excinfo.value.log_message
+        == "ESP firmware refresh failed; refresh-only update did not complete"
     )
     completion.complete_success.assert_not_awaited()
     deployment.deploy.assert_not_awaited()
@@ -138,7 +131,6 @@ async def test_execute_install_plan_stages_and_deploys_before_completion(tmp_pat
         stager,
         deployment,
         firmware_refresher,
-        status,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
@@ -167,7 +159,6 @@ async def test_execute_install_plan_stages_and_deploys_before_completion(tmp_pat
         message="Update completed successfully",
     )
     firmware_refresher.refresh_esp_firmware.assert_not_awaited()
-    status.fail.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -180,7 +171,6 @@ async def test_execute_install_plan_propagates_deploy_failure_before_completion(
         stager,
         deployment,
         _firmware_refresher,
-        status,
     ) = _executor()
     release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
@@ -205,4 +195,3 @@ async def test_execute_install_plan_propagates_deploy_failure_before_completion(
 
     deployment.deploy.assert_awaited_once_with(staged_release)
     completion.complete_success.assert_not_awaited()
-    status.fail.assert_not_called()

--- a/apps/server/tests/use_cases/updates/test_usb_internet.py
+++ b/apps/server/tests/use_cases/updates/test_usb_internet.py
@@ -5,10 +5,8 @@ from pathlib import Path
 import pytest
 from _update_manager_test_helpers import FakeRunner
 
-from vibesensor.use_cases.updates.usb_status import (
-    UsbInternetStatusService,
-    parse_nmcli_device_status,
-)
+from vibesensor.use_cases.updates.usb_status import UsbInternetStatusService
+from vibesensor.use_cases.updates.usb_status_inspection import parse_nmcli_device_status
 
 
 def _make_usb_interface(

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
@@ -155,19 +155,21 @@ async def test_cleanup_after_update_collects_cleanup_diagnostics(tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_complete_success_restores_hotspot_and_marks_success(tmp_path: Path) -> None:
+async def test_complete_success_restores_hotspot_without_marking_terminal_state(
+    tmp_path: Path,
+) -> None:
     session, _runner, tracker = _build_session(tmp_path)
     _seed_checked_phase(tracker)
 
-    await session.complete_success("Update completed successfully")
+    await session.complete_success()
 
-    assert tracker.status.state == UpdateState.success
-    assert tracker.status.phase == UpdatePhase.done
-    assert any("Update completed successfully" in line for line in tracker.status.log_tail)
+    assert tracker.status.state == UpdateState.running
+    assert tracker.status.phase == UpdatePhase.restoring_hotspot
+    assert any("Restoring hotspot..." in line for line in tracker.status.log_tail)
 
 
 @pytest.mark.asyncio
-async def test_complete_success_marks_failed_when_restore_fails(tmp_path: Path) -> None:
+async def test_complete_success_raises_when_restore_fails(tmp_path: Path) -> None:
     session, runner, tracker = _build_session(
         tmp_path,
         restore_retries=1,
@@ -177,11 +179,14 @@ async def test_complete_success_marks_failed_when_restore_fails(tmp_path: Path) 
     runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
 
     with pytest.raises(UpdateTransportError, match="Failed to restore hotspot after update"):
-        await session.complete_success("Update completed successfully")
+        await session.complete_success()
 
-    assert tracker.status.state == UpdateState.failed
+    assert tracker.status.state == UpdateState.running
+    assert tracker.status.phase == UpdatePhase.restoring_hotspot
     assert any(
-        issue.message == "Failed to restore hotspot after update" for issue in tracker.status.issues
+        issue.phase == UpdatePhase.restoring_hotspot.value
+        and issue.message == "Failed to restore hotspot after retries"
+        for issue in tracker.status.issues
     )
 
 

--- a/apps/server/vibesensor/shared/exceptions.py
+++ b/apps/server/vibesensor/shared/exceptions.py
@@ -64,9 +64,20 @@ class ProtocolError(VibeSensorError):
 class UpdateError(VibeSensorError):
     """OTA update system failure."""
 
-    def __init__(self, message: str, *, status: str = "error") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: str = "error",
+        phase: str | None = None,
+        detail: str = "",
+        log_message: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.status = status
+        self.phase = phase
+        self.detail = detail
+        self.log_message = log_message
 
 
 class UpdateCleanupError(UpdateError):
@@ -89,7 +100,12 @@ class UpdateCancelledError(UpdateError):
     """Update execution was cancelled intentionally."""
 
     def __init__(self, message: str = "Update was cancelled") -> None:
-        super().__init__(message, status="cancelled")
+        super().__init__(
+            message,
+            status="cancelled",
+            phase="cancelled",
+            log_message="Update cancelled",
+        )
 
 
 class RunNotFoundError(VibeSensorError):

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -24,7 +24,9 @@ The updater now has one explicit run-scoped workflow boundary per concern:
 - ``finalization.py`` owns unconditional transport cleanup and runtime refresh.
 - ``transport/`` owns prepared-transport interfaces, transport coordination,
   transport-neutral uplink readiness, and USB transport execution behavior.
-- ``usb_status.py`` inspects Linux/NetworkManager state for USB internet readiness.
+- ``usb_status.py`` owns the USB internet readiness service facade, while
+  ``usb_status_inspection.py`` and ``usb_status_evaluation.py`` split raw
+  Linux/NM probing from readiness ranking and diagnostics.
 - ``wifi/`` owns Wi-Fi-specific transport execution.
 - ``status/`` owns state transitions, persistence, logging buffers, secret
   redaction, and the explicit tracker used by manager/runtime composition.

--- a/apps/server/vibesensor/use_cases/updates/completion.py
+++ b/apps/server/vibesensor/use_cases/updates/completion.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.status import (
+    UpdateStatusTracker,
+    UpdateTerminalStateReporter,
+)
 from vibesensor.use_cases.updates.transport.lifecycles import PreparedUpdateTransport
 
 __all__ = ["UpdateCompletionCoordinator"]
@@ -12,14 +15,16 @@ __all__ = ["UpdateCompletionCoordinator"]
 class UpdateCompletionCoordinator:
     """Own post-success transport completion and restart follow-up."""
 
-    __slots__ = ("_restart_scheduler", "_status")
+    __slots__ = ("_reporter", "_restart_scheduler", "_status")
 
     def __init__(
         self,
         *,
         restart_scheduler: UpdateRestartScheduler,
+        reporter: UpdateTerminalStateReporter,
         status: UpdateStatusTracker,
     ) -> None:
+        self._reporter = reporter
         self._restart_scheduler = restart_scheduler
         self._status = status
 
@@ -29,12 +34,12 @@ class UpdateCompletionCoordinator:
         *,
         message: str,
     ) -> None:
-        await prepared_transport.complete_success(message)
-        if await self._restart_scheduler.schedule():
-            return
-        self._status.add_issue(
-            "done",
-            "Backend restart was not scheduled automatically",
-            "Run 'sudo systemctl restart vibesensor.service' manually",
-        )
-        self._status.log("Automatic backend restart scheduling failed")
+        await prepared_transport.complete_success()
+        self._reporter.mark_success(message)
+        if not await self._restart_scheduler.schedule():
+            self._status.add_issue(
+                "done",
+                "Backend restart was not scheduled automatically",
+                "Run 'sudo systemctl restart vibesensor.service' manually",
+            )
+            self._status.log("Automatic backend restart scheduling failed")

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
@@ -7,7 +7,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from urllib.request import Request, urlopen
+from urllib.request import urlopen
 
 from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
 from vibesensor.use_cases.updates.firmware.firmware_types import (
@@ -15,10 +15,9 @@ from vibesensor.use_cases.updates.firmware.firmware_types import (
     GitHubReleaseAssetPayload,
     GitHubReleasePayload,
 )
-from vibesensor.use_cases.updates.releases.release_fetcher import (
+from vibesensor.use_cases.updates.releases.github_api import (
     DOWNLOAD_CHUNK_BYTES,
-    GitHubAPIClient,
-    validate_https_url,
+    GitHubApiClient,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -74,19 +73,25 @@ def is_firmware_asset_name(name: str) -> bool:
     return name.startswith(_FW_ASSET_PREFIX) and name.endswith(_FW_ASSET_SUFFIX)
 
 
-class GitHubReleaseFetcher(GitHubAPIClient):
+class GitHubReleaseFetcher:
     """Fetch firmware bundles from GitHub Releases."""
 
-    def __init__(self, config: FirmwareCacheConfig) -> None:
+    __slots__ = ("_client", "_config")
+
+    def __init__(
+        self,
+        config: FirmwareCacheConfig,
+        *,
+        client: GitHubApiClient | None = None,
+    ) -> None:
         self._config = config
-        self._github_token = config.github_token
-        self._api_context = "firmware"
+        self._client = client or GitHubApiClient(
+            token=config.github_token,
+            context="firmware",
+        )
 
     def _download_asset(self, url: str, dest: Path) -> None:
-        validate_https_url(url, context="firmware")
-        headers = self._api_headers()
-        headers["Accept"] = "application/octet-stream"
-        req = Request(url, headers=headers)
+        req = self._client.build_request(url, accept="application/octet-stream")
         with urlopen(req, timeout=120) as resp:
             # Stream directly to a temp file to avoid buffering the entire
             # firmware binary in memory (Pi 3A+ has only 512 MB RAM).
@@ -126,13 +131,13 @@ class GitHubReleaseFetcher(GitHubAPIClient):
         if self._config.pinned_tag:
             url = f"{base}/tags/{self._config.pinned_tag}"
             LOGGER.info("Fetching pinned release: %s", self._config.pinned_tag)
-            release = self._api_get(url)
+            release = self._client.get_json(url)
             if not is_json_object(release):
                 raise ValueError("Unexpected GitHub API response format")
             return _coerce_release_payload(release)
 
         LOGGER.info("Fetching releases for channel '%s'", self._config.channel)
-        releases = self._api_get(f"{base}?per_page=50")
+        releases = self._client.get_json(f"{base}?per_page=50")
         if not isinstance(releases, list):
             raise ValueError("Unexpected GitHub API response format")
 

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -8,13 +8,15 @@ from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
     UpdateRequest,
-    UpdateState,
     UpdateTransport,
     UsbInternetStatus,
     validate_update_request,
 )
 from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.status import (
+    UpdateStatusTracker,
+    UpdateTerminalStateReporter,
+)
 from vibesensor.use_cases.updates.usb_status import UsbInternetStatusReader
 from vibesensor.use_cases.updates.workflow import UpdateWorkflow
 
@@ -26,6 +28,7 @@ class UpdateManager:
         self,
         *,
         status: UpdateStatusTracker,
+        reporter: UpdateTerminalStateReporter,
         workflow: UpdateWorkflow,
         startup_recovery: UpdateStartupRecoveryCoordinator,
         usb_status_service: UsbInternetStatusReader,
@@ -33,6 +36,7 @@ class UpdateManager:
         task_name: str = "system-update",
     ) -> None:
         self._status = status
+        self._reporter = reporter
         self._workflow = workflow
         self._startup_recovery = startup_recovery
         self._usb_status_service = usb_status_service
@@ -83,20 +87,16 @@ class UpdateManager:
                 self._workflow.run(request=request),
                 timeout=self._timeout_s,
             )
-        except UpdateCleanupError:
+        except UpdateCleanupError as exc:
+            self._reporter.fail(exc, default_phase="cleanup")
             raise
         except UpdateError as exc:
-            if self.status.state is UpdateState.running:
-                self._status.fail("workflow", str(exc))
+            self._reporter.fail(exc, default_phase="workflow")
             return
         except TimeoutError:
-            self._status.fail(
-                "timeout",
-                f"Update timed out after {self._timeout_s}s",
-                log_message=f"Update timed out after {self._timeout_s}s",
-            )
+            self._reporter.fail_timeout(timeout_s=self._timeout_s)
         except asyncio.CancelledError:
-            self._status.fail("cancelled", "Update was cancelled", log_message="Update cancelled")
+            self._reporter.fail_cancelled()
             raise
         finally:
             self._status.clear_secrets()

--- a/apps/server/vibesensor/use_cases/updates/release_deployment.py
+++ b/apps/server/vibesensor/use_cases/updates/release_deployment.py
@@ -32,12 +32,11 @@ class UpdateReleaseDeploymentCoordinator:
         self._status.transition(UpdatePhase.installing)
         self._status.log("Installing update...")
         if not await self._installer.snapshot_for_rollback():
-            self._status.fail(
-                UpdatePhase.installing.value,
+            raise UpdateReleaseError(
                 "Rollback snapshot could not be created",
-                "Install aborted before mutating the live environment",
+                phase=UpdatePhase.installing.value,
+                detail="Install aborted before mutating the live environment",
             )
-            raise UpdateReleaseError("Rollback snapshot could not be created")
         refresh_result = await self._firmware_refresher.refresh_esp_firmware(
             pinned_tag=staged_release.release.tag,
         )

--- a/apps/server/vibesensor/use_cases/updates/release_resolution.py
+++ b/apps/server/vibesensor/use_cases/updates/release_resolution.py
@@ -9,13 +9,13 @@ from typing import TYPE_CHECKING
 
 from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.releases import factory as release_fetcher_factory
+from vibesensor.use_cases.updates.releases.version_policy import select_update_release
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.updates.releases.release_fetcher import (
         ReleaseInfo,
         ServerReleaseFetcher,
     )
-    from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 __all__ = ["ServerReleaseResolver", "UpdateReleaseResolution"]
 
@@ -36,50 +36,43 @@ class UpdateReleaseResolution:
 class ServerReleaseResolver:
     """Own server release discovery independent from staging or install work."""
 
-    __slots__ = ("_rollback_dir", "_status")
+    __slots__ = ("_rollback_dir",)
 
     def __init__(
         self,
         *,
-        status: UpdateStatusTracker,
         rollback_dir: Path,
     ) -> None:
-        self._status = status
         self._rollback_dir = rollback_dir
 
     async def resolve(self, current_version: str) -> UpdateReleaseResolution:
         fetcher = release_fetcher_factory.build_server_release_fetcher(
             rollback_dir=self._rollback_dir,
         )
-        release = await self._check_for_update(fetcher, current_version)
+        latest_release = await self._find_latest_release(fetcher)
+        release = select_update_release(
+            current_version=current_version,
+            latest_release=latest_release,
+        )
         if release is None:
             return UpdateReleaseResolution(
                 current_version=current_version,
                 release=None,
-                latest_tag=await self._latest_tag(fetcher),
+                latest_tag=latest_release.tag,
             )
         return UpdateReleaseResolution(
             current_version=current_version,
             release=release,
         )
 
-    async def _check_for_update(
+    async def _find_latest_release(
         self,
         fetcher: ServerReleaseFetcher,
-        current_version: str,
-    ) -> ReleaseInfo | None:
+    ) -> ReleaseInfo:
         try:
-            return await asyncio.to_thread(fetcher.check_update_available, current_version)
+            return await asyncio.to_thread(fetcher.find_latest_release)
         except (OSError, ValueError) as exc:
-            self._status.fail("checking", f"Failed to check for updates: {exc}")
-            raise UpdateReleaseError(f"Failed to check for updates: {exc}") from exc
-
-    async def _latest_tag(self, fetcher: ServerReleaseFetcher) -> str:
-        try:
-            latest_release = await asyncio.to_thread(fetcher.find_latest_release)
-        except (OSError, ValueError) as exc:
-            self._status.log(
-                f"Could not resolve the latest release tag for ESP firmware sync: {exc}",
-            )
-            return ""
-        return latest_release.tag if isinstance(latest_release.tag, str) else ""
+            raise UpdateReleaseError(
+                f"Failed to check for updates: {exc}",
+                phase="checking",
+            ) from exc

--- a/apps/server/vibesensor/use_cases/updates/release_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/release_runtime.py
@@ -51,7 +51,6 @@ def build_update_release_runtime(
     )
     return UpdateReleaseRuntime(
         resolver=ServerReleaseResolver(
-            status=status,
             rollback_dir=config.rollback_dir,
         ),
         stager=ServerReleaseStager(

--- a/apps/server/vibesensor/use_cases/updates/release_staging.py
+++ b/apps/server/vibesensor/use_cases/updates/release_staging.py
@@ -74,6 +74,7 @@ class ServerReleaseStager:
         except OSError as exc:
             cleanup_error = UpdateCleanupError(
                 f"Failed to remove staged release directory: {exc}",
+                phase="cleanup",
             )
             if prior_error is not None:
                 prior_error.add_note(str(cleanup_error))
@@ -89,8 +90,10 @@ class ServerReleaseStager:
         try:
             return await asyncio.to_thread(fetcher.download_wheel, release, staging_dir)
         except (OSError, ValueError) as exc:
-            self._status.fail("downloading", f"Failed to download release: {exc}")
-            raise UpdateReleaseError(f"Failed to download release: {exc}") from exc
+            raise UpdateReleaseError(
+                f"Failed to download release: {exc}",
+                phase=UpdatePhase.downloading.value,
+            ) from exc
 
     async def _verify_download(self, release: ReleaseInfo, wheel_path: Path) -> None:
         """Verify SHA-256 digest of a downloaded wheel."""
@@ -102,12 +105,9 @@ class ServerReleaseStager:
         if actual_sha256 == expected_sha256:
             self._status.log(f"SHA-256 verified: {actual_sha256}")
             return
-        self._status.fail(
-            "downloading",
+        raise UpdateReleaseError(
             "Downloaded wheel SHA-256 mismatch",
-            f"expected={release.sha256} actual={actual_sha256}",
+            phase=UpdatePhase.downloading.value,
+            detail=f"expected={release.sha256} actual={actual_sha256}",
+            log_message=f"SHA-256 mismatch: expected {release.sha256} but got {actual_sha256}",
         )
-        self._status.log(
-            f"SHA-256 mismatch: expected {release.sha256} but got {actual_sha256}",
-        )
-        raise UpdateReleaseError("Downloaded wheel SHA-256 mismatch")

--- a/apps/server/vibesensor/use_cases/updates/releases/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/__init__.py
@@ -1,11 +1,33 @@
 """GitHub release fetch and validation helpers for updater workflows."""
 
 from . import release_validation
-from .release_fetcher import ReleaseFetcherConfig, ReleaseInfo, ServerReleaseFetcher
+from .github_api import (
+    DOWNLOAD_CHUNK_BYTES,
+    GitHubApiClient,
+    github_api_headers,
+    validate_https_url,
+)
+from .models import (
+    GitHubRelease,
+    GitHubReleaseAsset,
+    ReleaseFetcherConfig,
+    ReleaseInfo,
+    resolve_release_fetcher_config,
+)
+from .release_fetcher import ServerReleaseFetcher
+from .version_policy import select_update_release
 
 __all__ = [
+    "DOWNLOAD_CHUNK_BYTES",
+    "GitHubApiClient",
+    "GitHubRelease",
+    "GitHubReleaseAsset",
     "ReleaseFetcherConfig",
     "ReleaseInfo",
     "ServerReleaseFetcher",
+    "github_api_headers",
     "release_validation",
+    "resolve_release_fetcher_config",
+    "select_update_release",
+    "validate_https_url",
 ]

--- a/apps/server/vibesensor/use_cases/updates/releases/cli.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/cli.py
@@ -1,0 +1,39 @@
+"""Command-line entrypoints for updater release helpers."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from .models import resolve_release_fetcher_config
+from .release_fetcher import ServerReleaseFetcher
+
+__all__ = ["fetch_latest_wheel_cli"]
+
+
+def fetch_latest_wheel_cli() -> None:
+    """CLI entry point: fetch the latest server release wheel."""
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Fetch the latest VibeSensor server wheel from GitHub Releases",
+    )
+    parser.add_argument("--repo", default="", help="GitHub owner/repo")
+    parser.add_argument("--dest", default=".", help="Destination directory for the wheel")
+    args = parser.parse_args()
+
+    config = resolve_release_fetcher_config(server_repo=args.repo)
+    fetcher = ServerReleaseFetcher(config)
+
+    try:
+        release = fetcher.find_latest_release()
+        print(f"Latest release: {release.tag} ({release.version})")
+        whl = fetcher.download_wheel(release, dest_dir=args.dest)
+        print(f"Downloaded: {whl}")
+        print(f"SHA256: {release.sha256}")
+    except (OSError, ValueError) as exc:
+        logging.getLogger(__name__).exception("release fetch CLI failed")
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/apps/server/vibesensor/use_cases/updates/releases/factory.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/factory.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vibesensor.use_cases.updates.releases import release_fetcher
+from vibesensor.use_cases.updates.releases.models import resolve_release_fetcher_config
+from vibesensor.use_cases.updates.releases.release_fetcher import ServerReleaseFetcher
 
 __all__ = ["build_server_release_fetcher"]
 
 
-def build_server_release_fetcher(*, rollback_dir: Path) -> release_fetcher.ServerReleaseFetcher:
+def build_server_release_fetcher(*, rollback_dir: Path) -> ServerReleaseFetcher:
     """Create the canonical server-release fetcher for one updater run."""
 
-    return release_fetcher.ServerReleaseFetcher(
-        release_fetcher.ReleaseFetcherConfig(rollback_dir=str(rollback_dir)),
+    return ServerReleaseFetcher(
+        resolve_release_fetcher_config(rollback_dir=str(rollback_dir)),
     )

--- a/apps/server/vibesensor/use_cases/updates/releases/github_api.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/github_api.py
@@ -1,0 +1,65 @@
+"""Shared GitHub REST API helpers for updater release fetchers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from urllib.request import Request, urlopen
+
+from vibesensor.shared.types.json_types import JsonValue
+
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024  # 1 MB per read()
+
+__all__ = [
+    "DOWNLOAD_CHUNK_BYTES",
+    "GitHubApiClient",
+    "github_api_headers",
+    "validate_https_url",
+]
+
+
+def validate_https_url(url: str, *, context: str = "operation") -> None:
+    """Raise ``ValueError`` if *url* does not use the HTTPS scheme."""
+
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing non-HTTPS URL for {context}: {url}")
+
+
+def github_api_headers(
+    token: str = "",
+    *,
+    accept: str = "application/vnd.github+json",
+) -> dict[str, str]:
+    """Build standard GitHub REST API request headers."""
+
+    headers: dict[str, str] = {"Accept": accept}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubApiClient:
+    """Shared GitHub REST API client used by updater fetchers."""
+
+    token: str = ""
+    context: str = "github"
+
+    def api_headers(self, *, accept: str = "application/vnd.github+json") -> dict[str, str]:
+        return github_api_headers(self.token, accept=accept)
+
+    def build_request(
+        self,
+        url: str,
+        *,
+        accept: str = "application/vnd.github+json",
+    ) -> Request:
+        validate_https_url(url, context=self.context)
+        return Request(url, headers=self.api_headers(accept=accept))
+
+    def get_json(self, url: str) -> JsonValue:
+        """GET *url* and return the parsed JSON response."""
+
+        with urlopen(self.build_request(url), timeout=30) as resp:
+            result: JsonValue = json.loads(resp.read().decode("utf-8"))
+            return result

--- a/apps/server/vibesensor/use_cases/updates/releases/models.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/models.py
@@ -1,0 +1,135 @@
+"""Typed models and config resolution for server release fetching."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from vibesensor.shared.constants.github import GITHUB_REPO
+from vibesensor.shared.types.json_types import is_json_array, is_json_object
+
+DEFAULT_RELEASE_FETCHER_ROLLBACK_DIR = "/var/lib/vibesensor/rollback"
+
+__all__ = [
+    "DEFAULT_RELEASE_FETCHER_ROLLBACK_DIR",
+    "GitHubRelease",
+    "GitHubReleaseAsset",
+    "ReleaseFetcherConfig",
+    "ReleaseInfo",
+    "resolve_release_fetcher_config",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseFetcherConfig:
+    """Configuration for fetching server releases from GitHub."""
+
+    server_repo: str = GITHUB_REPO
+    github_token: str = ""
+    rollback_dir: str = DEFAULT_RELEASE_FETCHER_ROLLBACK_DIR
+
+
+def resolve_release_fetcher_config(
+    *,
+    server_repo: str = "",
+    github_token: str = "",
+    rollback_dir: str = "",
+) -> ReleaseFetcherConfig:
+    """Resolve runtime defaults for the server release fetcher config."""
+
+    return ReleaseFetcherConfig(
+        server_repo=server_repo or os.environ.get("VIBESENSOR_SERVER_REPO", GITHUB_REPO),
+        github_token=github_token or os.environ.get("GITHUB_TOKEN", ""),
+        rollback_dir=rollback_dir
+        or os.environ.get(
+            "VIBESENSOR_ROLLBACK_DIR",
+            DEFAULT_RELEASE_FETCHER_ROLLBACK_DIR,
+        ),
+    )
+
+
+@dataclass
+class ReleaseInfo:
+    """Metadata about a discovered server release."""
+
+    tag: str
+    version: str
+    asset_name: str
+    asset_url: str
+    sha256: str = ""
+    published_at: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialise discovered release metadata for status or debug output."""
+
+        return {
+            "tag": self.tag,
+            "version": self.version,
+            "asset_name": self.asset_name,
+            "asset_url": self.asset_url,
+            "sha256": self.sha256,
+            "published_at": self.published_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubReleaseAsset:
+    """Typed GitHub asset row used by the server release fetcher."""
+
+    name: str
+    url: str
+
+    @classmethod
+    def from_api_payload(cls, raw: object) -> GitHubReleaseAsset | None:
+        """Decode one GitHub asset payload into the typed helper model."""
+
+        if not is_json_object(raw):
+            return None
+        name = raw.get("name")
+        url = raw.get("url")
+        if not isinstance(name, str) or not isinstance(url, str):
+            return None
+        return cls(name=name, url=url)
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubRelease:
+    """Typed GitHub release row used by the server release fetcher."""
+
+    tag_name: str
+    draft: bool
+    prerelease: bool
+    published_at: str
+    assets: tuple[GitHubReleaseAsset, ...]
+
+    @classmethod
+    def from_api_payload(cls, raw: object) -> GitHubRelease | None:
+        """Decode one GitHub release payload into the typed helper model."""
+
+        if not is_json_object(raw):
+            return None
+        tag_name = raw.get("tag_name")
+        draft = raw.get("draft")
+        prerelease = raw.get("prerelease")
+        assets_raw = raw.get("assets")
+        if (
+            not isinstance(tag_name, str)
+            or not isinstance(draft, bool)
+            or not isinstance(prerelease, bool)
+            or not is_json_array(assets_raw)
+        ):
+            return None
+        published_at_raw = raw.get("published_at")
+        assets: list[GitHubReleaseAsset] = []
+        for item in assets_raw:
+            asset = GitHubReleaseAsset.from_api_payload(item)
+            if asset is None:
+                return None
+            assets.append(asset)
+        return cls(
+            tag_name=tag_name,
+            draft=draft,
+            prerelease=prerelease,
+            published_at=published_at_raw if isinstance(published_at_raw, str) else "",
+            assets=tuple(assets),
+        )

--- a/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
@@ -1,191 +1,42 @@
-"""Server release fetcher: download wheel artifacts from GitHub Releases.
-
-Follows the same patterns as :mod:`firmware_cache` for GitHub API access,
-HTTPS-only validation, and atomic staging.
-
-Release tag convention: ``server-v<CalVer>``  (e.g. ``server-v2025.6.15``).
-Asset pattern: ``vibesensor-*.whl``.
-"""
+"""Server release fetcher for wheel artifacts from GitHub Releases."""
 
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import os
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
-from urllib.request import Request, urlopen
+from urllib.request import urlopen
 
-from packaging.version import Version
+from vibesensor.shared.types.json_types import is_json_array
 
-from vibesensor.shared.constants.github import GITHUB_REPO
-from vibesensor.shared.types.json_types import JsonValue, is_json_array, is_json_object
+from .github_api import DOWNLOAD_CHUNK_BYTES, GitHubApiClient
+from .models import GitHubRelease, GitHubReleaseAsset, ReleaseFetcherConfig, ReleaseInfo
 
 LOGGER = logging.getLogger(__name__)
 
-_DEFAULT_ROLLBACK_DIR = "/var/lib/vibesensor/rollback"
-
-DOWNLOAD_CHUNK_BYTES = 1024 * 1024  # 1 MB per read()
-# Shared chunk size for both server and firmware GitHub asset downloads.
-
 _HASH_CHUNK_BYTES = 65536  # 64 KB per hash update
 
-
-@dataclass
-class ReleaseFetcherConfig:
-    """Configuration for fetching server releases from GitHub."""
-
-    server_repo: str = ""
-    github_token: str = ""
-    rollback_dir: str = ""
-
-    def __post_init__(self) -> None:
-        if not self.server_repo:
-            self.server_repo = os.environ.get("VIBESENSOR_SERVER_REPO", GITHUB_REPO)
-        if not self.github_token:
-            self.github_token = os.environ.get("GITHUB_TOKEN", "")
-        if not self.rollback_dir:
-            self.rollback_dir = os.environ.get("VIBESENSOR_ROLLBACK_DIR", _DEFAULT_ROLLBACK_DIR)
+__all__ = ["ServerReleaseFetcher"]
 
 
-@dataclass
-class ReleaseInfo:
-    """Metadata about a discovered server release."""
-
-    tag: str
-    version: str
-    asset_name: str
-    asset_url: str
-    sha256: str = ""
-    published_at: str = ""
-
-    def to_dict(self) -> dict[str, str]:
-        """Serialise discovered release metadata for status or debug output."""
-
-        return {
-            "tag": self.tag,
-            "version": self.version,
-            "asset_name": self.asset_name,
-            "asset_url": self.asset_url,
-            "sha256": self.sha256,
-            "published_at": self.published_at,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class GitHubReleaseAsset:
-    """Typed GitHub asset row used by the server release fetcher."""
-
-    name: str
-    url: str
-
-    @classmethod
-    def from_api_payload(cls, raw: object) -> GitHubReleaseAsset | None:
-        """Decode one GitHub asset payload into the typed helper model."""
-
-        if not is_json_object(raw):
-            return None
-        name = raw.get("name")
-        url = raw.get("url")
-        if not isinstance(name, str) or not isinstance(url, str):
-            return None
-        return cls(name=name, url=url)
-
-
-@dataclass(frozen=True, slots=True)
-class GitHubRelease:
-    """Typed GitHub release row used by the server release fetcher."""
-
-    tag_name: str
-    draft: bool
-    prerelease: bool
-    published_at: str
-    assets: tuple[GitHubReleaseAsset, ...]
-
-    @classmethod
-    def from_api_payload(cls, raw: object) -> GitHubRelease | None:
-        """Decode one GitHub release payload into the typed helper model."""
-
-        if not is_json_object(raw):
-            return None
-        tag_name = raw.get("tag_name")
-        draft = raw.get("draft")
-        prerelease = raw.get("prerelease")
-        assets_raw = raw.get("assets")
-        if (
-            not isinstance(tag_name, str)
-            or not isinstance(draft, bool)
-            or not isinstance(prerelease, bool)
-            or not is_json_array(assets_raw)
-        ):
-            return None
-        published_at_raw = raw.get("published_at")
-        assets: list[GitHubReleaseAsset] = []
-        for item in assets_raw:
-            asset = GitHubReleaseAsset.from_api_payload(item)
-            if asset is None:
-                return None
-            assets.append(asset)
-        return cls(
-            tag_name=tag_name,
-            draft=draft,
-            prerelease=prerelease,
-            published_at=published_at_raw if isinstance(published_at_raw, str) else "",
-            assets=tuple(assets),
-        )
-
-
-def validate_https_url(url: str, *, context: str = "operation") -> None:
-    """Raise ``ValueError`` if *url* does not use the HTTPS scheme."""
-    if not url.startswith("https://"):
-        raise ValueError(f"Refusing non-HTTPS URL for {context}: {url}")
-
-
-def github_api_headers(token: str = "") -> dict[str, str]:
-    """Build standard GitHub REST API request headers.
-
-    If *token* is non-empty it is included as a Bearer authorization header.
-    Used by both :class:`ServerReleaseFetcher` and
-    :class:`~vibesensor.use_cases.updates.firmware.firmware_release_fetcher.GitHubReleaseFetcher`
-    so that the header construction lives in one place.
-    """
-    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
-class GitHubAPIClient:
-    """Shared base for classes that call the GitHub REST API.
-
-    Subclasses must set ``_github_token`` and ``_api_context`` before
-    calling any API methods.
-    """
-
-    _github_token: str = ""
-    _api_context: str = "github"
-
-    def _api_headers(self) -> dict[str, str]:
-        return github_api_headers(self._github_token)
-
-    def _api_get(self, url: str) -> JsonValue:
-        """GET *url* and return the parsed JSON response."""
-        validate_https_url(url, context=self._api_context)
-        req = Request(url, headers=self._api_headers())
-        with urlopen(req, timeout=30) as resp:
-            result: JsonValue = json.loads(resp.read().decode("utf-8"))
-            return result
-
-
-class ServerReleaseFetcher(GitHubAPIClient):
+class ServerReleaseFetcher:
     """Fetch server wheel releases from GitHub Releases."""
 
-    def __init__(self, config: ReleaseFetcherConfig | None = None) -> None:
-        self._config = config or ReleaseFetcherConfig()
-        self._github_token = self._config.github_token
-        self._api_context = "release"
+    __slots__ = ("_client", "_config")
+
+    def __init__(
+        self,
+        config: ReleaseFetcherConfig,
+        *,
+        client: GitHubApiClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client or GitHubApiClient(
+            token=config.github_token,
+            context="release",
+        )
 
     _MAX_DOWNLOAD_BYTES = 200 * 1024 * 1024  # 200 MB hard limit
     _MAX_DOWNLOAD_MB = _MAX_DOWNLOAD_BYTES // (1024 * 1024)
@@ -193,10 +44,7 @@ class ServerReleaseFetcher(GitHubAPIClient):
     def _download_asset(self, url: str, dest: Path) -> None:
         """Stream a release asset to disk with an upper size bound."""
 
-        validate_https_url(url, context="release")
-        headers = self._api_headers()
-        headers["Accept"] = "application/octet-stream"
-        req = Request(url, headers=headers)
+        req = self._client.build_request(url, accept="application/octet-stream")
         tmp = dest.with_suffix(".tmp")
         max_bytes = self._MAX_DOWNLOAD_BYTES
         chunk_size = DOWNLOAD_CHUNK_BYTES
@@ -230,7 +78,7 @@ class ServerReleaseFetcher(GitHubAPIClient):
         owner, repo = self._config.server_repo.split("/", 1)
         url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=50"
         LOGGER.info("Querying releases from %s/%s", owner, repo)
-        releases_raw = self._api_get(url)
+        releases_raw = self._client.get_json(url)
         if not is_json_array(releases_raw):
             raise ValueError("Unexpected GitHub API response format")
         releases: list[GitHubRelease] = []
@@ -298,68 +146,3 @@ class ServerReleaseFetcher(GitHubAPIClient):
         release.sha256 = sha
         LOGGER.info("Downloaded %s (sha256=%s)", release.asset_name, sha)
         return dest
-
-    def check_update_available(self, current_version: str) -> ReleaseInfo | None:
-        """Check if a newer release is available.
-
-        Returns :class:`ReleaseInfo` if a newer version exists, ``None``
-        if already up-to-date or the latest release is older.
-        Raises on API errors.
-        """
-        release = self.find_latest_release()
-        if release.version == current_version:
-            LOGGER.info("Already up-to-date (version=%s)", current_version)
-            return None
-        # Guard against suggesting downgrades: compare versions so that only
-        # genuinely newer releases are reported.
-        try:
-            if Version(release.version) <= Version(current_version):
-                LOGGER.info(
-                    "Latest release %s is not newer than current %s; skipping",
-                    release.version,
-                    current_version,
-                )
-                return None
-        except ValueError:
-            # If versions are unparseable, fall through and treat any difference as an update.
-            LOGGER.warning(
-                "Could not compare versions %r vs %r; treating as update",
-                release.version,
-                current_version,
-                exc_info=True,
-            )
-        LOGGER.info(
-            "Update available: %s → %s",
-            current_version,
-            release.version,
-        )
-        return release
-
-
-def fetch_latest_wheel_cli() -> None:
-    """CLI entry point: fetch the latest server release wheel."""
-    import argparse
-    import sys
-
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-
-    parser = argparse.ArgumentParser(
-        description="Fetch the latest VibeSensor server wheel from GitHub Releases",
-    )
-    parser.add_argument("--repo", default="", help="GitHub owner/repo")
-    parser.add_argument("--dest", default=".", help="Destination directory for the wheel")
-    args = parser.parse_args()
-
-    config = ReleaseFetcherConfig(server_repo=args.repo)
-    fetcher = ServerReleaseFetcher(config)
-
-    try:
-        release = fetcher.find_latest_release()
-        print(f"Latest release: {release.tag} ({release.version})")
-        whl = fetcher.download_wheel(release, dest_dir=args.dest)
-        print(f"Downloaded: {whl}")
-        print(f"SHA256: {release.sha256}")
-    except (OSError, ValueError) as exc:
-        LOGGER.exception("release fetch CLI failed")
-        print(f"ERROR: {exc}", file=sys.stderr)
-        sys.exit(1)

--- a/apps/server/vibesensor/use_cases/updates/releases/version_policy.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/version_policy.py
@@ -1,0 +1,40 @@
+"""Version-selection policy for discovered server releases."""
+
+from __future__ import annotations
+
+import logging
+
+from packaging.version import Version
+
+from .models import ReleaseInfo
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = ["select_update_release"]
+
+
+def select_update_release(
+    *,
+    current_version: str,
+    latest_release: ReleaseInfo,
+) -> ReleaseInfo | None:
+    """Return *latest_release* only when it is newer than *current_version*."""
+
+    if latest_release.version == current_version:
+        return None
+    try:
+        if Version(latest_release.version) <= Version(current_version):
+            LOGGER.info(
+                "Latest release %s is not newer than current %s; skipping",
+                latest_release.version,
+                current_version,
+            )
+            return None
+    except ValueError:
+        LOGGER.warning(
+            "Could not compare versions %r vs %r; treating as update",
+            latest_release.version,
+            current_version,
+            exc_info=True,
+        )
+    return latest_release

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -46,6 +46,7 @@ def build_update_manager(
         runner=active_runner,
         commands=core.commands,
         status=core.status,
+        reporter=core.reporter,
         wifi_config=config.wifi_config,
         usb_internet_service=usb_internet_service,
         logger=LOGGER,
@@ -64,6 +65,7 @@ def build_update_manager(
     )
     return UpdateManager(
         status=core.status,
+        reporter=core.reporter,
         usb_status_service=transport.usb_status_service,
         startup_recovery=transport.startup_recovery,
         workflow=workflow,

--- a/apps/server/vibesensor/use_cases/updates/runtime_core.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime_core.py
@@ -13,6 +13,7 @@ from vibesensor.use_cases.updates.runner import (
 from vibesensor.use_cases.updates.status import (
     UpdateStateStore,
     UpdateStatusTracker,
+    UpdateTerminalStateReporter,
     build_update_status_tracker,
     collect_runtime_details,
 )
@@ -23,6 +24,7 @@ __all__ = ["UpdateRuntimeCore", "build_update_runtime_core"]
 @dataclass(frozen=True, slots=True)
 class UpdateRuntimeCore:
     status: UpdateStatusTracker
+    reporter: UpdateTerminalStateReporter
     commands: UpdateCommandExecutor
 
 
@@ -40,7 +42,11 @@ def build_update_runtime_core(
         runner=runner,
         reporter=UpdateStatusCommandReporter(status=status),
     )
-    return UpdateRuntimeCore(status=status, commands=commands)
+    return UpdateRuntimeCore(
+        status=status,
+        reporter=UpdateTerminalStateReporter(status=status),
+        commands=commands,
+    )
 
 
 def _build_status_tracker(

--- a/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
@@ -35,11 +35,10 @@ class UpdateRuntimeDetailsRefresher:
         try:
             runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
         except (OSError, UpdateError) as exc:
-            self._status.fail(
-                "cleanup",
-                "Runtime details refresh failed",
-                str(exc),
-            )
             self._logger.exception("update: runtime details refresh error")
-            raise UpdateCleanupError(f"Runtime details refresh failed: {exc}") from exc
+            raise UpdateCleanupError(
+                "Runtime details refresh failed",
+                phase="cleanup",
+                detail=str(exc),
+            ) from exc
         self._status.set_runtime(runtime_details)

--- a/apps/server/vibesensor/use_cases/updates/startup_recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/startup_recovery.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from vibesensor.use_cases.updates.models import UpdateState
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.status import (
+    UpdateStatusTracker,
+    UpdateTerminalStateReporter,
+)
 from vibesensor.use_cases.updates.transport.coordinator import UpdateTransportCoordinator
 
 __all__ = ["UpdateStartupRecoveryCoordinator"]
@@ -12,14 +15,16 @@ __all__ = ["UpdateStartupRecoveryCoordinator"]
 class UpdateStartupRecoveryCoordinator:
     """Recover transport-owned updater state after an interrupted server restart."""
 
-    __slots__ = ("_status", "_transport_coordinator")
+    __slots__ = ("_reporter", "_status", "_transport_coordinator")
 
     def __init__(
         self,
         *,
         status: UpdateStatusTracker,
+        reporter: UpdateTerminalStateReporter,
         transport_coordinator: UpdateTransportCoordinator,
     ) -> None:
+        self._reporter = reporter
         self._status = status
         self._transport_coordinator = transport_coordinator
 
@@ -27,5 +32,5 @@ class UpdateStartupRecoveryCoordinator:
         status = self._status.status
         if status.state != UpdateState.running or status.finished_at is not None:
             return
-        self._status.mark_interrupted("Update interrupted by server restart")
+        self._reporter.mark_interrupted("Update interrupted by server restart")
         await self._transport_coordinator.recover_interrupted(status)

--- a/apps/server/vibesensor/use_cases/updates/status/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/status/__init__.py
@@ -1,5 +1,6 @@
 """Update status boundary: canonical status surface plus persistence helpers."""
 
+from .reporter import UpdateTerminalStateReporter
 from .runtime_details import collect_runtime_details, hash_tree
 from .state_machine import UpdatePhaseTransitionError
 from .state_store import DEFAULT_STATE_PATH, UpdateStateStore
@@ -8,6 +9,7 @@ from .tracker import UpdateStatusTracker, build_update_status_tracker
 __all__ = [
     "DEFAULT_STATE_PATH",
     "UpdatePhaseTransitionError",
+    "UpdateTerminalStateReporter",
     "UpdateStateStore",
     "UpdateStatusTracker",
     "build_update_status_tracker",

--- a/apps/server/vibesensor/use_cases/updates/status/reporter.py
+++ b/apps/server/vibesensor/use_cases/updates/status/reporter.py
@@ -1,0 +1,47 @@
+"""Terminal updater state reporting over the mutable status tracker."""
+
+from __future__ import annotations
+
+from vibesensor.shared.exceptions import UpdateError
+from vibesensor.use_cases.updates.models import UpdateState
+
+from .tracker import UpdateStatusTracker
+
+__all__ = ["UpdateTerminalStateReporter"]
+
+
+class UpdateTerminalStateReporter:
+    """Own terminal updater state transitions from explicit workflow outcomes."""
+
+    __slots__ = ("_status",)
+
+    def __init__(self, *, status: UpdateStatusTracker) -> None:
+        self._status = status
+
+    def fail(self, error: UpdateError, *, default_phase: str) -> None:
+        if self._status.status.state is UpdateState.idle:
+            return
+        phase = error.phase or self._status.status.phase.value or default_phase
+        self._status.fail(
+            phase,
+            str(error),
+            error.detail,
+            log_message=error.log_message,
+        )
+
+    def fail_timeout(self, *, timeout_s: float) -> None:
+        if self._status.status.state is UpdateState.idle:
+            return
+        message = f"Update timed out after {timeout_s}s"
+        self._status.fail("timeout", message, log_message=message)
+
+    def fail_cancelled(self, *, message: str = "Update was cancelled") -> None:
+        if self._status.status.state is UpdateState.idle:
+            return
+        self._status.fail("cancelled", message, log_message="Update cancelled")
+
+    def mark_interrupted(self, message: str, detail: str = "") -> None:
+        self._status.mark_interrupted(message, detail)
+
+    def mark_success(self, message: str) -> None:
+        self._status.mark_success(message)

--- a/apps/server/vibesensor/use_cases/updates/transport/coordinator.py
+++ b/apps/server/vibesensor/use_cases/updates/transport/coordinator.py
@@ -6,7 +6,6 @@ import logging
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError, UpdateTransportError
 from vibesensor.use_cases.updates.models import UpdateJobStatus, UpdateRequest
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport.lifecycles import (
     PreparedUpdateTransport,
     UpdateTransportLifecycle,
@@ -19,17 +18,15 @@ __all__ = ["UpdateTransportCoordinator"]
 class UpdateTransportCoordinator:
     """Resolve transport lifecycles, return prepared handles, and wrap cleanup errors."""
 
-    __slots__ = ("_lifecycles", "_logger", "_status")
+    __slots__ = ("_lifecycles", "_logger")
 
     def __init__(
         self,
         *,
         lifecycles: UpdateTransportLifecycles,
-        status: UpdateStatusTracker,
         logger: logging.Logger,
     ) -> None:
         self._lifecycles = lifecycles
-        self._status = status
         self._logger = logger
 
     async def prepare(self, request: UpdateRequest) -> PreparedUpdateTransport:
@@ -52,9 +49,12 @@ class UpdateTransportCoordinator:
         try:
             await prepared_transport.cleanup_after_update()
         except (OSError, UpdateError) as exc:
-            self._status.fail("cleanup", "Transport cleanup failed", str(exc))
             self._logger.exception("update: transport cleanup error")
-            raise UpdateCleanupError(f"Transport cleanup failed: {exc}") from exc
+            raise UpdateCleanupError(
+                "Transport cleanup failed",
+                phase="cleanup",
+                detail=str(exc),
+            ) from exc
 
     async def recover_interrupted(self, status: UpdateJobStatus) -> None:
         await self._lifecycles.for_status(status).recover_interrupted_update(status)

--- a/apps/server/vibesensor/use_cases/updates/transport/lifecycles.py
+++ b/apps/server/vibesensor/use_cases/updates/transport/lifecycles.py
@@ -18,8 +18,8 @@ class PreparedUpdateTransport(Protocol):
 
     transport: UpdateTransport
 
-    async def complete_success(self, message: str) -> None:
-        """Finalize a successful update for this transport."""
+    async def complete_success(self) -> None:
+        """Finalize a successful update for this transport before status reporting."""
         ...
 
     async def cleanup_after_update(self) -> None:

--- a/apps/server/vibesensor/use_cases/updates/transport/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/transport/runtime.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING
 
 from vibesensor.use_cases.updates.runner import CommandRunner, UpdateCommandExecutor
 from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.status import (
+    UpdateStatusTracker,
+    UpdateTerminalStateReporter,
+)
 from vibesensor.use_cases.updates.transport.coordinator import UpdateTransportCoordinator
 from vibesensor.use_cases.updates.transport.lifecycles import UpdateTransportLifecycles
 from vibesensor.use_cases.updates.transport.usb_internet import UpdateUsbInternetSession
@@ -36,6 +39,7 @@ def build_update_transport_runtime(
     runner: CommandRunner,
     commands: UpdateCommandExecutor,
     status: UpdateStatusTracker,
+    reporter: UpdateTerminalStateReporter,
     wifi_config: UpdateWifiConfig,
     usb_internet_service: UsbInternetStatusReader | None,
     logger: logging.Logger,
@@ -48,13 +52,13 @@ def build_update_transport_runtime(
             wifi_config=wifi_config,
             status_service=status_service,
         ),
-        status=status,
         logger=logger,
     )
     return UpdateTransportRuntime(
         coordinator=coordinator,
         startup_recovery=UpdateStartupRecoveryCoordinator(
             status=status,
+            reporter=reporter,
             transport_coordinator=coordinator,
         ),
         usb_status_service=status_service,

--- a/apps/server/vibesensor/use_cases/updates/transport/usb_internet.py
+++ b/apps/server/vibesensor/use_cases/updates/transport/usb_internet.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from vibesensor.shared.exceptions import UpdateTransportError
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
     UpdatePhase,
@@ -86,13 +85,7 @@ class UpdateUsbInternetSession:
 
     async def prepare(self, _request: UpdateRequest) -> UpdateUsbInternetSession:
         self._status.transition(UpdatePhase.connecting_usb_internet)
-        try:
-            await self.ensure_uplink_ready()
-        except UpdateTransportStepError as exc:
-            self._status.fail(exc.phase, str(exc), exc.detail)
-            raise UpdateTransportError(
-                "Failed to prepare the USB internet uplink for update"
-            ) from exc
+        await self.ensure_uplink_ready()
         return self
 
     async def abort_preparation(self) -> None:
@@ -115,8 +108,8 @@ class UpdateUsbInternetSession:
             failure_message="USB internet detected, but internet/DNS is not ready",
         )
 
-    async def complete_success(self, message: str) -> None:
-        self._status.mark_success(message)
+    async def complete_success(self) -> None:
+        return None
 
     async def cleanup_after_update(self) -> None:
         pass

--- a/apps/server/vibesensor/use_cases/updates/usb_status.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_status.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
 from vibesensor.use_cases.updates.models import UsbInternetStatus
 from vibesensor.use_cases.updates.runner import CommandRunner, build_sudo_args
+from vibesensor.use_cases.updates.usb_status_evaluation import (
+    candidate_diagnostic,
+    select_best_candidate,
+    should_attempt_activation,
+    status_from_candidate,
+)
+from vibesensor.use_cases.updates.usb_status_inspection import (
+    DEFAULT_SYS_CLASS_NET,
+    UsbInternetStatusInspector,
+)
 
-_SYS_CLASS_NET = Path("/sys/class/net")
-_USB_NETWORK_DRIVERS = frozenset({"cdc_ether", "cdc_ncm", "ipheth", "rndis_host"})
-_USB_ACTIVATION_STATES = frozenset({"disconnected", "unavailable", "unknown"})
 _USB_ACTIVATION_WAIT_S = 15
 
 __all__ = [
     "UsbInternetStatusReader",
     "UsbInternetStatusService",
-    "parse_nmcli_device_status",
 ]
 
 
@@ -23,296 +28,22 @@ class UsbInternetStatusReader(Protocol):
     async def snapshot(self, *, activate: bool = False) -> UsbInternetStatus: ...
 
 
-@dataclass(frozen=True, slots=True)
-class _NmcliDeviceStatus:
-    interface_name: str
-    device_type: str
-    state: str
-    connection_name: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class _UsbCandidateStatus:
-    interface_name: str
-    state: str
-    connection_name: str | None
-    driver: str | None
-    carrier_on: bool | None
-    ipv4_addresses: tuple[str, ...]
-    gateway: str | None
-    has_default_route: bool
-    diagnostic: str
-
-    @property
-    def usable(self) -> bool:
-        return self.state == "connected" and bool(self.ipv4_addresses) and self.has_default_route
-
-
-def _safe_resolve(path: Path) -> Path | None:
-    try:
-        return path.resolve()
-    except OSError:
-        return None
-
-
-def _driver_name(interface_name: str, *, sys_class_net: Path = _SYS_CLASS_NET) -> str | None:
-    driver_link = sys_class_net / interface_name / "device" / "driver"
-    resolved = _safe_resolve(driver_link)
-    return resolved.name if resolved is not None else None
-
-
-def _carrier_on(interface_name: str, *, sys_class_net: Path = _SYS_CLASS_NET) -> bool | None:
-    carrier_path = sys_class_net / interface_name / "carrier"
-    try:
-        raw_value = carrier_path.read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    if raw_value == "1":
-        return True
-    if raw_value == "0":
-        return False
-    return None
-
-
-def _is_usb_backed_interface(interface_name: str, *, sys_class_net: Path = _SYS_CLASS_NET) -> bool:
-    device_dir = sys_class_net / interface_name / "device"
-    resolved = _safe_resolve(device_dir)
-    if resolved is None:
-        return False
-    resolved_text = str(resolved)
-    if "/usb" in resolved_text:
-        return True
-    driver = _driver_name(interface_name, sys_class_net=sys_class_net)
-    return driver in _USB_NETWORK_DRIVERS
-
-
-def _candidate_interfaces(*, sys_class_net: Path = _SYS_CLASS_NET) -> tuple[str, ...]:
-    if not sys_class_net.is_dir():
-        return ()
-    candidates = [
-        entry.name
-        for entry in sorted(sys_class_net.iterdir(), key=lambda item: item.name)
-        if (
-            entry.is_dir()
-            and entry.name != "lo"
-            and _is_usb_backed_interface(entry.name, sys_class_net=sys_class_net)
-        )
-    ]
-    return tuple(candidates)
-
-
-def parse_nmcli_device_status(stdout: str) -> dict[str, _NmcliDeviceStatus]:
-    statuses: dict[str, _NmcliDeviceStatus] = {}
-    for raw_line in stdout.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        parts = line.split(":", 3)
-        if len(parts) != 4:
-            continue
-        interface_name, device_type, state, connection_name = parts
-        normalized_connection = (
-            connection_name if connection_name and connection_name != "--" else None
-        )
-        statuses[interface_name] = _NmcliDeviceStatus(
-            interface_name=interface_name,
-            device_type=device_type,
-            state=state,
-            connection_name=normalized_connection,
-        )
-    return statuses
-
-
-def _parse_ipv4_addresses(stdout: str) -> tuple[str, ...]:
-    addresses: list[str] = []
-    for raw_line in stdout.splitlines():
-        parts = raw_line.split()
-        if "inet" not in parts:
-            continue
-        try:
-            inet_index = parts.index("inet")
-        except ValueError:
-            continue
-        address_index = inet_index + 1
-        if address_index < len(parts):
-            addresses.append(parts[address_index])
-    return tuple(addresses)
-
-
-def _parse_default_route(stdout: str) -> tuple[bool, str | None]:
-    for raw_line in stdout.splitlines():
-        line = raw_line.strip()
-        if not line or not line.startswith("default"):
-            continue
-        parts = line.split()
-        gateway: str | None = None
-        if "via" in parts:
-            via_index = parts.index("via")
-            if via_index + 1 < len(parts):
-                gateway = parts[via_index + 1]
-        return True, gateway
-    return False, None
-
-
-def _candidate_rank(candidate: _UsbCandidateStatus) -> tuple[int, int, int]:
-    return (
-        2 if candidate.usable else 0,
-        1 if candidate.state == "connected" else 0,
-        1 if candidate.driver == "ipheth" else 0,
-    )
-
-
-def _candidate_diagnostic(
-    interface_name: str,
-    *,
-    state: str,
-    carrier_on: bool | None,
-    nmcli_error: str,
-    addr_error: str,
-    route_error: str,
-    ipv4_addresses: tuple[str, ...],
-    has_default_route: bool,
-) -> str:
-    if nmcli_error:
-        return f"Could not query NetworkManager device status ({nmcli_error})."
-    if state != "connected":
-        if carrier_on is False:
-            return (
-                f"USB interface '{interface_name}' is detected, but link carrier is off. "
-                "Enable USB tethering/personal hotspot and trust this Pi on the phone."
-            )
-        return (
-            f"USB interface '{interface_name}' is detected, but NetworkManager reports "
-            f"state '{state or 'unknown'}'."
-        )
-    if addr_error:
-        return (
-            f"USB interface '{interface_name}' is connected, but IPv4 status "
-            f"could not be read ({addr_error})."
-        )
-    if not ipv4_addresses:
-        return (
-            f"USB interface '{interface_name}' is connected, but no IPv4 address is assigned yet."
-        )
-    if route_error:
-        return (
-            f"USB interface '{interface_name}' is connected, but route status "
-            f"could not be read ({route_error})."
-        )
-    if not has_default_route:
-        return (
-            f"USB interface '{interface_name}' is connected, but no default IPv4 route is active."
-        )
-    return f"USB internet is ready on '{interface_name}'."
-
-
-def _status_from_candidate(
-    candidate: _UsbCandidateStatus,
-    *,
-    diagnostic: str | None = None,
-) -> UsbInternetStatus:
-    return UsbInternetStatus(
-        detected=True,
-        usable=candidate.usable,
-        interface_name=candidate.interface_name,
-        connection_name=candidate.connection_name,
-        driver=candidate.driver,
-        ipv4_addresses=candidate.ipv4_addresses,
-        gateway=candidate.gateway,
-        has_default_route=candidate.has_default_route,
-        diagnostic=diagnostic if diagnostic is not None else candidate.diagnostic,
-    )
-
-
 class UsbInternetStatusService:
     """Inspect live Linux/NM state to determine whether USB internet is available."""
 
-    __slots__ = ("_runner", "_sys_class_net")
+    __slots__ = ("_inspector", "_runner")
 
     def __init__(
         self,
         *,
         runner: CommandRunner | None = None,
-        sys_class_net: Path = _SYS_CLASS_NET,
+        sys_class_net: Path = DEFAULT_SYS_CLASS_NET,
     ) -> None:
-        self._runner = runner or CommandRunner()
-        self._sys_class_net = sys_class_net
-
-    async def _collect_candidate_statuses(self) -> list[_UsbCandidateStatus]:
-        candidates = _candidate_interfaces(sys_class_net=self._sys_class_net)
-        if not candidates:
-            return []
-
-        nmcli_error = ""
-        rc, stdout, stderr = await self._runner.run(
-            ["nmcli", "-t", "-f", "DEVICE,TYPE,STATE,CONNECTION", "device", "status"],
-            timeout=10,
-        )
-        device_status = parse_nmcli_device_status(stdout) if rc == 0 else {}
-        if rc != 0:
-            nmcli_error = (stderr or stdout or f"exit {rc}").strip()
-
-        candidate_statuses: list[_UsbCandidateStatus] = []
-        for interface_name in candidates:
-            row = device_status.get(interface_name)
-            state = row.state if row is not None else "unknown"
-            connection_name = row.connection_name if row is not None else None
-            driver = _driver_name(interface_name, sys_class_net=self._sys_class_net)
-            carrier_on = _carrier_on(interface_name, sys_class_net=self._sys_class_net)
-
-            addr_rc, addr_stdout, addr_stderr = await self._runner.run(
-                ["ip", "-4", "-o", "addr", "show", "dev", interface_name, "scope", "global"],
-                timeout=10,
-            )
-            ipv4_addresses = _parse_ipv4_addresses(addr_stdout) if addr_rc == 0 else ()
-            addr_error = (
-                "" if addr_rc == 0 else (addr_stderr or addr_stdout or f"exit {addr_rc}").strip()
-            )
-
-            route_rc, route_stdout, route_stderr = await self._runner.run(
-                ["ip", "-4", "route", "show", "default", "dev", interface_name],
-                timeout=10,
-            )
-            has_default_route, gateway = (
-                _parse_default_route(route_stdout) if route_rc == 0 else (False, None)
-            )
-            route_error = (
-                ""
-                if route_rc == 0
-                else (route_stderr or route_stdout or f"exit {route_rc}").strip()
-            )
-
-            candidate_statuses.append(
-                _UsbCandidateStatus(
-                    interface_name=interface_name,
-                    state=state,
-                    connection_name=connection_name,
-                    driver=driver,
-                    carrier_on=carrier_on,
-                    ipv4_addresses=ipv4_addresses,
-                    gateway=gateway,
-                    has_default_route=has_default_route,
-                    diagnostic=_candidate_diagnostic(
-                        interface_name,
-                        state=state,
-                        carrier_on=carrier_on,
-                        nmcli_error=nmcli_error,
-                        addr_error=addr_error,
-                        route_error=route_error,
-                        ipv4_addresses=ipv4_addresses,
-                        has_default_route=has_default_route,
-                    ),
-                )
-            )
-
-        return candidate_statuses
-
-    @staticmethod
-    def _should_attempt_activation(candidate: _UsbCandidateStatus) -> bool:
-        return (
-            not candidate.usable
-            and candidate.state in _USB_ACTIVATION_STATES
-            and candidate.carrier_on is not False
+        command_runner = runner or CommandRunner()
+        self._runner = command_runner
+        self._inspector = UsbInternetStatusInspector(
+            runner=command_runner,
+            sys_class_net=sys_class_net,
         )
 
     async def _activate_interface(self, interface_name: str) -> str:
@@ -334,7 +65,7 @@ class UsbInternetStatusService:
         return (stderr or stdout or f"exit {rc}").strip()
 
     async def snapshot(self, *, activate: bool = False) -> UsbInternetStatus:
-        candidate_statuses = await self._collect_candidate_statuses()
+        candidate_statuses = await self._inspector.collect_candidates()
         if not candidate_statuses:
             return UsbInternetStatus(
                 detected=False,
@@ -342,22 +73,24 @@ class UsbInternetStatusService:
                 diagnostic="No USB network interface is currently detected.",
             )
 
-        best = max(candidate_statuses, key=_candidate_rank)
-        if not activate or not self._should_attempt_activation(best):
-            return _status_from_candidate(best)
+        best = select_best_candidate(candidate_statuses)
+        if not activate or not should_attempt_activation(best):
+            return status_from_candidate(best)
 
         activation_error = await self._activate_interface(best.interface_name)
-        candidate_statuses = await self._collect_candidate_statuses()
+        candidate_statuses = await self._inspector.collect_candidates()
         if not candidate_statuses:
             diagnostic = "USB network interface disappeared while attempting activation."
             if activation_error:
                 diagnostic = f"{diagnostic} Auto-activation failed ({activation_error})."
             return UsbInternetStatus(detected=False, usable=False, diagnostic=diagnostic)
 
-        best = max(candidate_statuses, key=_candidate_rank)
+        best = select_best_candidate(candidate_statuses)
         if activation_error and not best.usable:
-            return _status_from_candidate(
+            return status_from_candidate(
                 best,
-                diagnostic=f"{best.diagnostic} Auto-activation failed ({activation_error}).",
+                diagnostic=(
+                    f"{candidate_diagnostic(best)} Auto-activation failed ({activation_error})."
+                ),
             )
-        return _status_from_candidate(best)
+        return status_from_candidate(best)

--- a/apps/server/vibesensor/use_cases/updates/usb_status_evaluation.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_status_evaluation.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from vibesensor.use_cases.updates.models import UsbInternetStatus
+
+from .usb_status_inspection import UsbCandidateObservation
+
+_USB_ACTIVATION_STATES = frozenset({"disconnected", "unavailable", "unknown"})
+
+__all__ = [
+    "candidate_diagnostic",
+    "select_best_candidate",
+    "should_attempt_activation",
+    "status_from_candidate",
+]
+
+
+def _candidate_rank(candidate: UsbCandidateObservation) -> tuple[int, int, int]:
+    return (
+        2 if candidate.usable else 0,
+        1 if candidate.state == "connected" else 0,
+        1 if candidate.driver == "ipheth" else 0,
+    )
+
+
+def select_best_candidate(
+    candidates: list[UsbCandidateObservation],
+) -> UsbCandidateObservation:
+    return max(candidates, key=_candidate_rank)
+
+
+def candidate_diagnostic(candidate: UsbCandidateObservation) -> str:
+    if candidate.nmcli_error:
+        return f"Could not query NetworkManager device status ({candidate.nmcli_error})."
+    if candidate.state != "connected":
+        if candidate.carrier_on is False:
+            return (
+                f"USB interface '{candidate.interface_name}' is detected, but link carrier is off. "
+                "Enable USB tethering/personal hotspot and trust this Pi on the phone."
+            )
+        return (
+            f"USB interface '{candidate.interface_name}' is detected, but NetworkManager reports "
+            f"state '{candidate.state or 'unknown'}'."
+        )
+    if candidate.addr_error:
+        return (
+            f"USB interface '{candidate.interface_name}' is connected, but IPv4 status "
+            f"could not be read ({candidate.addr_error})."
+        )
+    if not candidate.ipv4_addresses:
+        return (
+            f"USB interface '{candidate.interface_name}' is connected, "
+            "but no IPv4 address is assigned yet."
+        )
+    if candidate.route_error:
+        return (
+            f"USB interface '{candidate.interface_name}' is connected, but route status "
+            f"could not be read ({candidate.route_error})."
+        )
+    if not candidate.has_default_route:
+        return (
+            f"USB interface '{candidate.interface_name}' is connected, "
+            "but no default IPv4 route is active."
+        )
+    return f"USB internet is ready on '{candidate.interface_name}'."
+
+
+def should_attempt_activation(candidate: UsbCandidateObservation) -> bool:
+    return (
+        not candidate.usable
+        and candidate.state in _USB_ACTIVATION_STATES
+        and candidate.carrier_on is not False
+    )
+
+
+def status_from_candidate(
+    candidate: UsbCandidateObservation,
+    *,
+    diagnostic: str | None = None,
+) -> UsbInternetStatus:
+    return UsbInternetStatus(
+        detected=True,
+        usable=candidate.usable,
+        interface_name=candidate.interface_name,
+        connection_name=candidate.connection_name,
+        driver=candidate.driver,
+        ipv4_addresses=candidate.ipv4_addresses,
+        gateway=candidate.gateway,
+        has_default_route=candidate.has_default_route,
+        diagnostic=diagnostic if diagnostic is not None else candidate_diagnostic(candidate),
+    )

--- a/apps/server/vibesensor/use_cases/updates/usb_status_inspection.py
+++ b/apps/server/vibesensor/use_cases/updates/usb_status_inspection.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from vibesensor.use_cases.updates.runner import CommandRunner
+
+DEFAULT_SYS_CLASS_NET = Path("/sys/class/net")
+_USB_NETWORK_DRIVERS = frozenset({"cdc_ether", "cdc_ncm", "ipheth", "rndis_host"})
+
+__all__ = [
+    "DEFAULT_SYS_CLASS_NET",
+    "NmcliDeviceStatus",
+    "UsbCandidateObservation",
+    "UsbInternetStatusInspector",
+    "parse_nmcli_device_status",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class NmcliDeviceStatus:
+    interface_name: str
+    device_type: str
+    state: str
+    connection_name: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class UsbCandidateObservation:
+    interface_name: str
+    state: str
+    connection_name: str | None
+    driver: str | None
+    carrier_on: bool | None
+    ipv4_addresses: tuple[str, ...]
+    gateway: str | None
+    has_default_route: bool
+    nmcli_error: str
+    addr_error: str
+    route_error: str
+
+    @property
+    def usable(self) -> bool:
+        return self.state == "connected" and bool(self.ipv4_addresses) and self.has_default_route
+
+
+def _safe_resolve(path: Path) -> Path | None:
+    try:
+        return path.resolve()
+    except OSError:
+        return None
+
+
+def _driver_name(interface_name: str, *, sys_class_net: Path = DEFAULT_SYS_CLASS_NET) -> str | None:
+    driver_link = sys_class_net / interface_name / "device" / "driver"
+    resolved = _safe_resolve(driver_link)
+    return resolved.name if resolved is not None else None
+
+
+def _carrier_on(interface_name: str, *, sys_class_net: Path = DEFAULT_SYS_CLASS_NET) -> bool | None:
+    carrier_path = sys_class_net / interface_name / "carrier"
+    try:
+        raw_value = carrier_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if raw_value == "1":
+        return True
+    if raw_value == "0":
+        return False
+    return None
+
+
+def _is_usb_backed_interface(
+    interface_name: str,
+    *,
+    sys_class_net: Path = DEFAULT_SYS_CLASS_NET,
+) -> bool:
+    device_dir = sys_class_net / interface_name / "device"
+    resolved = _safe_resolve(device_dir)
+    if resolved is None:
+        return False
+    if "/usb" in str(resolved):
+        return True
+    driver = _driver_name(interface_name, sys_class_net=sys_class_net)
+    return driver in _USB_NETWORK_DRIVERS
+
+
+def _candidate_interfaces(*, sys_class_net: Path = DEFAULT_SYS_CLASS_NET) -> tuple[str, ...]:
+    if not sys_class_net.is_dir():
+        return ()
+    candidates = [
+        entry.name
+        for entry in sorted(sys_class_net.iterdir(), key=lambda item: item.name)
+        if (
+            entry.is_dir()
+            and entry.name != "lo"
+            and _is_usb_backed_interface(entry.name, sys_class_net=sys_class_net)
+        )
+    ]
+    return tuple(candidates)
+
+
+def parse_nmcli_device_status(stdout: str) -> dict[str, NmcliDeviceStatus]:
+    statuses: dict[str, NmcliDeviceStatus] = {}
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(":", 3)
+        if len(parts) != 4:
+            continue
+        interface_name, device_type, state, connection_name = parts
+        normalized_connection = (
+            connection_name if connection_name and connection_name != "--" else None
+        )
+        statuses[interface_name] = NmcliDeviceStatus(
+            interface_name=interface_name,
+            device_type=device_type,
+            state=state,
+            connection_name=normalized_connection,
+        )
+    return statuses
+
+
+def _parse_ipv4_addresses(stdout: str) -> tuple[str, ...]:
+    addresses: list[str] = []
+    for raw_line in stdout.splitlines():
+        parts = raw_line.split()
+        if "inet" not in parts:
+            continue
+        try:
+            inet_index = parts.index("inet")
+        except ValueError:
+            continue
+        address_index = inet_index + 1
+        if address_index < len(parts):
+            addresses.append(parts[address_index])
+    return tuple(addresses)
+
+
+def _parse_default_route(stdout: str) -> tuple[bool, str | None]:
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line or not line.startswith("default"):
+            continue
+        parts = line.split()
+        gateway: str | None = None
+        if "via" in parts:
+            via_index = parts.index("via")
+            if via_index + 1 < len(parts):
+                gateway = parts[via_index + 1]
+        return True, gateway
+    return False, None
+
+
+class UsbInternetStatusInspector:
+    """Collect raw Linux and NetworkManager observations for USB tethering."""
+
+    __slots__ = ("_runner", "_sys_class_net")
+
+    def __init__(
+        self,
+        *,
+        runner: CommandRunner,
+        sys_class_net: Path = DEFAULT_SYS_CLASS_NET,
+    ) -> None:
+        self._runner = runner
+        self._sys_class_net = sys_class_net
+
+    async def collect_candidates(self) -> list[UsbCandidateObservation]:
+        candidates = _candidate_interfaces(sys_class_net=self._sys_class_net)
+        if not candidates:
+            return []
+
+        nmcli_error = ""
+        rc, stdout, stderr = await self._runner.run(
+            ["nmcli", "-t", "-f", "DEVICE,TYPE,STATE,CONNECTION", "device", "status"],
+            timeout=10,
+        )
+        device_status = parse_nmcli_device_status(stdout) if rc == 0 else {}
+        if rc != 0:
+            nmcli_error = (stderr or stdout or f"exit {rc}").strip()
+
+        observations: list[UsbCandidateObservation] = []
+        for interface_name in candidates:
+            row = device_status.get(interface_name)
+            state = row.state if row is not None else "unknown"
+            connection_name = row.connection_name if row is not None else None
+            driver = _driver_name(interface_name, sys_class_net=self._sys_class_net)
+            carrier_on = _carrier_on(interface_name, sys_class_net=self._sys_class_net)
+
+            addr_rc, addr_stdout, addr_stderr = await self._runner.run(
+                ["ip", "-4", "-o", "addr", "show", "dev", interface_name, "scope", "global"],
+                timeout=10,
+            )
+            ipv4_addresses = _parse_ipv4_addresses(addr_stdout) if addr_rc == 0 else ()
+            addr_error = (
+                "" if addr_rc == 0 else (addr_stderr or addr_stdout or f"exit {addr_rc}").strip()
+            )
+
+            route_rc, route_stdout, route_stderr = await self._runner.run(
+                ["ip", "-4", "route", "show", "default", "dev", interface_name],
+                timeout=10,
+            )
+            has_default_route, gateway = (
+                _parse_default_route(route_stdout) if route_rc == 0 else (False, None)
+            )
+            route_error = (
+                ""
+                if route_rc == 0
+                else (route_stderr or route_stdout or f"exit {route_rc}").strip()
+            )
+
+            observations.append(
+                UsbCandidateObservation(
+                    interface_name=interface_name,
+                    state=state,
+                    connection_name=connection_name,
+                    driver=driver,
+                    carrier_on=carrier_on,
+                    ipv4_addresses=ipv4_addresses,
+                    gateway=gateway,
+                    has_default_route=has_default_route,
+                    nmcli_error=nmcli_error,
+                    addr_error=addr_error,
+                    route_error=route_error,
+                )
+            )
+
+        return observations

--- a/apps/server/vibesensor/use_cases/updates/validation.py
+++ b/apps/server/vibesensor/use_cases/updates/validation.py
@@ -23,12 +23,10 @@ MIN_FREE_DISK_BYTES = 200 * 1024 * 1024
 
 
 def _fail_validation(
-    status: UpdateStatusTracker,
     message: str,
     detail: str = "",
 ) -> UpdatePreparationError:
-    status.fail("validating", message, detail)
-    return UpdatePreparationError(message)
+    return UpdatePreparationError(message, phase="validating", detail=detail)
 
 
 def _probe_rollback_dir(rollback_dir: Path) -> None:
@@ -72,7 +70,7 @@ async def validate_prerequisites(
         status.log("Starting update using existing USB internet")
     for tool in ("nmcli", "python3"):
         if not shutil.which(tool):
-            raise _fail_validation(status, f"Required tool not found: {tool}")
+            raise _fail_validation(f"Required tool not found: {tool}")
 
     if os.geteuid() != 0:
         result = await commands.run(
@@ -83,7 +81,6 @@ async def validate_prerequisites(
         )
         if result.returncode != 0:
             raise _fail_validation(
-                status,
                 "Insufficient privileges",
                 (
                     "Cannot run updater privileged commands non-interactively. "
@@ -95,7 +92,6 @@ async def validate_prerequisites(
         _probe_rollback_dir(config.rollback_dir)
     except OSError as exc:
         raise _fail_validation(
-            status,
             "Rollback directory is not writable",
             f"{config.rollback_dir}: {exc}",
         ) from exc
@@ -107,12 +103,10 @@ async def validate_prerequisites(
             free_mb = free_bytes // (1024 * 1024)
             min_mb = config.min_free_disk_bytes // (1024 * 1024)
             raise _fail_validation(
-                status,
                 f"Insufficient disk space: {free_mb} MiB free, {min_mb} MiB required",
             )
     except OSError as exc:
         raise _fail_validation(
-            status,
             "Could not verify free disk space",
             str(exc),
         ) from exc

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
@@ -13,7 +13,6 @@ from vibesensor.use_cases.updates.models import (
 )
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.transport.failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.transport.uplink_readiness import UpdateUplinkReadiness
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 from vibesensor.use_cases.updates.wifi.wifi_diagnostics import parse_wifi_diagnostics
@@ -103,22 +102,18 @@ class UpdateWifiSession:
         )
         await self._dns_readiness.wait_for_dns_ready()
 
-    def _record_transport_failure(self, exc: UpdateTransportStepError) -> None:
-        self._status.fail(exc.phase, str(exc), exc.detail)
-
     async def prepare(self, request: UpdateRequest) -> UpdateWifiSession:
         """Prepare the updater's Wi-Fi transport before release work begins."""
 
         self._status.transition(UpdatePhase.stopping_hotspot)
         if not await self._stop_hotspot():
-            raise UpdateTransportError("Failed to stop the hotspot before Wi-Fi update setup")
+            raise UpdateTransportError(
+                "Failed to stop the hotspot before Wi-Fi update setup",
+                phase=UpdatePhase.stopping_hotspot.value,
+            )
         self._status.transition(UpdatePhase.connecting_wifi)
         assert request.ssid is not None  # noqa: S101
-        try:
-            await self._connect_uplink(request.ssid, request.password)
-        except UpdateTransportStepError as exc:
-            self._record_transport_failure(exc)
-            raise UpdateTransportError("Failed to prepare the Wi-Fi uplink for update") from exc
+        await self._connect_uplink(request.ssid, request.password)
         return self
 
     async def abort_preparation(self) -> None:
@@ -142,19 +137,17 @@ class UpdateWifiSession:
             failure_message="Failed to restore hotspot after interrupted update",
         )
 
-    async def complete_success(self, message: str) -> None:
+    async def complete_success(self) -> None:
         """Restore the hotspot and then finalize the Wi-Fi update as successful."""
 
         self._status.transition(UpdatePhase.restoring_hotspot)
         self._status.log("Restoring hotspot...")
         restored = await self._restore_hotspot()
         if not restored:
-            self._status.fail(
-                UpdatePhase.restoring_hotspot.value,
+            raise UpdateTransportError(
                 "Failed to restore hotspot after update",
+                phase=UpdatePhase.restoring_hotspot.value,
             )
-            raise UpdateTransportError("Failed to restore hotspot after update")
-        self._status.mark_success(message)
 
     async def cleanup_after_update(self) -> None:
         """Restore hotspot ownership and attach cleanup diagnostics after a run."""

--- a/apps/server/vibesensor/use_cases/updates/workflow_executor.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_executor.py
@@ -15,7 +15,6 @@ from vibesensor.use_cases.updates.run_models import (
     PlannedUpdateRun,
     RefreshFirmwarePlan,
 )
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
 __all__ = ["UpdateWorkflowExecutor"]
 
@@ -23,13 +22,7 @@ __all__ = ["UpdateWorkflowExecutor"]
 class UpdateWorkflowExecutor:
     """Execute a prepared release plan while delegating side effects to focused collaborators."""
 
-    __slots__ = (
-        "_completion",
-        "_deployment",
-        "_firmware_refresher",
-        "_stager",
-        "_status",
-    )
+    __slots__ = ("_completion", "_deployment", "_firmware_refresher", "_stager")
 
     def __init__(
         self,
@@ -38,13 +31,11 @@ class UpdateWorkflowExecutor:
         stager: ServerReleaseStager,
         deployment: UpdateReleaseDeploymentCoordinator,
         firmware_refresher: FirmwareRefresher,
-        status: UpdateStatusTracker,
     ) -> None:
         self._completion = completion
         self._stager = stager
         self._deployment = deployment
         self._firmware_refresher = firmware_refresher
-        self._status = status
 
     async def execute(
         self,
@@ -71,13 +62,12 @@ class UpdateWorkflowExecutor:
             pinned_tag=plan.latest_tag,
         )
         if not refresh_result.succeeded:
-            self._status.fail(
-                refresh_result.phase,
+            raise UpdateReleaseError(
                 refresh_result.message,
-                refresh_result.detail,
+                phase=refresh_result.phase,
+                detail=refresh_result.detail,
                 log_message="ESP firmware refresh failed; refresh-only update did not complete",
             )
-            raise UpdateReleaseError(refresh_result.message)
         await self._completion.complete_success(
             workflow.prepared.prepared_transport,
             message="No server update needed; ESP firmware checked",

--- a/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
@@ -43,12 +43,12 @@ def build_update_workflow(
         workflow_executor=UpdateWorkflowExecutor(
             completion=UpdateCompletionCoordinator(
                 restart_scheduler=release.restart_scheduler,
+                reporter=core.reporter,
                 status=core.status,
             ),
             stager=release.stager,
             deployment=release.deployment,
             firmware_refresher=release.firmware_refresher,
-            status=core.status,
         ),
         finalizer=UpdateWorkflowFinalizer(
             transport_coordinator=transport.coordinator,


### PR DESCRIPTION
## Summary
- centralize updater terminal-state reporting around explicit update errors and a dedicated reporter
- split server release fetching into focused config/model, shared GitHub API, version policy, fetcher, and CLI modules while switching firmware fetching to composition
- split USB internet readiness into raw inspection, evaluation/diagnostic, and thin service-facade modules

## Validation
- make lint
- make typecheck-backend
- pytest -q apps/server/tests/use_cases/updates apps/server/tests/adapters/http/test_update_endpoints.py apps/server/tests/integration/test_multi_domain_regressions.py apps/server/tests/integration/test_refactor_contract_regressions.py apps/server/tests/hygiene/test_ai_smoke.py