### PR TITLE
Refactor report document composition

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_document_sections.py
+++ b/apps/server/tests/use_cases/history/test_report_document_sections.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from test_support.report_helpers import recapture_guidance_summary
+
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document.document_context import (
+    build_report_document_context,
+)
+from vibesensor.use_cases.history.report_document.document_sections import (
+    build_report_document_sections,
+)
+
+
+def _build_sections(mode: str):
+    context = build_report_document_context(prepare_report_input(recapture_guidance_summary(mode)))
+    return context, build_report_document_sections(context)
+
+
+def test_build_report_document_sections_keeps_recapture_guidance_in_sync() -> None:
+    _context, sections = _build_sections("overlap")
+
+    assert sections.appendix_a.mode == "recapture"
+    assert sections.appendix_a.capture_changes
+    assert [step.action for step in sections.next_steps] == sections.appendix_a.capture_changes
+    assert sections.verdict_page.reason_sentence == sections.appendix_a.capture_issues[0]
+
+
+def test_build_report_document_sections_aligns_verdict_and_appendix_b() -> None:
+    _context, sections = _build_sections("steady")
+
+    assert sections.appendix_b.coverage_label == sections.verdict_page.coverage_label
+    assert sections.appendix_b.runner_up_corner == sections.verdict_page.runner_up_corner

--- a/apps/server/vibesensor/use_cases/history/report_document/composition.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/composition.py
@@ -2,30 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
-
 from vibesensor.shared.boundaries.reporting import PreparedReportInput
-from vibesensor.shared.boundaries.reporting.document import (
-    AppendixAData,
-    NextStep,
-    ReportDocument,
-    VerdictPageData,
-)
-from vibesensor.shared.time_utils import format_utc_timestamp
+from vibesensor.shared.boundaries.reporting.document import ReportDocument
 
-from ._card_builder import build_system_cards
-from .appendix_c import build_appendix_c_data
-from .document_context import ReportDocumentContext, build_report_document_context
-from .location_appendix import build_appendix_b_data
-from .measurements import _measurement_rows
-from .narrative_summaries import _proof_summary_text
-from .pattern_evidence import build_pattern_evidence
-from .peak_table import build_peak_rows
-from .report_sections import build_data_trust, build_next_steps
-from .timeline_graph import build_timeline_graph_data
-from .traceability import build_traceability_rows
-from .verdict_page import build_observed_signature, build_verdict_page_data
-from .workflow_appendix import build_appendix_a_data
+from .document_context import build_report_document_context
+from .document_output import assemble_report_document
+from .document_sections import build_report_document_sections
 
 __all__ = ["compose_report_document"]
 
@@ -34,154 +16,7 @@ def compose_report_document(prepared: PreparedReportInput) -> ReportDocument:
     """Compose the canonical report document from prepared report input."""
 
     context = build_report_document_context(prepared)
-    appendix_a = build_appendix_a_data(
-        aggregate=context.test_run,
-        appendix_context=context.appendix_a_context,
-        tr=context.tr,
-    )
-    appendix_b = build_appendix_b_data(
-        aggregate=context.test_run,
-        primary_candidate_facts=context.decision_facts.primary_candidate,
-        active_sensor_intensity=context.sensor_facts.active_intensity,
-        appendix_context=context.appendix_b_context,
-        tr=context.tr,
-    )
-    data_trust = build_data_trust(
-        suitability_checks=context.decision_facts.suitability_checks,
-        warnings=context.decision_facts.warnings,
-        lang=context.lang,
-        tr=context.tr,
-    )
-    verdict_page = _build_verdict_page(context=context)
-    return ReportDocument(
-        title=context.tr("REPORT_FOOTER_TITLE"),
-        run_datetime=context.run_datetime,
-        run_id=context.run_facts.run_id,
-        duration_text=context.run_facts.duration_text,
-        start_time_utc=format_utc_timestamp(context.run_facts.start_time_utc),
-        end_time_utc=format_utc_timestamp(context.run_facts.end_time_utc),
-        sample_rate_hz=context.run_facts.sample_rate_hz,
-        tire_spec_text=context.run_facts.tire_spec_text,
-        sample_count=context.run_facts.sample_count,
-        sensor_count=context.primary.sensor_count,
-        sensor_locations=list(context.sensor_facts.active_locations),
-        sensor_model=context.run_facts.sensor_model,
-        firmware_version=context.run_facts.firmware_version,
-        car_name=context.run_facts.car_name,
-        car_type=context.run_facts.car_type,
-        observed=build_observed_signature(context.primary, tr=context.tr),
-        system_cards=build_system_cards(
-            context.test_run,
-            context.primary,
-            context.lang,
-            context.tr,
-        ),
-        next_steps=list(
-            _resolve_next_steps(
-                context=context,
-                appendix_a=appendix_a,
-            )
-        ),
-        data_trust=data_trust,
-        pattern_evidence=build_pattern_evidence(
-            aggregate=context.test_run,
-            origin=context.run_facts.origin,
-            primary=context.primary,
-            lang=context.lang,
-            tr=context.tr,
-        ),
-        peak_rows=build_peak_rows(
-            context.run_facts.peak_table_rows,
-            findings=list(context.findings),
-            lang=context.lang,
-            tr=context.tr,
-        ),
-        lang=context.lang,
-        certainty_tier_key=context.primary.tier,
-        findings=list(context.findings),
-        top_causes=list(context.top_causes),
-        sensor_intensity_by_location=list(context.sensor_facts.active_intensity),
-        location_hotspot_rows=list(context.sensor_facts.location_hotspot_rows),
-        verdict_page=verdict_page,
-        appendix_a=appendix_a,
-        appendix_b=appendix_b,
-        appendix_c=build_appendix_c_data(
-            primary=context.primary,
-            aggregate=context.test_run,
-            measurements=_measurement_rows(
-                context.run_facts,
-                aggregate=context.test_run,
-                tr=context.tr,
-            ),
-            report_facts=context.report_facts,
-            appendix_context=context.appendix_c_context,
-            data_trust=list(data_trust),
-            tr=context.tr,
-        ),
-        traceability_rows=list(
-            build_traceability_rows(
-                date_str=context.run_datetime,
-                run_id=context.run_facts.run_id,
-                tire_spec_text=context.run_facts.tire_spec_text,
-                sensor_model=context.run_facts.sensor_model,
-                firmware_version=context.run_facts.firmware_version,
-                sample_count=context.run_facts.sample_count,
-                sample_rate_hz=context.run_facts.sample_rate_hz,
-                tr=context.tr,
-            )
-        ),
-    )
-
-
-def _build_verdict_page(
-    *,
-    context: ReportDocumentContext,
-) -> VerdictPageData:
-    verdict_page = build_verdict_page_data(
-        aggregate=context.test_run,
-        primary_candidate_facts=context.decision_facts.primary_candidate,
-        duration_text=context.run_facts.duration_text,
-        verdict_context=context.verdict_page_context,
-        suitability_checks=context.decision_facts.suitability_checks,
-        warnings=context.decision_facts.warnings,
-        lang=context.lang,
-        tr=context.tr,
-    )
-    proof_summary = _proof_summary_text(
-        context.test_run,
-        context.primary,
-        context.report_facts,
-        runner_up_corner=context.verdict_page_context.runner_up_corner,
-        tr=context.tr,
-    )
-    return replace(
-        verdict_page,
-        proof_summary=proof_summary,
-        timeline_graph=build_timeline_graph_data(
-            context.report_facts,
-            duration_s=context.run_facts.duration_s,
-        ),
-    )
-
-
-def _resolve_next_steps(
-    *,
-    context: ReportDocumentContext,
-    appendix_a: AppendixAData,
-) -> tuple[NextStep, ...]:
-    recapture_mode = context.decision_facts.action_status_key == "recapture_before_acting"
-    if recapture_mode:
-        return tuple(NextStep(action=action) for action in appendix_a.capture_changes)
-    return tuple(
-        build_next_steps(
-            recommended_actions=context.decision_facts.recommended_actions,
-            primary_source=context.primary.primary_source,
-            primary_location=context.primary.primary_location,
-            tier=context.primary.tier,
-            cert_reason=context.primary.certainty_reason
-            or context.tr("REPORT_CAPTURE_ISSUE_GENERIC"),
-            recapture_mode=recapture_mode,
-            lang=context.lang,
-            tr=context.tr,
-        )
+    return assemble_report_document(
+        context=context,
+        sections=build_report_document_sections(context),
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/document_output.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_output.py
@@ -1,0 +1,55 @@
+"""Rendering-facing report-document output assembly."""
+
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.reporting.document import ReportDocument
+from vibesensor.shared.time_utils import format_utc_timestamp
+
+from .document_context import ReportDocumentContext
+from .document_sections import ReportDocumentSections
+from .verdict_page import build_observed_signature
+
+__all__ = ["assemble_report_document"]
+
+
+def assemble_report_document(
+    *,
+    context: ReportDocumentContext,
+    sections: ReportDocumentSections,
+) -> ReportDocument:
+    """Assemble the final PDF-facing document from context and prebuilt sections."""
+
+    return ReportDocument(
+        title=context.tr("REPORT_FOOTER_TITLE"),
+        run_datetime=context.run_datetime,
+        run_id=context.run_facts.run_id,
+        duration_text=context.run_facts.duration_text,
+        start_time_utc=format_utc_timestamp(context.run_facts.start_time_utc),
+        end_time_utc=format_utc_timestamp(context.run_facts.end_time_utc),
+        sample_rate_hz=context.run_facts.sample_rate_hz,
+        tire_spec_text=context.run_facts.tire_spec_text,
+        sample_count=context.run_facts.sample_count,
+        sensor_count=context.primary.sensor_count,
+        sensor_locations=list(context.sensor_facts.active_locations),
+        sensor_model=context.run_facts.sensor_model,
+        firmware_version=context.run_facts.firmware_version,
+        car_name=context.run_facts.car_name,
+        car_type=context.run_facts.car_type,
+        observed=build_observed_signature(context.primary, tr=context.tr),
+        system_cards=list(sections.system_cards),
+        next_steps=list(sections.next_steps),
+        data_trust=list(sections.data_trust),
+        pattern_evidence=sections.pattern_evidence,
+        peak_rows=list(sections.peak_rows),
+        lang=context.lang,
+        certainty_tier_key=context.primary.tier,
+        findings=list(context.findings),
+        top_causes=list(context.top_causes),
+        sensor_intensity_by_location=list(context.sensor_facts.active_intensity),
+        location_hotspot_rows=list(context.sensor_facts.location_hotspot_rows),
+        verdict_page=sections.verdict_page,
+        appendix_a=sections.appendix_a,
+        appendix_b=sections.appendix_b,
+        appendix_c=sections.appendix_c,
+        traceability_rows=list(sections.traceability_rows),
+    )

--- a/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
@@ -1,0 +1,134 @@
+"""Section assembly for report document composition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.reporting.document import (
+    AppendixAData,
+    AppendixBData,
+    AppendixCData,
+    DataTrustItem,
+    NextStep,
+    PatternEvidence,
+    PeakRow,
+    ReportLabelValueRow,
+    SystemFindingCard,
+    VerdictPageData,
+)
+
+from ._card_builder import build_system_cards
+from .appendix_c import build_appendix_c_data
+from .document_context import ReportDocumentContext
+from .location_appendix import build_appendix_b_data
+from .measurements import _measurement_rows
+from .next_steps import build_document_next_steps
+from .pattern_evidence import build_pattern_evidence
+from .peak_table import build_peak_rows
+from .report_sections import build_data_trust
+from .traceability import build_traceability_rows
+from .verdict_page import build_verdict_page
+from .workflow_appendix import build_appendix_a_data
+
+__all__ = ["ReportDocumentSections", "build_report_document_sections"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportDocumentSections:
+    """Prebuilt document sections ready for final ReportDocument assembly."""
+
+    system_cards: tuple[SystemFindingCard, ...]
+    next_steps: tuple[NextStep, ...]
+    data_trust: tuple[DataTrustItem, ...]
+    pattern_evidence: PatternEvidence
+    peak_rows: tuple[PeakRow, ...]
+    verdict_page: VerdictPageData
+    appendix_a: AppendixAData
+    appendix_b: AppendixBData
+    appendix_c: AppendixCData
+    traceability_rows: tuple[ReportLabelValueRow, ...]
+
+
+def build_report_document_sections(
+    context: ReportDocumentContext,
+) -> ReportDocumentSections:
+    """Assemble the report-document sections from shared prepared context."""
+
+    appendix_a = build_appendix_a_data(
+        aggregate=context.test_run,
+        appendix_context=context.appendix_a_context,
+        tr=context.tr,
+    )
+    appendix_b = build_appendix_b_data(
+        aggregate=context.test_run,
+        primary_candidate_facts=context.decision_facts.primary_candidate,
+        active_sensor_intensity=context.sensor_facts.active_intensity,
+        appendix_context=context.appendix_b_context,
+        tr=context.tr,
+    )
+    data_trust = tuple(
+        build_data_trust(
+            suitability_checks=context.decision_facts.suitability_checks,
+            warnings=context.decision_facts.warnings,
+            lang=context.lang,
+            tr=context.tr,
+        )
+    )
+    return ReportDocumentSections(
+        system_cards=tuple(
+            build_system_cards(
+                context.test_run,
+                context.primary,
+                context.lang,
+                context.tr,
+            )
+        ),
+        next_steps=build_document_next_steps(
+            context=context,
+            appendix_a=appendix_a,
+        ),
+        data_trust=data_trust,
+        pattern_evidence=build_pattern_evidence(
+            aggregate=context.test_run,
+            origin=context.run_facts.origin,
+            primary=context.primary,
+            lang=context.lang,
+            tr=context.tr,
+        ),
+        peak_rows=tuple(
+            build_peak_rows(
+                context.run_facts.peak_table_rows,
+                findings=list(context.findings),
+                lang=context.lang,
+                tr=context.tr,
+            )
+        ),
+        verdict_page=build_verdict_page(context=context),
+        appendix_a=appendix_a,
+        appendix_b=appendix_b,
+        appendix_c=build_appendix_c_data(
+            primary=context.primary,
+            aggregate=context.test_run,
+            measurements=_measurement_rows(
+                context.run_facts,
+                aggregate=context.test_run,
+                tr=context.tr,
+            ),
+            report_facts=context.report_facts,
+            appendix_context=context.appendix_c_context,
+            data_trust=list(data_trust),
+            tr=context.tr,
+        ),
+        traceability_rows=tuple(
+            build_traceability_rows(
+                date_str=context.run_datetime,
+                run_id=context.run_facts.run_id,
+                tire_spec_text=context.run_facts.tire_spec_text,
+                sensor_model=context.run_facts.sensor_model,
+                firmware_version=context.run_facts.firmware_version,
+                sample_count=context.run_facts.sample_count,
+                sample_rate_hz=context.run_facts.sample_rate_hz,
+                tr=context.tr,
+            )
+        ),
+    )

--- a/apps/server/vibesensor/use_cases/history/report_document/next_steps.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/next_steps.py
@@ -1,0 +1,35 @@
+"""Next-step section assembly for report documents."""
+
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.reporting.document import AppendixAData, NextStep
+
+from .document_context import ReportDocumentContext
+from .report_sections import build_next_steps
+
+__all__ = ["build_document_next_steps"]
+
+
+def build_document_next_steps(
+    *,
+    context: ReportDocumentContext,
+    appendix_a: AppendixAData,
+) -> tuple[NextStep, ...]:
+    """Build the report next-step section from the prepared document context."""
+
+    recapture_mode = context.decision_facts.action_status_key == "recapture_before_acting"
+    if recapture_mode:
+        return tuple(NextStep(action=action) for action in appendix_a.capture_changes)
+    return tuple(
+        build_next_steps(
+            recommended_actions=context.decision_facts.recommended_actions,
+            primary_source=context.primary.primary_source,
+            primary_location=context.primary.primary_location,
+            tier=context.primary.tier,
+            cert_reason=context.primary.certainty_reason
+            or context.tr("REPORT_CAPTURE_ISSUE_GENERIC"),
+            recapture_mode=recapture_mode,
+            lang=context.lang,
+            tr=context.tr,
+        )
+    )

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from dataclasses import replace
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import SuitabilityCheck, TestRun
 from vibesensor.report_i18n import human_source
@@ -22,9 +24,14 @@ from vibesensor.shared.report_presentation import (
 from vibesensor.shared.run_context_warning import RunContextWarning
 
 from ._candidate_resolver import PrimaryCandidateContext
+from .narrative_summaries import _proof_summary_text
 from .section_context import VerdictPageContext
+from .timeline_graph import build_timeline_graph_data
 
-__all__ = ["build_observed_signature", "build_verdict_page_data"]
+if TYPE_CHECKING:
+    from .document_context import ReportDocumentContext
+
+__all__ = ["build_observed_signature", "build_verdict_page", "build_verdict_page_data"]
 
 
 def build_observed_signature(
@@ -126,6 +133,36 @@ def build_verdict_page_data(
                 tr("REPORT_ROUTE_APPENDIX_C"),
                 tr("REPORT_ROUTE_APPENDIX_D"),
             )
+        ),
+    )
+
+
+def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
+    """Build the fully assembled verdict page from shared document context."""
+
+    verdict_page = build_verdict_page_data(
+        aggregate=context.test_run,
+        primary_candidate_facts=context.decision_facts.primary_candidate,
+        duration_text=context.run_facts.duration_text,
+        verdict_context=context.verdict_page_context,
+        suitability_checks=context.decision_facts.suitability_checks,
+        warnings=context.decision_facts.warnings,
+        lang=context.lang,
+        tr=context.tr,
+    )
+    proof_summary = _proof_summary_text(
+        context.test_run,
+        context.primary,
+        context.report_facts,
+        runner_up_corner=context.verdict_page_context.runner_up_corner,
+        tr=context.tr,
+    )
+    return replace(
+        verdict_page,
+        proof_summary=proof_summary,
+        timeline_graph=build_timeline_graph_data(
+            context.report_facts,
+            duration_s=context.run_facts.duration_s,
         ),
     )
 


### PR DESCRIPTION
## Summary
- make report_document/composition.py coordinate context, section assembly, and final document output only
- move report section assembly into document_sections.py and next-step branching into next_steps.py
- move rendering-facing ReportDocument field assembly into document_output.py and keep full verdict-page assembly in verdict_page.py

## Expected definitions of done satisfied in this wave
- Issue 2: Reporting/history presentation coupling

## Validation
- .venv/bin/python -m pytest -q apps/server/tests/use_cases/history/test_report_document_context.py apps/server/tests/use_cases/history/test_report_document_assembly_context.py apps/server/tests/use_cases/history/test_report_document_sections.py apps/server/tests/use_cases/history/test_report_section_context.py apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_mapping_pipeline.py apps/server/tests/adapters/pdf/test_report_content_coverage.py apps/server/tests/integration/test_contract_analysis_report.py
- make lint
- make typecheck-backend