### PR TITLE
feat(ui): move shell chrome into Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -188,6 +188,10 @@ Preact is now available for incremental migration work, but the current DOM
 runtime remains the live product path. New panel-by-panel migrations should
 mount Preact into existing hosts through `app/runtime/ui_preact_mount.ts`
 instead of introducing ad hoc framework entrypoints.
+The shell chrome owner path now starts at `app/runtime/ui_shell_chrome.tsx`,
+which mounts the shell island before `ui_runtime_dom.ts` resolves the shared
+shell selectors; the legacy shell runtime still owns state updates and
+cross-feature refresh behavior behind that rendered surface.
 
 ## Architecture guardrails
 

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -7,55 +7,7 @@
   </head>
   <body>
     <div class="wrap">
-      <header class="site-header">
-        <div class="site-header__main">
-          <div class="site-header__nav">
-            <h1 class="title" aria-label="VibeSensor">
-              <picture class="brandmark">
-                <source srcset="/branding/vibesensor-logo-header-dark.svg" media="(prefers-color-scheme: dark)" />
-                <img src="/branding/vibesensor-logo-header-light.svg" alt="VibeSensor" width="222" height="46" />
-              </picture>
-            </h1>
-            <nav class="menu" aria-label="Primary" role="tablist">
-              <button type="button" class="menu-btn active" data-view="dashboardView" id="tab-dashboard" role="tab" aria-controls="dashboardView" aria-selected="true" tabindex="0">
-                <span data-i18n="nav.live">Live</span>
-              </button>
-              <button type="button" class="menu-btn" data-view="historyView" id="tab-history" role="tab" aria-controls="historyView" aria-selected="false" tabindex="-1">
-                <span data-i18n="nav.history">History</span>
-              </button>
-              <button type="button" class="menu-btn" data-view="settingsView" id="tab-settings" role="tab" aria-controls="settingsView" aria-selected="false" tabindex="-1">
-                <span data-i18n="nav.settings">Settings</span>
-              </button>
-            </nav>
-          </div>
-          <div class="site-header__preferences">
-            <label class="header-select" for="speedUnitSelect">
-              <span class="mini-label" data-i18n="speed.unit">Unit</span>
-              <select id="speedUnitSelect" class="unit-picker" aria-label="Speed unit">
-                <option value="kmh" data-i18n="speed.unit.kmh">km/h</option>
-                <option value="mps" data-i18n="speed.unit.mps">m/s</option>
-              </select>
-              <div id="speedUnitFeedback" class="settings-feedback-slot settings-feedback-slot--compact" hidden></div>
-            </label>
-            <label class="header-select" for="languageSelect">
-              <span class="mini-label" data-i18n="settings.language">Language</span>
-              <select id="languageSelect" class="lang-picker" aria-label="Language">
-                <option value="en">🇺🇸 English</option>
-                <option value="nl">🇳🇱 Nederlands</option>
-              </select>
-              <div id="languageFeedback" class="settings-feedback-slot settings-feedback-slot--compact" hidden></div>
-            </label>
-          </div>
-        </div>
-        <div class="site-header__status">
-          <div class="site-header__status-pills">
-            <div id="linkState" class="pill pill--muted" aria-live="polite">Connecting...</div>
-            <div id="shellLiveStatus" class="pill pill--muted" aria-live="polite">No live signal</div>
-          </div>
-        </div>
-      </header>
-
-      <div id="appErrorBanner" class="connection-banner app-error-banner" hidden aria-live="assertive" role="alert"></div>
+      <div id="appShellChromeRoot"></div>
 
       <section id="dashboardView" class="view active" role="tabpanel" aria-labelledby="tab-dashboard">
         <div class="dashboard-grid">

--- a/apps/ui/src/app/dom/shell_dom.ts
+++ b/apps/ui/src/app/dom/shell_dom.ts
@@ -1,6 +1,7 @@
-import { getById, queryOne, queryRequiredAll } from "./dom_query";
+import { getById, queryOne, queryRequiredAll, requiredById } from "./dom_query";
 
 const SHELL_OWNER = "UI shell";
+const SHELL_CHROME_HOST_ID = "appShellChromeRoot";
 
 export interface UiShellDom {
   menuButtons: HTMLElement[];
@@ -13,6 +14,10 @@ export interface UiShellDom {
   linkState: HTMLElement | null;
   appErrorBanner: HTMLElement | null;
   appShellWrap: HTMLElement | null;
+}
+
+export function getUiShellChromeHost(): HTMLElement {
+  return requiredById<HTMLElement>(SHELL_CHROME_HOST_ID, SHELL_OWNER);
 }
 
 export function createUiShellDom(): UiShellDom {

--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -1,0 +1,255 @@
+import type { JSX } from "preact";
+
+import type { ShellState } from "../ui_app_state";
+import { createUiPreactMount } from "./ui_preact_mount";
+
+const SHELL_NAV_ITEMS = [
+  {
+    viewId: "dashboardView",
+    tabId: "tab-dashboard",
+    labelKey: "nav.live",
+    fallbackLabel: "Live",
+  },
+  {
+    viewId: "historyView",
+    tabId: "tab-history",
+    labelKey: "nav.history",
+    fallbackLabel: "History",
+  },
+  {
+    viewId: "settingsView",
+    tabId: "tab-settings",
+    labelKey: "nav.settings",
+    fallbackLabel: "Settings",
+  },
+] as const;
+
+const SPEED_UNIT_OPTIONS = [
+  { value: "kmh", labelKey: "speed.unit.kmh", fallbackLabel: "km/h" },
+  { value: "mps", labelKey: "speed.unit.mps", fallbackLabel: "m/s" },
+] as const;
+
+const LANGUAGE_OPTIONS = [
+  { value: "en", label: "🇺🇸 English" },
+  { value: "nl", label: "🇳🇱 Nederlands" },
+] as const;
+
+export interface UiShellChromeActions {
+  activateView(viewId: string): void;
+  saveLanguage(lang: string): Promise<void> | void;
+  saveSpeedUnit(unit: string): Promise<void> | void;
+}
+
+export interface UiShellChromeActionBridge {
+  readonly current: UiShellChromeActions;
+  attach(actions: UiShellChromeActions): void;
+}
+
+type UiShellChromeProps = {
+  bridge: UiShellChromeActionBridge;
+  initialShellState: Pick<ShellState, "activeViewId" | "lang" | "speedUnit">;
+};
+
+function noop(): void {
+  return;
+}
+
+function normalizeMenuIndex(index: number): number {
+  return ((index % SHELL_NAV_ITEMS.length) + SHELL_NAV_ITEMS.length) % SHELL_NAV_ITEMS.length;
+}
+
+function focusMenuButton(event: JSX.TargetedKeyboardEvent<HTMLButtonElement>, nextIndex: number): void {
+  const menu = event.currentTarget.closest(".menu");
+  if (!(menu instanceof HTMLElement)) {
+    return;
+  }
+  const buttons = Array.from(menu.querySelectorAll<HTMLButtonElement>(".menu-btn"));
+  buttons[normalizeMenuIndex(nextIndex)]?.focus();
+}
+
+function UiShellChrome(props: UiShellChromeProps) {
+  const { bridge, initialShellState } = props;
+
+  function activateView(viewId: string): void {
+    bridge.current.activateView(viewId);
+  }
+
+  function handleMenuKeyDown(
+    index: number,
+    event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
+  ): void {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      activateView(SHELL_NAV_ITEMS[index].viewId);
+      return;
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      const nextIndex = normalizeMenuIndex(index + 1);
+      activateView(SHELL_NAV_ITEMS[nextIndex].viewId);
+      focusMenuButton(event, nextIndex);
+      return;
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      const nextIndex = normalizeMenuIndex(index - 1);
+      activateView(SHELL_NAV_ITEMS[nextIndex].viewId);
+      focusMenuButton(event, nextIndex);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      activateView(SHELL_NAV_ITEMS[0].viewId);
+      focusMenuButton(event, 0);
+      return;
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      const nextIndex = SHELL_NAV_ITEMS.length - 1;
+      activateView(SHELL_NAV_ITEMS[nextIndex].viewId);
+      focusMenuButton(event, nextIndex);
+    }
+  }
+
+  return (
+    <>
+      <header class="site-header">
+        <div class="site-header__main">
+          <div class="site-header__nav">
+            <h1 class="title" aria-label="VibeSensor">
+              <picture class="brandmark">
+                <source
+                  srcSet="/branding/vibesensor-logo-header-dark.svg"
+                  media="(prefers-color-scheme: dark)"
+                />
+                <img
+                  src="/branding/vibesensor-logo-header-light.svg"
+                  alt="VibeSensor"
+                  width="222"
+                  height="46"
+                />
+              </picture>
+            </h1>
+            <nav class="menu" aria-label="Primary" role="tablist">
+              {SHELL_NAV_ITEMS.map((item, index) => {
+                const isActive = item.viewId === initialShellState.activeViewId;
+                return (
+                  <button
+                    key={item.viewId}
+                    type="button"
+                    class={isActive ? "menu-btn active" : "menu-btn"}
+                    data-view={item.viewId}
+                    id={item.tabId}
+                    role="tab"
+                    aria-controls={item.viewId}
+                    aria-selected={isActive ? "true" : "false"}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => activateView(item.viewId)}
+                    onKeyDown={(event) => handleMenuKeyDown(index, event)}
+                  >
+                    <span data-i18n={item.labelKey}>{item.fallbackLabel}</span>
+                  </button>
+                );
+              })}
+            </nav>
+          </div>
+          <div class="site-header__preferences">
+            <label class="header-select" htmlFor="speedUnitSelect">
+              <span class="mini-label" data-i18n="speed.unit">
+                Unit
+              </span>
+              <select
+                id="speedUnitSelect"
+                class="unit-picker"
+                aria-label="Speed unit"
+                defaultValue={initialShellState.speedUnit}
+                onChange={(event) => {
+                  void bridge.current.saveSpeedUnit(event.currentTarget.value);
+                }}
+              >
+                {SPEED_UNIT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value} data-i18n={option.labelKey}>
+                    {option.fallbackLabel}
+                  </option>
+                ))}
+              </select>
+              <div
+                id="speedUnitFeedback"
+                class="settings-feedback-slot settings-feedback-slot--compact"
+                hidden
+              />
+            </label>
+            <label class="header-select" htmlFor="languageSelect">
+              <span class="mini-label" data-i18n="settings.language">
+                Language
+              </span>
+              <select
+                id="languageSelect"
+                class="lang-picker"
+                aria-label="Language"
+                defaultValue={initialShellState.lang}
+                onChange={(event) => {
+                  void bridge.current.saveLanguage(event.currentTarget.value);
+                }}
+              >
+                {LANGUAGE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <div
+                id="languageFeedback"
+                class="settings-feedback-slot settings-feedback-slot--compact"
+                hidden
+              />
+            </label>
+          </div>
+        </div>
+        <div class="site-header__status">
+          <div class="site-header__status-pills">
+            <div id="linkState" class="pill pill--muted" aria-live="polite">
+              Connecting...
+            </div>
+            <div id="shellLiveStatus" class="pill pill--muted" aria-live="polite">
+              No live signal
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div
+        id="appErrorBanner"
+        class="connection-banner app-error-banner"
+        hidden
+        aria-live="assertive"
+        role="alert"
+      />
+    </>
+  );
+}
+
+export function createUiShellChromeActionBridge(): UiShellChromeActionBridge {
+  const current: UiShellChromeActions = {
+    activateView: noop,
+    saveLanguage: noop,
+    saveSpeedUnit: noop,
+  };
+  return {
+    current,
+    attach(actions: UiShellChromeActions): void {
+      current.activateView = actions.activateView;
+      current.saveLanguage = actions.saveLanguage;
+      current.saveSpeedUnit = actions.saveSpeedUnit;
+    },
+  };
+}
+
+export function mountUiShellChrome(
+  host: HTMLElement,
+  bridge: UiShellChromeActionBridge,
+  initialShellState: Pick<ShellState, "activeViewId" | "lang" | "speedUnit">,
+): void {
+  const mount = createUiPreactMount(host);
+  mount.render(<UiShellChrome bridge={bridge} initialShellState={initialShellState} />);
+}

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -26,11 +26,13 @@ import {
   createUiShellStatusModule,
   type UiShellStatusModule,
 } from "./ui_shell_status_module";
+import type { UiShellChromeActionBridge } from "./ui_shell_chrome";
 import { setVariantState } from "../style_state";
 
 type UiShellControllerDeps = {
   state: AppState;
   dom: UiShellDom;
+  chromeActions: UiShellChromeActionBridge;
 };
 
 export class UiShellController {
@@ -84,6 +86,11 @@ export class UiShellController {
       applyLanguage: (forceReloadInsights = false) => this.applyLanguage(forceReloadInsights),
       renderSpeedReadout: () => this.status.renderSpeedReadout(),
       showError: (message) => this.showError(message),
+    });
+    deps.chromeActions.attach({
+      activateView: (viewId) => this.setActiveView(viewId),
+      saveLanguage: (lang) => this.preferences.saveLanguage(lang),
+      saveSpeedUnit: (unit) => this.preferences.saveSpeedUnit(unit),
     });
     this.languageRefresh = createUiShellLanguageRefreshModule({
       state: this.state,
@@ -157,9 +164,7 @@ export class UiShellController {
   }
 
   bindUiEvents(): void {
-    this.navigation.bindHandlers();
     this.bindFeatureEvents();
-    this.preferences.bindHandlers();
   }
 
   async hydratePersistedPreferences(): Promise<void> {

--- a/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
@@ -11,7 +11,6 @@ export interface UiShellNavigationModuleDeps {
 
 export interface UiShellNavigationModule {
   setActiveView(viewId: string): void;
-  bindHandlers(): void;
 }
 
 export function createUiShellNavigationModule(
@@ -39,56 +38,7 @@ export function createUiShellNavigationModule(
     }
   }
 
-  function activateMenuButton(button: HTMLElement): void {
-    const viewId = button.dataset.view;
-    if (!viewId) return;
-    setActiveView(viewId);
-  }
-
-  function activateMenuTabByIndex(index: number): void {
-    if (!els.menuButtons.length) return;
-    const safeIndex = ((index % els.menuButtons.length) + els.menuButtons.length)
-      % els.menuButtons.length;
-    const button = els.menuButtons[safeIndex];
-    activateMenuButton(button);
-    button.focus();
-  }
-
-  function bindHandlers(): void {
-    els.menuButtons.forEach((button, index) => {
-      const activate = (): void => activateMenuButton(button);
-      button.addEventListener("click", activate);
-      button.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          activate();
-          return;
-        }
-        if (event.key === "ArrowRight") {
-          event.preventDefault();
-          activateMenuTabByIndex(index + 1);
-          return;
-        }
-        if (event.key === "ArrowLeft") {
-          event.preventDefault();
-          activateMenuTabByIndex(index - 1);
-          return;
-        }
-        if (event.key === "Home") {
-          event.preventDefault();
-          activateMenuTabByIndex(0);
-          return;
-        }
-        if (event.key === "End") {
-          event.preventDefault();
-          activateMenuTabByIndex(els.menuButtons.length - 1);
-        }
-      });
-    });
-  }
-
   return {
     setActiveView,
-    bindHandlers,
   };
 }

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -19,7 +19,6 @@ export interface UiShellPreferencesModuleDeps {
 }
 
 export interface UiShellPreferencesModule {
-  bindHandlers(): void;
   hydratePersistedPreferences(): Promise<void>;
   saveLanguage(lang: string): Promise<void>;
   saveSpeedUnit(unit: string): Promise<void>;
@@ -143,28 +142,7 @@ export function createUiShellPreferencesModule(
     }
   }
 
-  function bindHandlers(): void {
-    const languageSelect = els.languageSelect;
-    if (languageSelect) {
-      languageSelect.value = shell.lang;
-      languageSelect.addEventListener("change", () => {
-        clearPreferenceFeedback(els.languageSelect, els.languageFeedback);
-        void saveLanguage(languageSelect.value);
-      });
-    }
-
-    const speedUnitSelect = els.speedUnitSelect;
-    if (speedUnitSelect) {
-      speedUnitSelect.value = shell.speedUnit;
-      speedUnitSelect.addEventListener("change", () => {
-        clearPreferenceFeedback(els.speedUnitSelect, els.speedUnitFeedback);
-        void saveSpeedUnit(speedUnitSelect.value);
-      });
-    }
-  }
-
   return {
-    bindHandlers,
     hydratePersistedPreferences,
     saveLanguage,
     saveSpeedUnit,

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -1,7 +1,13 @@
 import "uplot/dist/uPlot.min.css";
 import "../styles/app.css";
+import { getUiShellChromeHost } from "./dom/shell_dom";
+import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
+import { createUiShellChromeActionBridge, mountUiShellChrome } from "./runtime/ui_shell_chrome";
 
 export function startUiApp(): void {
-  new UiAppRuntime().start();
+  const state = createAppState();
+  const shellChromeActions = createUiShellChromeActionBridge();
+  mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
+  new UiAppRuntime(undefined, state, shellChromeActions).start();
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -4,6 +4,10 @@ import type { AppState } from "./ui_app_state";
 import { createAppState } from "./ui_app_state";
 import { createUiRuntimeDom, type UiRuntimeDom } from "./ui_runtime_dom";
 import { UiLiveTransportController } from "./runtime/ui_live_transport_controller";
+import {
+  createUiShellChromeActionBridge,
+  type UiShellChromeActionBridge,
+} from "./runtime/ui_shell_chrome";
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
 import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
@@ -27,12 +31,14 @@ export class UiAppRuntime {
   constructor(
     dom: UiRuntimeDom = createUiRuntimeDom(),
     state: AppState = createAppState(),
+    shellChromeActions: UiShellChromeActionBridge = createUiShellChromeActionBridge(),
   ) {
     this.dom = dom;
     this.state = state;
     this.shell = new UiShellController({
       state: this.state,
       dom: this.dom.shell,
+      chromeActions: shellChromeActions,
     });
     this.spectrum = new UiSpectrumController({
       state: this.state,

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -33,8 +33,6 @@ type SelectStub = HTMLSelectElement & {
 };
 
 type ButtonStub = HTMLButtonElement & {
-  triggerClick(): void;
-  triggerKeydown(key: string): EventStub;
   focused: boolean;
   ariaSelected: string | null;
 };
@@ -78,18 +76,12 @@ function createView(id: string): HTMLElement {
 }
 
 function createMenuButton(viewId: string): ButtonStub {
-  let clickListener: EventListenerOrEventListenerObject | undefined;
-  let keydownListener: EventListenerOrEventListenerObject | undefined;
   const button = {
     dataset: { view: viewId },
     tabIndex: -1,
     classList: createClassList(),
     focused: false,
     ariaSelected: null as string | null,
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
-      if (type === "click") clickListener = listener;
-      if (type === "keydown") keydownListener = listener;
-    },
     setAttribute(name: string, value: string) {
       if (name === "aria-selected") {
         this.ariaSelected = value;
@@ -97,25 +89,6 @@ function createMenuButton(viewId: string): ButtonStub {
     },
     focus() {
       this.focused = true;
-    },
-    triggerClick() {
-      triggerListener(clickListener, {
-        defaultPrevented: false,
-        preventDefault() {
-          this.defaultPrevented = true;
-        },
-      });
-    },
-    triggerKeydown(key: string) {
-      const event: EventStub = {
-        key,
-        defaultPrevented: false,
-        preventDefault() {
-          this.defaultPrevented = true;
-        },
-      };
-      triggerListener(keydownListener, event);
-      return event;
     },
   } as unknown as ButtonStub;
   return button;
@@ -316,18 +289,6 @@ test.describe("createUiShellNavigationModule", () => {
     expect(appShellWrap.getAttribute("data-active-view")).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(resizeCalls).toBe(1);
   });
-
-  test("bindHandlers supports keyboard navigation", () => {
-    const state = createAppState();
-    const { els, historyButton } = createShellDeps();
-    const module = createUiShellNavigationModule({ shell: state.shell, dom: els });
-
-    module.bindHandlers();
-    const event = historyButton.triggerKeydown("ArrowLeft");
-
-    expect(event.defaultPrevented).toBe(true);
-    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
-  });
 });
 
 test.describe("createUiShellPreferencesModule", () => {
@@ -379,7 +340,48 @@ test.describe("createUiShellPreferencesModule", () => {
     expect(renderSpeedReadoutCalls).toBe(1);
   });
 
-  test("bindHandlers persists speed unit changes independently from navigation", async () => {
+  test("saveLanguage persists the selected language independently from shell navigation", async () => {
+    const state = createAppState();
+    const { els, languageSelect } = createShellDeps();
+    const requests: Array<{ url: string; method: string; body: string }> = [];
+
+    const applyLanguageCalls: boolean[] = [];
+    const module = createUiShellPreferencesModule({
+      shell: state.shell,
+      dom: els,
+      t: (key) => key,
+      normalizeLanguage: (lang) => lang,
+      applyLanguage: (forceReloadInsights = false) => {
+        applyLanguageCalls.push(forceReloadInsights);
+      },
+      renderSpeedReadout: () => {},
+      showError: () => {},
+    });
+
+    await withMockFetch((async (input: string | URL | RequestInfo, init?: RequestInit) => {
+      requests.push({
+        url: requestUrl(input),
+        method: init?.method ?? "GET",
+        body: String(init?.body ?? ""),
+      });
+      return jsonResponse({ language: "nl" });
+    }) as typeof fetch, async () => {
+      await module.saveLanguage("nl");
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "/api/settings/language",
+        method: "PUT",
+        body: JSON.stringify({ language: "nl" }),
+      },
+    ]);
+    expect(state.shell.lang).toBe("nl");
+    expect(languageSelect.value).toBe("nl");
+    expect(applyLanguageCalls).toEqual([true]);
+  });
+
+  test("saveSpeedUnit persists speed unit changes independently from navigation", async () => {
     const state = createAppState();
     const { els, speedUnitSelect } = createShellDeps();
     const requests: Array<{ url: string; method: string; body: string }> = [];
@@ -405,10 +407,7 @@ test.describe("createUiShellPreferencesModule", () => {
       });
       return jsonResponse({ speed_unit: "mps" });
     }) as typeof fetch, async () => {
-      module.bindHandlers();
-      speedUnitSelect.triggerChange("mps");
-      await expect.poll(() => state.shell.speedUnit).toBe("mps");
-      await expect.poll(() => renderSpeedReadoutCalls).toBe(1);
+      await module.saveSpeedUnit("mps");
     });
 
     expect(requests).toEqual([
@@ -419,6 +418,7 @@ test.describe("createUiShellPreferencesModule", () => {
       },
     ]);
     expect(state.shell.speedUnit).toBe("mps");
+    expect(speedUnitSelect.value).toBe("mps");
     expect(renderSpeedReadoutCalls).toBe(1);
   });
 
@@ -442,15 +442,14 @@ test.describe("createUiShellPreferencesModule", () => {
     await withMockFetch((async () => {
       throw new Error("save failed");
     }) as typeof fetch, async () => {
-      module.bindHandlers();
-      speedUnitSelect.triggerChange("mps");
-      await expect.poll(() => speedUnitFeedback.innerHTML).toContain("save failed");
+      await module.saveSpeedUnit("mps");
     });
 
     expect(errors).toEqual([]);
     expect(state.shell.speedUnit).toBe("kmh");
     expect(speedUnitSelect.value).toBe("kmh");
     expect(speedUnitFeedback.hidden).toBe(false);
+    expect(speedUnitFeedback.innerHTML).toContain("save failed");
   });
 });
 


### PR DESCRIPTION
## Summary

This PR completes the first real surface migration after the Preact bootstrap by
moving the top-level shell chrome behind a Preact island. The goal for #2218 was
not to rewrite the whole UI runtime or start migrating panel bodies early. The
goal was to establish the shell as a stable, low-risk owner path for the shared
header surface: top-level tabs, language and speed-unit selectors, the shell
status pills, and the shared error banner. That is the contract this change
lands.

Before this change, the shell header and banner were still authored directly in
`apps/ui/index.html`, while keyboard navigation, selector changes, and startup
hydration were spread across imperative runtime modules. That meant the first
surface migration was blocked on a basic architecture problem: there was no
actual island owner for the shell markup, and the runtime depended on raw DOM
listeners attached after lookup. This PR fixes that gap without destabilizing
the rest of the app.

## Approach

The main design choice here was to preserve the existing shell DOM contract for
the rest of the runtime while changing only the owner of the shell surface. The
rest of the UI still expects stable selectors and IDs such as
`#tab-dashboard`, `#languageSelect`, `#speedUnitSelect`, `#linkState`,
`#shellLiveStatus`, and `#appErrorBanner`. Replacing those IDs or forcing a
broader controller rewrite here would have created unnecessary churn across
realtime, history, settings, and the smoke suite before those surfaces are ready
to migrate.

Instead, the PR mounts a Preact shell island before `createUiRuntimeDom()` runs.
That lets the runtime continue resolving the same shell elements it already
knows about, but the actual markup and top-level shell event binding are now
owned by a Preact component rather than by static HTML plus imperative listener
registration. This keeps the change reviewable, preserves current behavior, and
still satisfies the issue requirement that the shell chrome render from a Preact
island and that the legacy shell-only binding layer be reduced to a thin
adapter.

## Main code changes

### 1. Move shell markup out of `index.html`

`apps/ui/index.html` no longer contains the fully authored shell header and
banner markup. Instead, it exposes a single `#appShellChromeRoot` host. The
dashboard, history, and settings panel bodies remain in place and are
intentionally unchanged, because they are explicitly out of scope for #2218.

This is the architectural pivot for the issue: the shell is no longer a static
document fragment owned by the HTML file.

### 2. Add the shell island owner

`apps/ui/src/app/runtime/ui_shell_chrome.tsx` is the new owner for the shell
surface. It renders:

- the top-level tab navigation
- the speed-unit selector
- the language selector
- the shell websocket/status pills
- the shared app error banner

The island also owns the top-level shell event binding that used to live in the
imperative modules:

- click activation for the main tabs
- keyboard tab navigation with `ArrowLeft`, `ArrowRight`, `Home`, `End`,
  `Enter`, and `Space`
- selector change handling for language and speed unit

To keep startup ordering simple, the island uses a small action bridge. The
component can render immediately, while the runtime later attaches the concrete
handlers that call into the existing shell controller and preference save paths.

### 3. Mount before DOM lookup

`start_ui_app.ts`, `shell_dom.ts`, and `ui_app_runtime.ts` now cooperate so the
shell island mounts before runtime DOM resolution happens. The startup path now:

1. creates the shared app state once
2. resolves the shell host
3. mounts the shell island into that host
4. constructs the runtime against the already-rendered shell DOM

This matters because `createUiRuntimeDom()` still resolves the shell selectors
used by the rest of the runtime and feature bundle. Mounting first means the
rest of the application does not need a parallel lookup path or a second DOM
registry just because the shell is now rendered by Preact.

### 4. Reduce legacy shell modules to thin adapters

`ui_shell_controller.ts` now attaches the island action bridge to the existing
controller methods. `ui_shell_navigation_module.ts` and
`ui_shell_preferences_module.ts` no longer own raw DOM listener registration.
They keep the state mutation, fallback logic, hydration, persistence, and inline
feedback responsibilities they already handled well.

That split is intentional. It removes the shell-specific imperative binding that
the issue targeted, but avoids prematurely rewriting status rendering,
translation refresh, or persistence behavior that still serves the legacy panel
surfaces below the shell.

In other words: the shell island owns markup and shell input decoding; the
existing modules continue to own shell state application and shared runtime side
effects.

## Tests and validation

I updated `apps/ui/tests/ui_shell_runtime_modules.spec.ts` so it matches the new
ownership boundary. The preference tests now exercise `saveLanguage()` and
`saveSpeedUnit()` directly instead of depending on the old DOM binding helpers.
That reflects the new design more accurately: shell event binding moved into the
Preact island, while the preference module remains the persistence/update
adapter.

I also validated the real shell behavior with the existing browser coverage that
already exercises the migrated surface:

- `npm run typecheck`
- `npm run build`
- `npm run lint`
- focused Playwright runs for:
  - `tests/smoke.bootstrap.spec.ts`
  - `tests/smoke.settings.spec.ts`
  - `tests/ui_shell_runtime_modules.spec.ts`

The smoke coverage is important here because it verifies the actual shell
contract, not just unit seams: top-level tab clicks, keyboard navigation,
selector changes, status visibility, and cross-feature behavior through the live
runtime path.

One environment note: the shared default Playwright port was already occupied by
another process in this workspace, so I ran the focused shell specs against an
isolated local port instead of relying on the shared default. That did not
change repo code or test semantics; it only avoided cross-process interference
in this environment.

## Risks, tradeoffs, and out-of-scope items

This PR intentionally does **not** migrate the dashboard, history, or settings
panel bodies. Those remain separate backlog items. It also does not force the
shell’s dynamic status rendering fully into Preact state yet. The existing shell
status, notification, and language-refresh modules still update the rendered DOM
through the stable selectors the rest of the runtime already knows about.

That is a deliberate tradeoff for this issue. Doing a deeper runtime rewrite
here would have mixed the shell migration with later panel migrations and made
it harder to reason about regressions. The follow-on issues can now migrate each
surface on top of a stable shell owner path, and the final cleanup issue can
collapse more of the remaining thin adapter layer once the rest of the UI is off
the legacy path.

Closes #2218
