### PR TITLE
fix(ui): clarify internet transport selection

### DIFF
--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -73,7 +73,7 @@ function InternetPanel() {
             <div class="speed-source-choice-grid">
               <label
                 id="updateTransportChoiceWifi"
-                class="speed-source-choice"
+                class="speed-source-choice update-transport-choice"
                 data-update-transport-choice="wifi"
               >
                 <input
@@ -100,7 +100,7 @@ function InternetPanel() {
               </label>
               <label
                 id="updateTransportChoiceUsb"
-                class="speed-source-choice"
+                class="speed-source-choice update-transport-choice"
                 data-update-transport-choice="usb_internet"
               >
                 <input

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -255,10 +255,14 @@ export function createUpdateFeaturePresenter(
     }
     setChoiceCardState(internetDom.updateTransportChoiceWifi, {
       selected: !usingUsb,
+      state: !usingUsb ? "active" : null,
+      badgeText: !usingUsb ? t("settings.update.transport.selected_badge") : null,
     });
     setChoiceCardState(internetDom.updateTransportChoiceUsb, {
       selected: usingUsb,
       disabled: !usbAvailable && !controlsLocked,
+      state: usingUsb ? "active" : null,
+      badgeText: usingUsb ? t("settings.update.transport.selected_badge") : null,
     });
     if (internetDom.updateWifiFields) {
       internetDom.updateWifiFields.hidden = usingUsb;

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -688,6 +688,7 @@
   "settings.update.transport.usb_summary": "Reuse the currently detected USB uplink without taking the hotspot down.",
   "settings.update.transport.usb_summary_interface": "Reuse the currently detected USB uplink on {interface}.",
   "settings.update.transport.usb_summary_unavailable": "USB internet is not ready yet.",
+  "settings.update.transport.selected_badge": "Selected",
   "settings.update.transport_value.wifi": "Wi-Fi",
   "settings.update.transport_value.wifi_ssid": "Wi-Fi ({ssid})",
   "settings.update.transport_value.usb": "USB internet",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -688,6 +688,7 @@
   "settings.update.transport.usb_summary": "Hergebruik de huidige USB-uplink zonder de hotspot uit te schakelen.",
   "settings.update.transport.usb_summary_interface": "Hergebruik de huidige USB-uplink op {interface}.",
   "settings.update.transport.usb_summary_unavailable": "USB-internet is nog niet klaar.",
+  "settings.update.transport.selected_badge": "Geselecteerd",
   "settings.update.transport_value.wifi": "Wi-Fi",
   "settings.update.transport_value.wifi_ssid": "Wi-Fi ({ssid})",
   "settings.update.transport_value.usb": "USB-internet",

--- a/apps/ui/src/styles/settings.css
+++ b/apps/ui/src/styles/settings.css
@@ -212,6 +212,19 @@
   background: var(--menu-hover);
   box-shadow: inset 0 0 0 1px var(--brand-500);
 }
+.update-transport-choice:hover {
+  border-color: var(--brand-300);
+  background: var(--surface-2);
+}
+.update-transport-choice:focus-within {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+.update-transport-choice[data-selected="true"] {
+  border-color: var(--brand-500);
+  background: color-mix(in srgb, var(--menu-hover) 65%, var(--surface-2));
+  box-shadow: inset 0 0 0 1px var(--brand-500);
+}
 .speed-source-choice[data-choice-state="active"]::after,
 .speed-source-choice[data-choice-state="draft"]::after {
   position: absolute;
@@ -250,6 +263,9 @@
   border-color: var(--border);
   background: var(--surface-2);
   box-shadow: none;
+}
+.update-transport-choice[data-disabled="true"]:focus-within {
+  outline-color: var(--focus);
 }
 .speed-source-choice__radio {
   position: absolute;

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -829,6 +829,12 @@ test.describe("createUpdateFeature polling", () => {
       expect(deps.updateTransportChoiceWifi.getAttribute("data-selected")).toBe(
         "true",
       );
+      expect(
+        deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
+      ).toBe("active");
+      expect(
+        deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
+      ).toBe("settings.update.transport.selected_badge");
       expect(deps.updateTransportChoiceUsb.getAttribute("data-disabled")).toBe(
         "true",
       );
@@ -1102,9 +1108,21 @@ test.describe("createUpdateFeature polling", () => {
       expect(
         deps.updateTransportChoiceWifi.getAttribute("data-selected"),
       ).toBeNull();
+      expect(
+        deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
+      ).toBeNull();
+      expect(
+        deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
+      ).toBeNull();
       expect(deps.updateTransportChoiceUsb.getAttribute("data-selected")).toBe(
         "true",
       );
+      expect(
+        deps.updateTransportChoiceUsb.getAttribute("data-choice-state"),
+      ).toBe("active");
+      expect(
+        deps.updateTransportChoiceUsb.getAttribute("data-choice-badge"),
+      ).toBe("settings.update.transport.selected_badge");
       expect(
         deps.updateTransportChoiceUsb.getAttribute("data-disabled"),
       ).toBeNull();

--- a/apps/ui/tests/smoke.update.spec.ts
+++ b/apps/ui/tests/smoke.update.spec.ts
@@ -95,6 +95,14 @@ test("settings update tab renders readiness guidance when idle", async ({
     "data-selected",
     "true",
   );
+  await expect(page.locator("#updateTransportChoiceWifi")).toHaveAttribute(
+    "data-choice-state",
+    "active",
+  );
+  await expect(page.locator("#updateTransportChoiceWifi")).toHaveAttribute(
+    "data-choice-badge",
+    "Selected",
+  );
   await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
     "data-disabled",
     "true",
@@ -216,6 +224,14 @@ test("settings internet tab and updater show USB internet when usable", async ({
     "data-selected",
     "true",
   );
+  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
+    "data-choice-state",
+    "active",
+  );
+  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
+    "data-choice-badge",
+    "Selected",
+  );
   await expect(page.locator("#updateWifiFields")).toHaveJSProperty(
     "hidden",
     true,
@@ -228,6 +244,19 @@ test("settings internet tab and updater show USB internet when usable", async ({
   );
   await expect(page.locator("#updateTransportNote")).toContainText(
     "Starting a USB-internet update keeps the hotspot up",
+  );
+  await page.locator("#updateTransportWifiRadio").focus();
+  await expect(page.locator("#updateTransportChoiceWifi")).toHaveCSS(
+    "outline-style",
+    "solid",
+  );
+  await expect(page.locator("#updateTransportChoiceWifi")).toHaveCSS(
+    "outline-width",
+    "2px",
+  );
+  await expect(page.locator("#updateTransportChoiceUsb")).toHaveAttribute(
+    "data-choice-state",
+    "active",
   );
   await page.locator('[data-settings-tab="updateTab"]').click();
   await expect(page.locator("#updateStartBtn")).toBeEnabled();


### PR DESCRIPTION
## Summary

This PR fixes the ambiguity called out in #2252 on the Internet settings page, where the maintenance readiness copy could already be describing one transport while the card styling still made the other path look visually active. The biggest problem was not the transport state itself; the update presenter was already driving the readiness panel, preflight note, and Wi-Fi field visibility from the effective transport choice. The confusing part was the presentation layer, where hover/focus treatment was too close to the persisted selection treatment.

The fix keeps the existing update workflow and transport model intact, but makes the chosen path visually explicit before an update starts. The selected card now carries a dedicated “Selected” badge, the Internet transport cards use a quieter hover state than the more general speed-source cards, and keyboard focus is now represented with a separate focus ring instead of looking like a second selected card. That gives the page three clearly different interaction states: a calm idle card, a transient hover/focus card, and a durable selected card that matches the readiness summary below it.

## Problem being solved

The issue report was specific: the readiness summary said the existing USB internet path was selected, but the Temporary Wi-Fi card still appeared emphasized in the audited screenshot. Whether that emphasis came from hover or focus, it meant an operator could walk away with the wrong mental model about which connection path would be used for a maintenance run. That is particularly risky on this page because the two choices have different operational consequences: Wi-Fi temporarily drops hotspot access, while USB internet keeps the hotspot up.

I treated this as a UI-state clarity problem rather than a workflow bug. The existing presenter already knew which transport was active and already changed the readiness copy, detail caption, Wi-Fi credential visibility, and updater start payload correctly. The goal of this patch was to make the visual affordance line up with that existing state instead of introducing a parallel transport model.

## Implementation approach

I kept the change deliberately narrow and reused the repository’s existing choice-card state system instead of inventing a new Internet-only component. `setChoiceCardState()` already supports `selected`, `state`, and `badgeText`, but the Internet transport cards were only using the plain selected/disabled flags. The presenter now sets the selected transport card to the existing `active` card state and provides a localized badge label.

To avoid changing the behavior of other settings surfaces that use the same base choice-card styles, I added an Internet/update-specific modifier class in `internet_panel.tsx`. The base `speed-source-choice` styles stay intact, while the update transport cards now get a targeted focus and hover treatment through `.update-transport-choice`. This keeps the fix scoped to the audited problem instead of silently restyling the Speed Source area or other settings panels that were not part of this issue.

## Main code changes by area

In `apps/ui/src/app/views/internet_panel.tsx`, both transport labels now opt into the new `update-transport-choice` modifier class. This is what lets the Internet page define its own interaction rules without forking the existing card markup.

In `apps/ui/src/app/views/update_feature_presenter.ts`, the transport sync logic now marks the active choice with the repository’s existing choice-card “active” state and a localized badge string. The selected Wi-Fi or USB card still uses the existing `data-selected` flag, but now it also carries `data-choice-state="active"` and the badge text when appropriate. This remains tied to the same `selectedTransport()` logic that already drives readiness copy and control visibility, so the visual state and the operational summary continue to come from one source of truth.

In `apps/ui/src/styles/settings.css`, I added the Internet-specific interaction treatment. Hover on update transport cards is now quieter so it no longer looks like a durable selection. The selected card keeps the stronger filled treatment. Keyboard focus uses `:focus-within` and a dedicated outline so tabbing onto the non-selected card does not imply that the persisted choice changed.

In `apps/ui/src/i18n/catalogs/en.json` and `apps/ui/src/i18n/catalogs/nl.json`, I added the localized badge copy for the selected transport card. There are no contract, schema, or API changes in this PR; the only content change is the new user-facing selection badge text.

## Validation and tests

I updated two layers of regression coverage. In `apps/ui/tests/smoke.update.spec.ts`, the browser-level Internet page scenarios now assert that the active transport card carries the selection badge in both the default Wi-Fi case and the USB-selected case. The USB flow also now focuses the non-selected Wi-Fi radio and checks for the focus outline on the Wi-Fi card while the USB card remains the one marked active.

In `apps/ui/tests/esp_flash_feature.spec.ts`, the DOM-level update feature tests now verify that the presenter emits the correct choice-card state and badge attributes for both the default Wi-Fi path and the USB-selected path.

Local validation for this change was:

`cd apps/ui && npm run typecheck`

`cd apps/ui && npm run build`

`cd apps/ui && npx playwright test --config=.ai-temp/playwright.issue-2245.config.ts smoke.update.spec.ts tests/esp_flash_feature.spec.ts --project=laptop-light --workers=1`

## Risks, tradeoffs, and edge cases

The main tradeoff here is that I intentionally reused the existing choice-card state/badge system instead of introducing a more bespoke Internet transport card component. That keeps the patch small, avoids duplicate styling logic, and lets the fix land quickly, but it also means the Internet page is still built on the generic choice-card foundation.

I also kept the styling override targeted to the Internet page rather than changing the global hover behavior of every choice card in the app. That reduces blast radius and avoids accidentally reopening earlier UI polish work on the Speed Source screen.

The implementation preserves important edge cases. If USB internet is unavailable, the USB card still renders disabled and the Wi-Fi path stays selected by default. If an update is already running, the presenter still reflects the locked transport taken from the active update state. The new badge and selected-card treatment follow that same state, so the locked running view continues to show the real transport path instead of whatever card the operator last focused.

## Out of scope

This PR does not restructure the broader Update or ESP Flash information architecture. That larger first-screen hierarchy work belongs to #2253. Here the goal is only to make transport selection unambiguous on the Internet tab and keep the visible card state aligned with the existing readiness and maintenance copy.

Closes #2252
