### PR TITLE
feat(ui): migrate history view to Preact island

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -117,8 +117,9 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/esp_flash_feature_presenter.ts` | ESP flash presenter that owns readiness/banner/journey/history/log/select rendering from workflow state |
 | `app/views/history_table_models.ts` | Typed row/detail/finding/heatmap view models that describe history table rendering without HTML fragments |
 | `app/views/history_table_presenters.ts` | Presenter builders that turn runs plus loaded insights/preview detail into typed history row and details models |
+| `app/views/history_panel.tsx` | Preact owner for the history panel shell that renders summary/toolbar chrome and binds typed row actions through a bridge |
 | `app/views/history_table_row_renderers.ts` | Focused history row/detail DOM builders that materialize typed history models into table rows and expanded evidence cards |
-| `app/views/history_table_view.ts` | Thin history-table view boundary that renders DOM rows/empty state and decodes typed table interactions |
+| `app/views/history_table_view.ts` | Thin history-panel bridge and DOM row adapter that renders typed empty/table states for the Preact history island |
 | `app/views/realtime_logging_view_models.ts` | Typed realtime logging and readiness view-model builders for summary, checklist, and control-state derivation |
 | `app/views/realtime_logging_panel.tsx` | Preact owner for the run-recording card that renders typed logging/readiness models and binds start/stop plus summary CTA actions through a bridge |
 | `app/views/settings_cars_presenter.ts` | Settings-car presenter that owns car-list rendering, active-car guidance, and analysis-control affordances from typed car state |
@@ -207,6 +208,12 @@ The run-recording panel now follows that same pattern through
 recording host, the realtime presenter feeds it typed logging/readiness models,
 and the existing workflow still owns polling plus start/stop recording actions
 behind that bridge.
+The history view now follows the same pattern through
+`app/views/history_panel.tsx`: startup mounts the panel island into the history
+host, the history feature/modules feed it typed summary and table models, and
+the existing row/detail presenters plus row-renderer adapter still own the
+typed history table body while the page-level toolbar/action wiring lives in
+the island bridge.
 
 ## Architecture guardrails
 

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -21,32 +21,7 @@
       </section>
 
       <section id="historyView" class="view" role="tabpanel" aria-labelledby="tab-history" hidden>
-        <div class="panel card">
-          <div class="history-toolbar">
-            <div class="history-toolbar__copy">
-              <div id="historySummary" class="history-toolbar__summary subtle">No runs yet.</div>
-            </div>
-            <div class="history-toolbar__actions">
-              <button id="refreshHistoryBtn" class="btn btn--muted" data-i18n="history.refresh">Refresh History</button>
-              <button id="deleteAllRunsBtn" class="btn btn--danger-quiet" data-i18n="history.delete_all" disabled>Delete All Runs</button>
-            </div>
-          </div>
-          <table class="history-table">
-            <thead>
-              <tr>
-                <th data-i18n="history.table.file">Run</th>
-                <th data-i18n="history.table.updated">Started</th>
-                <th class="numeric" data-i18n="history.table.size">Samples</th>
-                <th data-i18n="history.table.actions">Actions</th>
-              </tr>
-            </thead>
-            <tbody id="historyTableBody">
-              <tr>
-                <td colspan="4">No runs found.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <div id="historyPanelRoot" class="panel card"></div>
       </section>
 
       <section id="settingsView" class="view" role="tabpanel" aria-labelledby="tab-settings" hidden>

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -17,6 +17,7 @@ import {
 } from "./features/cars_feature";
 import { createEspFlashFeature } from "./features/esp_flash_feature";
 import { createHistoryFeature } from "./features/history_feature";
+import type { HistoryPanelView } from "./views/history_table_view";
 import {
   createRealtimeFeature,
   type RealtimeFeatureChromePorts,
@@ -54,6 +55,7 @@ export interface AppFeatureBundleSharedDeps {
 
 export interface AppFeatureBundleRuntimePorts {
   realtimeChrome: RealtimeFeatureChromePorts;
+  historyPanel: HistoryPanelView;
   transport: RealtimeFeatureSelectionPorts;
   view: SettingsFeatureViewPorts;
 }
@@ -92,6 +94,7 @@ export function createAppFeatureBundle(deps: AppFeatureBundleDeps): AppFeatureBu
     history: state.history,
     getLanguage: () => state.shell.lang,
     dom: historyDom,
+    panel: runtime.historyPanel,
     shellDom,
     t,
     escapeHtml,

--- a/apps/ui/src/app/dom/history_dom.ts
+++ b/apps/ui/src/app/dom/history_dom.ts
@@ -1,19 +1,15 @@
-import { getById, requiredById } from "./dom_query";
+import { requiredById } from "./dom_query";
 
 const HISTORY_OWNER = "History feature";
+const HISTORY_PANEL_HOST_ID = "historyPanelRoot";
+declare const uiHistoryDomBrand: unique symbol;
 
-export interface UiHistoryDom {
-  refreshHistoryBtn: HTMLButtonElement | null;
-  deleteAllRunsBtn: HTMLButtonElement | null;
-  historySummary: HTMLElement | null;
-  historyTableBody: HTMLElement;
+export type UiHistoryDom = { [uiHistoryDomBrand]?: never };
+
+export function getUiHistoryPanelHost(): HTMLElement {
+  return requiredById<HTMLElement>(HISTORY_PANEL_HOST_ID, HISTORY_OWNER);
 }
 
 export function createUiHistoryDom(): UiHistoryDom {
-  return {
-    refreshHistoryBtn: getById<HTMLButtonElement>("refreshHistoryBtn"),
-    deleteAllRunsBtn: getById<HTMLButtonElement>("deleteAllRunsBtn"),
-    historySummary: getById<HTMLElement>("historySummary"),
-    historyTableBody: requiredById<HTMLElement>("historyTableBody", HISTORY_OWNER),
-  };
+  return {};
 }

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -2,9 +2,9 @@ import type { UiHistoryDom } from "../dom/history_dom";
 import type { UiShellDom } from "../dom/shell_dom";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { HistoryState, RunDetail } from "../ui_app_state";
-import {
-  bindHistoryTableInteractions,
-  type HistoryRunAction,
+import type {
+  HistoryPanelView,
+  HistoryRunAction,
 } from "../views/history_table_view";
 import {
   createHistoryDetailModule,
@@ -21,6 +21,7 @@ import {
 
 export interface HistoryFeatureDeps extends FeatureDepsBase {
   dom: UiHistoryDom;
+  panel: HistoryPanelView;
   shellDom: Pick<UiShellDom, "menuButtons">;
   history: HistoryState;
   getLanguage: () => string;
@@ -40,7 +41,7 @@ export interface HistoryFeature {
 }
 
 export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
-  const { history, dom: els, shellDom } = ctx;
+  const { history, panel, shellDom } = ctx;
   let handlersBound = false;
   let previewPrefetchToken = 0;
 
@@ -123,7 +124,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       return;
     }
     handlersBound = true;
-    bindHistoryTableInteractions(els, {
+    panel.bindActions({
       onRefreshHistory: () => {
         void refreshHistory();
       },

--- a/apps/ui/src/app/features/history_list_module.ts
+++ b/apps/ui/src/app/features/history_list_module.ts
@@ -1,14 +1,13 @@
 import { getHistory, historyExportUrl } from "../../api";
-import type { UiHistoryDom } from "../dom/history_dom";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { HistoryState, RunDetail } from "../ui_app_state";
-import {
-  renderHistoryEmptyState,
-  renderHistoryTable as renderHistoryTableView,
+import type {
+  HistoryPanelRenderModel,
+  HistoryPanelView,
 } from "../views/history_table_view";
 
 export interface HistoryListModuleDeps extends FeatureDepsBase {
-  dom: UiHistoryDom;
+  panel: HistoryPanelView;
   history: HistoryState;
   fmt: (n: number, digits?: number) => string;
   fmtTs: (iso: string) => string;
@@ -23,45 +22,49 @@ export interface HistoryListModule {
 }
 
 export function createHistoryListModule(ctx: HistoryListModuleDeps): HistoryListModule {
-  const { history, dom: els, t, fmt, fmtTs, formatInt } = ctx;
+  const { history, panel, t, fmt, fmtTs, formatInt } = ctx;
+
+  function renderModel(model: HistoryPanelRenderModel): void {
+    panel.render(model);
+  }
 
   function renderHistoryTable(): void {
-    if (els.deleteAllRunsBtn) {
-      els.deleteAllRunsBtn.disabled = history.deleteAllRunsInFlight || history.runs.length === 0;
-    }
+    const deleteAllRunsDisabled = history.deleteAllRunsInFlight || history.runs.length === 0;
     if (!history.runs.length) {
-      if (els.historySummary) {
-        els.historySummary.textContent = t("history.none");
-      }
-      if (els.historyTableBody) {
-        renderHistoryEmptyState(els.historyTableBody, {
-          t,
-        });
-      }
       ctx.collapseExpandedRun();
+      renderModel({
+        historySummaryText: t("history.none"),
+        deleteAllRunsDisabled,
+        table: {
+          kind: "empty",
+          t,
+        },
+      });
       return;
     }
     if (history.expandedRunId && !history.runs.some((row) => row.run_id === history.expandedRunId)) {
       ctx.collapseExpandedRun();
     }
-    if (els.historySummary) {
-      els.historySummary.textContent = t("history.available_count", { count: history.runs.length });
-    }
     for (const run of history.runs) {
       ctx.ensureRunDetail(run.run_id);
     }
-    if (els.historyTableBody) {
-      renderHistoryTableView(els.historyTableBody, {
-        runs: history.runs,
-        expandedRunId: history.expandedRunId,
-        runDetailsById: history.runDetailsById,
-        t,
-        fmt,
-        fmtTs,
-        formatInt,
-        historyExportUrl,
-      });
-    }
+    renderModel({
+      historySummaryText: t("history.available_count", { count: history.runs.length }),
+      deleteAllRunsDisabled,
+      table: {
+        kind: "rows",
+        params: {
+          runs: history.runs,
+          expandedRunId: history.expandedRunId,
+          runDetailsById: history.runDetailsById,
+          t,
+          fmt,
+          fmtTs,
+          formatInt,
+          historyExportUrl,
+        },
+      },
+    });
   }
 
   async function refreshHistory(): Promise<void> {

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -1,10 +1,12 @@
 import "uplot/dist/uPlot.min.css";
 import "../styles/app.css";
+import { getUiHistoryPanelHost } from "./dom/history_dom";
 import { getUiLiveOverviewHost, getUiLoggingPanelHost } from "./dom/realtime_dom";
 import { getUiShellChromeHost } from "./dom/shell_dom";
 import { getUiSpectrumPanelHost } from "./dom/spectrum_dom";
 import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
+import { mountHistoryPanel } from "./views/history_panel";
 import { mountRealtimeLoggingPanel } from "./views/realtime_logging_panel";
 import { mountRealtimeLiveOverview } from "./views/realtime_live_overview";
 import { mountSpectrumPanel } from "./views/spectrum_panel";
@@ -16,6 +18,15 @@ export function startUiApp(): void {
   const spectrumPanel = mountSpectrumPanel(getUiSpectrumPanelHost());
   const liveOverview = mountRealtimeLiveOverview(getUiLiveOverviewHost());
   const loggingPanel = mountRealtimeLoggingPanel(getUiLoggingPanelHost());
+  const historyPanel = mountHistoryPanel(getUiHistoryPanelHost());
   mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
-  new UiAppRuntime(undefined, state, shellChromeActions, liveOverview, spectrumPanel, loggingPanel).start();
+  new UiAppRuntime(
+    undefined,
+    state,
+    shellChromeActions,
+    liveOverview,
+    spectrumPanel,
+    loggingPanel,
+    historyPanel,
+  ).start();
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -14,6 +14,10 @@ import { createNullSpectrumPanelView, type SpectrumPanelView } from "./runtime/s
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
 import {
+  createNullHistoryPanelView,
+  type HistoryPanelView,
+} from "./views/history_table_view";
+import {
   createNullRealtimeLoggingPanelBridge,
   type RealtimeLoggingPanelBridge,
 } from "./views/realtime_logging_panel";
@@ -44,6 +48,7 @@ export class UiAppRuntime {
     liveOverview: RealtimeLiveOverviewBridge = createNullRealtimeLiveOverviewBridge(),
     spectrumPanel: SpectrumPanelView = createNullSpectrumPanelView(),
     loggingPanel: RealtimeLoggingPanelBridge = createNullRealtimeLoggingPanelBridge(),
+    historyPanel: HistoryPanelView = createNullHistoryPanelView(),
   ) {
     this.dom = dom;
     this.state = state;
@@ -96,6 +101,7 @@ export class UiAppRuntime {
           liveOverview,
           loggingPanel,
         },
+        historyPanel,
         view: {
           renderSpectrum: () => this.spectrum.renderSpectrum(),
           renderSpeedReadout: () => this.shell.renderSpeedReadout(),

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -1,0 +1,146 @@
+import { useLayoutEffect, useRef } from "preact/hooks";
+
+import { createUiPreactMount } from "../runtime/ui_preact_mount";
+import { getTypedInlineStateAction } from "./dom_helpers";
+import {
+  getHistoryTableAction,
+  getHistoryTableRowRunId,
+  renderHistoryEmptyState,
+  renderHistoryTable,
+  type HistoryPanelActionHandlers,
+  type HistoryPanelRenderModel,
+  type HistoryPanelView,
+} from "./history_table_view";
+
+const HISTORY_INLINE_ACTIONS = ["open-live"] as const;
+
+interface HistoryPanelBridgeState extends HistoryPanelRenderModel {
+  actions: HistoryPanelActionHandlers | null;
+}
+
+const DEFAULT_PANEL_STATE: HistoryPanelBridgeState = {
+  historySummaryText: "No runs yet.",
+  deleteAllRunsDisabled: true,
+  table: null,
+  actions: null,
+};
+
+function HistoryPanel(props: { state: HistoryPanelBridgeState }) {
+  const { state } = props;
+  const tableBodyRef = useRef<HTMLTableSectionElement | null>(null);
+
+  useLayoutEffect(() => {
+    const tableBody = tableBodyRef.current;
+    if (!tableBody || state.table === null) {
+      return;
+    }
+    if (state.table.kind === "empty") {
+      renderHistoryEmptyState(tableBody, {
+        t: state.table.t,
+      });
+      return;
+    }
+    renderHistoryTable(tableBody, state.table.params);
+  }, [state.table]);
+
+  function handleTableClick(event: MouseEvent): void {
+    const inlineAction = getTypedInlineStateAction(event.target, HISTORY_INLINE_ACTIONS);
+    if (inlineAction) {
+      event.preventDefault();
+      event.stopPropagation();
+      state.actions?.onTableInteraction({ type: inlineAction });
+      return;
+    }
+    const action = getHistoryTableAction(event.target);
+    if (action) {
+      if (action.action !== "download-raw") {
+        event.preventDefault();
+      }
+      event.stopPropagation();
+      state.actions?.onTableInteraction({
+        type: "run-action",
+        action: action.action,
+        runId: action.runId,
+      });
+      return;
+    }
+    const runId = getHistoryTableRowRunId(event.target);
+    if (runId) {
+      state.actions?.onTableInteraction({ type: "toggle-run", runId });
+    }
+  }
+
+  return (
+    <>
+      <div class="history-toolbar">
+        <div class="history-toolbar__copy">
+          <div id="historySummary" class="history-toolbar__summary subtle">
+            {state.historySummaryText}
+          </div>
+        </div>
+        <div class="history-toolbar__actions">
+          <button
+            id="refreshHistoryBtn"
+            class="btn btn--muted"
+            type="button"
+            data-i18n="history.refresh"
+            onClick={() => state.actions?.onRefreshHistory()}
+          >
+            Refresh History
+          </button>
+          <button
+            id="deleteAllRunsBtn"
+            class="btn btn--danger-quiet"
+            type="button"
+            data-i18n="history.delete_all"
+            disabled={state.deleteAllRunsDisabled}
+            onClick={() => state.actions?.onDeleteAllRuns()}
+          >
+            Delete All Runs
+          </button>
+        </div>
+      </div>
+      <table class="history-table">
+        <thead>
+          <tr>
+            <th data-i18n="history.table.file">Run</th>
+            <th data-i18n="history.table.updated">Started</th>
+            <th class="numeric" data-i18n="history.table.size">Samples</th>
+            <th data-i18n="history.table.actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="historyTableBody" ref={tableBodyRef} onClick={handleTableClick}>
+          {state.table === null
+            ? (
+              <tr>
+                <td colSpan={4}>No runs found.</td>
+              </tr>
+            )
+            : null}
+        </tbody>
+      </table>
+    </>
+  );
+}
+
+export function mountHistoryPanel(host: HTMLElement): HistoryPanelView {
+  const mount = createUiPreactMount(host);
+  let state: HistoryPanelBridgeState = { ...DEFAULT_PANEL_STATE };
+
+  function render(): void {
+    mount.render(<HistoryPanel state={state} />);
+  }
+
+  render();
+
+  return {
+    render(model: HistoryPanelRenderModel): void {
+      state = { ...state, ...model };
+      render();
+    },
+    bindActions(handlers: HistoryPanelActionHandlers): void {
+      state = { ...state, actions: handlers };
+      render();
+    },
+  };
+}

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -1,14 +1,11 @@
-import type { UiHistoryDom } from "../dom/history_dom";
 import type { HistoryEntry } from "../../transport/http_models";
 import type { RunDetail } from "../ui_app_state";
 import {
   closestFromTarget,
   createInlineStatePanelElement,
   createTableEmptyRowElement,
-  getTypedInlineStateAction,
 } from "./dom_helpers";
 import { renderChildren } from "./dom_render";
-import { bindViewEvent, composeViewDisposers, type ViewDisposer } from "./dom_event_bindings";
 import { buildHistoryTableRowsViewModel } from "./history_table_presenters";
 import { createHistoryTableRowElements } from "./history_table_row_renderers";
 
@@ -29,7 +26,6 @@ const HISTORY_TABLE_ACTIONS = [
   "download-raw",
   "delete-run",
 ] as const;
-const HISTORY_INLINE_ACTIONS = ["open-live"] as const;
 
 export type HistoryRunAction = (typeof HISTORY_TABLE_ACTIONS)[number];
 
@@ -43,10 +39,38 @@ export type HistoryTableInteraction =
   | { type: "run-action"; action: HistoryRunAction; runId: string | null }
   | { type: "toggle-run"; runId: string };
 
-export interface HistoryTableBindingHandlers {
+export type HistoryPanelTableRenderModel =
+  | {
+      kind: "empty";
+      t: (key: string, vars?: Record<string, unknown>) => string;
+    }
+  | {
+      kind: "rows";
+      params: HistoryTableViewParams;
+    };
+
+export interface HistoryPanelRenderModel {
+  historySummaryText: string;
+  deleteAllRunsDisabled: boolean;
+  table: HistoryPanelTableRenderModel | null;
+}
+
+export interface HistoryPanelActionHandlers {
   onRefreshHistory(): void;
   onDeleteAllRuns(): void;
   onTableInteraction(action: HistoryTableInteraction): void;
+}
+
+export interface HistoryPanelView {
+  render(model: HistoryPanelRenderModel): void;
+  bindActions(handlers: HistoryPanelActionHandlers): void;
+}
+
+export function createNullHistoryPanelView(): HistoryPanelView {
+  return {
+    render() {},
+    bindActions() {},
+  };
 }
 
 export function renderHistoryEmptyState(
@@ -105,44 +129,4 @@ export function getHistoryTableAction(
 export function getHistoryTableRowRunId(target: EventTarget | null): string | null {
   return closestFromTarget<HTMLElement>(target, 'tr[data-run-row="1"]')
     ?.getAttribute("data-run") ?? null;
-}
-
-export function bindHistoryTableInteractions(
-  dom: Pick<UiHistoryDom, "refreshHistoryBtn" | "deleteAllRunsBtn" | "historyTableBody">,
-  handlers: HistoryTableBindingHandlers,
-): ViewDisposer {
-  return composeViewDisposers(
-    bindViewEvent(dom.refreshHistoryBtn, "click", () => {
-      handlers.onRefreshHistory();
-    }),
-    bindViewEvent(dom.deleteAllRunsBtn, "click", () => {
-      handlers.onDeleteAllRuns();
-    }),
-    bindViewEvent(dom.historyTableBody, "click", (event: MouseEvent) => {
-      const inlineAction = getTypedInlineStateAction(event.target, HISTORY_INLINE_ACTIONS);
-      if (inlineAction) {
-        event.preventDefault();
-        event.stopPropagation();
-        handlers.onTableInteraction({ type: inlineAction });
-        return;
-      }
-      const action = getHistoryTableAction(event.target);
-      if (action) {
-        if (action.action !== "download-raw") {
-          event.preventDefault();
-        }
-        event.stopPropagation();
-        handlers.onTableInteraction({
-          type: "run-action",
-          action: action.action,
-          runId: action.runId,
-        });
-        return;
-      }
-      const runId = getHistoryTableRowRunId(event.target);
-      if (runId) {
-        handlers.onTableInteraction({ type: "toggle-run", runId });
-      }
-    }),
-  );
 }

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -10,6 +10,12 @@ import { createHistoryListModule } from "../src/app/features/history_list_module
 import type { UiHistoryDom } from "../src/app/dom/history_dom";
 import type { UiShellDom } from "../src/app/dom/shell_dom";
 import { createAppState, type RunDetail } from "../src/app/ui_app_state";
+import {
+  renderHistoryEmptyState,
+  renderHistoryTable,
+  type HistoryPanelActionHandlers,
+  type HistoryPanelView,
+} from "../src/app/views/history_table_view";
 import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
 import {
   findByAttribute,
@@ -40,7 +46,7 @@ function createTextElement(tagName = "DIV"): HTMLElement {
 
 function createHistoryElements(): {
   dom: UiHistoryDom;
-  els: UiHistoryDom;
+  panel: HistoryPanelView;
   historySummary: FakeElement;
   historyTableBody: FakeElement;
   deleteAllRunsBtn: ButtonStub;
@@ -48,14 +54,32 @@ function createHistoryElements(): {
   const historySummary = createTextElement("DIV") as unknown as FakeElement;
   const historyTableBody = createTextElement("TBODY") as unknown as FakeElement;
   const deleteAllRunsBtn = createButton();
-  const dom = {
-    historySummary,
-    historyTableBody,
-    deleteAllRunsBtn,
-  } as unknown as UiHistoryDom;
+  let actions: HistoryPanelActionHandlers | null = null;
+  const panel: HistoryPanelView = {
+    render(model) {
+      historySummary.textContent = model.historySummaryText;
+      deleteAllRunsBtn.disabled = model.deleteAllRunsDisabled;
+      if (model.table === null) {
+        historyTableBody.textContent = "No runs found.";
+        return;
+      }
+      if (model.table.kind === "empty") {
+        renderHistoryEmptyState(historyTableBody as unknown as HTMLElement, {
+          t: model.table.t,
+        });
+        return;
+      }
+      renderHistoryTable(historyTableBody as unknown as HTMLElement, model.table.params);
+    },
+    bindActions(handlers) {
+      actions = handlers;
+    },
+  };
+  void actions;
+  const dom = {} as UiHistoryDom;
   return {
     dom,
-    els: dom,
+    panel,
     historySummary,
     historyTableBody,
     deleteAllRunsBtn,
@@ -192,7 +216,7 @@ test.afterEach(() => {
 
 test("history list module refreshes runs and renders table state", async () => {
   const state = createAppState();
-  const { dom, historySummary, historyTableBody, deleteAllRunsBtn } = createHistoryElements();
+  const { panel, historySummary, historyTableBody, deleteAllRunsBtn } = createHistoryElements();
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | RequestInfo) => {
     const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
@@ -206,7 +230,7 @@ test("history list module refreshes runs and renders table state", async () => {
 
   const module = createHistoryListModule({
     history: state.history,
-    dom,
+    panel,
     t: testTranslation,
     escapeHtml: (value) => String(value ?? ""),
     fmt: (value, digits = 0) => Number(value).toFixed(digits),
@@ -362,11 +386,11 @@ test("history list rendering promotes loaded findings ahead of supporting statis
     pdfLoading: false,
     pdfError: "",
   };
-  const { dom, historyTableBody } = createHistoryElements();
+  const { panel, historyTableBody } = createHistoryElements();
 
   const module = createHistoryListModule({
     history: state.history,
-    dom,
+    panel,
     t: testTranslation,
     escapeHtml: (value) => String(value ?? ""),
     fmt: (value, digits = 0) => Number(value).toFixed(digits),
@@ -406,7 +430,7 @@ test("history list rendering promotes loaded findings ahead of supporting statis
 
 test("history feature preloads collapsed row context for completed runs", async () => {
   const state = createAppState();
-  const { dom, historyTableBody } = createHistoryElements();
+  const { dom, panel, historyTableBody } = createHistoryElements();
   const originalFetch = globalThis.fetch;
   const requests: string[] = [];
   globalThis.fetch = (async (input: string | URL | RequestInfo) => {
@@ -423,6 +447,7 @@ test("history feature preloads collapsed row context for completed runs", async 
 
   const feature = createHistoryFeature({
     dom,
+    panel,
     shellDom: { menuButtons: [] } as Pick<UiShellDom, "menuButtons">,
     history: state.history,
     getLanguage: () => state.shell.lang,

--- a/apps/ui/tests/ui_action_bindings.spec.ts
+++ b/apps/ui/tests/ui_action_bindings.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 
 import { bindCarsFeatureInteractions } from "../src/app/views/cars_feature_bindings";
-import { bindHistoryTableInteractions } from "../src/app/views/history_table_view";
 import { bindRealtimeFeatureInteractions } from "../src/app/views/realtime_feature_bindings";
 import { bindSettingsCarListActions } from "../src/app/views/settings_car_list_view";
 import {
@@ -334,87 +333,6 @@ test("realtime view bindings emit typed sensor actions and clean up listeners", 
     target: identifyButton as unknown as EventTarget,
   });
   expect(sensorActions).toEqual([{ type: "identify", clientId: "sensor-1" }]);
-});
-
-test("history table bindings preserve typed row actions and download-raw default navigation", () => {
-  const refreshHistoryBtn = createButton();
-  const deleteAllRunsBtn = createButton();
-  const historyTableBody = createContainer("tbody");
-  const inlineButton = appendChild(historyTableBody, createButton({
-    attrs: { "data-inline-state-action": "open-live" },
-  }));
-  const deleteRunButton = appendChild(historyTableBody, createButton({
-    attrs: {
-      "data-run-action": "delete-run",
-      "data-run": "run-1",
-    },
-  }));
-  const downloadRawLink = appendChild(historyTableBody, (() => {
-    const link = createContainer("a");
-    link.setAttribute("data-run-action", "download-raw");
-    link.setAttribute("data-run", "run-2");
-    return link;
-  })());
-  const runRow = appendChild(historyTableBody, (() => {
-    const row = createContainer("tr");
-    row.setAttribute("data-run-row", "1");
-    row.setAttribute("data-run", "run-3");
-    return row;
-  })());
-  const rowCellButton = appendChild(runRow, createButton());
-
-  const interactions: Array<Record<string, string | null>> = [];
-  let refreshCalls = 0;
-  let deleteAllCalls = 0;
-
-  bindHistoryTableInteractions(
-    {
-      refreshHistoryBtn: refreshHistoryBtn as unknown as HTMLButtonElement,
-      deleteAllRunsBtn: deleteAllRunsBtn as unknown as HTMLButtonElement,
-      historyTableBody: historyTableBody as unknown as HTMLElement,
-    },
-    {
-      onRefreshHistory: () => {
-        refreshCalls += 1;
-      },
-      onDeleteAllRuns: () => {
-        deleteAllCalls += 1;
-      },
-      onTableInteraction: (action) => {
-        interactions.push(action as unknown as Record<string, string | null>);
-      },
-    },
-  );
-
-  refreshHistoryBtn.click();
-  deleteAllRunsBtn.click();
-  const inlineEvent = historyTableBody.dispatch("click", {
-    target: inlineButton as unknown as EventTarget,
-  });
-  const deleteRunEvent = historyTableBody.dispatch("click", {
-    target: deleteRunButton as unknown as EventTarget,
-  });
-  const downloadRawEvent = historyTableBody.dispatch("click", {
-    target: downloadRawLink as unknown as EventTarget,
-  });
-  historyTableBody.dispatch("click", {
-    target: rowCellButton as unknown as EventTarget,
-  });
-
-  expect(refreshCalls).toBe(1);
-  expect(deleteAllCalls).toBe(1);
-  expect(interactions).toEqual([
-    { type: "open-live" },
-    { type: "run-action", action: "delete-run", runId: "run-1" },
-    { type: "run-action", action: "download-raw", runId: "run-2" },
-    { type: "toggle-run", runId: "run-3" },
-  ]);
-  expect(inlineEvent.defaultPrevented).toBe(true);
-  expect(inlineEvent.propagationStopped).toBe(true);
-  expect(deleteRunEvent.defaultPrevented).toBe(true);
-  expect(deleteRunEvent.propagationStopped).toBe(true);
-  expect(downloadRawEvent.defaultPrevented).toBe(false);
-  expect(downloadRawEvent.propagationStopped).toBe(true);
 });
 
 test("settings car-list bindings surface typed list actions and disposer stops delegated clicks", () => {

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { getUiHistoryPanelHost } from "../src/app/dom/history_dom";
 import { getUiLiveOverviewHost, getUiLoggingPanelHost } from "../src/app/dom/realtime_dom";
 import { getUiSpectrumPanelHost } from "../src/app/dom/spectrum_dom";
 import { createUiRuntimeDom } from "../src/app/ui_runtime_dom";
@@ -31,7 +32,7 @@ function createBaseFixture(): SelectorFixture {
       spectrumPanelRoot: stubElement("spectrumPanelRoot"),
       specChart: stubElement("specChart"),
       liveOverviewRoot: stubElement("liveOverviewRoot"),
-      historyTableBody: stubElement("historyTableBody"),
+      historyPanelRoot: stubElement("historyPanelRoot"),
       addCarBtn: stubElement("addCarBtn"),
       addCarWizard: stubElement("addCarWizard"),
       updateStartBtn: stubElement("updateStartBtn"),
@@ -92,7 +93,7 @@ test("createUiRuntimeDom returns the feature-scoped startup bundle when required
     const dom = createUiRuntimeDom();
     expect(dom.shell.menuButtons).toHaveLength(2);
     expect(dom.spectrum.specChart.id).toBe("specChart");
-    expect(dom.history.historyTableBody.id).toBe("historyTableBody");
+    expect(dom.history).toEqual({});
     expect(dom.settings.settingsTabs).toHaveLength(2);
     expect(dom.cars.addCarBtn.id).toBe("addCarBtn");
     expect(dom.update.updateStartBtn.id).toBe("updateStartBtn");
@@ -124,6 +125,15 @@ test("getUiSpectrumPanelHost resolves the spectrum island host", () => {
   const restore = installDomFixture();
   try {
     expect(getUiSpectrumPanelHost().id).toBe("spectrumPanelRoot");
+  } finally {
+    restore();
+  }
+});
+
+test("getUiHistoryPanelHost resolves the history island host", () => {
+  const restore = installDomFixture();
+  try {
+    expect(getUiHistoryPanelHost().id).toBe("historyPanelRoot");
   } finally {
     restore();
   }
@@ -175,10 +185,10 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     }
   });
 
-  test("fails at the history boundary when the history table is missing", () => {
-    const restore = installDomFixture({ missingId: "historyTableBody" });
+  test("fails when the history panel host is missing", () => {
+    const restore = installDomFixture({ missingId: "historyPanelRoot" });
     try {
-      expect(() => createUiRuntimeDom()).toThrow("History feature requires #historyTableBody");
+      expect(() => getUiHistoryPanelHost()).toThrow("History feature requires #historyPanelRoot");
     } finally {
       restore();
     }


### PR DESCRIPTION
# Summary

This PR migrates the history page shell to a Preact island while preserving the
existing history workflows, typed view-model builders, and row/detail DOM
renderer as the narrow adapter seam for this step. The goal for `#2222` was not
to rewrite every history-specific renderer in one pass; it was to move
page-level ownership of the history surface into the same incremental island
architecture already used for shell chrome, the live overview card, the
spectrum panel, and the run-recording card.

Before this change, the history page still depended on static markup in
`apps/ui/index.html`, a feature-scoped DOM lookup surface that owned the
toolbar/buttons/summary/table body, and a delegated binding layer that decoded
history actions directly from the live DOM. That left the history page as one
of the larger remaining legacy UI surfaces, even though the history data path
was already in comparatively good shape: the list/detail/delete modules still
owned the behavior, and the typed history presenters already described the
table rows and expanded detail states well.

This PR moves the page shell, summary, toolbar controls, and interaction
binding behind a dedicated `history_panel.tsx` island, then feeds that island
through a typed `HistoryPanelView` bridge from the existing history feature
stack. The row/detail builders remain intact and continue to render the table
body through a focused adapter, which keeps the scope tight and preserves the
existing history behavior while still making the surface Preact-owned.

# Implementation approach

The implementation follows the migration pattern established by the earlier UI
islands:

1. Replace the static HTML surface with a stable host element in `index.html`.
2. Mount a Preact island before runtime startup in `start_ui_app.ts`.
3. Thread a typed bridge through `UiAppRuntime` and `app_feature_bundle.ts`.
4. Push typed render state into that bridge from the feature/modules instead of
   mutating page DOM directly.
5. Keep imperative seams only where they still provide a clean boundary.

For the history page, the cleanest boundary was the full page shell, not just
the `tbody`. The feature already had enough typed data to describe the surface,
and the issue explicitly called for the history shell, toolbar, runs table,
expanded details, and actions to move into an island. At the same time, the
row/detail renderer is large and already consumes well-structured typed models,
so rewriting that renderer to JSX in this issue would have added a lot of risk
without materially improving the architecture as much as moving the page shell
itself. The result is a middle step that removes the page-level legacy DOM
ownership while reducing the old render/bind layer to a focused table-body
adapter.

# Main code changes

The static history section in `apps/ui/index.html` is now replaced by a single
`#historyPanelRoot` host. `apps/ui/src/app/views/history_panel.tsx` is the new
Preact owner for the history panel shell. It renders the toolbar, summary,
refresh/delete-all buttons, table header, and table body host. It also decodes
history interactions directly inside the island: the empty-state “open live”
action, row actions such as delete/PDF/raw export/load-insights, and row toggle
clicks. That removes the old page-level delegated history binding layer from
the live product path.

Startup/runtime wiring was updated so the island is mounted before the runtime
resolves feature DOM. `start_ui_app.ts` now mounts the history panel alongside
the other islands. `ui_app_runtime.ts` accepts a `HistoryPanelView`, provides a
null implementation by default, and passes that bridge into
`app_feature_bundle.ts`. `app_feature_bundle.ts` then threads the bridge into
`createHistoryFeature()`.

On the history feature side, the biggest shift is that
`history_list_module.ts` no longer owns imperative history DOM updates. Instead
it builds a `HistoryPanelRenderModel` with the summary text, delete-all button
state, and either an empty-state or rows-state table payload, then calls
`panel.render(model)`. That keeps the existing history list module as the owner
of state derivation while removing direct page DOM mutation from it.

`history_feature.ts` now binds actions through `panel.bindActions(...)` rather
than `bindHistoryTableInteractions(...)`. That means the history feature still
owns the business behavior—refreshing history, deleting all runs, opening the
live dashboard, dispatching row actions, and toggling details—but the surface
that emits those actions is now the island rather than a DOM binding helper.

`history_table_view.ts` was deliberately reduced rather than deleted. It now
holds the typed `HistoryPanelView` contract plus the remaining table-body
adapter helpers: `renderHistoryEmptyState()`, `renderHistoryTable()`, and the
action/row decoding helpers used by the island. This matches the issue’s goal
of either removing the old history render/bind layer or reducing it to a thin
adapter.

`history_dom.ts` was also simplified. The history feature no longer depends on
individual DOM lookups for summary/buttons/table body. It now only owns the
required history panel host lookup, which matches the new island boundary.

# Tests and validation

The tests were updated to follow the new seam instead of pinning the old DOM
binding layer:

- `history_feature_modules.spec.ts` now uses a small history-panel bridge stub
  that renders through the table-body adapter helpers, so the existing module
  assertions still validate the rendered history output without depending on
  legacy page DOM ownership.
- `ui_runtime_dom.spec.ts` now checks the new `#historyPanelRoot` host lookup
  and no longer expects a required `#historyTableBody` anchor from
  `createUiRuntimeDom()`.
- `ui_action_bindings.spec.ts` removes the now-obsolete history binding test
  because the history page no longer uses the old delegated binding helper.
- The existing history table adapter tests remain in place to cover the typed
  empty/table body rendering.

Local validation covered the expected UI surfaces for this migration:

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- focused Playwright unit specs for the history modules, history table adapter,
  runtime DOM, and remaining action bindings
- focused Playwright browser smoke coverage for `smoke.history.spec.ts`,
  `smoke.history-layout.spec.ts`, and `smoke.bootstrap.spec.ts` on an isolated
  Vite port so the shared default smoke port would not interfere with the run

# Risks, tradeoffs, and follow-ups

The main tradeoff in this PR is intentional: the page shell is now Preact-owned,
but the typed row/detail renderer still materializes the table body through a
focused DOM adapter. That is a good fit for this issue because it removes the
page-level legacy shell/binding path now, preserves current history UX, and
avoids taking on a much larger row-by-row JSX rewrite in the same change set.

That remaining adapter seam is also explicit, not hidden. The next migration or
cleanup step can decide whether the history row/detail renderer should stay as a
shared typed DOM adapter or move fully into JSX once there is a clear payoff.
For `#2222`, the important result is that the history surface is now mounted and
controlled through the incremental island architecture, while the existing
history API behavior, destructive/export flows, preview/evidence rendering, and
expanded detail UX remain intact.

Closes #2222
