### PR TITLE
Fix dark-mode quiet danger buttons

### DIFF
--- a/apps/ui/src/styles/realtime.css
+++ b/apps/ui/src/styles/realtime.css
@@ -504,14 +504,14 @@
   margin-top: var(--space-2);
 }
 .btn--danger-quiet {
-  background: #fff4f4;
-  border-color: #efc1c1;
-  color: var(--danger-700);
+  background: var(--button-danger-quiet-surface);
+  border-color: var(--button-danger-quiet-border);
+  color: var(--button-danger-quiet-text);
 }
 .btn--danger-quiet:hover {
-  background: #fee2e2;
-  border-color: var(--danger-400);
-  color: var(--danger-700);
+  background: var(--button-danger-quiet-hover-surface);
+  border-color: var(--button-danger-quiet-hover-border);
+  color: var(--button-danger-quiet-text);
   filter: none;
 }
 .stat-grid--compact {

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -38,6 +38,11 @@
     --pill-warn-text: #fbbf24;
     --pill-bad-bg: rgba(248, 113, 113, 0.14);
     --pill-bad-text: #f87171;
+    --button-danger-quiet-surface: rgba(248, 113, 113, 0.12);
+    --button-danger-quiet-border: rgba(248, 113, 113, 0.28);
+    --button-danger-quiet-text: #f87171;
+    --button-danger-quiet-hover-surface: rgba(248, 113, 113, 0.18);
+    --button-danger-quiet-hover-border: rgba(248, 113, 113, 0.42);
     --warning-surface: rgba(251, 191, 36, 0.14);
     --warning-border: rgba(251, 191, 36, 0.34);
     --warning-text: #fbbf24;

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -50,6 +50,11 @@
   --pill-warn-text: #8a6d1d;
   --pill-bad-bg: #fae3e3;
   --pill-bad-text: #8c2b2b;
+  --button-danger-quiet-surface: #fff4f4;
+  --button-danger-quiet-border: #efc1c1;
+  --button-danger-quiet-text: #9f1b18;
+  --button-danger-quiet-hover-surface: #fee2e2;
+  --button-danger-quiet-hover-border: #d64e4b;
   --warning-surface: #fff8e5;
   --warning-border: #e6cf9b;
   --warning-text: #8a6d1d;

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -146,9 +146,9 @@ test("dark mode quiet danger buttons use semantic danger tokens in Cars", async 
     borderVar: "--button-danger-quiet-border",
     textVar: "--button-danger-quiet-text",
   });
-  expect(idleStyles.backgroundColor).toBe(idleStyles.expectedBackgroundColor);
-  expect(idleStyles.borderColor).toBe(idleStyles.expectedBorderColor);
-  expect(idleStyles.color).toBe(idleStyles.expectedColor);
+  await expect(deleteButton).toHaveCSS("background-color", idleStyles.expectedBackgroundColor);
+  await expect(deleteButton).toHaveCSS("border-top-color", idleStyles.expectedBorderColor);
+  await expect(deleteButton).toHaveCSS("color", idleStyles.expectedColor);
 
   const deleteButtonBox = await deleteButton.boundingBox();
   if (!deleteButtonBox) {
@@ -165,9 +165,9 @@ test("dark mode quiet danger buttons use semantic danger tokens in Cars", async 
     borderVar: "--button-danger-quiet-hover-border",
     textVar: "--button-danger-quiet-text",
   });
-  expect(hoverStyles.backgroundColor).toBe(hoverStyles.expectedBackgroundColor);
-  expect(hoverStyles.borderColor).toBe(hoverStyles.expectedBorderColor);
-  expect(hoverStyles.color).toBe(hoverStyles.expectedColor);
+  await expect(deleteButton).toHaveCSS("background-color", hoverStyles.expectedBackgroundColor);
+  await expect(deleteButton).toHaveCSS("border-top-color", hoverStyles.expectedBorderColor);
+  await expect(deleteButton).toHaveCSS("color", hoverStyles.expectedColor);
 });
 
 test("routes no-car blockers to the add-car flow from Live and Cars", async ({ page }) => {

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -104,6 +104,72 @@ test("dark mode warning pills use semantic theme tokens in Live and Cars", async
   expect(readinessStyles.color).toBe(readinessStyles.expectedColor);
 });
 
+test("dark mode quiet danger buttons use semantic danger tokens in Cars", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      const path = requestPath(route);
+      const method = route.request().method();
+      if (path === "/api/settings/cars" && method === "GET") {
+        await fulfillJson(route, {
+          cars: [
+            {
+              id: "car-1",
+              name: "Active Car",
+              type: "sedan",
+              aspects: {
+                tire_width_mm: 245,
+                tire_aspect_pct: 40,
+                rim_in: 18,
+                final_drive_ratio: 3.91,
+                current_gear_ratio: 0.82,
+              },
+            },
+          ],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+  const deleteButton = page.locator('#carListBody tr[data-car-id="car-1"] .car-delete-btn');
+  await expect(deleteButton).toBeVisible();
+
+  const idleStyles = await readSemanticToneStyles(deleteButton, {
+    surfaceVar: "--button-danger-quiet-surface",
+    borderVar: "--button-danger-quiet-border",
+    textVar: "--button-danger-quiet-text",
+  });
+  expect(idleStyles.backgroundColor).toBe(idleStyles.expectedBackgroundColor);
+  expect(idleStyles.borderColor).toBe(idleStyles.expectedBorderColor);
+  expect(idleStyles.color).toBe(idleStyles.expectedColor);
+
+  const deleteButtonBox = await deleteButton.boundingBox();
+  if (!deleteButtonBox) {
+    throw new Error("expected car delete button to have a layout box");
+  }
+  await page.mouse.move(
+    deleteButtonBox.x + (deleteButtonBox.width / 2),
+    deleteButtonBox.y + (deleteButtonBox.height / 2),
+  );
+  await expect.poll(() => deleteButton.evaluate((element) => element.matches(":hover"))).toBe(true);
+  await page.waitForTimeout(150);
+  const hoverStyles = await readSemanticToneStyles(deleteButton, {
+    surfaceVar: "--button-danger-quiet-hover-surface",
+    borderVar: "--button-danger-quiet-hover-border",
+    textVar: "--button-danger-quiet-text",
+  });
+  expect(hoverStyles.backgroundColor).toBe(hoverStyles.expectedBackgroundColor);
+  expect(hoverStyles.borderColor).toBe(hoverStyles.expectedBorderColor);
+  expect(hoverStyles.color).toBe(hoverStyles.expectedColor);
+});
+
 test("routes no-car blockers to the add-car flow from Live and Cars", async ({ page }) => {
   let analysisPutCalls = 0;
   await installCommonRoutes(page, {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -214,6 +214,46 @@ test("dark mode history warning pills and banners use semantic theme tokens", as
   expect(bannerStyles.color).toBe(bannerStyles.expectedColor);
 });
 
+test("dark mode quiet danger buttons use semantic danger tokens in History", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await installCommonRoutes(page, { runs: [historyListRun] });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-history").click();
+  await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
+  const deleteButton = page.locator('[data-run-action="delete-run"][data-run="run-001"]');
+  await expect(deleteButton).toBeVisible();
+
+  const idleStyles = await readSemanticToneStyles(deleteButton, {
+    surfaceVar: "--button-danger-quiet-surface",
+    borderVar: "--button-danger-quiet-border",
+    textVar: "--button-danger-quiet-text",
+  });
+  expect(idleStyles.backgroundColor).toBe(idleStyles.expectedBackgroundColor);
+  expect(idleStyles.borderColor).toBe(idleStyles.expectedBorderColor);
+  expect(idleStyles.color).toBe(idleStyles.expectedColor);
+
+  const deleteButtonBox = await deleteButton.boundingBox();
+  if (!deleteButtonBox) {
+    throw new Error("expected history delete button to have a layout box");
+  }
+  await page.mouse.move(
+    deleteButtonBox.x + (deleteButtonBox.width / 2),
+    deleteButtonBox.y + (deleteButtonBox.height / 2),
+  );
+  await expect.poll(() => deleteButton.evaluate((element) => element.matches(":hover"))).toBe(true);
+  await page.waitForTimeout(150);
+  const hoverStyles = await readSemanticToneStyles(deleteButton, {
+    surfaceVar: "--button-danger-quiet-hover-surface",
+    borderVar: "--button-danger-quiet-hover-border",
+    textVar: "--button-danger-quiet-text",
+  });
+  expect(hoverStyles.backgroundColor).toBe(hoverStyles.expectedBackgroundColor);
+  expect(hoverStyles.borderColor).toBe(hoverStyles.expectedBorderColor);
+  expect(hoverStyles.color).toBe(hoverStyles.expectedColor);
+});
+
 test("history empty state points users back to Live", async ({ page }) => {
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -230,9 +230,9 @@ test("dark mode quiet danger buttons use semantic danger tokens in History", asy
     borderVar: "--button-danger-quiet-border",
     textVar: "--button-danger-quiet-text",
   });
-  expect(idleStyles.backgroundColor).toBe(idleStyles.expectedBackgroundColor);
-  expect(idleStyles.borderColor).toBe(idleStyles.expectedBorderColor);
-  expect(idleStyles.color).toBe(idleStyles.expectedColor);
+  await expect(deleteButton).toHaveCSS("background-color", idleStyles.expectedBackgroundColor);
+  await expect(deleteButton).toHaveCSS("border-top-color", idleStyles.expectedBorderColor);
+  await expect(deleteButton).toHaveCSS("color", idleStyles.expectedColor);
 
   const deleteButtonBox = await deleteButton.boundingBox();
   if (!deleteButtonBox) {
@@ -249,9 +249,9 @@ test("dark mode quiet danger buttons use semantic danger tokens in History", asy
     borderVar: "--button-danger-quiet-hover-border",
     textVar: "--button-danger-quiet-text",
   });
-  expect(hoverStyles.backgroundColor).toBe(hoverStyles.expectedBackgroundColor);
-  expect(hoverStyles.borderColor).toBe(hoverStyles.expectedBorderColor);
-  expect(hoverStyles.color).toBe(hoverStyles.expectedColor);
+  await expect(deleteButton).toHaveCSS("background-color", hoverStyles.expectedBackgroundColor);
+  await expect(deleteButton).toHaveCSS("border-top-color", hoverStyles.expectedBorderColor);
+  await expect(deleteButton).toHaveCSS("color", hoverStyles.expectedColor);
 });
 
 test("history empty state points users back to Live", async ({ page }) => {


### PR DESCRIPTION
## Problem

Issue #2274 calls out a smaller but still visible dark-mode inconsistency: the shared `btn--danger-quiet` button variant keeps its light-theme pastel pink fill when the UI is in dark mode. The audit examples are all destructive actions that intentionally use the quieter destructive treatment instead of the fully saturated danger button: `Delete All Runs` in the History toolbar, per-run `Delete` in History details, `Delete` in Settings > Cars, and `Remove` in Settings > Sensors.

Before this change, the class was defined in `apps/ui/src/styles/realtime.css` with hardcoded light-mode values: a near-white pink background, a pale pink border, and red text. That styling looked fine on light surfaces, but in dark mode it read as a light-theme button pasted into a dark screen rather than a subtle destructive action that had been intentionally themed for dark surfaces. Because the class is shared, the issue was not isolated to a single screen or one-off button implementation. Any consumer of `btn--danger-quiet` inherited the same washed-out look.

## Implementation approach

The fix follows the same theme-token pattern used in the preceding dark-mode cleanups: move the shared visual contract into semantic tokens, then update the reused selector to consume those tokens instead of repeating hardcoded colors. In this case I kept the change narrowly focused on the quiet destructive button variant and its two important interactive states: idle and hover.

I added a dedicated token set for the variant rather than trying to overload the existing danger pill tokens. Quiet destructive buttons need slightly different behavior than badges or status pills: they need a button-appropriate border, a subdued but readable text color, and a hover state that deepens the surface without turning into the fully saturated destructive button. A button-specific token family also makes the hover contract explicit instead of encoding it as an ad hoc second literal in one stylesheet.

## Main code changes

In `apps/ui/src/styles/tokens.css` I added the light-mode quiet-danger button tokens:

- `--button-danger-quiet-surface`
- `--button-danger-quiet-border`
- `--button-danger-quiet-text`
- `--button-danger-quiet-hover-surface`
- `--button-danger-quiet-hover-border`

These preserve the intended light-mode treatment while centralizing the contract in the theme layer.

In `apps/ui/src/styles/theme.css` I added the dark-mode overrides for the same token family. The dark values are intentionally subtle: the idle surface is a low-alpha red tint, the border is stronger than the surface but still restrained, the text moves to the brighter red already used elsewhere in the dark theme, and the hover state deepens both surface and border without becoming a loud primary destructive button. That matches the issue’s “subdued without looking washed out” requirement more closely than simply reusing the existing light colors or swapping in a fully saturated danger fill.

In `apps/ui/src/styles/realtime.css`, the shared `.btn--danger-quiet` selector now consumes those tokens for both idle and hover states. I deliberately left the class where it already lives instead of broadening this issue into a larger stylesheet ownership refactor. The problem here was the hardcoded palette leak, not the file boundary. Updating the existing shared selector is the smallest complete fix that keeps all current consumers aligned.

Because `btn--danger-quiet` is reused across screens, the change automatically affects all of the destructive actions named in the issue body:

- History toolbar / management actions
- History expanded row delete action
- Cars delete buttons
- Sensor remove buttons

That shared-class reuse is exactly why I kept the implementation token-driven instead of changing one screen at a time.

## Test coverage

I extended the existing dark-mode smoke coverage on the real reused button surfaces rather than adding a synthetic style-only test. The updated coverage lives in:

- `apps/ui/tests/smoke.cars.spec.ts`
- `apps/ui/tests/smoke.history.spec.ts`

The Cars smoke now verifies that a visible Settings delete button resolves to the quiet-danger semantic tokens in dark mode. It checks both the idle state and the hover state.

The History smoke now does the same for the expanded run `Delete` action. That gives us coverage on two distinct screens that consume the same shared class, which is more valuable than asserting the selector in isolation because it proves the shared token path is actually reaching reused destructive actions in the UI.

Both tests reuse the previously added `readSemanticToneStyles()` helper so they compare computed button background, border, and text colors against the semantic CSS variables instead of comparing raw hardcoded RGB literals. That keeps the regression aligned with the real contract of the change: the shared button class must continue to resolve through the quiet-danger tokens, including the hover-state tokens.

One detail worth calling out is that the hover assertions now explicitly wait for the button transition to settle before reading styles. The shared button system already animates background and border changes, so sampling the hover state immediately after moving the pointer can catch the first frame of the transition. Waiting for the pointer state and then allowing the transition to complete makes the regression deterministic without weakening what the test is actually asserting.

## Validation

Local validation for this change was:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=../../.ai-temp/playwright.smoke.local.config.ts tests/smoke.cars.spec.ts tests/smoke.history.spec.ts --project=laptop-light --workers=1`

The isolated local Playwright config is the same shared-environment workaround used for the previous frontend dark-mode issues. It avoids reusing an unrelated service on the default preview port and keeps the smoke suite pointed at the actual VibeSensor app under test. As with the previous runs, the preview server still logs expected proxy noise for unstubbed `127.0.0.1:8000` requests in this environment, but the targeted button scenarios themselves complete cleanly and deterministically.

## Risks and tradeoffs

The main tradeoff here is adding a dedicated quiet-danger token family instead of trying to infer this variant from broader danger or bad-status tokens. I think that tradeoff is justified. The button variant has a real interactive contract with separate idle and hover states, and collapsing it into the existing pill/status tokens would either dilute those existing tokens or hide the hover behavior in selector-local literals again.

I also intentionally kept this change scoped away from the broader danger palette. The fully saturated destructive button path and the quiet destructive button path serve different UX roles, and the issue is specifically about the quiet one. Restricting the fix to the reused `btn--danger-quiet` class reduces risk and keeps the final backlog change reviewable.

## Out of scope

This PR does not refactor where shared button classes live, and it does not redesign the general danger palette beyond the quiet destructive variant requested here. It is specifically focused on making reused quiet destructive actions look correct in dark mode across History and Settings surfaces while preserving the subdued intent of the variant.

Closes #2274
