### PR TITLE
Fix dark-mode status card surfaces

### DIFF
--- a/apps/ui/src/styles/history.css
+++ b/apps/ui/src/styles/history.css
@@ -545,12 +545,12 @@
   background: var(--surface);
 }
 .history-diagnosis-card--success {
-  border-color: #a4d2b0;
-  background: #f5fbf7;
+  border-color: var(--history-diagnosis-success-border);
+  background: var(--history-diagnosis-success-surface);
 }
 .history-diagnosis-card--warn {
-  border-color: #e3c47a;
-  background: #fff8e7;
+  border-color: var(--history-diagnosis-warn-border);
+  background: var(--history-diagnosis-warn-surface);
 }
 .history-diagnosis-card__header {
   display: flex;

--- a/apps/ui/src/styles/realtime.css
+++ b/apps/ui/src/styles/realtime.css
@@ -357,16 +357,16 @@
   padding: var(--space-2) var(--space-3);
 }
 .capture-readiness__item[data-readiness-state="pass"] {
-  border-color: #c9ead7;
-  background: #f4fbf7;
+  border-color: var(--capture-readiness-pass-border);
+  background: var(--capture-readiness-pass-surface);
 }
 .capture-readiness__item[data-readiness-state="warn"] {
-  border-color: #ead9b3;
-  background: #fff9ee;
+  border-color: var(--capture-readiness-warn-border);
+  background: var(--capture-readiness-warn-surface);
 }
 .capture-readiness__item[data-readiness-state="fail"] {
-  border-color: #efc1c1;
-  background: #fff5f5;
+  border-color: var(--capture-readiness-fail-border);
+  background: var(--capture-readiness-fail-surface);
 }
 .capture-readiness__row {
   display: flex;

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -36,6 +36,16 @@
     --pill-ok-text: #4ade80;
     --pill-bad-bg: rgba(248, 113, 113, 0.14);
     --pill-bad-text: #f87171;
+    --capture-readiness-pass-surface: rgba(74, 222, 128, 0.14);
+    --capture-readiness-pass-border: rgba(74, 222, 128, 0.3);
+    --capture-readiness-warn-surface: rgba(251, 191, 36, 0.14);
+    --capture-readiness-warn-border: rgba(251, 191, 36, 0.34);
+    --capture-readiness-fail-surface: rgba(248, 113, 113, 0.14);
+    --capture-readiness-fail-border: rgba(248, 113, 113, 0.3);
+    --history-diagnosis-success-surface: rgba(74, 222, 128, 0.14);
+    --history-diagnosis-success-border: rgba(74, 222, 128, 0.3);
+    --history-diagnosis-warn-surface: rgba(251, 191, 36, 0.14);
+    --history-diagnosis-warn-border: rgba(251, 191, 36, 0.34);
     --row-even: #161923;
     --row-hover: rgba(139, 92, 246, 0.08);
     --chart-grid: #2a2d38;

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -48,6 +48,16 @@
   --pill-ok-text: #0b6a3d;
   --pill-bad-bg: #fae3e3;
   --pill-bad-text: #8c2b2b;
+  --capture-readiness-pass-surface: #f4fbf7;
+  --capture-readiness-pass-border: #c9ead7;
+  --capture-readiness-warn-surface: #fff9ee;
+  --capture-readiness-warn-border: #ead9b3;
+  --capture-readiness-fail-surface: #fff5f5;
+  --capture-readiness-fail-border: #efc1c1;
+  --history-diagnosis-success-surface: #f5fbf7;
+  --history-diagnosis-success-border: #a4d2b0;
+  --history-diagnosis-warn-surface: #fff8e7;
+  --history-diagnosis-warn-border: #e3c47a;
   --row-even: #fafafc;
   --row-hover: #f3f0fe;
   --chart-grid: #dcdfe6;
@@ -77,4 +87,3 @@ body {
   color: var(--text);
   font-size: 15px;
 }
-

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -5,6 +5,7 @@ import {
   fulfillJson,
   installCommonRoutes,
   installFakeWebSocket,
+  readSemanticSurfaceStyles,
   requestPath,
 } from "./smoke.helpers";
 
@@ -20,6 +21,126 @@ function parseElapsedSeconds(value: string): number {
   const [minutes, seconds] = value.trim().split(":").map((part) => Number(part));
   return (minutes * 60) + seconds;
 }
+
+test("dark mode readiness cards use semantic theme surfaces", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  let captureReadiness = buildCaptureReadiness({
+    isReady: true,
+    sensors: { state: "pass", reasonKey: "sensors_ready", details: { live_sensor_count: 1 } },
+    reference: { state: "pass", reasonKey: "reference_ready" },
+    speed: { state: "pass", reasonKey: "speed_stable", details: { dwell_elapsed_s: 8 } },
+  });
+  await installCommonRoutes(page, {
+    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
+    settingsHandler: async (route) => {
+      if (requestPath(route) === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [
+            {
+              id: "car-1",
+              name: "Test Hatch",
+              type: "Simulated setup",
+              variant: null,
+              aspects: {},
+            },
+          ],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/recording/status", async (route) => {
+    await fulfillJson(route, {
+      enabled: false,
+      run_id: null,
+      write_error: null,
+      analysis_in_progress: false,
+      start_time_utc: null,
+      samples_written: 0,
+      samples_dropped: 0,
+      last_completed_run_id: null,
+      last_completed_run_error: null,
+      capture_readiness: captureReadiness,
+    });
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      clients: [
+        {
+          id: "001122334455",
+          name: "Front Left",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_left_wheel",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: {
+        clients: {
+          "001122334455": {
+            freq: [1, 2, 3],
+            combined_spectrum_amp_g: [0.1, 0.2, 0.15],
+            strength_metrics: strengthMetrics,
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto("/");
+  await expect(page.locator("#loggingChecklist")).toBeVisible();
+  const passStyles = await readSemanticSurfaceStyles(
+    page.locator('.capture-readiness__item[data-readiness-state="pass"]').first(),
+    "--capture-readiness-pass-surface",
+    "--capture-readiness-pass-border",
+  );
+  expect(passStyles.backgroundColor).toBe(passStyles.expectedBackgroundColor);
+  expect(passStyles.borderColor).toBe(passStyles.expectedBorderColor);
+
+  captureReadiness = buildCaptureReadiness({
+    isReady: false,
+    sensors: { state: "pass", reasonKey: "sensors_ready", details: { live_sensor_count: 1 } },
+    reference: { state: "warn", reasonKey: "speed_sample_stale" },
+    speed: { state: "fail", reasonKey: "speed_sample_missing" },
+    overall: {
+      state: "fail",
+      reasonKey: "capture_blocked",
+      details: { blocking_check: "speed_stable" },
+    },
+  });
+  await page.reload();
+  await expect(page.locator("#loggingChecklist")).toBeVisible();
+
+  const expectations = [
+    {
+      locator: page.locator('.capture-readiness__item[data-readiness-state="warn"]').first(),
+      surfaceVar: "--capture-readiness-warn-surface",
+      borderVar: "--capture-readiness-warn-border",
+    },
+    {
+      locator: page.locator('.capture-readiness__item[data-readiness-state="fail"]').first(),
+      surfaceVar: "--capture-readiness-fail-surface",
+      borderVar: "--capture-readiness-fail-border",
+    },
+  ] as const;
+
+  for (const expectation of expectations) {
+    const styles = await readSemanticSurfaceStyles(
+      expectation.locator,
+      expectation.surfaceVar,
+      expectation.borderVar,
+    );
+    expect(styles.backgroundColor).toBe(styles.expectedBackgroundColor);
+    expect(styles.borderColor).toBe(styles.expectedBorderColor);
+  }
+});
 
 test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) => {
   let startCalls = 0;

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -1,4 +1,4 @@
-import type { Page, Route } from "@playwright/test";
+import type { Locator, Page, Route } from "@playwright/test";
 import { EXPECTED_SCHEMA_VERSION } from "../src/contracts/ws_payload_types";
 
 export type FakeWebSocketOptions = {
@@ -94,6 +94,42 @@ export function requestPath(route: Route): string {
 
 export async function fulfillJson(route: Route, body: unknown): Promise<void> {
   await route.fulfill(jsonOk(body));
+}
+
+export type SemanticSurfaceStyles = {
+  backgroundColor: string;
+  borderColor: string;
+  expectedBackgroundColor: string;
+  expectedBorderColor: string;
+};
+
+export async function readSemanticSurfaceStyles(
+  locator: Locator,
+  surfaceVar: string,
+  borderVar: string,
+): Promise<SemanticSurfaceStyles> {
+  return locator.evaluate(
+    (element, vars) => {
+      const probe = document.createElement("div");
+      probe.style.background = `var(${vars.surfaceVar})`;
+      probe.style.border = `1px solid var(${vars.borderVar})`;
+      probe.style.position = "absolute";
+      probe.style.visibility = "hidden";
+      probe.style.pointerEvents = "none";
+      document.body.appendChild(probe);
+      const elementStyles = getComputedStyle(element);
+      const probeStyles = getComputedStyle(probe);
+      const result = {
+        backgroundColor: elementStyles.backgroundColor,
+        borderColor: elementStyles.borderTopColor,
+        expectedBackgroundColor: probeStyles.backgroundColor,
+        expectedBorderColor: probeStyles.borderTopColor,
+      };
+      probe.remove();
+      return result;
+    },
+    { surfaceVar, borderVar },
+  );
 }
 
 export async function activateWizardCloseButton(page: Page): Promise<void> {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-import { fulfillJson, installCommonRoutes, installFakeWebSocket, requestPath } from "./smoke.helpers";
+import {
+  fulfillJson,
+  installCommonRoutes,
+  installFakeWebSocket,
+  readSemanticSurfaceStyles,
+  requestPath,
+} from "./smoke.helpers";
 
 const historyListRun = {
   run_id: "run-001",
@@ -12,6 +18,102 @@ const historyListRun = {
   car_name: "Track Car",
   error_message: null,
 };
+
+test("dark mode diagnosis cards use semantic theme surfaces", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  let confidenceTone: "success" | "warn" = "success";
+
+  await installCommonRoutes(page, {
+    historyHandler: async (route) => {
+      const pathname = requestPath(route);
+      if (!pathname.startsWith("/api/history") || pathname.includes("/insights")) {
+        await route.fallback();
+        return;
+      }
+      await fulfillJson(route, { runs: [historyListRun] });
+    },
+    settingsHandler: async (route) => {
+      if (requestPath(route) === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/history/**/insights**", async (route) => {
+    await fulfillJson(route, {
+      run_id: "run-001",
+      status: "complete",
+      start_time_utc: "2026-01-01T00:00:00Z",
+      duration_s: 12.3,
+      sensor_count_used: 2,
+      most_likely_origin: {
+        suspected_source: "Front-right wheel imbalance",
+        location: "Front-right wheel",
+        speed_band: "60-90 km/h",
+        explanation: "Order content and spatial dominance agree on the front-right wheel.",
+      },
+      findings: [
+        {
+          finding_id: "finding-1",
+          amplitude_metric: "db",
+          confidence: confidenceTone === "success" ? 0.92 : 0.67,
+          confidence_pct: confidenceTone === "success" ? "92%" : "67%",
+          confidence_tone: confidenceTone,
+          evidence_summary: "Diagnostic evidence remains strongest at the front-right wheel.",
+          frequency_hz_or_order: "1x wheel",
+          strongest_location: "Front-right wheel",
+          strongest_speed_band: "60-90 km/h",
+          suspected_source: "Front-right wheel imbalance",
+        },
+      ],
+      sensor_intensity_by_location: [
+        {
+          location: "Front Right Wheel",
+          p50_intensity_db: 18,
+          p95_intensity_db: 32,
+          max_intensity_db: 40,
+          dropped_frames_delta: 0,
+          queue_overflow_drops_delta: 0,
+          sample_count: 20,
+        },
+      ],
+    });
+  });
+  await installFakeWebSocket(page);
+
+  const expectations = [
+    {
+      tone: "success",
+      surfaceVar: "--history-diagnosis-success-surface",
+      borderVar: "--history-diagnosis-success-border",
+    },
+    {
+      tone: "warn",
+      surfaceVar: "--history-diagnosis-warn-surface",
+      borderVar: "--history-diagnosis-warn-border",
+    },
+  ] as const;
+
+  for (const expectation of expectations) {
+    confidenceTone = expectation.tone;
+    await page.goto("/");
+    await page.locator("#tab-history").click();
+    await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
+    const diagnosisCard = page.locator(`.history-diagnosis-card--${expectation.tone}`);
+    await expect(diagnosisCard).toBeVisible();
+    const styles = await readSemanticSurfaceStyles(
+      diagnosisCard,
+      expectation.surfaceVar,
+      expectation.borderVar,
+    );
+    expect(styles.backgroundColor).toBe(styles.expectedBackgroundColor);
+    expect(styles.borderColor).toBe(styles.expectedBorderColor);
+  }
+});
 
 test("history empty state points users back to Live", async ({ page }) => {
   await installCommonRoutes(page, {


### PR DESCRIPTION
## Summary

This PR fixes issue #2272, where dark mode still rendered key semantic status cards with light-mode pastel fills. The two affected surfaces were the live capture-readiness checklist cards and the history diagnosis cards. In dark mode those components were still using hardcoded light backgrounds such as pale green and pale yellow while the surrounding app correctly switched to dark surfaces and light foreground text. That combination produced washed-out cards and, in the success case called out in the issue, very poor contrast between the card fill and the inherited dark-theme text color. The problem was not that dark mode lacked semantic colors overall; it was that these specific selectors bypassed the theme system and held onto literal light-mode values. This change moves those cards onto theme-aware surface tokens so dark mode gets dedicated semantic panels while light mode keeps the current look.

## Problem analysis

The issue description already pointed to the two main CSS files involved: `apps/ui/src/styles/realtime.css` for `.capture-readiness__item[data-readiness-state=...]` and `apps/ui/src/styles/history.css` for `.history-diagnosis-card--success` and `.history-diagnosis-card--warn`. That turned out to be accurate. The live checklist states were hardcoded to fixed pastel success, warning, and failure fills, and the history diagnosis card variants were hardcoded to fixed success and warning fills. Meanwhile, the rest of the dark theme was correctly driven by tokens in `tokens.css` plus overrides in `theme.css`. So the cards were effectively opting out of theme switching.

One subtle detail here is that light mode already had slightly different semantic card palettes between the live readiness cards and the history diagnosis cards. Because of that, a single shared “success card” token would have solved dark mode but would also have collapsed two existing light-mode appearances into one. I chose not to do that. The issue explicitly says light mode should keep its current visual intent, so the safer approach was component-specific tokens that preserve today’s light defaults and only diverge in dark mode where the bug actually exists.

## Implementation approach

The implementation introduces card-surface tokens in two layers:

1. `apps/ui/src/styles/tokens.css` now defines the existing light-mode values for the live capture-readiness cards and history diagnosis cards. These are component-specific tokens rather than one generic semantic palette so the current light-mode presentation stays intact.
2. `apps/ui/src/styles/theme.css` now overrides those same tokens inside the dark-mode media query with dark-safe translucent semantic surfaces and borders.

From there, the two affected component styles simply read from those tokens instead of baking in literal colors. In `apps/ui/src/styles/realtime.css`, the `pass`, `warn`, and `fail` readiness cards now use `--capture-readiness-*-surface` and `--capture-readiness-*-border`. In `apps/ui/src/styles/history.css`, the success and warning diagnosis cards now use `--history-diagnosis-*-surface` and `--history-diagnosis-*-border`.

This keeps the code easy to reason about: component CSS owns which semantic token family it wants, `tokens.css` owns light defaults, and `theme.css` owns dark overrides. No JavaScript changes were required for the actual theme fix because the UI was already emitting stable semantic state classes and `data-readiness-state` attributes.

## Test coverage

Because this is a pure styling issue, I added regression coverage at the smoke-test level where the real DOM and compiled CSS can be exercised together. Unit-style rendering tests would not have been enough here because the bug only appears after the themed styles are resolved in the browser.

In `apps/ui/tests/smoke.helpers.ts`, I added a small shared helper named `readSemanticSurfaceStyles()`. It compares an element’s computed background and border colors to the computed values of a CSS variable-backed probe element. That means the tests verify that the rendered component is actually using the expected theme token rather than hardcoding a specific RGB string in the assertion.

In `apps/ui/tests/smoke.bootstrap.spec.ts`, I added a dark-mode readiness-card test that exercises the real presenter behavior in two phases. The first phase uses an all-pass capture-readiness payload so the pass card is visible in the checklist. The second phase reloads with blocked capture-readiness so the UI shows the warning and failure cards that are actually rendered during setup mode. This two-step structure matters because the readiness presenter intentionally hides passing rows during setup mode, so a single mixed-state payload cannot cover pass, warn, and fail cards at once.

In `apps/ui/tests/smoke.history.spec.ts`, I added a dark-mode diagnosis-card test that verifies both success and warning primary diagnosis cards. It reuses one route seam and reloads with different `confidence_tone` values so the browser resolves both semantic surfaces under dark mode and the test confirms they match the history diagnosis token family.

## Validation

I validated the change locally in the frontend stack with:

- a focused Playwright smoke run covering the updated bootstrap and history smoke specs against an isolated local Vite server,
- `npm run typecheck`,
- `npm run build`.

The smoke run had to use temporary local Playwright configs on alternate ports because this shared environment already had an unrelated process bound to the default UI test port. The committed tests themselves are normal smoke tests under `apps/ui/tests/`; the temporary config was only a local execution aid and is not part of the branch diff.

I also ran the visual spec against an isolated preview server. That local visual run still diverged for an existing environment reason: `tests/visual.spec.ts` in this shared setup falls back into missing backend proxy responses during the preview session, which changes the rendered page height and causes snapshot drift unrelated to these CSS changes. I did not update snapshots because the dark-mode fix is not the cause of that local preview mismatch. CI remains the authoritative visual gate for that part of the suite.

## Risks and tradeoffs

The main tradeoff is adding component-specific semantic tokens instead of a single app-wide status-card token set. I believe that is the correct trade here. A single shared token family would have been slightly simpler, but it would also have silently changed one component’s light-mode appearance to match the other. The current approach keeps the fix tightly scoped to the reported bug while still moving the affected cards onto a proper theme pathway.

Another intentional tradeoff is verifying the themed surfaces through smoke tests rather than low-level CSS snapshots. The smoke tests are slower, but they validate the actual browser-computed colors on the rendered elements, which is the level where this regression exists.

## Out of scope

This PR does not change warning pills, badges, or quiet danger buttons outside these card surfaces. Those are distinct follow-up issues in the backlog. It also does not redesign the visual language of the cards in light mode; it preserves the current light-mode appearance and limits the behavior change to theme-aware dark-mode surfaces for the affected live and history cards.

Closes #2272
