### PR TITLE
feat(ui): move spectrum panel into Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -197,6 +197,11 @@ The live overview card now follows the same pattern through
 overview host, the realtime presenter feeds it view-model data, and the
 remaining dashboard cards continue on the legacy path until their own issues
 land.
+The spectrum panel now follows the same incremental pattern through
+`app/views/spectrum_panel.tsx`: startup mounts the island into the spectrum
+host, `UiSpectrumController` keeps the chart renderer imperative behind the
+stable `specChart` seam, and interaction/overlay/legend state is pushed into
+the island through a typed bridge instead of direct DOM mutation.
 
 ## Architecture guardrails
 

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -13,26 +13,7 @@
         <div class="dashboard-grid">
           <div id="liveOverviewRoot" class="panel card dashboard-grid__overview"></div>
 
-          <div class="panel card dashboard-grid__main">
-            <div class="card__header">
-              <div class="card__title" data-i18n="chart.spectrum_title">Multi-Sensor Blended Spectrum</div>
-            </div>
-            <div id="specChartWrap" class="spectrum-wrap">
-              <div id="specChart"></div>
-              <div id="spectrumOverlay" class="empty-state" hidden>Waiting for sensor data...</div>
-            </div>
-            <div class="spectrum-controls-panel">
-              <div class="spectrum-toolbar">
-                <div class="card__subtle spectrum-toolbar__hint" data-i18n="spectrum.controls_hint">Use the trace chips to isolate one sensor at a time. Turn on reference bands when you need order context.</div>
-                <div class="spectrum-toolbar__bands">
-                  <button id="spectrumBandToggle" class="btn spectrum-toolbar__toggle" type="button" aria-pressed="false" hidden>Show reference bands</button>
-                  <div id="bandLegend" class="legend band-legend" hidden></div>
-                </div>
-              </div>
-              <div id="spectrumInspector" class="spectrum-inspector" aria-live="polite">Use the trace chips or hover the chart to inspect the current peak.</div>
-              <div id="legend" class="legend"></div>
-            </div>
-          </div>
+          <div id="spectrumPanelRoot" class="panel card dashboard-grid__main"></div>
 
           <div class="panel card dashboard-grid__controls">
             <div class="card__header card__header--stack">

--- a/apps/ui/src/app/dom/spectrum_dom.ts
+++ b/apps/ui/src/app/dom/spectrum_dom.ts
@@ -5,21 +5,15 @@ const SPECTRUM_OWNER = "Spectrum UI";
 export interface UiSpectrumDom {
   specChartWrap: HTMLElement | null;
   specChart: HTMLElement;
-  spectrumOverlay: HTMLElement | null;
-  spectrumInspector: HTMLElement | null;
-  legend: HTMLElement | null;
-  bandLegend: HTMLElement | null;
-  spectrumBandToggle: HTMLButtonElement | null;
 }
 
 export function createUiSpectrumDom(): UiSpectrumDom {
   return {
     specChartWrap: getById<HTMLElement>("specChartWrap"),
     specChart: requiredById<HTMLElement>("specChart", SPECTRUM_OWNER),
-    spectrumOverlay: getById<HTMLElement>("spectrumOverlay"),
-    spectrumInspector: getById<HTMLElement>("spectrumInspector"),
-    legend: getById<HTMLElement>("legend"),
-    bandLegend: getById<HTMLElement>("bandLegend"),
-    spectrumBandToggle: getById<HTMLButtonElement>("spectrumBandToggle"),
   };
+}
+
+export function getUiSpectrumPanelHost(): HTMLElement {
+  return requiredById<HTMLElement>("spectrumPanelRoot", SPECTRUM_OWNER);
 }

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -30,7 +30,7 @@ export interface SpectrumPreparedRenderData {
 
 export interface SpectrumCanvasRendererDeps {
   state: AppState;
-  dom: Pick<UiSpectrumDom, "specChart" | "specChartWrap" | "spectrumOverlay">;
+  dom: Pick<UiSpectrumDom, "specChart" | "specChartWrap">;
   t: (key: string, vars?: Record<string, unknown>) => string;
   getBandsVisible: () => boolean;
   getChartBands: () => readonly ChartBand[];
@@ -334,7 +334,6 @@ export class SpectrumCanvasRenderer {
     }
     this.deps.state.spectrum.spectrumPlot = new SpectrumChart(
       this.deps.dom.specChart,
-      this.deps.dom.spectrumOverlay,
       360,
       this.deps.dom.specChartWrap,
     );

--- a/apps/ui/src/app/runtime/spectrum_panel_view.ts
+++ b/apps/ui/src/app/runtime/spectrum_panel_view.ts
@@ -1,6 +1,9 @@
-import type { UiSpectrumDom } from "../dom/spectrum_dom";
-
 export type SpectrumLegendState = "all-visible" | "visible" | "isolated" | "inactive";
+
+export interface SpectrumPanelHeaderModel {
+  titleText: string;
+  hintText: string;
+}
 
 export interface SpectrumLegendResetModel {
   labelText: string;
@@ -38,15 +41,10 @@ export interface SpectrumBandLegendModel {
   emptyText: string;
 }
 
-type SpectrumLegendButton = {
-  button: HTMLButtonElement;
-  label: HTMLSpanElement;
-  meta: HTMLSpanElement | null;
-  swatch: HTMLSpanElement | null;
-};
-
 export interface SpectrumPanelView {
   bindBandToggle(onToggle: () => void): void;
+  renderHeader(model: SpectrumPanelHeaderModel): void;
+  renderOverlay(message: string | null): void;
   renderBandToggle(model: {
     hasBands: boolean;
     bandsVisible: boolean;
@@ -63,227 +61,14 @@ export interface SpectrumPanelView {
   renderInspectorText(text: string): void;
 }
 
-export interface SpectrumPanelViewDeps {
-  dom: Pick<
-    UiSpectrumDom,
-    "bandLegend" | "legend" | "spectrumBandToggle" | "spectrumInspector"
-  >;
-}
-
-export function createSpectrumPanelView(
-  deps: SpectrumPanelViewDeps,
-): SpectrumPanelView {
-  let legendResetButton: SpectrumLegendButton | null = null;
-  const legendSeriesButtons = new Map<string, SpectrumLegendButton>();
-
-  function setOptionalStateAttribute(
-    element: HTMLElement,
-    name: string,
-    value: string | null,
-  ): void {
-    if (!value) {
-      element.removeAttribute(name);
-      return;
-    }
-    element.setAttribute(name, value);
-  }
-
-  function bindBandToggle(onToggle: () => void): void {
-    deps.dom.spectrumBandToggle?.addEventListener("click", onToggle);
-  }
-
-  function renderBandToggle(model: {
-    hasBands: boolean;
-    bandsVisible: boolean;
-    text: string;
-  }): void {
-    const button = deps.dom.spectrumBandToggle;
-    if (!button) {
-      return;
-    }
-    button.setAttribute("aria-controls", "bandLegend");
-    button.hidden = !model.hasBands;
-    button.disabled = !model.hasBands;
-    button.setAttribute("aria-pressed", model.hasBands && model.bandsVisible ? "true" : "false");
-    button.setAttribute("aria-expanded", model.hasBands && model.bandsVisible ? "true" : "false");
-    button.textContent = model.text;
-  }
-
-  function renderSensorLegend(
-    model: SpectrumSensorLegendModel | null,
-    handlers?: {
-      onReset: () => void;
-      onSelect: (entryId: string) => void;
-    },
-  ): void {
-    const legend = deps.dom.legend;
-    if (!legend) {
-      return;
-    }
-    if (!model || model.items.length === 0 || !handlers) {
-      legendResetButton?.button.remove();
-      for (const parts of legendSeriesButtons.values()) {
-        parts.button.remove();
-      }
-      legendResetButton = null;
-      legendSeriesButtons.clear();
-      return;
-    }
-
-    const allButton = ensureLegendResetButton(handlers.onReset);
-    allButton.button.className = "legend-item legend-item--interactive legend-item--reset";
-    allButton.button.setAttribute("aria-pressed", model.reset.ariaPressed ? "true" : "false");
-    allButton.button.title = model.reset.titleText;
-    allButton.button.setAttribute("aria-label", model.reset.ariaLabel);
-    setOptionalStateAttribute(allButton.button, "data-legend-state", model.reset.active ? "active" : null);
-    allButton.label.textContent = model.reset.labelText;
-    placeLegendButton(legend, allButton.button, 0);
-
-    const activeIds = new Set<string>();
-    let nextIndex = 1;
-    for (const item of model.items) {
-      activeIds.add(item.id);
-      const parts = ensureLegendSeriesButton(item.id, handlers.onSelect);
-      parts.button.className = "legend-item legend-item--interactive";
-      parts.button.setAttribute("aria-pressed", item.ariaPressed ? "true" : "false");
-      parts.button.title = item.titleText;
-      parts.button.setAttribute("aria-label", item.ariaLabel);
-      setOptionalStateAttribute(
-        parts.button,
-        "data-legend-state",
-        item.active ? "active" : item.muted ? "muted" : null,
-      );
-      parts.label.textContent = item.labelText;
-      parts.swatch?.style.setProperty("--swatch-color", item.color);
-      if (parts.meta) {
-        parts.meta.textContent = item.detailText ?? "";
-      }
-      placeLegendButton(legend, parts.button, nextIndex);
-      nextIndex += 1;
-    }
-
-    for (const [entryId, parts] of legendSeriesButtons) {
-      if (activeIds.has(entryId)) {
-        continue;
-      }
-      parts.button.remove();
-      legendSeriesButtons.delete(entryId);
-    }
-  }
-
-  function renderBandLegend(model: SpectrumBandLegendModel): void {
-    const legend = deps.dom.bandLegend;
-    if (!legend) {
-      return;
-    }
-    legend.innerHTML = "";
-    legend.hidden = !model.visible;
-    if (!model.visible) {
-      return;
-    }
-    if (!model.items.length) {
-      const row = document.createElement("div");
-      row.className = "legend-item legend-item--band";
-      row.setAttribute("data-band-state", "empty");
-      row.textContent = model.emptyText;
-      legend.appendChild(row);
-      return;
-    }
-    for (const item of model.items) {
-      const row = document.createElement("div");
-      row.className = "legend-item legend-item--band";
-      row.setAttribute("data-band-state", "active");
-      row.style.setProperty("--band-color", item.color);
-      const swatch = document.createElement("span");
-      swatch.className = "swatch";
-      swatch.style.setProperty("--swatch-color", item.color);
-      const label = document.createElement("span");
-      label.textContent = item.labelText;
-      row.append(swatch, label);
-      legend.appendChild(row);
-    }
-  }
-
-  function renderInspectorText(text: string): void {
-    if (!deps.dom.spectrumInspector) {
-      return;
-    }
-    deps.dom.spectrumInspector.textContent = text;
-  }
-
-  function ensureLegendResetButton(onReset: () => void): SpectrumLegendButton {
-    if (legendResetButton) {
-      return legendResetButton;
-    }
-    const button = document.createElement("button");
-    button.type = "button";
-    button.addEventListener("click", onReset);
-    const label = document.createElement("span");
-    label.className = "legend-item__label";
-    button.appendChild(label);
-    legendResetButton = {
-      button,
-      label,
-      meta: null,
-      swatch: null,
-    };
-    return legendResetButton;
-  }
-
-  function ensureLegendSeriesButton(
-    entryId: string,
-    onSelect: (entryId: string) => void,
-  ): SpectrumLegendButton {
-    const existing = legendSeriesButtons.get(entryId);
-    if (existing) {
-      return existing;
-    }
-    const button = document.createElement("button");
-    button.type = "button";
-    button.addEventListener("click", () => onSelect(entryId));
-
-    const swatch = document.createElement("span");
-    swatch.className = "swatch";
-
-    const textGroup = document.createElement("span");
-    textGroup.className = "legend-item__text-group";
-
-    const label = document.createElement("span");
-    label.className = "legend-item__label";
-
-    const meta = document.createElement("span");
-    meta.className = "legend-item__meta";
-
-    textGroup.append(label, meta);
-    button.append(swatch, textGroup);
-
-    const created = {
-      button,
-      label,
-      meta,
-      swatch,
-    };
-    legendSeriesButtons.set(entryId, created);
-    return created;
-  }
-
-  function placeLegendButton(
-    legend: HTMLElement,
-    button: HTMLButtonElement,
-    index: number,
-  ): void {
-    const currentChild = legend.children[index];
-    if (currentChild === button) {
-      return;
-    }
-    legend.insertBefore(button, currentChild ?? null);
-  }
-
+export function createNullSpectrumPanelView(): SpectrumPanelView {
   return {
-    bindBandToggle,
-    renderBandToggle,
-    renderSensorLegend,
-    renderBandLegend,
-    renderInspectorText,
+    bindBandToggle() {},
+    renderHeader() {},
+    renderOverlay() {},
+    renderBandToggle() {},
+    renderSensorLegend() {},
+    renderBandLegend() {},
+    renderInspectorText() {},
   };
 }

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -2,16 +2,17 @@ import type { UiSpectrumDom } from "../dom/spectrum_dom";
 import type { AppState } from "../ui_app_state";
 import { SpectrumCanvasRenderer } from "./spectrum_canvas_renderer";
 import { SpectrumInteractionController } from "./spectrum_interaction_controller";
-import { createSpectrumPanelView } from "./spectrum_panel_view";
+import { createNullSpectrumPanelView, type SpectrumPanelView } from "./spectrum_panel_view";
 
 type UiSpectrumControllerDeps = {
   state: AppState;
   dom: UiSpectrumDom;
+  panel?: SpectrumPanelView;
   t: (key: string, vars?: Record<string, unknown>) => string;
 };
 
 export class UiSpectrumController {
-  private readonly panel: ReturnType<typeof createSpectrumPanelView>;
+  private readonly panel: SpectrumPanelView;
 
   private readonly interaction: SpectrumInteractionController;
 
@@ -20,9 +21,7 @@ export class UiSpectrumController {
   constructor(
     private readonly deps: UiSpectrumControllerDeps,
   ) {
-    this.panel = createSpectrumPanelView({
-      dom: this.els,
-    });
+    this.panel = this.deps.panel ?? createNullSpectrumPanelView();
     this.canvas = new SpectrumCanvasRenderer({
       state: this.state,
       dom: this.els,
@@ -63,6 +62,10 @@ export class UiSpectrumController {
   }
 
   renderSpectrum(): void {
+    this.panel.renderHeader({
+      titleText: this.t("chart.spectrum_title"),
+      hintText: this.t("spectrum.controls_hint"),
+    });
     const prepared = this.canvas.prepareFrame();
     this.state.spectrum.chartBands = prepared.chartBands;
     this.state.spectrum.hasSpectrumData = prepared.hasData;
@@ -99,10 +102,6 @@ export class UiSpectrumController {
   }
 
   private setSpectrumOverlay(message: string | null): void {
-    if (!this.els.spectrumOverlay) {
-      return;
-    }
-    this.els.spectrumOverlay.hidden = message === null;
-    this.els.spectrumOverlay.textContent = message ?? "";
+    this.panel.renderOverlay(message);
   }
 }

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -2,15 +2,18 @@ import "uplot/dist/uPlot.min.css";
 import "../styles/app.css";
 import { getUiLiveOverviewHost } from "./dom/realtime_dom";
 import { getUiShellChromeHost } from "./dom/shell_dom";
+import { getUiSpectrumPanelHost } from "./dom/spectrum_dom";
 import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
 import { mountRealtimeLiveOverview } from "./views/realtime_live_overview";
+import { mountSpectrumPanel } from "./views/spectrum_panel";
 import { createUiShellChromeActionBridge, mountUiShellChrome } from "./runtime/ui_shell_chrome";
 
 export function startUiApp(): void {
   const state = createAppState();
   const shellChromeActions = createUiShellChromeActionBridge();
+  const spectrumPanel = mountSpectrumPanel(getUiSpectrumPanelHost());
   const liveOverview = mountRealtimeLiveOverview(getUiLiveOverviewHost());
   mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
-  new UiAppRuntime(undefined, state, shellChromeActions, liveOverview).start();
+  new UiAppRuntime(undefined, state, shellChromeActions, liveOverview, spectrumPanel).start();
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -10,6 +10,7 @@ import {
 } from "./runtime/ui_shell_chrome";
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
 import { UiShellController } from "./runtime/ui_shell_controller";
+import { createNullSpectrumPanelView, type SpectrumPanelView } from "./runtime/spectrum_panel_view";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
 import {
@@ -37,6 +38,7 @@ export class UiAppRuntime {
     state: AppState = createAppState(),
     shellChromeActions: UiShellChromeActionBridge = createUiShellChromeActionBridge(),
     liveOverview: RealtimeLiveOverviewBridge = createNullRealtimeLiveOverviewBridge(),
+    spectrumPanel: SpectrumPanelView = createNullSpectrumPanelView(),
   ) {
     this.dom = dom;
     this.state = state;
@@ -49,6 +51,7 @@ export class UiAppRuntime {
     this.spectrum = new UiSpectrumController({
       state: this.state,
       dom: this.dom.spectrum,
+      panel: spectrumPanel,
       t: (key, vars) => this.shell.t(key, vars),
     });
     this.shell.attachSpectrumHooks({

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -1,0 +1,201 @@
+import { createUiPreactMount } from "../runtime/ui_preact_mount";
+import type {
+  SpectrumBandLegendModel,
+  SpectrumPanelHeaderModel,
+  SpectrumPanelView,
+  SpectrumSensorLegendModel,
+} from "../runtime/spectrum_panel_view";
+
+type SpectrumLegendHandlers = {
+  onReset: () => void;
+  onSelect: (entryId: string) => void;
+};
+
+type SpectrumPanelBridgeState = {
+  header: SpectrumPanelHeaderModel;
+  overlayMessage: string | null;
+  bandToggle: {
+    hasBands: boolean;
+    bandsVisible: boolean;
+    text: string;
+  };
+  sensorLegend: SpectrumSensorLegendModel | null;
+  sensorLegendHandlers: SpectrumLegendHandlers | null;
+  bandLegend: SpectrumBandLegendModel;
+  inspectorText: string;
+  onBandToggle: (() => void) | null;
+};
+
+const DEFAULT_PANEL_STATE: SpectrumPanelBridgeState = {
+  header: {
+    titleText: "Multi-Sensor Blended Spectrum",
+    hintText: "Use the trace chips to isolate one sensor at a time. Turn on reference bands when you need order context.",
+  },
+  overlayMessage: null,
+  bandToggle: {
+    hasBands: false,
+    bandsVisible: false,
+    text: "Show reference bands",
+  },
+  sensorLegend: null,
+  sensorLegendHandlers: null,
+  bandLegend: {
+    visible: false,
+    items: [],
+    emptyText: "No reference band",
+  },
+  inspectorText: "Use the trace chips or hover the chart to inspect the current peak.",
+  onBandToggle: null,
+};
+
+function SpectrumPanel(props: { state: SpectrumPanelBridgeState }) {
+  const { state } = props;
+
+  return (
+    <>
+      <div class="card__header">
+        <div class="card__title" data-i18n="chart.spectrum_title">
+          {state.header.titleText}
+        </div>
+      </div>
+      <div id="specChartWrap" class="spectrum-wrap">
+        <div id="specChart" />
+        <div id="spectrumOverlay" class="empty-state" hidden={state.overlayMessage === null}>
+          {state.overlayMessage ?? "Waiting for sensor data..."}
+        </div>
+      </div>
+      <div class="spectrum-controls-panel">
+        <div class="spectrum-toolbar">
+          <div class="card__subtle spectrum-toolbar__hint" data-i18n="spectrum.controls_hint">
+            {state.header.hintText}
+          </div>
+          <div class="spectrum-toolbar__bands">
+            <button
+              id="spectrumBandToggle"
+              class="btn spectrum-toolbar__toggle"
+              type="button"
+              aria-controls="bandLegend"
+              aria-pressed={state.bandToggle.hasBands && state.bandToggle.bandsVisible ? "true" : "false"}
+              aria-expanded={state.bandToggle.hasBands && state.bandToggle.bandsVisible ? "true" : "false"}
+              hidden={!state.bandToggle.hasBands}
+              disabled={!state.bandToggle.hasBands}
+              onClick={() => state.onBandToggle?.()}
+            >
+              {state.bandToggle.text}
+            </button>
+            <div id="bandLegend" class="legend band-legend" hidden={!state.bandLegend.visible}>
+              {state.bandLegend.visible
+                ? state.bandLegend.items.length
+                  ? state.bandLegend.items.map((item) => (
+                    <div
+                      key={item.labelText}
+                      class="legend-item legend-item--band"
+                      data-band-state="active"
+                      style={`--band-color: ${item.color}`}
+                    >
+                      <span class="swatch" style={`--swatch-color: ${item.color}`} />
+                      <span>{item.labelText}</span>
+                    </div>
+                  ))
+                  : (
+                    <div class="legend-item legend-item--band" data-band-state="empty">
+                      {state.bandLegend.emptyText}
+                    </div>
+                  )
+                : null}
+            </div>
+          </div>
+        </div>
+        <div id="spectrumInspector" class="spectrum-inspector" aria-live="polite">
+          {state.inspectorText}
+        </div>
+        <div id="legend" class="legend">
+          {state.sensorLegend && state.sensorLegend.items.length > 0 && state.sensorLegendHandlers
+            ? (
+              <>
+                <button
+                  type="button"
+                  class="legend-item legend-item--interactive legend-item--reset"
+                  aria-pressed={state.sensorLegend.reset.ariaPressed ? "true" : "false"}
+                  title={state.sensorLegend.reset.titleText}
+                  aria-label={state.sensorLegend.reset.ariaLabel}
+                  data-legend-state={state.sensorLegend.reset.active ? "active" : undefined}
+                  onClick={() => state.sensorLegendHandlers?.onReset()}
+                >
+                  <span class="legend-item__label">{state.sensorLegend.reset.labelText}</span>
+                </button>
+                {state.sensorLegend.items.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    class="legend-item legend-item--interactive"
+                    aria-pressed={item.ariaPressed ? "true" : "false"}
+                    title={item.titleText}
+                    aria-label={item.ariaLabel}
+                    data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
+                    onClick={() => state.sensorLegendHandlers?.onSelect(item.id)}
+                  >
+                    <span class="swatch" style={`--swatch-color: ${item.color}`} />
+                    <span class="legend-item__text-group">
+                      <span class="legend-item__label">{item.labelText}</span>
+                      <span class="legend-item__meta">{item.detailText ?? ""}</span>
+                    </span>
+                  </button>
+                ))}
+              </>
+            )
+            : null}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
+  const mount = createUiPreactMount(host);
+  let state: SpectrumPanelBridgeState = { ...DEFAULT_PANEL_STATE };
+
+  function render(): void {
+    mount.render(<SpectrumPanel state={state} />);
+  }
+
+  render();
+
+  return {
+    bindBandToggle(onToggle: () => void): void {
+      state = { ...state, onBandToggle: onToggle };
+      render();
+    },
+    renderHeader(model: SpectrumPanelHeaderModel): void {
+      state = { ...state, header: model };
+      render();
+    },
+    renderOverlay(message: string | null): void {
+      state = { ...state, overlayMessage: message };
+      render();
+    },
+    renderBandToggle(model: { hasBands: boolean; bandsVisible: boolean; text: string }): void {
+      state = { ...state, bandToggle: model };
+      render();
+    },
+    renderSensorLegend(
+      model: SpectrumSensorLegendModel | null,
+      handlers?: SpectrumLegendHandlers,
+    ): void {
+      state = {
+        ...state,
+        sensorLegend: model,
+        sensorLegendHandlers: model && handlers ? handlers : null,
+      };
+      render();
+    },
+    renderBandLegend(model: SpectrumBandLegendModel): void {
+      state = { ...state, bandLegend: model };
+      render();
+    },
+    renderInspectorText(text: string): void {
+      state = { ...state, inspectorText: text };
+      render();
+    },
+  };
+}

--- a/apps/ui/src/spectrum.ts
+++ b/apps/ui/src/spectrum.ts
@@ -42,7 +42,7 @@ export class SpectrumChart {
   private resizeObserver: ResizeObserver | null = null;
   private resizeRaf: number | null = null;
 
-  constructor(hostEl: HTMLElement, _overlayEl?: HTMLElement | null, height = 360, measureEl?: HTMLElement | null) {
+  constructor(hostEl: HTMLElement, height = 360, measureEl?: HTMLElement | null) {
     this.hostEl = hostEl;
     this.measureEl = measureEl || hostEl;
     this.height = height;

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -76,8 +76,7 @@ test.describe("SpectrumCanvasRenderer", () => {
         dom: {
           specChart: createElementStub("div"),
           specChartWrap: createElementStub("div"),
-          spectrumOverlay: null,
-        } as unknown as Pick<UiSpectrumDom, "specChart" | "specChartWrap" | "spectrumOverlay">,
+        } as unknown as Pick<UiSpectrumDom, "specChart" | "specChartWrap">,
         t: (key) => key,
         getBandsVisible: () => false,
         getChartBands: () => [],

--- a/apps/ui/tests/spectrum_interaction_controller.spec.ts
+++ b/apps/ui/tests/spectrum_interaction_controller.spec.ts
@@ -1,112 +1,157 @@
 import { expect, test } from "@playwright/test";
 
 import { SpectrumInteractionController } from "../src/app/runtime/spectrum_interaction_controller";
-import { createSpectrumPanelView } from "../src/app/runtime/spectrum_panel_view";
-import { installWindowGlobal } from "./async_test_helpers";
-import { createElementStub, installDocumentStub } from "./spectrum_test_support";
+import type {
+  SpectrumBandLegendModel,
+  SpectrumPanelView,
+  SpectrumSensorLegendModel,
+} from "../src/app/runtime/spectrum_panel_view";
+
+function createPanelStub(): {
+  panel: SpectrumPanelView;
+  bandToggleModel: { hasBands: boolean; bandsVisible: boolean; text: string } | null;
+  sensorLegend: {
+    model: SpectrumSensorLegendModel | null;
+    handlers: {
+      onReset: () => void;
+      onSelect: (entryId: string) => void;
+    } | null;
+  };
+  bandLegendModel: SpectrumBandLegendModel | null;
+  inspectorText: string;
+} {
+  let bandToggleModel: { hasBands: boolean; bandsVisible: boolean; text: string } | null = null;
+  let sensorLegend: {
+    model: SpectrumSensorLegendModel | null;
+    handlers: {
+      onReset: () => void;
+      onSelect: (entryId: string) => void;
+    } | null;
+  } = {
+    model: null,
+    handlers: null,
+  };
+  let bandLegendModel: SpectrumBandLegendModel | null = null;
+  let inspectorText = "";
+
+  return {
+    panel: {
+      bindBandToggle() {},
+      renderHeader() {},
+      renderOverlay() {},
+      renderBandToggle(model) {
+        bandToggleModel = model;
+      },
+      renderSensorLegend(model, handlers) {
+        sensorLegend = {
+          model,
+          handlers: handlers ?? null,
+        };
+      },
+      renderBandLegend(model) {
+        bandLegendModel = model;
+      },
+      renderInspectorText(text) {
+        inspectorText = text;
+      },
+    },
+    get bandToggleModel() {
+      return bandToggleModel;
+    },
+    get sensorLegend() {
+      return sensorLegend;
+    },
+    get bandLegendModel() {
+      return bandLegendModel;
+    },
+    get inspectorText() {
+      return inspectorText;
+    },
+  };
+}
 
 test.describe("SpectrumInteractionController", () => {
-  test.beforeEach(() => {
-    installWindowGlobal();
-  });
+  test("renders legend models and toggles isolated series", () => {
+    const panel = createPanelStub();
 
-  test("reuses legend buttons across live refreshes and click toggles", () => {
-    const restoreDocument = installDocumentStub();
-    try {
-      const legend = createElementStub("div");
-      const inspector = createElementStub("div");
-      const bandToggle = createElementStub("button");
-      const panel = createSpectrumPanelView({
-        dom: {
-          legend,
-          bandLegend: createElementStub("div"),
-          spectrumBandToggle: bandToggle,
-          spectrumInspector: inspector,
-        },
-      });
+    const strengthDbById = new Map([
+      ["sensor-a", 12],
+      ["sensor-b", 8],
+    ]);
+    let isolatedSeries: number | null = null;
 
-      const strengthDbById = new Map([
-        ["sensor-a", 12],
-        ["sensor-b", 8],
-      ]);
-      let isolatedSeries: number | null = null;
+    const controller = new SpectrumInteractionController({
+      panel: panel.panel,
+      t: (key, vars) => {
+        if (key === "spectrum.legend.state_all_visible") return "All visible";
+        if (key === "spectrum.legend.state_visible") return "Visible";
+        if (key === "spectrum.legend.state_isolated") return "Isolated";
+        if (key === "spectrum.legend.state_inactive") return "Inactive";
+        if (key === "spectrum.legend.sensor_level") {
+          return `Sensor level: ${String(vars?.value)} dB`;
+        }
+        if (key === "spectrum.legend.all_series") return "All sensor traces";
+        if (key === "spectrum.legend.clear_focus") return "Clear focus";
+        if (key === "spectrum.legend.focus_series") return `Focus ${String(vars?.sensor)}`;
+        if (key === "spectrum.inspector_idle") return "Idle";
+        if (key === "spectrum.inspector_no_band") return "No reference band";
+        if (key === "spectrum.bands.show") return "Show reference bands";
+        if (key === "spectrum.bands.hide") return "Hide reference bands";
+        if (key === "spectrum.bands.none") return "No reference band";
+        return vars?.sensor ? `${key}:${String(vars.sensor)}` : key;
+      },
+      getStrengthDb: (entryId) => strengthDbById.get(entryId) ?? null,
+      getTopPeakHz: (entryId) => (entryId === "sensor-a" ? 10 : 20),
+      setSeriesIsolation: (seriesIndex) => {
+        isolatedSeries = seriesIndex;
+      },
+      requestPlotRefresh: () => undefined,
+    });
 
-      const controller = new SpectrumInteractionController({
-        panel,
-        t: (key, vars) => {
-          if (key === "spectrum.legend.state_all_visible") return "All visible";
-          if (key === "spectrum.legend.state_visible") return "Visible";
-          if (key === "spectrum.legend.state_isolated") return "Isolated";
-          if (key === "spectrum.legend.state_inactive") return "Inactive";
-          if (key === "spectrum.legend.sensor_level") {
-            return `Sensor level: ${String(vars?.value)} dB`;
-          }
-          if (key === "spectrum.legend.all_series") return "All sensor traces";
-          if (key === "spectrum.legend.clear_focus") return "Clear focus";
-          if (key === "spectrum.legend.focus_series") return `Focus ${String(vars?.sensor)}`;
-          if (key === "spectrum.inspector_idle") return "Idle";
-          if (key === "spectrum.inspector_no_band") return "No reference band";
-          if (key === "spectrum.bands.show") return "Show reference bands";
-          if (key === "spectrum.bands.hide") return "Hide reference bands";
-          if (key === "spectrum.bands.none") return "No reference band";
-          return vars?.sensor ? `${key}:${String(vars.sensor)}` : key;
-        },
-        getStrengthDb: (entryId) => strengthDbById.get(entryId) ?? null,
-        getTopPeakHz: (entryId) => (entryId === "sensor-a" ? 10 : 20),
-        setSeriesIsolation: (seriesIndex) => {
-          isolatedSeries = seriesIndex;
-        },
-        requestPlotRefresh: () => undefined,
-      });
+    const entries = [
+      { id: "sensor-a", label: "Front Right Wheel", color: "#ff5500", values: [12, 11] },
+      { id: "sensor-b", label: "Rear Left Wheel", color: "#3366ff", values: [8, 7] },
+    ];
 
-      const entries = [
-        { id: "sensor-a", label: "Front Right Wheel", color: "#ff5500", values: [12, 11] },
-        { id: "sensor-b", label: "Rear Left Wheel", color: "#3366ff", values: [8, 7] },
-      ];
+    controller.sync({
+      entries,
+      freqAxis: [10, 20],
+      chartBands: [],
+    });
 
-      controller.sync({
-        entries,
-        freqAxis: [10, 20],
-        chartBands: [],
-      });
+    expect(panel.bandToggleModel).toEqual({
+      hasBands: false,
+      bandsVisible: false,
+      text: "Show reference bands",
+    });
+    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("Visible · Sensor level: 12.0 dB");
+    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(false);
+    expect(panel.sensorLegend.model?.items[1]?.detailText).toBe("Visible · Sensor level: 8.0 dB");
+    expect(isolatedSeries).toBeNull();
 
-      const allButton = legend.children[0];
-      const sensorButton = legend.children[1];
-      const sensorMeta = sensorButton.children[1].children[1];
-      expect(sensorMeta.textContent).toBe("Visible · Sensor level: 12.0 dB");
-      expect(isolatedSeries).toBeNull();
+    panel.sensorLegend.handlers?.onSelect("sensor-a");
+    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("Isolated · Sensor level: 12.0 dB");
+    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(true);
+    expect(panel.sensorLegend.model?.items[1]?.detailText).toBe("Inactive · Sensor level: 8.0 dB");
+    expect(isolatedSeries).toBe(1);
 
-      sensorButton.click();
-      expect(legend.children[0]).toBe(allButton);
-      expect(legend.children[1]).toBe(sensorButton);
-      expect(sensorButton.getAttribute("aria-pressed")).toBe("true");
-      expect(sensorMeta.textContent).toBe("Isolated · Sensor level: 12.0 dB");
-      expect(isolatedSeries).toBe(1);
-
-      strengthDbById.set("sensor-a", 13);
-      const refreshedEntries = [
+    strengthDbById.set("sensor-a", 13);
+    controller.sync({
+      entries: [
         { ...entries[0], values: [13, 12] },
         entries[1],
-      ];
-      controller.sync({
-        entries: refreshedEntries,
-        freqAxis: [10, 20],
-        chartBands: [],
-      });
+      ],
+      freqAxis: [10, 20],
+      chartBands: [],
+    });
 
-      expect(legend.children[0]).toBe(allButton);
-      expect(legend.children[1]).toBe(sensorButton);
-      expect(sensorMeta.textContent).toBe("Isolated · Sensor level: 13.0 dB");
-      expect(sensorButton.getAttribute("aria-pressed")).toBe("true");
+    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("Isolated · Sensor level: 13.0 dB");
+    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(true);
 
-      sensorButton.click();
-      expect(legend.children[0]).toBe(allButton);
-      expect(legend.children[1]).toBe(sensorButton);
-      expect(sensorButton.getAttribute("aria-pressed")).toBe("false");
-      expect(sensorMeta.textContent).toBe("Visible · Sensor level: 13.0 dB");
-      expect(isolatedSeries).toBeNull();
-    } finally {
-      restoreDocument();
-    }
+    panel.sensorLegend.handlers?.onSelect("sensor-a");
+    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("Visible · Sensor level: 13.0 dB");
+    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(false);
+    expect(panel.sensorLegend.model?.items[1]?.detailText).toBe("Visible · Sensor level: 8.0 dB");
+    expect(isolatedSeries).toBeNull();
   });
 });

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { getUiLiveOverviewHost } from "../src/app/dom/realtime_dom";
+import { getUiSpectrumPanelHost } from "../src/app/dom/spectrum_dom";
 import { createUiRuntimeDom } from "../src/app/ui_runtime_dom";
 
 type SelectorFixture = {
@@ -26,6 +27,7 @@ function stubElement(id = ""): HTMLElement {
 function createBaseFixture(): SelectorFixture {
   return {
     ids: {
+      spectrumPanelRoot: stubElement("spectrumPanelRoot"),
       specChart: stubElement("specChart"),
       startLoggingBtn: stubElement("startLoggingBtn"),
       liveOverviewRoot: stubElement("liveOverviewRoot"),
@@ -110,6 +112,15 @@ test("getUiLiveOverviewHost resolves the overview island host", () => {
   }
 });
 
+test("getUiSpectrumPanelHost resolves the spectrum island host", () => {
+  const restore = installDomFixture();
+  try {
+    expect(getUiSpectrumPanelHost().id).toBe("spectrumPanelRoot");
+  } finally {
+    restore();
+  }
+});
+
 test.describe("createUiRuntimeDom missing required feature anchors", () => {
   test("fails at the shell boundary when menu tabs are missing", () => {
     const restore = installDomFixture({ missingSelector: ".menu-btn" });
@@ -124,6 +135,15 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     const restore = installDomFixture({ missingId: "specChart" });
     try {
       expect(() => createUiRuntimeDom()).toThrow("Spectrum UI requires #specChart");
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails when the spectrum panel host is missing", () => {
+    const restore = installDomFixture({ missingId: "spectrumPanelRoot" });
+    try {
+      expect(() => getUiSpectrumPanelHost()).toThrow("Spectrum UI requires #spectrumPanelRoot");
     } finally {
       restore();
     }

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -1,12 +1,37 @@
 import { expect, test } from "@playwright/test";
 
 import type { UiSpectrumDom } from "../src/app/dom/spectrum_dom";
+import type { SpectrumPanelView } from "../src/app/runtime/spectrum_panel_view";
 import { createAppState } from "../src/app/ui_app_state";
 import { installWindowGlobal } from "./async_test_helpers";
 import { createElementStub, installDocumentStub } from "./spectrum_test_support";
 
 async function importUiSpectrumController() {
   return (await import("../src/app/runtime/ui_spectrum_controller")).UiSpectrumController;
+}
+
+function createPanelStub(): {
+  panel: SpectrumPanelView;
+  lastOverlayMessage: string | null;
+} {
+  let lastOverlayMessage: string | null = null;
+
+  return {
+    panel: {
+      bindBandToggle() {},
+      renderHeader() {},
+      renderOverlay(message: string | null) {
+        lastOverlayMessage = message;
+      },
+      renderBandToggle() {},
+      renderSensorLegend() {},
+      renderBandLegend() {},
+      renderInspectorText() {},
+    },
+    get lastOverlayMessage() {
+      return lastOverlayMessage;
+    },
+  };
 }
 
 test.describe("UiSpectrumController", () => {
@@ -21,26 +46,21 @@ test.describe("UiSpectrumController", () => {
       const state = createAppState();
       state.transport.wsState = "connecting";
       state.transport.hasReceivedPayload = false;
-      const overlay = createElementStub("div");
+      const panel = createPanelStub();
 
       const controller = new UiSpectrumController({
         state,
         dom: {
           specChartWrap: createElementStub("div"),
           specChart: createElementStub("div"),
-          spectrumOverlay: overlay,
-          spectrumInspector: null,
-          legend: null,
-          bandLegend: null,
-          spectrumBandToggle: null,
         } as unknown as UiSpectrumDom,
+        panel: panel.panel,
         t: (key) => key,
       });
 
       controller.updateSpectrumOverlay();
 
-      expect(overlay.hidden).toBe(false);
-      expect(overlay.textContent).toBe("spectrum.loading");
+      expect(panel.lastOverlayMessage).toBe("spectrum.loading");
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
Closes #2220

## Summary

This PR migrates the spectrum panel chrome into a Preact island while deliberately preserving the existing uPlot/canvas rendering path as the imperative seam. The issue scope for `#2220` was the spectrum panel container, overlay and empty-state handling, the band-toggle control, the inspector text, the band legend, and the sensor legend. It explicitly did **not** require a chart rewrite. The chart still renders through `SpectrumCanvasRenderer` and `SpectrumChart`; the migration changes who owns the surrounding UI and how controller state reaches that UI.

The old spectrum surface mixed two concerns in one place: the chart pipeline and an imperative DOM mutator (`createSpectrumPanelView`) that created and updated the surrounding controls node-by-node. That meant the controller owned both chart coordination and detailed DOM bookkeeping. This PR separates those responsibilities more cleanly. Preact now owns the spectrum panel subtree, while the controller and interaction logic push typed models into that island.

## Implementation approach

I chose the same migration pattern that worked for the shell and live-overview issues, but tailored it to the spectrum panel’s shape:

1. replace the static spectrum markup in `index.html` with a single host root,
2. mount a Preact spectrum island before `createUiRuntimeDom()` resolves the runtime DOM contract,
3. keep `specChart` and `specChartWrap` as stable ids so the chart renderer still has a clear imperative boundary,
4. turn the former panel view into a typed contract instead of a DOM mutator,
5. route overlay, band-toggle, legend, and inspector updates through that bridge,
6. update the focused tests so controller behavior is asserted through models and actions instead of the legacy DOM implementation details.

## Main code changes

### 1. Added a new spectrum panel island

`apps/ui/src/app/views/spectrum_panel.tsx` is the new spectrum owner. It renders:

- the card header,
- the chart wrapper and chart host,
- the overlay message,
- the toolbar hint,
- the reference-band toggle,
- the band legend,
- the inspector text,
- and the sensor legend buttons.

The island exposes the existing panel contract shape back to runtime code so controller logic can keep saying “render band legend”, “render inspector text”, or “render sensor legend” without knowing about Preact directly.

### 2. Replaced the old static markup with an island host

`apps/ui/index.html` no longer carries the full spectrum card subtree. It now exposes `#spectrumPanelRoot` in the same dashboard slot. Startup mounts the island into that root before runtime DOM discovery. That preserves the panel location and CSS footprint while making the ownership boundary explicit.

### 3. Shrunk the DOM contract to the real imperative seam

`apps/ui/src/app/dom/spectrum_dom.ts` now treats the spectrum DOM contract as chart-only. The runtime still resolves:

- `specChart`
- `specChartWrap`

Those are the elements the imperative chart renderer genuinely needs. The surrounding controls are no longer part of the DOM lookup contract because they are now owned through the spectrum panel bridge instead of direct element queries.

### 4. Converted the old panel view from DOM mutator to typed bridge

`apps/ui/src/app/runtime/spectrum_panel_view.ts` used to contain a lot of imperative DOM manipulation for the legend, band legend, inspector, and toggle button. That file is now reduced to the typed panel contract and a null implementation. The rendering work moved into the new island.

This simplifies the spectrum UI path: instead of runtime code building buttons, spans, swatches, and attributes by hand, the controller now pushes plain render models into a single render owner.

### 5. Updated controller wiring

`apps/ui/src/app/runtime/ui_spectrum_controller.ts` now accepts a `SpectrumPanelView` bridge instead of building its own DOM mutator. It uses that bridge to:

- render header text,
- render overlay state,
- and feed the interaction controller’s legend, inspector, and band-toggle models into the island.

`apps/ui/src/app/ui_app_runtime.ts` threads the bridge into `UiSpectrumController`, and `apps/ui/src/app/start_ui_app.ts` mounts the island and passes that bridge into runtime composition.

### 6. Kept the chart pipeline intact and simplified a stale API

`apps/ui/src/app/runtime/spectrum_canvas_renderer.ts` still owns chart preparation, band overlays, focus markers, and uPlot updates. That was an intentional non-change. The issue asked to wrap the existing chart path cleanly unless a rewrite was clearly warranted, and a rewrite was not warranted here.

Because the spectrum overlay is no longer chart-owned, I removed the unused overlay parameter from `apps/ui/src/spectrum.ts::SpectrumChart` and stopped passing it from the renderer. That is a small but worthwhile cleanup that falls directly out of the new ownership boundary.

## Tests and validation

I updated the focused tests to match the new architecture instead of pinning the deleted DOM mutator:

- `apps/ui/tests/ui_runtime_dom.spec.ts` now covers `getUiSpectrumPanelHost()`
- `apps/ui/tests/ui_spectrum_controller.spec.ts` now asserts overlay updates through a panel bridge stub
- `apps/ui/tests/spectrum_interaction_controller.spec.ts` now verifies controller-produced models and handlers rather than DOM node reuse inside the removed panel renderer
- `apps/ui/tests/spectrum_canvas_renderer.spec.ts` reflects the chart-only DOM seam

I also ran the relevant existing validation commands and focused Playwright/browser coverage:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/ui_runtime_dom.spec.ts tests/ui_spectrum_controller.spec.ts tests/spectrum_interaction_controller.spec.ts tests/spectrum_canvas_renderer.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.spectrum.spec.ts --config .ai-temp/playwright-2220.config.ts --workers=1`

As with the previous issue, the temporary Playwright config only existed to avoid the shared-environment collision on the default smoke port. The config was removed after the run, and the isolated Vite server was stopped immediately afterward.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is intentional dual ownership at the dashboard level for one more step in the migration: the spectrum panel is now island-owned, but the chart drawing inside that panel remains imperative. That is the correct tradeoff for this issue. The chart path is complex, animation-heavy, and already isolated behind `SpectrumCanvasRenderer`; pulling it into this PR would have created more risk than value.

Another deliberate change is in testing style. The old controller test asserted details of the DOM-building implementation. That was useful when the panel view itself was imperative, but it would be the wrong seam to preserve now that Preact owns the rendering. The rewritten test asserts the controller’s outputs and actions instead, which better matches the intended architecture.

I did not migrate the run-recording card, the live overview card, or any settings/history surfaces here. I also did not change the chart data model, uPlot plugin behavior, or the live transport flow beyond what was necessary to keep overlay and panel rendering correct. Those follow-ups belong to later issues in the backlog, not in this PR.

The long-term architectural takeaway is that the spectrum panel now mirrors the pattern we want for the rest of the migration: runtime computes state, typed bridges hand that state to a Preact owner, and the imperative parts that remain are the ones that genuinely need to stay imperative.
