### PR TITLE
refactor(ui): render car wizard in Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -116,9 +116,10 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/update_panel.tsx` | Preact owner for the update settings shell that mounts the update controls and status host while exposing the bridge consumed by the update feature |
 | `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that renders the full sensor table and exposes typed identify/remove/location callbacks to the realtime feature |
 | `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that mounts the full tab surface and exposes the shared typed bridge consumed by the speed-source and GPS-status modules |
-| `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that renders saved-car guidance/list rows in JSX, mounts the wizard chrome, and exposes typed list and wizard bridges |
+| `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that renders saved-car guidance/list rows plus the full add-car wizard internals in JSX and exposes typed list and wizard bridges |
 | `app/views/cars_feature_bindings.ts` | Typed car-wizard bindings reused as the thin wizard interaction adapter behind the car-management island |
-| `app/views/cars_feature_presenter.ts` | Car-wizard presenter reused as the thin wizard DOM adapter for dialog visibility, step rendering, summary updates, and focus targets |
+| `app/views/cars_feature_presenter.ts` | Thin car-wizard presenter that turns workflow state into typed wizard render models and delegates focus/manual-input access through the island bridge |
+| `app/views/car_wizard_view.ts` | Typed add-car wizard render-model builders for progress, option sections, selected specs, and summary rows reused by the Preact car-management island |
 | `app/features/update_feature.ts` | Thin update facade that binds DOM events, delegates state rendering to the presenter, and delegates update commands to the workflow |
 | `app/features/update_feature_workflow.ts` | DOM-free update workflow/controller for update polling, internet-status normalization, and start/cancel command orchestration |
 | `app/views/dom_render.ts` | Shared low-level DOM render helper for fragments, element creation, text updates, and class-state toggles |

--- a/apps/ui/src/app/dom/cars_dom.ts
+++ b/apps/ui/src/app/dom/cars_dom.ts
@@ -10,13 +10,8 @@ export interface UiCarsDom {
   addCarBtn: HTMLButtonElement;
   wizardBackdrop: HTMLElement | null;
   addCarWizard: HTMLElement;
-  wizardProgressText: HTMLElement | null;
   wizardCloseBtn: HTMLButtonElement | null;
   wizardBackBtn: HTMLButtonElement | null;
-  wizardSteps: Array<HTMLElement | null>;
-  wizardStepDots: HTMLElement[];
-  wizardSummaryPanel: HTMLElement | null;
-  wizardActionHint: HTMLElement | null;
   wizardBrandList: HTMLElement | null;
   wizardTypeList: HTMLElement | null;
   wizardModelList: HTMLElement | null;

--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -22,9 +22,8 @@ export interface CarsFeature {
 
 export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
   const presenter = createCarsFeaturePresenter({
-    dom: ctx.panel.dom,
-    escapeHtml: ctx.escapeHtml,
     fmt: ctx.fmt,
+    panel: ctx.panel,
     t: ctx.t,
   });
   const workflow = createCarsFeatureWorkflow({

--- a/apps/ui/src/app/views/car_wizard_view.ts
+++ b/apps/ui/src/app/views/car_wizard_view.ts
@@ -4,19 +4,24 @@ import type {
   CarLibraryTireOption,
   CarLibraryVariant,
 } from "../../transport/http_models";
-import type { UiCarsDom } from "../dom/cars_dom";
+import type {
+  CarsFeatureOptionsState,
+  CarsFeatureRenderState,
+} from "../features/cars_feature_workflow";
 
-type EscapeHtml = (value: unknown) => string;
 type FormatNumber = (value: number, digits?: number) => string;
 type Translate = (key: string, vars?: Record<string, unknown>) => string;
 
-interface WizardOptionSpec {
-  dataAttribute: string;
-  value: string;
-  label: string;
-  detail?: string;
-  selected?: boolean;
-}
+const WIZARD_STEP_LABEL_KEYS = [
+  "settings.car.step_brand_short",
+  "settings.car.step_type_short",
+  "settings.car.step_model_short",
+  "settings.car.step_variant_short",
+  "settings.car.step_specs_short",
+] as const;
+
+type WizardOptionAttribute = "data-value" | "data-idx" | "data-tire-idx";
+type WizardOptionLayout = "chips" | "list";
 
 export interface WizardSummaryData {
   currentStep: number;
@@ -29,181 +34,262 @@ export interface WizardSummaryData {
   gearbox: string | null;
 }
 
-function renderWizardOptions(
-  options: WizardOptionSpec[],
-  escapeHtml: EscapeHtml,
-): string {
-  return options
-    .map((option) => {
-      const detail = option.detail
-        ? `<span class="wiz-opt-detail">${escapeHtml(option.detail)}</span>`
-        : "";
-      const selectedAttrs = option.selected
-        ? ' data-selected="true" aria-pressed="true"'
-        : ' aria-pressed="false"';
-      return `<button type="button" class="wiz-opt"${selectedAttrs} data-${option.dataAttribute}="${escapeHtml(option.value)}"><span>${escapeHtml(option.label)}</span>${detail}</button>`;
-    })
-    .join("");
+export interface CarsWizardOptionItem {
+  detailText: string | null;
+  labelText: string;
+  selected: boolean;
+  value: string;
 }
 
-export function renderWizardMessage(
-  message: string,
-  escapeHtml: EscapeHtml,
-): string {
-  return `<em>${escapeHtml(message)}</em>`;
+export interface CarsWizardOptionsRenderModel {
+  attribute: WizardOptionAttribute;
+  layout: WizardOptionLayout;
+  messageText: string | null;
+  options: readonly CarsWizardOptionItem[];
 }
 
-export function renderWizardBrandOptions(
-  brands: string[],
-  escapeHtml: EscapeHtml,
-): string {
-  return renderWizardOptions(
-    brands.map((brand) => ({
-      dataAttribute: "value",
-      value: brand,
-      label: brand,
-    })),
-    escapeHtml,
-  );
+export interface CarsWizardSummaryRow {
+  labelText: string;
+  valueText: string;
 }
 
-export function renderWizardTypeOptions(
-  types: string[],
-  escapeHtml: EscapeHtml,
-): string {
-  return renderWizardOptions(
-    types.map((carType) => ({
-      dataAttribute: "value",
-      value: carType,
-      label: carType,
-    })),
-    escapeHtml,
-  );
+export interface CarsWizardSummaryRenderModel {
+  profileNameLabelText: string;
+  profileNameValueText: string;
+  rows: readonly CarsWizardSummaryRow[];
 }
 
-export function renderWizardModelOptions(
-  models: CarLibraryModel[],
-  escapeHtml: EscapeHtml,
-): string {
-  return renderWizardOptions(
-    models.map((model, index) => ({
-      dataAttribute: "idx",
+export interface CarsWizardRenderModel {
+  actionHintText: string;
+  backVisible: boolean;
+  brandOptions: CarsWizardOptionsRenderModel;
+  finishEnabled: boolean;
+  finishVisible: boolean;
+  gearboxOptions: CarsWizardOptionsRenderModel;
+  isOpen: boolean;
+  manualInputs: CarsFeatureRenderState["manualInputs"];
+  modelOptions: CarsWizardOptionsRenderModel;
+  progressText: string;
+  specBranch: "library" | "manual" | "pending" | null;
+  step: number;
+  summary: CarsWizardSummaryRenderModel;
+  tireOptions: CarsWizardOptionsRenderModel;
+  typeOptions: CarsWizardOptionsRenderModel;
+  variantOptions: CarsWizardOptionsRenderModel;
+}
+
+export function createClosedCarsWizardRenderModel(): CarsWizardRenderModel {
+  return {
+    actionHintText: "",
+    backVisible: false,
+    brandOptions: createOptionsModel("data-value"),
+    finishEnabled: false,
+    finishVisible: false,
+    gearboxOptions: createOptionsModel("data-idx", "list"),
+    isOpen: false,
+    manualInputs: {
+      finalDrive: "3.08",
+      rim: "18",
+      tireAspect: "45",
+      tireWidth: "225",
+      topGear: "0.64",
+    },
+    modelOptions: createOptionsModel("data-idx", "list"),
+    progressText: "",
+    specBranch: null,
+    step: 0,
+    summary: {
+      profileNameLabelText: "",
+      profileNameValueText: "",
+      rows: [],
+    },
+    tireOptions: createOptionsModel("data-tire-idx"),
+    typeOptions: createOptionsModel("data-value"),
+    variantOptions: createOptionsModel("data-idx", "list"),
+  };
+}
+
+function createOptionsModel(
+  attribute: WizardOptionAttribute,
+  layout: WizardOptionLayout = "chips",
+): CarsWizardOptionsRenderModel {
+  return {
+    attribute,
+    layout,
+    messageText: null,
+    options: [],
+  };
+}
+
+function buildOptionsModel<TOption>(
+  state: CarsFeatureOptionsState<TOption>,
+  attribute: WizardOptionAttribute,
+  buildItem: (option: TOption, index: number) => CarsWizardOptionItem,
+  layout: WizardOptionLayout = "chips",
+): CarsWizardOptionsRenderModel {
+  if (state.status === "loading" || state.status === "error") {
+    return {
+      attribute,
+      layout,
+      messageText: state.message ?? "",
+      options: [],
+    };
+  }
+  if (state.status !== "ready") {
+    return createOptionsModel(attribute, layout);
+  }
+  return {
+    attribute,
+    layout,
+    messageText: null,
+    options: state.options.map((option, index) => buildItem(option, index)),
+  };
+}
+
+function buildVariantOptionsModel(
+  variants: readonly CarLibraryVariant[],
+): CarsWizardOptionsRenderModel {
+  return {
+    attribute: "data-idx",
+    layout: "list",
+    messageText: null,
+    options: variants.map((variant, index) => ({
+      detailText: [variant.drivetrain, variant.engine].filter(Boolean).join(" · ") || null,
+      labelText: variant.name,
+      selected: false,
       value: String(index),
-      label: model.model,
-      detail: `${model.tire_width_mm}/${model.tire_aspect_pct}R${model.rim_in}`,
     })),
-    escapeHtml,
-  );
+  };
 }
 
-export function renderWizardVariantOptions(
-  variants: CarLibraryVariant[],
-  escapeHtml: EscapeHtml,
-): string {
-  return renderWizardOptions(
-    variants.map((variant, index) => ({
-      dataAttribute: "idx",
+function buildTireOptionsModel(
+  tireOptions: readonly CarLibraryTireOption[],
+  selectedTire: CarLibraryTireOption | null,
+): CarsWizardOptionsRenderModel {
+  return {
+    attribute: "data-tire-idx",
+    layout: "chips",
+    messageText: null,
+    options: tireOptions.map((tireOption, index) => ({
+      detailText: `${tireOption.tire_width_mm}/${tireOption.tire_aspect_pct}R${tireOption.rim_in}`,
+      labelText: tireOption.name,
+      selected: tireOption === selectedTire,
       value: String(index),
-      label: variant.name,
-      detail: [variant.drivetrain, variant.engine].filter(Boolean).join(" · "),
     })),
-    escapeHtml,
-  );
+  };
 }
 
-export function renderWizardTireOptions(
-  tireOptions: CarLibraryTireOption[],
-  escapeHtml: EscapeHtml,
-  selectedIndex = 0,
-): string {
-  return renderWizardOptions(
-    tireOptions.map((tireOption, index) => ({
-      dataAttribute: "tire-idx",
+function buildGearboxOptionsModel(
+  gearboxes: readonly CarLibraryGearbox[],
+  selectedGearbox: CarLibraryGearbox | null,
+  deps: { fmt: FormatNumber },
+  noGearboxesMessage: string | null,
+): CarsWizardOptionsRenderModel {
+  if (noGearboxesMessage) {
+    return {
+      attribute: "data-idx",
+      layout: "list",
+      messageText: noGearboxesMessage,
+      options: [],
+    };
+  }
+  return {
+    attribute: "data-idx",
+    layout: "list",
+    messageText: null,
+    options: gearboxes.map((gearbox, index) => ({
+      detailText: `FD: ${deps.fmt(gearbox.final_drive_ratio, 2)} · Top Gear: ${deps.fmt(gearbox.top_gear_ratio, 2)}`,
+      labelText: gearbox.name,
+      selected: gearbox === selectedGearbox,
       value: String(index),
-      label: tireOption.name,
-      detail: `${tireOption.tire_width_mm}/${tireOption.tire_aspect_pct}R${tireOption.rim_in}`,
-      selected: index === selectedIndex,
     })),
-    escapeHtml,
-  );
+  };
 }
 
-export function renderWizardGearboxOptions(
-  gearboxes: CarLibraryGearbox[],
-  deps: { escapeHtml: EscapeHtml; fmt: FormatNumber },
-  selectedIndex = -1,
-): string {
-  const { escapeHtml, fmt } = deps;
-  return renderWizardOptions(
-    gearboxes.map((gearbox, index) => ({
-      dataAttribute: "idx",
-      value: String(index),
-      label: gearbox.name,
-      detail: `FD: ${fmt(gearbox.final_drive_ratio, 2)} · Top Gear: ${fmt(gearbox.top_gear_ratio, 2)}`,
-      selected: index === selectedIndex,
-    })),
-    escapeHtml,
-  );
-}
-
-export function renderWizardSummary(
+function buildSummaryRows(
   summary: WizardSummaryData,
-  deps: { t: Translate; escapeHtml: EscapeHtml },
-): string {
-  const { t, escapeHtml } = deps;
+  t: Translate,
+): CarsWizardSummaryRow[] {
   const pending = t("settings.car.wizard_summary_pending");
   const rows = [
-    { label: t("settings.car.wizard_summary_brand"), value: summary.brand, visibleFromStep: 1 },
-    { label: t("settings.car.wizard_summary_type"), value: summary.carType, visibleFromStep: 2 },
-    { label: t("settings.car.wizard_summary_model"), value: summary.model, visibleFromStep: 3 },
-    { label: t("settings.car.wizard_summary_variant"), value: summary.variant, visibleFromStep: 4 },
-    { label: t("settings.car.wizard_summary_tire"), value: summary.tire, visibleFromStep: 4 },
-    { label: t("settings.car.wizard_summary_gearbox"), value: summary.gearbox, visibleFromStep: 4 },
-  ].filter((row) => row.value || summary.currentStep >= row.visibleFromStep);
-  return `
-    <div class="wizard-summary-preview">
-      <div class="wizard-summary-preview__label">${escapeHtml(t("settings.car.wizard_summary_name"))}</div>
-      <div class="wizard-summary-preview__value">${escapeHtml(summary.profileName || pending)}</div>
-    </div>
-    <dl class="wizard-summary-list">
-      ${rows.map(({ label, value }) => `
-        <div class="wizard-summary-item">
-          <dt>${escapeHtml(label)}</dt>
-          <dd>${escapeHtml(value || pending)}</dd>
-        </div>
-      `).join("")}
-    </dl>
-  `;
+    { labelText: t("settings.car.wizard_summary_brand"), valueText: summary.brand, visibleFromStep: 1 },
+    { labelText: t("settings.car.wizard_summary_type"), valueText: summary.carType, visibleFromStep: 2 },
+    { labelText: t("settings.car.wizard_summary_model"), valueText: summary.model, visibleFromStep: 3 },
+    { labelText: t("settings.car.wizard_summary_variant"), valueText: summary.variant, visibleFromStep: 4 },
+    { labelText: t("settings.car.wizard_summary_tire"), valueText: summary.tire, visibleFromStep: 4 },
+    { labelText: t("settings.car.wizard_summary_gearbox"), valueText: summary.gearbox, visibleFromStep: 4 },
+  ];
+  return rows
+    .filter((row) => row.valueText || summary.currentStep >= row.visibleFromStep)
+    .map((row) => ({
+      labelText: row.labelText,
+      valueText: row.valueText ?? pending,
+    }));
 }
 
-export function syncCarWizardStepState(
-  els: Pick<UiCarsDom, "wizardSteps" | "wizardStepDots" | "wizardBackBtn">,
-  step: number,
-): void {
-  els.wizardSteps.forEach((stepEl, index) => {
-    if (!stepEl) return;
-    stepEl.hidden = index !== step;
-  });
-  els.wizardStepDots.forEach((dot) => {
-    const dotStep = Number(dot.getAttribute("data-step"));
-    const stepState = dotStep === step ? "active" : dotStep < step ? "done" : "upcoming";
-    dot.setAttribute("data-step-state", stepState);
-    if (dotStep === step) {
-      dot.setAttribute("aria-current", "step");
-    } else {
-      dot.removeAttribute("aria-current");
-    }
-  });
-  if (els.wizardBackBtn) {
-    els.wizardBackBtn.style.display = step > 0 ? "" : "none";
-  }
-}
-
-export function writeCarWizardTireInputs(
-  els: Pick<UiCarsDom, "wizTireWidthInput" | "wizTireAspectInput" | "wizRimInput">,
-  tire: CarLibraryTireOption,
-): void {
-  if (els.wizTireWidthInput) els.wizTireWidthInput.value = String(tire.tire_width_mm);
-  if (els.wizTireAspectInput) els.wizTireAspectInput.value = String(tire.tire_aspect_pct);
-  if (els.wizRimInput) els.wizRimInput.value = String(tire.rim_in);
+export function buildCarsWizardRenderModel(
+  state: CarsFeatureRenderState,
+  deps: { fmt: FormatNumber; t: Translate },
+): CarsWizardRenderModel {
+  const { fmt, t } = deps;
+  const pending = t("settings.car.wizard_summary_pending");
+  return {
+    actionHintText: state.actionHint,
+    backVisible: state.step > 0,
+    brandOptions: buildOptionsModel(
+      state.brandOptions,
+      "data-value",
+      (brand) => ({
+        detailText: null,
+        labelText: brand,
+        selected: false,
+        value: brand,
+      }),
+    ),
+    finishEnabled: state.step === 4 && state.canFinish,
+    finishVisible: state.step === 4,
+    gearboxOptions: buildGearboxOptionsModel(
+      state.gearboxOptions,
+      state.selectedGearbox,
+      { fmt },
+      state.noGearboxesMessage,
+    ),
+    isOpen: state.isOpen,
+    manualInputs: { ...state.manualInputs },
+    modelOptions: buildOptionsModel(
+      state.modelOptions,
+      "data-idx",
+      (model, index) => ({
+        detailText: `${model.tire_width_mm}/${model.tire_aspect_pct}R${model.rim_in}`,
+        labelText: model.model,
+        selected: false,
+        value: String(index),
+      }),
+      "list",
+    ),
+    progressText: t("settings.car.wizard_progress", {
+      current: state.step + 1,
+      step: t(WIZARD_STEP_LABEL_KEYS[state.step] ?? WIZARD_STEP_LABEL_KEYS[0]),
+      total: WIZARD_STEP_LABEL_KEYS.length,
+    }),
+    specBranch: state.step === 4 ? state.resolvedSpecBranch ?? "pending" : null,
+    step: state.step,
+    summary: {
+      profileNameLabelText: t("settings.car.wizard_summary_name"),
+      profileNameValueText: state.summaryData.profileName ?? pending,
+      rows: buildSummaryRows(state.summaryData, t),
+    },
+    tireOptions: buildTireOptionsModel(state.tireOptions, state.selectedTire),
+    typeOptions: buildOptionsModel(
+      state.typeOptions,
+      "data-value",
+      (carType) => ({
+        detailText: null,
+        labelText: carType,
+        selected: false,
+        value: carType,
+      }),
+    ),
+    variantOptions: buildVariantOptionsModel(state.variantOptions),
+  };
 }

--- a/apps/ui/src/app/views/cars_feature_presenter.ts
+++ b/apps/ui/src/app/views/cars_feature_presenter.ts
@@ -1,61 +1,17 @@
-import type { UiCarsDom } from "../dom/cars_dom";
 import {
-  renderWizardBrandOptions,
-  renderWizardGearboxOptions,
-  renderWizardMessage,
-  renderWizardModelOptions,
-  renderWizardSummary,
-  renderWizardTireOptions,
-  renderWizardTypeOptions,
-  renderWizardVariantOptions,
-  syncCarWizardStepState,
+  buildCarsWizardRenderModel,
+  type CarsWizardRenderModel,
 } from "./car_wizard_view";
 import type {
   CarsFeatureFocusTarget,
   CarsFeatureManualInputState,
-  CarsFeatureOptionsState,
   CarsFeatureRenderState,
 } from "../features/cars_feature_workflow";
-
-const WIZARD_STEP_LABEL_KEYS = [
-  "settings.car.step_brand_short",
-  "settings.car.step_type_short",
-  "settings.car.step_model_short",
-  "settings.car.step_variant_short",
-  "settings.car.step_specs_short",
-] as const;
+import type { CarsWizardPanelBridge } from "./cars_panel";
 
 export interface CarsFeaturePresenterDeps {
-  dom: Pick<
-    UiCarsDom,
-    | "addCarBtn"
-    | "addCarWizard"
-    | "wizFinalDriveInput"
-    | "wizGearRatioInput"
-    | "wizRimInput"
-    | "wizTireAspectInput"
-    | "wizTireWidthInput"
-    | "wizardActionHint"
-    | "wizardBackdrop"
-    | "wizardBackBtn"
-    | "wizardBrandList"
-    | "wizardCloseBtn"
-    | "wizardCustomBrandInput"
-    | "wizardCustomModelInput"
-    | "wizardCustomTypeInput"
-    | "wizardGearboxList"
-    | "wizardManualAddBtn"
-    | "wizardModelList"
-    | "wizardProgressText"
-    | "wizardStepDots"
-    | "wizardSteps"
-    | "wizardSummaryPanel"
-    | "wizardTireList"
-    | "wizardTypeList"
-    | "wizardVariantList"
-  >;
-  escapeHtml: (value: unknown) => string;
   fmt: (value: number, digits?: number) => string;
+  panel: CarsWizardPanelBridge;
   t: (key: string, vars?: Record<string, unknown>) => string;
 }
 
@@ -67,224 +23,30 @@ export interface CarsFeaturePresenter {
   restoreFocus(target: HTMLElement | null): void;
 }
 
-function renderOptionsState<TOption>(
-  container: HTMLElement | null,
-  state: CarsFeatureOptionsState<TOption>,
-  renderReady: (options: readonly TOption[]) => string,
-  escapeHtml: (value: unknown) => string,
-): void {
-  if (!container) {
-    return;
-  }
-  if (state.status === "loading" || state.status === "error") {
-    container.innerHTML = renderWizardMessage(state.message ?? "", escapeHtml);
-    return;
-  }
-  container.innerHTML = state.status === "ready" ? renderReady(state.options) : "";
-}
-
-function focusElement(target: HTMLElement | null | undefined): void {
-  target?.focus();
-}
-
-function focusFirstOption(
-  container: ParentNode | null,
-  fallback: HTMLElement | null,
-): void {
-  const firstOption = container?.querySelector<HTMLButtonElement>(".wiz-opt");
-  focusElement(firstOption ?? fallback);
-}
-
-function syncInputValue(input: HTMLInputElement | null, value: string): void {
-  if (input && input.value !== value) {
-    input.value = value;
-  }
-}
-
 export function createCarsFeaturePresenter(
   deps: CarsFeaturePresenterDeps,
 ): CarsFeaturePresenter {
-  const { dom, escapeHtml, fmt, t } = deps;
-  let lastOpenState = false;
+  const { fmt, panel, t } = deps;
 
-  function syncVisibility(isOpen: boolean): void {
-    if (dom.wizardBackdrop) {
-      dom.wizardBackdrop.hidden = !isOpen;
-    }
-    dom.addCarWizard.hidden = !isOpen;
-    if (isOpen && !lastOpenState) {
-      dom.addCarWizard.scrollTop = 0;
-    }
-    if (isOpen) {
-      document.body.setAttribute("data-wizard-open", "true");
-    } else {
-      document.body.removeAttribute("data-wizard-open");
-    }
-    lastOpenState = isOpen;
-  }
-
-  function renderSpecsStep(state: CarsFeatureRenderState): void {
-    if (dom.wizardTireList) {
-      const selectedTireIndex = state.selectedTire ? state.tireOptions.indexOf(state.selectedTire) : -1;
-      dom.wizardTireList.innerHTML = state.tireOptions.length > 0
-        ? renderWizardTireOptions(
-          [...state.tireOptions],
-          escapeHtml,
-          selectedTireIndex >= 0 ? selectedTireIndex : 0,
-        )
-        : "";
-    }
-    if (dom.wizardGearboxList) {
-      const selectedGearboxIndex = state.selectedGearbox
-        ? state.gearboxOptions.indexOf(state.selectedGearbox)
-        : -1;
-      if (state.noGearboxesMessage) {
-        dom.wizardGearboxList.innerHTML = renderWizardMessage(state.noGearboxesMessage, escapeHtml);
-      } else {
-        dom.wizardGearboxList.innerHTML = renderWizardGearboxOptions(
-          [...state.gearboxOptions],
-          { escapeHtml, fmt },
-          selectedGearboxIndex,
-        );
-      }
-    }
-    syncInputValue(dom.wizTireWidthInput, state.manualInputs.tireWidth);
-    syncInputValue(dom.wizTireAspectInput, state.manualInputs.tireAspect);
-    syncInputValue(dom.wizRimInput, state.manualInputs.rim);
-    syncInputValue(dom.wizFinalDriveInput, state.manualInputs.finalDrive);
-    syncInputValue(dom.wizGearRatioInput, state.manualInputs.topGear);
+  function renderWizard(state: CarsFeatureRenderState): CarsWizardRenderModel {
+    return buildCarsWizardRenderModel(state, { fmt, t });
   }
 
   return {
     captureReturnFocusTarget(): HTMLElement | null {
-      return document.activeElement instanceof HTMLElement ? document.activeElement : dom.addCarBtn;
+      return panel.captureReturnFocusTarget();
     },
-
     focus(target): void {
-      switch (target) {
-        case "brand-option":
-          focusFirstOption(dom.wizardBrandList, dom.wizardCustomBrandInput);
-          return;
-        case "close":
-          focusElement(dom.wizardCloseBtn);
-          return;
-        case "custom-brand":
-          focusElement(dom.wizardCustomBrandInput);
-          return;
-        case "custom-model":
-          focusElement(dom.wizardCustomModelInput);
-          return;
-        case "custom-type":
-          focusElement(dom.wizardCustomTypeInput);
-          return;
-        case "finish":
-          focusElement(dom.wizardManualAddBtn);
-          return;
-        case "gearbox-option":
-          focusFirstOption(dom.wizardGearboxList, dom.wizardManualAddBtn);
-          return;
-        case "manual-final-drive":
-          focusElement(dom.wizFinalDriveInput);
-          return;
-        case "manual-rim":
-          focusElement(dom.wizRimInput);
-          return;
-        case "manual-tire-aspect":
-          focusElement(dom.wizTireAspectInput);
-          return;
-        case "manual-tire-width":
-          focusElement(dom.wizTireWidthInput);
-          return;
-        case "manual-top-gear":
-          focusElement(dom.wizGearRatioInput);
-          return;
-        case "model-option":
-          focusFirstOption(dom.wizardModelList, dom.wizardCustomModelInput);
-          return;
-        case "spec-selection":
-          focusElement(
-            dom.wizardTireList?.querySelector<HTMLButtonElement>(".wiz-opt")
-            ?? dom.wizardGearboxList?.querySelector<HTMLButtonElement>(".wiz-opt")
-            ?? dom.wizTireWidthInput,
-          );
-          return;
-        case "type-option":
-          focusFirstOption(dom.wizardTypeList, dom.wizardCustomTypeInput);
-          return;
-        case "variant-option":
-          focusFirstOption(dom.wizardVariantList, null);
-          return;
-      }
+      panel.focus(target);
     },
-
     readManualInputs(): CarsFeatureManualInputState {
-      return {
-        finalDrive: dom.wizFinalDriveInput?.value ?? "",
-        rim: dom.wizRimInput?.value ?? "",
-        tireAspect: dom.wizTireAspectInput?.value ?? "",
-        tireWidth: dom.wizTireWidthInput?.value ?? "",
-        topGear: dom.wizGearRatioInput?.value ?? "",
-      };
+      return panel.readManualInputs();
     },
-
     render(state): void {
-      syncVisibility(state.isOpen);
-      if (!state.isOpen) {
-        delete dom.addCarWizard.dataset.specBranch;
-        return;
-      }
-
-      syncCarWizardStepState(dom, state.step);
-      if (dom.wizardProgressText) {
-        dom.wizardProgressText.textContent = t("settings.car.wizard_progress", {
-          current: state.step + 1,
-          step: t(WIZARD_STEP_LABEL_KEYS[state.step] ?? WIZARD_STEP_LABEL_KEYS[0]),
-          total: WIZARD_STEP_LABEL_KEYS.length,
-        });
-      }
-      if (dom.wizardSummaryPanel) {
-        dom.wizardSummaryPanel.innerHTML = renderWizardSummary(state.summaryData, { escapeHtml, t });
-      }
-      if (dom.wizardActionHint) {
-        dom.wizardActionHint.textContent = state.actionHint;
-      }
-      if (state.step === 4) {
-        dom.addCarWizard.dataset.specBranch = state.resolvedSpecBranch ?? "pending";
-      } else {
-        delete dom.addCarWizard.dataset.specBranch;
-      }
-      if (dom.wizardManualAddBtn) {
-        dom.wizardManualAddBtn.hidden = state.step !== 4;
-        dom.wizardManualAddBtn.disabled = state.step !== 4 || !state.canFinish;
-      }
-
-      renderOptionsState(
-        dom.wizardBrandList,
-        state.brandOptions,
-        (options) => renderWizardBrandOptions([...options], escapeHtml),
-        escapeHtml,
-      );
-      renderOptionsState(
-        dom.wizardTypeList,
-        state.typeOptions,
-        (options) => renderWizardTypeOptions([...options], escapeHtml),
-        escapeHtml,
-      );
-      renderOptionsState(
-        dom.wizardModelList,
-        state.modelOptions,
-        (options) => renderWizardModelOptions([...options], escapeHtml),
-        escapeHtml,
-      );
-      if (dom.wizardVariantList) {
-        dom.wizardVariantList.innerHTML = renderWizardVariantOptions([...state.variantOptions], escapeHtml);
-      }
-      renderSpecsStep(state);
+      panel.render(renderWizard(state));
     },
-
     restoreFocus(target): void {
-      const safeTarget = target && document.contains(target) ? target : dom.addCarBtn;
-      focusElement(safeTarget);
+      panel.restoreFocus(target);
     },
   };
 }

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -1,9 +1,19 @@
 import type { UiCarsDom } from "../dom/cars_dom";
+import type {
+  CarsFeatureFocusTarget,
+  CarsFeatureManualInputState,
+} from "../features/cars_feature_workflow";
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import {
   bindCarsFeatureInteractions,
   type CarsFeatureInteractionHandlers,
 } from "./cars_feature_bindings";
+import {
+  createClosedCarsWizardRenderModel,
+  type CarsWizardOptionItem,
+  type CarsWizardOptionsRenderModel,
+  type CarsWizardRenderModel,
+} from "./car_wizard_view";
 import type { ViewDisposer } from "./dom_event_bindings";
 import {
   inlineStateActionClass,
@@ -28,6 +38,11 @@ export interface CarsListPanelView {
 export interface CarsWizardPanelBridge {
   readonly dom: UiCarsDom;
   bindActions(handlers: CarsFeatureInteractionHandlers): void;
+  captureReturnFocusTarget(): HTMLElement | null;
+  focus(target: CarsFeatureFocusTarget): void;
+  readManualInputs(): CarsFeatureManualInputState;
+  render(model: CarsWizardRenderModel): void;
+  restoreFocus(target: HTMLElement | null): void;
 }
 
 export interface CarsPanelView {
@@ -39,9 +54,19 @@ type CarsListPanelActionHandlers = {
   onAction(action: CarsListAction): void;
 };
 
+type CarsWizardOptionRefs = {
+  brandOption: HTMLButtonElement | null;
+  gearboxOption: HTMLButtonElement | null;
+  modelOption: HTMLButtonElement | null;
+  tireOption: HTMLButtonElement | null;
+  typeOption: HTMLButtonElement | null;
+  variantOption: HTMLButtonElement | null;
+};
+
 type CarsPanelBridgeState = {
   actions: CarsListPanelActionHandlers | null;
   model: CarsListRenderModel;
+  wizardModel: CarsWizardRenderModel;
 };
 
 const DEFAULT_CARS_PANEL_MODEL: CarsListRenderModel = {
@@ -49,11 +74,23 @@ const DEFAULT_CARS_PANEL_MODEL: CarsListRenderModel = {
   table: null,
 };
 
+const WIZARD_STEP_LABELS = [
+  { key: "settings.car.step_brand_short", fallback: "Brand" },
+  { key: "settings.car.step_type_short", fallback: "Type" },
+  { key: "settings.car.step_model_short", fallback: "Model" },
+  { key: "settings.car.step_variant_short", fallback: "Variant" },
+  { key: "settings.car.step_specs_short", fallback: "Specs" },
+] as const;
+
 function handleCarsListAction(
   actions: CarsListPanelActionHandlers | null,
   action: CarsListAction,
 ): void {
   actions?.onAction(action);
+}
+
+function focusElement(target: HTMLElement | null | undefined): void {
+  target?.focus();
 }
 
 function CarsInlineStatePanel(props: {
@@ -215,8 +252,105 @@ function CarsTableBody(props: {
   ));
 }
 
-function CarsPanel(props: { state: CarsPanelBridgeState }) {
-  const { state } = props;
+function wizardStepState(stepIndex: number, currentStep: number): "active" | "done" | "upcoming" {
+  if (stepIndex === currentStep) {
+    return "active";
+  }
+  return stepIndex < currentStep ? "done" : "upcoming";
+}
+
+function wizardOptionAttributeProps(
+  attribute: CarsWizardOptionsRenderModel["attribute"],
+  value: string,
+): Record<string, string> {
+  switch (attribute) {
+    case "data-idx":
+      return { "data-idx": value };
+    case "data-tire-idx":
+      return { "data-tire-idx": value };
+    default:
+      return { "data-value": value };
+  }
+}
+
+function WizardOptionButton(props: {
+  item: CarsWizardOptionItem;
+  attribute: CarsWizardOptionsRenderModel["attribute"];
+  optionRef?: (element: HTMLButtonElement | null) => void;
+}) {
+  const { attribute, item, optionRef } = props;
+  return (
+    <button
+      type="button"
+      class="wiz-opt"
+      data-selected={item.selected ? "true" : undefined}
+      aria-pressed={item.selected ? "true" : "false"}
+      ref={optionRef}
+      {...wizardOptionAttributeProps(attribute, item.value)}
+    >
+      <span>{item.labelText}</span>
+      {item.detailText ? <span class="wiz-opt-detail">{item.detailText}</span> : null}
+    </button>
+  );
+}
+
+function WizardOptions(props: {
+  firstOptionRef?: (element: HTMLButtonElement | null) => void;
+  id: string;
+  section: CarsWizardOptionsRenderModel;
+}) {
+  const { firstOptionRef, id, section } = props;
+  const className = section.layout === "list"
+    ? "wizard-options wizard-options--list"
+    : "wizard-options";
+  return (
+    <div class={className} id={id}>
+      {section.messageText ? <em>{section.messageText}</em> : null}
+      {section.options.map((item, index) => (
+        <WizardOptionButton
+          key={`${section.attribute}-${item.value}`}
+          attribute={section.attribute}
+          item={item}
+          optionRef={index === 0 ? firstOptionRef : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+function WizardSummaryPanel(props: { summary: CarsWizardRenderModel["summary"] }) {
+  const { summary } = props;
+  return (
+    <div id="wizardSummaryPanel">
+      <div class="wizard-summary-preview">
+        <div class="wizard-summary-preview__label">{summary.profileNameLabelText}</div>
+        <div class="wizard-summary-preview__value">{summary.profileNameValueText}</div>
+      </div>
+      <dl class="wizard-summary-list">
+        {summary.rows.map((row) => (
+          <div key={row.labelText} class="wizard-summary-item">
+            <dt>{row.labelText}</dt>
+            <dd>{row.valueText}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function CarsPanel(props: {
+  optionRefs: {
+    setBrandOption(element: HTMLButtonElement | null): void;
+    setGearboxOption(element: HTMLButtonElement | null): void;
+    setModelOption(element: HTMLButtonElement | null): void;
+    setTireOption(element: HTMLButtonElement | null): void;
+    setTypeOption(element: HTMLButtonElement | null): void;
+    setVariantOption(element: HTMLButtonElement | null): void;
+  };
+  state: CarsPanelBridgeState;
+}) {
+  const { optionRefs, state } = props;
+  const wizardModel = state.wizardModel;
   return (
     <>
       <div class="panel card">
@@ -251,251 +385,292 @@ function CarsPanel(props: { state: CarsPanelBridgeState }) {
         </div>
       </div>
 
-      <div id="wizardBackdrop" class="wizard-backdrop" hidden />
-      <div
-        id="addCarWizard"
-        class="panel card add-car-wizard"
-        hidden
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="wizardTitle"
-      >
-        <div class="wizard-header">
-          <div class="wizard-header__text">
-            <strong id="wizardTitle" data-i18n="settings.car.add_title">
-              Add a Car
-            </strong>
-            <div class="subtle" data-i18n="settings.car.wizard_intro">
-              Use the library when it fits, or branch into manual specs without losing your place.
+      <div class="wizard-modal-layer" hidden={!wizardModel.isOpen}>
+        <div id="wizardBackdrop" class="wizard-backdrop" hidden={!wizardModel.isOpen} />
+        <div
+          id="addCarWizard"
+          class="panel card add-car-wizard"
+          hidden={!wizardModel.isOpen}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="wizardTitle"
+          data-spec-branch={wizardModel.specBranch ?? undefined}
+        >
+          <div class="wizard-header">
+            <div class="wizard-header__text">
+              <strong id="wizardTitle" data-i18n="settings.car.add_title">
+                Add a Car
+              </strong>
+              <div class="subtle" data-i18n="settings.car.wizard_intro">
+                Use the library when it fits, or branch into manual specs without losing your place.
+              </div>
+              <div id="wizardProgressText" class="wizard-progress-text">
+                {wizardModel.progressText}
+              </div>
             </div>
-            <div id="wizardProgressText" class="wizard-progress-text">
-              Step 1 of 5 · Brand
-            </div>
+            <button
+              id="wizardCloseBtn"
+              class="btn btn--muted wizard-close"
+              aria-label="Close wizard"
+            >
+              {"\u00d7"}
+            </button>
           </div>
-          <button id="wizardCloseBtn" class="btn btn--muted wizard-close" aria-label="Close wizard">
-            {"\u00d7"}
-          </button>
-        </div>
-        <div class="wizard-shell">
-          <div class="wizard-main">
-            <div class="wizard-steps">
-              <div class="wizard-step-indicators" aria-label="Add car progress">
-                <span class="wizard-step-dot active" data-step="0">
-                  <span class="wizard-step-dot__number">1</span>
-                  <span class="wizard-step-dot__label" data-i18n="settings.car.step_brand_short">
-                    Brand
-                  </span>
-                </span>
-                <span class="wizard-step-dot" data-step="1">
-                  <span class="wizard-step-dot__number">2</span>
-                  <span class="wizard-step-dot__label" data-i18n="settings.car.step_type_short">
-                    Type
-                  </span>
-                </span>
-                <span class="wizard-step-dot" data-step="2">
-                  <span class="wizard-step-dot__number">3</span>
-                  <span class="wizard-step-dot__label" data-i18n="settings.car.step_model_short">
-                    Model
-                  </span>
-                </span>
-                <span class="wizard-step-dot" data-step="3">
-                  <span class="wizard-step-dot__number">4</span>
-                  <span class="wizard-step-dot__label" data-i18n="settings.car.step_variant_short">
-                    Variant
-                  </span>
-                </span>
-                <span class="wizard-step-dot" data-step="4">
-                  <span class="wizard-step-dot__number">5</span>
-                  <span class="wizard-step-dot__label" data-i18n="settings.car.step_specs_short">
-                    Specs
-                  </span>
-                </span>
-              </div>
+          <div class="wizard-shell">
+            <div class="wizard-main">
+              <div class="wizard-steps">
+                <div class="wizard-step-indicators" aria-label="Add car progress">
+                  {WIZARD_STEP_LABELS.map((label, index) => (
+                    <span
+                      key={label.key}
+                      class="wizard-step-dot"
+                      data-step={String(index)}
+                      data-step-state={wizardStepState(index, wizardModel.step)}
+                      aria-current={index === wizardModel.step ? "step" : undefined}
+                    >
+                      <span class="wizard-step-dot__number">{index + 1}</span>
+                      <span class="wizard-step-dot__label" data-i18n={label.key}>
+                        {label.fallback}
+                      </span>
+                    </span>
+                  ))}
+                </div>
 
-              <div id="wizardStep0" class="wizard-step active">
-                <h3 data-i18n="settings.car.step_brand">Select Brand</h3>
-                <div class="wizard-options" id="wizardBrandList" />
-                <div class="wizard-custom">
-                  <label data-i18n="settings.car.or_custom_brand">Or type a custom brand:</label>
-                  <input
-                    id="wizardCustomBrand"
-                    type="text"
-                    maxLength={32}
-                    placeholder="e.g. Mercedes-Benz"
+                <div id="wizardStep0" class="wizard-step" hidden={wizardModel.step !== 0}>
+                  <h3 data-i18n="settings.car.step_brand">Select Brand</h3>
+                  <WizardOptions
+                    id="wizardBrandList"
+                    section={wizardModel.brandOptions}
+                    firstOptionRef={optionRefs.setBrandOption}
                   />
-                  <button
-                    id="wizardCustomBrandBtn"
-                    class="btn btn--primary"
-                    data-i18n="settings.car.use_custom"
-                  >
-                    Use Custom
-                  </button>
-                </div>
-              </div>
-
-              <div id="wizardStep1" class="wizard-step">
-                <h3 data-i18n="settings.car.step_type">Select Type</h3>
-                <div class="wizard-options" id="wizardTypeList" />
-                <div class="wizard-custom">
-                  <label data-i18n="settings.car.or_custom_type">Or type a custom type:</label>
-                  <input id="wizardCustomType" type="text" maxLength={32} placeholder="e.g. Van" />
-                  <button
-                    id="wizardCustomTypeBtn"
-                    class="btn btn--primary"
-                    data-i18n="settings.car.use_custom"
-                  >
-                    Use Custom
-                  </button>
-                </div>
-              </div>
-
-              <div id="wizardStep2" class="wizard-step">
-                <h3 data-i18n="settings.car.step_model">Select Model</h3>
-                <div class="wizard-options wizard-options--list" id="wizardModelList" />
-                <div class="wizard-custom wizard-custom--branch">
-                  <strong class="wizard-branch-label" data-i18n="settings.car.manual_branch_title">
-                    Manual specs branch
-                  </strong>
-                  <div class="subtle wizard-branch-note" data-i18n="settings.car.manual_model_note">
-                    Skip library variants and finish with your own wheel and gearbox values.
+                  <div class="wizard-custom">
+                    <label data-i18n="settings.car.or_custom_brand">Or type a custom brand:</label>
+                    <input
+                      id="wizardCustomBrand"
+                      type="text"
+                      maxLength={32}
+                      placeholder="e.g. Mercedes-Benz"
+                    />
+                    <button
+                      id="wizardCustomBrandBtn"
+                      class="btn btn--primary"
+                      data-i18n="settings.car.use_custom"
+                    >
+                      Use Custom
+                    </button>
                   </div>
-                  <label data-i18n="settings.car.or_custom_model">Or type a custom model:</label>
-                  <input
-                    id="wizardCustomModel"
-                    type="text"
-                    maxLength={64}
-                    placeholder="e.g. C-Class W205"
+                </div>
+
+                <div id="wizardStep1" class="wizard-step" hidden={wizardModel.step !== 1}>
+                  <h3 data-i18n="settings.car.step_type">Select Type</h3>
+                  <WizardOptions
+                    id="wizardTypeList"
+                    section={wizardModel.typeOptions}
+                    firstOptionRef={optionRefs.setTypeOption}
                   />
-                  <button
-                    id="wizardCustomModelBtn"
-                    class="btn btn--primary"
-                    data-i18n="settings.car.use_custom"
-                  >
-                    Use Custom
-                  </button>
-                </div>
-              </div>
-
-              <div id="wizardStep3" class="wizard-step">
-                <h3 data-i18n="settings.car.step_variant">Select Variant</h3>
-                <div class="wizard-options wizard-options--list" id="wizardVariantList" />
-              </div>
-
-              <div id="wizardStep4" class="wizard-step">
-                <div class="wizard-branch-card wizard-branch-card--library">
-                  <div class="wizard-branch-card__header">
-                    <strong class="wizard-branch-label" data-i18n="settings.car.library_branch_title">
-                      Library-matched specs
-                    </strong>
-                    <div class="subtle wizard-branch-note" data-i18n="settings.car.library_branch_note">
-                      Choose the tire and gearbox that match this car. Finish stays pinned below.
-                    </div>
+                  <div class="wizard-custom">
+                    <label data-i18n="settings.car.or_custom_type">Or type a custom type:</label>
+                    <input id="wizardCustomType" type="text" maxLength={32} placeholder="e.g. Van" />
+                    <button
+                      id="wizardCustomTypeBtn"
+                      class="btn btn--primary"
+                      data-i18n="settings.car.use_custom"
+                    >
+                      Use Custom
+                    </button>
                   </div>
-                  <h3 data-i18n="settings.car.step_wheels">Select Wheels</h3>
-                  <div class="wizard-options" id="wizardTireList" />
-                  <h3 data-i18n="settings.car.step_gearbox" class="wizard-section-title">
-                    Select Gearbox
-                  </h3>
-                  <div class="wizard-options wizard-options--list" id="wizardGearboxList" />
                 </div>
-                <div class="wizard-branch-divider">
-                  <span data-i18n="settings.car.branch_divider">Or switch to the manual branch</span>
-                </div>
-                <div class="wizard-branch-card wizard-branch-card--manual wizard-custom-specs">
-                  <div class="wizard-branch-card__header">
+
+                <div id="wizardStep2" class="wizard-step" hidden={wizardModel.step !== 2}>
+                  <h3 data-i18n="settings.car.step_model">Select Model</h3>
+                  <WizardOptions
+                    id="wizardModelList"
+                    section={wizardModel.modelOptions}
+                    firstOptionRef={optionRefs.setModelOption}
+                  />
+                  <div class="wizard-custom wizard-custom--branch">
                     <strong class="wizard-branch-label" data-i18n="settings.car.manual_branch_title">
                       Manual specs branch
                     </strong>
-                    <div
-                      class="subtle wizard-custom-specs__note"
-                      data-i18n="settings.car.manual_specs_note"
+                    <div class="subtle wizard-branch-note" data-i18n="settings.car.manual_model_note">
+                      Skip library variants and finish with your own wheel and gearbox values.
+                    </div>
+                    <label data-i18n="settings.car.or_custom_model">Or type a custom model:</label>
+                    <input
+                      id="wizardCustomModel"
+                      type="text"
+                      maxLength={64}
+                      placeholder="e.g. C-Class W205"
+                    />
+                    <button
+                      id="wizardCustomModelBtn"
+                      class="btn btn--primary"
+                      data-i18n="settings.car.use_custom"
                     >
-                      Use this branch when the library stops short or you already know the wheel and
-                      gearbox measurements.
-                    </div>
+                      Use Custom
+                    </button>
                   </div>
-                  <div class="settings-subgrid">
-                    <div class="field">
-                      <label htmlFor="wizTireWidth" data-i18n="settings.tire_width">
-                        Tire Width (mm)
-                      </label>
-                      <input id="wizTireWidth" type="number" min="100" step="1" defaultValue="225" />
+                </div>
+
+                <div id="wizardStep3" class="wizard-step" hidden={wizardModel.step !== 3}>
+                  <h3 data-i18n="settings.car.step_variant">Select Variant</h3>
+                  <WizardOptions
+                    id="wizardVariantList"
+                    section={wizardModel.variantOptions}
+                    firstOptionRef={optionRefs.setVariantOption}
+                  />
+                </div>
+
+                <div id="wizardStep4" class="wizard-step" hidden={wizardModel.step !== 4}>
+                  <div class="wizard-branch-card wizard-branch-card--library">
+                    <div class="wizard-branch-card__header">
+                      <strong class="wizard-branch-label" data-i18n="settings.car.library_branch_title">
+                        Library-matched specs
+                      </strong>
+                      <div class="subtle wizard-branch-note" data-i18n="settings.car.library_branch_note">
+                        Choose the tire and gearbox that match this car. Finish stays pinned below.
+                      </div>
                     </div>
-                    <div class="field">
-                      <label htmlFor="wizTireAspect" data-i18n="settings.tire_aspect">
-                        Tire Aspect (%)
-                      </label>
-                      <input id="wizTireAspect" type="number" min="20" step="1" defaultValue="45" />
+                    <h3 data-i18n="settings.car.step_wheels">Select Wheels</h3>
+                    <WizardOptions
+                      id="wizardTireList"
+                      section={wizardModel.tireOptions}
+                      firstOptionRef={optionRefs.setTireOption}
+                    />
+                    <h3 data-i18n="settings.car.step_gearbox" class="wizard-section-title">
+                      Select Gearbox
+                    </h3>
+                    <WizardOptions
+                      id="wizardGearboxList"
+                      section={wizardModel.gearboxOptions}
+                      firstOptionRef={optionRefs.setGearboxOption}
+                    />
+                  </div>
+                  <div class="wizard-branch-divider">
+                    <span data-i18n="settings.car.branch_divider">Or switch to the manual branch</span>
+                  </div>
+                  <div class="wizard-branch-card wizard-branch-card--manual wizard-custom-specs">
+                    <div class="wizard-branch-card__header">
+                      <strong class="wizard-branch-label" data-i18n="settings.car.manual_branch_title">
+                        Manual specs branch
+                      </strong>
+                      <div
+                        class="subtle wizard-custom-specs__note"
+                        data-i18n="settings.car.manual_specs_note"
+                      >
+                        Use this branch when the library stops short or you already know the wheel and
+                        gearbox measurements.
+                      </div>
                     </div>
-                    <div class="field">
-                      <label htmlFor="wizRim" data-i18n="settings.rim_size">
-                        Rim Size (in)
-                      </label>
-                      <input id="wizRim" type="number" min="10" step="0.5" defaultValue="18" />
-                    </div>
-                    <div class="field">
-                      <label htmlFor="wizFinalDrive" data-i18n="settings.final_drive_ratio">
-                        Final Drive Ratio
-                      </label>
-                      <input
-                        id="wizFinalDrive"
-                        type="number"
-                        step="0.01"
-                        min="0.1"
-                        defaultValue="3.08"
-                      />
-                    </div>
-                    <div class="field">
-                      <label htmlFor="wizGearRatio" data-i18n="settings.top_gear_ratio">
-                        Top Gear Ratio
-                      </label>
-                      <input
-                        id="wizGearRatio"
-                        type="number"
-                        step="0.01"
-                        min="0.1"
-                        defaultValue="0.64"
-                      />
+                    <div class="settings-subgrid">
+                      <div class="field">
+                        <label htmlFor="wizTireWidth" data-i18n="settings.tire_width">
+                          Tire Width (mm)
+                        </label>
+                        <input
+                          id="wizTireWidth"
+                          type="number"
+                          min="100"
+                          step="1"
+                          value={wizardModel.manualInputs.tireWidth}
+                        />
+                      </div>
+                      <div class="field">
+                        <label htmlFor="wizTireAspect" data-i18n="settings.tire_aspect">
+                          Tire Aspect (%)
+                        </label>
+                        <input
+                          id="wizTireAspect"
+                          type="number"
+                          min="20"
+                          step="1"
+                          value={wizardModel.manualInputs.tireAspect}
+                        />
+                      </div>
+                      <div class="field">
+                        <label htmlFor="wizRim" data-i18n="settings.rim_size">
+                          Rim Size (in)
+                        </label>
+                        <input
+                          id="wizRim"
+                          type="number"
+                          min="10"
+                          step="0.5"
+                          value={wizardModel.manualInputs.rim}
+                        />
+                      </div>
+                      <div class="field">
+                        <label htmlFor="wizFinalDrive" data-i18n="settings.final_drive_ratio">
+                          Final Drive Ratio
+                        </label>
+                        <input
+                          id="wizFinalDrive"
+                          type="number"
+                          step="0.01"
+                          min="0.1"
+                          value={wizardModel.manualInputs.finalDrive}
+                        />
+                      </div>
+                      <div class="field">
+                        <label htmlFor="wizGearRatio" data-i18n="settings.top_gear_ratio">
+                          Top Gear Ratio
+                        </label>
+                        <input
+                          id="wizGearRatio"
+                          type="number"
+                          step="0.01"
+                          min="0.1"
+                          value={wizardModel.manualInputs.topGear}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            <div class="wizard-nav">
-              <div id="wizardActionHint" class="subtle wizard-nav__status" aria-live="polite" />
-              <div class="wizard-nav__actions">
-                <button id="wizardBackBtn" class="btn btn--muted" data-i18n="settings.car.back">
-                  Back
-                </button>
-                <button
-                  id="wizardManualAddBtn"
-                  class="btn btn--success"
-                  hidden
-                  data-i18n="settings.car.finish_add"
-                >
-                  Add Car
-                </button>
+              <div class="wizard-nav">
+                <div id="wizardActionHint" class="subtle wizard-nav__status" aria-live="polite">
+                  {wizardModel.actionHintText}
+                </div>
+                <div class="wizard-nav__actions">
+                  <button
+                    id="wizardBackBtn"
+                    class="btn btn--muted"
+                    hidden={!wizardModel.backVisible}
+                    data-i18n="settings.car.back"
+                  >
+                    Back
+                  </button>
+                  <button
+                    id="wizardManualAddBtn"
+                    class="btn btn--success"
+                    hidden={!wizardModel.finishVisible}
+                    disabled={!wizardModel.finishEnabled}
+                    data-i18n="settings.car.finish_add"
+                  >
+                    Add Car
+                  </button>
+                </div>
               </div>
             </div>
+
+            <aside class="wizard-summary-card" aria-live="polite">
+              <div class="wizard-task-callout">
+                <strong data-i18n="settings.car.wizard_task_title">Guided setup</strong>
+                <div class="subtle" data-i18n="settings.car.wizard_task_intro">
+                  This flow pauses the rest of Settings so you can build the next analysis profile step
+                  by step without losing your place.
+                </div>
+              </div>
+              <div class="wizard-summary-card__title" data-i18n="settings.car.wizard_summary_title">
+                Current selection
+              </div>
+              <div class="subtle" data-i18n="settings.car.wizard_summary_intro">
+                Your choices stay visible here while the profile comes together.
+              </div>
+              <WizardSummaryPanel summary={wizardModel.summary} />
+            </aside>
           </div>
-
-          <aside class="wizard-summary-card" aria-live="polite">
-            <div class="wizard-task-callout">
-              <strong data-i18n="settings.car.wizard_task_title">Guided setup</strong>
-              <div class="subtle" data-i18n="settings.car.wizard_task_intro">
-                This flow pauses the rest of Settings so you can build the next analysis profile step
-                by step without losing your place.
-              </div>
-            </div>
-            <div class="wizard-summary-card__title" data-i18n="settings.car.wizard_summary_title">
-              Current selection
-            </div>
-            <div class="subtle" data-i18n="settings.car.wizard_summary_intro">
-              Your choices stay visible here while the profile comes together.
-            </div>
-            <div id="wizardSummaryPanel" />
-          </aside>
         </div>
       </div>
     </>
@@ -519,15 +694,8 @@ function createCarsPanelDom(host: HTMLElement): UiCarsDom {
     addCarBtn: requireInHost<HTMLButtonElement>(host, "#addCarBtn"),
     wizardBackdrop: queryInHost<HTMLElement>(host, "#wizardBackdrop"),
     addCarWizard: requireInHost<HTMLElement>(host, "#addCarWizard"),
-    wizardProgressText: queryInHost<HTMLElement>(host, "#wizardProgressText"),
     wizardCloseBtn: queryInHost<HTMLButtonElement>(host, "#wizardCloseBtn"),
     wizardBackBtn: queryInHost<HTMLButtonElement>(host, "#wizardBackBtn"),
-    wizardSteps: [0, 1, 2, 3, 4].map((index) =>
-      queryInHost<HTMLElement>(host, `#wizardStep${index}`)
-    ),
-    wizardStepDots: Array.from(host.querySelectorAll<HTMLElement>(".wizard-step-dot")),
-    wizardSummaryPanel: queryInHost<HTMLElement>(host, "#wizardSummaryPanel"),
-    wizardActionHint: queryInHost<HTMLElement>(host, "#wizardActionHint"),
     wizardBrandList: queryInHost<HTMLElement>(host, "#wizardBrandList"),
     wizardTypeList: queryInHost<HTMLElement>(host, "#wizardTypeList"),
     wizardModelList: queryInHost<HTMLElement>(host, "#wizardModelList"),
@@ -553,13 +721,100 @@ export function mountCarsPanel(host: HTMLElement): CarsPanelView {
   const bridgeState: CarsPanelBridgeState = {
     actions: null,
     model: DEFAULT_CARS_PANEL_MODEL,
+    wizardModel: createClosedCarsWizardRenderModel(),
+  };
+  const optionRefs: CarsWizardOptionRefs = {
+    brandOption: null,
+    gearboxOption: null,
+    modelOption: null,
+    tireOption: null,
+    typeOption: null,
+    variantOption: null,
   };
   const mount = createUiPreactMount(host);
-  const render = () => mount.render(<CarsPanel state={bridgeState} />);
+  const render = () => mount.render(
+    <CarsPanel
+      optionRefs={{
+        setBrandOption: (element) => {
+          optionRefs.brandOption = element;
+        },
+        setGearboxOption: (element) => {
+          optionRefs.gearboxOption = element;
+        },
+        setModelOption: (element) => {
+          optionRefs.modelOption = element;
+        },
+        setTireOption: (element) => {
+          optionRefs.tireOption = element;
+        },
+        setTypeOption: (element) => {
+          optionRefs.typeOption = element;
+        },
+        setVariantOption: (element) => {
+          optionRefs.variantOption = element;
+        },
+      }}
+      state={bridgeState}
+    />,
+  );
   render();
 
   const dom = createCarsPanelDom(host);
+  let lastWizardOpenState = false;
   let wizardDisposer: ViewDisposer | null = null;
+
+  function focus(target: CarsFeatureFocusTarget): void {
+    switch (target) {
+      case "brand-option":
+        focusElement(optionRefs.brandOption ?? dom.wizardCustomBrandInput);
+        return;
+      case "close":
+        focusElement(dom.wizardCloseBtn);
+        return;
+      case "custom-brand":
+        focusElement(dom.wizardCustomBrandInput);
+        return;
+      case "custom-model":
+        focusElement(dom.wizardCustomModelInput);
+        return;
+      case "custom-type":
+        focusElement(dom.wizardCustomTypeInput);
+        return;
+      case "finish":
+        focusElement(dom.wizardManualAddBtn);
+        return;
+      case "gearbox-option":
+        focusElement(optionRefs.gearboxOption ?? dom.wizardManualAddBtn);
+        return;
+      case "manual-final-drive":
+        focusElement(dom.wizFinalDriveInput);
+        return;
+      case "manual-rim":
+        focusElement(dom.wizRimInput);
+        return;
+      case "manual-tire-aspect":
+        focusElement(dom.wizTireAspectInput);
+        return;
+      case "manual-tire-width":
+        focusElement(dom.wizTireWidthInput);
+        return;
+      case "manual-top-gear":
+        focusElement(dom.wizGearRatioInput);
+        return;
+      case "model-option":
+        focusElement(optionRefs.modelOption ?? dom.wizardCustomModelInput);
+        return;
+      case "spec-selection":
+        focusElement(optionRefs.tireOption ?? optionRefs.gearboxOption ?? dom.wizTireWidthInput);
+        return;
+      case "type-option":
+        focusElement(optionRefs.typeOption ?? dom.wizardCustomTypeInput);
+        return;
+      case "variant-option":
+        focusElement(optionRefs.variantOption);
+        return;
+    }
+  }
 
   return {
     list: {
@@ -577,6 +832,31 @@ export function mountCarsPanel(host: HTMLElement): CarsPanelView {
       bindActions(handlers): void {
         wizardDisposer?.();
         wizardDisposer = bindCarsFeatureInteractions(dom, handlers);
+      },
+      captureReturnFocusTarget(): HTMLElement | null {
+        return document.activeElement instanceof HTMLElement ? document.activeElement : dom.addCarBtn;
+      },
+      focus,
+      readManualInputs(): CarsFeatureManualInputState {
+        return {
+          finalDrive: dom.wizFinalDriveInput?.value ?? "",
+          rim: dom.wizRimInput?.value ?? "",
+          tireAspect: dom.wizTireAspectInput?.value ?? "",
+          tireWidth: dom.wizTireWidthInput?.value ?? "",
+          topGear: dom.wizGearRatioInput?.value ?? "",
+        };
+      },
+      render(model): void {
+        bridgeState.wizardModel = model;
+        render();
+        if (model.isOpen && !lastWizardOpenState) {
+          dom.addCarWizard.scrollTop = 0;
+        }
+        lastWizardOpenState = model.isOpen;
+      },
+      restoreFocus(target): void {
+        const safeTarget = target && document.contains(target) ? target : dom.addCarBtn;
+        focusElement(safeTarget);
       },
     },
   };

--- a/apps/ui/src/styles/settings.css
+++ b/apps/ui/src/styles/settings.css
@@ -564,23 +564,26 @@
 }
 
 /* Add car wizard */
-body[data-wizard-open="true"] { overflow: hidden; }
-.wizard-backdrop {
+.wizard-modal-layer {
   position: fixed;
   inset: 0;
   z-index: 105;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+.wizard-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
   background: rgba(15, 23, 42, 0.48);
   backdrop-filter: blur(4px);
 }
 .add-car-wizard {
-  position: fixed;
-  top: clamp(1rem, 3vw, 2rem);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 110;
+  position: relative;
+  z-index: 1;
   width: min(1120px, calc(100vw - 2rem));
   max-height: calc(100vh - 2rem);
-  margin: 0;
+  margin: clamp(1rem, 3vw, 2rem) auto;
   overflow: auto;
   border: 1px solid var(--border-strong);
   box-shadow: 0 28px 80px rgba(15, 23, 42, 0.24);
@@ -886,7 +889,7 @@ body[data-wizard-open="true"] { overflow: hidden; }
   .add-car-wizard {
     width: calc(100vw - 1.5rem);
     max-height: calc(100vh - 1.5rem);
-    top: 0.75rem;
+    margin: 0.75rem auto;
   }
   .wizard-shell {
     grid-template-columns: 1fr;
@@ -898,9 +901,7 @@ body[data-wizard-open="true"] { overflow: hidden; }
 
 @media (max-width: 720px) {
   .add-car-wizard:not([hidden]) {
-    top: 0;
-    left: 0;
-    transform: none;
+    margin: 0;
     width: 100vw;
     height: 100dvh;
     max-height: 100dvh;

--- a/apps/ui/tests/car_wizard_view.spec.ts
+++ b/apps/ui/tests/car_wizard_view.spec.ts
@@ -1,196 +1,221 @@
 import { expect, test } from "@playwright/test";
 
+import type {
+  CarLibraryGearbox,
+  CarLibraryModel,
+  CarLibraryTireOption,
+} from "../src/transport/http_models";
+import type {
+  CarsFeatureOptionsState,
+  CarsFeatureRenderState,
+} from "../src/app/features/cars_feature_workflow";
 import {
-  renderWizardGearboxOptions,
-  renderWizardModelOptions,
-  renderWizardSummary,
-  renderWizardTireOptions,
-  syncCarWizardStepState,
-  writeCarWizardTireInputs,
+  buildCarsWizardRenderModel,
+  createClosedCarsWizardRenderModel,
 } from "../src/app/views/car_wizard_view";
 
-type ClassListStub = {
-  add(name: string): void;
-  remove(name: string): void;
-  toggle(name: string, force?: boolean): void;
-  contains(name: string): boolean;
-};
-
-type ElementStub = HTMLElement & {
-  classList: ClassListStub;
-  getAttribute(name: string): string | null;
-  setAttribute(name: string, value: string): void;
-  removeAttribute(name: string): void;
-};
-
-function createClassList(initial: string[] = []): ClassListStub {
-  const active = new Set(initial);
-  return {
-    add(name: string): void {
-      active.add(name);
-    },
-    remove(name: string): void {
-      active.delete(name);
-    },
-    toggle(name: string, force?: boolean): void {
-      if (typeof force === "boolean") {
-        if (force) active.add(name);
-        else active.delete(name);
-        return;
-      }
-      if (active.has(name)) active.delete(name);
-      else active.add(name);
-    },
-    contains(name: string): boolean {
-      return active.has(name);
-    },
+function createTranslator(): (key: string, vars?: Record<string, unknown>) => string {
+  return (key, vars) => {
+    if (vars?.current && vars?.total && vars?.step) {
+      return `${key}:${vars.current}/${vars.total}:${String(vars.step)}`;
+    }
+    return key;
   };
 }
 
-function createElement(attributes: Record<string, string> = {}): ElementStub {
-  const activeAttributes = { ...attributes };
+function createOptionsState<TOption>(
+  options: readonly TOption[],
+  status: CarsFeatureOptionsState<TOption>["status"] = "ready",
+  message: string | null = null,
+): CarsFeatureOptionsState<TOption> {
   return {
-    classList: createClassList(),
-    getAttribute(name: string): string | null {
-      return activeAttributes[name] ?? null;
-    },
-    setAttribute(name: string, value: string): void {
-      activeAttributes[name] = value;
-    },
-    removeAttribute(name: string): void {
-      delete activeAttributes[name];
-    },
-  } as unknown as ElementStub;
+    message,
+    options,
+    status,
+  };
 }
 
-function createInput(): HTMLInputElement {
+function makeGearbox(overrides: Partial<CarLibraryGearbox> = {}): CarLibraryGearbox {
   return {
-    value: "",
-  } as unknown as HTMLInputElement;
+    final_drive_ratio: 3.91,
+    name: "6-speed",
+    top_gear_ratio: 0.82,
+    ...overrides,
+  };
 }
 
-test.describe("car wizard view helpers", () => {
-  test("syncCarWizardStepState updates step, dot, and back-button state", () => {
-    const wizardSteps = Array.from({ length: 5 }, () => createElement());
-    const wizardStepDots = Array.from({ length: 5 }, (_, index) =>
-      createElement({ "data-step": String(index) }));
-    const wizardBackBtn = {
-      style: { display: "" },
-    } as unknown as HTMLButtonElement;
+function makeTireOption(overrides: Partial<CarLibraryTireOption> = {}): CarLibraryTireOption {
+  return {
+    name: "Sport",
+    rim_in: 18,
+    tire_aspect_pct: 40,
+    tire_width_mm: 245,
+    ...overrides,
+  };
+}
 
-    syncCarWizardStepState({ wizardSteps, wizardStepDots, wizardBackBtn }, 3);
+function makeModel(overrides: Partial<CarLibraryModel> = {}): CarLibraryModel {
+  return {
+    gearboxes: [],
+    model: "Roadster",
+    rim_in: 18,
+    tire_aspect_pct: 40,
+    tire_options: [],
+    tire_width_mm: 245,
+    variants: [],
+    ...overrides,
+  };
+}
 
-    expect(wizardSteps[3].classList.contains("active")).toBe(true);
-    expect(wizardSteps[2].classList.contains("active")).toBe(false);
-    expect(wizardStepDots[3].classList.contains("active")).toBe(true);
-    expect(wizardStepDots[2].classList.contains("done")).toBe(true);
-    expect(wizardStepDots[3].getAttribute("aria-current")).toBe("step");
-    expect(wizardBackBtn.style.display).toBe("");
-
-    syncCarWizardStepState({ wizardSteps, wizardStepDots, wizardBackBtn }, 0);
-    expect(wizardSteps[0].classList.contains("active")).toBe(true);
-    expect(wizardStepDots[0].classList.contains("active")).toBe(true);
-    expect(wizardStepDots[1].classList.contains("done")).toBe(false);
-    expect(wizardStepDots[0].getAttribute("aria-current")).toBe("step");
-    expect(wizardStepDots[3].getAttribute("aria-current")).toBeNull();
-    expect(wizardBackBtn.style.display).toBe("none");
-  });
-
-  test("renderWizardSummary stages summary rows until they become relevant", () => {
-    const escapeHtml = (value: unknown) => String(value ?? "");
-    const labels: Record<string, string> = {
-      "settings.car.wizard_summary_pending": "Not selected yet",
-      "settings.car.wizard_summary_name": "Profile preview",
-      "settings.car.wizard_summary_brand": "Brand",
-      "settings.car.wizard_summary_type": "Type",
-      "settings.car.wizard_summary_model": "Model",
-      "settings.car.wizard_summary_variant": "Variant",
-      "settings.car.wizard_summary_tire": "Tires",
-      "settings.car.wizard_summary_gearbox": "Gearbox",
-    };
-    const t = (key: string) => labels[key] ?? key;
-
-    const earlyHtml = renderWizardSummary({
-      currentStep: 1,
+function createRenderState(overrides: Partial<CarsFeatureRenderState> = {}): CarsFeatureRenderState {
+  return {
+    actionHint: "",
+    brandOptions: createOptionsState(["BMW"]),
+    canFinish: false,
+    gearboxOptions: [],
+    isOpen: true,
+    manualInputs: {
+      finalDrive: "3.08",
+      rim: "18",
+      tireAspect: "45",
+      tireWidth: "225",
+      topGear: "0.64",
+    },
+    modelOptions: createOptionsState([makeModel()]),
+    noGearboxesMessage: null,
+    resolvedSpecBranch: null,
+    selectedGearbox: null,
+    selectedTire: null,
+    step: 0,
+    summaryData: {
+      currentStep: 0,
       profileName: null,
-      brand: "BMW",
+      brand: null,
       carType: null,
       model: null,
       variant: null,
       tire: null,
       gearbox: null,
-    }, { t, escapeHtml });
-    expect(earlyHtml).toContain("BMW");
-    expect(earlyHtml).not.toContain("Gearbox");
-    expect(earlyHtml).not.toContain("Tires");
+    },
+    tireOptions: [],
+    typeOptions: createOptionsState(["SUV"]),
+    variantOptions: [],
+    ...overrides,
+  };
+}
 
-    const html = renderWizardSummary({
-      currentStep: 4,
-      profileName: "BMW X5 M60i",
-      brand: "BMW",
-      carType: "SUV",
-      model: "X5 M60i",
-      variant: null,
-      tire: null,
-      gearbox: "8-speed",
-    }, { t, escapeHtml });
+test.describe("car wizard view helpers", () => {
+  test("createClosedCarsWizardRenderModel preserves the manual-spec defaults before the first open", () => {
+    const model = createClosedCarsWizardRenderModel();
 
-    expect(html).toContain("Profile preview");
-    expect(html).toContain("BMW X5 M60i");
-    expect(html).toContain("SUV");
-    expect(html).toContain("8-speed");
-    expect(html).toContain("Not selected yet");
+    expect(model.isOpen).toBe(false);
+    expect(model.manualInputs).toEqual({
+      finalDrive: "3.08",
+      rim: "18",
+      tireAspect: "45",
+      tireWidth: "225",
+      topGear: "0.64",
+    });
+    expect(model.finishVisible).toBe(false);
   });
 
-  test("render helpers produce the expected wizard option markup", () => {
-    const escapeHtml = (value: unknown) => String(value ?? "");
-    const fmt = (value: number, digits = 0) => Number(value).toFixed(digits);
-    const models: Parameters<typeof renderWizardModelOptions>[0] = [{
-      model: "Roadster",
-      tire_width_mm: 245,
-      tire_aspect_pct: 40,
-      rim_in: 18,
-      variants: [],
-      gearboxes: [],
-      tire_options: [],
-    }];
-    const tireOptions: Parameters<typeof renderWizardTireOptions>[0] = [{
-      name: "Sport",
-      tire_width_mm: 245,
-      tire_aspect_pct: 40,
-      rim_in: 18,
-    }];
-    const gearboxes: Parameters<typeof renderWizardGearboxOptions>[0] = [{
-      name: "6-speed",
-      final_drive_ratio: 3.91,
-      top_gear_ratio: 0.82,
-    }];
+  test("buildCarsWizardRenderModel converts option state and progress metadata into typed sections", () => {
+    const model = buildCarsWizardRenderModel(createRenderState({
+      brandOptions: createOptionsState(["BMW", "Volvo"]),
+      modelOptions: createOptionsState([], "loading", "Loading models"),
+      step: 2,
+      summaryData: {
+        currentStep: 2,
+        profileName: null,
+        brand: "BMW",
+        carType: "SUV",
+        model: null,
+        variant: null,
+        tire: null,
+        gearbox: null,
+      },
+      typeOptions: createOptionsState([], "error", "Types offline"),
+    }), {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+    });
 
-    expect(renderWizardModelOptions(models, escapeHtml)).toContain('data-idx="0"');
-    expect(renderWizardModelOptions(models, escapeHtml)).toContain("245/40R18");
-    expect(renderWizardTireOptions(tireOptions, escapeHtml)).toContain("selected");
-    expect(renderWizardGearboxOptions(gearboxes, { escapeHtml, fmt }, 0)).toContain("selected");
-    expect(renderWizardGearboxOptions(gearboxes, { escapeHtml, fmt }, 0)).toContain("FD: 3.91");
-    expect(renderWizardGearboxOptions(gearboxes, { escapeHtml, fmt }, 0)).toContain("Top Gear: 0.82");
+    expect(model.backVisible).toBe(true);
+    expect(model.progressText).toBe("settings.car.wizard_progress:3/5:settings.car.step_model_short");
+    expect(model.brandOptions.options.map((option) => option.value)).toEqual(["BMW", "Volvo"]);
+    expect(model.typeOptions.messageText).toBe("Types offline");
+    expect(model.modelOptions.messageText).toBe("Loading models");
+    expect(model.summary.rows).toEqual([
+      {
+        labelText: "settings.car.wizard_summary_brand",
+        valueText: "BMW",
+      },
+      {
+        labelText: "settings.car.wizard_summary_type",
+        valueText: "SUV",
+      },
+    ]);
   });
 
-  test("writeCarWizardTireInputs syncs the selected tire dimensions into manual inputs", () => {
-    const els: Parameters<typeof writeCarWizardTireInputs>[0] = {
-      wizTireWidthInput: createInput(),
-      wizTireAspectInput: createInput(),
-      wizRimInput: createInput(),
-    };
-    const tire: Parameters<typeof writeCarWizardTireInputs>[1] = {
-      name: "Touring",
-      tire_width_mm: 225,
-      tire_aspect_pct: 50,
-      rim_in: 17,
-    };
+  test("buildCarsWizardRenderModel formats selected library specs and pending summary rows", () => {
+    const tire = makeTireOption();
+    const gearbox = makeGearbox();
 
-    writeCarWizardTireInputs(els, tire);
+    const model = buildCarsWizardRenderModel(createRenderState({
+      actionHint: "Library path selected",
+      canFinish: true,
+      gearboxOptions: [gearbox],
+      resolvedSpecBranch: "library",
+      selectedGearbox: gearbox,
+      selectedTire: tire,
+      step: 4,
+      summaryData: {
+        currentStep: 4,
+        profileName: "BMW Roadster",
+        brand: "BMW",
+        carType: "Coupe",
+        model: "Roadster",
+        variant: null,
+        tire: "245/40R18",
+        gearbox: "6-speed",
+      },
+      tireOptions: [tire],
+      variantOptions: [{
+        drivetrain: "AWD",
+        engine: "V8",
+        name: "Competition",
+      }],
+    }), {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+    });
 
-    expect(els.wizTireWidthInput?.value).toBe("225");
-    expect(els.wizTireAspectInput?.value).toBe("50");
-    expect(els.wizRimInput?.value).toBe("17");
+    expect(model.finishVisible).toBe(true);
+    expect(model.finishEnabled).toBe(true);
+    expect(model.specBranch).toBe("library");
+    expect(model.actionHintText).toBe("Library path selected");
+    expect(model.tireOptions.options).toEqual([{
+      detailText: "245/40R18",
+      labelText: "Sport",
+      selected: true,
+      value: "0",
+    }]);
+    expect(model.gearboxOptions.options).toEqual([{
+      detailText: "FD: 3.91 · Top Gear: 0.82",
+      labelText: "6-speed",
+      selected: true,
+      value: "0",
+    }]);
+    expect(model.variantOptions.options).toEqual([{
+      detailText: "AWD · V8",
+      labelText: "Competition",
+      selected: false,
+      value: "0",
+    }]);
+    expect(model.summary.profileNameValueText).toBe("BMW Roadster");
+    expect(model.summary.rows.at(-1)).toEqual({
+      labelText: "settings.car.wizard_summary_gearbox",
+      valueText: "6-speed",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #2284.

This PR finishes the second half of the car-management migration by moving the add-car wizard’s remaining imperative rendering path into the existing Preact island. Before this change, `cars_panel.tsx` mounted the wizard shell, but the actual step content still depended on `cars_feature_presenter.ts` and `car_wizard_view.ts` to build option lists, summaries, and branch-state content with `innerHTML`, then restore focus by querying `.wiz-opt` buttons after each state transition. The wizard also toggled a `document.body` attribute just to represent its open state. That left the saved-car list in JSX, but the modal’s main interaction flow still lived in a DOM-mutation adapter.

The implementation keeps the existing workflow/controller contract in `cars_feature_workflow.ts` intact and instead changes the view seam. The wizard now renders from typed render models inside `cars_panel.tsx`, while `cars_feature_presenter.ts` is reduced to a thin adapter that translates workflow state into those render models and delegates focus/manual-input access through the panel bridge. This keeps the state machine and transport behavior out of the component layer, but removes the last imperative renderer inside the car-management island.

## Problem being solved

Issue #2284 was explicitly scoped to the wizard internals, not to the already-migrated saved-car list. The remaining problems were all in the view layer:

1. Brand, type, model, variant, tire, and gearbox choices were rendered as HTML strings.
2. The summary card and no-gearbox messaging were rendered through string builders instead of JSX.
3. Focus management depended on `.querySelector(".wiz-opt")` lookups after render.
4. The dialog open state depended on `document.body` mutation rather than island-owned UI state.
5. Existing wizard tests still validated the old helper seam instead of the typed render contract the migrated UI should expose.

Those problems made the wizard an imperative subsystem wrapped by a Preact host instead of a genuinely island-owned UI surface.

## Chosen approach

I kept the existing split between workflow, presenter, and panel instead of collapsing everything into one component. The workflow already owned the meaningful behavior: step advancement, library/manual branch selection, loading and error handling, summary data, validation, and focus target requests. Replacing that with component-local state would have widened the issue and made the migration harder to review.

Instead, the PR changes only the rendering seam:

- `car_wizard_view.ts` now builds typed render models instead of HTML fragments.
- `cars_panel.tsx` renders the full wizard body in JSX from that model.
- `cars_feature_presenter.ts` now adapts workflow state to the panel bridge instead of mutating the DOM directly.
- Focus still follows workflow-owned targets, but the panel now resolves those targets through stable refs and known inputs/buttons instead of post-render DOM queries.

I intentionally kept `cars_feature_bindings.ts` for this issue. The issue was about the rendering seam, and the existing typed event-decoding layer already fit the migrated DOM structure. Removing that layer too would have made the diff larger without helping the core requirement.

## Main code changes

### `apps/ui/src/app/views/cars_panel.tsx`

This is now the true owner of the add-car wizard UI, not just its outer shell. The component renders:

- step indicators and step visibility state
- option sections for brand/type/model/variant/tire/gearbox
- summary content
- branch highlighting through `data-spec-branch`
- action hint text
- finish/back button state
- controlled manual-spec inputs

The panel bridge now also owns focus and manual-input access for the wizard. Static focus targets still use direct element references, while the first option in each list is tracked through stable refs so the workflow can request focus without querying for `.wiz-opt` after each render.

The modal no longer relies on `document.body` for open-state styling. Instead, the panel renders an island-owned modal layer (`.wizard-modal-layer`) and keeps dialog/backdrop state within that surface.

### `apps/ui/src/app/views/car_wizard_view.ts`

This file was repurposed from HTML-string rendering helpers into typed wizard render-model builders. It now shapes:

- progress text
- typed option sections
- selected tire/gearbox state
- summary rows and profile preview
- branch-state metadata
- closed/default wizard state

That gives the panel a clean, declarative input contract while keeping formatting and row visibility logic out of JSX.

### `apps/ui/src/app/views/cars_feature_presenter.ts` and `apps/ui/src/app/features/cars_feature.ts`

The presenter is now a thin adapter instead of a DOM owner. It delegates:

- render → `buildCarsWizardRenderModel(...)` + panel bridge
- focus → panel bridge
- read/restore focus → panel bridge
- manual input reads → panel bridge

`cars_feature.ts` was updated to construct the presenter with the panel bridge instead of raw DOM and escaping helpers.

### `apps/ui/src/app/dom/cars_dom.ts` and `apps/ui/src/styles/settings.css`

The wizard DOM contract was trimmed to the pieces still needed by the bindings/manual-input bridge. Unused step/progress/summary DOM fields went away.

The CSS now supports the island-owned modal layer instead of the old body attribute path. The wizard still preserves the same mobile full-viewport behavior and sticky action area, but the open-state model is now local to the panel.

### Tests and docs

`apps/ui/tests/car_wizard_view.spec.ts` was rewritten to validate the new typed render-model seam instead of stale DOM-class assumptions from the old helper path. The existing workflow, binding, and browser wizard tests were kept and still pass, which was important because they verify behavior rather than implementation detail.

`apps/ui/README.md` now describes the car-management surface as owning the full wizard internals in JSX and documents the new role of `car_wizard_view.ts` and the thinner presenter.

## Validation performed

Focused validation that directly covers this issue is green:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/car_wizard_view.spec.ts tests/cars_feature_workflow.spec.ts tests/ui_action_bindings.spec.ts --workers=1`
- `cd apps/ui && npx playwright test --config=.ai-temp/playwright.page.local.config.ts tests/smoke.car-wizard.spec.ts --workers=1`

I also ran broader visual coverage. The default `npm run test:visual` result was not useful in this shared environment because the repo’s default Playwright config still targets `localhost:4173`, which can already be occupied here. I reran the full suite on an isolated local config using `127.0.0.1:4273`. That rerun passed 923 tests and reported 9 failures, all outside the wizard surface:

- 1 unrelated `tests/spectrum_canvas_renderer.spec.ts` failure (`document is not defined`)
- 8 existing snapshot diffs in `tests/visual.spec.ts` for live overview and settings-analysis screenshots

No wizard-specific browser or unit coverage failed in the isolated rerun.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that I intentionally left the typed wizard binding layer in place. That means this PR finishes the rendering migration without also reworking event decoding. I think that is the right cut for this issue because it keeps the behavior stable and limits the review surface to the view seam the issue actually called out.

I also did not touch the unrelated broad-suite failures surfaced by the isolated rerun because they are outside the wizard area and were not introduced by this change. Fixing spectrum test environment assumptions or refreshing unrelated snapshots would make this PR noisier and harder to review.

The result is a wizard that now renders as part of the island it lives in, keeps the existing workflow semantics, preserves focus/navigation behavior, and removes the specific imperative rendering dependencies called out in #2284.
