### PR TITLE
Fix stale history after analysis completes

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -79,6 +79,17 @@ const LOGGING_STATUS_IDLE_POLL_MS = 2_000;
 const LOGGING_STATUS_ACTIVE_POLL_MS = 2_000;
 const LOGGING_STATUS_ERROR_POLL_MS = 5_000;
 
+function didHistoryAffectingStatusChange(
+  previous: LoggingStatusPayload,
+  next: LoggingStatusPayload,
+): boolean {
+  return previous.enabled !== next.enabled
+    || previous.run_id !== next.run_id
+    || previous.analysis_in_progress !== next.analysis_in_progress
+    || previous.last_completed_run_id !== next.last_completed_run_id
+    || previous.last_completed_run_error !== next.last_completed_run_error;
+}
+
 export function createRealtimeFeatureWorkflow(
   deps: RealtimeFeatureWorkflowDeps,
 ): RealtimeFeatureWorkflow {
@@ -186,12 +197,25 @@ export function createRealtimeFeatureWorkflow(
       renderLoggingStatus();
       return;
     }
+    const previousStatus = realtime.loggingStatus;
+    let nextStatus: LoggingStatusPayload;
     try {
-      realtime.loggingStatus = await api.getLoggingStatus();
-      renderLoggingStatus();
+      nextStatus = await api.getLoggingStatus();
     } catch {
       pendingLoggingAction = null;
       view.renderLoggingUnavailable();
+      return;
+    }
+    realtime.loggingStatus = nextStatus;
+    renderLoggingStatus();
+    if (!didHistoryAffectingStatusChange(previousStatus, nextStatus)) {
+      return;
+    }
+    try {
+      await recording.onRecordingStatusChanged();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t("status.unavailable");
+      showError(message || t("status.unavailable"));
     }
   }
 

--- a/apps/ui/tests/realtime_feature_workflow.spec.ts
+++ b/apps/ui/tests/realtime_feature_workflow.spec.ts
@@ -193,6 +193,57 @@ test.describe("createRealtimeFeatureWorkflow", () => {
     ]);
   });
 
+  test("refreshes history once when polling observes analysis completion", async () => {
+    const harness = createHarness();
+    harness.state.realtime.loggingStatus = {
+      ...harness.state.realtime.loggingStatus,
+      analysis_in_progress: true,
+      last_completed_run_id: null,
+    };
+    const completedStatus: LoggingStatusPayload = {
+      ...harness.state.realtime.loggingStatus,
+      analysis_in_progress: false,
+      last_completed_run_id: "run-42",
+    };
+    const responses = [completedStatus, completedStatus];
+    const workflow = createRealtimeFeatureWorkflow({
+      realtime: harness.state.realtime,
+      t: (key) => key,
+      showError: (message) => {
+        harness.viewCalls.push(`showError:${message}`);
+      },
+      isDemoMode: false,
+      view: createViewPorts(harness),
+      selection: {
+        sendSelection() {
+          harness.selectionCalls.push("sendSelection");
+        },
+      },
+      recording: {
+        async onRecordingStatusChanged() {
+          harness.recordingCalls.push("onRecordingStatusChanged");
+        },
+      },
+      confirmRemoveClient: () => true,
+      api: {
+        async getLoggingStatus(): Promise<LoggingStatusPayload> {
+          const next = responses.shift();
+          if (!next) {
+            throw new Error("unexpected extra status request");
+          }
+          return next;
+        },
+      },
+    });
+
+    await workflow.refreshLoggingStatus();
+    await workflow.refreshLoggingStatus();
+
+    expect(harness.state.realtime.loggingStatus).toEqual(completedStatus);
+    expect(harness.recordingCalls).toEqual(["onRecordingStatusChanged"]);
+    expect(harness.viewCalls).toEqual(["renderLoggingStatus", "renderLoggingStatus"]);
+  });
+
   test("removes the selected client and emits a new selection without DOM fixtures", async () => {
     const harness = createHarness();
     harness.state.realtime.clients = [


### PR DESCRIPTION
## Summary

This PR fixes the stale history state reported in #2269. After a recording stopped, the UI correctly refreshed once and showed the new run as `analyzing`, but it stopped there. When the backend finished post-run analysis later, the realtime logging-status poll updated the logging state in memory without refreshing the history feature, so the history row and any expanded detail kept rendering the older `analyzing` snapshot until the user hard-refreshed the page. This change teaches the existing realtime workflow to trigger the existing history refresh seam when the polled recording status crosses lifecycle boundaries that materially change what history should show.

## Problem

The repo already had the right pieces, but they were only wired together for the beginning of the lifecycle. Startup refreshes history once through `UiStartupCoordinator`, and explicit start/stop actions refresh history through `recording.onRecordingStatusChanged()` in `createRealtimeFeatureWorkflow`. That covers the moment a run is created or stopped, but not the later async step where server-side analysis finishes. After stop, the UI enters an `analysis_in_progress` polling loop, and `refreshLoggingStatus()` keeps updating `realtime.loggingStatus`. The missing piece was that history never heard about that state transition, so `history.runs` remained stale and the row badge stayed on the previous `analyzing` state.

## Implementation approach

I kept the fix inside the existing realtime-to-history seam instead of adding a new history polling path. There is already a narrow runtime contract for “recording status changed, refresh history,” and reusing it keeps the ownership model intact: realtime owns the polling loop, history owns history loading/rendering, and the bridge stays in one place. The change therefore focuses on detecting when a polled logging-status response actually changes something history cares about, then calling the existing refresh callback exactly once for that transition. That solves the bug without introducing duplicate polling controllers or making history depend directly on realtime API polling.

## Main code changes

The main logic change is in `apps/ui/src/app/features/realtime_feature_workflow.ts`. I added a small helper, `didHistoryAffectingStatusChange()`, that compares the previous and next `LoggingStatusPayload` across the lifecycle fields that matter for history refresh decisions: `enabled`, `run_id`, `analysis_in_progress`, `last_completed_run_id`, and `last_completed_run_error`. Those are the values that tell the UI whether a run has started, stopped, finished analysis, or failed analysis. `refreshLoggingStatus()` now captures the previous status, fetches the next one, updates the realtime state, renders the logging UI immediately, and then triggers `recording.onRecordingStatusChanged()` only when one of those history-affecting fields actually changed.

That “render first, refresh second” ordering is intentional. The realtime status area should stay responsive as soon as the server responds, even if the subsequent history refresh takes additional time. I also kept the refresh targeted to transitions rather than every poll tick. That matters because the logging-status poll continues while analysis is active, and refreshing history on every 2-second poll would create unnecessary API traffic, repeated renders, and more opportunities for the UI to churn without any visible change. With the transition check in place, the history refresh runs when the state crosses a meaningful boundary, then stays quiet once the completed status stabilizes.

I also kept the existing error propagation behavior of the history refresh seam, but in the polling path the workflow now surfaces a refresh error through `showError` instead of misclassifying the whole logging-status fetch as unavailable. That preserves the distinction between “the logging endpoint failed” and “the follow-on history refresh failed after the logging endpoint succeeded,” which is more accurate operationally and avoids hiding the freshly updated logging state.

## Tests and regression coverage

I added focused regression coverage in `apps/ui/tests/realtime_feature_workflow.spec.ts`. The new test seeds the realtime state to represent the problematic moment: analysis is in progress and there is no completed run ID yet. The mocked `getLoggingStatus()` call then returns a completed status with `analysis_in_progress: false` and a new `last_completed_run_id`. The test calls `refreshLoggingStatus()` twice and asserts that the history refresh seam is triggered once on the transition and not retriggered on the second identical polling response. That covers both halves of the behavior we need: the history page updates when analysis finishes, and the fix does not degrade into a perpetual refresh loop after the state becomes stable.

The existing workflow tests for start/stop behavior, location refresh fallback, and selection changes remain untouched, which helps show that the fix is additive and localized rather than a broader rewrite of the realtime feature.

## Contracts, docs, and scope

There are no API contract, schema, config, or documentation changes in this PR. The server already exposes the status fields needed for the UI to detect analysis completion, and the existing history refresh pipeline already knew how to reload the list and prefetch preview data for newly completed runs. This issue was purely a frontend wiring gap, so the change stays in `apps/ui` and keeps the public contracts intact.

I also kept the scope deliberately narrow. I did not add a new background history poller, change history row presentation, or touch the PDF/history layout issues that are already tracked separately (#2270 and #2271). The goal here is specifically to make the existing history page stop requiring a hard refresh once analysis is done.

## Validation

I validated the change with the relevant frontend checks for this area:

- `cd apps/ui && npx playwright test tests/realtime_feature_workflow.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Those checks cover the new regression test, TypeScript safety, generated contract consistency, and production build behavior for the UI bundle.

## Risks, tradeoffs, and edge cases

The main tradeoff is how broad the transition detector should be. I chose a slightly broader set of lifecycle fields instead of only the exact `analysis_in_progress -> false` transition from the issue report. That means the history refresh also runs for other externally visible run lifecycle changes such as a new `run_id`, a changed completion ID, or a changed completion error. I think that is the safer long-term behavior because the underlying bug is really “history is not notified when polled recording lifecycle changes affect what history should display,” not just one specific boolean transition. At the same time, the helper is still narrow enough to avoid turning every poll into a history reload.

The key edge case covered by the new test is repeated stable polling after completion. Once the completed status is already reflected locally, the next identical poll should not re-refresh history. That is the behavior implemented here.

There are no known follow-ups required for this fix beyond watching CI and confirming the issue auto-closes on merge.

Fixes #2269
