### PR TITLE
fix(run): allow manual speed readiness

### DIFF
--- a/apps/server/tests/use_cases/run/test_capture_readiness_evaluator.py
+++ b/apps/server/tests/use_cases/run/test_capture_readiness_evaluator.py
@@ -82,10 +82,40 @@ def _observation(
     )
 
 
+def test_capture_readiness_evaluator_accepts_manual_speed_source_for_start_gate() -> None:
+    readiness = evaluate_capture_readiness(
+        policy=CaptureReadinessPolicy(low_sensor_count_warn_threshold=1),
+        observation=_observation(speed_status=_SpeedStatus(source="manual", speed_kmh=82.0)),
+        state=CaptureReadinessStateSnapshot(
+            integrity=IntegrityState(
+                active=False,
+                frames_dropped=0,
+                queue_overflow_drops=0,
+                server_queue_drops=0,
+                parse_errors=0,
+                quiet_period_remaining_s=None,
+            ),
+            speed_history=(),
+        ),
+    )
+
+    assert readiness.is_ready
+    reference_check = next(
+        check for check in readiness.checks if check.check_key == "reference_ready"
+    )
+    speed_check = next(check for check in readiness.checks if check.check_key == "speed_stable")
+    assert reference_check.state == "pass"
+    assert reference_check.reason_key == "reference_ready"
+    assert speed_check.state == "pass"
+    assert speed_check.reason_key == "speed_stable"
+
+
 def test_capture_readiness_evaluator_reports_non_live_speed_sources_explicitly() -> None:
     readiness = evaluate_capture_readiness(
         policy=CaptureReadinessPolicy(),
-        observation=_observation(speed_status=_SpeedStatus(source="manual")),
+        observation=_observation(
+            speed_status=_SpeedStatus(source="none", speed_kmh=None, age_s=None)
+        ),
         state=CaptureReadinessStateSnapshot(
             integrity=IntegrityState(
                 active=False,
@@ -103,6 +133,36 @@ def test_capture_readiness_evaluator_reports_non_live_speed_sources_explicitly()
         check for check in readiness.checks if check.check_key == "reference_ready"
     )
     assert reference_check.reason_key == "speed_source_not_live"
+
+
+def test_capture_readiness_evaluator_blocks_manual_fallback_reference_explicitly() -> None:
+    readiness = evaluate_capture_readiness(
+        policy=CaptureReadinessPolicy(),
+        observation=_observation(
+            speed_status=_SpeedStatus(
+                source="fallback_manual",
+                speed_kmh=82.0,
+                age_s=None,
+                fallback_active=True,
+            )
+        ),
+        state=CaptureReadinessStateSnapshot(
+            integrity=IntegrityState(
+                active=False,
+                frames_dropped=0,
+                queue_overflow_drops=0,
+                server_queue_drops=0,
+                parse_errors=0,
+                quiet_period_remaining_s=None,
+            ),
+            speed_history=(),
+        ),
+    )
+
+    reference_check = next(
+        check for check in readiness.checks if check.check_key == "reference_ready"
+    )
+    assert reference_check.reason_key == "speed_source_fallback_active"
 
 
 def test_capture_readiness_evaluator_accepts_ready_observation_from_state_snapshot() -> None:

--- a/apps/server/tests/use_cases/run/test_capture_readiness_runtime.py
+++ b/apps/server/tests/use_cases/run/test_capture_readiness_runtime.py
@@ -75,6 +75,36 @@ def test_capture_readiness_passes_after_stable_dwell(
     assert speed_check.reason_key == "speed_stable"
 
 
+def test_capture_readiness_accepts_manual_speed_source_for_start_gate(
+    fake_registry,
+    fake_gps_monitor,
+    mutable_fake_settings,
+) -> None:
+    tracker = CaptureReadinessTracker()
+    mutable_fake_settings.active_car = _active_car_snapshot()
+    fake_gps_monitor.speed_mps = 22.0
+    fake_gps_monitor.resolved_source = "manual"
+
+    readiness = tracker.evaluate(
+        _observation(
+            fake_registry=fake_registry,
+            fake_gps_monitor=fake_gps_monitor,
+            mutable_fake_settings=mutable_fake_settings,
+            now_mono=150.0,
+        )
+    )
+
+    reference_check = next(
+        check for check in readiness.checks if check.check_key == "reference_ready"
+    )
+    speed_check = next(check for check in readiness.checks if check.check_key == "speed_stable")
+    assert readiness.is_ready
+    assert reference_check.state == "pass"
+    assert reference_check.reason_key == "reference_ready"
+    assert speed_check.state == "pass"
+    assert speed_check.reason_key == "speed_stable"
+
+
 def test_capture_readiness_fails_when_recent_integrity_issues_are_detected(
     fake_registry,
     fake_gps_monitor,
@@ -124,15 +154,15 @@ def test_capture_readiness_fails_when_recent_integrity_issues_are_detected(
     assert sensors_check.reason_key == "limited_sensor_coverage"
 
 
-def test_capture_readiness_blocks_without_fresh_reference(
+def test_capture_readiness_blocks_without_resolved_speed_source(
     fake_registry,
     fake_gps_monitor,
     mutable_fake_settings,
 ) -> None:
     tracker = CaptureReadinessTracker()
     mutable_fake_settings.active_car = _active_car_snapshot()
-    fake_gps_monitor.speed_mps = 22.0
-    fake_gps_monitor.resolved_source = "manual"
+    fake_gps_monitor.speed_mps = None
+    fake_gps_monitor.resolved_source = "none"
 
     readiness = tracker.evaluate(
         _observation(
@@ -148,6 +178,34 @@ def test_capture_readiness_blocks_without_fresh_reference(
     )
     assert reference_check.state == "fail"
     assert reference_check.reason_key == "speed_source_not_live"
+    assert not readiness.is_ready
+
+
+def test_capture_readiness_blocks_when_manual_fallback_is_active(
+    fake_registry,
+    fake_gps_monitor,
+    mutable_fake_settings,
+) -> None:
+    tracker = CaptureReadinessTracker()
+    mutable_fake_settings.active_car = _active_car_snapshot()
+    fake_gps_monitor.speed_mps = 22.0
+    fake_gps_monitor.resolved_source = "fallback_manual"
+    fake_gps_monitor.fallback_active = True
+
+    readiness = tracker.evaluate(
+        _observation(
+            fake_registry=fake_registry,
+            fake_gps_monitor=fake_gps_monitor,
+            mutable_fake_settings=mutable_fake_settings,
+            now_mono=320.0,
+        )
+    )
+
+    reference_check = next(
+        check for check in readiness.checks if check.check_key == "reference_ready"
+    )
+    assert reference_check.state == "fail"
+    assert reference_check.reason_key == "speed_source_fallback_active"
     assert not readiness.is_ready
 
 

--- a/apps/server/vibesensor/use_cases/run/capture_readiness_evaluator.py
+++ b/apps/server/vibesensor/use_cases/run/capture_readiness_evaluator.py
@@ -137,12 +137,27 @@ def _reference_check(
         )
 
     speed_source = speed.source
-    if speed_source not in policy.live_speed_sources:
+    effective_speed_kmh = speed.speed_kmh
+    if speed_source == "manual":
+        if (
+            not _is_finite_number(effective_speed_kmh)
+            or effective_speed_kmh is None
+            or effective_speed_kmh <= 0.0
+        ):
+            return CaptureReadinessCheck(
+                check_key="reference_ready",
+                state="fail",
+                reason_key="speed_sample_missing",
+                details=(("speed_source", speed_source),),
+            )
         return CaptureReadinessCheck(
             check_key="reference_ready",
-            state="fail",
-            reason_key="speed_source_not_live",
-            details=(("speed_source", speed_source),),
+            state="pass",
+            reason_key="reference_ready",
+            details=(
+                ("speed_source", speed_source),
+                ("speed_kmh", round(effective_speed_kmh, 2)),
+            ),
         )
 
     if speed.fallback_active:
@@ -150,6 +165,14 @@ def _reference_check(
             check_key="reference_ready",
             state="fail",
             reason_key="speed_source_fallback_active",
+            details=(("speed_source", speed_source),),
+        )
+
+    if speed_source not in policy.live_speed_sources:
+        return CaptureReadinessCheck(
+            check_key="reference_ready",
+            state="fail",
+            reason_key="speed_source_not_live",
             details=(("speed_source", speed_source),),
         )
 
@@ -165,7 +188,6 @@ def _reference_check(
             ),
         )
 
-    effective_speed_kmh = speed.speed_kmh
     if (
         not _is_finite_number(effective_speed_kmh)
         or effective_speed_kmh is None
@@ -232,6 +254,36 @@ def _speed_check(
 
     speed_source = speed.source
     speed_kmh = speed.speed_kmh
+    if speed_source == "manual":
+        if not _is_finite_number(speed_kmh) or speed_kmh is None:
+            return CaptureReadinessCheck(
+                check_key="speed_stable",
+                state="fail",
+                reason_key="speed_sample_missing",
+                details=(("speed_source", speed_source),),
+            )
+        if speed_kmh < policy.min_ready_speed_kmh:
+            return CaptureReadinessCheck(
+                check_key="speed_stable",
+                state="fail",
+                reason_key="speed_too_low",
+                details=(
+                    ("speed_kmh", round(speed_kmh, 2)),
+                    ("minimum_speed_kmh", policy.min_ready_speed_kmh),
+                ),
+            )
+        return CaptureReadinessCheck(
+            check_key="speed_stable",
+            state="pass",
+            reason_key="speed_stable",
+            details=(
+                ("speed_kmh", round(speed_kmh, 2)),
+                ("mean_speed_kmh", round(speed_kmh, 2)),
+                ("range_kmh", 0.0),
+                ("dwell_elapsed_s", policy.stable_speed_dwell_s),
+            ),
+        )
+
     if (
         speed_source not in policy.live_speed_sources
         or speed.fallback_active

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -95,7 +95,7 @@
   "dashboard.capture_readiness.reference_ready.active_car_missing": "Choose an active car before recording.",
   "dashboard.capture_readiness.reference_ready.order_reference_incomplete": "Complete the active car's tire and driveline settings first.",
   "dashboard.capture_readiness.reference_ready.speed_source_missing": "No live speed source is available yet.",
-  "dashboard.capture_readiness.reference_ready.speed_source_not_live": "Use GPS or OBD-II speed for steady-state capture.",
+  "dashboard.capture_readiness.reference_ready.speed_source_not_live": "Choose GPS, OBD-II, or a manual speed before starting steady-state capture.",
   "dashboard.capture_readiness.reference_ready.speed_source_fallback_active": "Waiting for live speed updates instead of fallback speed.",
   "dashboard.capture_readiness.reference_ready.speed_sample_stale": "Waiting for a fresh live speed update.",
   "dashboard.capture_readiness.reference_ready.speed_sample_missing": "Waiting for a valid live speed reading.",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -95,7 +95,7 @@
   "dashboard.capture_readiness.reference_ready.active_car_missing": "Kies een actieve auto voordat je opneemt.",
   "dashboard.capture_readiness.reference_ready.order_reference_incomplete": "Vul eerst de banden- en aandrijflijninstellingen van de actieve auto aan.",
   "dashboard.capture_readiness.reference_ready.speed_source_missing": "Er is nog geen live snelheidsbron beschikbaar.",
-  "dashboard.capture_readiness.reference_ready.speed_source_not_live": "Gebruik GPS- of OBD-II-snelheid voor steady-state metingen.",
+  "dashboard.capture_readiness.reference_ready.speed_source_not_live": "Kies GPS-, OBD-II- of handmatige snelheid voordat je steady-state metingen start.",
   "dashboard.capture_readiness.reference_ready.speed_source_fallback_active": "Wachten op live snelheidsupdates in plaats van terugvalsnelheid.",
   "dashboard.capture_readiness.reference_ready.speed_sample_stale": "Wachten op een verse live snelheidsupdate.",
   "dashboard.capture_readiness.reference_ready.speed_sample_missing": "Wachten op een geldige live snelheidsmeting.",


### PR DESCRIPTION
## Summary

This PR fixes #2263 by making explicit manual speed selection count as valid speed for the Live recording readiness gate. Before this change, the backend capture-readiness evaluator treated `manual` as a non-live source and surfaced `speed_source_not_live`, which left the frontend’s existing Start Recording gate disabled even when the operator had intentionally selected manual speed and configured a positive value. The result was a user-visible contradiction: the product already presents manual speed as a supported analysis mode, but the readiness model still behaved as though only live GPS or OBD-II speed could unlock recording.

The fix is intentionally narrow. I did not change recorder start semantics, recorder persistence, HTTP contracts, speed-source configuration payloads, or the frontend gating logic itself. Instead, I updated the backend readiness evaluator so it interprets explicit `manual` source as a valid configured reference input for recording readiness. The UI already consumes that readiness snapshot, so once the backend reports the correct state, Start Recording unlocks through the existing surface without any separate workaround.

## Problem being solved

Issue #2263 included screenshots showing a configured manual speed source while the Live screen still refused to start recording. Tracing the flow made the problem clear:

1. The Live panel disables Start Recording from `capture_readiness.is_ready`.
2. `capture_readiness` is computed in the backend by `capture_readiness_evaluator.py`.
3. That evaluator rejected any source not in the “live” set (`gps`, `obd2`) before it considered whether manual mode was intentionally selected.

That meant manual mode could never satisfy `reference_ready`, and because readiness failed there, the UI never unlocked Start Recording. In practice, this made manual speed look like a supported option in Settings but not a supported option in the workflow that actually matters.

There was a second adjacent issue in the same decision path: fallback-manual states were also funneled into the generic `speed_source_not_live` reason even though the codebase already had a more precise `speed_source_fallback_active` reason and translation key. Since I was already in the same branch structure, I corrected that at the same time rather than leaving a misleading adjacent state behind.

## Implementation approach

I kept the change evaluator-scoped on purpose. The repo already has a well-defined speed-resolution layer that decides between GPS, OBD-II, explicit manual override, and fallback-manual behavior. I did not want to broaden low-level source policy or mutate recorder lifecycle rules just to fix a readiness interpretation bug.

Instead, I changed the readiness evaluator to reflect the intended product behavior:

- explicit `manual` means the operator deliberately chose a fixed speed and that value should count as a valid reference input,
- `fallback_manual` is still a degraded state and should remain blocked,
- unresolved or unusable sources should still report the existing “not live / not usable yet” family of problems.

For the speed-stability gate, I treated explicit manual speed as immediately stable when it is present and above the configured minimum threshold. That is the most natural interpretation of a fixed configured value: there is no live jitter to observe and no dwell window to wait through, because the operator is explicitly overriding the dynamic sample stream with a constant speed. This aligns better with the issue report than forcing manual mode through the live-source dwell logic.

## Main code changes by area

### Backend evaluator

In `apps/server/vibesensor/use_cases/run/capture_readiness_evaluator.py`, I added an explicit `manual` branch in both the reference-readiness and speed-stability checks.

For `reference_ready`, explicit manual now passes when it has a positive configured speed. It no longer gets rejected under `speed_source_not_live`. This keeps the existing checks for active car, order reference completeness, and invalid/missing speed values intact while removing the incorrect source-classification block.

For `speed_stable`, explicit manual now passes immediately when the configured speed is finite and above `min_ready_speed_kmh`. If the manual speed is present but too low, it still fails with the existing `speed_too_low` reason. If the value is absent or invalid, it still fails with `speed_sample_missing`.

I also reordered the fallback handling so a `fallback_manual` state now reports `speed_source_fallback_active` instead of falling through the generic not-live branch first. That makes the status output more specific without broadening scope beyond the touched evaluator.

### Backend regression tests

In `apps/server/tests/use_cases/run/test_capture_readiness_evaluator.py`, I updated the focused evaluator coverage to reflect the intended matrix:

- explicit manual source now passes both `reference_ready` and `speed_stable`,
- unresolved / unusable source still reports `speed_source_not_live`,
- fallback-manual state now reports `speed_source_fallback_active`.

In `apps/server/tests/use_cases/run/test_capture_readiness_runtime.py`, I added runtime-facing coverage so the behavior is exercised through the tracker/observation path that the recorder status actually uses. The runtime tests now confirm:

- explicit manual source unlocks readiness for the Live start gate,
- missing resolved source still blocks,
- fallback-manual remains blocked.

These tests are important because the original bug was not just a pure function mismatch; it was visible through the integrated recorder-status surface that the frontend already trusts.

### UI copy

In `apps/ui/src/i18n/catalogs/en.json` and `apps/ui/src/i18n/catalogs/nl.json`, I updated the `speed_source_not_live` string so it no longer implies that only GPS or OBD-II are valid setup choices. Since explicit manual speed is now supported by the readiness evaluator, the guidance needed to match that reality. No frontend logic or DOM structure changed in this PR.

## Schema, contract, config, and documentation impact

There are no API schema changes, no WebSocket contract changes, no config-file changes, and no recorder workflow contract changes in this PR. The fix is behaviorally significant but structurally small: it changes how existing readiness data is interpreted, not the transport shape that carries it.

I also did not need to update the top-level product documentation because it already described manual speed as a supported feature. This PR brings runtime behavior back into alignment with that existing documentation.

## Validation performed

Local validation for this change was:

- `pytest -q apps/server/tests/use_cases/run/test_capture_readiness_evaluator.py apps/server/tests/use_cases/run/test_capture_readiness_runtime.py`
- `make typecheck-backend`
- `cd apps/ui && npm run build`
- `make test-changed`
- `make lint`

The focused pytest pass verifies the changed evaluator and runtime behavior directly. The broader repo-standard checks make sure the fix did not introduce typing, lint, or frontend build regressions.

## Risks, tradeoffs, and edge cases

The main behavior change is intentional: explicit manual speed is now considered immediately usable for readiness instead of being treated as an invalid non-live source. That is the desired outcome for #2263, but it does slightly change the semantics of the readiness gate by recognizing a fixed configured value as “stable enough” without requiring live-sample dwell.

I kept that change limited to explicit manual mode only. I did not treat `fallback_manual` as equivalent. If GPS/OBD-II degrades into fallback-manual, the readiness gate still blocks, and now it reports the more accurate fallback-active reason. That preserves the distinction between an operator intentionally selecting manual mode and the system silently falling back because a live source degraded.

I also avoided changing the lower-level speed-resolution policy or the recorder start endpoint. That reduces blast radius: the UI and API continue to rely on the same readiness payload; only the evaluator’s interpretation of explicit manual mode changed.

## Out of scope

This PR does not redesign the broader capture-readiness model, does not alter minimum-speed thresholds, and does not change how fallback-manual should be surfaced elsewhere in the product beyond the corrected readiness reason. If there is future product work around manual-mode UX messaging or around making fallback-manual more operator-friendly, that should be handled as a separate issue.

Closes #2263
