### PR TITLE
Migrate the internet settings panel to a Preact island

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -110,6 +110,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_speed_source_transport.ts` | Speed-source settings transport wrapper over the UI-local settings and OBD APIs |
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
 | `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
+| `app/views/internet_panel.tsx` | Preact owner for the internet settings shell that mounts the USB-status plus transport/readiness surface and exposes the bridge consumed by the update feature |
 | `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that mounts the full table/card chrome and exposes the table-body bridge consumed by the realtime feature |
 | `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that mounts the full tab surface and exposes the shared typed bridge consumed by the speed-source and GPS-status modules |
 | `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that mounts the list shell and wizard chrome, then exposes typed list and wizard bridges |
@@ -231,6 +232,12 @@ host, the realtime presenter/workflow path still owns sensor row rendering plus
 identify/remove/location actions, and `realtime_sensor_table_view.ts` remains a
 thin table-body adapter behind the island-owned shell instead of a page-scoped
 DOM target.
+The internet settings tab now follows that same pattern through
+`app/views/internet_panel.tsx`: startup mounts the internet shell into its own
+tab host, and the existing update presenter/workflow path still owns USB-status
+rendering, transport selection, readiness messaging, and Wi-Fi credential
+handling through the typed internet-panel bridge instead of the page-wide update
+DOM registry.
 The car-management flow now follows that same island pattern through
 `app/views/cars_panel.tsx`: startup mounts the car tab and wizard shell into a
 single settings host, `settings_cars_module.ts` feeds saved-car list/guidance

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -70,13 +70,7 @@
         </div>
 
         <div id="internetTab" class="settings-tab-panel" role="tabpanel" hidden>
-          <div class="panel card">
-            <strong data-i18n="settings.internet.title">Internet</strong>
-            <div class="subtle" data-i18n="settings.internet.hint">USB internet is optional. When a compatible phone or USB network device is detected, the Pi can keep its hotspot active while using USB as the upstream connection.</div>
-            <div id="internetStatusPanel" class="maintenance-stack" aria-live="polite" style="margin-top:1rem;">
-              <!-- Rendered dynamically by update_feature.ts -->
-            </div>
-          </div>
+          <div id="internetPanelRoot"></div>
         </div>
 
         <!-- Update Tab -->
@@ -86,62 +80,10 @@
             <div class="subtle" data-i18n="settings.update.hint">Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.</div>
             <div class="subtle" data-i18n="settings.update.reconnect_note" style="margin-top:0.25rem;">Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.</div>
             <div class="maintenance-stack" style="margin-top:1rem;">
-              <section class="maintenance-card">
-                <div class="maintenance-card__header">
-                  <div>
-                    <div class="maintenance-card__title" data-i18n="settings.update.controls_title">Update connection</div>
-                    <div class="subtle" data-i18n="settings.update.controls_intro">Use Wi-Fi credentials as before, or choose the existing USB internet uplink when the Pi detects one.</div>
-                  </div>
-                </div>
-                <div class="update-form">
-                  <div id="updateTransportOptions" class="maintenance-stack maintenance-stack--tight">
-                    <div class="subtle" data-i18n="settings.update.transport_label">Internet source</div>
-                    <div class="speed-source-choice-grid">
-                      <label id="updateTransportChoiceWifi" class="speed-source-choice" data-update-transport-choice="wifi">
-                        <input class="speed-source-choice__radio" type="radio" id="updateTransportWifiRadio" name="updateTransport" value="wifi" checked />
-                        <span class="speed-source-choice__title" data-i18n="settings.update.transport.wifi_title">Temporary Wi-Fi</span>
-                        <span class="speed-source-choice__caption" data-i18n="settings.update.transport.wifi_summary">Pause the hotspot, join a Wi-Fi network, install, then restore the hotspot.</span>
-                      </label>
-                      <label id="updateTransportChoiceUsb" class="speed-source-choice" data-update-transport-choice="usb_internet">
-                        <input class="speed-source-choice__radio" type="radio" id="updateTransportUsbRadio" name="updateTransport" value="usb_internet" />
-                        <span class="speed-source-choice__title" data-i18n="settings.update.transport.usb_title">Existing USB internet</span>
-                        <span id="updateUsbTransportSummary" class="speed-source-choice__caption"></span>
-                      </label>
-                    </div>
-                  </div>
-                  <div id="updateWifiFields">
-                    <div class="form-group">
-                      <label for="updateSsidInput" data-i18n="settings.update.ssid">Wi-Fi SSID</label>
-                      <input type="text" id="updateSsidInput" autocomplete="off" maxlength="64" style="width:100%;max-width:20rem;" />
-                    </div>
-                    <div class="form-group">
-                      <label for="updatePasswordInput" data-i18n="settings.update.password">Wi-Fi Password</label>
-                      <div style="display:flex;gap:0.5rem;align-items:center;">
-                        <input type="password" id="updatePasswordInput" autocomplete="off" maxlength="128" style="width:100%;max-width:20rem;" />
-                        <button type="button" id="updateTogglePasswordBtn" class="btn btn--small">
-                          <span data-i18n="settings.update.show_password">Show</span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  <div id="updateReadinessSummary" class="maintenance-stack maintenance-stack--tight" aria-live="polite"></div>
-                  <details class="settings-help-disclosure settings-help-disclosure--inline">
-                    <summary class="settings-help-disclosure__summary">
-                      <span class="settings-help-disclosure__heading">
-                        <span class="settings-help-disclosure__title" data-i18n="settings.update.details_title">What happens next</span>
-                        <span id="updateDetailsCaption" class="settings-help-disclosure__caption"></span>
-                      </span>
-                    </summary>
-                    <div class="settings-help-disclosure__body">
-                      <div id="updateTransportNote" class="maintenance-note" data-i18n="settings.update.preflight_note_wifi">Starting a Wi-Fi update temporarily pauses hotspot access while the Pi joins Wi-Fi, downloads the next release, and restores the local web UI when the job is done.</div>
-                    </div>
-                  </details>
-                  <div class="maintenance-action-row">
-                    <button type="button" id="updateStartBtn" class="btn btn--success" data-i18n="settings.update.start">Start Update</button>
-                    <button type="button" id="updateCancelBtn" class="btn btn--danger" hidden data-i18n="settings.update.cancel">Cancel Update</button>
-                  </div>
-                </div>
-              </section>
+              <div class="maintenance-action-row">
+                <button type="button" id="updateStartBtn" class="btn btn--success" data-i18n="settings.update.start">Start Update</button>
+                <button type="button" id="updateCancelBtn" class="btn btn--danger" hidden data-i18n="settings.update.cancel">Cancel Update</button>
+              </div>
 
               <div id="updateStatusPanel" class="maintenance-stack" aria-live="polite">
                 <!-- Rendered dynamically by update_feature.ts -->

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -30,6 +30,7 @@ import { createUpdateFeature } from "./features/update_feature";
 import type { AppState } from "./ui_app_state";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
 import type { AnalysisPanelView } from "./views/analysis_panel";
+import type { InternetPanelView } from "./views/internet_panel";
 import type { SensorsPanelView } from "./views/sensors_panel";
 import type { SpeedSourcePanelView } from "./views/speed_source_panel";
 
@@ -57,6 +58,7 @@ export interface AppFeatureBundleSharedDeps {
 export interface AppFeatureBundleRuntimePorts {
   analysisPanel: AnalysisPanelView;
   carsPanel: CarsPanelView;
+  internetPanel: InternetPanelView;
   sensorsPanel: SensorsPanelView;
   speedSourcePanel: SpeedSourcePanelView;
   realtimeChrome: RealtimeFeatureChromePorts;
@@ -166,6 +168,7 @@ export function createAppFeatureBundle(
 
   const update = createUpdateFeature({
     dom: updateDom,
+    internetPanel: runtime.internetPanel,
     t,
     escapeHtml,
     showError,

--- a/apps/ui/src/app/dom/internet_dom.ts
+++ b/apps/ui/src/app/dom/internet_dom.ts
@@ -1,0 +1,7 @@
+import { requiredById } from "./dom_query";
+
+const INTERNET_OWNER = "Internet settings";
+
+export function getUiInternetPanelHost(): HTMLElement {
+  return requiredById("internetPanelRoot", INTERNET_OWNER);
+}

--- a/apps/ui/src/app/dom/update_dom.ts
+++ b/apps/ui/src/app/dom/update_dom.ts
@@ -3,20 +3,6 @@ import { getById, requiredById } from "./dom_query";
 const UPDATE_OWNER = "Update feature";
 
 export interface UiUpdateDom {
-  internetStatusPanel: HTMLElement | null;
-  updateTransportOptions: HTMLElement | null;
-  updateTransportChoiceWifi: HTMLElement | null;
-  updateTransportChoiceUsb: HTMLElement | null;
-  updateWifiFields: HTMLElement | null;
-  updateReadinessSummary: HTMLElement | null;
-  updateDetailsCaption: HTMLElement | null;
-  updateTransportNote: HTMLElement | null;
-  updateTransportWifiRadio: HTMLInputElement | null;
-  updateTransportUsbRadio: HTMLInputElement | null;
-  updateUsbTransportSummary: HTMLElement | null;
-  updateSsidInput: HTMLInputElement | null;
-  updatePasswordInput: HTMLInputElement | null;
-  updateTogglePasswordBtn: HTMLButtonElement | null;
   updateStartBtn: HTMLButtonElement;
   updateCancelBtn: HTMLButtonElement | null;
   updateStatusPanel: HTMLElement | null;
@@ -24,21 +10,10 @@ export interface UiUpdateDom {
 
 export function createUiUpdateDom(): UiUpdateDom {
   return {
-    internetStatusPanel: getById<HTMLElement>("internetStatusPanel"),
-    updateTransportOptions: getById<HTMLElement>("updateTransportOptions"),
-    updateTransportChoiceWifi: getById<HTMLElement>("updateTransportChoiceWifi"),
-    updateTransportChoiceUsb: getById<HTMLElement>("updateTransportChoiceUsb"),
-    updateWifiFields: getById<HTMLElement>("updateWifiFields"),
-    updateReadinessSummary: getById<HTMLElement>("updateReadinessSummary"),
-    updateDetailsCaption: getById<HTMLElement>("updateDetailsCaption"),
-    updateTransportNote: getById<HTMLElement>("updateTransportNote"),
-    updateTransportWifiRadio: getById<HTMLInputElement>("updateTransportWifiRadio"),
-    updateTransportUsbRadio: getById<HTMLInputElement>("updateTransportUsbRadio"),
-    updateUsbTransportSummary: getById<HTMLElement>("updateUsbTransportSummary"),
-    updateSsidInput: getById<HTMLInputElement>("updateSsidInput"),
-    updatePasswordInput: getById<HTMLInputElement>("updatePasswordInput"),
-    updateTogglePasswordBtn: getById<HTMLButtonElement>("updateTogglePasswordBtn"),
-    updateStartBtn: requiredById<HTMLButtonElement>("updateStartBtn", UPDATE_OWNER),
+    updateStartBtn: requiredById<HTMLButtonElement>(
+      "updateStartBtn",
+      UPDATE_OWNER,
+    ),
     updateCancelBtn: getById<HTMLButtonElement>("updateCancelBtn"),
     updateStatusPanel: getById<HTMLElement>("updateStatusPanel"),
   };

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -2,9 +2,11 @@ import type { UiUpdateDom } from "../dom/update_dom";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import { createUpdateFeatureWorkflow } from "./update_feature_workflow";
 import { createUpdateFeaturePresenter } from "../views/update_feature_presenter";
+import type { InternetPanelView } from "../views/internet_panel";
 
 export interface UpdateFeatureDeps extends FeatureDepsBase {
   dom: UiUpdateDom;
+  internetPanel: InternetPanelView;
 }
 
 export interface UpdateFeature {
@@ -16,6 +18,7 @@ export interface UpdateFeature {
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   const presenter = createUpdateFeaturePresenter({
     dom: ctx.dom,
+    internetDom: ctx.internetPanel.dom,
     t: ctx.t,
     escapeHtml: ctx.escapeHtml,
   });
@@ -33,21 +36,32 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     handlersBound = true;
     ctx.dom.updateStartBtn.addEventListener("click", () => {
       workflow.renderCurrentState();
-      void workflow.startUpdate(presenter.readStartIntent(workflow.getRenderState()));
+      void workflow.startUpdate(
+        presenter.readStartIntent(workflow.getRenderState()),
+      );
     });
     ctx.dom.updateCancelBtn?.addEventListener("click", () => {
       void workflow.cancelUpdate();
     });
-    ctx.dom.updateTogglePasswordBtn?.addEventListener("click", () => {
-      presenter.togglePassword();
-    });
-    ctx.dom.updateTransportWifiRadio?.addEventListener("change", () => {
-      workflow.renderCurrentState();
-    });
-    ctx.dom.updateTransportUsbRadio?.addEventListener("change", () => {
-      workflow.renderCurrentState();
-    });
-    ctx.dom.updateSsidInput?.addEventListener("input", () => {
+    ctx.internetPanel.dom.updateTogglePasswordBtn?.addEventListener(
+      "click",
+      () => {
+        presenter.togglePassword();
+      },
+    );
+    ctx.internetPanel.dom.updateTransportWifiRadio?.addEventListener(
+      "change",
+      () => {
+        workflow.renderCurrentState();
+      },
+    );
+    ctx.internetPanel.dom.updateTransportUsbRadio?.addEventListener(
+      "change",
+      () => {
+        workflow.renderCurrentState();
+      },
+    );
+    ctx.internetPanel.dom.updateSsidInput?.addEventListener("input", () => {
       workflow.renderCurrentState();
     });
     workflow.renderCurrentState();

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -3,6 +3,7 @@ import "../styles/app.css";
 import { getUiAnalysisPanelHost } from "./dom/analysis_dom";
 import { getUiCarsPanelHost } from "./dom/cars_dom";
 import { getUiHistoryPanelHost } from "./dom/history_dom";
+import { getUiInternetPanelHost } from "./dom/internet_dom";
 import { getUiSensorsPanelHost } from "./dom/sensors_dom";
 import { getUiSpeedSourcePanelHost } from "./dom/speed_source_dom";
 import {
@@ -14,8 +15,9 @@ import { getUiSpectrumPanelHost } from "./dom/spectrum_dom";
 import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
 import { mountAnalysisPanel } from "./views/analysis_panel";
-import { mountHistoryPanel } from "./views/history_panel";
 import { mountCarsPanel } from "./views/cars_panel";
+import { mountHistoryPanel } from "./views/history_panel";
+import { mountInternetPanel } from "./views/internet_panel";
 import { mountRealtimeLoggingPanel } from "./views/realtime_logging_panel";
 import { mountRealtimeLiveOverview } from "./views/realtime_live_overview";
 import { mountSensorsPanel } from "./views/sensors_panel";
@@ -35,6 +37,7 @@ export function startUiApp(): void {
   const historyPanel = mountHistoryPanel(getUiHistoryPanelHost());
   const carsPanel = mountCarsPanel(getUiCarsPanelHost());
   const analysisPanel = mountAnalysisPanel(getUiAnalysisPanelHost());
+  const internetPanel = mountInternetPanel(getUiInternetPanelHost());
   const sensorsPanel = mountSensorsPanel(getUiSensorsPanelHost());
   const speedSourcePanel = mountSpeedSourcePanel(getUiSpeedSourcePanelHost());
   mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
@@ -48,6 +51,7 @@ export function startUiApp(): void {
     historyPanel,
     carsPanel,
     analysisPanel,
+    internetPanel,
     sensorsPanel,
     speedSourcePanel,
   ).start();

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -23,6 +23,7 @@ import {
   createNullHistoryPanelView,
   type HistoryPanelView,
 } from "./views/history_table_view";
+import type { InternetPanelView } from "./views/internet_panel";
 import {
   createNullRealtimeLoggingPanelBridge,
   type RealtimeLoggingPanelBridge,
@@ -61,6 +62,7 @@ export class UiAppRuntime {
     historyPanel: HistoryPanelView = createNullHistoryPanelView(),
     carsPanel: CarsPanelView,
     analysisPanel: AnalysisPanelView,
+    internetPanel: InternetPanelView,
     sensorsPanel: SensorsPanelView,
     speedSourcePanel: SpeedSourcePanelView,
   ) {
@@ -112,6 +114,7 @@ export class UiAppRuntime {
       runtime: {
         analysisPanel,
         carsPanel,
+        internetPanel,
         sensorsPanel,
         speedSourcePanel,
         realtimeChrome: {

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -1,0 +1,246 @@
+import { h } from "preact";
+
+import { createUiPreactMount } from "../runtime/ui_preact_mount";
+
+export interface InternetPanelDom {
+  internetStatusPanel: HTMLElement | null;
+  updateTransportOptions: HTMLElement | null;
+  updateTransportChoiceWifi: HTMLElement | null;
+  updateTransportChoiceUsb: HTMLElement | null;
+  updateWifiFields: HTMLElement | null;
+  updateReadinessSummary: HTMLElement | null;
+  updateDetailsCaption: HTMLElement | null;
+  updateTransportNote: HTMLElement | null;
+  updateTransportWifiRadio: HTMLInputElement | null;
+  updateTransportUsbRadio: HTMLInputElement | null;
+  updateUsbTransportSummary: HTMLElement | null;
+  updateSsidInput: HTMLInputElement | null;
+  updatePasswordInput: HTMLInputElement | null;
+  updateTogglePasswordBtn: HTMLButtonElement | null;
+}
+
+export interface InternetPanelView {
+  readonly dom: InternetPanelDom;
+}
+
+function InternetPanel() {
+  return (
+    <div class="maintenance-stack">
+      <div class="panel card">
+        <strong data-i18n="settings.internet.title">Internet</strong>
+        <div class="subtle" data-i18n="settings.internet.hint">
+          USB internet is optional. When a compatible phone or USB network
+          device is detected, the Pi can keep its hotspot active while using USB
+          as the upstream connection.
+        </div>
+        <div
+          id="internetStatusPanel"
+          class="maintenance-stack"
+          aria-live="polite"
+          style="margin-top:1rem;"
+        ></div>
+      </div>
+
+      <section class="maintenance-card">
+        <div class="maintenance-card__header">
+          <div>
+            <div
+              class="maintenance-card__title"
+              data-i18n="settings.update.controls_title"
+            >
+              Update connection
+            </div>
+            <div
+              class="subtle"
+              data-i18n="settings.update.controls_intro"
+            >
+              Use Wi-Fi credentials as before, or choose the existing USB
+              internet uplink when the Pi detects one.
+            </div>
+          </div>
+        </div>
+        <div class="update-form">
+          <div
+            id="updateTransportOptions"
+            class="maintenance-stack maintenance-stack--tight"
+          >
+            <div
+              class="subtle"
+              data-i18n="settings.update.transport_label"
+            >
+              Internet source
+            </div>
+            <div class="speed-source-choice-grid">
+              <label
+                id="updateTransportChoiceWifi"
+                class="speed-source-choice"
+                data-update-transport-choice="wifi"
+              >
+                <input
+                  class="speed-source-choice__radio"
+                  type="radio"
+                  id="updateTransportWifiRadio"
+                  name="updateTransport"
+                  value="wifi"
+                  checked
+                />
+                <span
+                  class="speed-source-choice__title"
+                  data-i18n="settings.update.transport.wifi_title"
+                >
+                  Temporary Wi-Fi
+                </span>
+                <span
+                  class="speed-source-choice__caption"
+                  data-i18n="settings.update.transport.wifi_summary"
+                >
+                  Pause the hotspot, join a Wi-Fi network, install, then restore
+                  the hotspot.
+                </span>
+              </label>
+              <label
+                id="updateTransportChoiceUsb"
+                class="speed-source-choice"
+                data-update-transport-choice="usb_internet"
+              >
+                <input
+                  class="speed-source-choice__radio"
+                  type="radio"
+                  id="updateTransportUsbRadio"
+                  name="updateTransport"
+                  value="usb_internet"
+                />
+                <span
+                  class="speed-source-choice__title"
+                  data-i18n="settings.update.transport.usb_title"
+                >
+                  Existing USB internet
+                </span>
+                <span
+                  id="updateUsbTransportSummary"
+                  class="speed-source-choice__caption"
+                ></span>
+              </label>
+            </div>
+          </div>
+          <div id="updateWifiFields">
+            <div class="form-group">
+              <label htmlFor="updateSsidInput" data-i18n="settings.update.ssid">
+                Wi-Fi SSID
+              </label>
+              <input
+                type="text"
+                id="updateSsidInput"
+                autoComplete="off"
+                maxLength={64}
+                style="width:100%;max-width:20rem;"
+              />
+            </div>
+            <div class="form-group">
+              <label
+                htmlFor="updatePasswordInput"
+                data-i18n="settings.update.password"
+              >
+                Wi-Fi Password
+              </label>
+              <div style="display:flex;gap:0.5rem;align-items:center;">
+                <input
+                  type="password"
+                  id="updatePasswordInput"
+                  autoComplete="off"
+                  maxLength={128}
+                  style="width:100%;max-width:20rem;"
+                />
+                <button
+                  type="button"
+                  id="updateTogglePasswordBtn"
+                  class="btn btn--small"
+                >
+                  <span data-i18n="settings.update.show_password">Show</span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            id="updateReadinessSummary"
+            class="maintenance-stack maintenance-stack--tight"
+            aria-live="polite"
+          ></div>
+          <details class="settings-help-disclosure settings-help-disclosure--inline">
+            <summary class="settings-help-disclosure__summary">
+              <span class="settings-help-disclosure__heading">
+                <span
+                  class="settings-help-disclosure__title"
+                  data-i18n="settings.update.details_title"
+                >
+                  What happens next
+                </span>
+                <span
+                  id="updateDetailsCaption"
+                  class="settings-help-disclosure__caption"
+                ></span>
+              </span>
+            </summary>
+            <div class="settings-help-disclosure__body">
+              <div
+                id="updateTransportNote"
+                class="maintenance-note"
+                data-i18n="settings.update.preflight_note_wifi"
+              >
+                Starting a Wi-Fi update temporarily pauses hotspot access while
+                the Pi joins Wi-Fi, downloads the next release, and restores the
+                local web UI when the job is done.
+              </div>
+            </div>
+          </details>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function createInternetPanelDom(host: HTMLElement): InternetPanelDom {
+  return {
+    internetStatusPanel: host.querySelector<HTMLElement>("#internetStatusPanel"),
+    updateTransportOptions: host.querySelector<HTMLElement>(
+      "#updateTransportOptions",
+    ),
+    updateTransportChoiceWifi: host.querySelector<HTMLElement>(
+      "#updateTransportChoiceWifi",
+    ),
+    updateTransportChoiceUsb: host.querySelector<HTMLElement>(
+      "#updateTransportChoiceUsb",
+    ),
+    updateWifiFields: host.querySelector<HTMLElement>("#updateWifiFields"),
+    updateReadinessSummary: host.querySelector<HTMLElement>(
+      "#updateReadinessSummary",
+    ),
+    updateDetailsCaption: host.querySelector<HTMLElement>(
+      "#updateDetailsCaption",
+    ),
+    updateTransportNote: host.querySelector<HTMLElement>("#updateTransportNote"),
+    updateTransportWifiRadio: host.querySelector<HTMLInputElement>(
+      "#updateTransportWifiRadio",
+    ),
+    updateTransportUsbRadio: host.querySelector<HTMLInputElement>(
+      "#updateTransportUsbRadio",
+    ),
+    updateUsbTransportSummary: host.querySelector<HTMLElement>(
+      "#updateUsbTransportSummary",
+    ),
+    updateSsidInput: host.querySelector<HTMLInputElement>("#updateSsidInput"),
+    updatePasswordInput: host.querySelector<HTMLInputElement>(
+      "#updatePasswordInput",
+    ),
+    updateTogglePasswordBtn: host.querySelector<HTMLButtonElement>(
+      "#updateTogglePasswordBtn",
+    ),
+  };
+}
+
+export function mountInternetPanel(host: HTMLElement): InternetPanelView {
+  createUiPreactMount(host).render(<InternetPanel />);
+  return {
+    dom: createInternetPanelDom(host),
+  };
+}

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -5,6 +5,7 @@ import type {
   UsbInternetStatusPayload,
 } from "../../transport/http_models";
 import type { UiUpdateDom } from "../dom/update_dom";
+import type { InternetPanelDom } from "./internet_panel";
 import {
   formatUsbInternetSummary,
   renderInternetStatusPanel,
@@ -45,6 +46,7 @@ interface UpdateFeatureActionSummary {
 
 export interface UpdateFeaturePresenterDeps {
   dom: UiUpdateDom;
+  internetDom: InternetPanelDom;
   t: (key: string, vars?: Record<string, unknown>) => string;
   escapeHtml: (value: unknown) => string;
 }
@@ -60,7 +62,7 @@ export interface UpdateFeaturePresenter {
 export function createUpdateFeaturePresenter(
   ctx: UpdateFeaturePresenterDeps,
 ): UpdateFeaturePresenter {
-  const { dom: els, t, escapeHtml } = ctx;
+  const { dom: updateEls, internetDom, t, escapeHtml } = ctx;
 
   let passwordVisible = false;
   let lastActionSummary: UpdateFeatureActionSummary | null = null;
@@ -71,24 +73,25 @@ export function createUpdateFeaturePresenter(
     if (state.updateState === "running") {
       return state.updateTransport;
     }
-    if (state.internetStatus.usable && els.updateTransportUsbRadio?.checked) {
+    if (
+      state.internetStatus.usable &&
+      internetDom.updateTransportUsbRadio?.checked
+    ) {
       return "usb_internet";
     }
     return "wifi";
   }
 
-  function hasBlockingHealthIssue(
-    state: UpdateFeatureRenderState,
-  ): boolean {
+  function hasBlockingHealthIssue(state: UpdateFeatureRenderState): boolean {
     const health = state.healthStatus;
     if (!health) {
       return false;
     }
     return (
-      health.status === "degraded"
-      || health.persistence.write_error != null
-      || health.startup_error != null
-      || health.db_corruption_detected === true
+      health.status === "degraded" ||
+      health.persistence.write_error != null ||
+      health.startup_error != null ||
+      health.db_corruption_detected === true
     );
   }
 
@@ -98,7 +101,7 @@ export function createUpdateFeaturePresenter(
     const transport = selectedTransport(state);
     const usingUsb = transport === "usb_internet";
     const isRunning = state.updateState === "running";
-    const ssid = els.updateSsidInput?.value.trim() ?? "";
+    const ssid = internetDom.updateSsidInput?.value.trim() ?? "";
     const usbInterface = state.internetStatus.interface_name;
     const readinessItems = [
       {
@@ -113,10 +116,13 @@ export function createUpdateFeaturePresenter(
             label: t("settings.update.readiness.item.connection"),
             detail: state.internetStatus.usable
               ? t("settings.update.readiness.item.connection_usb_ready", {
-                  interface: usbInterface || t("settings.update.transport.usb_title"),
+                  interface:
+                    usbInterface || t("settings.update.transport.usb_title"),
                 })
               : t("settings.update.readiness.item.connection_usb_blocked"),
-            state: state.internetStatus.usable ? ("ready" as const) : ("blocked" as const),
+            state: state.internetStatus.usable
+              ? ("ready" as const)
+              : ("blocked" as const),
           }
         : {
             label: t("settings.update.readiness.item.connection"),
@@ -133,8 +139,12 @@ export function createUpdateFeaturePresenter(
         state: "blocked",
       });
     }
-    const hasBlockedItem = readinessItems.some((item) => item.state === "blocked");
-    const failure = state.updateStatus ? getUpdateFailureSummary(state.updateStatus, t) : null;
+    const hasBlockedItem = readinessItems.some(
+      (item) => item.state === "blocked",
+    );
+    const failure = state.updateStatus
+      ? getUpdateFailureSummary(state.updateStatus, t)
+      : null;
     const isRecoveryState = failure !== null;
     const stateLabel = isRecoveryState
       ? hasBlockedItem
@@ -166,13 +176,17 @@ export function createUpdateFeaturePresenter(
             detail: hasBlockedItem
               ? t("settings.update.recovery.item.next_step_blocked")
               : `${failure.recoveryTitle} — ${failure.recoveryDetail}`,
-            state: hasBlockedItem ? ("blocked" as const) : ("attention" as const),
+            state: hasBlockedItem
+              ? ("blocked" as const)
+              : ("attention" as const),
           },
         ]
       : readinessItems;
     return {
       canStart: !isRunning && !hasBlockedItem,
-      startLabel: t(isRecoveryState ? "settings.update.retry" : "settings.update.start"),
+      startLabel: t(
+        isRecoveryState ? "settings.update.retry" : "settings.update.start",
+      ),
       transport,
       panelModel: {
         title: t(
@@ -192,7 +206,13 @@ export function createUpdateFeaturePresenter(
                 : "settings.update.readiness.summary_ready",
         ),
         stateLabel,
-        stateVariant: isRecoveryState ? "bad" : isRunning ? "warn" : hasBlockedItem ? "bad" : "ok",
+        stateVariant: isRecoveryState
+          ? "bad"
+          : isRunning
+            ? "warn"
+            : hasBlockedItem
+              ? "bad"
+              : "ok",
         items,
       },
     };
@@ -202,55 +222,56 @@ export function createUpdateFeaturePresenter(
     const usbAvailable = state.internetStatus.usable;
     const controlsLocked = state.updateState === "running";
     const usingUsb = selectedTransport(state) === "usb_internet";
-    if (els.updateTransportOptions) {
-      els.updateTransportOptions.hidden = false;
+    if (internetDom.updateTransportOptions) {
+      internetDom.updateTransportOptions.hidden = false;
     }
-    if (els.updateUsbTransportSummary) {
-      els.updateUsbTransportSummary.textContent = usbAvailable
+    if (internetDom.updateUsbTransportSummary) {
+      internetDom.updateUsbTransportSummary.textContent = usbAvailable
         ? formatUsbInternetSummary(state.internetStatus, t)
         : t("settings.update.transport.usb_summary_unavailable");
     }
     if (!usbAvailable && !controlsLocked) {
-      if (els.updateTransportWifiRadio) {
-        els.updateTransportWifiRadio.checked = true;
+      if (internetDom.updateTransportWifiRadio) {
+        internetDom.updateTransportWifiRadio.checked = true;
       }
-      if (els.updateTransportUsbRadio) {
-        els.updateTransportUsbRadio.checked = false;
+      if (internetDom.updateTransportUsbRadio) {
+        internetDom.updateTransportUsbRadio.checked = false;
       }
     }
-    if (els.updateTransportWifiRadio) {
-      els.updateTransportWifiRadio.disabled = controlsLocked;
+    if (internetDom.updateTransportWifiRadio) {
+      internetDom.updateTransportWifiRadio.disabled = controlsLocked;
     }
-    if (els.updateTransportUsbRadio) {
-      els.updateTransportUsbRadio.disabled = controlsLocked || !usbAvailable;
+    if (internetDom.updateTransportUsbRadio) {
+      internetDom.updateTransportUsbRadio.disabled =
+        controlsLocked || !usbAvailable;
     }
     if (controlsLocked) {
-      if (els.updateTransportWifiRadio) {
-        els.updateTransportWifiRadio.checked = !usingUsb;
+      if (internetDom.updateTransportWifiRadio) {
+        internetDom.updateTransportWifiRadio.checked = !usingUsb;
       }
-      if (els.updateTransportUsbRadio) {
-        els.updateTransportUsbRadio.checked = usingUsb;
+      if (internetDom.updateTransportUsbRadio) {
+        internetDom.updateTransportUsbRadio.checked = usingUsb;
       }
     }
-    setChoiceCardState(els.updateTransportChoiceWifi, {
+    setChoiceCardState(internetDom.updateTransportChoiceWifi, {
       selected: !usingUsb,
     });
-    setChoiceCardState(els.updateTransportChoiceUsb, {
+    setChoiceCardState(internetDom.updateTransportChoiceUsb, {
       selected: usingUsb,
       disabled: !usbAvailable && !controlsLocked,
     });
-    if (els.updateWifiFields) {
-      els.updateWifiFields.hidden = usingUsb;
+    if (internetDom.updateWifiFields) {
+      internetDom.updateWifiFields.hidden = usingUsb;
     }
-    if (els.updateTransportNote) {
-      els.updateTransportNote.textContent = t(
+    if (internetDom.updateTransportNote) {
+      internetDom.updateTransportNote.textContent = t(
         usingUsb
           ? "settings.update.preflight_note_usb"
           : "settings.update.preflight_note_wifi",
       );
     }
-    if (els.updateDetailsCaption) {
-      els.updateDetailsCaption.textContent = t(
+    if (internetDom.updateDetailsCaption) {
+      internetDom.updateDetailsCaption.textContent = t(
         usingUsb
           ? "settings.update.details_caption_usb"
           : "settings.update.details_caption_wifi",
@@ -263,21 +284,21 @@ export function createUpdateFeaturePresenter(
     actionSummary: UpdateFeatureActionSummary,
   ): void {
     const isRunning = state.updateState === "running";
-    els.updateStartBtn.textContent = actionSummary.startLabel;
-    els.updateStartBtn.hidden = isRunning;
-    els.updateStartBtn.disabled = isRunning || !actionSummary.canStart;
-    if (els.updateCancelBtn) {
-      els.updateCancelBtn.hidden = !isRunning;
-      els.updateCancelBtn.disabled = !isRunning;
+    updateEls.updateStartBtn.textContent = actionSummary.startLabel;
+    updateEls.updateStartBtn.hidden = isRunning;
+    updateEls.updateStartBtn.disabled = isRunning || !actionSummary.canStart;
+    if (updateEls.updateCancelBtn) {
+      updateEls.updateCancelBtn.hidden = !isRunning;
+      updateEls.updateCancelBtn.disabled = !isRunning;
     }
-    if (els.updateSsidInput) {
-      els.updateSsidInput.disabled = isRunning;
+    if (internetDom.updateSsidInput) {
+      internetDom.updateSsidInput.disabled = isRunning;
     }
-    if (els.updatePasswordInput) {
-      els.updatePasswordInput.disabled = isRunning;
+    if (internetDom.updatePasswordInput) {
+      internetDom.updatePasswordInput.disabled = isRunning;
     }
-    if (els.updateTogglePasswordBtn) {
-      els.updateTogglePasswordBtn.disabled = isRunning;
+    if (internetDom.updateTogglePasswordBtn) {
+      internetDom.updateTogglePasswordBtn.disabled = isRunning;
     }
   }
 
@@ -285,33 +306,39 @@ export function createUpdateFeaturePresenter(
     state: UpdateFeatureRenderState,
     actionSummary: UpdateFeatureActionSummary,
   ): void {
-    if (els.updateReadinessSummary) {
-      els.updateReadinessSummary.innerHTML = renderMaintenanceReadinessPanel(
-        actionSummary.panelModel,
-        escapeHtml,
-      );
+    if (internetDom.updateReadinessSummary) {
+      internetDom.updateReadinessSummary.innerHTML =
+        renderMaintenanceReadinessPanel(actionSummary.panelModel, escapeHtml);
     }
     if (
-      els.updateStatusPanel
-      && state.updateStatus
-      && state.healthStatus
+      updateEls.updateStatusPanel &&
+      state.updateStatus &&
+      state.healthStatus
     ) {
       renderUpdateStatusPanel(
-        els.updateStatusPanel,
-        buildUpdateStatusPanelViewModel(state.updateStatus, state.healthStatus, {
-          t,
-          selectedTransport: actionSummary.transport,
-        }),
+        updateEls.updateStatusPanel,
+        buildUpdateStatusPanelViewModel(
+          state.updateStatus,
+          state.healthStatus,
+          {
+            t,
+            selectedTransport: actionSummary.transport,
+          },
+        ),
       );
     }
     if (
-      els.internetStatusPanel
-      && state.updateStatus
-      && state.healthStatus
+      internetDom.internetStatusPanel &&
+      state.updateStatus &&
+      state.healthStatus
     ) {
-      renderInternetStatusPanel(els.internetStatusPanel, state.internetStatus, {
-        t,
-      });
+      renderInternetStatusPanel(
+        internetDom.internetStatusPanel,
+        state.internetStatus,
+        {
+          t,
+        },
+      );
     }
   }
 
@@ -329,8 +356,8 @@ export function createUpdateFeaturePresenter(
     const actionSummary = lastActionSummary ?? buildActionSummary(state);
     return {
       canStart: actionSummary.canStart,
-      password: els.updatePasswordInput?.value ?? "",
-      ssid: els.updateSsidInput?.value.trim() ?? "",
+      password: internetDom.updatePasswordInput?.value ?? "",
+      ssid: internetDom.updateSsidInput?.value.trim() ?? "",
       transport: actionSummary.transport,
       usbAvailable: state.internetStatus.usable,
     };
@@ -338,11 +365,13 @@ export function createUpdateFeaturePresenter(
 
   function togglePassword(): void {
     passwordVisible = !passwordVisible;
-    if (els.updatePasswordInput) {
-      els.updatePasswordInput.type = passwordVisible ? "text" : "password";
+    if (internetDom.updatePasswordInput) {
+      internetDom.updatePasswordInput.type = passwordVisible
+        ? "text"
+        : "password";
     }
-    if (els.updateTogglePasswordBtn) {
-      const span = els.updateTogglePasswordBtn.querySelector("span");
+    if (internetDom.updateTogglePasswordBtn) {
+      const span = internetDom.updateTogglePasswordBtn.querySelector("span");
       if (span) {
         span.textContent = t(
           passwordVisible
@@ -358,11 +387,11 @@ export function createUpdateFeaturePresenter(
     readStartIntent,
     togglePassword,
     focusSsidInput() {
-      els.updateSsidInput?.focus();
+      internetDom.updateSsidInput?.focus();
     },
     clearPassword() {
-      if (els.updatePasswordInput) {
-        els.updatePasswordInput.value = "";
+      if (internetDom.updatePasswordInput) {
+        internetDom.updatePasswordInput.value = "";
       }
     },
   };

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -21,16 +21,32 @@ function pendingPollDelays(timers: TimerHarness): number[] {
 }
 
 function installFetchMock(
-  handler: (url: URL, method: string, body: string) => Promise<Response> | Response,
+  handler: (
+    url: URL,
+    method: string,
+    body: string,
+  ) => Promise<Response> | Response,
 ): () => void {
   const originalFetch = globalThis.fetch;
 
-  globalThis.fetch = (async (input: string | URL | RequestInfo, init?: RequestInit) => {
+  globalThis.fetch = (async (
+    input: string | URL | RequestInfo,
+    init?: RequestInit,
+  ) => {
     const requestUrl =
-      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    const requestMethod = init?.method ?? (input instanceof Request ? input.method : "GET");
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const requestMethod =
+      init?.method ?? (input instanceof Request ? input.method : "GET");
     const requestBody = typeof init?.body === "string" ? init.body : "";
-    return handler(new URL(requestUrl, "http://vibesensor.test"), requestMethod, requestBody);
+    return handler(
+      new URL(requestUrl, "http://vibesensor.test"),
+      requestMethod,
+      requestBody,
+    );
   }) as typeof fetch;
 
   return () => {
@@ -44,7 +60,10 @@ function createButton(): HTMLButtonElement {
   return {
     disabled: false,
     hidden: false,
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
       if (type !== "click") return;
       onClick = () => {
         const event = new Event("click");
@@ -65,12 +84,18 @@ function createButton(): HTMLButtonElement {
 }
 
 function createSelect(value: string): HTMLSelectElement {
-  const listeners = new Map<string, Array<EventListenerOrEventListenerObject>>();
+  const listeners = new Map<
+    string,
+    Array<EventListenerOrEventListenerObject>
+  >();
   return {
     value,
     disabled: false,
     innerHTML: "",
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
       const typeListeners = listeners.get(type) ?? [];
       typeListeners.push(listener);
       listeners.set(type, typeListeners);
@@ -90,13 +115,19 @@ function createSelect(value: string): HTMLSelectElement {
 }
 
 function createInput(value = "", type = "text"): HTMLInputElement {
-  const listeners = new Map<string, Array<EventListenerOrEventListenerObject>>();
+  const listeners = new Map<
+    string,
+    Array<EventListenerOrEventListenerObject>
+  >();
   return {
     value,
     type,
     disabled: false,
     focus() {},
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
       const typeListeners = listeners.get(type) ?? [];
       typeListeners.push(listener);
       listeners.set(type, typeListeners);
@@ -169,10 +200,16 @@ test.afterEach(() => {
   restoreDomGlobals = () => undefined;
 });
 
-async function expectDelays(readDelays: () => number[], expected: number[]): Promise<void> {
+async function expectDelays(
+  readDelays: () => number[],
+  expected: number[],
+): Promise<void> {
   for (let attempt = 0; attempt < 25; attempt += 1) {
     const actual = readDelays();
-    if (actual.length === expected.length && actual.every((delay, index) => delay === expected[index])) {
+    if (
+      actual.length === expected.length &&
+      actual.every((delay, index) => delay === expected[index])
+    ) {
       expect(actual).toEqual(expected);
       return;
     }
@@ -181,11 +218,17 @@ async function expectDelays(readDelays: () => number[], expected: number[]): Pro
   expect(readDelays()).toEqual(expected);
 }
 
-async function expectPollDelays(timers: TimerHarness, expected: number[]): Promise<void> {
+async function expectPollDelays(
+  timers: TimerHarness,
+  expected: number[],
+): Promise<void> {
   await expectDelays(() => pendingPollDelays(timers), expected);
 }
 
-async function expectTimerDelays(timers: TimerHarness, expected: number[]): Promise<void> {
+async function expectTimerDelays(
+  timers: TimerHarness,
+  expected: number[],
+): Promise<void> {
   await expectDelays(() => timers.pendingDelays(), expected);
 }
 
@@ -264,11 +307,7 @@ function createUpdateDeps() {
   const updateCancelBtn = createButton();
   const updateStatusPanel = createPanel();
 
-  const dom = {
-    menuButtons: [],
-    views: [],
-    settingsTabs: [],
-    settingsTabPanels: [],
+  const internetDom = {
     internetStatusPanel,
     updateTransportOptions,
     updateTransportChoiceWifi,
@@ -283,6 +322,9 @@ function createUpdateDeps() {
     updateSsidInput,
     updatePasswordInput,
     updateTogglePasswordBtn,
+  };
+
+  const dom = {
     updateStartBtn,
     updateCancelBtn,
     updateStatusPanel,
@@ -290,6 +332,9 @@ function createUpdateDeps() {
 
   return {
     dom,
+    internetPanel: {
+      dom: internetDom,
+    },
     els: dom,
     internetStatusPanel,
     updateTransportOptions,
@@ -334,10 +379,28 @@ test.describe("createEspFlashFeature polling", () => {
   test("idle state renders readiness, empty log, and empty history context", async () => {
     const restoreFetch = installFetchMock(async (url) => {
       if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [{ port: "/dev/ttyUSB0", description: "USB UART", vid: 1, pid: 2, serial_number: "abc" }] });
+        return jsonResponse({
+          ports: [
+            {
+              port: "/dev/ttyUSB0",
+              description: "USB UART",
+              vid: 1,
+              pid: 2,
+              serial_number: "abc",
+            },
+          ],
+        });
       }
       if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({ state: "idle", phase: "idle", selected_port: null, auto_detect: true, last_success_at: null, error: null, log_count: 0 });
+        return jsonResponse({
+          state: "idle",
+          phase: "idle",
+          selected_port: null,
+          auto_detect: true,
+          last_success_at: null,
+          error: null,
+          log_count: 0,
+        });
       }
       if (url.pathname === "/api/esp-flash/history") {
         return jsonResponse({ attempts: [] });
@@ -363,14 +426,30 @@ test.describe("createEspFlashFeature polling", () => {
       );
       expect(deps.espFlashStartBtn.disabled).toBe(false);
       expect(deps.espFlashCancelBtn.hidden).toBe(true);
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.readiness.summary.ready_ports");
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.readiness.one_port");
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.auto_detect");
-      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain("settings.esp_flash.journey_title");
-      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain("settings.esp_flash.phase.validating");
-      expect(deps.espFlashJourneyPanel.innerHTML).toContain("settings.esp_flash.phase.validating");
-      expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain("settings.esp_flash.logs_idle_title");
-      expect((deps.els.espFlashHistoryPanel as HTMLElement).innerHTML).toContain("settings.esp_flash.history_empty_title");
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+        "settings.esp_flash.readiness.summary.ready_ports",
+      );
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+        "settings.esp_flash.readiness.one_port",
+      );
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+        "settings.esp_flash.auto_detect",
+      );
+      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain(
+        "settings.esp_flash.journey_title",
+      );
+      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain(
+        "settings.esp_flash.phase.validating",
+      );
+      expect(deps.espFlashJourneyPanel.innerHTML).toContain(
+        "settings.esp_flash.phase.validating",
+      );
+      expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
+        "settings.esp_flash.logs_idle_title",
+      );
+      expect(
+        (deps.els.espFlashHistoryPanel as HTMLElement).innerHTML,
+      ).toContain("settings.esp_flash.history_empty_title");
     } finally {
       restoreFetch();
     }
@@ -382,7 +461,15 @@ test.describe("createEspFlashFeature polling", () => {
         return jsonResponse({ ports: [] });
       }
       if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({ state: "idle", phase: "idle", selected_port: null, auto_detect: true, last_success_at: null, error: null, log_count: 0 });
+        return jsonResponse({
+          state: "idle",
+          phase: "idle",
+          selected_port: null,
+          auto_detect: true,
+          last_success_at: null,
+          error: null,
+          log_count: 0,
+        });
       }
       if (url.pathname === "/api/esp-flash/history") {
         return jsonResponse({ attempts: [] });
@@ -416,7 +503,17 @@ test.describe("createEspFlashFeature polling", () => {
   test("running state highlights the active stage and marks completed stages done", async () => {
     const restoreFetch = installFetchMock(async (url) => {
       if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [{ port: "/dev/ttyUSB0", description: "USB UART", vid: 1, pid: 2, serial_number: "abc" }] });
+        return jsonResponse({
+          ports: [
+            {
+              port: "/dev/ttyUSB0",
+              description: "USB UART",
+              vid: 1,
+              pid: 2,
+              serial_number: "abc",
+            },
+          ],
+        });
       }
       if (url.pathname === "/api/esp-flash/status") {
         return jsonResponse({
@@ -454,10 +551,16 @@ test.describe("createEspFlashFeature polling", () => {
         "settings.esp_flash.logs_running_title",
       );
       const html = deps.espFlashJourneyPanel.innerHTML;
-      expect(html).toMatch(/data-stage-phase="flashing" data-stage-state="active" aria-current="step"/);
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("settings.esp_flash.readiness.current_step");
+      expect(html).toMatch(
+        /data-stage-phase="flashing" data-stage-state="active" aria-current="step"/,
+      );
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+        "settings.esp_flash.readiness.current_step",
+      );
       expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
-      expect(html.match(/<span class="maintenance-stage__marker">✓<\/span>/g)).toHaveLength(3);
+      expect(
+        html.match(/<span class="maintenance-stage__marker">✓<\/span>/g),
+      ).toHaveLength(3);
     } finally {
       restoreFetch();
     }
@@ -475,7 +578,17 @@ test.describe("createEspFlashFeature polling", () => {
     };
     const restoreFetch = installFetchMock(async (url) => {
       if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [{ port: "/dev/ttyUSB0", description: "USB UART", vid: 1, pid: 2, serial_number: "abc" }] });
+        return jsonResponse({
+          ports: [
+            {
+              port: "/dev/ttyUSB0",
+              description: "USB UART",
+              vid: 1,
+              pid: 2,
+              serial_number: "abc",
+            },
+          ],
+        });
       }
       if (url.pathname === "/api/esp-flash/status") {
         return jsonResponse(status);
@@ -507,20 +620,28 @@ test.describe("createEspFlashFeature polling", () => {
       await flushAsyncWork();
 
       const html = deps.espFlashJourneyPanel.innerHTML;
-      expect(html).toMatch(/data-stage-phase="flashing" data-stage-state="attention"/);
-      expect(deps.espFlashStartSummary.innerHTML).toContain("settings.esp_flash.recovery.title");
+      expect(html).toMatch(
+        /data-stage-phase="flashing" data-stage-state="attention"/,
+      );
+      expect(deps.espFlashStartSummary.innerHTML).toContain(
+        "settings.esp_flash.recovery.title",
+      );
       expect(deps.espFlashStartSummary.innerHTML).toContain(
         "settings.esp_flash.recovery.flashing.detail",
       );
-      expect(deps.espFlashStartBtn.textContent).toBe("settings.esp_flash.retry");
+      expect(deps.espFlashStartBtn.textContent).toBe(
+        "settings.esp_flash.retry",
+      );
       expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
         "settings.esp_flash.logs_failed_title",
       );
-      expect((deps.els.espFlashHistoryPanel as HTMLElement).innerHTML).toContain(
+      expect(
+        (deps.els.espFlashHistoryPanel as HTMLElement).innerHTML,
+      ).toContain("serial port disconnected");
+      expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
+      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
         "serial port disconnected",
       );
-      expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain("serial port disconnected");
     } finally {
       restoreFetch();
     }
@@ -530,7 +651,17 @@ test.describe("createEspFlashFeature polling", () => {
     const timers = installTimerHarness();
     const restoreFetch = installFetchMock(async (url, method) => {
       if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [{ port: "/dev/ttyUSB0", description: "USB UART", vid: 1, pid: 2, serial_number: "abc" }] });
+        return jsonResponse({
+          ports: [
+            {
+              port: "/dev/ttyUSB0",
+              description: "USB UART",
+              vid: 1,
+              pid: 2,
+              serial_number: "abc",
+            },
+          ],
+        });
       }
       if (url.pathname === "/api/esp-flash/start" && method === "POST") {
         return jsonResponse({ status: "started", job_id: 1 });
@@ -566,7 +697,8 @@ test.describe("createEspFlashFeature polling", () => {
   test("cancel replaces the previous poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
     const restoreFetch = installFetchMock(async (url, method) => {
-      if (url.pathname === "/api/esp-flash/ports") return jsonResponse({ ports: [] });
+      if (url.pathname === "/api/esp-flash/ports")
+        return jsonResponse({ ports: [] });
       if (url.pathname === "/api/esp-flash/cancel" && method === "POST") {
         return jsonResponse({ status: "cancelled" });
       }
@@ -602,8 +734,10 @@ test.describe("createEspFlashFeature polling", () => {
     const timers = installTimerHarness();
     const deferredStatus = createDeferred<Response>();
     const restoreFetch = installFetchMock(async (url) => {
-      if (url.pathname === "/api/esp-flash/ports") return jsonResponse({ ports: [] });
-      if (url.pathname === "/api/esp-flash/status") return deferredStatus.promise;
+      if (url.pathname === "/api/esp-flash/ports")
+        return jsonResponse({ ports: [] });
+      if (url.pathname === "/api/esp-flash/status")
+        return deferredStatus.promise;
       if (url.pathname === "/api/esp-flash/logs") {
         return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
       }
@@ -622,7 +756,9 @@ test.describe("createEspFlashFeature polling", () => {
       expect(pendingPollDelays(timers)).toEqual([]);
 
       feature.stopPolling();
-      deferredStatus.resolve(jsonResponse({ state: "idle", log_count: 0, error: null }));
+      deferredStatus.resolve(
+        jsonResponse({ state: "idle", log_count: 0, error: null }),
+      );
       await flushAsyncWork();
 
       expect(pendingPollDelays(timers)).toEqual([]);
@@ -655,25 +791,53 @@ test.describe("createUpdateFeature polling", () => {
       feature.startPolling();
       await flushAsyncWork();
 
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("settings.update.current_status_title");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("settings.update.current_status_summary.ready");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("settings.update.journey_title");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("settings.update.phase.validating");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).not.toContain("settings.update.issues_empty_title");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("settings.update.log_empty_title");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("1.2.3");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain("settings.update.health_card_title");
-      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain("settings.internet.card_title");
-      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain("settings.internet.summary.not_detected");
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.update.current_status_title",
+      );
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.update.current_status_summary.ready",
+      );
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.update.journey_title",
+      );
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.update.phase.validating",
+      );
+      expect(
+        (deps.els.updateStatusPanel as HTMLElement).innerHTML,
+      ).not.toContain("settings.update.issues_empty_title");
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.update.log_empty_title",
+      );
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "1.2.3",
+      );
+      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.update.health_card_title",
+      );
+      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.internet.card_title",
+      );
+      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
+        "settings.internet.summary.not_detected",
+      );
       expect(deps.updateTransportOptions.hidden).toBe(false);
-      expect(deps.updateTransportChoiceWifi.getAttribute("data-selected")).toBe("true");
-      expect(deps.updateTransportChoiceUsb.getAttribute("data-disabled")).toBe("true");
+      expect(deps.updateTransportChoiceWifi.getAttribute("data-selected")).toBe(
+        "true",
+      );
+      expect(deps.updateTransportChoiceUsb.getAttribute("data-disabled")).toBe(
+        "true",
+      );
       expect(deps.updateTransportUsbRadio.disabled).toBe(true);
-      expect(deps.updateReadinessSummary.innerHTML).toContain("settings.update.readiness.summary_ready");
+      expect(deps.updateReadinessSummary.innerHTML).toContain(
+        "settings.update.readiness.summary_ready",
+      );
       expect(deps.updateReadinessSummary.innerHTML).toContain(
         "settings.update.readiness.item.connection_wifi_ready",
       );
-      expect(deps.updateDetailsCaption.textContent).toBe("settings.update.details_caption_wifi");
+      expect(deps.updateDetailsCaption.textContent).toBe(
+        "settings.update.details_caption_wifi",
+      );
       expect(deps.updateStartBtn.disabled).toBe(false);
       expect(deps.updateUsbTransportSummary.textContent).toBe(
         "settings.update.transport.usb_summary_unavailable",
@@ -751,9 +915,13 @@ test.describe("createUpdateFeature polling", () => {
 
       const html = (deps.els.updateStatusPanel as HTMLElement).innerHTML;
       expect(html).toContain("settings.update.log_running_title");
-      expect(html).toMatch(/data-stage-phase="installing" data-stage-state="active" aria-current="step"/);
+      expect(html).toMatch(
+        /data-stage-phase="installing" data-stage-state="active" aria-current="step"/,
+      );
       expect(html.match(/data-stage-state="done"/g)).toHaveLength(5);
-      expect(html.match(/<span class="maintenance-stage__marker">✓<\/span>/g)).toHaveLength(5);
+      expect(
+        html.match(/<span class="maintenance-stage__marker">✓<\/span>/g),
+      ).toHaveLength(5);
     } finally {
       restoreFetch();
     }
@@ -793,16 +961,26 @@ test.describe("createUpdateFeature polling", () => {
       await flushAsyncWork();
 
       const html = (deps.els.updateStatusPanel as HTMLElement).innerHTML;
-      expect(deps.updateReadinessSummary.innerHTML).toContain("settings.update.recovery.title");
-      expect(deps.updateReadinessSummary.innerHTML).toContain("settings.update.recovery.wifi.title");
-      expect(deps.updateReadinessSummary.innerHTML).toContain("settings.update.recovery.wifi.detail");
+      expect(deps.updateReadinessSummary.innerHTML).toContain(
+        "settings.update.recovery.title",
+      );
+      expect(deps.updateReadinessSummary.innerHTML).toContain(
+        "settings.update.recovery.wifi.title",
+      );
+      expect(deps.updateReadinessSummary.innerHTML).toContain(
+        "settings.update.recovery.wifi.detail",
+      );
       expect(deps.updateStartBtn.textContent).toBe("settings.update.retry");
       expect(html).toContain("settings.update.issues");
       expect(html).toContain("settings.update.attempt_title");
       expect(html).toContain("settings.update.log_failed_title");
       expect(html).toContain("Hotspot restart timed out");
-      expect(html).toContain("NetworkManager is still reconnecting to the uplink.");
-      expect(html).toMatch(/data-stage-phase="restoring_hotspot" data-stage-state="attention"/);
+      expect(html).toContain(
+        "NetworkManager is still reconnecting to the uplink.",
+      );
+      expect(html).toMatch(
+        /data-stage-phase="restoring_hotspot" data-stage-state="attention"/,
+      );
     } finally {
       restoreFetch();
     }
@@ -814,7 +992,11 @@ test.describe("createUpdateFeature polling", () => {
     const restoreFetch = installFetchMock(async (url, method, body) => {
       if (url.pathname === "/api/update/start" && method === "POST") {
         startBody = body;
-        return jsonResponse({ status: "started", transport: "wifi", ssid: "MyWiFi" });
+        return jsonResponse({
+          status: "started",
+          transport: "wifi",
+          ssid: "MyWiFi",
+        });
       }
       if (url.pathname === "/api/update/status") {
         return jsonResponse(createIdleUpdateStatus());
@@ -855,7 +1037,11 @@ test.describe("createUpdateFeature polling", () => {
     const restoreFetch = installFetchMock(async (url, method, body) => {
       if (url.pathname === "/api/update/start" && method === "POST") {
         startBody = body;
-        return jsonResponse({ status: "started", transport: "usb_internet", ssid: null });
+        return jsonResponse({
+          status: "started",
+          transport: "usb_internet",
+          ssid: null,
+        });
       }
       if (url.pathname === "/api/update/status") {
         return jsonResponse(createIdleUpdateStatus());
@@ -900,20 +1086,35 @@ test.describe("createUpdateFeature polling", () => {
       expect(deps.updateReadinessSummary.innerHTML).toContain(
         "settings.update.readiness.item.connection_usb_ready",
       );
-      expect(deps.updateDetailsCaption.textContent).toBe("settings.update.details_caption_usb");
-      expect(deps.updateTransportNote.textContent).toBe("settings.update.preflight_note_usb");
+      expect(deps.updateDetailsCaption.textContent).toBe(
+        "settings.update.details_caption_usb",
+      );
+      expect(deps.updateTransportNote.textContent).toBe(
+        "settings.update.preflight_note_usb",
+      );
       expect(deps.updateUsbTransportSummary.textContent).toBe(
         "settings.update.transport.usb_summary_interface",
       );
-      expect(deps.updateTransportChoiceWifi.getAttribute("data-selected")).toBeNull();
-      expect(deps.updateTransportChoiceUsb.getAttribute("data-selected")).toBe("true");
-      expect(deps.updateTransportChoiceUsb.getAttribute("data-disabled")).toBeNull();
-      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain("usb0");
+      expect(
+        deps.updateTransportChoiceWifi.getAttribute("data-selected"),
+      ).toBeNull();
+      expect(deps.updateTransportChoiceUsb.getAttribute("data-selected")).toBe(
+        "true",
+      );
+      expect(
+        deps.updateTransportChoiceUsb.getAttribute("data-disabled"),
+      ).toBeNull();
+      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
+        "usb0",
+      );
 
       deps.updateStartBtn.click();
       await flushAsyncWork();
 
-      expect(JSON.parse(startBody)).toEqual({ transport: "usb_internet", password: "" });
+      expect(JSON.parse(startBody)).toEqual({
+        transport: "usb_internet",
+        password: "",
+      });
     } finally {
       restoreFetch();
     }

--- a/apps/ui/tests/smoke.update.spec.ts
+++ b/apps/ui/tests/smoke.update.spec.ts
@@ -1,8 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-import { fulfillJson, installCommonRoutes, installFakeWebSocket } from "./smoke.helpers";
+import {
+  fulfillJson,
+  installCommonRoutes,
+  installFakeWebSocket,
+} from "./smoke.helpers";
 
-test("settings update tab renders readiness guidance when idle", async ({ page }) => {
+test("settings update tab renders readiness guidance when idle", async ({
+  page,
+}) => {
   await installCommonRoutes(page);
   await page.route("**/api/update/status", async (route) => {
     await fulfillJson(route, {
@@ -63,41 +69,66 @@ test("settings update tab renders readiness guidance when idle", async ({ page }
   await expect(page.locator("#updateStatusPanel")).toContainText(
     "Ready to start once the Pi has either temporary Wi-Fi credentials or a usable USB internet uplink.",
   );
-  await expect(page.locator("#updateStatusPanel")).toContainText("Update journey");
-  await expect(page.locator("#updateStatusPanel")).toContainText("Validating...");
-  await expect(page.locator("#updateStatusPanel")).not.toContainText("No blockers recorded");
-  await expect(page.locator("#updateStatusPanel")).toContainText("No updater log yet");
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "Update journey",
+  );
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "Validating...",
+  );
+  await expect(page.locator("#updateStatusPanel")).not.toContainText(
+    "No blockers recorded",
+  );
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "No updater log yet",
+  );
   await expect(page.locator("#updateStatusPanel")).toContainText("1.2.3");
-  await expect(page.locator("#updateStatusPanel")).toContainText("Background service health");
-  await expect(page.locator("#updateTransportOptions")).toHaveJSProperty("hidden", false);
-  await expect(page.locator("#updateTransportChoiceWifi")).toHaveAttribute("data-selected", "true");
-  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute("data-disabled", "true");
-  await expect(page.locator("#updateTransportChoiceUsb")).toContainText("USB internet is not ready yet.");
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "Background service health",
+  );
+  await expect(page.locator("#updateStartBtn")).toBeDisabled();
+  await page.locator('[data-settings-tab="internetTab"]').click();
+  await expect(page.locator("#updateTransportOptions")).toHaveJSProperty(
+    "hidden",
+    false,
+  );
+  await expect(page.locator("#updateTransportChoiceWifi")).toHaveAttribute(
+    "data-selected",
+    "true",
+  );
+  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
+    "data-disabled",
+    "true",
+  );
+  await expect(page.locator("#updateTransportChoiceUsb")).toContainText(
+    "USB internet is not ready yet.",
+  );
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "Complete the blocked item before starting the update.",
   );
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "Enter a Wi-Fi SSID to enable Start Update.",
   );
-  await expect(page.locator("#updateStartBtn")).toBeDisabled();
-  await expect(page.locator("#updateTab")).toContainText("What happens next");
+  await expect(page.locator("#internetTab")).toContainText("What happens next");
   await expect(page.locator("#updateDetailsCaption")).toContainText(
     "Hotspot access pauses while the Pi joins Wi-Fi.",
   );
-  await expect(page.locator("#updateTab")).toContainText(
+  await expect(page.locator("#internetTab")).toContainText(
     "Starting a Wi-Fi update temporarily pauses hotspot access",
   );
   await page.locator("#updateSsidInput").fill("Workshop Wi-Fi");
-  await expect(page.locator("#updateStartBtn")).toBeEnabled();
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "All visible prerequisites are ready to start the update.",
   );
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "A Wi-Fi network name is entered and ready to use.",
   );
+  await page.locator('[data-settings-tab="updateTab"]').click();
+  await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });
 
-test("settings internet tab and updater show USB internet when usable", async ({ page }) => {
+test("settings internet tab and updater show USB internet when usable", async ({
+  page,
+}) => {
   await installCommonRoutes(page);
   await page.route("**/api/update/status", async (route) => {
     await fulfillJson(route, {
@@ -168,16 +199,27 @@ test("settings internet tab and updater show USB internet when usable", async ({
   await page.goto("/");
   await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="internetTab"]').click();
-  await expect(page.locator("#internetStatusPanel")).toContainText("USB internet status");
+  await expect(page.locator("#internetStatusPanel")).toContainText(
+    "USB internet status",
+  );
   await expect(page.locator("#internetStatusPanel")).toContainText("usb0");
   await expect(page.locator("#internetStatusPanel")).toContainText("Usable");
-  await page.locator('[data-settings-tab="updateTab"]').click();
-  await expect(page.locator("#updateTransportOptions")).toHaveJSProperty("hidden", false);
-  await expect(page.locator("#updateTransportChoiceUsb")).toContainText("Existing USB internet");
+  await expect(page.locator("#updateTransportOptions")).toHaveJSProperty(
+    "hidden",
+    false,
+  );
+  await expect(page.locator("#updateTransportChoiceUsb")).toContainText(
+    "Existing USB internet",
+  );
   await page.locator("#updateTransportChoiceUsb").click();
-  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute("data-selected", "true");
-  await expect(page.locator("#updateWifiFields")).toHaveJSProperty("hidden", true);
-  await expect(page.locator("#updateStartBtn")).toBeEnabled();
+  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
+    "data-selected",
+    "true",
+  );
+  await expect(page.locator("#updateWifiFields")).toHaveJSProperty(
+    "hidden",
+    true,
+  );
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "USB internet is ready on usb0.",
   );
@@ -187,9 +229,13 @@ test("settings internet tab and updater show USB internet when usable", async ({
   await expect(page.locator("#updateTransportNote")).toContainText(
     "Starting a USB-internet update keeps the hotspot up",
   );
+  await page.locator('[data-settings-tab="updateTab"]').click();
+  await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });
 
-test("settings update failure shows retry guidance, failed-stage retention, and latest attempt context", async ({ page }) => {
+test("settings update failure shows retry guidance, failed-stage retention, and latest attempt context", async ({
+  page,
+}) => {
   await installCommonRoutes(page);
   await page.route("**/api/update/status", async (route) => {
     await fulfillJson(route, {
@@ -208,7 +254,8 @@ test("settings update failure shows retry guidance, failed-stage retention, and 
         {
           phase: "downloading",
           message: "GitHub release download timed out",
-          detail: "The upstream connection dropped while fetching the release package.",
+          detail:
+            "The upstream connection dropped while fetching the release package.",
         },
       ],
       log_tail: [],
@@ -265,20 +312,36 @@ test("settings update failure shows retry guidance, failed-stage retention, and 
   await installFakeWebSocket(page);
   await page.goto("/");
   await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await page.locator('[data-settings-tab="internetTab"]').click();
   await page.locator("#updateTransportChoiceUsb").click();
+  await expect(page.locator("#updateReadinessSummary")).toContainText(
+    "Recovery guidance",
+  );
+  await expect(page.locator("#updateReadinessSummary")).toContainText(
+    "Failed step",
+  );
+  await expect(page.locator("#updateReadinessSummary")).toContainText(
+    "Downloading update",
+  );
+  await expect(page.locator("#updateReadinessSummary")).toContainText(
+    "Check upstream connectivity",
+  );
+  await page.locator('[data-settings-tab="updateTab"]').click();
   await expect(page.locator("#updateStartBtn")).toHaveText("Retry Update");
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
-  await expect(page.locator("#updateReadinessSummary")).toContainText("Recovery guidance");
-  await expect(page.locator("#updateReadinessSummary")).toContainText("Failed step");
-  await expect(page.locator("#updateReadinessSummary")).toContainText("Downloading update");
-  await expect(page.locator("#updateReadinessSummary")).toContainText("Check upstream connectivity");
-  await expect(page.locator("#updateStatusPanel")).toContainText("GitHub release download timed out");
-  await expect(page.locator("#updateStatusPanel")).toContainText("Latest attempt");
-  await expect(page.locator("#updateStatusPanel")).toContainText("Exit code");
-  await expect(page.locator("#updateStatusPanel")).toContainText("No failure log was captured");
-  await expect(page.locator('#updateStatusPanel .maintenance-stage[data-stage-phase="downloading"]')).toHaveAttribute(
-    "data-stage-state",
-    "attention",
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "GitHub release download timed out",
   );
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "Latest attempt",
+  );
+  await expect(page.locator("#updateStatusPanel")).toContainText("Exit code");
+  await expect(page.locator("#updateStatusPanel")).toContainText(
+    "No failure log was captured",
+  );
+  await expect(
+    page.locator(
+      '#updateStatusPanel .maintenance-stage[data-stage-phase="downloading"]',
+    ),
+  ).toHaveAttribute("data-stage-state", "attention");
 });

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { getUiAnalysisPanelHost } from "../src/app/dom/analysis_dom";
 import { getUiCarsPanelHost } from "../src/app/dom/cars_dom";
 import { getUiHistoryPanelHost } from "../src/app/dom/history_dom";
+import { getUiInternetPanelHost } from "../src/app/dom/internet_dom";
 import { getUiSensorsPanelHost } from "../src/app/dom/sensors_dom";
 import { getUiSpeedSourcePanelHost } from "../src/app/dom/speed_source_dom";
 import {
@@ -42,6 +43,7 @@ function createBaseFixture(): SelectorFixture {
       historyPanelRoot: stubElement("historyPanelRoot"),
       carsPanelRoot: stubElement("carsPanelRoot"),
       analysisPanelRoot: stubElement("analysisPanelRoot"),
+      internetPanelRoot: stubElement("internetPanelRoot"),
       sensorsPanelRoot: stubElement("sensorsPanelRoot"),
       speedSourcePanelRoot: stubElement("speedSourcePanelRoot"),
       addCarBtn: stubElement("addCarBtn"),
@@ -176,6 +178,15 @@ test("getUiAnalysisPanelHost resolves the analysis island host", () => {
   }
 });
 
+test("getUiInternetPanelHost resolves the internet island host", () => {
+  const restore = installDomFixture();
+  try {
+    expect(getUiInternetPanelHost().id).toBe("internetPanelRoot");
+  } finally {
+    restore();
+  }
+});
+
 test("getUiSensorsPanelHost resolves the sensors island host", () => {
   const restore = installDomFixture();
   try {
@@ -275,6 +286,17 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     try {
       expect(() => getUiAnalysisPanelHost()).toThrow(
         "Analysis feature requires #analysisPanelRoot",
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("fails when the internet panel host is missing", () => {
+    const restore = installDomFixture({ missingId: "internetPanelRoot" });
+    try {
+      expect(() => getUiInternetPanelHost()).toThrow(
+        "Internet settings requires #internetPanelRoot",
       );
     } finally {
       restore();


### PR DESCRIPTION
## Summary

This PR migrates the **settings internet panel** to a dedicated Preact island and makes that tab the canonical owner of the USB status card plus the transport-selection/readiness surface that had still been living under the update feature’s page-scoped DOM. The goal is not to rewrite update behavior. Instead, the internet-facing shell moves into `app/views/internet_panel.tsx` while the existing update workflow/presenter path keeps owning USB internet status rendering, transport selection, readiness derivation, and Wi-Fi credential handling through a shared typed bridge. The update tab is reduced to the remaining execution/status surface that issue `#2228` is meant to migrate next.

## Problem

Before this change, the internet/update boundary no longer matched either the backlog or the intended UI architecture. The standalone `internetTab` only rendered a small USB internet status card, while the operator-facing controls for choosing Wi-Fi vs USB internet, entering Wi-Fi credentials, reading readiness feedback, and reviewing “what happens next” guidance still lived inside `updateTab`. That surface was also still wired through `UiUpdateDom`, so `update_feature_presenter.ts` reached into one page-scoped DOM bundle to drive both the internet status card and the update transport controls.

Because `#2227` explicitly scopes the transport choice UI, uplink readiness messaging, and related guidance as part of the internet panel, the right migration was not just “mount the status card into a host.” The right migration was to move the whole internet-facing operator surface into the internet tab, keep the update feature as the behavior owner behind a typed bridge, and shrink the legacy update DOM down to the execution/status elements that belong to the next issue.

## Implementation approach

I used the same incremental Preact-island pattern as the earlier UI migration issues, but the seam here is shared between two tabs instead of being contained within one panel. `internetTab` becomes a dedicated island host, the new island renders both the USB internet status section and the transport/readiness shell, `update_feature.ts` plus `update_feature_presenter.ts` still own the behavior through a typed `InternetPanelView` bridge, and `updateTab` keeps only the start/cancel controls and update status output that `#2228` will migrate next. That keeps the refactor behavior-safe while still producing a real architectural simplification: the update feature is not duplicated, the internet panel gets a clear owner, and `UiUpdateDom` loses the internet-related selectors it no longer should own.

## Main code changes

### 1. New internet panel owner and host lookup

`apps/ui/index.html` now replaces the old static internet tab markup with a single host element: `#internetPanelRoot`. The new `apps/ui/src/app/views/internet_panel.tsx` file renders the entire internet-facing shell:

- the existing internet title and hint
- the USB status container (`#internetStatusPanel`)
- the moved transport-choice card
- Wi-Fi credential inputs
- the readiness summary
- the “what happens next” disclosure and transport note

I intentionally kept the existing control IDs for the moved transport surface (`#updateTransportOptions`, `#updateTransportChoiceUsb`, `#updateReadinessSummary`, and related inputs). That lets the behavior path stay narrow.

`apps/ui/src/app/dom/internet_dom.ts` adds the required host lookup helper so startup fails fast if the internet island host is missing, matching the same owner pattern already used by the other migrated panels.

### 2. Runtime and feature wiring

`apps/ui/src/app/start_ui_app.ts` now mounts the internet panel island before the runtime starts. `apps/ui/src/app/ui_app_runtime.ts` accepts that mounted `InternetPanelView`, and `apps/ui/src/app/app_feature_bundle.ts` threads it into the update feature wiring.

This keeps the ownership chain consistent with the rest of the migration work: startup mounts the island, runtime composes it, and the feature receives an explicit typed port.

### 3. Update feature retargeted to the island bridge

The behavior seam is now split between the update DOM and the new internet bridge.

`apps/ui/src/app/dom/update_dom.ts` now only owns:

- `updateStartBtn`
- `updateCancelBtn`
- `updateStatusPanel`

All internet-related selectors were removed from `UiUpdateDom`.

`apps/ui/src/app/features/update_feature.ts` now receives `internetPanel: InternetPanelView` and binds the password toggle, transport radio changes, and SSID input changes against `internetPanel.dom`. Start/cancel actions stay on the reduced update DOM, which keeps the execution controls anchored to the update tab.

`apps/ui/src/app/views/update_feature_presenter.ts` is the main logic update. It now reads and writes transport/readiness state through `internetDom`, while continuing to drive the update execution controls and status rendering through the reduced update DOM. In practice, that means:

- transport selection and Wi-Fi field visibility now update inside the internet island
- readiness messaging and transport notes now render inside the internet tab
- USB internet status still renders through `renderInternetStatusPanel()`, but into the island-owned host
- the update start/cancel buttons and update status panel remain on the update tab

This preserves the current behavior owner path instead of inventing a parallel “internet feature” abstraction just for this migration.

### 4. Update tab simplified for the next issue

The static `updateTab` markup in `index.html` now drops the transport/readiness card and keeps only the remaining update execution shell: the start/cancel action row and `#updateStatusPanel`. That is an intentional preparatory cleanup for `#2228`. After this PR, the update panel is materially closer to its final island seam, and the internet-related UI no longer straddles two tabs.

## Tests and validation

I ran the standard local UI checks:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

I also ran focused Playwright coverage on an isolated local Vite port (`4185`) to avoid interference from the shared environment:

- `tests/ui_runtime_dom.spec.ts`
- `tests/esp_flash_feature.spec.ts`
- `tests/smoke.update.spec.ts`

That coverage directly matches the blast radius of the change: `ui_runtime_dom.spec.ts` covers the new internet island host lookup, `esp_flash_feature.spec.ts` exercises the update feature harness after the DOM split between the update tab and the internet bridge, and `smoke.update.spec.ts` proves the user-facing behavior now spans the tabs the new way: transport/readiness lives on the internet tab, while update start/retry/status behavior still works from the update tab.

## Risks, tradeoffs, and out of scope

The main tradeoff here is that this PR intentionally moves some UI from `updateTab` to `internetTab`, which is a visible structural change even though the behavior owner stays the same. I made that tradeoff because it matches the actual issue scope and reduces the architectural mismatch between the tab names and the DOM ownership.

I did **not** add a new dedicated internet feature or split the update workflow logic into separate controllers. That would have broadened the change well beyond the issue. The update feature still owns the behavior; only the rendered shell ownership changed.

I also did not touch the deeper update-status renderer stack (`update_status_view.ts` and the section model builders) beyond the minimum wiring required for the split. That remains the responsibility of the update-panel migration in `#2228`. I reused the existing strings instead of introducing new translations, because this PR moves existing operator guidance into the internet panel but does not introduce new copy.

Closes #2227
