### PR TITLE
fix(ui): contain add car wizard on phones

### DIFF
--- a/apps/ui/src/styles/settings.css
+++ b/apps/ui/src/styles/settings.css
@@ -871,20 +871,62 @@ body[data-wizard-open="true"] { overflow: hidden; }
 }
 
 @media (max-width: 720px) {
+  .add-car-wizard:not([hidden]) {
+    top: 0;
+    left: 0;
+    transform: none;
+    width: 100vw;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+    border-width: 0;
+    box-shadow: none;
+    overflow: hidden;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    padding: var(--space-3);
+  }
   .wizard-header {
     flex-direction: column;
   }
   .wizard-close {
     align-self: flex-end;
   }
+  .wizard-shell {
+    min-height: 0;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: var(--space-3);
+    overflow: hidden;
+  }
+  .wizard-main {
+    min-height: 0;
+    grid-template-rows: minmax(0, 1fr) auto;
+  }
+  .wizard-steps {
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 0.1rem;
+  }
   .wizard-step-dot {
     min-width: 120px;
+  }
+  .wizard-nav {
+    position: static;
+    margin-top: var(--space-3);
+    padding-top: var(--space-2);
+    background: var(--surface);
   }
   .wizard-options .wiz-opt,
   .wizard-custom input,
   .wizard-custom .btn {
     width: 100%;
     min-width: 0;
+  }
+  .wizard-summary-card {
+    order: -1;
+    max-height: min(22vh, 9rem);
+    overflow-y: auto;
   }
   .wizard-nav__actions {
     flex-direction: column-reverse;

--- a/apps/ui/tests/smoke.car-wizard.spec.ts
+++ b/apps/ui/tests/smoke.car-wizard.spec.ts
@@ -51,6 +51,82 @@ test("opens the add car wizard in a focused task container and restores focus wh
   await expect(page.locator("#addCarBtn")).toBeFocused();
 });
 
+test("uses the full mobile viewport and keeps the final action visible on short screens", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 667 });
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "/api/settings/cars": {
+        cars: [{ id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} }],
+        active_car_id: "car-1",
+      },
+    }),
+  });
+  await page.route("**/api/car-library/**", async (route) => {
+    const path = requestPath(route);
+    if (path === "/api/car-library/brands") {
+      await fulfillJson(route, { brands: ["BMW"] });
+      return;
+    }
+    if (path === "/api/car-library/types") {
+      await fulfillJson(route, { types: ["SUV"] });
+      return;
+    }
+    if (path === "/api/car-library/models") {
+      await fulfillJson(route, {
+        models: [{
+          model: "X5",
+          tire_width_mm: 275,
+          tire_aspect_pct: 40,
+          rim_in: 21,
+          variants: [],
+          gearboxes: [],
+          tire_options: [],
+        }],
+      });
+      return;
+    }
+    await fulfillJson(route, { brands: [], types: [], models: [] });
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+  await page.locator("#addCarBtn").click();
+  await page.locator("#wizardBrandList .wiz-opt").click();
+  await page.locator("#wizardTypeList .wiz-opt").click();
+  await page.locator("#wizardCustomModel").fill("X5 M60i");
+  await page.locator("#wizardCustomModelBtn").click();
+
+  const wizard = page.locator("#addCarWizard");
+  await expect(wizard).toBeVisible();
+  await expect(page.locator("#wizardManualAddBtn")).toBeVisible();
+
+  const box = await wizard.boundingBox();
+  if (!box) {
+    throw new Error("Expected mobile wizard to have a bounding box");
+  }
+  expect(Math.round(box.x)).toBe(0);
+  expect(Math.round(box.y)).toBe(0);
+  expect(Math.abs(Math.round(box.width) - 390)).toBeLessThanOrEqual(1);
+
+  const overflowMetrics = await wizard.evaluate((wizardElement) => {
+    const steps = wizardElement.querySelector<HTMLElement>(".wizard-steps");
+    if (!steps) {
+      throw new Error("Expected wizard steps container");
+    }
+    const stepsStyle = window.getComputedStyle(steps);
+    return {
+      stepsOverflowY: stepsStyle.overflowY,
+      wizardClientHeight: Math.round(wizardElement.clientHeight),
+      wizardScrollHeight: Math.round(wizardElement.scrollHeight),
+    };
+  });
+
+  expect(overflowMetrics.stepsOverflowY).toBe("auto");
+  expect(overflowMetrics.wizardScrollHeight).toBeLessThanOrEqual(overflowMetrics.wizardClientHeight + 2);
+});
+
 test("keeps the manual branch deliberate while summarizing selections and activating the new car", async ({ page }) => {
   const cars = [{ id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} }];
   let activeCarId = "car-1";


### PR DESCRIPTION
## Summary

This PR fixes the mobile Add Car wizard overflow problem tracked in #2250. The issue was not in the wizard's step logic or data flow; it was in how the existing desktop-oriented shell behaved once the viewport got short enough that the modal, the summary card, and the footer actions all had to compete for the same vertical space. On phone-sized screens the settings page still showed beside the modal, the lower part of the wizard felt clipped, and the last controls were only comfortably reachable by treating the whole modal as one large scroll surface.

The implementation keeps the current wizard structure, steps, and copy intact, but changes the mobile layout so the wizard behaves like a proper focused task surface. On small screens it now owns the full viewport, keeps the header outside the scrolling content area, gives the main step body explicit overflow ownership, and keeps the footer actions visible instead of letting them drift with the rest of the modal.

## Problem being solved

The audit issue called out four concrete problems: the wizard was leaking surrounding page content at the edges, the step surface looked clipped, the footer area was not cleanly contained, and the final CTA was at risk of falling off the usable viewport on common phone heights. After tracing the current CSS, the root cause was straightforward: the wizard still behaved like a centered modal that had only been partially adapted for smaller widths. The width and max-height rules under the existing mobile breakpoints narrowed the shell, but they did not fully reassign layout ownership for phone-sized heights.

That meant three different things were effectively fighting each other:

1. the outer modal container,
2. the step content itself, and
3. the summary/footer region.

In practice that created the “desktop modal squeezed onto a phone” feeling captured in the audit screenshot. It also made the body/footer relationship brittle because the whole modal was responsible for scrolling instead of the actual step content region.

## Implementation approach

I intentionally kept the fix in the CSS owner for the surface, `apps/ui/src/styles/settings.css`, rather than changing wizard markup or introducing new presenter logic. The wizard already had the right structural regions in the DOM: a shell, a main content area, the step body, the summary card, and the footer navigation. The missing piece was a stricter mobile layout contract.

For the `max-width: 720px` breakpoint, the wizard now becomes a full-viewport surface only while it is actually open. The `:not([hidden])` guard matters here because the presenter relies on the `hidden` attribute to keep the wizard out of the interaction tree. During validation I found that setting `display: grid` unconditionally on the mobile selector could accidentally override the closed state and leave the hidden wizard intercepting pointer events above the Cars tab. Scoping the mobile grid behavior to the open state fixed that regression without touching presenter code.

Once open, the wizard now uses a simple two-row grid: the header gets its own row and everything else lives inside a bounded content row. Inside that bounded area, the shell also becomes a two-row layout on phones. The summary card moves into the top slot and gets a capped height, while the main wizard content gets the remaining space. Inside the main area, the steps region becomes the inner scroll container and the footer navigation is kept outside that scrolling body. This is the key behavioral improvement: the form content can scroll independently, but the primary action region stays visible and stable.

## Main code changes by area

In `apps/ui/src/styles/settings.css`, the mobile wizard rules now:

- remove the centered-modal geometry by pinning the open wizard to the full viewport,
- remove the mobile border/radius treatment that exposed surrounding page chrome,
- switch the open wizard into a two-row grid so the header does not collapse into the scrollable area,
- make the shell itself height-bounded on phones,
- move overflow ownership to `.wizard-steps`,
- make `.wizard-nav` static within the bounded layout instead of relying on the prior sticky/whole-modal relationship,
- move the summary card ahead of the main content on phones and cap its height so it cannot cover lower controls.

These are layout-only changes. They do not alter the wizard's steps, API calls, activation behavior, or manual-vs-library selection flow.

In `apps/ui/tests/smoke.car-wizard.spec.ts`, I added a focused short-phone regression case using a `390x667` viewport. That test exercises the real wizard flow deep enough to reach the final action area and then asserts the things that matter for this issue:

- the wizard occupies the full mobile viewport instead of behaving like a floating inset modal,
- the final Add Car action remains visible on a short phone-height screen,
- the inner steps region is configured as the scroll owner,
- the outer wizard itself is no longer the thing that needs to scroll to expose the CTA.

I kept the existing open/cancel, manual-path, and library-path smoke coverage in place, so the new test extends coverage rather than replacing prior expectations.

## Contracts, config, and docs

There are no contract, schema, or API changes in this PR. The wizard continues to submit the same data and use the same routes. There are also no documentation changes because the issue is a contained UI layout fix and the existing user-facing docs do not describe the wizard's internal shell behavior.

## Validation

I ran the focused frontend validation path that matches the change surface:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=.ai-temp/playwright.issue-2245.config.ts smoke.car-wizard.spec.ts --project=laptop-light --workers=1`

The Playwright run covers the newly added short-height mobile case plus the existing cancel/manual/library wizard flows. During implementation, the validation loop also caught the hidden-state regression described above, which is why the final CSS uses the `:not([hidden])` guard instead of applying the grid layout to the closed wizard as well.

## Risks, tradeoffs, and edge cases

The main tradeoff is that on phone-sized screens the summary card now sits above the main step surface instead of below or beside it. I chose that because the audit problem was about reachability and containment, not about preserving the exact visual order from the desktop layout. Keeping the summary compact and above the form avoids the more serious failure mode where lower controls become visually or physically crowded out.

I also kept the change at the `720px` breakpoint so tablet and desktop behavior stay aligned with the existing wider-layout design. This keeps the blast radius small while still fully addressing the reported mobile bug.

Closes #2250
