### PR TITLE
Prevent page-1 PDF header metadata overlap

### DIFF
--- a/apps/server/tests/adapters/pdf/test_page1_header.py
+++ b/apps/server/tests/adapters/pdf/test_page1_header.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from reportlab.lib.units import mm
+from reportlab.pdfgen.canvas import Canvas
+
+from vibesensor.adapters.pdf.page1_header import draw_header_strip
+from vibesensor.adapters.pdf.report_types import Page1RenderPlan
+from vibesensor.shared.boundaries.reporting.document import VerdictPageData
+
+
+def test_draw_header_strip_truncates_long_car_name_to_single_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_draw_text(
+        c: Canvas,
+        x: float,
+        y_top: float,
+        w: float,
+        text: str,
+        *,
+        font: str,
+        size: float,
+        color: str,
+        leading: float,
+        max_lines: int | None = None,
+    ) -> float:
+        calls.append(
+            {
+                "text": text,
+                "max_lines": max_lines,
+            }
+        )
+        return y_top - leading
+
+    monkeypatch.setattr("vibesensor.adapters.pdf.page1_header._draw_text", fake_draw_text)
+
+    plan = Page1RenderPlan(
+        title="VibeSensor Diagnostic Report",
+        lang="en",
+        run_datetime="2026-01-01 10:00 UTC",
+        duration_text="12.3 s",
+        car_name="A very long car name that would otherwise wrap into the next metadata row",
+        car_type="Track Edition",
+        sensor_count=4,
+        sensor_locations=(),
+        sensor_intensity_by_location=(),
+        location_hotspot_rows=(),
+        verdict_page=VerdictPageData(speed_window_label="60-90 km/h"),
+        next_steps=(),
+        findings=(),
+        top_causes=(),
+    )
+    canvas = Canvas(BytesIO())
+
+    draw_header_strip(
+        canvas,
+        plan,
+        tr=lambda key, **_: key,
+        x=10 * mm,
+        y=10 * mm,
+        w=180 * mm,
+        h=24 * mm,
+    )
+
+    drawn_texts = [str(call["text"]) for call in calls]
+    assert "12.3 s" in drawn_texts
+    assert "60-90 km/h" in drawn_texts
+    assert any(text.endswith("...") for text in drawn_texts)
+    assert all(call["max_lines"] == 1 for call in calls)

--- a/apps/server/vibesensor/adapters/pdf/page1_header.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_header.py
@@ -20,7 +20,7 @@ from vibesensor.adapters.pdf.pdf_style import (
     SUB_CLR,
     TEXT_CLR,
 )
-from vibesensor.adapters.pdf.pdf_text import _draw_text, _measure_text_height
+from vibesensor.adapters.pdf.pdf_text import _draw_text, _measure_text_height, _truncate_single_line
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf.report_types import Page1RenderPlan
@@ -64,6 +64,7 @@ def draw_header_strip(
         col = index % 3
         col_x = inner_x + (col * (col_w + col_gap))
         row_y = top_y - (row * 8.2 * mm)
+        value_text = _truncate_single_line(str(value), col_w, FS_BODY)
         c.setFillColor(_hex(SUB_CLR))
         c.setFont(FONT, FS_SMALL)
         c.drawString(col_x, row_y, label)
@@ -74,12 +75,12 @@ def draw_header_strip(
             col_x,
             row_y - 4.0 * mm,
             col_w,
-            str(value),
+            value_text,
             font=FONT_B,
             size=FS_BODY,
             color=TEXT_CLR,
             leading=FS_BODY + 1.0,
-            max_lines=2,
+            max_lines=1,
         )
 
 

--- a/apps/server/vibesensor/adapters/pdf/pdf_text.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_text.py
@@ -29,6 +29,17 @@ def _wrap_lines(text: str, width_pt: float, font_size: float) -> list[str]:
     return lines
 
 
+def _truncate_single_line(text: str, width_pt: float, font_size: float) -> str:
+    """Return *text* truncated to one wrapped line, adding ``...`` when needed."""
+    lines = _wrap_lines(text, width_pt, font_size)
+    if len(lines) <= 1:
+        return text
+    first_line = lines[0].rstrip()
+    if len(first_line) <= 3:
+        return "..."
+    return f"{first_line[:-3].rstrip()}..."
+
+
 def _measure_text_height(
     text: str,
     *,


### PR DESCRIPTION
## Summary

This PR fixes issue #2271, where a long car name in the PDF header could wrap into the row below and visually overlap the duration and speed-band metadata. The problem lives in the first-page header strip, which uses a compact fixed-height, two-row grid for report metadata. That grid works well for typical values, but the car label column could receive a much longer combined string than the neighboring fields because it joins `car_name` and `car_type`. Once that combined value wrapped to a second line, the second line was drawn low enough to collide with the next metadata row. The issue report explicitly asked for a fix that guarantees non-overlap and prefers ellipsis or smaller font over letting the boxes collide. I chose deterministic single-line truncation with `...`, which keeps the layout stable and readable without introducing variable font sizes into an already dense header.

## Implementation approach

The key design decision here was to fix the root cause in the header metadata renderer instead of trying to special-case only one reported string shape. The real problem was not just “one specific car name is too long”; it was that the header strip allowed wrapped values inside a layout that only has vertical room for one line per metadata slot. As long as that mismatch remained, the same overlap class could happen again with other long values, including unusually verbose speed-band labels or localized text. Rather than add a one-off car-name check, this change standardizes the entire page-one metadata strip on a single-line contract. If a value fits, it is rendered unchanged. If it would wrap, it is truncated to one fitted line with `...`. That makes the layout behavior predictable and eliminates the overlap vector entirely for the metadata strip.

## Main code changes

In `apps/server/vibesensor/adapters/pdf/pdf_text.py`, I added a small shared helper named `_truncate_single_line`. It reuses the existing `_wrap_lines()` approximation that the PDF renderer already uses for layout decisions, so truncation is based on the same width heuristic as the rest of the text system. When the text already fits within one wrapped line, the helper returns it unchanged. When it would spill to a second line, the helper shortens the first wrapped line and replaces the tail with `...`. This keeps the output width aligned with the same estimate used during wrapping instead of introducing a second measurement model.

In `apps/server/vibesensor/adapters/pdf/page1_header.py`, the page-one metadata strip now applies `_truncate_single_line()` to each rendered value before drawing it. The header renderer also now draws those metadata values with `max_lines=1` instead of `max_lines=2`. That is the layout guarantee that actually fixes the overlap. Previously, the renderer allowed up to two lines even though the strip’s row spacing only safely accommodates one. Now the metadata contract and the geometry agree: the strip is a one-line-per-slot layout, and long values are shortened to honor that constraint. I intentionally applied this to the full metadata strip rather than just the car field, so the fix protects the row structure as a whole instead of leaving similar edge cases behind in adjacent cells.

I also added focused regression coverage in `apps/server/tests/adapters/pdf/test_page1_header.py`. The new test constructs a minimal `Page1RenderPlan` with a deliberately long car name, monkeypatches the header module’s text drawing seam, and asserts that the header renderer emits single-line metadata values and ellipsizes the long one instead of drawing a wrapped second line. The test also checks that neighboring metadata like duration and speed band are still rendered as distinct values, which guards the bug the issue describes: preserving the other cells while preventing the car label from spilling into them.

## Validation

I validated the fix at three levels. First, I ran a focused regression test on the new seam with `pytest -q apps/server/tests/adapters/pdf/test_page1_header.py` to confirm the long-header behavior directly. Second, I ran the broader PDF adapter test suite with `pytest -q apps/server/tests/adapters/pdf` to make sure this change did not destabilize other report rendering behavior or nearby layout assumptions. That suite remained fully green. Third, I ran `make typecheck-backend` so the shared helper addition and the updated header renderer stayed consistent with the backend’s typing constraints. No schema, API, or contract updates were needed because this is a renderer-only layout correction with no payload or persistence impact.

## Risks, tradeoffs, and edge cases

The main tradeoff is that very long header values now sacrifice completeness in the top metadata strip in exchange for preserving layout integrity. I think that trade is correct for this surface. The header strip is meant to be a compact summary, not the only place where all contextual data appears. The alternative of dynamically shrinking font sizes would make the layout more variable, could reduce readability for already-dense report headers, and would still need guardrails for pathological input lengths. Ellipsis is deterministic, easy to reason about, and was explicitly called out as an acceptable outcome in the issue itself.

Another deliberate tradeoff is that the fix applies to every value in the page-one metadata strip, not only the car label. That slightly broadens the change, but in a safe direction: the same fixed-row geometry now has one consistent rendering rule. This avoids solving the currently reported string and leaving identical overlap behavior available through a different field later. The helper also handles narrow-width worst cases by collapsing extremely short available lines to `...`, which is preferable to drawing broken or overlapping text.

## Out of scope

This PR does not redesign the header strip, change report typography globally, or introduce adaptive font scaling across the PDF renderer. It also does not alter any report content, translations, or the underlying report document model. The issue was specifically about preventing overlap in the existing metadata header, and this change keeps the solution scoped to that renderer contract while making the no-overlap behavior explicit and test-covered.

Closes #2271
