### PR TITLE
fix: restore saved updater ssid after reboot

### DIFF
--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -69,6 +69,27 @@ export function createUpdateFeaturePresenter(
 
   let passwordVisible = false;
   let lastActionSummary: UpdateFeatureActionSummary | null = null;
+  let hasHydratedPersistedWifiSettings = false;
+
+  function hydratePersistedWifiSettings(
+    state: UpdateFeatureRenderState,
+  ): void {
+    if (hasHydratedPersistedWifiSettings || state.updateStatus == null) {
+      return;
+    }
+    hasHydratedPersistedWifiSettings = true;
+    if (
+      state.updateStatus.transport !== "wifi" ||
+      !state.updateStatus.ssid ||
+      !internetDom.updateSsidInput
+    ) {
+      return;
+    }
+    if (internetDom.updateSsidInput.value.trim()) {
+      return;
+    }
+    internetDom.updateSsidInput.value = state.updateStatus.ssid;
+  }
 
   function selectedTransport(
     state: UpdateFeatureRenderState,
@@ -343,6 +364,7 @@ export function createUpdateFeaturePresenter(
   }
 
   function render(state: UpdateFeatureRenderState): void {
+    hydratePersistedWifiSettings(state);
     syncTransportUi(state);
     const actionSummary = buildActionSummary(state);
     lastActionSummary = actionSummary;

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -939,6 +939,78 @@ test.describe("createUpdateFeature polling", () => {
     }
   });
 
+  test("persisted Wi-Fi ssid rehydrates the update input after startup", async () => {
+    const restoreFetch = installFetchMock(async (url) => {
+      if (url.pathname === "/api/update/status") {
+        return jsonResponse({
+          ...createIdleUpdateStatus(),
+          ssid: "Workshop Wi-Fi",
+          updated_at: 123,
+          last_success_at: 123,
+        });
+      }
+      if (url.pathname === "/api/health") {
+        return jsonResponse(createHealthyUpdateStatus());
+      }
+      if (url.pathname === "/api/update/internet-status") {
+        return jsonResponse(createUsbInternetStatus());
+      }
+      return jsonResponse({});
+    });
+
+    try {
+      const deps = createUpdateDeps();
+      deps.internetPanel.dom.updateSsidInput.value = "";
+      const feature = createUpdateFeature(deps);
+
+      feature.startPolling();
+      await flushAsyncWork();
+
+      expect(deps.internetPanel.dom.updateSsidInput.value).toBe("Workshop Wi-Fi");
+      expect(deps.updateReadinessSummary.innerHTML).toContain(
+        "settings.update.readiness.summary_ready",
+      );
+      expect(deps.updateStartBtn.disabled).toBe(false);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("persisted Wi-Fi ssid does not overwrite a user edit already in progress", async () => {
+    const restoreFetch = installFetchMock(async (url) => {
+      if (url.pathname === "/api/update/status") {
+        return jsonResponse({
+          ...createIdleUpdateStatus(),
+          ssid: "Workshop Wi-Fi",
+          updated_at: 123,
+          last_success_at: 123,
+        });
+      }
+      if (url.pathname === "/api/health") {
+        return jsonResponse(createHealthyUpdateStatus());
+      }
+      if (url.pathname === "/api/update/internet-status") {
+        return jsonResponse(createUsbInternetStatus());
+      }
+      return jsonResponse({});
+    });
+
+    try {
+      const deps = createUpdateDeps();
+      deps.internetPanel.dom.updateSsidInput.value = "Driver-entered Wi-Fi";
+      const feature = createUpdateFeature(deps);
+
+      feature.startPolling();
+      await flushAsyncWork();
+
+      expect(deps.internetPanel.dom.updateSsidInput.value).toBe(
+        "Driver-entered Wi-Fi",
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
   test("failed update state surfaces the failed stage and issue details", async () => {
     const restoreFetch = installFetchMock(async (url) => {
       if (url.pathname === "/api/update/status") {

--- a/apps/ui/tests/smoke.update.spec.ts
+++ b/apps/ui/tests/smoke.update.spec.ts
@@ -265,6 +265,74 @@ test("settings internet tab and updater show USB internet when usable", async ({
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });
 
+test("settings internet tab restores persisted Wi-Fi SSID after reboot", async ({
+  page,
+}) => {
+  await installCommonRoutes(page);
+  await page.route("**/api/update/status", async (route) => {
+    await fulfillJson(route, {
+      state: "idle",
+      phase: "idle",
+      transport: "wifi",
+      ssid: "Workshop Wi-Fi",
+      uplink_interface: null,
+      started_at: null,
+      phase_started_at: null,
+      phase_elapsed_s: null,
+      finished_at: null,
+      last_success_at: 123,
+      updated_at: 123,
+      issues: [],
+      log_tail: [],
+      exit_code: null,
+      runtime: {
+        version: "1.2.3",
+        commit: "abcdef1234567890",
+        ui_source_hash: "ui-hash",
+        static_assets_hash: "feedfacecafebeef",
+        static_build_source_hash: "build-hash",
+        static_build_commit: "build-commit",
+        assets_verified: true,
+        has_packaged_static: true,
+      },
+    });
+  });
+  await page.route("**/api/health", async (route) => {
+    await fulfillJson(route, {
+      status: "ok",
+      processing_state: "idle",
+      processing_failures: 0,
+      degradation_reasons: [],
+      data_loss: {
+        affected_clients: 0,
+        tracked_clients: 0,
+        frames_dropped: 0,
+        queue_overflow_drops: 0,
+        server_queue_drops: 0,
+        parse_errors: 0,
+      },
+      persistence: {
+        analysis_in_progress: false,
+        analysis_queue_depth: 0,
+        write_error: null,
+        analysis_active_run_id: null,
+        analysis_started_at: null,
+        analysis_elapsed_s: null,
+      },
+    });
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="internetTab"]').click();
+  await expect(page.locator("#updateSsidInput")).toHaveValue("Workshop Wi-Fi");
+  await expect(page.locator("#updateReadinessSummary")).toContainText(
+    "All visible prerequisites are ready to start the update.",
+  );
+  await page.locator('[data-settings-tab="updateTab"]').click();
+  await expect(page.locator("#updateStartBtn")).toBeEnabled();
+});
+
 test("settings update failure shows retry guidance, failed-stage retention, and latest attempt context", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

This PR fixes #2266 by restoring the saved updater Wi-Fi SSID into the Internet panel after reboot. The important part of the bug is that the backend was already persisting the updater status, including the last Wi-Fi `ssid`, across restarts. The problem was on the frontend side: once the app booted again, the update presenter never copied that persisted `ssid` back into the `updateSsidInput`, so the page looked blank and behaved as though the Wi-Fi settings had been lost.

The fix is intentionally UI-scoped. I did not add a new persistence layer, did not change how updater state is written on disk, and did not start storing the Wi-Fi password. Instead, the presenter now hydrates the saved SSID from the existing persisted update status the first time a real status snapshot is rendered. That gets the reboot experience back in sync with the state that was already surviving on the backend.

## Problem being solved

Issue #2266 was reported as “wifi settings not saved after reboot.” Tracing the updater flow showed that this was not a backend write failure.

The existing behavior was:

1. `UpdateStatusSession` persists `UpdateJobStatus`, including `transport` and `ssid`.
2. `UpdateManager` reloads that persisted status on startup.
3. `/api/update/status` returns the restored `ssid` after reboot.
4. The update presenter uses the status payload for cards and summaries, but not for the editable SSID input field.

That last step is the real bug. After reboot, the backend still knew the saved network name, but the Internet panel left the input blank because it only reflected live DOM state, not the restored status payload. From the operator’s point of view, the saved Wi-Fi choice appeared to be gone even though the updater state file still had it.

I also confirmed that password persistence is intentionally out of scope. The updater tests already assert that the Wi-Fi password must not be written into the persisted status file. So the right fix for this issue is to restore the saved SSID only, while continuing to leave the password blank.

## Implementation approach

I kept the implementation in `update_feature_presenter.ts` because that is the boundary where persisted updater status becomes visible form state.

The approach is:

- hydrate from `state.updateStatus.ssid`, not from a new API,
- do it once on the first real status render,
- only hydrate when the saved transport is Wi-Fi and the SSID field is still blank,
- never overwrite a user edit already in progress.

That last rule matters because the update feature polls continuously. A naive implementation that wrote `state.updateStatus.ssid` into the input on every render would make the form fight the operator while they typed. The fix avoids that by restoring the saved value only once and only when the field is empty.

## Main code changes by area

### Update presenter

In `apps/ui/src/app/views/update_feature_presenter.ts`, I added a small `hydratePersistedWifiSettings()` helper and a `hasHydratedPersistedWifiSettings` guard.

On the first render that includes a real `updateStatus` payload, the presenter now:

- exits immediately if hydration already happened,
- exits when the persisted transport is not Wi-Fi,
- exits when there is no saved `ssid`,
- exits when the input already contains user-entered text,
- otherwise copies the saved `ssid` into `updateSsidInput`.

The helper is called at the start of `render()` so the rest of the existing presenter flow can keep working unchanged. That means the already-existing readiness summary and Start Update button logic immediately benefit from the restored input value without any separate branching.

### Focused local regression coverage

In `apps/ui/tests/esp_flash_feature.spec.ts`, I added two focused update-feature tests:

1. a startup case that begins with an empty SSID field and a persisted updater status containing `"Workshop Wi-Fi"`, then confirms the field is restored, the readiness summary moves to ready, and Start Update is enabled;
2. a protection case that begins with a user-entered value already in the field and confirms the persisted SSID does not overwrite that draft.

These tests run in the existing fake-DOM/fetch harness, so they cover the actual feature wiring deterministically without needing a browser server.

### Browser smoke coverage

In `apps/ui/tests/smoke.update.spec.ts`, I added a page-level regression that boots the Settings Internet tab with an idle persisted Wi-Fi SSID and verifies the restored input plus the now-enabled update path. This is the closest reproduction of the reported reboot symptom from the operator’s point of view.

## Schema, contract, config, and documentation impact

There are no API or schema changes in this PR. I did not add endpoints, did not change `/api/update/status`, and did not change the persisted updater payload shape. The backend was already persisting and returning the relevant `ssid`.

There are also no config or documentation changes. The issue was not missing documentation; it was a frontend restore gap against already-persisted backend state.

## Validation performed

Local validation for this change was:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/esp_flash_feature.spec.ts -g "persisted Wi-Fi ssid"`
- `make lint`

Those checks passed.

I also added a browser smoke regression in `tests/smoke.update.spec.ts`, but a direct local run of that smoke file was not trustworthy in this shared environment because Playwright reused an unrelated existing server already bound to `127.0.0.1:4173`, which served a completely different application. I did not treat that as app signal. The new smoke case is still valuable and will run in CI’s clean environment.

## Risks, tradeoffs, and edge cases

The main tradeoff is that the presenter now owns a little bit of one-time hydration state. I think that is the right place for it because this is fundamentally UI restore behavior, not a transport or persistence concern.

I deliberately kept the scope narrow:

- restore only the SSID, not the password,
- reuse the existing persisted status instead of inventing a second save path,
- and avoid any repeated polling-time overwrite of the live field.

One edge case I explicitly covered is the user who already started typing before the first persisted status render completes. In that case, the presenter now preserves the draft instead of snapping the field back to the older saved SSID.

## Out of scope

This PR does not persist Wi-Fi passwords, redesign the updater settings model, or add a dedicated “save internet settings” API. It also does not change the updater backend persistence format. For #2266, the smallest complete fix was to make the Internet panel restore the already-persisted SSID that survived reboot and present it back to the operator correctly.

Closes #2266
