### PR TITLE
Render analysis settings in Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -105,7 +105,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/realtime_feature_workflow.ts` | DOM-free realtime workflow/controller for polling, logging actions, location updates, and client mutations |
 | `app/features/settings_cars_module.ts` | Settings-side car controller that owns list loading, activation/deletion flows, highlight feedback, and typed tab/view-driven feedback dismissal plus the explicit open-wizard port |
 | `app/features/settings_cars_transport.ts` | Settings-car transport wrapper over load/activate/delete API calls |
-| `app/features/settings_analysis_module.ts` | Analysis-settings behavior owner for validation, save/reset orchestration, field guidance, and spectrum refreshes behind the island DOM bridge |
+| `app/features/settings_analysis_module.ts` | Analysis-settings behavior owner for validation, save/reset orchestration, field guidance, and spectrum refreshes behind the typed analysis-panel bridge |
 | `app/features/settings_speed_source_module.ts` | Thin speed-source settings facade that wires the transport seam, DOM-free workflow, presenter, and typed bindings together |
 | `app/features/settings_speed_source_transport.ts` | Speed-source settings transport wrapper over the UI-local settings and OBD APIs |
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -480,10 +480,6 @@ export function createSettingsAnalysisModule(
       onReset: resetAnalysisToDefaults,
       onSave: saveAnalysisFromInputs,
     });
-    panel.setCarAvailability({
-      hasActiveCar: ctx.hasValidActiveCar(),
-      isLoading: false,
-    });
     renderPanel();
   }
 

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -1,13 +1,19 @@
 import type {
-  AnalysisSettingsRequest,
   AnalysisSettingsPayload,
+  AnalysisSettingsRequest,
 } from "../../transport/http_models";
 import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import { defaultVehicleSettings, type SettingsState } from "../ui_app_state";
-import type { SettingsAnalysisPanelDom } from "../views/analysis_panel";
-import { setSettingsAnalysisGuidance } from "../views/settings_analysis_guidance";
-import { setSettingsFeedback } from "../views/settings_feedback";
+import type {
+  AnalysisPanelFieldKey,
+  AnalysisPanelRenderModel,
+  AnalysisPanelView,
+} from "../views/analysis_panel";
+import {
+  buildSettingsAnalysisGuidanceRenderModel,
+} from "../views/settings_analysis_guidance";
+import type { SettingsFeedbackMessage } from "../views/settings_feedback";
 
 export const ANALYSIS_SETTING_KEYS = [
   "tire_width_mm",
@@ -28,7 +34,7 @@ export const ANALYSIS_SETTING_KEYS = [
 ] as const satisfies readonly (keyof AnalysisSettingsPayload)[];
 
 export interface SettingsAnalysisModuleDeps extends FeatureDepsBase {
-  dom: SettingsAnalysisPanelDom;
+  panel: AnalysisPanelView;
   settings: SettingsState;
   renderSpectrum: () => void;
   hasValidActiveCar: () => boolean;
@@ -43,178 +49,170 @@ export interface SettingsAnalysisModule {
   saveAnalysisFromInputs(): void;
 }
 
+type EditableAnalysisDrafts = Record<AnalysisPanelFieldKey, string>;
+type UnitSuffix = "%" | " Hz";
+
+interface AnalysisFieldConfig {
+  key: AnalysisPanelFieldKey;
+  labelKey: string;
+  unit: UnitSuffix;
+  hardMin: number;
+  hardMax: number;
+  guidedMin: number;
+  guidedMax: number;
+  defaultValue: number;
+}
+
+interface AnalysisFieldState {
+  config: AnalysisFieldConfig;
+  rawValue: string;
+  numericValue: number;
+}
+
+const EDITABLE_ANALYSIS_KEYS = [
+  "wheel_bandwidth_pct",
+  "driveshaft_bandwidth_pct",
+  "engine_bandwidth_pct",
+  "speed_uncertainty_pct",
+  "tire_diameter_uncertainty_pct",
+  "final_drive_uncertainty_pct",
+  "gear_uncertainty_pct",
+  "min_abs_band_hz",
+  "max_band_half_width_pct",
+] as const satisfies readonly AnalysisPanelFieldKey[];
+
+const ANALYSIS_FIELD_CONFIGS: Record<AnalysisPanelFieldKey, AnalysisFieldConfig> = {
+  wheel_bandwidth_pct: {
+    key: "wheel_bandwidth_pct",
+    labelKey: "settings.wheel_bandwidth",
+    unit: "%",
+    hardMin: 0.1,
+    hardMax: 100,
+    guidedMin: 2,
+    guidedMax: 12,
+    defaultValue: defaultVehicleSettings.wheel_bandwidth_pct,
+  },
+  driveshaft_bandwidth_pct: {
+    key: "driveshaft_bandwidth_pct",
+    labelKey: "settings.driveshaft_bandwidth",
+    unit: "%",
+    hardMin: 0.1,
+    hardMax: 100,
+    guidedMin: 2,
+    guidedMax: 10,
+    defaultValue: defaultVehicleSettings.driveshaft_bandwidth_pct,
+  },
+  engine_bandwidth_pct: {
+    key: "engine_bandwidth_pct",
+    labelKey: "settings.engine_bandwidth",
+    unit: "%",
+    hardMin: 0.1,
+    hardMax: 100,
+    guidedMin: 2,
+    guidedMax: 12,
+    defaultValue: defaultVehicleSettings.engine_bandwidth_pct,
+  },
+  speed_uncertainty_pct: {
+    key: "speed_uncertainty_pct",
+    labelKey: "settings.speed_uncertainty",
+    unit: "%",
+    hardMin: 0,
+    hardMax: 100,
+    guidedMin: 0,
+    guidedMax: 5,
+    defaultValue: defaultVehicleSettings.speed_uncertainty_pct,
+  },
+  tire_diameter_uncertainty_pct: {
+    key: "tire_diameter_uncertainty_pct",
+    labelKey: "settings.tire_diameter_uncertainty",
+    unit: "%",
+    hardMin: 0,
+    hardMax: 100,
+    guidedMin: 0,
+    guidedMax: 5,
+    defaultValue: defaultVehicleSettings.tire_diameter_uncertainty_pct,
+  },
+  final_drive_uncertainty_pct: {
+    key: "final_drive_uncertainty_pct",
+    labelKey: "settings.final_drive_uncertainty",
+    unit: "%",
+    hardMin: 0,
+    hardMax: 100,
+    guidedMin: 0,
+    guidedMax: 2,
+    defaultValue: defaultVehicleSettings.final_drive_uncertainty_pct,
+  },
+  gear_uncertainty_pct: {
+    key: "gear_uncertainty_pct",
+    labelKey: "settings.gear_slip_uncertainty",
+    unit: "%",
+    hardMin: 0,
+    hardMax: 100,
+    guidedMin: 0,
+    guidedMax: 4,
+    defaultValue: defaultVehicleSettings.gear_uncertainty_pct,
+  },
+  min_abs_band_hz: {
+    key: "min_abs_band_hz",
+    labelKey: "settings.min_half_width",
+    unit: " Hz",
+    hardMin: 0,
+    hardMax: 500,
+    guidedMin: 0,
+    guidedMax: 2,
+    defaultValue: defaultVehicleSettings.min_abs_band_hz,
+  },
+  max_band_half_width_pct: {
+    key: "max_band_half_width_pct",
+    labelKey: "settings.max_half_width",
+    unit: "%",
+    hardMin: 0.1,
+    hardMax: 100,
+    guidedMin: 1,
+    guidedMax: 12,
+    defaultValue: defaultVehicleSettings.max_band_half_width_pct,
+  },
+};
+
+function analysisFieldConfig(key: AnalysisPanelFieldKey): AnalysisFieldConfig {
+  return ANALYSIS_FIELD_CONFIGS[key];
+}
+
+function buildDraftValues(settings: SettingsState): EditableAnalysisDrafts {
+  return {
+    wheel_bandwidth_pct: formatSettingValue(settings.vehicleSettings.wheel_bandwidth_pct),
+    driveshaft_bandwidth_pct: formatSettingValue(
+      settings.vehicleSettings.driveshaft_bandwidth_pct,
+    ),
+    engine_bandwidth_pct: formatSettingValue(settings.vehicleSettings.engine_bandwidth_pct),
+    speed_uncertainty_pct: formatSettingValue(settings.vehicleSettings.speed_uncertainty_pct),
+    tire_diameter_uncertainty_pct: formatSettingValue(
+      settings.vehicleSettings.tire_diameter_uncertainty_pct,
+    ),
+    final_drive_uncertainty_pct: formatSettingValue(
+      settings.vehicleSettings.final_drive_uncertainty_pct,
+    ),
+    gear_uncertainty_pct: formatSettingValue(settings.vehicleSettings.gear_uncertainty_pct),
+    min_abs_band_hz: formatSettingValue(settings.vehicleSettings.min_abs_band_hz),
+    max_band_half_width_pct: formatSettingValue(
+      settings.vehicleSettings.max_band_half_width_pct,
+    ),
+  };
+}
+
+function formatSettingValue(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : String(Number(value.toFixed(1)));
+}
+
 export function createSettingsAnalysisModule(
   ctx: SettingsAnalysisModuleDeps,
 ): SettingsAnalysisModule {
-  const { settings, dom: els, t } = ctx;
-  type EditableAnalysisKey =
-    | "wheel_bandwidth_pct"
-    | "driveshaft_bandwidth_pct"
-    | "engine_bandwidth_pct"
-    | "speed_uncertainty_pct"
-    | "tire_diameter_uncertainty_pct"
-    | "final_drive_uncertainty_pct"
-    | "gear_uncertainty_pct"
-    | "min_abs_band_hz"
-    | "max_band_half_width_pct";
-  type UnitSuffix = "%" | " Hz";
-  interface AnalysisFieldConfig {
-    key: EditableAnalysisKey;
-    labelKey: string;
-    unit: UnitSuffix;
-    hardMin: number;
-    hardMax: number;
-    guidedMin: number;
-    guidedMax: number;
-    defaultValue: number;
-    guidanceId: string;
-    guidance: () => HTMLElement | null;
-    input: () => HTMLInputElement | null;
-  }
-  const analysisFields: readonly AnalysisFieldConfig[] = [
-    {
-      key: "wheel_bandwidth_pct",
-      labelKey: "settings.wheel_bandwidth",
-      unit: "%",
-      hardMin: 0.1,
-      hardMax: 100,
-      guidedMin: 2,
-      guidedMax: 12,
-      defaultValue: defaultVehicleSettings.wheel_bandwidth_pct,
-      guidanceId: "wheelBandwidthGuidance",
-      guidance: () => els.analysisFieldGuidance.wheelBandwidth,
-      input: () => els.wheelBandwidthInput,
-    },
-    {
-      key: "driveshaft_bandwidth_pct",
-      labelKey: "settings.driveshaft_bandwidth",
-      unit: "%",
-      hardMin: 0.1,
-      hardMax: 100,
-      guidedMin: 2,
-      guidedMax: 10,
-      defaultValue: defaultVehicleSettings.driveshaft_bandwidth_pct,
-      guidanceId: "driveshaftBandwidthGuidance",
-      guidance: () => els.analysisFieldGuidance.driveshaftBandwidth,
-      input: () => els.driveshaftBandwidthInput,
-    },
-    {
-      key: "engine_bandwidth_pct",
-      labelKey: "settings.engine_bandwidth",
-      unit: "%",
-      hardMin: 0.1,
-      hardMax: 100,
-      guidedMin: 2,
-      guidedMax: 12,
-      defaultValue: defaultVehicleSettings.engine_bandwidth_pct,
-      guidanceId: "engineBandwidthGuidance",
-      guidance: () => els.analysisFieldGuidance.engineBandwidth,
-      input: () => els.engineBandwidthInput,
-    },
-    {
-      key: "speed_uncertainty_pct",
-      labelKey: "settings.speed_uncertainty",
-      unit: "%",
-      hardMin: 0,
-      hardMax: 100,
-      guidedMin: 0,
-      guidedMax: 5,
-      defaultValue: defaultVehicleSettings.speed_uncertainty_pct,
-      guidanceId: "speedUncertaintyGuidance",
-      guidance: () => els.analysisFieldGuidance.speedUncertainty,
-      input: () => els.speedUncertaintyInput,
-    },
-    {
-      key: "tire_diameter_uncertainty_pct",
-      labelKey: "settings.tire_diameter_uncertainty",
-      unit: "%",
-      hardMin: 0,
-      hardMax: 100,
-      guidedMin: 0,
-      guidedMax: 5,
-      defaultValue: defaultVehicleSettings.tire_diameter_uncertainty_pct,
-      guidanceId: "tireDiameterUncertaintyGuidance",
-      guidance: () => els.analysisFieldGuidance.tireDiameterUncertainty,
-      input: () => els.tireDiameterUncertaintyInput,
-    },
-    {
-      key: "final_drive_uncertainty_pct",
-      labelKey: "settings.final_drive_uncertainty",
-      unit: "%",
-      hardMin: 0,
-      hardMax: 100,
-      guidedMin: 0,
-      guidedMax: 2,
-      defaultValue: defaultVehicleSettings.final_drive_uncertainty_pct,
-      guidanceId: "finalDriveUncertaintyGuidance",
-      guidance: () => els.analysisFieldGuidance.finalDriveUncertainty,
-      input: () => els.finalDriveUncertaintyInput,
-    },
-    {
-      key: "gear_uncertainty_pct",
-      labelKey: "settings.gear_slip_uncertainty",
-      unit: "%",
-      hardMin: 0,
-      hardMax: 100,
-      guidedMin: 0,
-      guidedMax: 4,
-      defaultValue: defaultVehicleSettings.gear_uncertainty_pct,
-      guidanceId: "gearUncertaintyGuidance",
-      guidance: () => els.analysisFieldGuidance.gearUncertainty,
-      input: () => els.gearUncertaintyInput,
-    },
-    {
-      key: "min_abs_band_hz",
-      labelKey: "settings.min_half_width",
-      unit: " Hz",
-      hardMin: 0,
-      hardMax: 500,
-      guidedMin: 0,
-      guidedMax: 2,
-      defaultValue: defaultVehicleSettings.min_abs_band_hz,
-      guidanceId: "minAbsBandHzGuidance",
-      guidance: () => els.analysisFieldGuidance.minAbsBandHz,
-      input: () => els.minAbsBandHzInput,
-    },
-    {
-      key: "max_band_half_width_pct",
-      labelKey: "settings.max_half_width",
-      unit: "%",
-      hardMin: 0.1,
-      hardMax: 100,
-      guidedMin: 1,
-      guidedMax: 12,
-      defaultValue: defaultVehicleSettings.max_band_half_width_pct,
-      guidanceId: "maxBandHalfWidthGuidance",
-      guidance: () => els.analysisFieldGuidance.maxBandHalfWidth,
-      input: () => els.maxBandHalfWidthInput,
-    },
-  ];
-
-  interface AnalysisFieldState {
-    config: AnalysisFieldConfig;
-    rawValue: string;
-    numericValue: number;
-  }
-  const fieldErrorMessages = new Map<EditableAnalysisKey, string>();
-
-  function formatSettingValue(value: number): string {
-    return Number.isInteger(value)
-      ? String(value)
-      : String(Number(value.toFixed(1)));
-  }
-
-  function clearFieldValidationState(): void {
-    fieldErrorMessages.clear();
-    for (const field of analysisFields) {
-      field.input()?.removeAttribute("aria-invalid");
-    }
-    renderFieldGuidance();
-  }
-
-  function openAnalysisGuidance(): void {
-    els.analysisGuidanceHelp?.setAttribute("open", "");
-  }
+  const { panel, settings, t } = ctx;
+  let draftValues = buildDraftValues(settings);
+  let saveFeedback: SettingsFeedbackMessage | null = null;
+  const fieldErrorMessages = new Map<AnalysisPanelFieldKey, string>();
 
   function formatRange(min: number, max: number, unit: UnitSuffix): string {
     return t("settings.analysis.range_value", {
@@ -224,22 +222,32 @@ export function createSettingsAnalysisModule(
     });
   }
 
-  function markFieldInvalid(field: AnalysisFieldConfig, message: string): void {
-    fieldErrorMessages.set(field.key, message);
-    renderFieldGuidance();
-    field.input()?.setAttribute("aria-invalid", "true");
-    field.input()?.focus();
-    openAnalysisGuidance();
+  function buildPanelModel(): AnalysisPanelRenderModel {
+    return {
+      fields: {
+        wheel_bandwidth_pct: buildFieldRenderModel("wheel_bandwidth_pct"),
+        driveshaft_bandwidth_pct: buildFieldRenderModel("driveshaft_bandwidth_pct"),
+        engine_bandwidth_pct: buildFieldRenderModel("engine_bandwidth_pct"),
+        speed_uncertainty_pct: buildFieldRenderModel("speed_uncertainty_pct"),
+        tire_diameter_uncertainty_pct: buildFieldRenderModel(
+          "tire_diameter_uncertainty_pct",
+        ),
+        final_drive_uncertainty_pct: buildFieldRenderModel(
+          "final_drive_uncertainty_pct",
+        ),
+        gear_uncertainty_pct: buildFieldRenderModel("gear_uncertainty_pct"),
+        min_abs_band_hz: buildFieldRenderModel("min_abs_band_hz"),
+        max_band_half_width_pct: buildFieldRenderModel("max_band_half_width_pct"),
+      },
+      saveFeedback,
+    };
   }
 
-  function renderFieldGuidance(): void {
-    for (const field of analysisFields) {
-      const help = field.guidance();
-      if (!help) {
-        continue;
-      }
-      const errorMessage = fieldErrorMessages.get(field.key);
-      setSettingsAnalysisGuidance(help, {
+  function buildFieldRenderModel(fieldKey: AnalysisPanelFieldKey) {
+    const field = analysisFieldConfig(fieldKey);
+    const errorMessage = fieldErrorMessages.get(field.key);
+    return {
+      guidance: buildSettingsAnalysisGuidanceRenderModel({
         lines: [
           {
             label: t("settings.analysis.recommended_range_label"),
@@ -251,27 +259,35 @@ export function createSettingsAnalysisModule(
           },
         ],
         errorMessage,
-        escapeHtml: ctx.escapeHtml,
-      });
-    }
+      }),
+      invalid: errorMessage !== undefined,
+      value: draftValues[field.key],
+    };
   }
 
-  function applyInputConstraints(): void {
-    for (const field of analysisFields) {
-      const input = field.input();
-      if (!input) {
-        continue;
-      }
-      input.min = String(field.hardMin);
-      input.max = String(field.hardMax);
-      input.step = "0.1";
-      input.setAttribute("aria-describedby", field.guidanceId);
-    }
+  function renderPanel(): void {
+    panel.render(buildPanelModel());
+  }
+
+  function clearFieldValidationState(): void {
+    fieldErrorMessages.clear();
+  }
+
+  function openAnalysisGuidance(): void {
+    panel.openGuidance();
+  }
+
+  function markFieldInvalid(field: AnalysisFieldConfig, message: string): void {
+    fieldErrorMessages.set(field.key, message);
+    renderPanel();
+    panel.focusField(field.key);
+    openAnalysisGuidance();
   }
 
   function collectFieldStates(): AnalysisFieldState[] {
-    return analysisFields.map((config) => {
-      const rawValue = config.input()?.value.trim() ?? "";
+    return EDITABLE_ANALYSIS_KEYS.map((fieldKey) => {
+      const config = analysisFieldConfig(fieldKey);
+      const rawValue = draftValues[fieldKey].trim();
       return {
         config,
         rawValue,
@@ -299,7 +315,8 @@ export function createSettingsAnalysisModule(
       return;
     }
     clearFieldValidationState();
-    setSettingsFeedback(els.analysisSaveFeedback, null);
+    saveFeedback = null;
+    renderPanel();
     void syncAnalysisSettingsToServer({
       wheel_bandwidth_pct: defaultVehicleSettings.wheel_bandwidth_pct,
       driveshaft_bandwidth_pct: defaultVehicleSettings.driveshaft_bandwidth_pct,
@@ -315,53 +332,11 @@ export function createSettingsAnalysisModule(
     });
   }
 
-  function syncNumericInputValue(
-    input: HTMLInputElement | null,
-    value: number,
-  ): void {
-    if (input) input.value = String(value);
-  }
-
   function syncSettingsInputs(): void {
-    applyInputConstraints();
+    draftValues = buildDraftValues(settings);
     clearFieldValidationState();
-    setSettingsFeedback(els.analysisSaveFeedback, null);
-    syncNumericInputValue(
-      els.wheelBandwidthInput,
-      settings.vehicleSettings.wheel_bandwidth_pct,
-    );
-    syncNumericInputValue(
-      els.driveshaftBandwidthInput,
-      settings.vehicleSettings.driveshaft_bandwidth_pct,
-    );
-    syncNumericInputValue(
-      els.engineBandwidthInput,
-      settings.vehicleSettings.engine_bandwidth_pct,
-    );
-    syncNumericInputValue(
-      els.speedUncertaintyInput,
-      settings.vehicleSettings.speed_uncertainty_pct,
-    );
-    syncNumericInputValue(
-      els.tireDiameterUncertaintyInput,
-      settings.vehicleSettings.tire_diameter_uncertainty_pct,
-    );
-    syncNumericInputValue(
-      els.finalDriveUncertaintyInput,
-      settings.vehicleSettings.final_drive_uncertainty_pct,
-    );
-    syncNumericInputValue(
-      els.gearUncertaintyInput,
-      settings.vehicleSettings.gear_uncertainty_pct,
-    );
-    syncNumericInputValue(
-      els.minAbsBandHzInput,
-      settings.vehicleSettings.min_abs_band_hz,
-    );
-    syncNumericInputValue(
-      els.maxBandHalfWidthInput,
-      settings.vehicleSettings.max_band_half_width_pct,
-    );
+    saveFeedback = null;
+    renderPanel();
   }
 
   function applyAnalysisSettingsPayload(
@@ -369,7 +344,9 @@ export function createSettingsAnalysisModule(
   ): void {
     for (const key of ANALYSIS_SETTING_KEYS) {
       const value = serverSettings[key];
-      if (typeof value === "number") settings.vehicleSettings[key] = value;
+      if (typeof value === "number") {
+        settings.vehicleSettings[key] = value;
+      }
     }
     syncSettingsInputs();
     ctx.renderSpectrum();
@@ -383,13 +360,15 @@ export function createSettingsAnalysisModule(
       applyAnalysisSettingsPayload(saved);
     } catch (error) {
       openAnalysisGuidance();
-      setSettingsFeedback(els.analysisSaveFeedback, {
+      saveFeedback = {
         tone: "error",
         title: t("settings.analysis.save_failed_title"),
         body:
           error instanceof Error ? error.message : t("settings.save_failed"),
         detail: t("settings.analysis.save_failed_detail"),
-      });
+      };
+      renderPanel();
+      ctx.onSaveError(error);
     }
   }
 
@@ -410,6 +389,7 @@ export function createSettingsAnalysisModule(
       return;
     }
     clearFieldValidationState();
+    saveFeedback = null;
     const fieldStates = collectFieldStates();
     const missingField = fieldStates.find(
       (field) =>
@@ -482,19 +462,29 @@ export function createSettingsAnalysisModule(
     void syncAnalysisSettingsToServer(payload);
   }
 
+  function handleFieldInput(
+    action: { field: AnalysisPanelFieldKey; value: string },
+  ): void {
+    draftValues = {
+      ...draftValues,
+      [action.field]: action.value,
+    };
+    fieldErrorMessages.delete(action.field);
+    saveFeedback = null;
+    renderPanel();
+  }
+
   function bindHandlers(): void {
-    applyInputConstraints();
-    renderFieldGuidance();
-    els.saveAnalysisBtn?.addEventListener("click", saveAnalysisFromInputs);
-    els.resetAnalysisBtn?.addEventListener("click", resetAnalysisToDefaults);
-    for (const field of analysisFields) {
-      field.input()?.addEventListener("input", () => {
-        field.input()?.removeAttribute("aria-invalid");
-        fieldErrorMessages.delete(field.key);
-        renderFieldGuidance();
-        setSettingsFeedback(els.analysisSaveFeedback, null);
-      });
-    }
+    panel.bindActions({
+      onFieldInput: handleFieldInput,
+      onReset: resetAnalysisToDefaults,
+      onSave: saveAnalysisFromInputs,
+    });
+    panel.setCarAvailability({
+      hasActiveCar: ctx.hasValidActiveCar(),
+      isLoading: false,
+    });
+    renderPanel();
   }
 
   return {

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -11,7 +11,7 @@ import type { CarRecord, CarsPayload } from "../../transport/http_models";
 import type {
   CarsListPanelView,
 } from "../views/cars_panel";
-import type { SettingsAnalysisPanelDom } from "../views/analysis_panel";
+import type { AnalysisPanelView } from "../views/analysis_panel";
 import {
   buildCarsGuidanceRenderModel,
   buildSettingsCarListRenderModel,
@@ -24,10 +24,7 @@ import {
 
 export interface SettingsCarsModuleDeps extends FeatureDepsBase {
   confirmDelete?: (message: string) => boolean;
-  analysisDom: Pick<
-    SettingsAnalysisPanelDom,
-    "analysisNoCarMessage" | "resetAnalysisBtn" | "saveAnalysisBtn"
-  >;
+  analysisPanel: Pick<AnalysisPanelView, "setCarAvailability">;
   fmt: (value: number, digits?: number) => string;
   openAnalysisTab: () => void;
   openCarWizard: () => void;
@@ -107,17 +104,10 @@ export function createSettingsCarsModule(
   }
 
   function syncAnalysisControls(carSelectionState: CarSelectionState): void {
-    const hasActiveCar = carSelectionState.kind === "active";
-    if (ctx.analysisDom.saveAnalysisBtn) {
-      ctx.analysisDom.saveAnalysisBtn.disabled = !hasActiveCar;
-    }
-    if (ctx.analysisDom.resetAnalysisBtn) {
-      ctx.analysisDom.resetAnalysisBtn.disabled = !hasActiveCar;
-    }
-    if (ctx.analysisDom.analysisNoCarMessage) {
-      ctx.analysisDom.analysisNoCarMessage.hidden =
-        hasActiveCar || carSelectionState.kind === "loading";
-    }
+    ctx.analysisPanel.setCarAvailability({
+      hasActiveCar: carSelectionState.kind === "active",
+      isLoading: carSelectionState.kind === "loading",
+    });
   }
 
   function renderCarList(): void {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -87,7 +87,7 @@ export function createSettingsFeature(
   }
 
   const analysisModule: SettingsAnalysisModule = createSettingsAnalysisModule({
-    dom: ctx.analysisPanel.dom,
+    panel: ctx.analysisPanel,
     t,
     escapeHtml,
     showError: ctx.showError,
@@ -121,9 +121,9 @@ export function createSettingsFeature(
       fmt,
       syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
       renderSpeedReadout: ctx.view.renderSpeedReadout,
-    });
+  });
   carsModule = createSettingsCarsModule({
-    analysisDom: ctx.analysisPanel.dom,
+    analysisPanel: ctx.analysisPanel,
     escapeHtml,
     fmt,
     openAnalysisTab: () => openSettingsTab("analysisTab"),

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -1,46 +1,307 @@
-import { h } from "preact";
+import type { JSX } from "preact";
 
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
+import type {
+  SettingsAnalysisGuidanceRenderModel,
+} from "./settings_analysis_guidance";
+import type { SettingsFeedbackMessage } from "./settings_feedback";
 
-export interface SettingsAnalysisFieldGuidanceSlots {
-  wheelBandwidth: HTMLElement | null;
-  driveshaftBandwidth: HTMLElement | null;
-  engineBandwidth: HTMLElement | null;
-  speedUncertainty: HTMLElement | null;
-  tireDiameterUncertainty: HTMLElement | null;
-  finalDriveUncertainty: HTMLElement | null;
-  gearUncertainty: HTMLElement | null;
-  minAbsBandHz: HTMLElement | null;
-  maxBandHalfWidth: HTMLElement | null;
+export type AnalysisPanelFieldKey =
+  | "wheel_bandwidth_pct"
+  | "driveshaft_bandwidth_pct"
+  | "engine_bandwidth_pct"
+  | "speed_uncertainty_pct"
+  | "tire_diameter_uncertainty_pct"
+  | "final_drive_uncertainty_pct"
+  | "gear_uncertainty_pct"
+  | "min_abs_band_hz"
+  | "max_band_half_width_pct";
+
+export interface AnalysisPanelFieldRenderModel {
+  guidance: SettingsAnalysisGuidanceRenderModel;
+  invalid: boolean;
+  value: string;
 }
 
-export interface SettingsAnalysisPanelDom {
-  wheelBandwidthInput: HTMLInputElement | null;
-  driveshaftBandwidthInput: HTMLInputElement | null;
-  engineBandwidthInput: HTMLInputElement | null;
-  speedUncertaintyInput: HTMLInputElement | null;
-  tireDiameterUncertaintyInput: HTMLInputElement | null;
-  finalDriveUncertaintyInput: HTMLInputElement | null;
-  gearUncertaintyInput: HTMLInputElement | null;
-  minAbsBandHzInput: HTMLInputElement | null;
-  maxBandHalfWidthInput: HTMLInputElement | null;
-  saveAnalysisBtn: HTMLButtonElement | null;
-  resetAnalysisBtn: HTMLButtonElement | null;
-  analysisGuidanceHelp: HTMLDetailsElement | null;
-  analysisFieldGuidance: SettingsAnalysisFieldGuidanceSlots;
-  analysisSaveFeedback: HTMLElement | null;
-  analysisNoCarMessage: HTMLElement | null;
+export interface AnalysisPanelRenderModel {
+  fields: Record<AnalysisPanelFieldKey, AnalysisPanelFieldRenderModel>;
+  saveFeedback: SettingsFeedbackMessage | null;
+}
+
+export interface AnalysisPanelCarAvailability {
+  hasActiveCar: boolean;
+  isLoading: boolean;
+}
+
+export interface AnalysisPanelActionHandlers {
+  onFieldInput(action: { field: AnalysisPanelFieldKey; value: string }): void;
+  onReset(): void;
+  onSave(): void;
 }
 
 export interface AnalysisPanelView {
-  readonly dom: SettingsAnalysisPanelDom;
+  bindActions(handlers: AnalysisPanelActionHandlers): void;
+  focusField(field: AnalysisPanelFieldKey): void;
+  openGuidance(): void;
+  render(model: AnalysisPanelRenderModel): void;
+  setCarAvailability(state: AnalysisPanelCarAvailability): void;
 }
 
-function AnalysisPanel() {
+type AnalysisFieldSpec = {
+  fallbackLabel: string;
+  guidanceId: string;
+  inputId: string;
+  key: AnalysisPanelFieldKey;
+  labelKey: string;
+  step: string;
+};
+
+type AnalysisPanelBridgeState = {
+  actions: AnalysisPanelActionHandlers | null;
+  availability: AnalysisPanelCarAvailability;
+  model: AnalysisPanelRenderModel;
+};
+
+const EMPTY_GUIDANCE_MODEL: SettingsAnalysisGuidanceRenderModel = {
+  error: null,
+  lines: [],
+};
+
+const DEFAULT_ANALYSIS_PANEL_MODEL: AnalysisPanelRenderModel = {
+  fields: {
+    wheel_bandwidth_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    driveshaft_bandwidth_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    engine_bandwidth_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    speed_uncertainty_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    tire_diameter_uncertainty_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    final_drive_uncertainty_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    gear_uncertainty_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    min_abs_band_hz: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+    max_band_half_width_pct: {
+      guidance: EMPTY_GUIDANCE_MODEL,
+      invalid: false,
+      value: "",
+    },
+  },
+  saveFeedback: null,
+};
+
+const DEFAULT_ANALYSIS_CAR_AVAILABILITY: AnalysisPanelCarAvailability = {
+  hasActiveCar: true,
+  isLoading: false,
+};
+
+const ORDER_BAND_FIELDS: readonly AnalysisFieldSpec[] = [
+  {
+    fallbackLabel: "Wheel Bandwidth (%)",
+    guidanceId: "wheelBandwidthGuidance",
+    inputId: "wheelBandwidthInput",
+    key: "wheel_bandwidth_pct",
+    labelKey: "settings.wheel_bandwidth",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Driveshaft Bandwidth (%)",
+    guidanceId: "driveshaftBandwidthGuidance",
+    inputId: "driveshaftBandwidthInput",
+    key: "driveshaft_bandwidth_pct",
+    labelKey: "settings.driveshaft_bandwidth",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Engine Bandwidth (%)",
+    guidanceId: "engineBandwidthGuidance",
+    inputId: "engineBandwidthInput",
+    key: "engine_bandwidth_pct",
+    labelKey: "settings.engine_bandwidth",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Min Half-width (Hz)",
+    guidanceId: "minAbsBandHzGuidance",
+    inputId: "minAbsBandHzInput",
+    key: "min_abs_band_hz",
+    labelKey: "settings.min_half_width",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Max Half-width (%)",
+    guidanceId: "maxBandHalfWidthGuidance",
+    inputId: "maxBandHalfWidthInput",
+    key: "max_band_half_width_pct",
+    labelKey: "settings.max_half_width",
+    step: "0.1",
+  },
+] as const;
+
+const UNCERTAINTY_FIELDS: readonly AnalysisFieldSpec[] = [
+  {
+    fallbackLabel: "Speed Uncertainty (%)",
+    guidanceId: "speedUncertaintyGuidance",
+    inputId: "speedUncertaintyInput",
+    key: "speed_uncertainty_pct",
+    labelKey: "settings.speed_uncertainty",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Tire Diameter Uncertainty (%)",
+    guidanceId: "tireDiameterUncertaintyGuidance",
+    inputId: "tireDiameterUncertaintyInput",
+    key: "tire_diameter_uncertainty_pct",
+    labelKey: "settings.tire_diameter_uncertainty",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Final Drive Uncertainty (%)",
+    guidanceId: "finalDriveUncertaintyGuidance",
+    inputId: "finalDriveUncertaintyInput",
+    key: "final_drive_uncertainty_pct",
+    labelKey: "settings.final_drive_uncertainty",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Gear/Slip Uncertainty (%)",
+    guidanceId: "gearUncertaintyGuidance",
+    inputId: "gearUncertaintyInput",
+    key: "gear_uncertainty_pct",
+    labelKey: "settings.gear_slip_uncertainty",
+    step: "0.1",
+  },
+] as const;
+
+function feedbackClassName(message: SettingsFeedbackMessage): string {
+  const tone = message.tone ?? "info";
+  const classNames = ["settings-feedback", `settings-feedback--${tone}`];
+  if (message.compact) {
+    classNames.push("settings-feedback--compact");
+  }
+  return classNames.join(" ");
+}
+
+function SettingsFeedbackBlock(props: {
+  message: SettingsFeedbackMessage;
+}) {
+  const { message } = props;
+  return (
+    <div
+      class={feedbackClassName(message)}
+      aria-live={message.tone === "error" ? "assertive" : "polite"}
+    >
+      {message.title ? (
+        <strong class="settings-feedback__title">{message.title}</strong>
+      ) : null}
+      <span class="settings-feedback__body">{message.body}</span>
+      {message.detail ? (
+        <span class="settings-feedback__detail">{message.detail}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function handleFieldInput(
+  actions: AnalysisPanelActionHandlers | null,
+  field: AnalysisPanelFieldKey,
+  event: JSX.TargetedEvent<HTMLInputElement, Event>,
+): void {
+  actions?.onFieldInput({
+    field,
+    value: event.currentTarget.value,
+  });
+}
+
+function AnalysisFieldGuidance(props: {
+  guidanceId: string;
+  model: SettingsAnalysisGuidanceRenderModel;
+}) {
+  const { guidanceId, model } = props;
+  return (
+    <div id={guidanceId} class="subtle settings-field-guidance">
+      {model.lines.map((line) => (
+        <div key={`${guidanceId}-${line.label}`} class="settings-field-guidance__row">
+          <span class="settings-field-guidance__label">{line.label}</span>
+          {" "}
+          <span class="settings-field-guidance__value">{line.value}</span>
+        </div>
+      ))}
+      {model.error ? <SettingsFeedbackBlock message={model.error} /> : null}
+    </div>
+  );
+}
+
+function AnalysisField(props: {
+  actions: AnalysisPanelActionHandlers | null;
+  model: AnalysisPanelFieldRenderModel;
+  onInputRef: (element: HTMLInputElement | null) => void;
+  spec: AnalysisFieldSpec;
+}) {
+  const { actions, model, onInputRef, spec } = props;
+  return (
+    <div class="field">
+      <label htmlFor={spec.inputId} data-i18n={spec.labelKey}>
+        {spec.fallbackLabel}
+      </label>
+      <input
+        id={spec.inputId}
+        ref={onInputRef}
+        type="number"
+        step={spec.step}
+        inputMode="decimal"
+        value={model.value}
+        aria-invalid={model.invalid ? "true" : undefined}
+        onInput={(event) => handleFieldInput(actions, spec.key, event)}
+      />
+      <AnalysisFieldGuidance guidanceId={spec.guidanceId} model={model.guidance} />
+    </div>
+  );
+}
+
+function AnalysisPanel(props: {
+  guidanceHelpRef: (element: HTMLDetailsElement | null) => void;
+  inputRef: (
+    field: AnalysisPanelFieldKey,
+    element: HTMLInputElement | null,
+  ) => void;
+  state: AnalysisPanelBridgeState;
+}) {
+  const { guidanceHelpRef, inputRef, state } = props;
+  const noCarSelected = !state.availability.hasActiveCar && !state.availability.isLoading;
   return (
     <div class="panel card settings-layout">
       <details
         id="analysisGuidanceHelp"
+        ref={guidanceHelpRef}
         class="settings-help-disclosure settings-help-disclosure--banner"
       >
         <summary class="settings-help-disclosure__summary">
@@ -81,7 +342,7 @@ function AnalysisPanel() {
       <div
         id="analysisNoCarMessage"
         class="empty-state empty-state--inline"
-        hidden
+        hidden={!noCarSelected}
         data-i18n="settings.analysis.no_car_selected"
       >
         No car selected. Select or create a car in Settings → Car to save
@@ -114,71 +375,15 @@ function AnalysisPanel() {
             </div>
           </details>
           <div class="settings-subgrid">
-            <div class="field">
-              <label
-                htmlFor="wheelBandwidthInput"
-                data-i18n="settings.wheel_bandwidth"
-              >
-                Wheel Bandwidth (%)
-              </label>
-              <input id="wheelBandwidthInput" type="number" step="0.1" />
-              <div
-                id="wheelBandwidthGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="driveshaftBandwidthInput"
-                data-i18n="settings.driveshaft_bandwidth"
-              >
-                Driveshaft Bandwidth (%)
-              </label>
-              <input id="driveshaftBandwidthInput" type="number" step="0.1" />
-              <div
-                id="driveshaftBandwidthGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="engineBandwidthInput"
-                data-i18n="settings.engine_bandwidth"
-              >
-                Engine Bandwidth (%)
-              </label>
-              <input id="engineBandwidthInput" type="number" step="0.1" />
-              <div
-                id="engineBandwidthGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="minAbsBandHzInput"
-                data-i18n="settings.min_half_width"
-              >
-                Min Half-width (Hz)
-              </label>
-              <input id="minAbsBandHzInput" type="number" step="0.1" />
-              <div
-                id="minAbsBandHzGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="maxBandHalfWidthInput"
-                data-i18n="settings.max_half_width"
-              >
-                Max Half-width (%)
-              </label>
-              <input id="maxBandHalfWidthInput" type="number" step="0.1" />
-              <div
-                id="maxBandHalfWidthGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
+            {ORDER_BAND_FIELDS.map((field) => (
+              <AnalysisField
+                key={field.key}
+                actions={state.actions}
+                model={state.model.fields[field.key]}
+                onInputRef={(element) => inputRef(field.key, element)}
+                spec={field}
+              />
+            ))}
           </div>
         </section>
 
@@ -214,82 +419,45 @@ function AnalysisPanel() {
             </div>
           </details>
           <div class="settings-subgrid settings-subgrid--aligned-labels">
-            <div class="field">
-              <label
-                htmlFor="speedUncertaintyInput"
-                data-i18n="settings.speed_uncertainty"
-              >
-                Speed Uncertainty (%)
-              </label>
-              <input id="speedUncertaintyInput" type="number" step="0.1" />
-              <div
-                id="speedUncertaintyGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="tireDiameterUncertaintyInput"
-                data-i18n="settings.tire_diameter_uncertainty"
-              >
-                Tire Diameter Uncertainty (%)
-              </label>
-              <input
-                id="tireDiameterUncertaintyInput"
-                type="number"
-                step="0.1"
+            {UNCERTAINTY_FIELDS.map((field) => (
+              <AnalysisField
+                key={field.key}
+                actions={state.actions}
+                model={state.model.fields[field.key]}
+                onInputRef={(element) => inputRef(field.key, element)}
+                spec={field}
               />
-              <div
-                id="tireDiameterUncertaintyGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="finalDriveUncertaintyInput"
-                data-i18n="settings.final_drive_uncertainty"
-              >
-                Final Drive Uncertainty (%)
-              </label>
-              <input
-                id="finalDriveUncertaintyInput"
-                type="number"
-                step="0.1"
-              />
-              <div
-                id="finalDriveUncertaintyGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
-            <div class="field">
-              <label
-                htmlFor="gearUncertaintyInput"
-                data-i18n="settings.gear_slip_uncertainty"
-              >
-                Gear/Slip Uncertainty (%)
-              </label>
-              <input id="gearUncertaintyInput" type="number" step="0.1" />
-              <div
-                id="gearUncertaintyGuidance"
-                class="subtle settings-field-guidance"
-              ></div>
-            </div>
+            ))}
           </div>
         </section>
       </div>
-      <div id="analysisSaveFeedback" class="settings-feedback-slot" hidden></div>
+      <div
+        id="analysisSaveFeedback"
+        class="settings-feedback-slot"
+        hidden={state.model.saveFeedback === null}
+      >
+        {state.model.saveFeedback ? (
+          <SettingsFeedbackBlock message={state.model.saveFeedback} />
+        ) : null}
+      </div>
       <div class="settings-actions settings-actions--sticky">
         <button
           id="resetAnalysisBtn"
+          type="button"
           class="btn"
           data-i18n="settings.analysis.reset"
+          disabled={!state.availability.hasActiveCar}
+          onClick={() => state.actions?.onReset()}
         >
           Reset to defaults
         </button>
         <button
           id="saveAnalysisBtn"
+          type="button"
           class="btn btn--primary"
           data-i18n="settings.analysis.save"
+          disabled={!state.availability.hasActiveCar}
+          onClick={() => state.actions?.onSave()}
         >
           Save Analysis Settings
         </button>
@@ -298,52 +466,62 @@ function AnalysisPanel() {
   );
 }
 
-function createAnalysisPanelDom(host: HTMLElement): SettingsAnalysisPanelDom {
-  const queryById = <T extends HTMLElement>(id: string): T | null =>
-    host.querySelector<T>(`#${id}`);
-
+function createInputRefs(): Record<AnalysisPanelFieldKey, HTMLInputElement | null> {
   return {
-    wheelBandwidthInput: queryById<HTMLInputElement>("wheelBandwidthInput"),
-    driveshaftBandwidthInput: queryById<HTMLInputElement>(
-      "driveshaftBandwidthInput",
-    ),
-    engineBandwidthInput: queryById<HTMLInputElement>("engineBandwidthInput"),
-    speedUncertaintyInput: queryById<HTMLInputElement>("speedUncertaintyInput"),
-    tireDiameterUncertaintyInput: queryById<HTMLInputElement>(
-      "tireDiameterUncertaintyInput",
-    ),
-    finalDriveUncertaintyInput: queryById<HTMLInputElement>(
-      "finalDriveUncertaintyInput",
-    ),
-    gearUncertaintyInput: queryById<HTMLInputElement>("gearUncertaintyInput"),
-    minAbsBandHzInput: queryById<HTMLInputElement>("minAbsBandHzInput"),
-    maxBandHalfWidthInput: queryById<HTMLInputElement>("maxBandHalfWidthInput"),
-    saveAnalysisBtn: queryById<HTMLButtonElement>("saveAnalysisBtn"),
-    resetAnalysisBtn: queryById<HTMLButtonElement>("resetAnalysisBtn"),
-    analysisGuidanceHelp: queryById<HTMLDetailsElement>("analysisGuidanceHelp"),
-    analysisFieldGuidance: {
-      wheelBandwidth: queryById<HTMLElement>("wheelBandwidthGuidance"),
-      driveshaftBandwidth: queryById<HTMLElement>("driveshaftBandwidthGuidance"),
-      engineBandwidth: queryById<HTMLElement>("engineBandwidthGuidance"),
-      speedUncertainty: queryById<HTMLElement>("speedUncertaintyGuidance"),
-      tireDiameterUncertainty: queryById<HTMLElement>(
-        "tireDiameterUncertaintyGuidance",
-      ),
-      finalDriveUncertainty: queryById<HTMLElement>(
-        "finalDriveUncertaintyGuidance",
-      ),
-      gearUncertainty: queryById<HTMLElement>("gearUncertaintyGuidance"),
-      minAbsBandHz: queryById<HTMLElement>("minAbsBandHzGuidance"),
-      maxBandHalfWidth: queryById<HTMLElement>("maxBandHalfWidthGuidance"),
-    },
-    analysisSaveFeedback: queryById<HTMLElement>("analysisSaveFeedback"),
-    analysisNoCarMessage: queryById<HTMLElement>("analysisNoCarMessage"),
+    wheel_bandwidth_pct: null,
+    driveshaft_bandwidth_pct: null,
+    engine_bandwidth_pct: null,
+    speed_uncertainty_pct: null,
+    tire_diameter_uncertainty_pct: null,
+    final_drive_uncertainty_pct: null,
+    gear_uncertainty_pct: null,
+    min_abs_band_hz: null,
+    max_band_half_width_pct: null,
   };
 }
 
 export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
-  createUiPreactMount(host).render(<AnalysisPanel />);
+  const bridgeState: AnalysisPanelBridgeState = {
+    actions: null,
+    availability: DEFAULT_ANALYSIS_CAR_AVAILABILITY,
+    model: DEFAULT_ANALYSIS_PANEL_MODEL,
+  };
+  const inputRefs = createInputRefs();
+  let guidanceHelp: HTMLDetailsElement | null = null;
+  const mount = createUiPreactMount(host);
+  const render = () => mount.render(
+    <AnalysisPanel
+      guidanceHelpRef={(element) => {
+        guidanceHelp = element;
+      }}
+      inputRef={(field, element) => {
+        inputRefs[field] = element;
+      }}
+      state={bridgeState}
+    />,
+  );
+  render();
+
   return {
-    dom: createAnalysisPanelDom(host),
+    bindActions(handlers) {
+      bridgeState.actions = handlers;
+      render();
+    },
+    focusField(field) {
+      inputRefs[field]?.focus();
+    },
+    openGuidance() {
+      if (guidanceHelp) {
+        guidanceHelp.open = true;
+      }
+    },
+    render(model) {
+      bridgeState.model = model;
+      render();
+    },
+    setCarAvailability(state) {
+      bridgeState.availability = state;
+      render();
+    },
   };
 }

--- a/apps/ui/src/app/views/settings_analysis_guidance.ts
+++ b/apps/ui/src/app/views/settings_analysis_guidance.ts
@@ -1,4 +1,4 @@
-import { renderSettingsFeedback } from "./settings_feedback";
+import type { SettingsFeedbackMessage } from "./settings_feedback";
 
 export interface SettingsAnalysisGuidanceLine {
   label: string;
@@ -8,32 +8,24 @@ export interface SettingsAnalysisGuidanceLine {
 export interface SettingsAnalysisGuidanceOptions {
   lines: readonly SettingsAnalysisGuidanceLine[];
   errorMessage?: string | null;
-  escapeHtml: (value: unknown) => string;
 }
 
-function renderGuidanceLine(
-  line: SettingsAnalysisGuidanceLine,
-  escapeHtml: SettingsAnalysisGuidanceOptions["escapeHtml"],
-): string {
-  return `<span class="settings-field-guidance__line"><span class="settings-field-guidance__label">${escapeHtml(line.label)}</span> ${escapeHtml(line.value)}</span>`;
+export interface SettingsAnalysisGuidanceRenderModel {
+  error: SettingsFeedbackMessage | null;
+  lines: readonly SettingsAnalysisGuidanceLine[];
 }
 
-export function setSettingsAnalysisGuidance(
-  slot: HTMLElement | null,
+export function buildSettingsAnalysisGuidanceRenderModel(
   options: SettingsAnalysisGuidanceOptions,
-): void {
-  if (!slot) {
-    return;
-  }
-  const guidanceHtml = options.lines
-    .map((line) => renderGuidanceLine(line, options.escapeHtml))
-    .join("");
-  const errorHtml = options.errorMessage
-    ? renderSettingsFeedback({
-        tone: "error",
-        body: options.errorMessage,
-        compact: true,
-      })
-    : "";
-  slot.innerHTML = `<span class="settings-field-guidance__stack">${guidanceHtml}</span>${errorHtml}`;
+): SettingsAnalysisGuidanceRenderModel {
+  return {
+    error: options.errorMessage
+      ? {
+          body: options.errorMessage,
+          compact: true,
+          tone: "error",
+        }
+      : null,
+    lines: [...options.lines],
+  };
 }

--- a/apps/ui/src/app/views/settings_feedback.ts
+++ b/apps/ui/src/app/views/settings_feedback.ts
@@ -8,34 +8,60 @@ export interface SettingsFeedbackMessage {
   compact?: boolean;
 }
 
-function escapeHtml(value: unknown): string {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+function appendTextElement(
+  documentRef: Document,
+  parent: HTMLElement,
+  tagName: "span" | "strong",
+  className: string,
+  text: string | undefined,
+): void {
+  const trimmedText = text?.trim();
+  if (!trimmedText) {
+    return;
+  }
+  const element = documentRef.createElement(tagName);
+  element.className = className;
+  element.textContent = trimmedText;
+  parent.append(element);
 }
 
-export function renderSettingsFeedback(message: SettingsFeedbackMessage): string {
+function feedbackClassName(message: SettingsFeedbackMessage): string {
   const tone = message.tone ?? "info";
   const classNames = ["settings-feedback", `settings-feedback--${tone}`];
   if (message.compact) {
     classNames.push("settings-feedback--compact");
   }
-  const titleHtml = message.title
-    ? `<strong class="settings-feedback__title">${escapeHtml(message.title)}</strong>`
-    : "";
-  const detailHtml = message.detail
-    ? `<span class="settings-feedback__detail">${escapeHtml(message.detail)}</span>`
-    : "";
-  return `
-    <div class="${classNames.join(" ")}">
-      ${titleHtml}
-      <span class="settings-feedback__body">${escapeHtml(message.body)}</span>
-      ${detailHtml}
-    </div>
-  `;
+  return classNames.join(" ");
+}
+
+export function createSettingsFeedbackElement(
+  documentRef: Document,
+  message: SettingsFeedbackMessage,
+): HTMLDivElement {
+  const root = documentRef.createElement("div");
+  root.className = feedbackClassName(message);
+  appendTextElement(
+    documentRef,
+    root,
+    "strong",
+    "settings-feedback__title",
+    message.title,
+  );
+  appendTextElement(
+    documentRef,
+    root,
+    "span",
+    "settings-feedback__body",
+    message.body,
+  );
+  appendTextElement(
+    documentRef,
+    root,
+    "span",
+    "settings-feedback__detail",
+    message.detail,
+  );
+  return root;
 }
 
 export function setSettingsFeedback(
@@ -47,11 +73,11 @@ export function setSettingsFeedback(
   }
   if (!message) {
     slot.hidden = true;
-    slot.innerHTML = "";
+    slot.replaceChildren();
     slot.removeAttribute("aria-live");
     return;
   }
   slot.hidden = false;
   slot.setAttribute("aria-live", message.tone === "error" ? "assertive" : "polite");
-  slot.innerHTML = renderSettingsFeedback(message);
+  slot.replaceChildren(createSettingsFeedbackElement(slot.ownerDocument, message));
 }

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+
+import { createSettingsAnalysisModule } from "../src/app/features/settings_analysis_module";
+import { createAppState } from "../src/app/ui_app_state";
+import type {
+  AnalysisPanelActionHandlers,
+  AnalysisPanelCarAvailability,
+  AnalysisPanelFieldKey,
+  AnalysisPanelRenderModel,
+  AnalysisPanelView,
+} from "../src/app/views/analysis_panel";
+
+function lastRender(renders: AnalysisPanelRenderModel[]): AnalysisPanelRenderModel {
+  const render = renders.at(-1);
+  if (!render) {
+    throw new Error("Expected analysis panel to render");
+  }
+  return render;
+}
+
+function translate(key: string, vars?: Record<string, unknown>): string {
+  switch (key) {
+    case "settings.analysis.range_value":
+      return `${vars?.min}-${vars?.max}${String(vars?.unit ?? "")}`;
+    case "settings.analysis.recommended_range_label":
+      return "Recommended range";
+    case "settings.analysis.default_label":
+      return "Default";
+    case "settings.wheel_bandwidth":
+      return "Wheel bandwidth";
+    case "settings.analysis.invalid_number":
+      return `${vars?.field ?? "Field"} must be a number`;
+    case "settings.analysis.invalid_value":
+      return `${vars?.field ?? "Field"} must stay between ${vars?.min ?? "?"} and ${vars?.max ?? "?"}${String(vars?.unit ?? "")}`;
+    case "settings.analysis.reset_confirm":
+      return "Reset analysis settings?";
+    default:
+      return key;
+  }
+}
+
+test("settings analysis module renders guidance and surfaces invalid input through the typed panel bridge", () => {
+  const state = createAppState().settings;
+  const renders: AnalysisPanelRenderModel[] = [];
+  const availabilityUpdates: AnalysisPanelCarAvailability[] = [];
+  let actions: AnalysisPanelActionHandlers | null = null;
+  let focusedField: AnalysisPanelFieldKey | null = null;
+  let guidanceOpened = false;
+
+  const panel: AnalysisPanelView = {
+    bindActions(nextActions) {
+      actions = nextActions;
+    },
+    focusField(field) {
+      focusedField = field;
+    },
+    openGuidance() {
+      guidanceOpened = true;
+    },
+    render(model) {
+      renders.push(model);
+    },
+    setCarAvailability(model) {
+      availabilityUpdates.push(model);
+    },
+  };
+
+  const module = createSettingsAnalysisModule({
+    panel,
+    escapeHtml: (value) => String(value ?? ""),
+    hasValidActiveCar: () => true,
+    onMissingActiveCar: () => undefined,
+    onSaveError: () => undefined,
+    renderSpectrum: () => undefined,
+    settings: state,
+    showError: () => undefined,
+    t: translate,
+  });
+
+  module.bindHandlers();
+
+  expect(availabilityUpdates).toEqual([{
+    hasActiveCar: true,
+    isLoading: false,
+  }]);
+  expect(lastRender(renders).fields.wheel_bandwidth_pct.guidance.lines).toEqual([
+    {
+      label: "Recommended range",
+      value: "2-12%",
+    },
+    {
+      label: "Default",
+      value: "5%",
+    },
+  ]);
+
+  actions?.onFieldInput({
+    field: "wheel_bandwidth_pct",
+    value: "200",
+  });
+  module.saveAnalysisFromInputs();
+
+  const invalidRender = lastRender(renders);
+  expect(invalidRender.fields.wheel_bandwidth_pct.invalid).toBe(true);
+  expect(invalidRender.fields.wheel_bandwidth_pct.guidance.error).toMatchObject({
+    body: "Wheel bandwidth must stay between 0.1 and 100%",
+    compact: true,
+    tone: "error",
+  });
+  expect(focusedField).toBe("wheel_bandwidth_pct");
+  expect(guidanceOpened).toBe(true);
+
+  actions?.onFieldInput({
+    field: "wheel_bandwidth_pct",
+    value: "5",
+  });
+
+  const recoveredRender = lastRender(renders);
+  expect(recoveredRender.fields.wheel_bandwidth_pct.invalid).toBe(false);
+  expect(recoveredRender.fields.wheel_bandwidth_pct.guidance.error).toBeNull();
+});

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -4,7 +4,6 @@ import { createSettingsAnalysisModule } from "../src/app/features/settings_analy
 import { createAppState } from "../src/app/ui_app_state";
 import type {
   AnalysisPanelActionHandlers,
-  AnalysisPanelCarAvailability,
   AnalysisPanelFieldKey,
   AnalysisPanelRenderModel,
   AnalysisPanelView,
@@ -42,7 +41,6 @@ function translate(key: string, vars?: Record<string, unknown>): string {
 test("settings analysis module renders guidance and surfaces invalid input through the typed panel bridge", () => {
   const state = createAppState().settings;
   const renders: AnalysisPanelRenderModel[] = [];
-  const availabilityUpdates: AnalysisPanelCarAvailability[] = [];
   let actions: AnalysisPanelActionHandlers | null = null;
   let focusedField: AnalysisPanelFieldKey | null = null;
   let guidanceOpened = false;
@@ -60,8 +58,8 @@ test("settings analysis module renders guidance and surfaces invalid input throu
     render(model) {
       renders.push(model);
     },
-    setCarAvailability(model) {
-      availabilityUpdates.push(model);
+    setCarAvailability() {
+      return;
     },
   };
 
@@ -79,10 +77,6 @@ test("settings analysis module renders guidance and surfaces invalid input throu
 
   module.bindHandlers();
 
-  expect(availabilityUpdates).toEqual([{
-    hasActiveCar: true,
-    isLoading: false,
-  }]);
   expect(lastRender(renders).fields.wheel_bandwidth_pct.guidance.lines).toEqual([
     {
       label: "Recommended range",

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -27,10 +27,10 @@ test("settings cars module dismisses transient creation feedback through typed t
   };
 
   const module = createSettingsCarsModule({
-    analysisDom: {
-      analysisNoCarMessage: null,
-      resetAnalysisBtn: null,
-      saveAnalysisBtn: null,
+    analysisPanel: {
+      setCarAvailability() {
+        return;
+      },
     },
     escapeHtml: (value) => String(value ?? ""),
     fmt: (value, digits = 0) => Number(value).toFixed(digits),


### PR DESCRIPTION
## Summary

Closes #2285.

This PR finishes the analysis-settings migration by moving the remaining validation guidance, feedback, and button/no-car state into the existing Preact island instead of letting the feature module mutate DOM slots directly. Before this change, `analysis_panel.tsx` only mounted the outer shell. The real interaction seam still lived in imperative helpers: `settings_analysis_module.ts` read raw input elements, bound `click`/`input` listeners by hand, and wrote feedback into empty slots; `settings_analysis_guidance.ts` generated `innerHTML` for recommended/default guidance plus inline validation errors; `settings_feedback.ts` returned HTML strings for save feedback; and `settings_cars_module.ts` reached into the analysis DOM to disable actions or reveal the “no car selected” message.

The implementation keeps the existing behavioral split intact. Validation, risky-value confirmation, transport sync, and server payload application still live in `settings_analysis_module.ts`. The change is at the view seam: `analysis_panel.tsx` now owns rendering and typed callbacks, and the module now pushes draft/form state into that bridge instead of reading and mutating the DOM directly.

## Problem being solved

Issue #2285 was not about changing the analysis rules or save semantics. The real problem was that the analysis surface was only partially migrated:

1. Recommended range/default guidance still rendered through imperative slot writes.
2. Inline field validation errors still depended on `innerHTML`.
3. Save/reset actions still relied on manually attached DOM listeners.
4. Save feedback still used an HTML-string renderer.
5. Car-selection state still mutated the analysis panel through raw button/message DOM references.

Those seams made the form harder to reason about, left rendering logic split across multiple files, and kept the panel from behaving like the rest of the migrated settings islands.

## Chosen approach

I kept the controller/view split rather than collapsing all analysis behavior into component-local state. The module already owned the meaningful workflow:

- field configuration and default ranges
- numeric parsing and hard-limit validation
- risky-value confirmation prompts
- save/reset orchestration
- server load/save integration
- spectrum refresh after successful saves

Replacing that with component state would have widened the issue and mixed transport/validation behavior into the view layer. Instead, this PR introduces a typed analysis-panel bridge:

- the panel exposes typed `onFieldInput`, `onSave`, and `onReset` callbacks
- the module keeps draft values and validation state in plain data
- the module renders a typed panel model whenever drafts, errors, or feedback change
- the cars module sets analysis availability through an explicit panel method instead of mutating DOM directly

## Main code changes

### `apps/ui/src/app/views/analysis_panel.tsx`

This file is now the true owner of the analysis UI, not just its shell. The panel renders:

- all analysis inputs as controlled values
- the per-field recommended/default guidance rows
- inline validation feedback blocks
- the save-feedback slot
- the “no car selected” empty state
- save/reset disabled state

It also exposes the typed bridge used by the feature layer: render model updates, typed action binding, field focus, guidance disclosure opening, and car-availability updates. That removes the old `analysisPanel.dom` shape as the main integration contract.

### `apps/ui/src/app/features/settings_analysis_module.ts`

This module still owns the workflow, but it no longer reads the form from DOM nodes or binds listeners directly to elements. Instead, it keeps a draft-value record and field-error map, builds typed render models, and responds to panel callbacks.

The validation behavior is intentionally preserved:

- missing/invalid numeric values still produce field-specific errors
- hard-limit violations still focus the field and open the guidance disclosure
- risky values still require explicit confirmation
- failed saves still preserve the draft and explain that the previously saved settings remain active

The difference is that those states now flow through render data instead of imperative DOM mutation.

### `apps/ui/src/app/views/settings_analysis_guidance.ts`

This file no longer writes HTML into a target element. It now builds a small DOM-free render model with guidance lines plus optional compact error feedback, which removes `innerHTML` from the normal analysis validation flow.

### `apps/ui/src/app/views/settings_feedback.ts`

The shared feedback helper is still needed by non-analysis consumers for now, so I did not delete it. Instead, I removed the HTML-string path and replaced it with DOM-node creation via `replaceChildren(...)`. That keeps the current API for remaining callers while eliminating the string-render seam called out in the issue.

This is a deliberate intermediate cut: analysis now renders feedback in JSX, while the remaining imperative consumers can migrate in their own follow-up issues without preserving the old HTML-string implementation.

### `apps/ui/src/app/features/settings_cars_module.ts` and `settings_feature.ts`

The cars module no longer disables analysis actions or toggles the no-car message through raw DOM references. It now calls `analysisPanel.setCarAvailability(...)`, which keeps that cross-feature dependency explicit and typed. `settings_feature.ts` was updated to pass the typed panel bridge into both the analysis and cars modules.

### Tests and docs

I added `apps/ui/tests/settings_analysis_module.spec.ts` to cover the new typed module/panel seam directly. The test verifies that:

- the module renders analysis guidance through the panel model
- invalid values surface through typed render data
- the module requests field focus and opens the guidance disclosure when validation fails
- typing a new value clears the inline validation state through the typed callback path

`apps/ui/tests/settings_cars_module.spec.ts` was updated for the new analysis availability bridge, and `apps/ui/README.md` now describes `settings_analysis_module.ts` as using the typed analysis-panel bridge instead of an island DOM seam.

## Validation performed

Focused validation for this issue is green:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/settings_analysis_module.spec.ts tests/settings_cars_module.spec.ts --workers=1`
- `cd apps/ui && npx playwright test --config=.ai-temp/playwright.page.local.config.ts tests/smoke.settings.spec.ts --grep "analysis" --workers=1`

The existing browser smoke coverage still exercises the important visible contract: helper guidance copy, reset-to-default flow, risky-value confirmation, hard-limit inline field errors, and failed-save feedback with draft preservation. I kept the isolated 4273 Playwright config for the smoke slice because this shared environment still makes the default `localhost:4173` config unreliable.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that `settings_feedback.ts` still exists after this PR. That is intentional. Speed-source and shell-preference flows still consume that helper, so deleting it here would have broadened the issue into later migration work. The important change for #2285 is that the helper no longer uses HTML strings, and the analysis surface itself no longer depends on it for normal rendering.

I also did not touch the broader speed-source, update, shell, or spectrum seams because those are already tracked by the remaining backlog issues (#2286-#2291). This PR is focused on making the analysis settings surface genuinely island-owned without folding unrelated follow-up work into the same review.

The result is a smaller and cleaner analysis boundary: the module keeps behavior, the panel owns rendering, validation feedback stays typed, and the cross-feature no-car state no longer depends on raw DOM mutation.
