### PR TITLE
Migrate the sensors settings panel to a Preact island

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -110,6 +110,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_speed_source_transport.ts` | Speed-source settings transport wrapper over the UI-local settings and OBD APIs |
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
 | `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
+| `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that mounts the full table/card chrome and exposes the table-body bridge consumed by the realtime feature |
 | `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that mounts the full tab surface and exposes the shared typed bridge consumed by the speed-source and GPS-status modules |
 | `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that mounts the list shell and wizard chrome, then exposes typed list and wizard bridges |
 | `app/views/cars_feature_bindings.ts` | Typed car-wizard bindings reused as the thin wizard interaction adapter behind the car-management island |
@@ -224,6 +225,12 @@ the existing speed-source workflow/presenter/binding path keeps owning
 validation, save/load, and OBD scan behavior, and `settings_gps_status_module.ts`
 still owns the live GPS/OBD diagnostics rows through the same typed panel
 bridge instead of the page-wide settings DOM registry.
+The sensors settings tab now follows the same pattern through
+`app/views/sensors_panel.tsx`: startup mounts the island into the sensors tab
+host, the realtime presenter/workflow path still owns sensor row rendering plus
+identify/remove/location actions, and `realtime_sensor_table_view.ts` remains a
+thin table-body adapter behind the island-owned shell instead of a page-scoped
+DOM target.
 The car-management flow now follows that same island pattern through
 `app/views/cars_panel.tsx`: startup mounts the car tab and wizard shell into a
 single settings host, `settings_cars_module.ts` feeds saved-car list/guidance

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -66,26 +66,7 @@
 
         <!-- Sensors Tab -->
         <div id="sensorsTab" class="settings-tab-panel" role="tabpanel" hidden>
-          <div class="panel card">
-            <strong data-i18n="settings.sensors.title">Sensors</strong>
-            <div class="subtle" data-i18n="settings.sensors.hint">Manage sensor names and locations. Default name is the MAC address.</div>
-            <table class="clients-table">
-              <thead>
-                <tr>
-                  <th data-i18n="settings.sensors.name">Name</th>
-                  <th data-i18n="settings.sensors.mac">MAC Address</th>
-                  <th data-i18n="settings.sensors.location">Location</th>
-                  <th data-i18n="settings.sensors.identify">Identify</th>
-                  <th data-i18n="settings.sensors.remove">Remove</th>
-                </tr>
-              </thead>
-              <tbody id="sensorsSettingsBody">
-                <tr>
-                  <td colspan="5">No sensors detected yet.</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <div id="sensorsPanelRoot"></div>
         </div>
 
         <div id="internetTab" class="settings-tab-panel" role="tabpanel" hidden>

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -30,6 +30,7 @@ import { createUpdateFeature } from "./features/update_feature";
 import type { AppState } from "./ui_app_state";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
 import type { AnalysisPanelView } from "./views/analysis_panel";
+import type { SensorsPanelView } from "./views/sensors_panel";
 import type { SpeedSourcePanelView } from "./views/speed_source_panel";
 
 export type { AppFeatureBundle } from "./app_feature_ports";
@@ -56,6 +57,7 @@ export interface AppFeatureBundleSharedDeps {
 export interface AppFeatureBundleRuntimePorts {
   analysisPanel: AnalysisPanelView;
   carsPanel: CarsPanelView;
+  sensorsPanel: SensorsPanelView;
   speedSourcePanel: SpeedSourcePanelView;
   realtimeChrome: RealtimeFeatureChromePorts;
   historyPanel: HistoryPanelView;
@@ -116,6 +118,7 @@ export function createAppFeatureBundle(
     showError,
     formatInt,
     chrome: runtime.realtimeChrome,
+    sensorsPanel: runtime.sensorsPanel,
     selection: runtime.transport,
     recording: createRealtimeFeatureRecordingPorts(history),
   });

--- a/apps/ui/src/app/dom/realtime_dom.ts
+++ b/apps/ui/src/app/dom/realtime_dom.ts
@@ -5,7 +5,6 @@ const LIVE_OVERVIEW_HOST_ID = "liveOverviewRoot";
 const LOGGING_PANEL_HOST_ID = "loggingPanelRoot";
 
 export interface UiRealtimeDom {
-  sensorsSettingsBody: HTMLElement | null;
   shellLiveStatus: HTMLElement | null;
 }
 
@@ -19,7 +18,6 @@ export function getUiLoggingPanelHost(): HTMLElement {
 
 export function createUiRealtimeDom(): UiRealtimeDom {
   return {
-    sensorsSettingsBody: getById<HTMLElement>("sensorsSettingsBody"),
     shellLiveStatus: getById<HTMLElement>("shellLiveStatus"),
   };
 }

--- a/apps/ui/src/app/dom/sensors_dom.ts
+++ b/apps/ui/src/app/dom/sensors_dom.ts
@@ -1,0 +1,7 @@
+import { requiredById } from "./dom_query";
+
+const SENSORS_OWNER = "Sensors feature";
+
+export function getUiSensorsPanelHost(): HTMLElement {
+  return requiredById("sensorsPanelRoot", SENSORS_OWNER);
+}

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -3,14 +3,17 @@ import type { UiRealtimeDom } from "../dom/realtime_dom";
 import type { UiSettingsDom } from "../dom/settings_dom";
 import type { UiShellDom } from "../dom/shell_dom";
 import type { FeatureDepsBase } from "../feature_deps_base";
-import type { RealtimeState, SettingsState, SpectrumState } from "../ui_app_state";
+import type {
+  RealtimeState,
+  SettingsState,
+  SpectrumState,
+} from "../ui_app_state";
 import type { LocationOption } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
-import {
-  bindRealtimeFeatureInteractions,
-} from "../views/realtime_feature_bindings";
+import { bindRealtimeFeatureInteractions } from "../views/realtime_feature_bindings";
 import type { RealtimeLoggingPanelBridge } from "../views/realtime_logging_panel";
 import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
+import type { SensorsPanelView } from "../views/sensors_panel";
 import { createRealtimeFeatureWorkflow } from "./realtime_feature_workflow";
 import { createRealtimeFeaturePresenter } from "../views/realtime_feature_presenter";
 
@@ -25,6 +28,7 @@ export interface RealtimeFeatureDeps extends FeatureDepsBase {
   getLanguage: () => string;
   formatInt: (value: number) => string;
   chrome: RealtimeFeatureChromePorts;
+  sensorsPanel: SensorsPanelView;
   selection: RealtimeFeatureSelectionPorts;
   recording: RealtimeFeatureRecordingPorts;
 }
@@ -54,7 +58,9 @@ export interface RealtimeFeature {
   refreshLocationOptions(): Promise<void>;
 }
 
-export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature {
+export function createRealtimeFeature(
+  ctx: RealtimeFeatureDeps,
+): RealtimeFeature {
   const isDemoMode = new URLSearchParams(window.location.search).has("demo");
   const presenter = createRealtimeFeaturePresenter({
     realtime: ctx.realtime,
@@ -65,6 +71,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
     shellDom: ctx.shellDom,
     settingsDom: ctx.settingsDom,
     carsDom: ctx.carsDom,
+    sensorsDom: ctx.sensorsPanel.dom,
     t: ctx.t,
     escapeHtml: ctx.escapeHtml,
     formatInt: ctx.formatInt,
@@ -115,7 +122,7 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
       },
     });
     workflow.bindHandlers();
-    bindRealtimeFeatureInteractions(ctx.dom, {
+    bindRealtimeFeatureInteractions(ctx.sensorsPanel.dom, {
       onSensorLocationChange: (change) => {
         void workflow.setClientLocation(change.clientId, change.locationCode);
       },
@@ -132,7 +139,8 @@ export function createRealtimeFeature(ctx: RealtimeFeatureDeps): RealtimeFeature
   return {
     bindHandlers,
     buildLocationOptions: (codes) => presenter.buildLocationOptions(codes),
-    maybeRenderSensorsSettingsList: (force) => presenter.maybeRenderSensorsSettingsList(force),
+    maybeRenderSensorsSettingsList: (force) =>
+      presenter.maybeRenderSensorsSettingsList(force),
     updateClientSelection: () => workflow.updateClientSelection(),
     renderStatus: (clientRow) => presenter.renderStatus(clientRow),
     renderLoggingStatus: () => workflow.renderLoggingStatus(),

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -3,6 +3,7 @@ import "../styles/app.css";
 import { getUiAnalysisPanelHost } from "./dom/analysis_dom";
 import { getUiCarsPanelHost } from "./dom/cars_dom";
 import { getUiHistoryPanelHost } from "./dom/history_dom";
+import { getUiSensorsPanelHost } from "./dom/sensors_dom";
 import { getUiSpeedSourcePanelHost } from "./dom/speed_source_dom";
 import {
   getUiLiveOverviewHost,
@@ -17,6 +18,7 @@ import { mountHistoryPanel } from "./views/history_panel";
 import { mountCarsPanel } from "./views/cars_panel";
 import { mountRealtimeLoggingPanel } from "./views/realtime_logging_panel";
 import { mountRealtimeLiveOverview } from "./views/realtime_live_overview";
+import { mountSensorsPanel } from "./views/sensors_panel";
 import { mountSpeedSourcePanel } from "./views/speed_source_panel";
 import { mountSpectrumPanel } from "./views/spectrum_panel";
 import {
@@ -33,6 +35,7 @@ export function startUiApp(): void {
   const historyPanel = mountHistoryPanel(getUiHistoryPanelHost());
   const carsPanel = mountCarsPanel(getUiCarsPanelHost());
   const analysisPanel = mountAnalysisPanel(getUiAnalysisPanelHost());
+  const sensorsPanel = mountSensorsPanel(getUiSensorsPanelHost());
   const speedSourcePanel = mountSpeedSourcePanel(getUiSpeedSourcePanelHost());
   mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
   new UiAppRuntime(
@@ -45,6 +48,7 @@ export function startUiApp(): void {
     historyPanel,
     carsPanel,
     analysisPanel,
+    sensorsPanel,
     speedSourcePanel,
   ).start();
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -33,6 +33,7 @@ import {
 } from "./views/realtime_live_overview";
 import type { CarsPanelView } from "./views/cars_panel";
 import type { AnalysisPanelView } from "./views/analysis_panel";
+import type { SensorsPanelView } from "./views/sensors_panel";
 import type { SpeedSourcePanelView } from "./views/speed_source_panel";
 
 export class UiAppRuntime {
@@ -60,6 +61,7 @@ export class UiAppRuntime {
     historyPanel: HistoryPanelView = createNullHistoryPanelView(),
     carsPanel: CarsPanelView,
     analysisPanel: AnalysisPanelView,
+    sensorsPanel: SensorsPanelView,
     speedSourcePanel: SpeedSourcePanelView,
   ) {
     this.dom = dom;
@@ -110,6 +112,7 @@ export class UiAppRuntime {
       runtime: {
         analysisPanel,
         carsPanel,
+        sensorsPanel,
         speedSourcePanel,
         realtimeChrome: {
           setPillState: (el, variant, text) =>

--- a/apps/ui/src/app/views/realtime_feature_bindings.ts
+++ b/apps/ui/src/app/views/realtime_feature_bindings.ts
@@ -1,5 +1,9 @@
-import type { UiRealtimeDom } from "../dom/realtime_dom";
-import { bindViewEvent, composeViewDisposers, type ViewDisposer } from "./dom_event_bindings";
+import type { SensorsPanelDom } from "./sensors_panel";
+import {
+  bindViewEvent,
+  composeViewDisposers,
+  type ViewDisposer,
+} from "./dom_event_bindings";
 import {
   getRealtimeSensorTableClickAction,
   getRealtimeSensorTableLocationChange,
@@ -13,7 +17,7 @@ export interface RealtimeFeatureBindingHandlers {
 }
 
 export function bindRealtimeFeatureInteractions(
-  dom: Pick<UiRealtimeDom, "sensorsSettingsBody">,
+  dom: SensorsPanelDom,
   handlers: RealtimeFeatureBindingHandlers,
 ): ViewDisposer {
   return composeViewDisposers(

--- a/apps/ui/src/app/views/realtime_feature_presenter.ts
+++ b/apps/ui/src/app/views/realtime_feature_presenter.ts
@@ -5,7 +5,11 @@ import type { UiShellDom } from "../dom/shell_dom";
 import { deriveCarSelectionState } from "../car_selection_state";
 import { classifyDataFreshness } from "../features/data_freshness";
 import { createRealtimeSensorState } from "../features/realtime_sensor_state";
-import type { RealtimeState, SettingsState, SpectrumState } from "../ui_app_state";
+import type {
+  RealtimeState,
+  SettingsState,
+  SpectrumState,
+} from "../ui_app_state";
 import type { LocationOption } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
 import {
@@ -19,13 +23,12 @@ import type {
   RealtimeLoggingPanelBridge,
   RealtimeLoggingPanelRenderModel,
 } from "./realtime_logging_panel";
-import {
-  renderRealtimeSensorTable,
-} from "./realtime_sensor_table_view";
+import { renderRealtimeSensorTable } from "./realtime_sensor_table_view";
 import type {
   RealtimeLiveOverviewBridge,
   RealtimeLiveOverviewRenderModel,
 } from "./realtime_live_overview";
+import type { SensorsPanelDom } from "./sensors_panel";
 
 export type RealtimeFeaturePendingLoggingAction = RealtimeLoggingPendingAction;
 
@@ -36,6 +39,7 @@ export interface RealtimeFeatureRenderState {
 
 export interface RealtimeFeaturePresenterDeps {
   dom: UiRealtimeDom;
+  sensorsDom: SensorsPanelDom;
   shellDom: Pick<UiShellDom, "menuButtons">;
   settingsDom: Pick<UiSettingsDom, "settingsTabs">;
   carsDom: Pick<UiCarsDom, "addCarBtn">;
@@ -47,7 +51,11 @@ export interface RealtimeFeaturePresenterDeps {
   escapeHtml: (value: unknown) => string;
   formatInt: (value: number) => string;
   chrome: {
-    setPillState: (el: HTMLElement | null, variant: string, text: string) => void;
+    setPillState: (
+      el: HTMLElement | null,
+      variant: string,
+      text: string,
+    ) => void;
     liveOverview: RealtimeLiveOverviewBridge;
     loggingPanel: RealtimeLoggingPanelBridge;
   };
@@ -73,6 +81,7 @@ export function createRealtimeFeaturePresenter(
 ): RealtimeFeaturePresenter {
   const {
     dom: els,
+    sensorsDom,
     shellDom,
     settingsDom,
     carsDom,
@@ -113,17 +122,22 @@ export function createRealtimeFeaturePresenter(
     const connected = connectedClients();
     const ages = connected
       .map((client) => client.last_seen_age_ms)
-      .filter((age): age is number => typeof age === "number" && Number.isFinite(age));
+      .filter(
+        (age): age is number => typeof age === "number" && Number.isFinite(age),
+      );
     if (!ages.length) {
       return t("dashboard.data_freshness_none");
     }
     const captureReadiness = realtime.loggingStatus.capture_readiness ?? null;
-    const referenceCheck = captureReadinessCheck(captureReadiness, "reference_ready");
+    const referenceCheck = captureReadinessCheck(
+      captureReadiness,
+      "reference_ready",
+    );
     const referenceReason = referenceCheck?.reason_key ?? "";
     if (
-      referenceCheck
-      && referenceCheck.state !== "pass"
-      && [
+      referenceCheck &&
+      referenceCheck.state !== "pass" &&
+      [
         "speed_source_missing",
         "speed_source_not_live",
         "speed_source_fallback_active",
@@ -146,22 +160,30 @@ export function createRealtimeFeaturePresenter(
   }
 
   function computeCurrentLiveHealth() {
-    return computeLiveHealth((readiness) => captureReadinessSummaryText(readiness, {
-      t,
-      formatInt,
-    }));
+    return computeLiveHealth((readiness) =>
+      captureReadinessSummaryText(readiness, {
+        t,
+        formatInt,
+      }),
+    );
   }
 
   function liveSensorOverviewLabel(client: AdaptedClient): string {
     const code = locationCodeForClient(client);
     if (!code) {
-      return String(client.name || client.id || t("dashboard.sensor_unassigned")).trim();
+      return String(
+        client.name || client.id || t("dashboard.sensor_unassigned"),
+      ).trim();
     }
-    const option = realtime.locationOptions.find((location) => location.code === code);
+    const option = realtime.locationOptions.find(
+      (location) => location.code === code,
+    );
     return option?.label ?? code;
   }
 
-  function buildLiveOverviewModel(phaseText: string): RealtimeLiveOverviewRenderModel {
+  function buildLiveOverviewModel(
+    phaseText: string,
+  ): RealtimeLiveOverviewRenderModel {
     const signal = strongestSignal();
     const health = computeCurrentLiveHealth();
     const totalClients = realtime.clients.length;
@@ -209,7 +231,9 @@ export function createRealtimeFeaturePresenter(
       connectedCountText: formatInt(connectedClients().length),
       assignedCountText: formatInt(assignedClientCount()),
       runIdText: recordingRunIdText(realtime.loggingStatus),
-      elapsedText: realtime.loggingStatus.enabled ? formatElapsed(realtime.loggingStatus.start_time_utc) : "--",
+      elapsedText: realtime.loggingStatus.enabled
+        ? formatElapsed(realtime.loggingStatus.start_time_utc)
+        : "--",
       samplesText: formatInt(realtime.loggingStatus.samples_written ?? 0),
       lastCompletedElapsedText,
       t,
@@ -247,7 +271,11 @@ export function createRealtimeFeaturePresenter(
   function renderLiveOverview(phaseText: string): void {
     const model = buildLiveOverviewModel(phaseText);
     chrome.liveOverview.render(model);
-    setPillState(els.shellLiveStatus, model.runHealth.variant, model.runHealth.text);
+    setPillState(
+      els.shellLiveStatus,
+      model.runHealth.variant,
+      model.runHealth.text,
+    );
   }
 
   function sensorsSettingsSignature(): string {
@@ -257,7 +285,9 @@ export function createRealtimeFeaturePresenter(
         return `${client.id}|${client.name || ""}|${client.mac_address || ""}|${connected}|${client.location_code || ""}`;
       })
       .join("||");
-    const locationPart = realtime.locationOptions.map((loc) => `${loc.code}|${loc.label}`).join("||");
+    const locationPart = realtime.locationOptions
+      .map((loc) => `${loc.code}|${loc.label}`)
+      .join("||");
     return `${clientPart}##${locationPart}`;
   }
 
@@ -270,8 +300,8 @@ export function createRealtimeFeaturePresenter(
   }
 
   function renderSensorsSettingsList(): void {
-    if (!els.sensorsSettingsBody) return;
-    renderRealtimeSensorTable(els.sensorsSettingsBody, {
+    if (!sensorsDom.sensorsSettingsBody) return;
+    renderRealtimeSensorTable(sensorsDom.sensorsSettingsBody, {
       clients: realtime.clients,
       locationOptions: realtime.locationOptions,
       t,
@@ -294,7 +324,10 @@ export function createRealtimeFeaturePresenter(
     if (!startTimeUtc) return "--";
     const startMs = Date.parse(startTimeUtc);
     if (!Number.isFinite(startMs)) return "--";
-    const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startMs) / 1000));
+    const elapsedSeconds = Math.max(
+      0,
+      Math.floor((Date.now() - startMs) / 1000),
+    );
     const hours = Math.floor(elapsedSeconds / 3600);
     const minutes = Math.floor((elapsedSeconds % 3600) / 60);
     const seconds = elapsedSeconds % 60;
@@ -305,7 +338,11 @@ export function createRealtimeFeaturePresenter(
   }
 
   function syncLoggingElapsedTimer(handlersBound: boolean): void {
-    const shouldTick = handlersBound && Boolean(realtime.loggingStatus.enabled && realtime.loggingStatus.start_time_utc);
+    const shouldTick =
+      handlersBound &&
+      Boolean(
+        realtime.loggingStatus.enabled && realtime.loggingStatus.start_time_utc,
+      );
     if (!shouldTick) {
       clearLoggingElapsedTimer();
       return;
@@ -327,17 +364,23 @@ export function createRealtimeFeaturePresenter(
       return t("dashboard.logging.run_id", { runId: status.run_id });
     }
     if (status.last_completed_run_id) {
-      return t("dashboard.logging.last_run_id", { runId: status.last_completed_run_id });
+      return t("dashboard.logging.last_run_id", {
+        runId: status.last_completed_run_id,
+      });
     }
     return "";
   }
 
   function activatePrimaryView(viewId: string): void {
-    shellDom.menuButtons.find((button) => button.dataset.view === viewId)?.click();
+    shellDom.menuButtons
+      .find((button) => button.dataset.view === viewId)
+      ?.click();
   }
 
   function activateSettingsTab(tabId: string): void {
-    settingsDom.settingsTabs.find((button) => button.getAttribute("data-settings-tab") === tabId)?.click();
+    settingsDom.settingsTabs
+      .find((button) => button.getAttribute("data-settings-tab") === tabId)
+      ?.click();
   }
 
   function openSettingsView(tabId: string): void {
@@ -354,11 +397,13 @@ export function createRealtimeFeaturePresenter(
 
   function getIdleCaptureReadinessSignature(): string {
     const clientsSignature = realtime.clients
-      .map((client) => [
-        client.id,
-        client.connected ? "1" : "0",
-        locationCodeForClient(client),
-      ].join(":"))
+      .map((client) =>
+        [
+          client.id,
+          client.connected ? "1" : "0",
+          locationCodeForClient(client),
+        ].join(":"),
+      )
       .sort()
       .join("|");
     return `${settings.activeCarId ?? ""}##${clientsSignature}`;

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -1,0 +1,51 @@
+import { h } from "preact";
+
+import { createUiPreactMount } from "../runtime/ui_preact_mount";
+
+export interface SensorsPanelDom {
+  sensorsSettingsBody: HTMLElement | null;
+}
+
+export interface SensorsPanelView {
+  readonly dom: SensorsPanelDom;
+}
+
+function SensorsPanel() {
+  return (
+    <div class="panel card">
+      <strong data-i18n="settings.sensors.title">Sensors</strong>
+      <div class="subtle" data-i18n="settings.sensors.hint">
+        Manage sensor names and locations. Default name is the MAC address.
+      </div>
+      <table class="clients-table">
+        <thead>
+          <tr>
+            <th data-i18n="settings.sensors.name">Name</th>
+            <th data-i18n="settings.sensors.mac">MAC Address</th>
+            <th data-i18n="settings.sensors.location">Location</th>
+            <th data-i18n="settings.sensors.identify">Identify</th>
+            <th data-i18n="settings.sensors.remove">Remove</th>
+          </tr>
+        </thead>
+        <tbody id="sensorsSettingsBody">
+          <tr>
+            <td colSpan={5}>No sensors detected yet.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function createSensorsPanelDom(host: HTMLElement): SensorsPanelDom {
+  return {
+    sensorsSettingsBody: host.querySelector<HTMLElement>("#sensorsSettingsBody"),
+  };
+}
+
+export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
+  createUiPreactMount(host).render(<SensorsPanel />);
+  return {
+    dom: createSensorsPanelDom(host),
+  };
+}

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { getUiAnalysisPanelHost } from "../src/app/dom/analysis_dom";
 import { getUiCarsPanelHost } from "../src/app/dom/cars_dom";
 import { getUiHistoryPanelHost } from "../src/app/dom/history_dom";
+import { getUiSensorsPanelHost } from "../src/app/dom/sensors_dom";
 import { getUiSpeedSourcePanelHost } from "../src/app/dom/speed_source_dom";
 import {
   getUiLiveOverviewHost,
@@ -41,6 +42,7 @@ function createBaseFixture(): SelectorFixture {
       historyPanelRoot: stubElement("historyPanelRoot"),
       carsPanelRoot: stubElement("carsPanelRoot"),
       analysisPanelRoot: stubElement("analysisPanelRoot"),
+      sensorsPanelRoot: stubElement("sensorsPanelRoot"),
       speedSourcePanelRoot: stubElement("speedSourcePanelRoot"),
       addCarBtn: stubElement("addCarBtn"),
       addCarWizard: stubElement("addCarWizard"),
@@ -169,6 +171,15 @@ test("getUiAnalysisPanelHost resolves the analysis island host", () => {
   const restore = installDomFixture();
   try {
     expect(getUiAnalysisPanelHost().id).toBe("analysisPanelRoot");
+  } finally {
+    restore();
+  }
+});
+
+test("getUiSensorsPanelHost resolves the sensors island host", () => {
+  const restore = installDomFixture();
+  try {
+    expect(getUiSensorsPanelHost().id).toBe("sensorsPanelRoot");
   } finally {
     restore();
   }
@@ -308,6 +319,17 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     try {
       expect(() => createUiRuntimeDom()).toThrow(
         "ESP flash feature requires #espFlashStartBtn",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails when the sensors panel host is missing", () => {
+    const restore = installDomFixture({ missingId: "sensorsPanelRoot" });
+    try {
+      expect(() => getUiSensorsPanelHost()).toThrow(
+        "Sensors feature requires #sensorsPanelRoot",
       );
     } finally {
       restore();


### PR DESCRIPTION
## Summary

This PR migrates the **settings sensors tab** to a dedicated Preact island and keeps the existing sensor-management behavior on its current realtime feature path. The end state is intentionally narrow: the panel chrome and table shell are now rendered by `app/views/sensors_panel.tsx`, while the existing identify, remove, location-change, and refresh behavior still flows through `realtime_feature.ts`, `realtime_feature_presenter.ts`, `realtime_feature_workflow.ts`, and `realtime_sensor_table_view.ts`. That matches the actual ownership seam in the current app instead of trying to force the panel through `settings_feature.ts`, which would have broadened the change and mixed responsibilities across feature boundaries.

## Problem

Before this change, the sensors settings panel still lived on the legacy page-scoped DOM path. The markup for the whole tab was hard-coded in `apps/ui/index.html`, and the realtime feature reached into that global DOM registry to find `#sensorsSettingsBody` for rendering and delegated interaction binding. That arrangement had the same problems as the earlier migrated surfaces: panel structure and behavior were coupled through a global DOM bag, the settings tab shell could not be reasoned about as an owned UI surface, and startup/runtime composition still carried legacy assumptions about static markup for a panel that is really just another feature-owned island candidate.

The main wrinkle here was that this panel is not actually owned by `settings_feature.ts`. The live owner path for sensor-management behavior remains the realtime feature stack, because the same area is tightly connected to connected-client state, location options, identify/remove actions, and related refresh behavior. So the right migration was not “move the sensors tab into settings code.” The right migration was “move the tab shell into an island, then point the realtime owner path at that island through a typed bridge.”

## Implementation approach

I followed the same incremental island pattern used in the previous migration issues, but adapted it to the realtime-owned seam for this panel. The change replaces the old static sensors tab body in `index.html` with a single host element, mounts a Preact-owned panel into that host during startup, and exposes a minimal typed DOM bridge containing only the table body that still needs imperative row rendering and delegated event decoding.

That approach keeps the change small and behavior-safe:

- Preact owns the sensors panel chrome and stable structure.
- The realtime feature still owns sensor row rendering, selection-aware location options, identify/remove actions, and refresh orchestration.
- `realtime_sensor_table_view.ts` remains a thin table-body adapter instead of being pulled into a larger rewrite.
- The page-wide realtime DOM registry shrinks, because it no longer owns the settings sensors table body.

## Main code changes

### 1. New panel owner and host lookup

`apps/ui/index.html` now replaces the old sensors panel markup with `<div id="sensorsPanelRoot"></div>`. The new `apps/ui/src/app/views/sensors_panel.tsx` file renders the full panel shell: title, hint text, table header, and default empty row state. After mounting, it exposes a `SensorsPanelDom` bridge that currently contains `sensorsSettingsBody`, which is the only imperative seam the existing realtime presenter still needs.

`apps/ui/src/app/dom/sensors_dom.ts` adds the required host lookup helper so startup fails fast if the new sensors island host is missing, matching the same pattern already used by the other migrated panels.

### 2. Startup and runtime wiring

`apps/ui/src/app/start_ui_app.ts` now mounts the sensors panel island before the app runtime starts, alongside the other already-migrated surfaces. `apps/ui/src/app/ui_app_runtime.ts` accepts the mounted `SensorsPanelView` as a runtime dependency, and `apps/ui/src/app/app_feature_bundle.ts` threads that view into the feature bundle so the realtime feature can consume it directly.

This is important because it keeps the architecture consistent: startup owns mounting, runtime owns composition, and features receive explicit typed ports instead of re-querying the document later.

### 3. Realtime feature retargeted to the island bridge

The core behavioral seam changes live in `apps/ui/src/app/features/realtime_feature.ts`, `apps/ui/src/app/views/realtime_feature_presenter.ts`, and `apps/ui/src/app/views/realtime_feature_bindings.ts`.

`realtime_feature.ts` now accepts `sensorsPanel: SensorsPanelView` as a dependency and passes `sensorsPanel.dom` into both the presenter and the interaction bindings. That keeps all sensor-table behavior on the existing realtime path, but no longer through the global realtime DOM.

`realtime_feature_presenter.ts` now takes a dedicated `sensorsDom` dependency. The presenter’s sensor list rendering path writes into `sensorsDom.sensorsSettingsBody`, which means the list rendering and refresh signature logic stay exactly where they already belonged, but the destination is now the island-owned bridge instead of the page-scoped DOM registry. Navigation actions like `openSensorsSettings()` still work the same way; the point of this PR is not to rewrite panel workflow, only to move ownership of the shell.

`realtime_feature_bindings.ts` now binds change and click handlers against `SensorsPanelDom` rather than `UiRealtimeDom`. That is the real cleanup win for the behavior path: the binding surface is reduced to the one DOM bridge the realtime feature actually needs for this settings panel.

### 4. Shrinking the legacy DOM registry

`apps/ui/src/app/dom/realtime_dom.ts` drops `sensorsSettingsBody`, leaving only the realtime-specific shared shell references it still legitimately owns. This is exactly the kind of incremental cleanup the migration is supposed to produce: each island removes one more panel-shaped concern from the legacy page-wide DOM bag.

### 5. Docs and regression coverage

`apps/ui/tests/ui_runtime_dom.spec.ts` now covers the sensors host lookup and the corresponding missing-host failure case. `apps/ui/README.md` documents that the sensors settings shell is now owned by `app/views/sensors_panel.tsx`, while the realtime presenter/workflow path still owns the row behavior through the typed bridge.

## Validation

I ran the standard local UI checks for the touched area:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

I also ran focused Playwright coverage on an isolated local Vite port (`4185`) to avoid interference from the shared environment:

- `tests/realtime_feature_workflow.spec.ts`
- `tests/ui_action_bindings.spec.ts`
- `tests/ui_runtime_dom.spec.ts`
- the sensors-specific cases in `tests/smoke.settings.spec.ts`

That coverage was selected to match the actual blast radius of the diff: realtime-owned workflow behavior, typed binding decode paths, runtime host lookup, and the browser-facing settings interactions that exercise sensor naming/location assignment behavior.

## Risks, tradeoffs, and out of scope

The main tradeoff here is intentional: this PR does **not** rewrite the sensor row renderer into fully declarative Preact. `realtime_sensor_table_view.ts` remains the row-level imperative adapter, because that is the smallest complete move that satisfies the issue without broadening into a deeper realtime feature rewrite. The island now owns the panel shell, while the existing realtime owner path still owns row content and actions. That keeps risk low and makes the follow-on cleanup issue more honest about what still remains after the per-panel migrations.

Out of scope for this PR:

- live overview roster behavior
- other settings tabs
- deeper simplification of realtime feature workflow/presenter internals
- the final shared-runtime cleanup reserved for the closing migration issue

Closes #2226
