### PR TITLE
fix: use persisted sensor locations in readiness

### DIFF
--- a/apps/server/tests/use_cases/run/test_capture_readiness_runtime.py
+++ b/apps/server/tests/use_cases/run/test_capture_readiness_runtime.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from vibesensor.domain import CarSnapshot
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
@@ -34,12 +37,14 @@ def _observation(
     fake_registry,
     fake_gps_monitor,
     mutable_fake_settings,
+    sensor_metadata_reader=None,
     now_mono: float,
 ):
     return observe_capture_readiness(
         registry=fake_registry,
         run_context=_run_context(mutable_fake_settings),
         speed_provider=fake_gps_monitor,
+        sensor_metadata_reader=sensor_metadata_reader,
         now_mono=now_mono,
     )
 
@@ -103,6 +108,58 @@ def test_capture_readiness_accepts_manual_speed_source_for_start_gate(
     assert reference_check.reason_key == "reference_ready"
     assert speed_check.state == "pass"
     assert speed_check.reason_key == "speed_stable"
+
+
+def test_capture_readiness_uses_persisted_sensor_location_metadata_when_runtime_location_is_blank(
+    fake_gps_monitor,
+    mutable_fake_settings,
+) -> None:
+    tracker = CaptureReadinessTracker()
+    mutable_fake_settings.active_car = _active_car_snapshot()
+    fake_gps_monitor.speed_mps = 23.0
+    fake_gps_monitor.engine_rpm = 2450.0
+    fake_gps_monitor.resolved_source = "obd2"
+
+    sensor_id = "001122334455"
+    fake_registry = MagicMock()
+    fake_registry.active_client_ids.return_value = [sensor_id]
+    fake_registry.get.return_value = SimpleNamespace(
+        client_id=sensor_id,
+        name=sensor_id,
+        location_code="",
+        frames_dropped=0,
+        queue_overflow_drops=0,
+        server_queue_drops=0,
+        parse_errors=0,
+    )
+    sensor_metadata_reader = MagicMock()
+    sensor_metadata_reader.get_sensors.return_value = {
+        sensor_id: {
+            "name": sensor_id,
+            "location_code": "front_left_wheel",
+        }
+    }
+
+    snapshots = []
+    for now_mono in (100.0, 104.0, 108.0):
+        snapshots.append(
+            tracker.evaluate(
+                _observation(
+                    fake_registry=fake_registry,
+                    fake_gps_monitor=fake_gps_monitor,
+                    mutable_fake_settings=mutable_fake_settings,
+                    sensor_metadata_reader=sensor_metadata_reader,
+                    now_mono=now_mono,
+                )
+            )
+        )
+
+    sensors_check = next(
+        check for check in snapshots[-1].checks if check.check_key == "sensors_ready"
+    )
+    assert sensors_check.state == "warn"
+    assert sensors_check.reason_key == "limited_sensor_coverage"
+    assert snapshots[-1].is_ready
 
 
 def test_capture_readiness_fails_when_recent_integrity_issues_are_detected(

--- a/apps/server/vibesensor/use_cases/run/capture_readiness_observation.py
+++ b/apps/server/vibesensor/use_cases/run/capture_readiness_observation.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from vibesensor.domain import RunContextSnapshot
-from vibesensor.shared.ports import ClientTracker, TrackedClient
+from vibesensor.shared.ports import ClientTracker, SensorMetadataReader, TrackedClient
+from vibesensor.shared.sensor_metadata import resolve_sensor_presentation
+from vibesensor.shared.types.sensor_config import SensorConfigPayload
 
 __all__ = [
     "CaptureReadinessObservation",
@@ -88,10 +91,12 @@ def observe_capture_readiness(
     registry: ClientTracker,
     run_context: RunContextSnapshot,
     speed_provider: object,
+    sensor_metadata_reader: SensorMetadataReader | None = None,
     now_mono: float | None = None,
 ) -> CaptureReadinessObservation:
     observed_at_mono_s = time.monotonic() if now_mono is None else now_mono
-    active_sensors = _active_sensors(registry)
+    sensors_by_mac = sensor_metadata_reader.get_sensors() if sensor_metadata_reader else {}
+    active_sensors = _active_sensors(registry, sensors_by_mac=sensors_by_mac)
     return CaptureReadinessObservation(
         observed_at_mono_s=observed_at_mono_s,
         active_sensors=active_sensors,
@@ -101,19 +106,33 @@ def observe_capture_readiness(
     )
 
 
-def _active_sensors(registry: ClientTracker) -> tuple[CaptureReadinessSensorObservation, ...]:
+def _active_sensors(
+    registry: ClientTracker,
+    *,
+    sensors_by_mac: Mapping[str, SensorConfigPayload],
+) -> tuple[CaptureReadinessSensorObservation, ...]:
     active_sensors: list[CaptureReadinessSensorObservation] = []
     for client_id in registry.active_client_ids():
         client = registry.get(client_id)
         if client is not None:
-            active_sensors.append(_sensor_observation(client))
+            active_sensors.append(_sensor_observation(client, sensors_by_mac=sensors_by_mac))
     return tuple(active_sensors)
 
 
-def _sensor_observation(client: TrackedClient) -> CaptureReadinessSensorObservation:
+def _sensor_observation(
+    client: TrackedClient,
+    *,
+    sensors_by_mac: Mapping[str, SensorConfigPayload],
+) -> CaptureReadinessSensorObservation:
+    _, location_code = resolve_sensor_presentation(
+        sensor_id=client.client_id,
+        sensors_by_mac=sensors_by_mac,
+        fallback_name=str(getattr(client, "name", "") or ""),
+        fallback_location_code=str(client.location_code),
+    )
     return CaptureReadinessSensorObservation(
         client_id=client.client_id,
-        location_code=str(client.location_code),
+        location_code=location_code,
         frames_dropped=int(getattr(client, "frames_dropped", 0)),
         queue_overflow_drops=int(getattr(client, "queue_overflow_drops", 0)),
         server_queue_drops=int(getattr(client, "server_queue_drops", 0)),

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -77,6 +77,7 @@ class RunRecorder:
         self.gps_monitor = gps_monitor
         self.processor = processor
         self._settings_reader = settings_reader
+        self._sensor_metadata_reader = sensor_metadata_reader
         self.sensor_model = config.sensor_model.strip() or "unknown"
         self.default_sample_rate_hz = int(config.default_sample_rate_hz)
         self.fft_window_size_samples = int(config.fft_window_size_samples)
@@ -220,6 +221,7 @@ class RunRecorder:
                         registry=self.registry,
                         run_context=self._live_run_context_snapshot(),
                         speed_provider=self.gps_monitor,
+                        sensor_metadata_reader=self._sensor_metadata_reader,
                         now_mono=time.monotonic(),
                     )
                 )


### PR DESCRIPTION
## Summary

This PR fixes #2264 by making the backend capture-readiness observer use persisted sensor metadata when it decides whether a live sensor has a location. Before this change, the system already persisted sensor assignments and already overlaid that metadata into the HTTP and WebSocket client projections shown elsewhere in the UI. The problem was that capture readiness still inspected the raw runtime registry record directly, so after a reboot it could see a blank `location_code` even though the persisted assignment was still present.

The fix keeps the behavior aligned across the backend instead of adding a special-case UI workaround. I threaded the existing `SensorMetadataReader` into the capture-readiness observation path and resolved each active sensor through the shared `resolve_sensor_presentation()` helper before readiness evaluation runs. That way the main page now uses the same persisted location view that the rest of the live sensor surfaces already use.

## Problem being solved

Issue #2264 included screenshots showing a mismatch after reboot: the sensor still had a location assigned in the persisted settings surface, but the main page behaved as though the live sensor was still missing its location. Tracing the code paths showed that this was not a persistence bug and not a frontend rendering bug. The system already had the right data; it was just being consumed inconsistently.

The key split was:

- API and WebSocket client rows already go through `snapshot_for_api(...)` and `resolve_sensor_presentation(...)`, which means they overlay persisted sensor metadata on top of the live runtime client snapshot.
- Sample building already uses the same metadata-aware presentation helper.
- Capture readiness was the outlier. `observe_capture_readiness()` walked the raw registry and copied `client.location_code` directly into the readiness observation model.

That meant a rebooted sensor could end up in an inconsistent state from the UI’s point of view. The roster-style views could still show the persisted assignment correctly, while the readiness path concluded that the sensor had no location. Because the Live page trusts capture readiness for its operator guidance, that inconsistency surfaced as a false “needs a location” message.

## Implementation approach

I kept the fix on the backend capture-readiness path rather than trying to patch the frontend or add another fallback rule in the view layer. The rest of the system already had a canonical way to project sensor name/location from persisted metadata plus runtime state, so the cleanest fix was to make capture readiness use that same path.

Concretely, the implementation does three things:

1. `observe_capture_readiness()` now accepts an optional `SensorMetadataReader`.
2. It reads the persisted sensor map once per observation and passes that map into active-sensor projection.
3. Each active sensor observation resolves its presented location with `resolve_sensor_presentation(...)` instead of copying the raw runtime `client.location_code` field directly.

This is intentionally small in scope. I did not add new persistence rules, mutate how sensor metadata is stored, or change HTTP/WebSocket contract shapes. One backend consumer was bypassing the shared projection logic, so the fix makes that consumer consistent with the existing architecture.

## Main code changes by area

### Capture-readiness observation

In `apps/server/vibesensor/use_cases/run/capture_readiness_observation.py`, I extended the observer signature with `sensor_metadata_reader: SensorMetadataReader | None = None`.

From there, the observation logic now:

- calls `sensor_metadata_reader.get_sensors()` once when the reader is available,
- passes the resulting `sensors_by_mac` map into `_active_sensors(...)`,
- and resolves each sensor’s display/location data with `resolve_sensor_presentation(...)`.

The important behavior change is that `CaptureReadinessSensorObservation.location_code` now reflects the persisted assignment when that assignment exists, even if the raw runtime client record is temporarily blank after reboot. If the reader is unavailable or the sensor id does not resolve cleanly, the code still falls back to the existing runtime field.

### Recorder status wiring

In `apps/server/vibesensor/use_cases/run/logger.py`, `RunRecorder` already received a `sensor_metadata_reader`, but the capture-readiness status path was not using it. I stored that dependency on the recorder instance and forwarded it into `observe_capture_readiness()` inside `RunRecorder.status()`.

That change is small, but it is the important runtime connection for this issue: it makes the recorder status endpoint and the Live page readiness model metadata-aware without introducing a second sensor lookup mechanism.

### Regression coverage

In `apps/server/tests/use_cases/run/test_capture_readiness_runtime.py`, I added focused runtime coverage for the reboot-style failure mode.

The new test simulates:

- a valid active sensor id,
- a blank runtime `location_code`,
- persisted sensor metadata that still contains `front_left_wheel`,
- and otherwise healthy speed/reference inputs so readiness can succeed if location resolution is correct.

The assertion checks that the final readiness result only warns for limited sensor coverage and still reports the run as ready, rather than failing the sensor-location gate. That exercises the operator-visible behavior that broke in the issue, not just an isolated helper.

## Schema, contract, config, and documentation impact

There are no schema or transport contract changes in this PR. I did not change API payload shapes, WebSocket payload shapes, config files, or stored sensor metadata structure. I also did not need to update documentation, because the issue was not a docs mismatch; capture readiness had simply drifted away from the established metadata projection path used elsewhere in the app.

## Validation performed

Local validation for this change was:

- `pytest -q apps/server/tests/use_cases/run/test_capture_readiness_runtime.py apps/server/tests/use_cases/run/test_capture_readiness_evaluator.py`
- `make typecheck-backend`
- `make test-changed`
- `make lint`

The focused pytest run confirms the readiness behavior directly, including the new persisted-location regression. The broader changed-file test pass and repo lint/type checks confirm the fix did not break adjacent run/use-case behavior or backend typing/formatting rules.

## Risks, tradeoffs, and edge cases

The main tradeoff is that capture readiness is now intentionally coupled to the same persisted sensor presentation layer already used by the API/WS projection code. That is the correct tradeoff here because the bug existed precisely because capture readiness was the one outlier that was not using the shared projection logic.

One edge case worth noting is invalid sensor ids. `resolve_sensor_presentation(...)` already handles those by falling back to the runtime values. That means this PR improves the reboot/persisted-metadata case without changing the existing behavior for malformed or non-normalizable ids.

## Out of scope

This PR does not redesign sensor hydration after reboot, alter how client registry state is populated, or touch the main-page rendering logic itself. For #2264, the smallest complete fix was to remove the inconsistent raw-registry read from capture readiness and make it use the same shared metadata projection as the other live sensor surfaces.

Closes #2264
