### PR TITLE
Migrate the update settings panel to a Preact island

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -83,8 +83,8 @@ source-of-truth export commands remain the only writers for those files.
 | File | Purpose |
 |------|---------|
 | `main.ts` | Thin Vite entry that boots the UI runtime |
-| `app/start_ui_app.ts` | CSS-aware startup entry that constructs and starts the app runtime |
-| `app/ui_runtime_dom.ts` | Startup bundle that resolves feature-scoped DOM locators and fails early when required feature anchors are missing |
+| `app/start_ui_app.ts` | CSS-aware startup entry that mounts the Preact panel islands, then constructs and starts the app runtime |
+| `app/ui_runtime_dom.ts` | Startup bundle that resolves the remaining non-island feature-scoped DOM locators and fails early when required feature anchors are missing |
 | `app/dom/` | Feature-scoped DOM locator modules for shell, spectrum, realtime, history, analysis, settings, cars, update, and ESP flash surfaces |
 | `app/ui_app_runtime.ts` | UI composition root that wires state, feature-scoped DOM locators, focused runtime controllers, and explicit feature port bundles |
 | `app/runtime/ui_preact_mount.ts` | Canonical helper for mounting and disposing incremental Preact islands inside existing DOM hosts |
@@ -111,6 +111,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
 | `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
 | `app/views/internet_panel.tsx` | Preact owner for the internet settings shell that mounts the USB-status plus transport/readiness surface and exposes the bridge consumed by the update feature |
+| `app/views/update_panel.tsx` | Preact owner for the update settings shell that mounts the update controls and status host while exposing the bridge consumed by the update feature |
 | `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that mounts the full table/card chrome and exposes the table-body bridge consumed by the realtime feature |
 | `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that mounts the full tab surface and exposes the shared typed bridge consumed by the speed-source and GPS-status modules |
 | `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that mounts the list shell and wizard chrome, then exposes typed list and wizard bridges |
@@ -131,8 +132,8 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/settings_car_list_view.ts` | Thin settings-car table renderer and action decoder reused by the car-management island for the saved-car table body |
 | `app/views/settings_speed_source_bindings.ts` | Typed speed-source form bindings that decode radio/input/navigation/device actions away from the workflow |
 | `app/views/settings_speed_source_presenter.ts` | Speed-source presenter that owns summary, validation, and OBD-device-list DOM rendering from typed workflow state |
-| `app/views/update_feature_presenter.ts` | Update presenter that owns readiness derivation, transport/control DOM state, and typed handoff into the update status/internet panels |
-| `app/views/update_status_view.ts` | Thin update-status coordinator that assembles typed section models into the settings update panel |
+| `app/views/update_feature_presenter.ts` | Update presenter that owns readiness derivation, transport/control DOM state, and typed handoff into the island-owned update and internet panel bridges |
+| `app/views/update_status_view.ts` | Thin update-status coordinator that assembles typed section models into the island-owned settings update panel |
 | `app/views/update_status_view_models.ts` | Typed update-status section builders for current status, journey, issues, attempt history, health, and log cards |
 | `app/views/update_status_overview_view.ts` | Focused current-status and journey card renderers built from typed section inputs |
 | `app/views/update_status_history_view.ts` | Focused issues and latest-attempt card renderers for update history and failure context |

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -75,21 +75,7 @@
 
         <!-- Update Tab -->
         <div id="updateTab" class="settings-tab-panel" role="tabpanel" hidden>
-          <div class="panel card">
-            <strong data-i18n="settings.update.title">System Update</strong>
-            <div class="subtle" data-i18n="settings.update.hint">Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.</div>
-            <div class="subtle" data-i18n="settings.update.reconnect_note" style="margin-top:0.25rem;">Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.</div>
-            <div class="maintenance-stack" style="margin-top:1rem;">
-              <div class="maintenance-action-row">
-                <button type="button" id="updateStartBtn" class="btn btn--success" data-i18n="settings.update.start">Start Update</button>
-                <button type="button" id="updateCancelBtn" class="btn btn--danger" hidden data-i18n="settings.update.cancel">Cancel Update</button>
-              </div>
-
-              <div id="updateStatusPanel" class="maintenance-stack" aria-live="polite">
-                <!-- Rendered dynamically by update_feature.ts -->
-              </div>
-            </div>
-          </div>
+          <div id="updatePanelRoot"></div>
         </div>
 
         <div id="espFlashTab" class="settings-tab-panel" role="tabpanel" hidden>

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -4,7 +4,6 @@ import type { UiHistoryDom } from "./dom/history_dom";
 import type { UiRealtimeDom } from "./dom/realtime_dom";
 import type { UiSettingsDom } from "./dom/settings_dom";
 import type { UiShellDom } from "./dom/shell_dom";
-import type { UiUpdateDom } from "./dom/update_dom";
 import {
   createAppFeaturePorts,
   createRealtimeFeatureRecordingPorts,
@@ -33,6 +32,7 @@ import type { AnalysisPanelView } from "./views/analysis_panel";
 import type { InternetPanelView } from "./views/internet_panel";
 import type { SensorsPanelView } from "./views/sensors_panel";
 import type { SpeedSourcePanelView } from "./views/speed_source_panel";
+import type { UpdatePanelView } from "./views/update_panel";
 
 export type { AppFeatureBundle } from "./app_feature_ports";
 
@@ -42,7 +42,6 @@ export interface AppFeatureBundleDom {
   history: UiHistoryDom;
   settings: UiSettingsDom;
   cars: UiCarsDom;
-  update: UiUpdateDom;
   espFlash: UiEspFlashDom;
 }
 
@@ -61,6 +60,7 @@ export interface AppFeatureBundleRuntimePorts {
   internetPanel: InternetPanelView;
   sensorsPanel: SensorsPanelView;
   speedSourcePanel: SpeedSourcePanelView;
+  updatePanel: UpdatePanelView;
   realtimeChrome: RealtimeFeatureChromePorts;
   historyPanel: HistoryPanelView;
   transport: RealtimeFeatureSelectionPorts;
@@ -85,7 +85,6 @@ export function createAppFeatureBundle(
       history: historyDom,
       settings: settingsDom,
       cars: carsDom,
-      update: updateDom,
       espFlash: espFlashDom,
     },
     shared: { t, escapeHtml, showError, fmt, fmtTs, formatInt },
@@ -167,7 +166,7 @@ export function createAppFeatureBundle(
   carsFeature = cars;
 
   const update = createUpdateFeature({
-    dom: updateDom,
+    panel: runtime.updatePanel,
     internetPanel: runtime.internetPanel,
     t,
     escapeHtml,

--- a/apps/ui/src/app/dom/update_dom.ts
+++ b/apps/ui/src/app/dom/update_dom.ts
@@ -1,20 +1,7 @@
-import { getById, requiredById } from "./dom_query";
+import { requiredById } from "./dom_query";
 
 const UPDATE_OWNER = "Update feature";
 
-export interface UiUpdateDom {
-  updateStartBtn: HTMLButtonElement;
-  updateCancelBtn: HTMLButtonElement | null;
-  updateStatusPanel: HTMLElement | null;
-}
-
-export function createUiUpdateDom(): UiUpdateDom {
-  return {
-    updateStartBtn: requiredById<HTMLButtonElement>(
-      "updateStartBtn",
-      UPDATE_OWNER,
-    ),
-    updateCancelBtn: getById<HTMLButtonElement>("updateCancelBtn"),
-    updateStatusPanel: getById<HTMLElement>("updateStatusPanel"),
-  };
+export function getUiUpdatePanelHost(): HTMLElement {
+  return requiredById("updatePanelRoot", UPDATE_OWNER);
 }

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -1,11 +1,11 @@
-import type { UiUpdateDom } from "../dom/update_dom";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import { createUpdateFeatureWorkflow } from "./update_feature_workflow";
 import { createUpdateFeaturePresenter } from "../views/update_feature_presenter";
 import type { InternetPanelView } from "../views/internet_panel";
+import type { UpdatePanelView } from "../views/update_panel";
 
 export interface UpdateFeatureDeps extends FeatureDepsBase {
-  dom: UiUpdateDom;
+  panel: UpdatePanelView;
   internetPanel: InternetPanelView;
 }
 
@@ -17,7 +17,7 @@ export interface UpdateFeature {
 
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   const presenter = createUpdateFeaturePresenter({
-    dom: ctx.dom,
+    dom: ctx.panel.dom,
     internetDom: ctx.internetPanel.dom,
     t: ctx.t,
     escapeHtml: ctx.escapeHtml,
@@ -34,13 +34,13 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       return;
     }
     handlersBound = true;
-    ctx.dom.updateStartBtn.addEventListener("click", () => {
+    ctx.panel.dom.updateStartBtn.addEventListener("click", () => {
       workflow.renderCurrentState();
       void workflow.startUpdate(
         presenter.readStartIntent(workflow.getRenderState()),
       );
     });
-    ctx.dom.updateCancelBtn?.addEventListener("click", () => {
+    ctx.panel.dom.updateCancelBtn.addEventListener("click", () => {
       void workflow.cancelUpdate();
     });
     ctx.internetPanel.dom.updateTogglePasswordBtn?.addEventListener(

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -6,6 +6,7 @@ import { getUiHistoryPanelHost } from "./dom/history_dom";
 import { getUiInternetPanelHost } from "./dom/internet_dom";
 import { getUiSensorsPanelHost } from "./dom/sensors_dom";
 import { getUiSpeedSourcePanelHost } from "./dom/speed_source_dom";
+import { getUiUpdatePanelHost } from "./dom/update_dom";
 import {
   getUiLiveOverviewHost,
   getUiLoggingPanelHost,
@@ -23,6 +24,7 @@ import { mountRealtimeLiveOverview } from "./views/realtime_live_overview";
 import { mountSensorsPanel } from "./views/sensors_panel";
 import { mountSpeedSourcePanel } from "./views/speed_source_panel";
 import { mountSpectrumPanel } from "./views/spectrum_panel";
+import { mountUpdatePanel } from "./views/update_panel";
 import {
   createUiShellChromeActionBridge,
   mountUiShellChrome,
@@ -38,6 +40,7 @@ export function startUiApp(): void {
   const carsPanel = mountCarsPanel(getUiCarsPanelHost());
   const analysisPanel = mountAnalysisPanel(getUiAnalysisPanelHost());
   const internetPanel = mountInternetPanel(getUiInternetPanelHost());
+  const updatePanel = mountUpdatePanel(getUiUpdatePanelHost());
   const sensorsPanel = mountSensorsPanel(getUiSensorsPanelHost());
   const speedSourcePanel = mountSpeedSourcePanel(getUiSpeedSourcePanelHost());
   mountUiShellChrome(getUiShellChromeHost(), shellChromeActions, state.shell);
@@ -52,6 +55,7 @@ export function startUiApp(): void {
     carsPanel,
     analysisPanel,
     internetPanel,
+    updatePanel,
     sensorsPanel,
     speedSourcePanel,
   ).start();

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -36,6 +36,7 @@ import type { CarsPanelView } from "./views/cars_panel";
 import type { AnalysisPanelView } from "./views/analysis_panel";
 import type { SensorsPanelView } from "./views/sensors_panel";
 import type { SpeedSourcePanelView } from "./views/speed_source_panel";
+import type { UpdatePanelView } from "./views/update_panel";
 
 export class UiAppRuntime {
   private readonly dom: UiRuntimeDom;
@@ -63,6 +64,7 @@ export class UiAppRuntime {
     carsPanel: CarsPanelView,
     analysisPanel: AnalysisPanelView,
     internetPanel: InternetPanelView,
+    updatePanel: UpdatePanelView,
     sensorsPanel: SensorsPanelView,
     speedSourcePanel: SpeedSourcePanelView,
   ) {
@@ -100,7 +102,6 @@ export class UiAppRuntime {
         history: this.dom.history,
         settings: this.dom.settings,
         cars: this.dom.cars,
-        update: this.dom.update,
         espFlash: this.dom.espFlash,
       },
       shared: {
@@ -115,6 +116,7 @@ export class UiAppRuntime {
         analysisPanel,
         carsPanel,
         internetPanel,
+        updatePanel,
         sensorsPanel,
         speedSourcePanel,
         realtimeChrome: {

--- a/apps/ui/src/app/ui_runtime_dom.ts
+++ b/apps/ui/src/app/ui_runtime_dom.ts
@@ -5,7 +5,6 @@ import { createUiRealtimeDom, type UiRealtimeDom } from "./dom/realtime_dom";
 import { createUiSettingsDom, type UiSettingsDom } from "./dom/settings_dom";
 import { createUiShellDom, type UiShellDom } from "./dom/shell_dom";
 import { createUiSpectrumDom, type UiSpectrumDom } from "./dom/spectrum_dom";
-import { createUiUpdateDom, type UiUpdateDom } from "./dom/update_dom";
 
 export interface UiRuntimeDom {
   shell: UiShellDom;
@@ -14,7 +13,6 @@ export interface UiRuntimeDom {
   history: UiHistoryDom;
   settings: UiSettingsDom;
   cars: UiCarsDom;
-  update: UiUpdateDom;
   espFlash: UiEspFlashDom;
 }
 
@@ -26,7 +24,6 @@ export function createUiRuntimeDom(): UiRuntimeDom {
     history: createUiHistoryDom(),
     settings: createUiSettingsDom(),
     cars: createUiCarsDom(),
-    update: createUiUpdateDom(),
     espFlash: createUiEspFlashDom(),
   };
 }

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -4,8 +4,8 @@ import type {
   UpdateStatusPayload,
   UsbInternetStatusPayload,
 } from "../../transport/http_models";
-import type { UiUpdateDom } from "../dom/update_dom";
 import type { InternetPanelDom } from "./internet_panel";
+import type { UpdatePanelDom } from "./update_panel";
 import {
   formatUsbInternetSummary,
   renderInternetStatusPanel,
@@ -45,7 +45,7 @@ interface UpdateFeatureActionSummary {
 }
 
 export interface UpdateFeaturePresenterDeps {
-  dom: UiUpdateDom;
+  dom: UpdatePanelDom;
   internetDom: InternetPanelDom;
   t: (key: string, vars?: Record<string, unknown>) => string;
   escapeHtml: (value: unknown) => string;
@@ -287,10 +287,8 @@ export function createUpdateFeaturePresenter(
     updateEls.updateStartBtn.textContent = actionSummary.startLabel;
     updateEls.updateStartBtn.hidden = isRunning;
     updateEls.updateStartBtn.disabled = isRunning || !actionSummary.canStart;
-    if (updateEls.updateCancelBtn) {
-      updateEls.updateCancelBtn.hidden = !isRunning;
-      updateEls.updateCancelBtn.disabled = !isRunning;
-    }
+    updateEls.updateCancelBtn.hidden = !isRunning;
+    updateEls.updateCancelBtn.disabled = !isRunning;
     if (internetDom.updateSsidInput) {
       internetDom.updateSsidInput.disabled = isRunning;
     }
@@ -310,11 +308,7 @@ export function createUpdateFeaturePresenter(
       internetDom.updateReadinessSummary.innerHTML =
         renderMaintenanceReadinessPanel(actionSummary.panelModel, escapeHtml);
     }
-    if (
-      updateEls.updateStatusPanel &&
-      state.updateStatus &&
-      state.healthStatus
-    ) {
+    if (state.updateStatus && state.healthStatus) {
       renderUpdateStatusPanel(
         updateEls.updateStatusPanel,
         buildUpdateStatusPanelViewModel(

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -1,0 +1,87 @@
+import { h } from "preact";
+
+import { createUiPreactMount } from "../runtime/ui_preact_mount";
+
+export interface UpdatePanelDom {
+  updateStartBtn: HTMLButtonElement;
+  updateCancelBtn: HTMLButtonElement;
+  updateStatusPanel: HTMLElement;
+}
+
+export interface UpdatePanelView {
+  readonly dom: UpdatePanelDom;
+}
+
+function UpdatePanel() {
+  return (
+    <div class="panel card">
+      <strong data-i18n="settings.update.title">System Update</strong>
+      <div class="subtle" data-i18n="settings.update.hint">
+        Use either temporary Wi-Fi credentials or an already-connected USB
+        internet uplink to update from GitHub. The hotspot only pauses for the
+        Wi-Fi path.
+      </div>
+      <div
+        class="subtle"
+        data-i18n="settings.update.reconnect_note"
+        style="margin-top:0.25rem;"
+      >
+        Note: The page may disconnect while the hotspot is down for the Wi-Fi
+        path. It will reconnect automatically.
+      </div>
+      <div class="maintenance-stack" style="margin-top:1rem;">
+        <div class="maintenance-action-row">
+          <button
+            type="button"
+            id="updateStartBtn"
+            class="btn btn--success"
+            data-i18n="settings.update.start"
+          >
+            Start Update
+          </button>
+          <button
+            type="button"
+            id="updateCancelBtn"
+            class="btn btn--danger"
+            hidden
+            data-i18n="settings.update.cancel"
+          >
+            Cancel Update
+          </button>
+        </div>
+
+        <div
+          id="updateStatusPanel"
+          class="maintenance-stack"
+          aria-live="polite"
+        ></div>
+      </div>
+    </div>
+  );
+}
+
+function requiredInHost<T extends Element>(
+  host: ParentNode,
+  selector: string,
+): T {
+  const element = host.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`Update feature requires ${selector}`);
+  }
+  return element;
+}
+
+function createUpdatePanelDom(host: HTMLElement): UpdatePanelDom {
+  return {
+    updateStartBtn: requiredInHost<HTMLButtonElement>(host, "#updateStartBtn"),
+    updateCancelBtn: requiredInHost<HTMLButtonElement>(host, "#updateCancelBtn"),
+    updateStatusPanel: requiredInHost<HTMLElement>(host, "#updateStatusPanel"),
+  };
+}
+
+export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
+  createUiPreactMount(host).render(<UpdatePanel />);
+  return {
+    dom: createUpdatePanelDom(host),
+  };
+}

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
 import type { UiEspFlashDom } from "../src/app/dom/esp_flash_dom";
-import type { UiUpdateDom } from "../src/app/dom/update_dom";
 import { createEspFlashFeature } from "../src/app/features/esp_flash_feature";
 import { createUpdateFeature } from "../src/app/features/update_feature";
+import type { UpdatePanelDom } from "../src/app/views/update_panel";
 import {
   createDeferred,
   flushAsyncWork,
@@ -328,10 +328,12 @@ function createUpdateDeps() {
     updateStartBtn,
     updateCancelBtn,
     updateStatusPanel,
-  } as unknown as UiUpdateDom;
+  } as UpdatePanelDom;
 
   return {
-    dom,
+    panel: {
+      dom,
+    },
     internetPanel: {
       dom: internetDom,
     },

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -6,6 +6,7 @@ import { getUiHistoryPanelHost } from "../src/app/dom/history_dom";
 import { getUiInternetPanelHost } from "../src/app/dom/internet_dom";
 import { getUiSensorsPanelHost } from "../src/app/dom/sensors_dom";
 import { getUiSpeedSourcePanelHost } from "../src/app/dom/speed_source_dom";
+import { getUiUpdatePanelHost } from "../src/app/dom/update_dom";
 import {
   getUiLiveOverviewHost,
   getUiLoggingPanelHost,
@@ -44,11 +45,11 @@ function createBaseFixture(): SelectorFixture {
       carsPanelRoot: stubElement("carsPanelRoot"),
       analysisPanelRoot: stubElement("analysisPanelRoot"),
       internetPanelRoot: stubElement("internetPanelRoot"),
+      updatePanelRoot: stubElement("updatePanelRoot"),
       sensorsPanelRoot: stubElement("sensorsPanelRoot"),
       speedSourcePanelRoot: stubElement("speedSourcePanelRoot"),
       addCarBtn: stubElement("addCarBtn"),
       addCarWizard: stubElement("addCarWizard"),
-      updateStartBtn: stubElement("updateStartBtn"),
       espFlashStartBtn: stubElement("espFlashStartBtn"),
     },
     selectorOne: {
@@ -117,7 +118,6 @@ test("createUiRuntimeDom returns the feature-scoped startup bundle when required
     expect(dom.history).toEqual({});
     expect(dom.settings.settingsTabs).toHaveLength(2);
     expect(dom.cars.addCarBtn.id).toBe("addCarBtn");
-    expect(dom.update.updateStartBtn.id).toBe("updateStartBtn");
     expect(dom.espFlash.espFlashStartBtn.id).toBe("espFlashStartBtn");
   } finally {
     restore();
@@ -182,6 +182,15 @@ test("getUiInternetPanelHost resolves the internet island host", () => {
   const restore = installDomFixture();
   try {
     expect(getUiInternetPanelHost().id).toBe("internetPanelRoot");
+  } finally {
+    restore();
+  }
+});
+
+test("getUiUpdatePanelHost resolves the update island host", () => {
+  const restore = installDomFixture();
+  try {
+    expect(getUiUpdatePanelHost().id).toBe("updatePanelRoot");
   } finally {
     restore();
   }
@@ -303,6 +312,17 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     }
   });
 
+  test("fails when the update panel host is missing", () => {
+    const restore = installDomFixture({ missingId: "updatePanelRoot" });
+    try {
+      expect(() => getUiUpdatePanelHost()).toThrow(
+        "Update feature requires #updatePanelRoot",
+      );
+    } finally {
+      restore();
+    }
+  });
+
   test("fails at the settings boundary when tab controls are missing", () => {
     const restore = installDomFixture({ missingSelector: ".settings-tab" });
     try {
@@ -319,17 +339,6 @@ test.describe("createUiRuntimeDom missing required feature anchors", () => {
     try {
       expect(() => createUiRuntimeDom()).toThrow(
         "Cars feature requires #addCarBtn",
-      );
-    } finally {
-      restore();
-    }
-  });
-
-  test("fails at the update boundary when the updater trigger is missing", () => {
-    const restore = installDomFixture({ missingId: "updateStartBtn" });
-    try {
-      expect(() => createUiRuntimeDom()).toThrow(
-        "Update feature requires #updateStartBtn",
       );
     } finally {
       restore();


### PR DESCRIPTION
## Summary

This PR migrates the **settings update panel** to a dedicated Preact island and removes the update surface from the remaining page-wide runtime DOM bundle. After `#2227`, the update and internet tabs had already been split by behavior: the internet tab owned transport choice, Wi-Fi credentials, USB internet status, readiness messaging, and operator guidance, while the update tab had been reduced to the execution and status surface. This change finishes that next seam by making the update tab itself a mounted island, then threading a typed `UpdatePanelView` bridge through startup and runtime composition so the existing update workflow continues to drive the same behavior without depending on `createUiRuntimeDom()` to discover update-panel elements globally.

## Problem

Before this change, the update tab was in an awkward halfway state. It no longer contained the transport and readiness controls that originally justified its broad page-level DOM bundle, but the remaining update controls still lived on the legacy startup path. `index.html` still carried the static update card markup, `createUiRuntimeDom()` still treated the update feature like a startup-owned document surface, and the update feature consumed a `UiUpdateDom` object resolved globally instead of from a dedicated panel host.

## Implementation approach

I followed the same incremental-island pattern used for the earlier settings migrations. Instead of rewriting the update workflow or moving transport logic out of the internet tab, this PR introduces a dedicated update island for the remaining update-tab shell and keeps the existing update workflow, presenter, and status view-model stack as the behavior owner behind that island-owned DOM bridge. That keeps the scope tight while still delivering a real architectural improvement: the update panel now matches the same ownership model as the other migrated settings tabs.

## Main code changes

### 1. Dedicated update-panel island

`apps/ui/index.html` now replaces the remaining static update card markup with a dedicated `#updatePanelRoot` host. The new `apps/ui/src/app/views/update_panel.tsx` file renders the update tab shell:

- the update title and hint copy
- the reconnect note
- the start/cancel action row
- the `#updateStatusPanel` host used by the existing status renderer stack

The control IDs remain stable (`#updateStartBtn`, `#updateCancelBtn`, `#updateStatusPanel`) so the feature behavior does not need a second migration just to follow the new owner path.

### 2. Update DOM ownership moved out of the runtime bundle

`apps/ui/src/app/dom/update_dom.ts` is no longer a startup-time selector bundle for the update feature controls. It is now the narrow host lookup helper for `#updatePanelRoot`, matching the pattern already used by `analysis_dom.ts`, `internet_dom.ts`, `speed_source_dom.ts`, and the other migrated panel host files.

That change lets `apps/ui/src/app/ui_runtime_dom.ts` drop the update surface entirely. `createUiRuntimeDom()` now only resolves the still-live non-island feature surfaces instead of continuing to special-case the update tab.

### 3. Startup/runtime/app-feature wiring now carry `UpdatePanelView`

`apps/ui/src/app/start_ui_app.ts` now mounts the update island before creating the runtime. `apps/ui/src/app/ui_app_runtime.ts` accepts the mounted `UpdatePanelView`, and `apps/ui/src/app/app_feature_bundle.ts` threads that explicit runtime port into `createUpdateFeature()`.

This is the same composition pattern already used for the other migrated panel surfaces: startup mounts, runtime composes, features consume a typed bridge. It also means the update feature now has a panel-scoped owner path instead of reaching back into the startup DOM bundle.

### 4. Update feature and presenter retargeted to the island bridge

`apps/ui/src/app/features/update_feature.ts` now depends on `panel: UpdatePanelView` instead of a `UiUpdateDom` startup bundle. The click bindings for start and cancel now attach to the island-owned `updatePanel.dom`, while the transport and readiness controls continue to bind through the internet island created in `#2227`.

`apps/ui/src/app/views/update_feature_presenter.ts` now receives `UpdatePanelDom` from the island bridge. The presenter still owns the same behavior:

- start/retry button text and enabled state
- cancel-button visibility
- rendering the typed update status view model into `#updateStatusPanel`
- coordinating that surface with the readiness and transport state already rendered in the internet tab

The important difference is where those update elements come from. They are no longer resolved globally from the document at runtime startup; they are resolved from the update island host.

## Tests and validation

I ran the standard local frontend validation:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

I also ran focused Playwright coverage on an isolated local port (`4185`) because the shared environment is not reliable on the default dev-server port:

- `tests/ui_runtime_dom.spec.ts`
- `tests/esp_flash_feature.spec.ts`
- `tests/smoke.update.spec.ts`

Those tests match the actual blast radius of this change. `ui_runtime_dom.spec.ts` now verifies the update panel island host contract. `esp_flash_feature.spec.ts` confirms the update feature still renders state and drives start/cancel behavior through the new panel bridge. `smoke.update.spec.ts` verifies the browser-facing behavior remains intact across the split introduced in `#2227`: readiness and transport guidance still live in the internet tab, while the update tab still shows the update execution and status surface correctly.

## Risks, tradeoffs, and out of scope

The main tradeoff is that this PR intentionally does **not** rewrite the deeper update status rendering stack into native JSX section components. The typed status view-model builders and focused section renderers remain in place and still render into `#updateStatusPanel`. I kept that boundary on purpose because it delivers the requested panel migration without broadening into a larger rewrite of the update feature internals. For this issue, that stack becomes the thin adapter behind an island-owned host.

I also did not touch the internet-tab surface introduced in `#2227`, and I did not overlap the ESP flash panel work that belongs to `#2229`. The goal here was to finish the update-tab owner-path migration cleanly, not to reopen neighboring seams that were already intentionally separated.

With this PR merged, the next panel issue gets cleaner: `#2229` can focus on the ESP flash surface, and `#2230` can then remove the remaining old runtime wiring with fewer dual-path leftovers still attached to settings tabs.

Closes #2228
