### PR TITLE
fix(ui): streamline blocked Live setup

### DIFF
--- a/apps/ui/src/app/views/realtime_feature_presenter.ts
+++ b/apps/ui/src/app/views/realtime_feature_presenter.ts
@@ -174,11 +174,12 @@ export function createRealtimeFeaturePresenter(
     const health = computeCurrentLiveHealth();
     const totalClients = realtime.clients.length;
     const activeCar = activeCarDisplayState();
+    const setupBlockReason = selectionBlockReason();
     return {
       connectedSensorsText: `${formatInt(connectedClients().length)} / ${formatInt(totalClients)}`,
       activeCar: {
         text: activeCar.text,
-        warning: activeCar.isWarning,
+        warning: setupBlockReason === null && activeCar.isWarning,
       },
       recordingStateText: phaseText,
       dataFreshnessText: dataFreshnessText(),

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -138,6 +138,7 @@ function RealtimeLoggingChecklist(props: {
 function RealtimeLoggingPanel(props: { state: RealtimeLoggingPanelBridgeState }) {
   const { state } = props;
   const loggingRowHidden = !state.showPill && state.runIdText === "";
+  const showProgressSection = !state.setupMode || state.checklist !== null;
 
   return (
     <>
@@ -167,36 +168,42 @@ function RealtimeLoggingPanel(props: { state: RealtimeLoggingPanelBridgeState })
           {state.runIdText}
         </span>
       </div>
-      <div class="mini-label" data-i18n="dashboard.recording_progress">
-        Run progress
-      </div>
-      <div class="stat-grid stat-grid--compact">
-        <div id="loggingPhase" class="stat stat--compact" hidden>
-          <div class="stat__label" data-i18n="dashboard.recording_phase">
-            Run phase
-          </div>
-          <div class="stat__value" data-value>
-            {state.phaseText}
-          </div>
-        </div>
-        <div id="loggingElapsed" class="stat stat--compact">
-          <div class="stat__label" data-i18n="dashboard.recording_elapsed">
-            Elapsed
-          </div>
-          <div class="stat__value" data-value>
-            {state.elapsedText}
-          </div>
-        </div>
-        <div id="loggingSamples" class="stat stat--compact">
-          <div class="stat__label" data-i18n="dashboard.recording_samples">
-            Samples recorded
-          </div>
-          <div class="stat__value" data-value>
-            {state.samplesText}
-          </div>
-        </div>
-      </div>
-      <RealtimeLoggingChecklist checklist={state.checklist} />
+      {showProgressSection
+        ? (
+          <>
+            <div class="mini-label" data-i18n="dashboard.recording_progress">
+              Run progress
+            </div>
+            <div class="stat-grid stat-grid--compact">
+              <div id="loggingPhase" class="stat stat--compact" hidden>
+                <div class="stat__label" data-i18n="dashboard.recording_phase">
+                  Run phase
+                </div>
+                <div class="stat__value" data-value>
+                  {state.phaseText}
+                </div>
+              </div>
+              <div id="loggingElapsed" class="stat stat--compact">
+                <div class="stat__label" data-i18n="dashboard.recording_elapsed">
+                  Elapsed
+                </div>
+                <div class="stat__value" data-value>
+                  {state.elapsedText}
+                </div>
+              </div>
+              <div id="loggingSamples" class="stat stat--compact">
+                <div class="stat__label" data-i18n="dashboard.recording_samples">
+                  Samples recorded
+                </div>
+                <div class="stat__value" data-value>
+                  {state.samplesText}
+                </div>
+              </div>
+            </div>
+            <RealtimeLoggingChecklist checklist={state.checklist} />
+          </>
+        )
+        : null}
       <div class="logging-actions">
         <button
           id="startLoggingBtn"

--- a/apps/ui/src/app/views/realtime_logging_view_models.ts
+++ b/apps/ui/src/app/views/realtime_logging_view_models.ts
@@ -531,11 +531,7 @@ export function buildRealtimeLoggingPanelViewModel(
       startDisabled: true,
       stopDisabled: true,
       showPill: false,
-      checklist: buildRealtimeCaptureReadinessChecklistModel(captureReadiness, {
-        setupMode: true,
-        t,
-        formatInt,
-      }),
+      checklist: null,
       setupMode: true,
       nextLastCompletedElapsedText,
     };

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -29,7 +29,10 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({ p
   });
   await installFakeWebSocket(page);
   await page.goto("/");
+  await expect(page.locator("#liveActiveCar")).not.toHaveAttribute("data-variant", "warn");
+  await expect(page.locator("#liveActiveCar .stat__value-icon")).toHaveCount(0);
   await expect(page.locator("#liveActiveCar [data-value]")).toContainText("No cars added yet");
+  await expect(page.locator("#loggingChecklist")).toBeHidden();
   const liveSummary = page.locator("#loggingSummary");
   await expect(liveSummary).toContainText("Add a car before recording.");
   await expect(liveSummary).toContainText("Runs need an active car");
@@ -331,13 +334,13 @@ test("shows a live warning state until an active car is selected, then clears it
   });
 
   await page.goto("/");
-  await expect(page.locator("#liveActiveCar")).toHaveAttribute("data-variant", "warn");
-  await expect(page.locator("#liveActiveCar .stat__value-icon")).toHaveAttribute("data-variant", "warn");
-  await expect(page.locator("#liveActiveCar .stat__value-icon")).toHaveText("!");
+  await expect(page.locator("#liveActiveCar")).not.toHaveAttribute("data-variant", "warn");
+  await expect(page.locator("#liveActiveCar .stat__value-icon")).toHaveCount(0);
   await expect(page.locator("#liveActiveCar [data-value]")).toContainText("No active car selected");
   await expect(page.locator("#liveRecordingState [data-value]")).toHaveText("Blocked");
   await expect(page.locator("#liveRunHealth")).toHaveText("Needs attention");
   await expect(page.locator("#loggingStatus")).toBeHidden();
+  await expect(page.locator("#loggingChecklist")).toBeHidden();
   const liveSummary = page.locator("#loggingSummary");
   await expect(liveSummary).toContainText("Choose the active car before recording.");
   await expect(liveSummary).toContainText("none is active for the next run");


### PR DESCRIPTION
## Summary

Closes #2245.

This change tightens the blocked Live setup experience so the page stops competing with itself when recording is impossible because no car is configured yet. The audit screenshot behind #2245 showed the same blocker presented in three different ways at once: the active-car stat was rendered as a warning, the logging card showed a large actionable “Add a car before recording” panel, and the capture-readiness checklist repeated additional waiting states underneath. The implementation in this PR keeps the actionable add/choose-car panel as the primary blocker surface, defers the readiness checklist until the car prerequisite is resolved, and removes the duplicate warning styling from the overview stat while the setup panel is active.

## Problem being solved

The core issue was not that any single message was wrong. The problem was hierarchy. In the blocked state, the UI was already telling the operator exactly what to do through the inline logging summary panel, but then the rest of the page continued to escalate the same problem in parallel. On a first-run system with no cars and no live sensors, the result was a large yellow active-car warning, a “Blocked” run state, a full inline panel, and then a three-item capture-readiness checklist listing live sensors, reference data, and steady cruise. Even though the first step was obviously “go create a car,” the page still asked the user to visually process several other blockers that were not yet actionable. This PR narrows that experience so the first required setup task owns the screen instead of competing with secondary readiness diagnostics.

## Chosen implementation approach

I kept the existing Live architecture intact and changed the view-model/rendering rules rather than introducing a new specialized empty-state component. That was the smallest complete fix because the app already has the right primitives: a summary panel for the primary blocked state, a checklist for readiness details, and a setup-mode dashboard layout that collapses the main spectrum area. The problem was simply that all of them were active at the same time for selection-blocked states. The fix therefore targets the state transition rules for `selectionBlockReason` and the layout logic that decides whether the progress section should render at all. This preserves the rest of the readiness flow: once a car is configured and the user is blocked by sensors, speed source, or steady-cruise conditions, the checklist still returns and remains the right UI for those follow-on blockers.

## Main code changes

In `apps/ui/src/app/views/realtime_logging_view_models.ts`, the `selectionBlockReason` branch now returns `checklist: null` instead of building a readiness checklist immediately. The blocked summary panel still renders, still points the user to Cars, and still keeps `setupMode: true` so the Live page stays in the slimmed-down setup layout. The important behavioral change is that the page no longer enumerates the secondary readiness items before the car prerequisite has been handled.

In `apps/ui/src/app/views/realtime_logging_panel.tsx`, I added a `showProgressSection` guard so the “Run progress” label, compact stats, and checklist only render when they actually have useful content. This matters because once the checklist is intentionally deferred for the car-selection blocker, the old markup would have left a stray “Run progress” heading with nothing meaningful below it. The new conditional keeps the logging card visually tight in setup-blocked states without changing the normal recording, processing, or ready flows.

In `apps/ui/src/app/views/realtime_feature_presenter.ts`, the Live overview model now suppresses active-car warning chrome while a selection blocker is active. The underlying active-car text still communicates “No cars added yet” or “No active car selected,” so the operator does not lose context. What changes is the emphasis: the summary panel in the recording card becomes the single primary call to action instead of sharing attention with another warning-styled stat tile. This directly addresses the audit feedback that the page felt like it was shouting the same blocker from multiple places.

Finally, `apps/ui/tests/smoke.cars.spec.ts` was updated to reflect the intended hierarchy. The no-car and no-active-car states now assert that the active-car stat is no longer rendered with warning styling or an icon, and that the capture-readiness checklist is hidden until the prerequisite is resolved. The actionable summary panel and navigation behavior remain covered. I also reran the broader car/bootstrap smoke coverage to make sure the change did not spill into adjacent Live flows.

## Schema, contract, config, and documentation impact

There are no backend API, schema, generated contract, documentation, or persistent repo-configuration changes in this PR. The behavior shift is entirely in frontend view-model and rendering logic for an existing Live state.

## Validation performed

I validated the change at two levels. First, I ran the standard frontend safety checks:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Second, I ran Playwright smoke coverage against the affected area using an isolated local dev-server port so the tests exercised this repo’s UI instead of a reused shared server:

- focused blocked-state smoke coverage for the two issue-specific scenarios plus a representative bootstrap flow
- broader `smoke.bootstrap.spec.ts` and `smoke.cars.spec.ts` coverage for the laptop-light project

Those smoke runs passed after the rendering changes, which gave confidence that the new hierarchy works for both the first-run no-car state and the existing-car/no-active selection state without regressing surrounding Cars or bootstrap workflows.

## Risks, tradeoffs, and edge cases considered

The main tradeoff in this change is deliberate: the Live page now hides secondary readiness details while the car-selection prerequisite is still unresolved. That means the user will not immediately see every future blocker on first load. I think that is the correct tradeoff for this issue because surfacing all blockers before the first prerequisite is resolved was exactly what made the screen feel noisy and low-signal. The checklist still reappears as soon as the page moves past the selection blocker, so we are not deleting diagnostic detail; we are sequencing it behind the most actionable first step.

I also chose not to remove the active-car stat text entirely. The overview still benefits from showing the current state of car selection, even in blocked mode. What changes is the warning chrome, not the information itself.

## Out of scope / follow-up

This PR intentionally stays within #2245. It does not attempt to rebalance the populated Live dashboard, adjust spectrum control density, or redesign other settings/history surfaces from the audit. Those remain tracked separately in the backlog, especially #2246 for the broader Live hierarchy work.
