### PR TITLE
Show PDF button when analysis is complete

### DIFF
--- a/apps/ui/src/app/views/history_table_presenters.ts
+++ b/apps/ui/src/app/views/history_table_presenters.ts
@@ -322,7 +322,7 @@ function buildCollapsedAction(
   detail: RunDetail,
   t: PresenterParams["t"],
 ): HistoryCollapsedActionViewModel {
-  const reportReady = run.status === "complete" && (detail.insights !== null || detail.preview !== null);
+  const reportReady = run.status === "complete";
   if (!reportReady) {
     return {
       hintText: t("history.quick_report_pending"),

--- a/apps/ui/tests/history_table_presenters.spec.ts
+++ b/apps/ui/tests/history_table_presenters.spec.ts
@@ -172,9 +172,9 @@ test("history table presenter keeps loading and error state outside the renderer
   expect(row.summaryHeadline).toBe("history.row_summary_loading");
   expect(row.summaryMeta).toBe("history.summary_size: 12.0 s");
   expect(row.collapsedAction).toEqual({
-    hintText: "history.quick_report_pending",
-    pdfLabel: null,
-    pdfLoading: false,
+    hintText: null,
+    pdfLabel: "history.generating_pdf",
+    pdfLoading: true,
   });
   expect(row.details?.insights.stateMessage).toBe("history.loading_insights");
   expect(row.details?.heatmap).toMatchObject({
@@ -182,4 +182,32 @@ test("history table presenter keeps loading and error state outside the renderer
     stateTone: "subtle",
   });
   expect(row.details?.insightsError).toBe("history.error.insights");
+});
+
+test("history table presenter keeps PDF pending until analysis completes", () => {
+  const run = {
+    ...historyListRun("run-003"),
+    status: "analyzing" as const,
+  };
+  const rows = buildHistoryTableRowsViewModel({
+    runs: [run],
+    expandedRunId: null,
+    runDetailsById: {
+      "run-003": defaultDetail({
+        preview: populatedInsights("run-003") as RunDetail["preview"],
+      }),
+    },
+    t: testTranslation,
+    fmt: (value, digits = 0) => Number(value).toFixed(digits),
+    fmtTs: (iso) => iso,
+    formatInt: (value) => String(value),
+  });
+
+  const row = rows[0];
+  expect(row.summaryChips.map((chip) => chip.text)).toContain("history.row_status.preview_ready");
+  expect(row.collapsedAction).toEqual({
+    hintText: "history.quick_report_pending",
+    pdfLabel: null,
+    pdfLoading: false,
+  });
 });

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -201,7 +201,8 @@ test("history keeps destructive actions inside the expanded management footer", 
   await page.locator("#tab-history").click();
   const row = page.locator('[data-run-row="1"][data-run="run-001"]');
   const actionCell = row.locator("td").nth(3);
-  await expect(actionCell).toContainText("PDF after preview.");
+  await expect(actionCell.locator('[data-run-action="download-pdf"][data-run="run-001"]')).toContainText("PDF");
+  await expect(actionCell).not.toContainText("PDF after preview.");
   await expect(actionCell).not.toContainText("Export");
   await expect(actionCell).not.toContainText("Delete");
   await row.locator('[data-run-toggle="details"]').click();


### PR DESCRIPTION
## Summary

This PR fixes the history-row action bug reported in #2270. The UI already knew when a run had reached the `complete` state, but the collapsed action area still kept the `PDF after preview.` placeholder until preview or insights data had been fetched into the local row detail cache. That made the action area lag behind the real server capability: once a run is complete, the backend report endpoint is already ready, so the user should see the PDF download button immediately instead of waiting for the separate preview-loading path to finish.

## Problem

The bug sits in the presenter layer rather than in the download path itself. `downloadReportPdfForRun()` already requests the server-side PDF endpoint directly, and the backend contract already decides whether the request is allowed. Existing E2E coverage in `apps/server/tests_e2e/test_e2e_docker_history_status.py` shows that the PDF endpoint is unavailable while analysis is still in progress and becomes valid once the run reaches a completed state. The frontend, however, was not mirroring that same readiness rule. In `buildCollapsedAction()`, the PDF button was only exposed when `run.status === "complete"` *and* `detail.insights` or `detail.preview` had already been loaded locally.

That second condition is what caused the stale placeholder. The row could already be complete from the history list response, which means the report endpoint is legitimately ready, but the UI would still render `history.quick_report_pending` because preview loading was asynchronous and separate from the core run status. In practice, that meant the action area could briefly or persistently tell the user “PDF after preview” even though analysis was already done and the report export should have been immediately available.

## Implementation approach

I kept the fix limited to the presenter and its regression tests. The core principle is simple: the button should follow the same readiness boundary as the backend report endpoint. If the run is still analyzing, keep the placeholder. If the run is complete, show the PDF button even if preview content is still loading or has not yet been fetched. That makes the UI match the server contract and removes an unnecessary dependency between two independent concerns: export availability and preview hydration.

I did not change the download path, the history refresh flow, or the backend route logic. The presenter was the right place to fix this because the bug was purely about how the action area interpreted already-available state. Keeping the change there also avoids introducing any new polling, loading flags, or transport logic.

## Main code changes

The runtime change is in `apps/ui/src/app/views/history_table_presenters.ts`. `buildCollapsedAction()` previously treated the PDF action as ready only when both of these were true:

1. the run status was `complete`, and
2. the row had already loaded `detail.preview` or `detail.insights`

That made the action area depend on cached preview state even though the actual PDF download endpoint only depends on the run being complete. The fix removes the preview/insights requirement and uses `run.status === "complete"` as the readiness gate. The button label and loading state continue to come from `detail.pdfLoading`, so the UX still reflects an in-flight PDF export correctly.

This keeps the intended “not ready yet” behavior for analyzing runs. If a run is still marked `analyzing`, the presenter continues to render the `history.quick_report_pending` hint instead of exposing a button that would only lead to a server-side 422. In other words, the action boundary is now aligned with the same state transition the server already enforces: analyzing => placeholder, complete => PDF button.

## Tests and regression coverage

I updated `apps/ui/tests/history_table_presenters.spec.ts` to capture both sides of that contract.

First, I changed the existing completed-run loading/error test so it now expects the collapsed action to expose the PDF button for a `complete` run even while preview data is still loading. This is the direct regression for the user-reported bug. The row still shows diagnosis-loading state elsewhere, but the export control is no longer held back by preview hydration.

Second, I added a new focused test for the opposite case: a run that is still `analyzing` but already has preview data loaded. That test verifies the summary chip can say `Preview ready` while the collapsed action still keeps the `history.quick_report_pending` hint instead of exposing the button too early. This is important because it preserves the backend contract proven by the existing E2E test matrix: preview availability alone does not mean the PDF route is ready; completion does.

After opening the PR, the CI `UI smoke tests` job surfaced one more place that still encoded the old behavior: `apps/ui/tests/smoke.history.spec.ts` expected the collapsed action cell to contain the `PDF after preview.` placeholder for a completed run. I updated that smoke assertion to expect the actual completed-run PDF button instead, while keeping the existing checks that `Export` and `Delete` stay inside the expanded footer. That follow-up keeps the smoke suite aligned with the same presenter contract as the focused unit/spec coverage.

Together, those tests pin the intended rule cleanly:

- complete run => PDF button available
- analyzing run => placeholder remains, even if preview content exists

That gives the UI a stable boundary and prevents the presenter from drifting back toward the old “wait for preview” behavior.

## Contracts, docs, and scope

There are no API, schema, contract-generation, config, or documentation changes in this PR. The backend already had the correct readiness behavior, and the frontend already had the right data shape. The bug was a mismatch between the run-status contract and the presenter logic that turned that contract into UI actions.

I also kept the scope intentionally narrow. I did not change the row summary chips, the detailed diagnosis panel, the preview-loading messages, or the actual download implementation in `history_download_delete_module.ts`. The only behavior change is when the collapsed action switches from the placeholder text to the PDF button.

## Validation

I validated the change with the focused presenter regression test plus the standard frontend checks for this area:

- `cd apps/ui && npx playwright test tests/history_table_presenters.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Those checks confirm the new readiness rule at the unit/spec level, preserve TypeScript correctness, and ensure the updated UI code still builds cleanly against the generated contracts.

## Risks, tradeoffs, and edge cases

The main tradeoff is that the PDF button can now appear slightly earlier in the client lifecycle than before: as soon as the history list says the run is complete, even if preview content has not yet rendered locally. That is intentional and desirable because the PDF export is server-backed and does not actually depend on the preview cache.

The important edge case is the opposite direction: a run with preview-ready UI state but still `analyzing` should not expose the button yet. The new regression test covers that explicitly, and the presenter continues to keep the placeholder in that state.

There are no known follow-ups from this change. It is a narrow alignment fix between existing backend readiness and existing frontend action gating.

Fixes #2270
