### PR TITLE
Refactor updater release boundaries

### DIFF
--- a/apps/server/tests/integration/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/integration/test_io_and_time_guard_regressions.py
@@ -2,7 +2,7 @@
 
 Covers:
   1. firmware_cache.refresh() – target/old_current initialised before try
-  2. firmware_release_fetcher._download_asset() – fd leak guard when os.fdopen fails
+2. shared updater asset download – fd leak guard when os.fdopen fails
   3. gps_speed.resolve_speed() – TOCTOU snapshot of speed_mps
   4. gps_speed._is_gps_stale() – TOCTOU snapshot of last_update_ts
   5. report_cli.main() – PDF generation errors return 1 instead of traceback
@@ -85,7 +85,7 @@ class TestFirmwareCacheRefreshUnboundGuard:
 
 
 # ------------------------------------------------------------------
-# 2. firmware_release_fetcher._download_asset() – fd leak guard
+# 2. shared updater asset download – fd leak guard
 # ------------------------------------------------------------------
 
 
@@ -106,7 +106,7 @@ class TestDownloadAssetFdLeakGuard:
 
         with (
             patch(
-                "vibesensor.use_cases.updates.firmware.firmware_release_fetcher.urlopen",
+                "vibesensor.use_cases.updates.asset_download.urlopen",
                 return_value=fake_resp,
             ),
             patch("os.fdopen", side_effect=OSError("mock fdopen failure")),

--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -148,7 +148,7 @@ class TestFirmwareCacheStreamingDownload:
         mock_resp.__exit__ = lambda s, *a: None
 
         with patch(
-            "vibesensor.use_cases.updates.firmware.firmware_release_fetcher.urlopen",
+            "vibesensor.use_cases.updates.asset_download.urlopen",
             return_value=mock_resp,
         ):
             fetcher._download_asset("https://example.com/fw.bin", dest)

--- a/apps/server/vibesensor/use_cases/updates/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/__init__.py
@@ -8,8 +8,10 @@ The updater now has one explicit run-scoped workflow boundary per concern:
   manager instance.
 - ``runtime_config.py`` owns runtime config resolution.
 - ``runtime_core.py`` owns status-tracker and command-executor assembly.
-- ``release_runtime.py`` owns release-specific runtime assembly.
-- ``workflow_runtime.py`` owns workflow assembly from the focused runtime bundles.
+- ``release_planning_runtime.py`` owns release-planner assembly.
+- ``release_execution_runtime.py`` owns release-execution assembly.
+- ``workflow_runtime.py`` owns workflow assembly from the focused planning,
+  execution, transport, and core collaborators.
 - ``run_models.py`` holds the canonical prepared/planned run models shared
   across the workflow.
 - ``workflow.py`` owns request-scoped orchestration across preparation,

--- a/apps/server/vibesensor/use_cases/updates/asset_download.py
+++ b/apps/server/vibesensor/use_cases/updates/asset_download.py
@@ -1,0 +1,58 @@
+"""Common streaming asset download helpers for updater release fetchers."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+from typing import Protocol
+from urllib.request import Request, urlopen
+
+__all__ = ["download_release_asset"]
+
+
+class GitHubAssetRequestBuilder(Protocol):
+    def build_request(self, url: str, *, accept: str = "") -> Request: ...
+
+
+def download_release_asset(
+    *,
+    client: GitHubAssetRequestBuilder,
+    url: str,
+    dest: Path,
+    timeout_s: float,
+    max_bytes: int,
+    chunk_size: int,
+    size_limit_message: str,
+    temp_suffix: str = ".dl_tmp",
+) -> None:
+    """Stream a GitHub release asset to *dest* with temp-file cleanup and a size bound."""
+
+    req = client.build_request(url, accept="application/octet-stream")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with urlopen(req, timeout=timeout_s) as resp:
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), suffix=temp_suffix)
+        fdopen_ok = False
+        downloaded = False
+        try:
+            total = 0
+            with os.fdopen(tmp_fd, "wb") as tmp_f:
+                fdopen_ok = True
+                while True:
+                    chunk = resp.read(chunk_size)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise ValueError(size_limit_message)
+                    tmp_f.write(chunk)
+            Path(tmp_path).replace(dest)
+            downloaded = True
+        finally:
+            if not fdopen_ok:
+                with contextlib.suppress(OSError):
+                    os.close(tmp_fd)
+            if not downloaded:
+                with contextlib.suppress(OSError):
+                    Path(tmp_path).unlink()

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_fetcher.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
-import os
-import tempfile
 from pathlib import Path
-from urllib.request import urlopen
 
-from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
+from vibesensor.use_cases.updates.asset_download import download_release_asset
+from vibesensor.use_cases.updates.firmware.firmware_release_selection import (
+    find_firmware_asset,
+    is_firmware_asset_name,
+    require_release_payload,
+    select_firmware_release,
+)
 from vibesensor.use_cases.updates.firmware.firmware_types import (
     FirmwareCacheConfig,
     GitHubReleaseAssetPayload,
@@ -30,47 +32,6 @@ __all__ = [
 ]
 
 _MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024  # 100 MB hard limit for firmware assets
-_FW_ASSET_PREFIX = "vibesensor-fw-"
-_FW_ASSET_SUFFIX = ".zip"
-
-
-def _coerce_release_asset_payload(raw: JsonObject) -> GitHubReleaseAssetPayload:
-    """Project a raw GitHub asset JSON object into the updater payload shape."""
-
-    payload: GitHubReleaseAssetPayload = {}
-    name = raw.get("name")
-    url = raw.get("url")
-    if isinstance(name, str):
-        payload["name"] = name
-    if isinstance(url, str):
-        payload["url"] = url
-    return payload
-
-
-def _coerce_release_payload(raw: JsonObject) -> GitHubReleasePayload:
-    """Project a raw GitHub release JSON object into the updater payload shape."""
-
-    payload: GitHubReleasePayload = {}
-    tag_name = raw.get("tag_name")
-    if isinstance(tag_name, str):
-        payload["tag_name"] = tag_name
-    draft = raw.get("draft")
-    if isinstance(draft, bool):
-        payload["draft"] = draft
-    prerelease = raw.get("prerelease")
-    if isinstance(prerelease, bool):
-        payload["prerelease"] = prerelease
-    assets = raw.get("assets")
-    if is_json_array(assets):
-        payload["assets"] = [
-            _coerce_release_asset_payload(asset) for asset in assets if is_json_object(asset)
-        ]
-    return payload
-
-
-def is_firmware_asset_name(name: str) -> bool:
-    """Return True if *name* matches the firmware bundle naming convention."""
-    return name.startswith(_FW_ASSET_PREFIX) and name.endswith(_FW_ASSET_SUFFIX)
 
 
 class GitHubReleaseFetcher:
@@ -91,37 +52,18 @@ class GitHubReleaseFetcher:
         )
 
     def _download_asset(self, url: str, dest: Path) -> None:
-        req = self._client.build_request(url, accept="application/octet-stream")
-        with urlopen(req, timeout=120) as resp:
-            # Stream directly to a temp file to avoid buffering the entire
-            # firmware binary in memory (Pi 3A+ has only 512 MB RAM).
-            tmp_fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), suffix=".dl_tmp")
-            fdopen_ok = False
-            downloaded = False
-            try:
-                total = 0
-                with os.fdopen(tmp_fd, "wb") as tmp_f:
-                    fdopen_ok = True
-                    while True:
-                        chunk = resp.read(DOWNLOAD_CHUNK_BYTES)
-                        if not chunk:
-                            break
-                        total += len(chunk)
-                        if total > _MAX_DOWNLOAD_BYTES:
-                            raise ValueError(
-                                f"Firmware asset exceeds {_MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB "
-                                f"size limit; aborting download to prevent OOM.",
-                            )
-                        tmp_f.write(chunk)
-                Path(tmp_path).replace(dest)
-                downloaded = True
-            finally:
-                if not fdopen_ok:
-                    with contextlib.suppress(OSError):
-                        os.close(tmp_fd)
-                if not downloaded:
-                    with contextlib.suppress(OSError):
-                        Path(tmp_path).unlink()
+        download_release_asset(
+            client=self._client,
+            url=url,
+            dest=dest,
+            timeout_s=120,
+            max_bytes=_MAX_DOWNLOAD_BYTES,
+            chunk_size=DOWNLOAD_CHUNK_BYTES,
+            size_limit_message=(
+                f"Firmware asset exceeds {_MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB "
+                "size limit; aborting download to prevent OOM."
+            ),
+        )
 
     def find_release(self) -> GitHubReleasePayload:
         """Find the target release based on config (pinned tag, channel)."""
@@ -131,64 +73,18 @@ class GitHubReleaseFetcher:
         if self._config.pinned_tag:
             url = f"{base}/tags/{self._config.pinned_tag}"
             LOGGER.info("Fetching pinned release: %s", self._config.pinned_tag)
-            release = self._client.get_json(url)
-            if not is_json_object(release):
-                raise ValueError("Unexpected GitHub API response format")
-            return _coerce_release_payload(release)
+            return require_release_payload(self._client.get_json(url))
 
         LOGGER.info("Fetching releases for channel '%s'", self._config.channel)
-        releases = self._client.get_json(f"{base}?per_page=50")
-        if not isinstance(releases, list):
-            raise ValueError("Unexpected GitHub API response format")
-
-        for release in releases:
-            if not is_json_object(release):
-                continue
-            is_prerelease = release.get("prerelease", False)
-            is_draft = release.get("draft", False)
-            if is_draft:
-                continue
-            release_payload = _coerce_release_payload(release)
-            if not self._release_has_firmware_asset(release_payload):
-                continue
-            if self._config.channel == "stable" and not is_prerelease:
-                return release_payload
-            if self._config.channel in ("prerelease", "edge") and is_prerelease:
-                return release_payload
-
-        # Fallback: use the latest prerelease (firmware releases are typically prereleases)
-        for release in releases:
-            if not is_json_object(release):
-                continue
-            if release.get("draft", False):
-                continue
-            release_payload = _coerce_release_payload(release)
-            if not self._release_has_firmware_asset(release_payload):
-                continue
-            return release_payload
-
-        raise ValueError(
-            f"No eligible firmware release found for channel '{self._config.channel}' "
-            f"in {self._config.firmware_repo}",
-        )
-
-    @staticmethod
-    def _release_has_firmware_asset(release: GitHubReleasePayload) -> bool:
-        """Return whether the release exposes at least one firmware bundle asset."""
-
-        return any(
-            is_firmware_asset_name(str(a.get("name", ""))) for a in release.get("assets", [])
+        return select_firmware_release(
+            self._client.get_json(f"{base}?per_page=50"),
+            channel=self._config.channel,
+            firmware_repo=self._config.firmware_repo,
         )
 
     def find_firmware_asset(self, release: GitHubReleasePayload) -> GitHubReleaseAssetPayload:
         """Find the firmware bundle asset in a release."""
-        for asset in release.get("assets", []):
-            if is_firmware_asset_name(str(asset.get("name", ""))):
-                return asset
-        raise ValueError(
-            f"No firmware bundle asset found in release '{release.get('tag_name', '?')}'. "
-            "Expected an asset named vibesensor-fw-*.zip",
-        )
+        return find_firmware_asset(release)
 
     def download_asset(self, asset: GitHubReleaseAssetPayload, dest: Path) -> Path:
         """Download a firmware asset zip to *dest*."""

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_selection.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_release_selection.py
@@ -1,0 +1,124 @@
+"""Release payload shaping and selection helpers for firmware bundle fetching."""
+
+from __future__ import annotations
+
+from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
+from vibesensor.use_cases.updates.firmware.firmware_types import (
+    GitHubReleaseAssetPayload,
+    GitHubReleasePayload,
+)
+
+__all__ = [
+    "find_firmware_asset",
+    "is_firmware_asset_name",
+    "require_release_payload",
+    "select_firmware_release",
+]
+
+_FW_ASSET_PREFIX = "vibesensor-fw-"
+_FW_ASSET_SUFFIX = ".zip"
+
+
+def _coerce_release_asset_payload(raw: JsonObject) -> GitHubReleaseAssetPayload:
+    """Project a raw GitHub asset JSON object into the updater payload shape."""
+
+    payload: GitHubReleaseAssetPayload = {}
+    name = raw.get("name")
+    url = raw.get("url")
+    if isinstance(name, str):
+        payload["name"] = name
+    if isinstance(url, str):
+        payload["url"] = url
+    return payload
+
+
+def _coerce_release_payload(raw: JsonObject) -> GitHubReleasePayload:
+    """Project a raw GitHub release JSON object into the updater payload shape."""
+
+    payload: GitHubReleasePayload = {}
+    tag_name = raw.get("tag_name")
+    if isinstance(tag_name, str):
+        payload["tag_name"] = tag_name
+    draft = raw.get("draft")
+    if isinstance(draft, bool):
+        payload["draft"] = draft
+    prerelease = raw.get("prerelease")
+    if isinstance(prerelease, bool):
+        payload["prerelease"] = prerelease
+    assets = raw.get("assets")
+    if is_json_array(assets):
+        payload["assets"] = [
+            _coerce_release_asset_payload(asset) for asset in assets if is_json_object(asset)
+        ]
+    return payload
+
+
+def is_firmware_asset_name(name: str) -> bool:
+    """Return True if *name* matches the firmware bundle naming convention."""
+
+    return name.startswith(_FW_ASSET_PREFIX) and name.endswith(_FW_ASSET_SUFFIX)
+
+
+def require_release_payload(raw: object) -> GitHubReleasePayload:
+    """Decode one GitHub release response into the firmware payload shape."""
+
+    if not is_json_object(raw):
+        raise ValueError("Unexpected GitHub API response format")
+    return _coerce_release_payload(raw)
+
+
+def _release_has_firmware_asset(release: GitHubReleasePayload) -> bool:
+    return any(is_firmware_asset_name(str(a.get("name", ""))) for a in release.get("assets", []))
+
+
+def _preferred_release(
+    release: GitHubReleasePayload,
+    *,
+    wants_prerelease: bool,
+) -> bool:
+    if release.get("draft", False):
+        return False
+    if not _release_has_firmware_asset(release):
+        return False
+    return bool(release.get("prerelease", False)) is wants_prerelease
+
+
+def _fallback_release(release: GitHubReleasePayload) -> bool:
+    return not release.get("draft", False) and _release_has_firmware_asset(release)
+
+
+def select_firmware_release(
+    releases_raw: object,
+    *,
+    channel: str,
+    firmware_repo: str,
+) -> GitHubReleasePayload:
+    """Select the target firmware release for *channel* from the GitHub releases response."""
+
+    if not is_json_array(releases_raw):
+        raise ValueError("Unexpected GitHub API response format")
+    releases = [
+        _coerce_release_payload(release) for release in releases_raw if is_json_object(release)
+    ]
+    wants_prerelease = channel in ("prerelease", "edge")
+    for release in releases:
+        if _preferred_release(release, wants_prerelease=wants_prerelease):
+            return release
+    for release in releases:
+        if _fallback_release(release):
+            return release
+    raise ValueError(
+        f"No eligible firmware release found for channel '{channel}' in {firmware_repo}",
+    )
+
+
+def find_firmware_asset(release: GitHubReleasePayload) -> GitHubReleaseAssetPayload:
+    """Find the firmware bundle asset in a release."""
+
+    for asset in release.get("assets", []):
+        if is_firmware_asset_name(str(asset.get("name", ""))):
+            return asset
+    raise ValueError(
+        f"No firmware bundle asset found in release '{release.get('tag_name', '?')}'. "
+        "Expected an asset named vibesensor-fw-*.zip",
+    )

--- a/apps/server/vibesensor/use_cases/updates/release_execution_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/release_execution_runtime.py
@@ -1,43 +1,39 @@
-"""Release-focused updater runtime assembly."""
+"""Release-execution runtime assembly for updater workflows."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
+from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.firmware import FirmwareRefresher
 from vibesensor.use_cases.updates.installer import UpdateInstaller
 from vibesensor.use_cases.updates.release_deployment import (
     UpdateReleaseDeploymentCoordinator,
 )
-from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
 from vibesensor.use_cases.updates.release_staging import ServerReleaseStager
 from vibesensor.use_cases.updates.restart_scheduler import UpdateRestartScheduler
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.runtime_config import UpdateRuntimeConfig
-from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.status import (
+    UpdateStatusTracker,
+    UpdateTerminalStateReporter,
+)
+from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
 
-__all__ = ["UpdateReleaseRuntime", "build_update_release_runtime"]
+__all__ = ["build_update_workflow_executor"]
 
 ESP_FIRMWARE_REFRESH_TIMEOUT_S = 240
 UPDATE_RESTART_UNIT = "vibesensor-post-update-restart"
 UPDATE_SERVICE_NAME = "vibesensor.service"
 
 
-@dataclass(frozen=True, slots=True)
-class UpdateReleaseRuntime:
-    resolver: ServerReleaseResolver
-    stager: ServerReleaseStager
-    deployment: UpdateReleaseDeploymentCoordinator
-    firmware_refresher: FirmwareRefresher
-    restart_scheduler: UpdateRestartScheduler
-
-
-def build_update_release_runtime(
+def build_update_workflow_executor(
     *,
     commands: UpdateCommandExecutor,
     status: UpdateStatusTracker,
+    reporter: UpdateTerminalStateReporter,
     config: UpdateRuntimeConfig,
-) -> UpdateReleaseRuntime:
+) -> UpdateWorkflowExecutor:
+    """Build the canonical release-execution boundary for one updater workflow."""
+
     firmware_refresher = FirmwareRefresher(
         commands=commands,
         status=status,
@@ -49,9 +45,16 @@ def build_update_release_runtime(
         status=status,
         config=config.installer_config,
     )
-    return UpdateReleaseRuntime(
-        resolver=ServerReleaseResolver(
-            rollback_dir=config.rollback_dir,
+    return UpdateWorkflowExecutor(
+        completion=UpdateCompletionCoordinator(
+            restart_scheduler=UpdateRestartScheduler(
+                commands=commands,
+                status=status,
+                service_name=UPDATE_SERVICE_NAME,
+                restart_unit=UPDATE_RESTART_UNIT,
+            ),
+            reporter=reporter,
+            status=status,
         ),
         stager=ServerReleaseStager(
             status=status,
@@ -63,10 +66,4 @@ def build_update_release_runtime(
             status=status,
         ),
         firmware_refresher=firmware_refresher,
-        restart_scheduler=UpdateRestartScheduler(
-            commands=commands,
-            status=status,
-            service_name=UPDATE_SERVICE_NAME,
-            restart_unit=UPDATE_RESTART_UNIT,
-        ),
     )

--- a/apps/server/vibesensor/use_cases/updates/release_planning_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/release_planning_runtime.py
@@ -1,0 +1,25 @@
+"""Release-planning runtime assembly for updater workflows."""
+
+from __future__ import annotations
+
+from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
+from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
+from vibesensor.use_cases.updates.runtime_config import UpdateRuntimeConfig
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+
+__all__ = ["build_update_release_planner"]
+
+
+def build_update_release_planner(
+    *,
+    status: UpdateStatusTracker,
+    config: UpdateRuntimeConfig,
+) -> UpdateReleasePlanner:
+    """Build the canonical release planner for one updater workflow."""
+
+    return UpdateReleasePlanner(
+        status=status,
+        resolver=ServerReleaseResolver(
+            rollback_dir=config.rollback_dir,
+        ),
+    )

--- a/apps/server/vibesensor/use_cases/updates/releases/release_discovery.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_discovery.py
@@ -1,0 +1,67 @@
+"""Server release discovery helpers for updater fetchers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from vibesensor.shared.types.json_types import is_json_array
+
+from .models import GitHubRelease, GitHubReleaseAsset, ReleaseInfo
+
+__all__ = [
+    "decode_server_releases",
+    "find_latest_server_release",
+    "find_server_wheel_asset",
+]
+
+
+def decode_server_releases(releases_raw: object) -> tuple[GitHubRelease, ...]:
+    """Decode the GitHub releases response into typed server-release rows."""
+
+    if not is_json_array(releases_raw):
+        raise ValueError("Unexpected GitHub API response format")
+    releases: list[GitHubRelease] = []
+    for item in releases_raw:
+        release = GitHubRelease.from_api_payload(item)
+        if release is None:
+            raise ValueError("Unexpected GitHub API response format")
+        releases.append(release)
+    return tuple(releases)
+
+
+def find_server_wheel_asset(release: GitHubRelease) -> GitHubReleaseAsset | None:
+    """Return the server wheel asset for *release* when present."""
+
+    for asset in release.assets:
+        if asset.name.startswith("vibesensor") and asset.name.endswith(".whl"):
+            return asset
+    return None
+
+
+def find_latest_server_release(
+    releases: Iterable[GitHubRelease],
+    *,
+    server_repo: str,
+) -> ReleaseInfo:
+    """Select the first eligible server release from decoded GitHub rows."""
+
+    for release in releases:
+        if release.draft:
+            continue
+        tag = release.tag_name
+        if not tag.startswith("server-v"):
+            continue
+        asset = find_server_wheel_asset(release)
+        if asset is None:
+            continue
+        return ReleaseInfo(
+            tag=tag,
+            version=tag.removeprefix("server-v"),
+            asset_name=asset.name,
+            asset_url=asset.url,
+            sha256="",
+            published_at=release.published_at,
+        )
+    raise ValueError(
+        f"No server release found with tag 'server-v*' in {server_repo}",
+    )

--- a/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_fetcher.py
@@ -2,21 +2,18 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
-import os
 import tempfile
 from pathlib import Path
-from urllib.request import urlopen
 
-from vibesensor.shared.types.json_types import is_json_array
+from vibesensor.use_cases.updates.artifact_validation import sha256_file
+from vibesensor.use_cases.updates.asset_download import download_release_asset
 
 from .github_api import DOWNLOAD_CHUNK_BYTES, GitHubApiClient
-from .models import GitHubRelease, GitHubReleaseAsset, ReleaseFetcherConfig, ReleaseInfo
+from .models import ReleaseFetcherConfig, ReleaseInfo
+from .release_discovery import decode_server_releases, find_latest_server_release
 
 LOGGER = logging.getLogger(__name__)
-
-_HASH_CHUNK_BYTES = 65536  # 64 KB per hash update
 
 __all__ = ["ServerReleaseFetcher"]
 
@@ -44,30 +41,16 @@ class ServerReleaseFetcher:
     def _download_asset(self, url: str, dest: Path) -> None:
         """Stream a release asset to disk with an upper size bound."""
 
-        req = self._client.build_request(url, accept="application/octet-stream")
-        tmp = dest.with_suffix(".tmp")
-        max_bytes = self._MAX_DOWNLOAD_BYTES
-        chunk_size = DOWNLOAD_CHUNK_BYTES
-        replaced = False
-        try:
-            with urlopen(req, timeout=300) as resp:
-                total = 0
-                with tmp.open("wb") as f:
-                    while True:
-                        chunk = resp.read(chunk_size)
-                        if not chunk:
-                            break
-                        total += len(chunk)
-                        if total > max_bytes:
-                            raise ValueError(f"Asset exceeds {self._MAX_DOWNLOAD_MB} MB limit")
-                        f.write(chunk)
-                    f.flush()
-                    os.fsync(f.fileno())
-            tmp.replace(dest)
-            replaced = True
-        finally:
-            if not replaced:
-                tmp.unlink(missing_ok=True)
+        download_release_asset(
+            client=self._client,
+            url=url,
+            dest=dest,
+            timeout_s=300,
+            max_bytes=self._MAX_DOWNLOAD_BYTES,
+            chunk_size=DOWNLOAD_CHUNK_BYTES,
+            size_limit_message=f"Asset exceeds {self._MAX_DOWNLOAD_MB} MB limit",
+            temp_suffix=".whl_tmp",
+        )
 
     def find_latest_release(self) -> ReleaseInfo:
         """Find the latest server release (tag matching ``server-v*``).
@@ -78,47 +61,10 @@ class ServerReleaseFetcher:
         owner, repo = self._config.server_repo.split("/", 1)
         url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=50"
         LOGGER.info("Querying releases from %s/%s", owner, repo)
-        releases_raw = self._client.get_json(url)
-        if not is_json_array(releases_raw):
-            raise ValueError("Unexpected GitHub API response format")
-        releases: list[GitHubRelease] = []
-        for item in releases_raw:
-            release = GitHubRelease.from_api_payload(item)
-            if release is None:
-                raise ValueError("Unexpected GitHub API response format")
-            releases.append(release)
-
-        for release in releases:
-            if release.draft:
-                continue
-            tag = release.tag_name
-            if not tag.startswith("server-v"):
-                continue
-            version = tag.removeprefix("server-v")
-            asset = self._find_wheel_asset(release)
-            if asset is None:
-                continue
-            return ReleaseInfo(
-                tag=tag,
-                version=version,
-                asset_name=asset.name,
-                asset_url=asset.url,
-                sha256="",
-                published_at=release.published_at,
-            )
-
-        raise ValueError(
-            f"No server release found with tag 'server-v*' in {self._config.server_repo}",
+        return find_latest_server_release(
+            decode_server_releases(self._client.get_json(url)),
+            server_repo=self._config.server_repo,
         )
-
-    @staticmethod
-    def _find_wheel_asset(release: GitHubRelease) -> GitHubReleaseAsset | None:
-        """Find a .whl asset in a release."""
-        for asset in release.assets:
-            name = asset.name
-            if name.startswith("vibesensor") and name.endswith(".whl"):
-                return asset
-        return None
 
     def download_wheel(
         self,
@@ -137,12 +83,6 @@ class ServerReleaseFetcher:
         dest = dest_dir / release.asset_name
         LOGGER.info("Downloading %s", release.asset_name)
         self._download_asset(release.asset_url, dest)
-
-        h = hashlib.sha256()
-        with dest.open("rb") as f:
-            for chunk in iter(lambda: f.read(_HASH_CHUNK_BYTES), b""):
-                h.update(chunk)
-        sha = h.hexdigest()
-        release.sha256 = sha
-        LOGGER.info("Downloaded %s (sha256=%s)", release.asset_name, sha)
+        release.sha256 = sha256_file(dest)
+        LOGGER.info("Downloaded %s (sha256=%s)", release.asset_name, release.sha256)
         return dest

--- a/apps/server/vibesensor/use_cases/updates/runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 from vibesensor.use_cases.updates.manager import UpdateManager
-from vibesensor.use_cases.updates.release_runtime import build_update_release_runtime
 from vibesensor.use_cases.updates.runner import CommandRunner
 from vibesensor.use_cases.updates.runtime_config import resolve_update_runtime_config
 from vibesensor.use_cases.updates.runtime_core import build_update_runtime_core
@@ -51,16 +50,10 @@ def build_update_manager(
         usb_internet_service=usb_internet_service,
         logger=LOGGER,
     )
-    release = build_update_release_runtime(
-        commands=core.commands,
-        status=core.status,
-        config=config,
-    )
     workflow = build_update_workflow(
         core=core,
         config=config,
         transport=transport,
-        release=release,
         logger=LOGGER,
     )
     return UpdateManager(

--- a/apps/server/vibesensor/use_cases/updates/workflow.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import sys
 from dataclasses import dataclass
 
 from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
@@ -30,19 +30,12 @@ class UpdateWorkflow:
         request: UpdateRequest,
     ) -> None:
         prepared: PreparedUpdateRun | None = None
-        prior_error: BaseException | None = None
         try:
             prepared = await self.preparation.prepare(request)
             planned = await self.release_planner.plan(prepared)
             await self.workflow_executor.execute(planned)
-        except asyncio.CancelledError as exc:
-            prior_error = exc
-            raise
-        except Exception as exc:
-            prior_error = exc
-            raise
         finally:
             await self.finalizer.finalize(
                 None if prepared is None else prepared.prepared_transport,
-                prior_error=prior_error,
+                prior_error=sys.exc_info()[1],
             )

--- a/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
+++ b/apps/server/vibesensor/use_cases/updates/workflow_runtime.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 
-from vibesensor.use_cases.updates.completion import UpdateCompletionCoordinator
 from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.preparation import UpdatePreparationCoordinator
-from vibesensor.use_cases.updates.release_planner import UpdateReleasePlanner
-from vibesensor.use_cases.updates.release_runtime import UpdateReleaseRuntime
+from vibesensor.use_cases.updates.release_execution_runtime import (
+    build_update_workflow_executor,
+)
+from vibesensor.use_cases.updates.release_planning_runtime import (
+    build_update_release_planner,
+)
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.runtime_config import UpdateRuntimeConfig
 from vibesensor.use_cases.updates.runtime_core import UpdateRuntimeCore
@@ -16,7 +19,6 @@ from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRef
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport.runtime import UpdateTransportRuntime
 from vibesensor.use_cases.updates.workflow import UpdateWorkflow
-from vibesensor.use_cases.updates.workflow_executor import UpdateWorkflowExecutor
 
 __all__ = ["build_update_workflow"]
 
@@ -26,7 +28,6 @@ def build_update_workflow(
     core: UpdateRuntimeCore,
     config: UpdateRuntimeConfig,
     transport: UpdateTransportRuntime,
-    release: UpdateReleaseRuntime,
     logger: logging.Logger,
 ) -> UpdateWorkflow:
     return UpdateWorkflow(
@@ -36,19 +37,15 @@ def build_update_workflow(
             transport=transport,
             config=config,
         ),
-        release_planner=UpdateReleasePlanner(
+        release_planner=build_update_release_planner(
             status=core.status,
-            resolver=release.resolver,
+            config=config,
         ),
-        workflow_executor=UpdateWorkflowExecutor(
-            completion=UpdateCompletionCoordinator(
-                restart_scheduler=release.restart_scheduler,
-                reporter=core.reporter,
-                status=core.status,
-            ),
-            stager=release.stager,
-            deployment=release.deployment,
-            firmware_refresher=release.firmware_refresher,
+        workflow_executor=build_update_workflow_executor(
+            commands=core.commands,
+            status=core.status,
+            reporter=core.reporter,
+            config=config,
         ),
         finalizer=UpdateWorkflowFinalizer(
             transport_coordinator=transport.coordinator,
@@ -63,10 +60,10 @@ def build_update_workflow(
 
 def _build_preparation(
     *,
-    commands: UpdateCommandExecutor,
-    status: UpdateStatusTracker,
     transport: UpdateTransportRuntime,
     config: UpdateRuntimeConfig,
+    commands: UpdateCommandExecutor,
+    status: UpdateStatusTracker,
 ) -> UpdatePreparationCoordinator:
     return UpdatePreparationCoordinator(
         status=status,


### PR DESCRIPTION
## Summary
- replace the remaining updater release runtime bundle with focused planning and execution builders
- extract shared updater asset downloading plus focused server/firmware release selection helpers
- remove the broad workflow exception handoff and keep updater tests pointed at the canonical download path

## Expected definitions of done satisfied in this wave
- Issue 1: Updates subsystem boundaries
- Issue 5: Residual broad outer fault handling in the touched updater workflow seam

## Validation
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/updates apps/server/tests/use_cases/updates/releases/test_release_fetcher.py apps/server/tests/use_cases/updates/firmware/test_firmware_cache.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py apps/server/tests/integration/test_refactor_contract_regressions.py
- make lint
- make typecheck-backend