### PR TITLE
Fix dark-mode warning pills and banners

### DIFF
--- a/apps/ui/src/styles/components.css
+++ b/apps/ui/src/styles/components.css
@@ -147,7 +147,7 @@ button[hidden],
 .pill[data-variant="ok"],
 .status-pill.online,
 .badge.on { background: var(--pill-ok-bg); color: var(--pill-ok-text); }
-.pill[data-variant="warn"] { background: #fff3cd; color: #8a6d1d; }
+.pill[data-variant="warn"] { background: var(--pill-warn-bg); color: var(--pill-warn-text); }
 .pill[data-variant="bad"],
 .status-pill.offline,
 .badge.off { background: var(--pill-bad-bg); color: var(--pill-bad-text); }
@@ -187,7 +187,7 @@ button[hidden],
 .stat { min-height: 72px; }
 .stat__label { font-size: 0.76rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
 .stat__value { margin-top: var(--space-1); font-size: 1.1rem; font-weight: 700; overflow-wrap: anywhere; }
-.stat__value[data-variant="warn"] { color: #8a6d1d; }
+.stat__value[data-variant="warn"] { color: var(--warning-text); }
 .stat__value[data-has-icon="true"] {
   display: inline-flex;
   align-items: flex-start;
@@ -207,9 +207,9 @@ button[hidden],
   margin-top: 2px;
 }
 .stat__value-icon[data-variant="warn"] {
-  border: 1px solid rgba(183, 121, 31, 0.3);
-  background: #fff3cd;
-  color: #8a6d1d;
+  border: 1px solid var(--warning-border);
+  background: var(--pill-warn-bg);
+  color: var(--pill-warn-text);
 }
 
 .matrix-tooltip {

--- a/apps/ui/src/styles/history.css
+++ b/apps/ui/src/styles/history.css
@@ -97,8 +97,8 @@
   border-color: transparent;
 }
 .history-row__summary-chip--warn {
-  background: #fff3cd;
-  color: #8a6d1d;
+  background: var(--pill-warn-bg);
+  color: var(--pill-warn-text);
   border-color: transparent;
 }
 .history-row__summary-chip--bad {
@@ -319,10 +319,10 @@
   gap: var(--space-2);
 }
 .history-warning-banner {
-  border: 1px solid #d2b15c;
+  border: 1px solid var(--warning-border);
   border-radius: var(--radius-sm);
-  background: #fff7e1;
-  color: #6f4f12;
+  background: var(--warning-surface);
+  color: var(--warning-text);
   padding: var(--space-2) var(--space-3);
   font-size: 0.84rem;
 }
@@ -584,8 +584,8 @@
   color: var(--pill-ok-text);
 }
 .history-diagnosis-card__confidence--warn {
-  background: #fff3cd;
-  color: #8a6d1d;
+  background: var(--pill-warn-bg);
+  color: var(--pill-warn-text);
 }
 .history-findings-overview__explanation {
   margin: 0;
@@ -665,7 +665,7 @@
   border-color: #c4dec8;
 }
 .history-finding-card--warn {
-  border-color: #e6cf9b;
+  border-color: var(--warning-border);
 }
 .history-finding-card--empty {
   color: var(--muted);
@@ -705,8 +705,8 @@
   color: var(--pill-ok-text);
 }
 .history-finding-card__confidence--warn {
-  background: #fff3cd;
-  color: #8a6d1d;
+  background: var(--pill-warn-bg);
+  color: var(--pill-warn-text);
 }
 .history-finding-card__meta {
   display: grid;

--- a/apps/ui/src/styles/realtime.css
+++ b/apps/ui/src/styles/realtime.css
@@ -41,14 +41,14 @@
 }
 
 .stat[data-variant="warn"] {
-  border: 1px solid rgba(183, 121, 31, 0.28);
+  border: 1px solid var(--warning-border);
   border-radius: var(--radius-sm);
-  background: #fff8e5;
+  background: var(--warning-surface);
   padding-inline: var(--space-3);
 }
 
 .stat[data-variant="warn"] .stat__label {
-  color: #8a6d1d;
+  color: var(--warning-text);
 }
 
 .live-sensor-roster__header {
@@ -385,7 +385,7 @@
   color: var(--success-700);
 }
 .capture-readiness__item[data-readiness-state="warn"] .capture-readiness__state {
-  color: var(--warning);
+  color: var(--warning-text);
 }
 .capture-readiness__item[data-readiness-state="fail"] .capture-readiness__state {
   color: var(--danger-700);

--- a/apps/ui/src/styles/settings.css
+++ b/apps/ui/src/styles/settings.css
@@ -425,8 +425,8 @@
   border: 1px solid var(--border);
 }
 .car-readiness-pill[data-state="incomplete"] {
-  background: #fff3cd;
-  color: #8a6d1d;
+  background: var(--pill-warn-bg);
+  color: var(--pill-warn-text);
 }
 .car-created-pill {
   background: rgba(22, 163, 74, 0.12);

--- a/apps/ui/src/styles/shell.css
+++ b/apps/ui/src/styles/shell.css
@@ -164,9 +164,9 @@
 .connection-banner[hidden] { display: none; }
 
 .connection-banner[data-variant="warn"] {
-  background: #fff3cd;
-  color: #8a6d1d;
-  border-bottom-color: #ffe69c;
+  background: var(--warning-surface);
+  color: var(--warning-text);
+  border-bottom-color: var(--warning-border);
 }
 
 .connection-banner[data-variant="bad"] {

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -34,8 +34,13 @@
     --pill-muted-text: #9b9da8;
     --pill-ok-bg: rgba(74, 222, 128, 0.14);
     --pill-ok-text: #4ade80;
+    --pill-warn-bg: rgba(251, 191, 36, 0.16);
+    --pill-warn-text: #fbbf24;
     --pill-bad-bg: rgba(248, 113, 113, 0.14);
     --pill-bad-text: #f87171;
+    --warning-surface: rgba(251, 191, 36, 0.14);
+    --warning-border: rgba(251, 191, 36, 0.34);
+    --warning-text: #fbbf24;
     --capture-readiness-pass-surface: rgba(74, 222, 128, 0.14);
     --capture-readiness-pass-border: rgba(74, 222, 128, 0.3);
     --capture-readiness-warn-surface: rgba(251, 191, 36, 0.14);

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -46,8 +46,13 @@
   --pill-muted-text: #4a4d5a;
   --pill-ok-bg: #dff4e8;
   --pill-ok-text: #0b6a3d;
+  --pill-warn-bg: #fff3cd;
+  --pill-warn-text: #8a6d1d;
   --pill-bad-bg: #fae3e3;
   --pill-bad-text: #8c2b2b;
+  --warning-surface: #fff8e5;
+  --warning-border: #e6cf9b;
+  --warning-text: #8a6d1d;
   --capture-readiness-pass-surface: #f4fbf7;
   --capture-readiness-pass-border: #c9ead7;
   --capture-readiness-warn-surface: #fff9ee;

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -6,6 +6,7 @@ import {
   installCommonRoutes,
   installFakeWebSocket,
   readSemanticSurfaceStyles,
+  readSemanticToneStyles,
   requestPath,
 } from "./smoke.helpers";
 
@@ -140,6 +141,57 @@ test("dark mode readiness cards use semantic theme surfaces", async ({ page }) =
     expect(styles.backgroundColor).toBe(styles.expectedBackgroundColor);
     expect(styles.borderColor).toBe(styles.expectedBorderColor);
   }
+});
+
+test("dark mode shell warning banner uses semantic theme tokens", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      if (requestPath(route) === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  const banner = page.locator(".app-error-banner");
+  await banner.evaluate((element) => {
+    if (!(element instanceof HTMLElement)) {
+      throw new Error("expected app error banner element");
+    }
+    element.hidden = false;
+    element.dataset.variant = "warn";
+    element.textContent = "Attention needed";
+  });
+
+  const bannerStyles = await readSemanticToneStyles(banner, {
+    surfaceVar: "--warning-surface",
+    borderVar: "--warning-border",
+    textVar: "--warning-text",
+  });
+  const bannerBorderColor = await banner.evaluate((element) => {
+    const probe = document.createElement("div");
+    probe.style.borderBottom = "1px solid var(--warning-border)";
+    probe.style.position = "absolute";
+    probe.style.visibility = "hidden";
+    probe.style.pointerEvents = "none";
+    document.body.appendChild(probe);
+    const result = {
+      actual: getComputedStyle(element).borderBottomColor,
+      expected: getComputedStyle(probe).borderBottomColor,
+    };
+    probe.remove();
+    return result;
+  });
+  expect(bannerStyles.backgroundColor).toBe(bannerStyles.expectedBackgroundColor);
+  expect(bannerBorderColor.actual).toBe(bannerBorderColor.expected);
+  expect(bannerStyles.color).toBe(bannerStyles.expectedColor);
 });
 
 test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) => {

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -6,8 +6,103 @@ import {
   fulfillJson,
   installCommonRoutes,
   installFakeWebSocket,
+  readSemanticToneStyles,
   requestPath,
 } from "./smoke.helpers";
+
+test("dark mode warning pills use semantic theme tokens in Live and Cars", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      const path = requestPath(route);
+      const method = route.request().method();
+      if (path === "/api/settings/cars" && method === "GET") {
+        await fulfillJson(route, {
+          cars: [
+            {
+              id: "car-1",
+              name: "Needs Work",
+              type: "coupe",
+              aspects: {
+                tire_width_mm: 245,
+              },
+            },
+          ],
+          active_car_id: null,
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/recording/status", async (route) => {
+    await fulfillJson(route, {
+      enabled: false,
+      run_id: null,
+      write_error: null,
+      analysis_in_progress: false,
+      start_time_utc: null,
+      samples_written: 0,
+      samples_dropped: 0,
+      last_completed_run_id: null,
+      last_completed_run_error: null,
+      capture_readiness: buildCaptureReadiness({
+        isReady: false,
+        sensors: { state: "pass", reasonKey: "sensors_ready", details: { live_sensor_count: 1 } },
+        reference: { state: "fail", reasonKey: "active_car_missing" },
+        speed: { state: "pass", reasonKey: "speed_stable", details: { dwell_elapsed_s: 8 } },
+        overall: {
+          state: "fail",
+          reasonKey: "capture_blocked",
+          details: { blocking_check: "reference_ready" },
+        },
+      }),
+    });
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      clients: [
+        {
+          id: "001122334455",
+          name: "Front Left",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 12,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_left_wheel",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: { clients: {} },
+    },
+  });
+
+  await page.goto("/");
+  const liveHealth = page.locator("#liveRunHealth");
+  await expect(liveHealth).toHaveText("Needs attention");
+  const liveHealthStyles = await readSemanticToneStyles(liveHealth, {
+    surfaceVar: "--pill-warn-bg",
+    textVar: "--pill-warn-text",
+  });
+  expect(liveHealthStyles.backgroundColor).toBe(liveHealthStyles.expectedBackgroundColor);
+  expect(liveHealthStyles.color).toBe(liveHealthStyles.expectedColor);
+
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+  const readinessPill = page.locator(
+    '#carListBody tr[data-car-id="car-1"] .car-readiness-pill[data-state="incomplete"]',
+  );
+  await expect(readinessPill).toHaveText("Needs specs");
+  const readinessStyles = await readSemanticToneStyles(readinessPill, {
+    surfaceVar: "--pill-warn-bg",
+    textVar: "--pill-warn-text",
+  });
+  expect(readinessStyles.backgroundColor).toBe(readinessStyles.expectedBackgroundColor);
+  expect(readinessStyles.color).toBe(readinessStyles.expectedColor);
+});
 
 test("routes no-car blockers to the add-car flow from Live and Cars", async ({ page }) => {
   let analysisPutCalls = 0;

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -103,16 +103,31 @@ export type SemanticSurfaceStyles = {
   expectedBorderColor: string;
 };
 
-export async function readSemanticSurfaceStyles(
+export type SemanticToneStyles = {
+  backgroundColor: string;
+  borderColor: string;
+  color: string;
+  expectedBackgroundColor: string;
+  expectedBorderColor: string;
+  expectedColor: string;
+};
+
+export async function readSemanticToneStyles(
   locator: Locator,
-  surfaceVar: string,
-  borderVar: string,
-): Promise<SemanticSurfaceStyles> {
+  vars: {
+    surfaceVar: string;
+    borderVar?: string;
+    textVar?: string;
+  },
+): Promise<SemanticToneStyles> {
   return locator.evaluate(
     (element, vars) => {
       const probe = document.createElement("div");
       probe.style.background = `var(${vars.surfaceVar})`;
-      probe.style.border = `1px solid var(${vars.borderVar})`;
+      probe.style.border = vars.borderVar
+        ? `1px solid var(${vars.borderVar})`
+        : "1px solid transparent";
+      probe.style.color = vars.textVar ? `var(${vars.textVar})` : "inherit";
       probe.style.position = "absolute";
       probe.style.visibility = "hidden";
       probe.style.pointerEvents = "none";
@@ -122,14 +137,30 @@ export async function readSemanticSurfaceStyles(
       const result = {
         backgroundColor: elementStyles.backgroundColor,
         borderColor: elementStyles.borderTopColor,
+        color: elementStyles.color,
         expectedBackgroundColor: probeStyles.backgroundColor,
         expectedBorderColor: probeStyles.borderTopColor,
+        expectedColor: probeStyles.color,
       };
       probe.remove();
       return result;
     },
-    { surfaceVar, borderVar },
+    vars,
   );
+}
+
+export async function readSemanticSurfaceStyles(
+  locator: Locator,
+  surfaceVar: string,
+  borderVar: string,
+): Promise<SemanticSurfaceStyles> {
+  const styles = await readSemanticToneStyles(locator, { surfaceVar, borderVar });
+  return {
+    backgroundColor: styles.backgroundColor,
+    borderColor: styles.borderColor,
+    expectedBackgroundColor: styles.expectedBackgroundColor,
+    expectedBorderColor: styles.expectedBorderColor,
+  };
 }
 
 export async function activateWizardCloseButton(page: Page): Promise<void> {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -5,6 +5,7 @@ import {
   installCommonRoutes,
   installFakeWebSocket,
   readSemanticSurfaceStyles,
+  readSemanticToneStyles,
   requestPath,
 } from "./smoke.helpers";
 
@@ -113,6 +114,104 @@ test("dark mode diagnosis cards use semantic theme surfaces", async ({ page }) =
     expect(styles.backgroundColor).toBe(styles.expectedBackgroundColor);
     expect(styles.borderColor).toBe(styles.expectedBorderColor);
   }
+});
+
+test("dark mode history warning pills and banners use semantic theme tokens", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+
+  await installCommonRoutes(page, {
+    historyHandler: async (route) => {
+      const pathname = requestPath(route);
+      if (!pathname.startsWith("/api/history") || pathname.includes("/insights")) {
+        await route.fallback();
+        return;
+      }
+      await fulfillJson(route, { runs: [historyListRun] });
+    },
+    settingsHandler: async (route) => {
+      if (requestPath(route) === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/history/**/insights**", async (route) => {
+    await fulfillJson(route, {
+      run_id: "run-001",
+      status: "complete",
+      start_time_utc: "2026-01-01T00:00:00Z",
+      duration_s: 12.3,
+      sensor_count_used: 2,
+      most_likely_origin: {
+        suspected_source: "Front-right wheel imbalance",
+        location: "Front-right wheel",
+        speed_band: "60-90 km/h",
+        explanation: "Diagnostic evidence remains strongest at the front-right wheel.",
+      },
+      findings: [
+        {
+          finding_id: "finding-1",
+          amplitude_metric: "db",
+          confidence: 0.67,
+          confidence_pct: "67%",
+          confidence_tone: "warn",
+          evidence_summary: "Secondary driveline evidence remains present.",
+          frequency_hz_or_order: "1x wheel",
+          strongest_location: "Front-right wheel",
+          strongest_speed_band: "60-90 km/h",
+          suspected_source: "Front-right wheel imbalance",
+        },
+      ],
+      warnings: [
+        {
+          code: "speed-gap",
+          severity: "warn",
+          title: "history.warning.speed_gap",
+          detail: "Speed samples were sparse through part of the run.",
+        },
+      ],
+      sensor_intensity_by_location: [
+        {
+          location: "Front Right Wheel",
+          p50_intensity_db: 18,
+          p95_intensity_db: 32,
+          max_intensity_db: 40,
+          dropped_frames_delta: 0,
+          queue_overflow_drops_delta: 0,
+          sample_count: 20,
+        },
+      ],
+    });
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-history").click();
+  await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
+
+  const confidencePill = page.locator(".history-diagnosis-card__confidence--warn");
+  await expect(confidencePill).toBeVisible();
+  const confidenceStyles = await readSemanticToneStyles(confidencePill, {
+    surfaceVar: "--pill-warn-bg",
+    textVar: "--pill-warn-text",
+  });
+  expect(confidenceStyles.backgroundColor).toBe(confidenceStyles.expectedBackgroundColor);
+  expect(confidenceStyles.color).toBe(confidenceStyles.expectedColor);
+
+  const warningBanner = page.locator(".history-warning-banner").first();
+  await expect(warningBanner).toBeVisible();
+  const bannerStyles = await readSemanticToneStyles(warningBanner, {
+    surfaceVar: "--warning-surface",
+    borderVar: "--warning-border",
+    textVar: "--warning-text",
+  });
+  expect(bannerStyles.backgroundColor).toBe(bannerStyles.expectedBackgroundColor);
+  expect(bannerStyles.borderColor).toBe(bannerStyles.expectedBorderColor);
+  expect(bannerStyles.color).toBe(bannerStyles.expectedColor);
 });
 
 test("history empty state points users back to Live", async ({ page }) => {


### PR DESCRIPTION
## Problem

Issue #2273 reports that dark mode still leaks the light-theme warning palette into several parts of the UI. The most obvious examples are the Live health pill (`Needs attention`) and the Cars settings incomplete badge (`Needs specs`), but the issue correctly points out that the problem is broader than those two screenshots. Shared warning selectors in `components.css`, `shell.css`, `realtime.css`, `settings.css`, and `history.css` were still hardcoding beige/yellow fills and brown text that were tuned for light mode. In dark mode, those colors produced pastel warning surfaces that looked disconnected from the rest of the theme and inconsistent with the dark-aware semantic surfaces that were already introduced for other status cards.

The practical effect was that warning UI looked only partially themed. Success and danger states were already routed through dark-aware tokens, and the capture readiness / diagnosis surfaces fixed in the previous dark-mode issue also switched correctly, but pills, badges, banners, and inline warning states were still bypassing the theme layer. That meant the warning treatment across Live, Settings, History, and shell-level alerts remained visually fragmented.

## Implementation approach

The fix standardizes warning styling around shared semantic tokens instead of continuing to patch each screen independently. I added a compact warning pill token pair and a broader warning surface token set in the shared theme sources, then rewired the warning selectors that were still hardcoded to consume those tokens. This keeps light mode stable while giving dark mode a single place to override warning fills, borders, and text.

I intentionally used two token families rather than one catch-all token. Small warning pills and badges need a slightly denser fill treatment than larger warning surfaces such as the shell banner or highlighted warning stat blocks. The shared token split is:

- `--pill-warn-bg` / `--pill-warn-text` for compact pills and badges
- `--warning-surface` / `--warning-border` / `--warning-text` for larger warning surfaces and inline warning emphasis

This keeps the overall warning treatment consistent while still matching the shape and visual weight of each component.

## Main code changes

In `apps/ui/src/styles/tokens.css` I defined the new light-mode warning tokens, and in `apps/ui/src/styles/theme.css` I added the dark-mode overrides. These are now the authoritative warning semantic values for shared UI. One nice side effect is that newer styles which already referenced `--pill-warn-*` now resolve through a real theme token instead of depending on an undefined variable.

In `apps/ui/src/styles/components.css`, the shared warning pill selector (`.pill[data-variant="warn"]`) now uses the new pill tokens. The warning stat text and icon styles also moved off hardcoded brown/yellow values and onto the warning text / border / pill tokens. This matters because multiple feature surfaces reuse the generic pill and inline stat treatment, so fixing it centrally reduces the chance of another dark-mode drift.

In `apps/ui/src/styles/shell.css`, the shell warning banner now uses the semantic warning surface, border, and text tokens instead of a baked-in light-theme yellow strip. That brings shell-level alerts onto the same dark-aware path as the rest of the UI and removes one of the issue’s specifically named root causes.

In `apps/ui/src/styles/realtime.css`, the highlighted warning stat treatment now uses the new warning surface and border tokens, and the warning label text now uses a semantic warning text token instead of a hardcoded brown. This keeps inline warning emphasis readable when the page is in dark mode and aligns the Live warning blocks with the newer dark-theme surfaces.

In `apps/ui/src/styles/settings.css`, the Cars readiness pill for incomplete profiles (`Needs specs`) now uses `--pill-warn-bg` and `--pill-warn-text`. That directly fixes one of the issue’s repro cases.

In `apps/ui/src/styles/history.css`, I moved several warning selectors onto the shared tokens: summary chips, warning banners, diagnosis confidence pills, warning finding card borders, and secondary finding confidence pills. That keeps History from mixing token-backed dark surfaces with leftover light-mode warning pills inside the same expanded results view.

## Test coverage

I extended the Playwright smoke helpers with a reusable `readSemanticToneStyles()` utility so the tests can compare computed background, text color, and (when relevant) border color against CSS variables rather than asserting hardcoded RGB strings. This mirrors the actual contract of the change: the selectors should use the semantic tokens, not just “some dark-ish color.”

I added three focused dark-mode smoke checks:

1. `apps/ui/tests/smoke.cars.spec.ts` now verifies that the Live warning pill (`Needs attention`) and the Cars incomplete badge (`Needs specs`) both resolve to the shared warning pill tokens in dark mode.
2. `apps/ui/tests/smoke.history.spec.ts` now verifies that History warning confidence pills use the pill tokens and that History warning banners use the warning surface / border / text tokens.
3. `apps/ui/tests/smoke.bootstrap.spec.ts` now verifies that the shell warning banner uses the shared warning theme tokens in dark mode.

Those checks intentionally cover the cross-screen warning surfaces called out in the issue instead of testing only a single selector in isolation.

## Validation

Local validation for this change was:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=../../.ai-temp/playwright.smoke.local.config.ts tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts tests/smoke.history.spec.ts --project=laptop-light --workers=1`

The isolated Playwright config is the same local-only shared-environment workaround used in the previous frontend dark-mode issue so the smoke suite does not accidentally reuse an unrelated app already listening on the default preview port. The Vite proxy still logs expected `127.0.0.1:8000` connection-refused noise for unstubbed background requests in this environment, but the targeted smoke scenarios themselves remain green and deterministic.

## Risks and tradeoffs

The main tradeoff here is centralization versus pixel-for-pixel preservation of every old light-theme warning selector. I favored centralization because the issue itself describes the problem as a shared warning palette leak, not as isolated one-off regressions. The shared tokens make future warning-themed work much safer: warning pills, banners, and inline warning states now have a canonical dark-mode override path instead of repeating palette literals in multiple files.

I still kept the implementation conservative in two ways. First, I did not broaden this into a larger status-color redesign; only warning selectors that were relevant to the reported issue were rewired. Second, I kept the compact warning pill tokens separate from the larger warning surface tokens so small badges do not become visually washed out and larger banners do not become overly saturated.

## Out of scope

This PR does not change the quiet danger button palette from issue #2274, and it does not attempt a general refactor of all semantic colors beyond the warning surfaces in scope here. It is intentionally focused on removing the remaining light-mode yellow warning leakage and making the warning treatment consistent across Live, Settings, History, and shell-level alerts.

Closes #2273
