### PR TITLE
feat(ui): move live overview into Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -192,6 +192,11 @@ The shell chrome owner path now starts at `app/runtime/ui_shell_chrome.tsx`,
 which mounts the shell island before `ui_runtime_dom.ts` resolves the shared
 shell selectors; the legacy shell runtime still owns state updates and
 cross-feature refresh behavior behind that rendered surface.
+The live overview card now follows the same pattern through
+`app/views/realtime_live_overview.tsx`: startup mounts the island into the
+overview host, the realtime presenter feeds it view-model data, and the
+remaining dashboard cards continue on the legacy path until their own issues
+land.
 
 ## Architecture guardrails
 

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -11,45 +11,7 @@
 
       <section id="dashboardView" class="view active" role="tabpanel" aria-labelledby="tab-dashboard">
         <div class="dashboard-grid">
-          <div class="panel card dashboard-grid__overview">
-            <div class="card__header card__header--stack">
-              <div>
-                <div class="card__title" data-i18n="dashboard.live_overview">Live overview</div>
-                <div class="card__subtle" data-i18n="dashboard.live_overview_hint">Check readiness, current run state, and the strongest sensor level before reading the chart.</div>
-              </div>
-              <div id="liveRunHealth" class="pill pill--muted" aria-live="polite">No live signal</div>
-            </div>
-            <div class="stat-grid live-overview__stats">
-              <div id="liveConnectedSensors" class="stat">
-                <div class="stat__label" data-i18n="dashboard.connected_sensors">Sensors online</div>
-                <div class="stat__value" data-value>--</div>
-              </div>
-              <div id="liveActiveCar" class="stat">
-                <div class="stat__label" data-i18n="dashboard.active_car">Active car</div>
-                <div class="stat__value" data-value>--</div>
-              </div>
-              <div id="liveRecordingState" class="stat">
-                <div class="stat__label" data-i18n="dashboard.recording_state">Run state</div>
-                <div class="stat__value" data-value>--</div>
-              </div>
-              <div id="liveDataFreshness" class="stat">
-                <div class="stat__label" data-i18n="dashboard.data_freshness">Feed freshness</div>
-                <div class="stat__value" data-value>--</div>
-              </div>
-              <div id="liveStrongestSignal" class="stat">
-                <div class="stat__label" data-i18n="dashboard.strongest_signal">Strongest sensor level</div>
-                <div class="stat__value" data-value>--</div>
-              </div>
-              <div class="stat">
-                <div class="stat__label" data-i18n="dashboard.current_speed">Current speed</div>
-                <div id="speed" class="stat__value speed" aria-live="polite">--</div>
-              </div>
-            </div>
-            <div class="live-sensor-roster__header">
-              <div class="mini-label" data-i18n="dashboard.sensor_coverage">Sensor coverage</div>
-            </div>
-            <div id="liveSensorRoster" class="live-sensor-roster"></div>
-          </div>
+          <div id="liveOverviewRoot" class="panel card dashboard-grid__overview"></div>
 
           <div class="panel card dashboard-grid__main">
             <div class="card__header">

--- a/apps/ui/src/app/dom/realtime_dom.ts
+++ b/apps/ui/src/app/dom/realtime_dom.ts
@@ -1,6 +1,7 @@
 import { getById, requiredById } from "./dom_query";
 
 const REALTIME_OWNER = "Realtime feature";
+const LIVE_OVERVIEW_HOST_ID = "liveOverviewRoot";
 
 export interface UiRealtimeDom {
   loggingStatus: HTMLElement | null;
@@ -13,14 +14,11 @@ export interface UiRealtimeDom {
   startLoggingBtn: HTMLButtonElement;
   stopLoggingBtn: HTMLButtonElement | null;
   sensorsSettingsBody: HTMLElement | null;
-  liveConnectedSensors: HTMLElement | null;
-  liveActiveCar: HTMLElement | null;
-  liveRecordingState: HTMLElement | null;
-  liveDataFreshness: HTMLElement | null;
-  liveStrongestSignal: HTMLElement | null;
-  liveRunHealth: HTMLElement | null;
-  liveSensorRoster: HTMLElement | null;
   shellLiveStatus: HTMLElement | null;
+}
+
+export function getUiLiveOverviewHost(): HTMLElement {
+  return requiredById<HTMLElement>(LIVE_OVERVIEW_HOST_ID, REALTIME_OWNER);
 }
 
 export function createUiRealtimeDom(): UiRealtimeDom {
@@ -35,13 +33,6 @@ export function createUiRealtimeDom(): UiRealtimeDom {
     startLoggingBtn: requiredById<HTMLButtonElement>("startLoggingBtn", REALTIME_OWNER),
     stopLoggingBtn: getById<HTMLButtonElement>("stopLoggingBtn"),
     sensorsSettingsBody: getById<HTMLElement>("sensorsSettingsBody"),
-    liveConnectedSensors: getById<HTMLElement>("liveConnectedSensors"),
-    liveActiveCar: getById<HTMLElement>("liveActiveCar"),
-    liveRecordingState: getById<HTMLElement>("liveRecordingState"),
-    liveDataFreshness: getById<HTMLElement>("liveDataFreshness"),
-    liveStrongestSignal: getById<HTMLElement>("liveStrongestSignal"),
-    liveRunHealth: getById<HTMLElement>("liveRunHealth"),
-    liveSensorRoster: getById<HTMLElement>("liveSensorRoster"),
     shellLiveStatus: getById<HTMLElement>("shellLiveStatus"),
   };
 }

--- a/apps/ui/src/app/dom/shell_dom.ts
+++ b/apps/ui/src/app/dom/shell_dom.ts
@@ -10,7 +10,6 @@ export interface UiShellDom {
   languageFeedback: HTMLElement | null;
   speedUnitSelect: HTMLSelectElement | null;
   speedUnitFeedback: HTMLElement | null;
-  speed: HTMLElement | null;
   linkState: HTMLElement | null;
   appErrorBanner: HTMLElement | null;
   appShellWrap: HTMLElement | null;
@@ -28,7 +27,6 @@ export function createUiShellDom(): UiShellDom {
     languageFeedback: getById<HTMLElement>("languageFeedback"),
     speedUnitSelect: getById<HTMLSelectElement>("speedUnitSelect"),
     speedUnitFeedback: getById<HTMLElement>("speedUnitFeedback"),
-    speed: getById<HTMLElement>("speed"),
     linkState: getById<HTMLElement>("linkState"),
     appErrorBanner: getById<HTMLElement>("appErrorBanner"),
     appShellWrap: queryOne<HTMLElement>(".wrap"),

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -9,6 +9,7 @@ import type { AdaptedClient } from "../../transport/live_models";
 import {
   bindRealtimeFeatureInteractions,
 } from "../views/realtime_feature_bindings";
+import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
 import { createRealtimeFeatureWorkflow } from "./realtime_feature_workflow";
 import { createRealtimeFeaturePresenter } from "../views/realtime_feature_presenter";
 
@@ -30,6 +31,7 @@ export interface RealtimeFeatureDeps extends FeatureDepsBase {
 export interface RealtimeFeatureChromePorts {
   setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
   setStatValue: (container: HTMLElement | null, value: string | number) => void;
+  liveOverview: RealtimeLiveOverviewBridge;
 }
 
 export interface RealtimeFeatureSelectionPorts {

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -28,11 +28,13 @@ import {
 } from "./ui_shell_status_module";
 import type { UiShellChromeActionBridge } from "./ui_shell_chrome";
 import { setVariantState } from "../style_state";
+import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
 
 type UiShellControllerDeps = {
   state: AppState;
   dom: UiShellDom;
   chromeActions: UiShellChromeActionBridge;
+  liveOverview: RealtimeLiveOverviewBridge;
 };
 
 export class UiShellController {
@@ -77,6 +79,7 @@ export class UiShellController {
       dom: this.els,
       t: (key, vars) => this.t(key, vars),
       setPillState: (el, variant, text) => this.setPillState(el, variant, text),
+      renderLiveOverviewSpeed: (text) => deps.liveOverview.setSpeedText(text),
     });
     this.preferences = createUiShellPreferencesModule({
       shell: this.state.shell,

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -28,6 +28,7 @@ export interface UiShellStatusModuleDeps {
   dom: UiShellDom;
   t: (key: string, vars?: Record<string, unknown>) => string;
   setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
+  renderLiveOverviewSpeed: (text: string) => void;
 }
 
 export interface UiShellStatusModule {
@@ -47,7 +48,6 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
   }
 
   function renderSpeedReadout(): void {
-    if (!els.speed) return;
     const unitLabel = selectedSpeedUnitLabel();
     if (typeof realtime.speedMps === "number" && Number.isFinite(realtime.speedMps)) {
       const value = speedValueInSelectedUnit(realtime.speedMps);
@@ -55,13 +55,13 @@ export function createUiShellStatusModule(ctx: UiShellStatusModuleDeps): UiShell
         settings,
         realtime.rotationalSpeeds?.basis_speed_source ?? null,
       );
-      els.speed.textContent = ctx.t(labelKey, {
+      ctx.renderLiveOverviewSpeed(ctx.t(labelKey, {
         value: fmt(value, 1),
         unit: unitLabel,
-      });
+      }));
       return;
     }
-    els.speed.textContent = ctx.t("speed.none", { unit: unitLabel });
+    ctx.renderLiveOverviewSpeed(ctx.t("speed.none", { unit: unitLabel }));
   }
 
   function renderWsState(): void {

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -1,13 +1,16 @@
 import "uplot/dist/uPlot.min.css";
 import "../styles/app.css";
+import { getUiLiveOverviewHost } from "./dom/realtime_dom";
 import { getUiShellChromeHost } from "./dom/shell_dom";
 import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
+import { mountRealtimeLiveOverview } from "./views/realtime_live_overview";
 import { createUiShellChromeActionBridge, mountUiShellChrome } from "./runtime/ui_shell_chrome";
 
 export function startUiApp(): void {
   const state = createAppState();
   const shellChromeActions = createUiShellChromeActionBridge();
+  const liveOverview = mountRealtimeLiveOverview(getUiLiveOverviewHost());
   mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
-  new UiAppRuntime(undefined, state, shellChromeActions).start();
+  new UiAppRuntime(undefined, state, shellChromeActions, liveOverview).start();
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -12,6 +12,10 @@ import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
 import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
+import {
+  createNullRealtimeLiveOverviewBridge,
+  type RealtimeLiveOverviewBridge,
+} from "./views/realtime_live_overview";
 
 export class UiAppRuntime {
   private readonly dom: UiRuntimeDom;
@@ -32,6 +36,7 @@ export class UiAppRuntime {
     dom: UiRuntimeDom = createUiRuntimeDom(),
     state: AppState = createAppState(),
     shellChromeActions: UiShellChromeActionBridge = createUiShellChromeActionBridge(),
+    liveOverview: RealtimeLiveOverviewBridge = createNullRealtimeLiveOverviewBridge(),
   ) {
     this.dom = dom;
     this.state = state;
@@ -39,6 +44,7 @@ export class UiAppRuntime {
       state: this.state,
       dom: this.dom.shell,
       chromeActions: shellChromeActions,
+      liveOverview,
     });
     this.spectrum = new UiSpectrumController({
       state: this.state,
@@ -80,6 +86,7 @@ export class UiAppRuntime {
         realtimeChrome: {
           setPillState: (el, variant, text) => this.shell.setPillState(el, variant, text),
           setStatValue: (container, value) => this.shell.setStatValue(container, value),
+          liveOverview,
         },
         view: {
           renderSpectrum: () => this.spectrum.renderSpectrum(),

--- a/apps/ui/src/app/views/realtime_feature_presenter.ts
+++ b/apps/ui/src/app/views/realtime_feature_presenter.ts
@@ -19,9 +19,12 @@ import {
   renderRealtimeLoggingSummary,
 } from "./realtime_logging_view";
 import {
-  renderRealtimeSensorOverview,
   renderRealtimeSensorTable,
 } from "./realtime_sensor_table_view";
+import type {
+  RealtimeLiveOverviewBridge,
+  RealtimeLiveOverviewRenderModel,
+} from "./realtime_live_overview";
 
 export type RealtimeFeaturePendingLoggingAction = RealtimeLoggingPendingAction;
 
@@ -45,6 +48,7 @@ export interface RealtimeFeaturePresenterDeps {
   chrome: {
     setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
     setStatValue: (container: HTMLElement | null, value: string | number) => void;
+    liveOverview: RealtimeLiveOverviewBridge;
   };
 }
 
@@ -104,37 +108,6 @@ export function createRealtimeFeaturePresenter(
     strongestSignalText,
   } = sensorState;
 
-  function renderActiveCarStat(): void {
-    const container = els.liveActiveCar;
-    const valueEl = container?.querySelector<HTMLElement>("[data-value]");
-    if (!container || !valueEl) {
-      return;
-    }
-    const state = activeCarDisplayState();
-    if (state.isWarning) {
-      container.setAttribute("data-variant", "warn");
-      valueEl.setAttribute("data-variant", "warn");
-      valueEl.setAttribute("data-has-icon", "true");
-    } else {
-      container.removeAttribute("data-variant");
-      valueEl.removeAttribute("data-variant");
-      valueEl.removeAttribute("data-has-icon");
-    }
-    valueEl.replaceChildren();
-    if (state.isWarning) {
-      const iconEl = document.createElement("span");
-      iconEl.className = "stat__value-icon";
-      iconEl.setAttribute("data-variant", "warn");
-      iconEl.setAttribute("aria-hidden", "true");
-      iconEl.textContent = "!";
-      const textEl = document.createElement("span");
-      textEl.textContent = state.text;
-      valueEl.append(iconEl, textEl);
-      return;
-    }
-    valueEl.textContent = state.text;
-  }
-
   function dataFreshnessText(): string {
     const connected = connectedClients();
     const ages = connected
@@ -190,17 +163,42 @@ export function createRealtimeFeaturePresenter(
     }));
   }
 
-  function renderLiveSensorRoster(): void {
-    if (!els.liveSensorRoster) return;
+  function liveSensorOverviewLabel(client: AdaptedClient): string {
+    const code = locationCodeForClient(client);
+    if (!code) {
+      return String(client.name || client.id || t("dashboard.sensor_unassigned")).trim();
+    }
+    const option = realtime.locationOptions.find((location) => location.code === code);
+    return option?.label ?? code;
+  }
+
+  function buildLiveOverviewModel(phaseText: string): RealtimeLiveOverviewRenderModel {
     const signal = strongestSignal();
-    renderRealtimeSensorOverview(els.liveSensorRoster, {
-      clients: realtime.clients,
-      locationOptions: realtime.locationOptions,
-      locationCodeForClient,
-      strongestClientId: signal?.client.id ?? null,
-      t,
-      escapeHtml,
-    });
+    const health = computeCurrentLiveHealth();
+    const totalClients = realtime.clients.length;
+    const activeCar = activeCarDisplayState();
+    return {
+      connectedSensorsText: `${formatInt(connectedClients().length)} / ${formatInt(totalClients)}`,
+      activeCar: {
+        text: activeCar.text,
+        warning: activeCar.isWarning,
+      },
+      recordingStateText: phaseText,
+      dataFreshnessText: dataFreshnessText(),
+      strongestSignalText: strongestSignalText(signal),
+      runHealth: {
+        hidden: !health.showOverviewPill,
+        text: health.text,
+        variant: health.variant,
+      },
+      sensorCards: realtime.clients.map((client) => ({
+        id: client.id,
+        label: liveSensorOverviewLabel(client),
+        connected: Boolean(client.connected),
+        statusText: client.connected ? t("status.online") : t("status.offline"),
+        strongest: signal?.client.id === client.id,
+      })),
+    };
   }
 
   function selectionBlockReason(): "no_cars" | "no_active" | null {
@@ -230,20 +228,10 @@ export function createRealtimeFeaturePresenter(
     });
   }
 
-  function renderLiveOverviewStats(phaseText: string): void {
-    const signal = strongestSignal();
-    const totalClients = realtime.clients.length;
-    setStatValue(els.liveConnectedSensors, `${formatInt(connectedClients().length)} / ${formatInt(totalClients)}`);
-    renderActiveCarStat();
-    setStatValue(els.liveRecordingState, phaseText);
-    setStatValue(els.liveDataFreshness, dataFreshnessText());
-    setStatValue(els.liveStrongestSignal, strongestSignalText(signal));
-  }
-
-  function renderLiveHealth(): void {
-    const health = computeCurrentLiveHealth();
-    setDashboardPillState(els.liveRunHealth, health.variant, health.text, { hidden: !health.showOverviewPill });
-    setPillState(els.shellLiveStatus, health.variant, health.text);
+  function renderLiveOverview(phaseText: string): void {
+    const model = buildLiveOverviewModel(phaseText);
+    chrome.liveOverview.render(model);
+    setPillState(els.shellLiveStatus, model.runHealth.variant, model.runHealth.text);
   }
 
   function sensorsSettingsSignature(): string {
@@ -262,7 +250,7 @@ export function createRealtimeFeaturePresenter(
     if (!force && nextSig === realtime.sensorsSettingsSignature) return;
     realtime.sensorsSettingsSignature = nextSig;
     renderSensorsSettingsList();
-    renderLiveSensorRoster();
+    renderLiveOverview(buildLoggingPanelViewModel(null).phaseText);
   }
 
   function renderSensorsSettingsList(): void {
@@ -270,7 +258,6 @@ export function createRealtimeFeaturePresenter(
     renderRealtimeSensorTable(els.sensorsSettingsBody, {
       clients: realtime.clients,
       locationOptions: realtime.locationOptions,
-      locationCodeForClient,
       t,
       escapeHtml,
     });
@@ -278,7 +265,7 @@ export function createRealtimeFeaturePresenter(
 
   function renderStatus(clientRow?: AdaptedClient): void {
     void clientRow;
-    renderLiveOverviewStats(buildLoggingPanelViewModel(null).phaseText);
+    renderLiveOverview(buildLoggingPanelViewModel(null).phaseText);
   }
 
   function clearLoggingElapsedTimer(): void {
@@ -364,7 +351,7 @@ export function createRealtimeFeaturePresenter(
     } else {
       dashboardGrid?.removeAttribute("data-layout");
     }
-    renderLiveOverviewStats(panelState.phaseText);
+    renderLiveOverview(panelState.phaseText);
     setDashboardPillState(els.loggingStatus, panelState.pillVariant, panelState.pillText, {
       hidden: !panelState.showPill,
     });
@@ -398,7 +385,7 @@ export function createRealtimeFeaturePresenter(
       els.stopLoggingBtn.disabled = panelState.stopDisabled;
     }
     syncLoggingElapsedTimer(state.handlersBound);
-    renderLiveHealth();
+    renderLiveOverview(panelState.phaseText);
   }
 
   function renderLoggingUnavailable(): void {

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -1,0 +1,215 @@
+import { createUiPreactMount } from "../runtime/ui_preact_mount";
+
+export interface RealtimeLiveOverviewActiveCarModel {
+  text: string;
+  warning: boolean;
+}
+
+export interface RealtimeLiveOverviewHealthModel {
+  hidden: boolean;
+  text: string;
+  variant: "muted" | "ok" | "warn" | "bad";
+}
+
+export interface RealtimeLiveOverviewSensorCardModel {
+  id: string;
+  label: string;
+  connected: boolean;
+  statusText: string;
+  strongest: boolean;
+}
+
+export interface RealtimeLiveOverviewRenderModel {
+  connectedSensorsText: string;
+  activeCar: RealtimeLiveOverviewActiveCarModel;
+  recordingStateText: string;
+  dataFreshnessText: string;
+  strongestSignalText: string;
+  runHealth: RealtimeLiveOverviewHealthModel;
+  sensorCards: RealtimeLiveOverviewSensorCardModel[];
+}
+
+interface RealtimeLiveOverviewBridgeState extends RealtimeLiveOverviewRenderModel {
+  speedText: string;
+}
+
+export interface RealtimeLiveOverviewBridge {
+  render(model: RealtimeLiveOverviewRenderModel): void;
+  setSpeedText(text: string): void;
+}
+
+const DEFAULT_OVERVIEW_STATE: RealtimeLiveOverviewBridgeState = {
+  connectedSensorsText: "--",
+  activeCar: {
+    text: "--",
+    warning: false,
+  },
+  recordingStateText: "--",
+  dataFreshnessText: "--",
+  strongestSignalText: "--",
+  runHealth: {
+    hidden: false,
+    text: "No live signal",
+    variant: "muted",
+  },
+  sensorCards: [],
+  speedText: "--",
+};
+
+function RealtimeLiveOverview(props: { state: RealtimeLiveOverviewBridgeState }) {
+  const { state } = props;
+
+  return (
+    <>
+      <div class="card__header card__header--stack">
+        <div>
+          <div class="card__title" data-i18n="dashboard.live_overview">
+            Live overview
+          </div>
+          <div class="card__subtle" data-i18n="dashboard.live_overview_hint">
+            Check readiness, current run state, and the strongest sensor level before reading the
+            chart.
+          </div>
+        </div>
+        <div
+          id="liveRunHealth"
+          class="pill"
+          data-variant={state.runHealth.variant}
+          hidden={state.runHealth.hidden}
+          aria-live="polite"
+        >
+          {state.runHealth.text}
+        </div>
+      </div>
+      <div class="stat-grid live-overview__stats">
+        <div id="liveConnectedSensors" class="stat">
+          <div class="stat__label" data-i18n="dashboard.connected_sensors">
+            Sensors online
+          </div>
+          <div class="stat__value" data-value>
+            {state.connectedSensorsText}
+          </div>
+        </div>
+        <div
+          id="liveActiveCar"
+          class="stat"
+          data-variant={state.activeCar.warning ? "warn" : undefined}
+        >
+          <div class="stat__label" data-i18n="dashboard.active_car">
+            Active car
+          </div>
+          <div
+            class="stat__value"
+            data-value
+            data-variant={state.activeCar.warning ? "warn" : undefined}
+            data-has-icon={state.activeCar.warning ? "true" : undefined}
+          >
+            {state.activeCar.warning
+              ? (
+                <>
+                  <span class="stat__value-icon" data-variant="warn" aria-hidden="true">
+                    !
+                  </span>
+                  <span>{state.activeCar.text}</span>
+                </>
+              )
+              : state.activeCar.text}
+          </div>
+        </div>
+        <div id="liveRecordingState" class="stat">
+          <div class="stat__label" data-i18n="dashboard.recording_state">
+            Run state
+          </div>
+          <div class="stat__value" data-value>
+            {state.recordingStateText}
+          </div>
+        </div>
+        <div id="liveDataFreshness" class="stat">
+          <div class="stat__label" data-i18n="dashboard.data_freshness">
+            Feed freshness
+          </div>
+          <div class="stat__value" data-value>
+            {state.dataFreshnessText}
+          </div>
+        </div>
+        <div id="liveStrongestSignal" class="stat">
+          <div class="stat__label" data-i18n="dashboard.strongest_signal">
+            Strongest sensor level
+          </div>
+          <div class="stat__value" data-value>
+            {state.strongestSignalText}
+          </div>
+        </div>
+        <div class="stat">
+          <div class="stat__label" data-i18n="dashboard.current_speed">
+            Current speed
+          </div>
+          <div id="speed" class="stat__value speed" aria-live="polite">
+            {state.speedText}
+          </div>
+        </div>
+      </div>
+      <div class="live-sensor-roster__header">
+        <div class="mini-label" data-i18n="dashboard.sensor_coverage">
+          Sensor coverage
+        </div>
+      </div>
+      <div id="liveSensorRoster" class="live-sensor-roster">
+        {state.sensorCards.length
+          ? state.sensorCards.map((card) => {
+            const statusClass = card.connected ? "online" : "offline";
+            return (
+              <article
+                key={card.id}
+                class={card.strongest ? "live-sensor-card live-sensor-card--strongest" : "live-sensor-card"}
+              >
+                <div class="live-sensor-card__header">
+                  <strong>{card.label}</strong>
+                  <span
+                    class={`live-sensor-card__status-dot live-sensor-card__status-dot--${statusClass}`}
+                    role="img"
+                    aria-label={card.statusText}
+                    title={card.statusText}
+                  />
+                </div>
+              </article>
+            );
+          })
+          : (
+            <div class="subtle" data-i18n="settings.sensors.no_sensors">
+              No sensors yet.
+            </div>
+          )}
+      </div>
+    </>
+  );
+}
+
+export function createNullRealtimeLiveOverviewBridge(): RealtimeLiveOverviewBridge {
+  return {
+    render() {},
+    setSpeedText() {},
+  };
+}
+
+export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
+  const mount = createUiPreactMount(host);
+  let state: RealtimeLiveOverviewBridgeState = { ...DEFAULT_OVERVIEW_STATE };
+
+  function render(): void {
+    mount.render(<RealtimeLiveOverview state={state} />);
+  }
+
+  render();
+
+  return {
+    render(model: RealtimeLiveOverviewRenderModel): void {
+      state = { ...state, ...model };
+      render();
+    },
+    setSpeedText(text: string): void {
+      state = { ...state, speedText: text };
+      render();
+    },
+  };
+}

--- a/apps/ui/src/app/views/realtime_sensor_table_view.ts
+++ b/apps/ui/src/app/views/realtime_sensor_table_view.ts
@@ -5,33 +5,8 @@ import { closestFromTarget, renderTableEmptyRow } from "./dom_helpers";
 export interface RealtimeSensorTableViewParams {
   clients: AdaptedClient[];
   locationOptions: LocationOption[];
-  locationCodeForClient: (client: AdaptedClient) => string;
-  strongestClientId?: string | null;
   t: (key: string, vars?: Record<string, unknown>) => string;
   escapeHtml: (value: unknown) => string;
-}
-
-function locationLabelForClient(
-  client: AdaptedClient,
-  params: RealtimeSensorTableViewParams,
-): string {
-  const code = params.locationCodeForClient(client);
-  if (!code) {
-    return params.t("dashboard.sensor_unassigned");
-  }
-  const option = params.locationOptions.find((location) => location.code === code);
-  return option?.label ?? code;
-}
-
-function liveSensorOverviewLabelForClient(
-  client: AdaptedClient,
-  params: RealtimeSensorTableViewParams,
-): string {
-  const code = params.locationCodeForClient(client);
-  if (!code) {
-    return client.name || client.id || params.t("dashboard.sensor_unassigned");
-  }
-  return locationLabelForClient(client, params);
 }
 
 export interface RealtimeSensorTableClickAction {
@@ -62,7 +37,7 @@ export function renderRealtimeSensorTable(
   container: HTMLElement,
   params: RealtimeSensorTableViewParams,
 ): void {
-  const { clients, locationOptions, locationCodeForClient, t, escapeHtml } = params;
+  const { clients, locationOptions, t, escapeHtml } = params;
   if (!clients.length) {
     container.innerHTML = renderTableEmptyRow(
       escapeHtml(t("settings.sensors.no_sensors")),
@@ -79,28 +54,6 @@ export function renderRealtimeSensorTable(
       const statusClass = connected ? "online" : "offline";
       const macAddress = client.mac_address || client.id;
       return `<tr data-client-id="${escapeHtml(client.id)}"><td><strong>${escapeHtml(client.name || client.id)}</strong><div class="subtle">${escapeHtml(client.id)}</div><div class="status-pill ${statusClass}">${statusText}</div></td><td><code>${escapeHtml(macAddress)}</code></td><td><select class="row-location-select" data-client-id="${escapeHtml(client.id)}">${locationOptionsMarkup(locationOptions, selectedCode, t, escapeHtml)}</select></td><td><button class="btn btn--primary row-identify" data-client-id="${escapeHtml(client.id)}"${connected ? "" : " disabled"}>${escapeHtml(t("actions.identify"))}</button></td><td><button class="btn btn--danger row-remove" data-client-id="${escapeHtml(client.id)}">${escapeHtml(t("actions.remove"))}</button></td></tr>`;
-    })
-    .join("");
-}
-
-export function renderRealtimeSensorOverview(
-  container: HTMLElement,
-  params: RealtimeSensorTableViewParams,
-): void {
-  const { clients, t, escapeHtml } = params;
-  if (!clients.length) {
-    container.innerHTML = `<div class="subtle">${escapeHtml(t("settings.sensors.no_sensors"))}</div>`;
-    return;
-  }
-
-  container.innerHTML = clients
-    .map((client) => {
-      const connected = Boolean(client.connected);
-      const statusText = connected ? t("status.online") : t("status.offline");
-      const statusClass = connected ? "online" : "offline";
-      const strongestClass = params.strongestClientId === client.id ? " live-sensor-card--strongest" : "";
-      const locationLabel = escapeHtml(liveSensorOverviewLabelForClient(client, params));
-      return `<article class="live-sensor-card${strongestClass}"><div class="live-sensor-card__header"><strong>${locationLabel}</strong><span class="live-sensor-card__status-dot live-sensor-card__status-dot--${statusClass}" role="img" aria-label="${escapeHtml(statusText)}" title="${escapeHtml(statusText)}"></span></div></article>`;
     })
     .join("");
 }

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { getUiLiveOverviewHost } from "../src/app/dom/realtime_dom";
 import { createUiRuntimeDom } from "../src/app/ui_runtime_dom";
 
 type SelectorFixture = {
@@ -27,6 +28,7 @@ function createBaseFixture(): SelectorFixture {
     ids: {
       specChart: stubElement("specChart"),
       startLoggingBtn: stubElement("startLoggingBtn"),
+      liveOverviewRoot: stubElement("liveOverviewRoot"),
       historyTableBody: stubElement("historyTableBody"),
       addCarBtn: stubElement("addCarBtn"),
       addCarWizard: stubElement("addCarWizard"),
@@ -99,6 +101,15 @@ test("createUiRuntimeDom returns the feature-scoped startup bundle when required
   }
 });
 
+test("getUiLiveOverviewHost resolves the overview island host", () => {
+  const restore = installDomFixture();
+  try {
+    expect(getUiLiveOverviewHost().id).toBe("liveOverviewRoot");
+  } finally {
+    restore();
+  }
+});
+
 test.describe("createUiRuntimeDom missing required feature anchors", () => {
   test("fails at the shell boundary when menu tabs are missing", () => {
     const restore = installDomFixture({ missingSelector: ".menu-btn" });
@@ -122,6 +133,15 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     const restore = installDomFixture({ missingId: "startLoggingBtn" });
     try {
       expect(() => createUiRuntimeDom()).toThrow("Realtime feature requires #startLoggingBtn");
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails when the live overview host is missing", () => {
+    const restore = installDomFixture({ missingId: "liveOverviewRoot" });
+    try {
+      expect(() => getUiLiveOverviewHost()).toThrow("Realtime feature requires #liveOverviewRoot");
     } finally {
       restore();
     }

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -162,7 +162,6 @@ function createShellDeps(overrides?: Partial<UiShellDom>): {
   languageFeedback: HTMLElement;
   speedUnitSelect: SelectStub;
   speedUnitFeedback: HTMLElement;
-  speed: HTMLElement;
   linkState: HTMLElement;
   appErrorBanner: HTMLElement;
   appShellWrap: HTMLElement;
@@ -175,7 +174,6 @@ function createShellDeps(overrides?: Partial<UiShellDom>): {
   const languageFeedback = createTextElement();
   const speedUnitSelect = createSelect("kmh");
   const speedUnitFeedback = createTextElement();
-  const speed = createTextElement();
   const linkState = createTextElement();
   const appErrorBanner = createTextElement();
   const appShellWrap = createTextElement();
@@ -187,7 +185,6 @@ function createShellDeps(overrides?: Partial<UiShellDom>): {
     languageFeedback,
     speedUnitSelect,
     speedUnitFeedback,
-    speed,
     linkState,
     appErrorBanner,
     appShellWrap,
@@ -205,7 +202,6 @@ function createShellDeps(overrides?: Partial<UiShellDom>): {
     languageFeedback,
     speedUnitSelect,
     speedUnitFeedback,
-    speed,
     linkState,
     appErrorBanner,
     appShellWrap,
@@ -511,7 +507,8 @@ test.describe("createUiShellStatusModule", () => {
     state.settings.carsLoaded = true;
     state.settings.cars = [];
     state.settings.activeCarId = null;
-    const { els, speed } = createShellDeps();
+    const { els } = createShellDeps();
+    let renderedSpeedText = "";
     const module = createUiShellStatusModule({
       shell: state.shell,
       transport: state.transport,
@@ -520,12 +517,15 @@ test.describe("createUiShellStatusModule", () => {
       dom: els,
       t: testTranslation,
       setPillState: () => {},
+      renderLiveOverviewSpeed: (text) => {
+        renderedSpeedText = text;
+      },
     });
 
     module.renderSpeedReadout();
 
-    expect(speed.textContent).toContain("speed.override");
-    expect(speed.textContent).toContain("\"unit\":\"speed.unit.kmh\"");
+    expect(renderedSpeedText).toContain("speed.override");
+    expect(renderedSpeedText).toContain("\"unit\":\"speed.unit.kmh\"");
   });
 
   test("renders OBD2 when OBD2 is the resolved speed source", () => {
@@ -534,7 +534,8 @@ test.describe("createUiShellStatusModule", () => {
     state.settings.speedSource = "obd2";
     state.settings.resolvedSpeedSource = "obd2";
     state.shell.speedUnit = "kmh";
-    const { els, speed } = createShellDeps();
+    const { els } = createShellDeps();
+    let renderedSpeedText = "";
     const module = createUiShellStatusModule({
       shell: state.shell,
       transport: state.transport,
@@ -543,12 +544,15 @@ test.describe("createUiShellStatusModule", () => {
       dom: els,
       t: testTranslation,
       setPillState: () => {},
+      renderLiveOverviewSpeed: (text) => {
+        renderedSpeedText = text;
+      },
     });
 
     module.renderSpeedReadout();
 
-    expect(speed.textContent).toContain("speed.obd2");
-    expect(speed.textContent).toContain("\"unit\":\"speed.unit.kmh\"");
+    expect(renderedSpeedText).toContain("speed.obd2");
+    expect(renderedSpeedText).toContain("\"unit\":\"speed.unit.kmh\"");
   });
 });
 


### PR DESCRIPTION
Closes #2219

## Summary

This PR migrates the dashboard live-overview surface into its own Preact island without widening the scope into the spectrum or run-recording cards. The goal for this issue was not to rewrite the whole realtime screen, but to pick a clean ownership seam for the overview card and make the existing runtime feed that surface through an explicit render contract instead of direct DOM mutation. That seam now exists: startup mounts a dedicated overview island into the existing dashboard slot, the realtime presenter computes a typed view model for that island, and the remaining dashboard features continue to run through the legacy path until their own migration issues land.

The biggest functional wrinkle in this panel was the current-speed readout. In the legacy DOM path, shell status code wrote directly into `#speed` inside the overview card. That would become brittle as soon as the overview card was re-rendered by Preact, because a shell-owned DOM mutation inside a Preact-owned subtree is an easy way to create stale nodes, lost text, or confusing update ordering. Rather than leave that cross-owner edge in place, this PR routes speed text through the new overview bridge so the island owns the entire card output consistently.

## Implementation approach

I kept the migration intentionally narrow:

1. keep the existing dashboard location and CSS hooks for the live overview card,
2. replace the static overview markup in `index.html` with a single host element,
3. mount a Preact island into that host during startup,
4. thread a small bridge through runtime composition so existing modules can push overview state into the island,
5. remove overview-specific imperative DOM rendering where it no longer has a good reason to exist,
6. leave spectrum, logging, and the rest of the dashboard on the legacy path for now.

That keeps the change reviewable and aligned with the issue definition, while still deleting a meaningful slice of old DOM-specific presenter/view code instead of just layering a new renderer beside it.

## Main code changes

### 1. Added a dedicated overview island

`apps/ui/src/app/views/realtime_live_overview.tsx` is the new owner for the live overview card. It defines the render model, the default state, and a mount helper that exposes a simple bridge with `render()` and `renderSpeed()` methods. The component renders:

- the live health pill,
- connected sensor count,
- active car state,
- run state,
- data freshness,
- strongest signal,
- current speed,
- and the sensor coverage roster.

This keeps the view logic concentrated in one place and gives later issues a stable pattern to repeat.

### 2. Replaced the old overview HTML with a host

`apps/ui/index.html` no longer contains the full overview-card subtree. Instead, it now exposes `#liveOverviewRoot` in the same dashboard position. That preserves the existing layout slot while making it clear that this card is now application-rendered rather than static HTML plus imperative patching.

### 3. Mounted the island during startup and threaded it through runtime composition

`apps/ui/src/app/start_ui_app.ts` now mounts the live-overview island before `UiAppRuntime` starts, matching the shell-chrome pattern introduced in the previous issue.

`apps/ui/src/app/ui_app_runtime.ts` accepts the overview bridge and passes it into the realtime feature and shell controller wiring. This is the composition point that lets the old runtime keep producing the same behavior while the render owner changes underneath it.

### 4. Redirected overview and speed updates through the bridge

The realtime presenter was the old owner of the overview card’s imperative DOM updates. In `apps/ui/src/app/views/realtime_feature_presenter.ts`, that logic now builds a `RealtimeLiveOverviewRenderModel` and sends it to `chrome.liveOverview.render(model)`. The presenter still computes the same domain-facing values it did before—connected counts, active-car messaging, freshness, strongest-signal text, and roster labeling—but it no longer reaches into overview DOM nodes one by one.

On the shell side, `apps/ui/src/app/runtime/ui_shell_status_module.ts` no longer writes directly to `dom.speed`. Instead, it renders the localized speed string through `renderLiveOverviewSpeed()`, which keeps the full overview card under one render owner. `ui_shell_controller.ts` provides that bridge wiring.

### 5. Removed obsolete overview-specific DOM contracts

Because the overview card is no longer resolved as a bundle of individual elements, `apps/ui/src/app/dom/realtime_dom.ts` now focuses on the remaining realtime DOM contract plus a host lookup for the live overview island. `apps/ui/src/app/dom/shell_dom.ts` also drops the direct `speed` field, since speed is no longer a shell-owned DOM node.

`apps/ui/src/app/views/realtime_sensor_table_view.ts` no longer carries the separate `renderRealtimeSensorOverview()` helper. That renderer existed specifically for the imperative live-overview roster path, so once the overview island became the owner, keeping that extra renderer would just preserve duplication.

### 6. Updated docs and tests to match the new ownership seam

`apps/ui/README.md` now documents the live-overview owner path next to the shell island notes, so the incremental migration architecture stays understandable as more surfaces move.

The focused tests were updated in two places:

- `apps/ui/tests/ui_runtime_dom.spec.ts` now covers `getUiLiveOverviewHost()` and the missing-host failure path.
- `apps/ui/tests/ui_shell_runtime_modules.spec.ts` now asserts that shell status pushes speed output through the overview bridge instead of mutating a shell DOM field.

I also ran browser-level smoke coverage for the affected dashboard/settings/cars behavior to catch regressions in integrated startup and realtime rendering.

## Validation

I ran the existing frontend validation commands and focused UI specs that cover the changed seams:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/ui_runtime_dom.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts tests/smoke.settings-alignment.spec.ts tests/smoke.settings.spec.ts --config .ai-temp/playwright-2219.config.ts --workers=1`

The temporary Playwright config only existed to avoid the shared-environment port collision on the default smoke port; it was removed after the run, and the isolated Vite server was shut down once the suite passed.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that the runtime still spans both Preact-owned and legacy-owned dashboard surfaces. That is intentional for this migration sequence: the overview card now has a clear owner and bridge, but the spectrum and recording cards are left untouched so their issues can stay small and independently reviewable.

I specifically did not move logging-card rendering into this PR even though the presenter sits nearby, because that would have crossed into issue `#2221`. I also did not rewrite the underlying realtime state model or transport flow; those paths continue to feed the UI as before, which keeps the change safer and makes it easier to compare behavior before and after the render-owner swap.

If there is follow-up risk here, it is mostly around future migrations continuing to honor ownership boundaries. The pattern in this PR is the one I want repeated: Preact owns the rendered subtree, legacy modules either compute view models or act as thin bridges, and cross-surface updates avoid direct DOM writes into another owner’s tree.
