### PR TITLE
fix(ci): retry backend pip installs

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -21,12 +21,61 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        python -m pip install --upgrade pip
+        set -euo pipefail
+
+        retry_command() {
+          local max_attempts=$1
+          shift
+          local attempt=1
+
+          while true; do
+            if "$@"; then
+              return 0
+            fi
+
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              return 1
+            fi
+
+            local delay=$(( attempt * 5 ))
+            echo "Command failed on attempt ${attempt}/${max_attempts}: $*" >&2
+            echo "Retrying in ${delay}s..." >&2
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+          done
+        }
+
+        retry_command 3 python -m pip install --upgrade pip
         # Reuse the backend dev extra so CI matches the local editable setup.
-        python -m pip install -e "./apps/server[dev]"
+        retry_command 3 python -m pip install -e "./apps/server[dev]"
 
     - name: Install PlatformIO dependencies
       # Keep firmware tooling opt-in so non-firmware jobs reuse the shared backend setup.
       if: ${{ inputs.include-platformio == 'true' }}
       shell: bash
-      run: python -m pip install "platformio>=6,<7"
+      run: |
+        set -euo pipefail
+
+        retry_command() {
+          local max_attempts=$1
+          shift
+          local attempt=1
+
+          while true; do
+            if "$@"; then
+              return 0
+            fi
+
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              return 1
+            fi
+
+            local delay=$(( attempt * 5 ))
+            echo "Command failed on attempt ${attempt}/${max_attempts}: $*" >&2
+            echo "Retrying in ${delay}s..." >&2
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+          done
+        }
+
+        retry_command 3 python -m pip install "platformio>=6,<7"

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -696,9 +696,17 @@ def _pip_install_markers(commands: list[str]) -> set[str]:
         tokens = shlex.split(command)
         if len(tokens) < 5:
             continue
-        if tokens[1:4] != ["-m", "pip", "install"]:
+        pip_install_index = next(
+            (
+                index
+                for index in range(len(tokens) - 3)
+                if tokens[index + 1 : index + 4] == ["-m", "pip", "install"]
+            ),
+            None,
+        )
+        if pip_install_index is None:
             continue
-        args = tokens[4:]
+        args = tokens[pip_install_index + 4 :]
         i = 0
         while i < len(args):
             token = args[i]


### PR DESCRIPTION
## Summary
- retry backend pip install commands in the shared setup-backend action
- preserve the separate PlatformIO install step while making it retryable too
- update the hygiene parser so wrapped pip install commands still count toward CI/bootstrap sync

## Why
The latest `main` CI run failed in the E2E job before tests even started. The failure was inside `./.github/actions/setup-backend`, where `python -m pip install -e "./apps/server[dev]"` died with an SSL transport error while downloading wheels on the GitHub runner. That is a transient infrastructure failure mode, but without retries it still leaves `main` red.

## Validation
- parsed `.github/actions/setup-backend/action.yml`
- ran `python3 tools/dev/check_hygiene.py`

## Context
Fixes the broken `main` CI run for merge commit `751ee50f` (`CI` run `24396377777`), which failed in the `E2E` job during backend dependency bootstrap.
