### PR TITLE
fix(ui): compact History diagnosis layout

### DIFF
--- a/apps/ui/src/app/views/history_table_row_renderers.ts
+++ b/apps/ui/src/app/views/history_table_row_renderers.ts
@@ -420,6 +420,57 @@ function createWarningsElement(
   });
 }
 
+function createRunActionsPanelElement(
+  row: HistoryRowViewModel,
+  details: NonNullable<HistoryRowViewModel["details"]>,
+  params: HistoryTableRendererParams,
+): HTMLDivElement {
+  return createElementNode("div", {
+    className: "history-details-footer",
+    children: [
+      createElementNode("div", {
+        className: "history-details-footer__copy",
+        children: [
+          createElementNode("div", {
+            className: "history-details-footer__eyebrow",
+            text: details.footerEyebrow,
+          }),
+          createElementNode("div", {
+            className: "history-details-footer__body",
+            text: details.footerBody,
+          }),
+        ],
+      }),
+      createElementNode("div", {
+        className: "history-details-footer__actions",
+        children: [
+          createElementNode("a", {
+            className: "btn btn--muted",
+            attrs: {
+              href: params.historyExportUrl(row.runId),
+              download: `${row.runId}.zip`,
+            },
+            data: {
+              runAction: "download-raw",
+              run: row.runId,
+            },
+            text: details.exportLabel,
+          }),
+          createElementNode("button", {
+            className: "btn btn--danger-quiet",
+            attrs: { type: "button" },
+            data: {
+              runAction: "delete-run",
+              run: row.runId,
+            },
+            text: details.deleteLabel,
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
 function createDetailsRowElement(
   row: HistoryRowViewModel,
   details: NonNullable<HistoryRowViewModel["details"]>,
@@ -491,57 +542,19 @@ function createDetailsRowElement(
               createElementNode("div", {
                 className: "history-results-layout",
                 children: [
-                  createInsightsElement(details.insights),
+                  createElementNode("div", {
+                    className: "history-main-column",
+                    children: [
+                      createInsightsElement(details.insights),
+                      createRunActionsPanelElement(row, details, params),
+                    ],
+                  }),
                   createElementNode("div", {
                     className: "history-evidence-column",
                     children: [
                       createElementNode("div", {
                         className: "history-evidence-panel",
                         children: [createHeatmapElement(details.heatmap)],
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-              createElementNode("div", {
-                className: "history-details-footer",
-                children: [
-                  createElementNode("div", {
-                    className: "history-details-footer__copy",
-                    children: [
-                      createElementNode("div", {
-                        className: "history-details-footer__eyebrow",
-                        text: details.footerEyebrow,
-                      }),
-                      createElementNode("div", {
-                        className: "history-details-footer__body",
-                        text: details.footerBody,
-                      }),
-                    ],
-                  }),
-                  createElementNode("div", {
-                    className: "history-details-footer__actions",
-                    children: [
-                      createElementNode("a", {
-                        className: "btn btn--muted",
-                        attrs: {
-                          href: params.historyExportUrl(row.runId),
-                          download: `${row.runId}.zip`,
-                        },
-                        data: {
-                          runAction: "download-raw",
-                          run: row.runId,
-                        },
-                        text: details.exportLabel,
-                      }),
-                      createElementNode("button", {
-                        className: "btn btn--danger-quiet",
-                        attrs: { type: "button" },
-                        data: {
-                          runAction: "delete-run",
-                          run: row.runId,
-                        },
-                        text: details.deleteLabel,
                       }),
                     ],
                   }),

--- a/apps/ui/src/styles/history.css
+++ b/apps/ui/src/styles/history.css
@@ -239,7 +239,7 @@
   background: var(--surface-2);
   padding: var(--space-4);
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 .history-details-header {
   display: grid;
@@ -285,8 +285,10 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-3);
   align-items: start;
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
 }
 .history-details-footer__copy {
   display: grid;
@@ -309,7 +311,7 @@
 .history-details-footer__actions {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: var(--space-2);
 }
 .history-warning-list {
@@ -334,9 +336,14 @@
 }
 .history-results-layout {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-3);
   grid-template-columns: minmax(0, 1.25fr) minmax(240px, 0.75fr);
   align-items: start;
+}
+.history-main-column {
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
 }
 .history-evidence-column {
   display: grid;

--- a/apps/ui/tests/history_table_view.spec.ts
+++ b/apps/ui/tests/history_table_view.spec.ts
@@ -150,10 +150,13 @@ test("renderHistoryTable builds rows and expanded details from typed history mod
   const toggle = expectSingleByAttribute(root, "data-run-toggle", "details");
   const zone = expectSingleByAttribute(root, "data-location-key", "front-right wheel");
   const rawExport = expectSingleByAttribute(root, "data-run-action", "download-raw");
+  const mainColumn = findByClass(root, "history-main-column");
 
   expect(row.getAttribute("data-run")).toBe("run-001");
   expect(toggle.getAttribute("aria-expanded")).toBe("true");
   expect(findByClass(root, "history-details-row")).toHaveLength(1);
+  expect(mainColumn).toHaveLength(1);
+  expect(findByClass(mainColumn[0], "history-details-footer")).toHaveLength(1);
   expect(findByClass(root, "history-warning-banner")).toHaveLength(1);
   expect(zone.textContent).toContain("32.0 dB");
   expect(findByClass(root, "history-findings-chip__label").map((label) => label.textContent))

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -206,6 +206,7 @@ test("history keeps destructive actions inside the expanded management footer", 
   await expect(actionCell).not.toContainText("Delete");
   await row.locator('[data-run-toggle="details"]').click();
   const footer = page.locator(".history-details-footer");
+  await expect(page.locator(".history-main-column .history-details-footer")).toHaveCount(1);
   await expect(footer).toContainText("Reports and data");
   await expect(footer.locator('[data-run-action="download-raw"][data-run="run-001"]')).toContainText("Export");
   const deleteButton = footer.locator('[data-run-action="delete-run"][data-run="run-001"]');
@@ -338,5 +339,18 @@ test("history loaded insights promote the result summary above supporting eviden
   await expect(page.locator(".history-secondary-findings")).toContainText("Secondary candidates");
   await expect(page.locator(".history-finding-card--secondary")).toHaveCount(1);
   await expect(page.locator(".history-finding-card--secondary")).toContainText("Secondary driveline contribution");
+  await expect(page.locator(".history-main-column .history-details-footer")).toHaveCount(1);
   await expect(page.locator(".history-evidence-column .history-preview-stats")).toHaveCount(0);
+  const layoutMetrics = await page.locator(".history-results-layout").evaluate((layout) => {
+    const mainColumn = layout.querySelector<HTMLElement>(".history-main-column");
+    const insights = layout.querySelector<HTMLElement>(".history-insights-block");
+    const footer = layout.querySelector<HTMLElement>(".history-details-footer");
+    if (!mainColumn || !insights || !footer) {
+      throw new Error("history detail layout is missing expected sections");
+    }
+    return {
+      footerAfterInsightsGap: Math.round(footer.getBoundingClientRect().top - insights.getBoundingClientRect().bottom),
+    };
+  });
+  expect(layoutMetrics.footerAfterInsightsGap).toBeLessThanOrEqual(24);
 });


### PR DESCRIPTION
## Summary

Closes #2248.

This PR compacts the expanded History diagnosis layout for sparse-detail cases by moving the run-action panel up into the main diagnosis column instead of leaving it below the entire two-column detail surface. The audit issue behind this change focused on an expanded run where the findings content was relatively light and the heatmap content was also limited. In that state, the detail view still reserved enough structure for a much denser case, which made the left side feel like it ended early while the export/delete actions stayed detached at the very bottom. The fix here is intentionally structural rather than cosmetic: keep the detail surface intact, but place the action panel where users finish reading the diagnosis instead of at the end of the whole layout.

## Problem being solved

The expanded History detail view already had the right ingredients: title, run summary, findings, heatmap, and the run-management actions. The problem was where those ingredients lived relative to each other. The findings summary and secondary evidence were grouped in the left column, the heatmap lived in the right column, and the report/delete actions sat below both columns in a full-width footer. When the findings side was relatively short, that created a visually empty strip underneath the diagnosis content before the next useful thing appeared. The user had already reached the end of the meaningful interpretation, but still had to travel to the bottom of the full layout to export or delete the run. That made the expanded state feel heavier than the content required and weakened the sense that the detail view is a focused evidence-review surface.

## Chosen implementation approach

I kept the overall detail-card structure and the existing diagnosis/heatmap content, but changed the ownership of the run-actions panel. Instead of rendering the action footer after the entire two-column results layout, the detail renderer now treats it as part of the main diagnosis column. That means the summary, findings, and run-management actions form one coherent reading/action flow, while the evidence column remains dedicated to the heatmap. This is the smallest complete fix because the issue was not missing data or incorrect ranking; it was the layout relationship between already-correct sections. I deliberately did not redesign the findings cards, heatmap, or export/delete behavior. The change is focused on where the action panel belongs, not on inventing a new panel model.

## Main code changes

In `apps/ui/src/app/views/history_table_row_renderers.ts`, I extracted the existing run-action footer markup into a dedicated helper and moved it into the main diagnosis column within `history-results-layout`. The renderer now creates a `history-main-column` that contains the insights block followed immediately by the run-actions panel, while the `history-evidence-column` continues to own the heatmap panel. This is the core of the fix. The export and delete controls, their labels, and their handlers are unchanged; only their position in the expanded detail hierarchy changed.

In `apps/ui/src/styles/history.css`, I updated the detail layout to support that structural move. The detail card gap is slightly tighter, the main/results layout gap is reduced, and the old footer styling was converted from a full-width bottom border section into a panel-like surface that fits naturally inside the main column. I also changed the footer action alignment so the buttons read as part of the diagnosis workflow instead of as a distant trailing control cluster. The new `history-main-column` layout keeps the actions close to the diagnosis summary while preserving the heatmap as a separate evidence surface.

I did not need to change the responsive adaptive rules very much because the existing mobile stack already collapses the detail surface to one column. Once the run-actions panel becomes part of the main content column, the small-screen layout benefits automatically from the same structure.

## Tests and validation

I validated this change across the renderer, the DOM-level detail structure, and the browser-facing History smoke flows.

The standard frontend checks passed:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

I then ran focused Playwright coverage with the isolated temporary config used elsewhere in this shared environment so the tests do not reuse another process on the default Vite port. The relevant suites passed:

- `tests/history_table_view.spec.ts`
- `smoke.history.spec.ts`
- `smoke.history-layout.spec.ts`

Those test updates are directly tied to the layout change. The DOM-level History table view test now asserts that the actions panel lives inside the new main detail column. The smoke coverage asserts the same structure in the browser and adds a sparse-detail layout check that the run-actions panel follows the diagnosis content closely instead of being pushed far below it.

## Schema, contracts, docs, and config impact

There are no backend API changes, no schema changes, no generated contract changes, and no documentation changes in this PR. There are also no user-facing text changes. The temporary isolated Playwright config used for local validation is not part of the committed diff.

## Risks, tradeoffs, and edge cases considered

The main tradeoff is that the action panel is now conceptually associated with the diagnosis column rather than the entire detail surface. I think that is the correct tradeoff for this issue because the actions are semantically tied to the user’s review of the diagnosis summary: after reading the diagnosis, export the run or delete it. Keeping those actions near the diagnosis improves flow without reducing access to the heatmap or other evidence.

I also intentionally did not make this a larger redesign of the detail card. It would have been possible to rebalance the findings and heatmap sections more aggressively, but that would overlap with the broader detail-layout work already captured in the issue backlog. This PR stays narrow: remove the sparse-case dead space, keep the actions near the diagnosis summary, and avoid changing unrelated report/history behavior.

## Out of scope / follow-up

This PR does not change the collapsed History run rows from #2247, the Cars/Sensors density work, or the later settings/maintenance audit items. It also does not materially redesign the internal findings cards or the heatmap itself. The scope here is limited to the expanded History diagnosis layout: keep the action panel close to the diagnosis summary, reduce empty vertical travel in sparse-detail cases, and make the expanded view feel more intentional when the selected run has limited evidence content.
