### PR TITLE
Render saved car list in Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -103,7 +103,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/cars_feature_workflow.ts` | DOM-free car-wizard workflow/controller for step transitions, library loading, branch selection, and finish validation |
 | `app/features/realtime_feature.ts` | Thin realtime facade that wires the workflow, presenter, and delegated event bindings together |
 | `app/features/realtime_feature_workflow.ts` | DOM-free realtime workflow/controller for polling, logging actions, location updates, and client mutations |
-| `app/features/settings_cars_module.ts` | Settings-side car controller that owns list loading, activation/deletion flows, highlight feedback, and the explicit open-wizard port |
+| `app/features/settings_cars_module.ts` | Settings-side car controller that owns list loading, activation/deletion flows, highlight feedback, and typed tab/view-driven feedback dismissal plus the explicit open-wizard port |
 | `app/features/settings_cars_transport.ts` | Settings-car transport wrapper over load/activate/delete API calls |
 | `app/features/settings_analysis_module.ts` | Analysis-settings behavior owner for validation, save/reset orchestration, field guidance, and spectrum refreshes behind the island DOM bridge |
 | `app/features/settings_speed_source_module.ts` | Thin speed-source settings facade that wires the transport seam, DOM-free workflow, presenter, and typed bindings together |
@@ -116,7 +116,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/update_panel.tsx` | Preact owner for the update settings shell that mounts the update controls and status host while exposing the bridge consumed by the update feature |
 | `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that renders the full sensor table and exposes typed identify/remove/location callbacks to the realtime feature |
 | `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that mounts the full tab surface and exposes the shared typed bridge consumed by the speed-source and GPS-status modules |
-| `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that mounts the list shell and wizard chrome, then exposes typed list and wizard bridges |
+| `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that renders saved-car guidance/list rows in JSX, mounts the wizard chrome, and exposes typed list and wizard bridges |
 | `app/views/cars_feature_bindings.ts` | Typed car-wizard bindings reused as the thin wizard interaction adapter behind the car-management island |
 | `app/views/cars_feature_presenter.ts` | Car-wizard presenter reused as the thin wizard DOM adapter for dialog visibility, step rendering, summary updates, and focus targets |
 | `app/features/update_feature.ts` | Thin update facade that binds DOM events, delegates state rendering to the presenter, and delegates update commands to the workflow |
@@ -131,7 +131,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/history_table_view.ts` | Thin history-panel bridge that defines the typed empty/table render contract consumed by the Preact history island |
 | `app/views/realtime_logging_view_models.ts` | Typed realtime logging and readiness view-model builders for summary, checklist, and control-state derivation |
 | `app/views/realtime_logging_panel.tsx` | Preact owner for the run-recording card that renders typed logging/readiness models and binds start/stop plus summary CTA actions through a bridge |
-| `app/views/settings_car_list_view.ts` | Thin settings-car table renderer and action decoder reused by the car-management island for the saved-car table body |
+| `app/views/settings_car_list_view.ts` | Typed saved-car list and guidance view-model builders reused by the car-management island for row, empty-state, and highlight rendering |
 | `app/views/settings_speed_source_bindings.ts` | Typed speed-source form bindings that decode radio/input/navigation/device actions away from the workflow |
 | `app/views/settings_speed_source_presenter.ts` | Speed-source presenter that owns summary, validation, and OBD-device-list DOM rendering from typed workflow state |
 | `app/views/update_feature_presenter.ts` | Update presenter that owns readiness derivation, transport/control DOM state, and typed handoff into the island-owned update and internet panel bridges |
@@ -184,8 +184,8 @@ panel wrappers, and the individual page/settings panel islands own their local
 chrome plus typed bridges. The remaining imperative paths are deliberate seams:
 the shell controller still owns app-level status/preference state, the spectrum
 controller still owns the uPlot/canvas lifecycle behind `specChart`, and a few
-feature-local render helpers still materialize table bodies or structured status
-cards behind island-owned hosts.
+feature-local presenters still materialize structured wizard or status surfaces
+behind island-owned hosts.
 
 Realtime follows that same split explicitly: `realtime_feature.ts` is the thin
 facade, `realtime_feature_workflow.ts` owns the controller-style polling and

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -57,6 +57,7 @@ export interface AppFeatureBundleRuntimePorts {
   espFlashPanel: EspFlashPanelView;
   navigation: {
     activatePrimaryView(viewId: string): void;
+    subscribeActiveViewChanges(listener: (viewId: string) => void): () => void;
   };
   realtimeChrome: RealtimeFeatureChromePorts;
   historyPanel: HistoryPanelView;
@@ -132,6 +133,7 @@ export function createAppFeatureBundle(
     escapeHtml,
     showError,
     fmt,
+    subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
     view: runtime.view,
     realtime: createSettingsFeatureRealtimePorts(realtime),
   });

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -1,4 +1,3 @@
-import type { UiShellDom } from "../dom/shell_dom";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import {
   type CarSelectionState,
@@ -10,12 +9,14 @@ import {
 import type { SettingsState } from "../ui_app_state";
 import type { CarRecord, CarsPayload } from "../../transport/http_models";
 import type {
-  CarsListHighlightedFeedback,
   CarsListPanelView,
-  CarsListRenderModel,
 } from "../views/cars_panel";
 import type { SettingsAnalysisPanelDom } from "../views/analysis_panel";
-import type { SettingsShellDom } from "../views/settings_shell";
+import {
+  buildCarsGuidanceRenderModel,
+  buildSettingsCarListRenderModel,
+  type CarsListHighlightedFeedback,
+} from "../views/settings_car_list_view";
 import {
   createSettingsCarsTransport,
   type SettingsCarsTransport,
@@ -23,7 +24,6 @@ import {
 
 export interface SettingsCarsModuleDeps extends FeatureDepsBase {
   confirmDelete?: (message: string) => boolean;
-  dom: Pick<SettingsShellDom, "settingsTabs">;
   analysisDom: Pick<
     SettingsAnalysisPanelDom,
     "analysisNoCarMessage" | "resetAnalysisBtn" | "saveAnalysisBtn"
@@ -35,7 +35,8 @@ export interface SettingsCarsModuleDeps extends FeatureDepsBase {
   renderRealtimeStatus: () => void;
   renderSpectrum: () => void;
   settings: SettingsState;
-  shellDom: Pick<UiShellDom, "menuButtons">;
+  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
   syncAnalysisInputs: () => void;
   panel: CarsListPanelView;
   transport?: Partial<SettingsCarsTransport>;
@@ -84,20 +85,29 @@ export function createSettingsCarsModule(
     return deriveCarSelectionState(settings);
   }
 
-  function renderState(): CarsListRenderModel {
+  function createPanelModel(
+    carSelectionState: CarSelectionState,
+  ): Parameters<CarsListPanelView["render"]>[0] {
     return {
-      activeCarId: settings.activeCarId,
-      carSelectionState: getCarSelectionState(),
-      cars: settings.cars,
-      highlightedCarFeedback,
-      escapeHtml: ctx.escapeHtml,
-      fmt: ctx.fmt,
-      t,
+      guidance: buildCarsGuidanceRenderModel({
+        carSelectionState,
+        highlightedCarFeedback,
+        t,
+      }),
+      table: carSelectionState.kind === "loading"
+        ? null
+        : buildSettingsCarListRenderModel({
+          activeCarId: settings.activeCarId,
+          cars: settings.cars,
+          highlightedCarId: highlightedCarFeedback?.carId ?? null,
+          fmt: ctx.fmt,
+          t,
+        }),
     };
   }
 
-  function syncAnalysisControls(state: CarsListRenderModel): void {
-    const hasActiveCar = state.carSelectionState.kind === "active";
+  function syncAnalysisControls(carSelectionState: CarSelectionState): void {
+    const hasActiveCar = carSelectionState.kind === "active";
     if (ctx.analysisDom.saveAnalysisBtn) {
       ctx.analysisDom.saveAnalysisBtn.disabled = !hasActiveCar;
     }
@@ -106,14 +116,14 @@ export function createSettingsCarsModule(
     }
     if (ctx.analysisDom.analysisNoCarMessage) {
       ctx.analysisDom.analysisNoCarMessage.hidden =
-        hasActiveCar || state.carSelectionState.kind === "loading";
+        hasActiveCar || carSelectionState.kind === "loading";
     }
   }
 
   function renderCarList(): void {
-    const state = renderState();
-    syncAnalysisControls(state);
-    ctx.panel.render(state);
+    const carSelectionState = getCarSelectionState();
+    syncAnalysisControls(carSelectionState);
+    ctx.panel.render(createPanelModel(carSelectionState));
   }
 
   function clearHighlightedCarFeedback(): void {
@@ -126,98 +136,6 @@ export function createSettingsCarsModule(
     }
     clearHighlightedCarFeedback();
     renderCarList();
-  }
-
-  function settingsTabIdAt(index: number): string | null {
-    if (!ctx.dom.settingsTabs.length) {
-      return null;
-    }
-    const safeIndex =
-      ((index % ctx.dom.settingsTabs.length) + ctx.dom.settingsTabs.length) %
-      ctx.dom.settingsTabs.length;
-    return ctx.dom.settingsTabs[safeIndex].getAttribute("data-settings-tab");
-  }
-
-  function primaryViewIdAt(index: number): string | undefined {
-    if (!ctx.shellDom.menuButtons.length) {
-      return undefined;
-    }
-    const safeIndex =
-      ((index % ctx.shellDom.menuButtons.length) +
-        ctx.shellDom.menuButtons.length) %
-      ctx.shellDom.menuButtons.length;
-    return ctx.shellDom.menuButtons[safeIndex].dataset.view;
-  }
-
-  function bindHighlightedCarFeedbackResetEvents(): void {
-    const dismissForSettingsTab = (tabId: string | null): void => {
-      if (tabId && tabId !== "carTab") {
-        dismissHighlightedCarFeedback();
-      }
-    };
-    const dismissForPrimaryView = (viewId: string | undefined): void => {
-      if (viewId && viewId !== "settingsView") {
-        dismissHighlightedCarFeedback();
-      }
-    };
-
-    ctx.dom.settingsTabs.forEach((tab, index) => {
-      tab.addEventListener("click", () => {
-        dismissForSettingsTab(tab.getAttribute("data-settings-tab"));
-      });
-      tab.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          dismissForSettingsTab(tab.getAttribute("data-settings-tab"));
-          return;
-        }
-        if (event.key === "ArrowRight") {
-          dismissForSettingsTab(settingsTabIdAt(index + 1));
-          return;
-        }
-        if (event.key === "ArrowLeft") {
-          dismissForSettingsTab(settingsTabIdAt(index - 1));
-          return;
-        }
-        if (event.key === "Home") {
-          dismissForSettingsTab(settingsTabIdAt(0));
-          return;
-        }
-        if (event.key === "End") {
-          dismissForSettingsTab(
-            settingsTabIdAt(ctx.dom.settingsTabs.length - 1),
-          );
-        }
-      });
-    });
-
-    ctx.shellDom.menuButtons.forEach((button, index) => {
-      button.addEventListener("click", () => {
-        dismissForPrimaryView(button.dataset.view);
-      });
-      button.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          dismissForPrimaryView(button.dataset.view);
-          return;
-        }
-        if (event.key === "ArrowRight") {
-          dismissForPrimaryView(primaryViewIdAt(index + 1));
-          return;
-        }
-        if (event.key === "ArrowLeft") {
-          dismissForPrimaryView(primaryViewIdAt(index - 1));
-          return;
-        }
-        if (event.key === "Home") {
-          dismissForPrimaryView(primaryViewIdAt(0));
-          return;
-        }
-        if (event.key === "End") {
-          dismissForPrimaryView(
-            primaryViewIdAt(ctx.shellDom.menuButtons.length - 1),
-          );
-        }
-      });
-    });
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
@@ -336,7 +254,16 @@ export function createSettingsCarsModule(
       return;
     }
     handlersBound = true;
-    bindHighlightedCarFeedbackResetEvents();
+    ctx.subscribeSettingsTabChanges((tabId) => {
+      if (tabId !== "carTab") {
+        dismissHighlightedCarFeedback();
+      }
+    });
+    ctx.subscribePrimaryViewChanges((viewId) => {
+      if (viewId !== "settingsView") {
+        dismissHighlightedCarFeedback();
+      }
+    });
     ctx.panel.bindActions({
       onAction: (action) => {
         if (action.type === "add") {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -30,6 +30,7 @@ export interface SettingsFeatureDeps extends FeatureDepsBase {
   getSpeedUnit: () => string;
   fmt: (n: number, digits?: number) => string;
   openCarWizard: () => void;
+  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   settingsShell: SettingsShellView;
   carsPanel: CarsListPanelView;
   analysisPanel: AnalysisPanelView;
@@ -122,7 +123,6 @@ export function createSettingsFeature(
       renderSpeedReadout: ctx.view.renderSpeedReadout,
     });
   carsModule = createSettingsCarsModule({
-    dom: ctx.settingsShell.dom,
     analysisDom: ctx.analysisPanel.dom,
     escapeHtml,
     fmt,
@@ -132,7 +132,8 @@ export function createSettingsFeature(
     renderRealtimeStatus: ctx.realtime.renderRealtimeStatus,
     renderSpectrum: ctx.view.renderSpectrum,
     settings,
-    shellDom,
+    subscribePrimaryViewChanges: ctx.subscribePrimaryViewChanges,
+    subscribeSettingsTabChanges: ctx.settingsShell.subscribeActiveTabChanges,
     showError: ctx.showError,
     syncAnalysisInputs: analysisModule.syncSettingsInputs,
     panel: ctx.carsPanel,

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -52,6 +52,8 @@ export class UiShellController {
 
   private readonly languageRefresh: UiShellLanguageRefreshModule;
 
+  private readonly activeViewListeners = new Set<(viewId: string) => void>();
+
   private ports: UiShellFeaturePorts | null = null;
 
   private renderSpectrumChart: (() => void) | null = null;
@@ -151,8 +153,21 @@ export class UiShellController {
     this.setPillState(this.els.shellLiveStatus, variant, text);
   }
 
+  subscribeActiveViewChanges(listener: (viewId: string) => void): () => void {
+    this.activeViewListeners.add(listener);
+    return () => {
+      this.activeViewListeners.delete(listener);
+    };
+  }
+
   setActiveView(viewId: string): void {
+    const previousViewId = this.state.shell.activeViewId;
     this.navigation.setActiveView(viewId);
+    if (this.state.shell.activeViewId !== previousViewId) {
+      for (const listener of this.activeViewListeners) {
+        listener(this.state.shell.activeViewId);
+      }
+    }
   }
 
   applyLanguage(forceReloadInsights = false): void {

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -122,6 +122,8 @@ export class UiAppRuntime {
         espFlashPanel,
         navigation: {
           activatePrimaryView: (viewId) => this.shell.setActiveView(viewId),
+          subscribeActiveViewChanges: (listener) =>
+            this.shell.subscribeActiveViewChanges(listener),
         },
         realtimeChrome: {
           setShellLiveStatus: (variant, text) =>

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -1,36 +1,27 @@
-import type { CarSelectionState } from "../car_selection_state";
 import type { UiCarsDom } from "../dom/cars_dom";
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
-import type { CarRecord } from "../../transport/http_models";
 import {
   bindCarsFeatureInteractions,
   type CarsFeatureInteractionHandlers,
 } from "./cars_feature_bindings";
 import type { ViewDisposer } from "./dom_event_bindings";
-import { renderInlineStatePanel } from "./dom_helpers";
 import {
-  bindSettingsCarListActions,
-  renderSettingsCarList,
-  type SettingsCarListAction,
+  inlineStateActionClass,
+} from "./dom_helpers";
+import {
+  type CarsInlineStateViewModel,
+  type CarsListAction,
+  type CarsListRowViewModel,
+  type SettingsCarListTableRenderModel,
 } from "./settings_car_list_view";
 
-export interface CarsListHighlightedFeedback {
-  carId: string;
-  carName: string;
-}
-
 export interface CarsListRenderModel {
-  activeCarId: string | null;
-  carSelectionState: CarSelectionState;
-  cars: readonly CarRecord[];
-  highlightedCarFeedback: CarsListHighlightedFeedback | null;
-  t: (key: string, vars?: Record<string, unknown>) => string;
-  escapeHtml: (value: unknown) => string;
-  fmt: (value: number, digits?: number) => string;
+  guidance: CarsInlineStateViewModel | null;
+  table: SettingsCarListTableRenderModel | null;
 }
 
 export interface CarsListPanelView {
-  bindActions(handlers: { onAction(action: SettingsCarListAction): void }): void;
+  bindActions(handlers: { onAction(action: CarsListAction): void }): void;
   render(model: CarsListRenderModel): void;
 }
 
@@ -44,7 +35,188 @@ export interface CarsPanelView {
   readonly wizard: CarsWizardPanelBridge;
 }
 
-function CarsPanel() {
+type CarsListPanelActionHandlers = {
+  onAction(action: CarsListAction): void;
+};
+
+type CarsPanelBridgeState = {
+  actions: CarsListPanelActionHandlers | null;
+  model: CarsListRenderModel;
+};
+
+const DEFAULT_CARS_PANEL_MODEL: CarsListRenderModel = {
+  guidance: null,
+  table: null,
+};
+
+function handleCarsListAction(
+  actions: CarsListPanelActionHandlers | null,
+  action: CarsListAction,
+): void {
+  actions?.onAction(action);
+}
+
+function CarsInlineStatePanel(props: {
+  actions: CarsListPanelActionHandlers | null;
+  state: CarsInlineStateViewModel;
+}) {
+  const { actions, state } = props;
+  const rootClass = state.tone === "success"
+    ? "empty-state empty-state--inline car-selection-feedback car-selection-feedback--success"
+    : "empty-state empty-state--inline empty-state--actionable";
+  return (
+    <div class={rootClass} role={state.tone === "success" ? "status" : undefined}>
+      <strong class="empty-state__title">{state.titleText}</strong>
+      <span class="empty-state__body">{state.bodyText}</span>
+      {state.detailText ? (
+        <span class="empty-state__detail">{state.detailText}</span>
+      ) : null}
+      {state.action ? (
+        <div class="empty-state__actions">
+          <button
+            type="button"
+            class={inlineStateActionClass(state.action.variant)}
+            data-inline-state-action={state.action.type === "add" ? "add-car" : state.action.type}
+            onClick={() =>
+              handleCarsListAction(actions, {
+                type: state.action?.type ?? "add",
+                carId: null,
+              })}
+          >
+            {state.action.labelText}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CarsTableRow(props: {
+  actions: CarsListPanelActionHandlers | null;
+  row: CarsListRowViewModel;
+}) {
+  const { actions, row } = props;
+  const primaryAction = row.primaryAction;
+  return (
+    <tr
+      class={row.isHighlighted ? "car-list-row--highlighted" : undefined}
+      data-car-id={row.carId}
+      data-car-complete={row.isComplete ? "true" : "false"}
+      data-highlighted={row.isHighlighted ? "true" : "false"}
+    >
+      <td>
+        <div class="car-row__identity">
+          <div class="car-row__heading">
+            <strong>{row.displayName}</strong>
+          </div>
+          {row.metaTypeText || row.metaVariantText ? (
+            <div class="car-row__meta">
+              {row.metaTypeText ? <span class="car-row__type">{row.metaTypeText}</span> : null}
+              {row.metaVariantText ? (
+                <span class="car-row__variant">{row.metaVariantText}</span>
+              ) : null}
+            </div>
+          ) : null}
+          <div class="car-status-stack">
+            <span
+              class="car-active-pill settings-entity-status"
+              data-state={row.activeState}
+            >
+              {row.activeStatusText}
+            </span>
+            <span
+              class="car-readiness-pill settings-entity-status"
+              data-state={row.readinessState}
+            >
+              {row.readinessStatusText}
+            </span>
+            {row.highlightedStatusText ? (
+              <span class="car-created-pill settings-entity-status">
+                {row.highlightedStatusText}
+              </span>
+            ) : null}
+          </div>
+          {row.completionDetailText ? (
+            <span class="subtle car-row__detail">{row.completionDetailText}</span>
+          ) : null}
+        </div>
+      </td>
+      <td>
+        <div class="car-row__setup">
+          {row.setupMetrics.map((metric) => (
+            <div key={metric.labelText} class="car-row__setup-item">
+              <span class="car-row__setup-label">{metric.labelText}</span>
+              <span class="car-row__setup-value">
+                {metric.isCode ? <code>{metric.valueText}</code> : metric.valueText}
+              </span>
+            </div>
+          ))}
+        </div>
+      </td>
+      <td>
+        <div class="car-list-actions">
+          {primaryAction ? (
+            <button
+              type="button"
+              class={primaryAction.className}
+              data-car-action={primaryAction.type}
+              data-car-id={row.carId}
+              onClick={() =>
+                handleCarsListAction(actions, {
+                  type: primaryAction.type,
+                  carId: row.carId,
+                })}
+            >
+              {primaryAction.labelText}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            class="btn btn--danger-quiet car-delete-btn"
+            data-car-action="delete"
+            data-car-id={row.carId}
+            onClick={() => handleCarsListAction(actions, { type: "delete", carId: row.carId })}
+          >
+            {row.deleteLabelText}
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function CarsTableBody(props: {
+  actions: CarsListPanelActionHandlers | null;
+  table: SettingsCarListTableRenderModel | null;
+}) {
+  const { actions, table } = props;
+  if (table === null) {
+    return (
+      <tr>
+        <td colSpan={3} data-i18n="settings.car.no_cars">
+          No cars added yet.
+        </td>
+      </tr>
+    );
+  }
+  if (table.kind === "empty") {
+    return (
+      <tr>
+        <td colSpan={3}>
+          <div class="settings-table-empty-state">
+            <CarsInlineStatePanel actions={actions} state={table.emptyState} />
+          </div>
+        </td>
+      </tr>
+    );
+  }
+  return table.rows.map((row) => (
+    <CarsTableRow key={row.carId} actions={actions} row={row} />
+  ));
+}
+
+function CarsPanel(props: { state: CarsPanelBridgeState }) {
+  const { state } = props;
   return (
     <>
       <div class="panel card">
@@ -58,7 +230,11 @@ function CarsPanel() {
           Add cars from the library or enter specs manually. Activate a car to use it for
           analysis.
         </div>
-        <div id="carSelectionGuidance" class="empty-state empty-state--inline" hidden />
+        <div id="carSelectionGuidance" hidden={state.model.guidance === null}>
+          {state.model.guidance ? (
+            <CarsInlineStatePanel actions={state.actions} state={state.model.guidance} />
+          ) : null}
+        </div>
         <div class="settings-table-wrap">
           <table class="car-list-table settings-entity-table settings-entity-table--cars">
             <thead>
@@ -69,11 +245,7 @@ function CarsPanel() {
               </tr>
             </thead>
             <tbody id="carListBody">
-              <tr>
-                <td colSpan={3} data-i18n="settings.car.no_cars">
-                  No cars added yet.
-                </td>
-              </tr>
+              <CarsTableBody actions={state.actions} table={state.model.table} />
             </tbody>
           </table>
         </div>
@@ -377,80 +549,27 @@ function createCarsPanelDom(host: HTMLElement): UiCarsDom {
   };
 }
 
-function renderCreationFeedback(
-  feedback: CarsListHighlightedFeedback,
-  deps: Pick<CarsListRenderModel, "escapeHtml" | "t">,
-): string {
-  return `
-    <div class="empty-state empty-state--inline car-selection-feedback car-selection-feedback--success" role="status">
-      <strong class="empty-state__title">${deps.escapeHtml(deps.t("settings.car.created_title"))}</strong>
-      <span class="empty-state__body">${deps.escapeHtml(
-        deps.t("settings.car.created_body", { name: feedback.carName }),
-      )}</span>
-      <span class="empty-state__detail">${deps.escapeHtml(deps.t("settings.car.created_detail"))}</span>
-    </div>
-  `;
-}
-
-function renderCarsGuidance(target: HTMLElement | null, model: CarsListRenderModel): void {
-  if (!target) {
-    return;
-  }
-  if (
-    model.carSelectionState.kind === "loading"
-    || model.carSelectionState.kind === "no_cars"
-  ) {
-    target.hidden = true;
-    target.replaceChildren();
-    return;
-  }
-  if (model.carSelectionState.kind === "active" && model.highlightedCarFeedback) {
-    target.hidden = false;
-    target.innerHTML = renderCreationFeedback(model.highlightedCarFeedback, model);
-    return;
-  }
-  if (model.carSelectionState.kind === "active") {
-    target.hidden = true;
-    target.replaceChildren();
-    return;
-  }
-  target.hidden = false;
-  target.innerHTML = renderInlineStatePanel({
-    titleHtml: model.escapeHtml(model.t("settings.car.guidance.no_active_title")),
-    bodyHtml: model.escapeHtml(model.t("settings.car.guidance.no_active")),
-    detailHtml: model.escapeHtml(model.t("settings.car.guidance.no_active_detail")),
-  });
-}
-
 export function mountCarsPanel(host: HTMLElement): CarsPanelView {
+  const bridgeState: CarsPanelBridgeState = {
+    actions: null,
+    model: DEFAULT_CARS_PANEL_MODEL,
+  };
   const mount = createUiPreactMount(host);
-  mount.render(<CarsPanel />);
+  const render = () => mount.render(<CarsPanel state={bridgeState} />);
+  render();
 
   const dom = createCarsPanelDom(host);
-  const carSelectionGuidance = requireInHost<HTMLElement>(host, "#carSelectionGuidance");
-  const carListBody = requireInHost<HTMLElement>(host, "#carListBody");
-  let listDisposer: ViewDisposer | null = null;
   let wizardDisposer: ViewDisposer | null = null;
 
   return {
     list: {
       bindActions(handlers): void {
-        listDisposer?.();
-        listDisposer = bindSettingsCarListActions({ carListBody }, handlers);
+        bridgeState.actions = handlers;
+        render();
       },
       render(model): void {
-        renderCarsGuidance(carSelectionGuidance, model);
-        if (model.carSelectionState.kind === "loading") {
-          return;
-        }
-        renderSettingsCarList(carListBody, {
-          activeCarId: model.activeCarId,
-          cars: [...model.cars],
-          highlightedCarId: model.highlightedCarFeedback?.carId ?? null,
-          t: model.t,
-          escapeHtml: model.escapeHtml,
-          fmt: model.fmt,
-        });
+        bridgeState.model = model;
+        render();
       },
     },
     wizard: {

--- a/apps/ui/src/app/views/settings_car_list_view.ts
+++ b/apps/ui/src/app/views/settings_car_list_view.ts
@@ -1,29 +1,77 @@
 import type { CarRecord } from "../../transport/http_models";
-import { getCarCompleteness } from "../car_selection_state";
-import {
-  closestFromTarget,
-  renderInlineStatePanel,
-  renderTableEmptyRow,
-} from "./dom_helpers";
-import { bindViewEvent, type ViewDisposer } from "./dom_event_bindings";
+import { type CarSelectionState, getCarCompleteness } from "../car_selection_state";
+
+export interface CarsListHighlightedFeedback {
+  carId: string;
+  carName: string;
+}
 
 export interface SettingsCarListViewParams {
-  cars: CarRecord[];
+  cars: readonly CarRecord[];
   activeCarId: string | null;
   highlightedCarId?: string | null;
   t: (key: string, vars?: Record<string, unknown>) => string;
-  escapeHtml: (value: unknown) => string;
   fmt: (value: number, digits?: number) => string;
 }
 
-export interface SettingsCarListAction {
+export interface CarsListAction {
   type: "activate" | "complete" | "delete" | "add";
   carId: string | null;
 }
 
-export interface SettingsCarListBindingDom {
-  carListBody: HTMLElement | null;
+export interface CarsInlineActionViewModel {
+  labelText: string;
+  type: CarsListAction["type"];
+  variant?: "primary" | "success" | "muted";
 }
+
+export interface CarsInlineStateViewModel {
+  bodyText: string;
+  detailText?: string;
+  titleText: string;
+  action?: CarsInlineActionViewModel;
+  tone?: "default" | "success";
+}
+
+export interface CarsListRowMetricViewModel {
+  isCode?: boolean;
+  labelText: string;
+  valueText: string;
+}
+
+export interface CarsListRowActionViewModel {
+  className: string;
+  labelText: string;
+  type: Exclude<CarsListAction["type"], "add">;
+}
+
+export interface CarsListRowViewModel {
+  activeState: "active" | "inactive";
+  activeStatusText: string;
+  carId: string;
+  completionDetailText: string | null;
+  deleteLabelText: string;
+  displayName: string;
+  highlightedStatusText: string | null;
+  isComplete: boolean;
+  isHighlighted: boolean;
+  metaTypeText: string | null;
+  metaVariantText: string | null;
+  primaryAction: CarsListRowActionViewModel | null;
+  readinessState: "ready" | "incomplete";
+  readinessStatusText: string;
+  setupMetrics: readonly CarsListRowMetricViewModel[];
+}
+
+export type SettingsCarListTableRenderModel =
+  | {
+      emptyState: CarsInlineStateViewModel;
+      kind: "empty";
+    }
+  | {
+      kind: "rows";
+      rows: readonly CarsListRowViewModel[];
+    };
 
 function hasConfiguredNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
@@ -54,162 +102,130 @@ function formatRatioValue(
   return params.fmt(value, 2);
 }
 
-function renderRowActionButtons(
-  car: CarRecord,
-  options: {
+function buildPrimaryAction(options: {
     isActive: boolean;
     isComplete: boolean;
-    params: Pick<SettingsCarListViewParams, "escapeHtml" | "t">;
+    t: SettingsCarListViewParams["t"];
   },
-): string {
-  const {
-    isActive,
-    isComplete,
-    params: { escapeHtml, t },
-  } = options;
-  const primaryButton = isComplete
-    ? (!isActive
-        ? `<button class="btn car-activate-btn" data-car-action="activate" data-car-id="${escapeHtml(car.id)}">${escapeHtml(t("settings.car.activate"))}</button>`
-        : "")
-    : `<button class="btn btn--primary car-complete-btn" data-car-action="complete" data-car-id="${escapeHtml(car.id)}">${escapeHtml(t(isActive ? "settings.car.open_analysis" : "settings.car.finish_setup"))}</button>`;
-  return `
-    <div class="car-list-actions">
-      ${primaryButton}
-      <button class="btn btn--danger-quiet car-delete-btn" data-car-action="delete" data-car-id="${escapeHtml(car.id)}">${escapeHtml(t("settings.car.delete"))}</button>
-    </div>
-  `;
+): CarsListRowActionViewModel | null {
+  const { isActive, isComplete, t } = options;
+  if (isComplete) {
+    if (isActive) {
+      return null;
+    }
+    return {
+      className: "btn car-activate-btn",
+      labelText: t("settings.car.activate"),
+      type: "activate",
+    };
+  }
+  return {
+    className: "btn btn--primary car-complete-btn",
+    labelText: t(isActive ? "settings.car.open_analysis" : "settings.car.finish_setup"),
+    type: "complete",
+  };
 }
 
-function renderSetupMetric(labelHtml: string, valueHtml: string): string {
-  return `
-    <div class="car-row__setup-item">
-      <span class="car-row__setup-label">${labelHtml}</span>
-      <span class="car-row__setup-value">${valueHtml}</span>
-    </div>
-  `;
+export function buildCarsGuidanceRenderModel(options: {
+  carSelectionState: CarSelectionState;
+  highlightedCarFeedback: CarsListHighlightedFeedback | null;
+  t: SettingsCarListViewParams["t"];
+}): CarsInlineStateViewModel | null {
+  const { carSelectionState, highlightedCarFeedback, t } = options;
+  if (
+    carSelectionState.kind === "loading"
+    || carSelectionState.kind === "no_cars"
+  ) {
+    return null;
+  }
+  if (carSelectionState.kind === "active" && highlightedCarFeedback) {
+    return {
+      bodyText: t("settings.car.created_body", { name: highlightedCarFeedback.carName }),
+      detailText: t("settings.car.created_detail"),
+      titleText: t("settings.car.created_title"),
+      tone: "success",
+    };
+  }
+  if (carSelectionState.kind === "active") {
+    return null;
+  }
+  return {
+    bodyText: t("settings.car.guidance.no_active"),
+    detailText: t("settings.car.guidance.no_active_detail"),
+    titleText: t("settings.car.guidance.no_active_title"),
+    tone: "default",
+  };
 }
 
-export function renderSettingsCarList(
-  container: HTMLElement,
+export function buildSettingsCarListRenderModel(
   params: SettingsCarListViewParams,
-): void {
+): SettingsCarListTableRenderModel {
   const {
     cars,
     activeCarId,
     highlightedCarId = null,
     t,
-    escapeHtml,
     fmt,
   } = params;
-  if (!cars.length) {
-    container.innerHTML = renderTableEmptyRow(
-      `<div class="settings-table-empty-state">${renderInlineStatePanel({
-        titleHtml: escapeHtml(t("settings.car.empty.title")),
-        bodyHtml: escapeHtml(t("settings.car.empty.body")),
-        detailHtml: escapeHtml(t("settings.car.empty.detail")),
+  if (cars.length === 0) {
+    return {
+      kind: "empty",
+      emptyState: {
         action: {
-          action: "add-car",
-          labelHtml: escapeHtml(t("settings.car.empty.action")),
+          labelText: t("settings.car.empty.action"),
+          type: "add",
           variant: "success",
         },
-      })}</div>`,
-      3,
-    );
-    return;
+        bodyText: t("settings.car.empty.body"),
+        detailText: t("settings.car.empty.detail"),
+        titleText: t("settings.car.empty.title"),
+      },
+    };
   }
 
-  container.innerHTML = cars
-    .map((car) => {
+  return {
+    kind: "rows",
+    rows: cars.map((car) => {
       const isActive = car.id === activeCarId;
       const isHighlighted = car.id === highlightedCarId;
       const { isComplete } = getCarCompleteness(car);
-      const tireStr = formatTireSummary(car, t);
-      const driveStr = formatRatioValue(car.aspects?.final_drive_ratio, { fmt, t });
-      const gearStr = formatRatioValue(car.aspects?.current_gear_ratio, { fmt, t });
-      const typeMarkup = car.type
-        ? `<span class="car-row__type">${escapeHtml(car.type)}</span>`
-        : "";
-      const variantMarkup = car.variant
-        ? `<span class="car-row__variant">${escapeHtml(car.variant)}</span>`
-        : "";
-      const metaMarkup = typeMarkup || variantMarkup
-        ? `<div class="car-row__meta">${typeMarkup}${variantMarkup}</div>`
-        : "";
-      const completionDetail = isComplete
-        ? ""
-        : `<span class="subtle car-row__detail">${escapeHtml(t("settings.car.incomplete_detail"))}</span>`;
-      const rowClass = isHighlighted ? ' class="car-list-row--highlighted"' : "";
-      return `
-        <tr
-          ${rowClass}
-          data-car-id="${escapeHtml(car.id)}"
-          data-car-complete="${isComplete ? "true" : "false"}"
-          data-highlighted="${isHighlighted ? "true" : "false"}"
-        >
-          <td>
-            <div class="car-row__identity">
-              <div class="car-row__heading">
-                <strong>${escapeHtml(car.name)}</strong>
-              </div>
-              ${metaMarkup}
-              <div class="car-status-stack">
-                <span class="car-active-pill settings-entity-status" data-state="${isActive ? "active" : "inactive"}">${isActive ? escapeHtml(t("settings.car.active_label")) : escapeHtml(t("settings.car.inactive_label"))}</span>
-                <span class="car-readiness-pill settings-entity-status" data-state="${isComplete ? "ready" : "incomplete"}">${escapeHtml(t(isComplete ? "settings.car.ready_label" : "settings.car.incomplete_label"))}</span>
-                ${isHighlighted ? `<span class="car-created-pill settings-entity-status">${escapeHtml(t("settings.car.just_added"))}</span>` : ""}
-              </div>
-              ${completionDetail}
-            </div>
-          </td>
-          <td>
-            <div class="car-row__setup">
-              ${renderSetupMetric(escapeHtml(t("settings.car.col_tires")), `<code>${escapeHtml(tireStr)}</code>`)}
-              ${renderSetupMetric(escapeHtml(t("settings.car.col_drive")), escapeHtml(driveStr))}
-              ${renderSetupMetric(escapeHtml(t("settings.car.col_gear")), escapeHtml(gearStr))}
-            </div>
-          </td>
-          <td>${renderRowActionButtons(car, { isActive, isComplete, params: { escapeHtml, t } })}</td>
-        </tr>
-      `;
-    })
-    .join("");
-}
-
-export function getSettingsCarListAction(
-  target: EventTarget | null,
-): SettingsCarListAction | null {
-  const inlineAction = closestFromTarget<HTMLElement>(target, '[data-inline-state-action="add-car"]');
-  if (inlineAction) {
-    return {
-      type: "add",
-      carId: null,
-    };
-  }
-  const button = closestFromTarget<HTMLButtonElement>(target, "[data-car-action]");
-  if (!button) {
-    return null;
-  }
-  const type = button.getAttribute("data-car-action");
-  if (type !== "activate" && type !== "complete" && type !== "delete") {
-    return null;
-  }
-  const carId = button.getAttribute("data-car-id");
-  if (!carId) {
-    return null;
-  }
-  return {
-    type,
-    carId,
+      return {
+        activeState: isActive ? "active" : "inactive",
+        activeStatusText: t(
+          isActive ? "settings.car.active_label" : "settings.car.inactive_label",
+        ),
+        carId: car.id,
+        completionDetailText: isComplete
+          ? null
+          : t("settings.car.incomplete_detail"),
+        deleteLabelText: t("settings.car.delete"),
+        displayName: car.name,
+        highlightedStatusText: isHighlighted ? t("settings.car.just_added") : null,
+        isComplete,
+        isHighlighted,
+        metaTypeText: car.type ?? null,
+        metaVariantText: car.variant ?? null,
+        primaryAction: buildPrimaryAction({ isActive, isComplete, t }),
+        readinessState: isComplete ? "ready" : "incomplete",
+        readinessStatusText: t(
+          isComplete ? "settings.car.ready_label" : "settings.car.incomplete_label",
+        ),
+        setupMetrics: [
+          {
+            isCode: true,
+            labelText: t("settings.car.col_tires"),
+            valueText: formatTireSummary(car, t),
+          },
+          {
+            labelText: t("settings.car.col_drive"),
+            valueText: formatRatioValue(car.aspects?.final_drive_ratio, { fmt, t }),
+          },
+          {
+            labelText: t("settings.car.col_gear"),
+            valueText: formatRatioValue(car.aspects?.current_gear_ratio, { fmt, t }),
+          },
+        ],
+      };
+    }),
   };
-}
-
-export function bindSettingsCarListActions(
-  dom: SettingsCarListBindingDom,
-  handlers: { onAction(action: SettingsCarListAction): void },
-): ViewDisposer {
-  return bindViewEvent(dom.carListBody, "click", (event: MouseEvent) => {
-    const action = getSettingsCarListAction(event.target);
-    if (action) {
-      handlers.onAction(action);
-    }
-  });
 }

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "preact";
 
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
+import type { ViewDisposer } from "./dom_event_bindings";
 
 const SETTINGS_TABS = [
   {
@@ -56,6 +57,7 @@ export interface SettingsShellDom {
 export interface SettingsShellView {
   readonly dom: SettingsShellDom;
   activateTab(tabId: string): void;
+  subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer;
 }
 
 type SettingsShellProps = {
@@ -184,14 +186,29 @@ function createSettingsShellDom(host: HTMLElement): SettingsShellDom {
 export function mountSettingsShell(host: HTMLElement): SettingsShellView {
   const mount = createUiPreactMount(host);
   let activeTabId: SettingsShellTabId = "carTab";
+  const activeTabListeners = new Set<(tabId: string) => void>();
+
+  function notifyActiveTabListeners(): void {
+    for (const listener of activeTabListeners) {
+      listener(activeTabId);
+    }
+  }
+
+  function setActiveTab(tabId: SettingsShellTabId): void {
+    if (tabId === activeTabId) {
+      return;
+    }
+    activeTabId = tabId;
+    render();
+    notifyActiveTabListeners();
+  }
 
   function render(): void {
     mount.render(
       <SettingsShell
         activeTabId={activeTabId}
         onActivateTab={(tabId) => {
-          activeTabId = tabId;
-          render();
+          setActiveTab(tabId);
         }}
       />,
     );
@@ -206,11 +223,13 @@ export function mountSettingsShell(host: HTMLElement): SettingsShellView {
       if (!isSettingsShellTabId(tabId)) {
         return;
       }
-      if (tabId === activeTabId) {
-        return;
-      }
-      activeTabId = tabId;
-      render();
+      setActiveTab(tabId);
+    },
+    subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer {
+      activeTabListeners.add(listener);
+      return () => {
+        activeTabListeners.delete(listener);
+      };
     },
   };
 }

--- a/apps/ui/tests/car_list_state.spec.ts
+++ b/apps/ui/tests/car_list_state.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "@playwright/test";
 
 import { getCarCompleteness } from "../src/app/car_selection_state";
-import { renderSettingsCarList } from "../src/app/views/settings_car_list_view";
+import {
+  buildCarsGuidanceRenderModel,
+  buildSettingsCarListRenderModel,
+} from "../src/app/views/settings_car_list_view";
 import type { CarRecord } from "../src/transport/http_models";
 
 function makeCar(overrides: Partial<CarRecord> = {}): CarRecord {
@@ -35,14 +38,19 @@ const labels: Record<string, string> = {
   "settings.car.value_missing": "Not set",
   "settings.car.tires_missing": "Tire size not set",
   "settings.car.incomplete_detail": "Open Analysis to finish the missing tire and drivetrain specs before using this car.",
+  "settings.car.created_title": "Car added",
+  "settings.car.created_body": "{name} was added and selected for this setup.",
+  "settings.car.created_detail": "Review the highlighted row below or open Analysis to confirm the setup before the next run.",
+  "settings.car.guidance.no_active_title": "Activate one car for this setup.",
+  "settings.car.guidance.no_active": "Activate a car from the list below or add a new one to unlock analysis settings.",
+  "settings.car.guidance.no_active_detail": "Use Activate on a ready row, or Finish setup on an incomplete row, to unlock the rest of Settings.",
 };
 
-function t(key: string): string {
+function t(key: string, vars?: Record<string, unknown>): string {
+  if (key === "settings.car.created_body") {
+    return `${vars?.name ?? "Unknown"} was added and selected for this setup.`;
+  }
   return labels[key] ?? key;
-}
-
-function escapeHtml(value: unknown): string {
-  return String(value ?? "");
 }
 
 function fmt(value: number, digits = 0): string {
@@ -75,10 +83,8 @@ test("getCarCompleteness reports whether the required car specs are present", ()
   ]);
 });
 
-test("renderSettingsCarList shows explicit readiness labels and completion actions", () => {
-  const container = { innerHTML: "" } as HTMLElement;
-
-  renderSettingsCarList(container, {
+test("buildSettingsCarListRenderModel produces typed row state for readiness, highlight, and actions", () => {
+  const model = buildSettingsCarListRenderModel({
     cars: [
       makeCar({
         id: "car-ready",
@@ -114,28 +120,120 @@ test("renderSettingsCarList shows explicit readiness labels and completion actio
     activeCarId: "car-ready",
     highlightedCarId: "car-new",
     t,
-    escapeHtml,
     fmt,
   });
 
-  expect(container.innerHTML).toContain('data-car-id="car-ready"');
-  expect(container.innerHTML).toContain('data-car-complete="true"');
-  expect(container.innerHTML).toContain("Active");
-  expect(container.innerHTML).toContain("Ready");
-  expect(container.innerHTML).toContain('data-car-id="car-ready-inactive"');
-  expect(container.innerHTML).toContain('data-car-action="activate"');
-  expect(container.innerHTML).toContain('data-car-id="car-new"');
-  expect(container.innerHTML).toContain('data-car-complete="false"');
-  expect(container.innerHTML).toContain("Inactive");
-  expect(container.innerHTML).toContain("Needs specs");
-  expect(container.innerHTML).toContain("Finish setup");
-  expect(container.innerHTML).toContain("Tire size not set");
-  expect(container.innerHTML).toContain("Not set");
-  expect(container.innerHTML).toContain("car-row__setup");
-  expect(container.innerHTML).toContain("Top Gear");
-  expect(container.innerHTML).toContain("Open Analysis to finish the missing tire and drivetrain specs before using this car.");
-  expect(container.innerHTML).toContain("car-list-row--highlighted");
-  expect(container.innerHTML).toContain("New");
-  expect(container.innerHTML).toContain("btn--danger-quiet");
-  expect(container.innerHTML).not.toContain("?");
+  expect(model.kind).toBe("rows");
+  if (model.kind !== "rows") {
+    return;
+  }
+
+  expect(model.rows).toHaveLength(3);
+  expect(model.rows[0]).toMatchObject({
+    activeState: "active",
+    activeStatusText: "Active",
+    carId: "car-ready",
+    completionDetailText: null,
+    displayName: "Ready Car",
+    highlightedStatusText: null,
+    isComplete: true,
+    isHighlighted: false,
+    primaryAction: null,
+    readinessState: "ready",
+    readinessStatusText: "Ready",
+  });
+  expect(model.rows[1].primaryAction).toEqual({
+    className: "btn car-activate-btn",
+    labelText: "Activate",
+    type: "activate",
+  });
+  expect(model.rows[2]).toMatchObject({
+    activeState: "inactive",
+    carId: "car-new",
+    completionDetailText: "Open Analysis to finish the missing tire and drivetrain specs before using this car.",
+    highlightedStatusText: "New",
+    isComplete: false,
+    isHighlighted: true,
+    metaVariantText: "Project",
+    readinessState: "incomplete",
+    readinessStatusText: "Needs specs",
+  });
+  expect(model.rows[2].primaryAction).toEqual({
+    className: "btn btn--primary car-complete-btn",
+    labelText: "Finish setup",
+    type: "complete",
+  });
+  expect(model.rows[2].setupMetrics).toEqual([
+    { isCode: true, labelText: "Tires", valueText: "Tire size not set" },
+    { labelText: "Drive", valueText: "Not set" },
+    { labelText: "Top Gear", valueText: "Not set" },
+  ]);
+});
+
+test("buildSettingsCarListRenderModel produces the actionable empty state when no cars exist", () => {
+  const model = buildSettingsCarListRenderModel({
+    cars: [],
+    activeCarId: null,
+    t,
+    fmt,
+  });
+
+  expect(model).toEqual({
+    kind: "empty",
+    emptyState: {
+      action: {
+        labelText: "Add a car",
+        type: "add",
+        variant: "success",
+      },
+      bodyText: "Cars define the setup used for recording, saved runs, and analysis settings.",
+      detailText: "Start with the add-car wizard so the next recording has the right context.",
+      titleText: "Add the first car profile.",
+    },
+  });
+});
+
+test("buildCarsGuidanceRenderModel returns success, guidance, or hidden states based on selection", () => {
+  expect(
+    buildCarsGuidanceRenderModel({
+      carSelectionState: {
+        kind: "active",
+        car: makeCar({ id: "car-1", name: "Track Demo" }),
+      },
+      highlightedCarFeedback: {
+        carId: "car-1",
+        carName: "Track Demo",
+      },
+      t,
+    }),
+  ).toEqual({
+    bodyText: "Track Demo was added and selected for this setup.",
+    detailText: "Review the highlighted row below or open Analysis to confirm the setup before the next run.",
+    titleText: "Car added",
+    tone: "success",
+  });
+
+  expect(
+    buildCarsGuidanceRenderModel({
+      carSelectionState: { kind: "no_active_car" },
+      highlightedCarFeedback: null,
+      t,
+    }),
+  ).toEqual({
+    bodyText: "Activate a car from the list below or add a new one to unlock analysis settings.",
+    detailText: "Use Activate on a ready row, or Finish setup on an incomplete row, to unlock the rest of Settings.",
+    titleText: "Activate one car for this setup.",
+    tone: "default",
+  });
+
+  expect(
+    buildCarsGuidanceRenderModel({
+      carSelectionState: { kind: "loading" },
+      highlightedCarFeedback: {
+        carId: "car-1",
+        carName: "Track Demo",
+      },
+      t,
+    }),
+  ).toBeNull();
 });

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+
+import { createSettingsCarsModule } from "../src/app/features/settings_cars_module";
+import type { CarsListRenderModel, CarsListPanelView } from "../src/app/views/cars_panel";
+import { createAppState } from "../src/app/ui_app_state";
+import type { CarsPayload } from "../src/transport/http_models";
+
+function lastRender(renders: CarsListRenderModel[]): CarsListRenderModel {
+  const render = renders.at(-1);
+  if (!render) {
+    throw new Error("Expected cars panel to render");
+  }
+  return render;
+}
+
+test("settings cars module dismisses transient creation feedback through typed tab and view callbacks", () => {
+  const state = createAppState().settings;
+  const renders: CarsListRenderModel[] = [];
+  let settingsTabListener: ((tabId: string) => void) | null = null;
+  let primaryViewListener: ((viewId: string) => void) | null = null;
+
+  const panel: CarsListPanelView = {
+    bindActions() {},
+    render(model) {
+      renders.push(model);
+    },
+  };
+
+  const module = createSettingsCarsModule({
+    analysisDom: {
+      analysisNoCarMessage: null,
+      resetAnalysisBtn: null,
+      saveAnalysisBtn: null,
+    },
+    escapeHtml: (value) => String(value ?? ""),
+    fmt: (value, digits = 0) => Number(value).toFixed(digits),
+    openAnalysisTab: () => undefined,
+    openCarWizard: () => undefined,
+    panel,
+    renderRealtimeLoggingStatus: () => undefined,
+    renderRealtimeStatus: () => undefined,
+    renderSpectrum: () => undefined,
+    settings: state,
+    showError: () => undefined,
+    subscribePrimaryViewChanges(listener) {
+      primaryViewListener = listener;
+      return () => {
+        if (primaryViewListener === listener) {
+          primaryViewListener = null;
+        }
+      };
+    },
+    subscribeSettingsTabChanges(listener) {
+      settingsTabListener = listener;
+      return () => {
+        if (settingsTabListener === listener) {
+          settingsTabListener = null;
+        }
+      };
+    },
+    syncAnalysisInputs: () => undefined,
+    t: (key, vars) => {
+      if (key === "settings.car.created_body") {
+        return `${vars?.name ?? "Unknown"} was added and selected for this setup.`;
+      }
+      return key;
+    },
+  });
+
+  const payload: CarsPayload = {
+    active_car_id: "car-1",
+    cars: [{
+      id: "car-1",
+      name: "Track Demo",
+      type: "Coupe",
+      variant: null,
+      aspects: {
+        tire_width_mm: 225,
+        tire_aspect_pct: 45,
+        rim_in: 18,
+        final_drive_ratio: 3.08,
+        current_gear_ratio: 0.64,
+      },
+    }],
+  };
+
+  module.bindHandlers();
+  module.syncCarsPayload(payload);
+  module.showCarCreationSuccess("car-1", "Track Demo");
+
+  const highlighted = lastRender(renders);
+  expect(highlighted.guidance).toMatchObject({
+    titleText: "settings.car.created_title",
+    tone: "success",
+  });
+  expect(highlighted.table?.kind).toBe("rows");
+  if (highlighted.table?.kind !== "rows") {
+    return;
+  }
+  expect(highlighted.table.rows[0].isHighlighted).toBe(true);
+  expect(highlighted.table.rows[0].highlightedStatusText).toBe("settings.car.just_added");
+
+  settingsTabListener?.("analysisTab");
+
+  const dismissedByTab = lastRender(renders);
+  expect(dismissedByTab.guidance).toBeNull();
+  expect(dismissedByTab.table?.kind).toBe("rows");
+  if (dismissedByTab.table?.kind !== "rows") {
+    return;
+  }
+  expect(dismissedByTab.table.rows[0].isHighlighted).toBe(false);
+  expect(dismissedByTab.table.rows[0].highlightedStatusText).toBeNull();
+
+  module.showCarCreationSuccess("car-1", "Track Demo");
+  primaryViewListener?.("dashboardView");
+
+  const dismissedByView = lastRender(renders);
+  expect(dismissedByView.guidance).toBeNull();
+  expect(dismissedByView.table?.kind).toBe("rows");
+  if (dismissedByView.table?.kind !== "rows") {
+    return;
+  }
+  expect(dismissedByView.table.rows[0].isHighlighted).toBe(false);
+  expect(dismissedByView.table.rows[0].highlightedStatusText).toBeNull();
+});

--- a/apps/ui/tests/ui_action_bindings.spec.ts
+++ b/apps/ui/tests/ui_action_bindings.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 
 import { bindCarsFeatureInteractions } from "../src/app/views/cars_feature_bindings";
-import { bindSettingsCarListActions } from "../src/app/views/settings_car_list_view";
 import {
   bindSettingsSpeedSourceInteractions,
   type SettingsSpeedSourceInteraction,
@@ -258,47 +257,6 @@ test.beforeEach(() => {
 test.afterEach(() => {
   restoreDomGlobals();
   restoreDomGlobals = () => undefined;
-});
-
-test("settings car-list bindings surface typed list actions and disposer stops delegated clicks", () => {
-  const carListBody = createContainer("tbody");
-  const addCarButton = appendChild(carListBody, createButton({
-    attrs: { "data-inline-state-action": "add-car" },
-  }));
-  const activateCarButton = appendChild(carListBody, createButton({
-    attrs: {
-      "data-car-action": "activate",
-      "data-car-id": "car-1",
-    },
-  }));
-
-  const actions: Array<{ type: string; carId: string | null }> = [];
-
-  const dispose = bindSettingsCarListActions(
-    {
-      carListBody: carListBody as unknown as HTMLElement,
-    },
-    {
-      onAction: (action) => {
-        actions.push(action);
-      },
-    },
-  );
-
-  carListBody.dispatch("click", { target: addCarButton as unknown as EventTarget });
-  carListBody.dispatch("click", { target: activateCarButton as unknown as EventTarget });
-
-  expect(actions).toEqual([
-    { type: "add", carId: null },
-    { type: "activate", carId: "car-1" },
-  ]);
-
-  dispose();
-  carListBody.dispatch("click", { target: activateCarButton as unknown as EventTarget });
-  expect(actions).toEqual([
-    { type: "add", carId: null },
-    { type: "activate", carId: "car-1" },
-  ]);
 });
 
 test("cars wizard bindings decode typed wizard actions and stop after disposal", () => {


### PR DESCRIPTION
## Summary

This PR completes issue #2283 by finishing the saved-car list side of the car-management migration. The car shell had already moved into `cars_panel.tsx`, but the list inside that shell still behaved like an older imperative surface: `settings_car_list_view.ts` built HTML strings for rows and the empty state, `cars_panel.tsx` wrote creation/no-active guidance into DOM slots with `innerHTML` and `replaceChildren()`, and `settings_cars_module.ts` attached raw listeners to the settings-tab strip and top-level shell menu solely so it could clear the “just added” feedback after the user navigated away. That mix meant the user was looking at a Preact island while some of the most visible list behavior still depended on manual DOM rendering and ad hoc event wiring.

The change here keeps the existing controller/workflow split intact and focuses only on the rendering seam plus the navigation-feedback bridge that supported it. The result is that the saved-car list, empty state, transient creation banner, and “no active car” guidance are now island-owned JSX, while the settings feature continues to own transport, activation, deletion, highlighting state, and the explicit “open wizard” / “open analysis” workflows.

## Implementation approach

I kept the same pattern that worked in the previous history and sensors migrations:

1. preserve a typed model seam instead of pushing raw business logic into the component,
2. let the Preact island own rendering directly in JSX,
3. replace delegated DOM decoding with typed callbacks, and
4. remove the glue code that only existed to support the imperative path.

For this issue there was an additional requirement: the transient “car added” highlight had to keep dismissing after the user leaves the car screen and returns, but without the old raw DOM listeners. Rather than introducing another generic event layer, I added narrow typed subscriptions to the existing Preact navigation owners so the cars module can react to settings-tab and primary-view changes through explicit callbacks instead of DOM event scraping.

## Main code changes by area

### 1. Saved-car list rendering moved from HTML strings to typed models + JSX

`apps/ui/src/app/views/settings_car_list_view.ts` no longer renders HTML or decodes delegated clicks. Instead it now builds typed view models for:

- saved-car rows,
- row actions,
- inline empty-state content, and
- the success/no-active guidance states.

That keeps formatting, readiness derivation, tire/ratio summaries, and action-label selection in a pure builder module that is easy to test without DOM assertions.

`apps/ui/src/app/views/cars_panel.tsx` now renders those models directly. The component owns:

- the saved-car table body,
- the actionable empty state,
- the transient creation-success banner,
- the no-active-car guidance banner, and
- the row action buttons.

The existing CSS hooks and browser-test selectors were intentionally preserved, including the row classes and `data-*` attributes such as `data-car-id`, `data-car-complete`, `data-highlighted`, `data-car-action`, and `data-inline-state-action`. That lets the browser coverage keep validating the visible behavior while the implementation underneath becomes island-owned.

### 2. Typed list callbacks replaced delegated action decoding

Before this PR, list interactions depended on a delegated click listener plus attribute/class inspection. That indirection is gone. The cars panel bridge now exposes typed list callbacks, and the row buttons call those callbacks directly from JSX. The obsolete list binding path was removed along with the old HTML-string rendering assumptions.

This makes the saved-car surface consistent with the sensors and history islands: render model in, typed callbacks out.

### 3. Transient feedback dismissal now follows typed navigation callbacks

The old `settings_cars_module.ts` approach used raw listeners on:

- the settings tabs, and
- the shell menu buttons

only to notice when the user left the car screen so it could clear highlight feedback. That behavior is still needed, and `tests/settings_car_feedback_reset.spec.ts` locks it in, but the mechanism is different now.

This PR adds explicit subscription hooks to the existing navigation owners:

- `settings_shell.tsx` now exposes typed active-tab change subscriptions,
- `ui_shell_controller.ts` now exposes typed active-view change subscriptions,
- `ui_app_runtime.ts` and `app_feature_bundle.ts` wire those subscriptions into the feature layer, and
- `settings_cars_module.ts` consumes them to dismiss transient highlight feedback when the active settings tab stops being `carTab` or the active primary view stops being `settingsView`.

That removes the raw DOM-listener coupling without changing the visible behavior. The cars module now reacts to navigation through typed island-owned callbacks instead of scraping tab/menu DOM events.

### 4. Tests were updated around the new seam

The focused coverage changed with the implementation:

- `apps/ui/tests/car_list_state.spec.ts` now asserts typed row, empty-state, and guidance models instead of HTML-string fragments.
- `apps/ui/tests/settings_cars_module.spec.ts` is new and verifies the typed tab/view subscription flow that dismisses transient creation feedback.
- `apps/ui/tests/ui_action_bindings.spec.ts` drops the obsolete saved-car delegated binding test because that binding layer no longer exists.
- `apps/ui/tests/settings_car_feedback_reset.spec.ts` continues to prove the user-facing dismissal behavior across tab and top-level view changes.
- `apps/ui/tests/smoke.cars.spec.ts` continues to cover the browser-level car-management flows, including the creation banner/highlight and “Finish setup” routing.

## Documentation changes

`apps/ui/README.md` now reflects the live architecture more accurately:

- `cars_panel.tsx` is described as the JSX owner of the saved-car guidance/list surface,
- `settings_car_list_view.ts` is described as a typed model builder instead of a thin HTML renderer/action decoder, and
- the overview text no longer cites feature-local table-body render helpers as part of the remaining imperative UI seams in this area.

## Validation

I ran the focused frontend checks for this surface:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/car_list_state.spec.ts tests/settings_cars_module.spec.ts tests/ui_action_bindings.spec.ts --workers=1`
- `cd apps/ui && npx playwright test --config=.ai-temp/playwright.page.local.config.ts tests/settings_car_feedback_reset.spec.ts tests/smoke.cars.spec.ts --workers=1`

The browser run used the local port-4273 config because this shared environment can have an unrelated service already bound to the default port. Vite proxy noise for `/api/update/status` and `/api/health` still appears when no backend is running on `127.0.0.1:8000`, but the targeted car flows are mocked and passed.

## Risks, tradeoffs, and follow-ups

The main tradeoff here is that I added small typed subscription hooks to the settings shell and shell controller rather than inventing a broader shared navigation bus. That is intentionally narrow: the code only exposes the callbacks this migration needed, and it keeps navigation ownership where it already belongs.

I also preserved the current loading behavior for the saved-car list bridge rather than broadening the scope into a larger UX rewrite. The list still starts from the existing fallback row while data is unresolved, then shifts to the actionable empty state or row view once the settings payload is known.

What this PR does **not** do is migrate the add-car wizard internals. The wizard still uses its existing presenter path, which is the explicit follow-up in issue #2284. This PR is only the saved-car list / inline feedback half of the car-management migration.

Closes #2283
