### PR TITLE
Render speed-source settings in Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -106,7 +106,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_cars_module.ts` | Settings-side car controller that owns list loading, activation/deletion flows, highlight feedback, and typed tab/view-driven feedback dismissal plus the explicit open-wizard port |
 | `app/features/settings_cars_transport.ts` | Settings-car transport wrapper over load/activate/delete API calls |
 | `app/features/settings_analysis_module.ts` | Analysis-settings behavior owner for validation, save/reset orchestration, field guidance, and spectrum refreshes behind the typed analysis-panel bridge |
-| `app/features/settings_speed_source_module.ts` | Thin speed-source settings facade that wires the transport seam, DOM-free workflow, presenter, and typed bindings together |
+| `app/features/settings_speed_source_module.ts` | Thin speed-source settings facade that wires the transport seam, DOM-free workflow, pure presenter, and typed bindings into the shared panel bridge |
 | `app/features/settings_speed_source_transport.ts` | Speed-source settings transport wrapper over the UI-local settings and OBD APIs |
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
 | `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
@@ -115,7 +115,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/internet_panel.tsx` | Preact owner for the internet settings shell that mounts the USB-status plus transport/readiness surface and exposes the bridge consumed by the update feature |
 | `app/views/update_panel.tsx` | Preact owner for the update settings shell that mounts the update controls and status host while exposing the bridge consumed by the update feature |
 | `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that renders the full sensor table and exposes typed identify/remove/location callbacks to the realtime feature |
-| `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that mounts the full tab surface and exposes the shared typed bridge consumed by the speed-source and GPS-status modules |
+| `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that renders the full tab plus live diagnostics in JSX and exposes the shared bridge consumed by the speed-source and GPS-status modules |
 | `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that renders saved-car guidance/list rows plus the full add-car wizard internals in JSX and exposes typed list and wizard bridges |
 | `app/views/cars_feature_bindings.ts` | Typed car-wizard bindings reused as the thin wizard interaction adapter behind the car-management island |
 | `app/views/cars_feature_presenter.ts` | Thin car-wizard presenter that turns workflow state into typed wizard render models and delegates focus/manual-input access through the island bridge |
@@ -134,7 +134,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/realtime_logging_panel.tsx` | Preact owner for the run-recording card that renders typed logging/readiness models and binds start/stop plus summary CTA actions through a bridge |
 | `app/views/settings_car_list_view.ts` | Typed saved-car list and guidance view-model builders reused by the car-management island for row, empty-state, and highlight rendering |
 | `app/views/settings_speed_source_bindings.ts` | Typed speed-source form bindings that decode radio/input/navigation/device actions away from the workflow |
-| `app/views/settings_speed_source_presenter.ts` | Speed-source presenter that owns summary, validation, and OBD-device-list DOM rendering from typed workflow state |
+| `app/views/settings_speed_source_presenter.ts` | Pure speed-source presenter that turns typed workflow state and live status payloads into panel and diagnostics render models |
 | `app/views/update_feature_presenter.ts` | Update presenter that owns readiness derivation, transport/control DOM state, and typed handoff into the island-owned update and internet panel bridges |
 | `app/views/update_status_view.ts` | Thin update-status coordinator that assembles typed section models into the island-owned settings update panel |
 | `app/views/update_status_view_models.ts` | Typed update-status section builders for current status, journey, issues, attempt history, health, and log cards |

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -100,6 +100,7 @@ export function createSettingsFeature(
   const speedSourceModule: SettingsSpeedSourceModule =
     createSettingsSpeedSourceModule({
       dom: speedSourceDom,
+      panel: ctx.speedSourcePanel,
       shellDom,
       t,
       escapeHtml,
@@ -108,11 +109,10 @@ export function createSettingsFeature(
       getSpeedUnit: ctx.getSpeedUnit,
       fmt,
       renderSpeedReadout: ctx.view.renderSpeedReadout,
-      onSaveError: showSettingsSaveError,
     });
   const gpsStatusModule: SettingsGpsStatusModule =
     createSettingsGpsStatusModule({
-      dom: ctx.speedSourcePanel.dom,
+      panel: ctx.speedSourcePanel,
       t,
       escapeHtml,
       showError: ctx.showError,

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -1,30 +1,16 @@
-import type {
-  ObdStatusPayload,
-  SpeedSourceStatusPayload,
-} from "../../transport/http_models";
 import { getSettingsObdStatus, getSpeedSourceStatus } from "../../api";
 import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
 import type { FeatureDepsBase } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
-import type { SettingsSpeedSourcePanelDom } from "../views/speed_source_panel";
+import type { SpeedSourcePanelView } from "../views/speed_source_panel";
+import {
+  buildSpeedSourceDiagnosticsRenderModel,
+  type SettingsSpeedSourcePresenterDeps,
+} from "../views/settings_speed_source_presenter";
 import { createPollingController } from "./polling_controller";
 
-const CONNECTION_STATE_I18N: Record<string, string> = {
-  disabled: "settings.speed.state_disabled",
-  disconnected: "settings.speed.state_disconnected",
-  connected: "settings.speed.state_connected",
-  stale: "settings.speed.state_stale",
-};
-
-const OBD_POLL_MODE_I18N: Record<string, string> = {
-  rpm_priority: "settings.speed.obd_mode_rpm_priority",
-  rpm_priority_backoff: "settings.speed.obd_mode_rpm_priority_backoff",
-  rpm_only: "settings.speed.obd_mode_rpm_only",
-  rpm_only_backoff: "settings.speed.obd_mode_rpm_only_backoff",
-};
-
 export interface SettingsGpsStatusModuleDeps extends FeatureDepsBase {
-  dom: SettingsSpeedSourcePanelDom;
+  panel: SpeedSourcePanelView;
   settings: SettingsState;
   getSpeedUnit: () => string;
   fmt: (n: number, digits?: number) => string;
@@ -40,206 +26,12 @@ export interface SettingsGpsStatusModule {
 export function createSettingsGpsStatusModule(
   ctx: SettingsGpsStatusModuleDeps,
 ): SettingsGpsStatusModule {
-  const { settings, dom: els, t, fmt } = ctx;
-
-  function connectionStateLabel(connectionState: string): string {
-    const key = CONNECTION_STATE_I18N[connectionState];
-    return key ? t(key) : connectionState;
-  }
-
-  function speedKmhInSelectedUnit(speedKmh: number | null): number | null {
-    if (speedKmh === null || !Number.isFinite(speedKmh)) return null;
-    return ctx.getSpeedUnit() === "mps" ? speedKmh / 3.6 : speedKmh;
-  }
-
-  function selectedSpeedUnitLabel(): string {
-    return ctx.getSpeedUnit() === "mps"
-      ? t("speed.unit.mps")
-      : t("speed.unit.kmh");
-  }
-
-  function formatSpeedValue(
-    speedKmh: number | null,
-    unitLabel: string,
-  ): string | null {
-    const speed = speedKmhInSelectedUnit(speedKmh);
-    return speed != null ? `${fmt(speed, 1)} ${unitLabel}` : null;
-  }
-
-  function boolLabel(value: boolean): string {
-    return value
-      ? t("settings.speed.fallback_yes")
-      : t("settings.speed.fallback_no");
-  }
-
-  function formatAgeSeconds(ageSeconds: number | null): string | null {
-    return ageSeconds != null
-      ? t("settings.speed.last_update_value", {
-          value: {
-            number: ageSeconds,
-            options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-          },
-        })
-      : null;
-  }
-
-  function formatCadenceFromTarget(intervalMs: number | null): string | null {
-    if (intervalMs == null || intervalMs <= 0) return null;
-    return `${fmt(1000 / intervalMs, 1)} Hz (${fmt(intervalMs, 0)} ms)`;
-  }
-
-  function formatCadenceHz(hz: number | null): string | null {
-    return hz != null ? `${fmt(hz, 1)} Hz` : null;
-  }
-
-  function formatMilliseconds(ms: number | null): string | null {
-    return ms != null ? `${fmt(ms, 0)} ms` : null;
-  }
-
-  function obdPollModeLabel(mode: string | null): string | null {
-    if (mode == null) return null;
-    const key = OBD_POLL_MODE_I18N[mode];
-    return key ? t(key) : mode;
-  }
-
-  function renderGpsStatus(status: SpeedSourceStatusPayload): void {
-    const unitLabel = selectedSpeedUnitLabel();
-    if (els.gpsStatusState)
-      els.gpsStatusState.textContent = connectionStateLabel(
-        status.connection_state,
-      );
-    if (els.gpsStatusDevice)
-      els.gpsStatusDevice.textContent = status.device ?? "--";
-    if (els.gpsStatusLastUpdate) {
-      els.gpsStatusLastUpdate.textContent =
-        status.last_update_age_s != null
-          ? t("settings.speed.last_update_value", {
-              value: {
-                number: status.last_update_age_s,
-                options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
-              },
-            })
-          : t("settings.speed.last_update_never");
-    }
-    if (els.gpsStatusRawSpeed) {
-      els.gpsStatusRawSpeed.textContent =
-        formatSpeedValue(status.raw_speed_kmh, unitLabel) ?? "--";
-    }
-    if (els.gpsStatusEffectiveSpeed) {
-      els.gpsStatusEffectiveSpeed.textContent =
-        formatSpeedValue(status.effective_speed_kmh, unitLabel) ?? "--";
-    }
-    if (els.gpsStatusLastError) {
-      els.gpsStatusLastError.textContent = status.last_error ?? "--";
-    }
-    if (els.gpsStatusReconnect) {
-      els.gpsStatusReconnect.textContent =
-        status.reconnect_delay_s != null
-          ? `${fmt(status.reconnect_delay_s, 1)}s`
-          : "--";
-    }
-    if (els.gpsStatusFallback) {
-      els.gpsStatusFallback.textContent = status.fallback_active
-        ? t("settings.speed.fallback_yes")
-        : t("settings.speed.fallback_no");
-    }
-  }
-
-  function formatConfiguredDevice(status: ObdStatusPayload): string {
-    if (status.configured_device_name && status.configured_device_mac) {
-      return `${status.configured_device_name} (${status.configured_device_mac})`;
-    }
-    return (
-      status.configured_device_name ??
-      status.configured_device_mac ??
-      t("settings.speed.obd_not_configured")
-    );
-  }
-
-  function renderObdStatus(status: ObdStatusPayload | null): void {
-    if (els.obdStatusPanel) {
-      els.obdStatusPanel.hidden = status === null;
-    }
-    if (status === null) {
-      if (els.obdStatusConfiguredDevice)
-        els.obdStatusConfiguredDevice.textContent = "--";
-      if (els.obdStatusPairing) els.obdStatusPairing.textContent = "--";
-      if (els.obdStatusTrusted) els.obdStatusTrusted.textContent = "--";
-      if (els.obdStatusConnected) els.obdStatusConnected.textContent = "--";
-      if (els.obdStatusRfcommChannel)
-        els.obdStatusRfcommChannel.textContent = "--";
-      if (els.obdStatusLastRpm) els.obdStatusLastRpm.textContent = "--";
-      if (els.obdStatusRpmAge) els.obdStatusRpmAge.textContent = "--";
-      if (els.obdStatusTargetCadence)
-        els.obdStatusTargetCadence.textContent = "--";
-      if (els.obdStatusEffectiveCadence)
-        els.obdStatusEffectiveCadence.textContent = "--";
-      if (els.obdStatusRequestRtt) els.obdStatusRequestRtt.textContent = "--";
-      if (els.obdStatusTimeouts) els.obdStatusTimeouts.textContent = "--";
-      if (els.obdStatusErrors) els.obdStatusErrors.textContent = "--";
-      if (els.obdStatusMode) els.obdStatusMode.textContent = "--";
-      if (els.obdStatusBackoff) els.obdStatusBackoff.textContent = "--";
-      if (els.obdStatusRawResponse) els.obdStatusRawResponse.textContent = "--";
-      if (els.obdStatusDebugHint) els.obdStatusDebugHint.textContent = "--";
-      return;
-    }
-    if (els.obdStatusConfiguredDevice) {
-      els.obdStatusConfiguredDevice.textContent =
-        formatConfiguredDevice(status);
-    }
-    if (els.obdStatusPairing) {
-      els.obdStatusPairing.textContent = boolLabel(status.paired);
-    }
-    if (els.obdStatusTrusted) {
-      els.obdStatusTrusted.textContent = boolLabel(status.trusted);
-    }
-    if (els.obdStatusConnected) {
-      els.obdStatusConnected.textContent = boolLabel(status.connected);
-    }
-    if (els.obdStatusRfcommChannel) {
-      els.obdStatusRfcommChannel.textContent =
-        status.rfcomm_channel != null ? String(status.rfcomm_channel) : "--";
-    }
-    if (els.obdStatusLastRpm) {
-      els.obdStatusLastRpm.textContent =
-        status.last_rpm != null ? fmt(status.last_rpm, 0) : "--";
-    }
-    if (els.obdStatusRpmAge) {
-      els.obdStatusRpmAge.textContent =
-        formatAgeSeconds(status.rpm_sample_age_s) ?? "--";
-    }
-    if (els.obdStatusTargetCadence) {
-      els.obdStatusTargetCadence.textContent =
-        formatCadenceFromTarget(status.rpm_target_interval_ms) ?? "--";
-    }
-    if (els.obdStatusEffectiveCadence) {
-      els.obdStatusEffectiveCadence.textContent =
-        formatCadenceHz(status.rpm_effective_hz) ?? "--";
-    }
-    if (els.obdStatusRequestRtt) {
-      els.obdStatusRequestRtt.textContent =
-        formatMilliseconds(status.request_rtt_ms) ?? "--";
-    }
-    if (els.obdStatusTimeouts) {
-      els.obdStatusTimeouts.textContent = String(status.timeout_count);
-    }
-    if (els.obdStatusErrors) {
-      els.obdStatusErrors.textContent = String(status.error_count);
-    }
-    if (els.obdStatusMode) {
-      els.obdStatusMode.textContent =
-        obdPollModeLabel(status.poll_mode) ?? "--";
-    }
-    if (els.obdStatusBackoff) {
-      els.obdStatusBackoff.textContent = boolLabel(status.backoff_active);
-    }
-    if (els.obdStatusRawResponse) {
-      els.obdStatusRawResponse.textContent = status.last_raw_response ?? "--";
-    }
-    if (els.obdStatusDebugHint) {
-      els.obdStatusDebugHint.textContent = status.debug_hint ?? "--";
-    }
-  }
+  const { panel, settings } = ctx;
+  const presenterDeps: SettingsSpeedSourcePresenterDeps = {
+    fmt: ctx.fmt,
+    getSpeedUnit: ctx.getSpeedUnit,
+    t: ctx.t,
+  };
 
   const polling = createPollingController({
     poll: async () => {
@@ -252,8 +44,9 @@ export function createSettingsGpsStatusModule(
       settings.gpsFallbackActive = status.fallback_active;
       settings.gpsEffectiveSpeedKph = status.effective_speed_kmh;
       settings.resolvedSpeedSource = status.speed_source;
-      renderGpsStatus(status);
-      renderObdStatus(obdStatus);
+      panel.renderDiagnostics(
+        buildSpeedSourceDiagnosticsRenderModel(status, obdStatus, presenterDeps),
+      );
       ctx.syncSpeedSourceSelectionUi();
       ctx.renderSpeedReadout();
       return status.connection_state === "connected"

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -4,20 +4,26 @@ import {
   bindSettingsSpeedSourceInteractions,
   type SettingsSpeedSourceInteraction,
 } from "../views/settings_speed_source_bindings";
-import { createSettingsSpeedSourcePresenter } from "../views/settings_speed_source_presenter";
+import {
+  buildSettingsSpeedSourcePanelModel,
+  type SettingsSpeedSourcePresenterDeps,
+} from "../views/settings_speed_source_presenter";
 import type { SettingsShellDom } from "../views/settings_shell";
-import type { SettingsSpeedSourcePanelDom } from "../views/speed_source_panel";
+import type {
+  SettingsSpeedSourcePanelDom,
+  SpeedSourcePanelView,
+} from "../views/speed_source_panel";
 import type { SettingsState } from "../ui_app_state";
 import { createSettingsSpeedSourceWorkflow } from "./settings_speed_source_workflow";
 
 export interface SettingsSpeedSourceModuleDeps extends FeatureDepsBase {
   dom: Pick<SettingsShellDom, "settingsTabs"> & SettingsSpeedSourcePanelDom;
+  panel: SpeedSourcePanelView;
   shellDom: Pick<UiShellDom, "menuButtons">;
   settings: SettingsState;
   getSpeedUnit: () => string;
   fmt: (n: number, digits?: number) => string;
   renderSpeedReadout: () => void;
-  onSaveError: (error: unknown) => void;
 }
 
 export interface SettingsSpeedSourceModule {
@@ -32,18 +38,25 @@ export function createSettingsSpeedSourceModule(
   ctx: SettingsSpeedSourceModuleDeps,
 ): SettingsSpeedSourceModule {
   const { settings, dom: els, shellDom, t } = ctx;
-  const presenter = createSettingsSpeedSourcePresenter({
-    dom: els,
+  const presenterDeps: SettingsSpeedSourcePresenterDeps = {
     fmt: ctx.fmt,
     getSpeedUnit: ctx.getSpeedUnit,
     t,
-  });
+  };
   const workflow = createSettingsSpeedSourceWorkflow({
     renderSpeedReadout: ctx.renderSpeedReadout,
     settings,
     showError: ctx.showError,
     t,
-    view: presenter,
+    view: {
+      focusManualSpeedInput: ctx.panel.focusManualSpeedInput,
+      focusScanObdDevices: ctx.panel.focusScanObdDevices,
+      focusStaleTimeoutInput: ctx.panel.focusStaleTimeoutInput,
+      isObdConfigVisible: ctx.panel.isObdConfigVisible,
+      render(state): void {
+        ctx.panel.render(buildSettingsSpeedSourcePanelModel(state, presenterDeps));
+      },
+    },
   });
   let handlersBound = false;
 

--- a/apps/ui/src/app/views/settings_speed_source_presenter.ts
+++ b/apps/ui/src/app/views/settings_speed_source_presenter.ts
@@ -1,4 +1,8 @@
-import type { ObdDevicePayload } from "../../transport/http_models";
+import type {
+  ObdDevicePayload,
+  ObdStatusPayload,
+  SpeedSourceStatusPayload,
+} from "../../transport/http_models";
 import {
   deriveDisplayedSpeedSourceMode,
   isManualLikeSpeedSource,
@@ -6,13 +10,14 @@ import {
   type DisplayedSpeedSourceMode,
   type SpeedSourceStateSource,
 } from "../speed_source_state";
-import { createElementNode, renderChildren } from "./dom_render";
-import type { SettingsSpeedSourcePanelDom } from "./speed_source_panel";
-import {
-  setSettingsFeedback,
-  type SettingsFeedbackMessage,
-} from "./settings_feedback";
-import { setChoiceCardState } from "../style_state";
+import type {
+  SpeedSourceChoiceCardRenderModel,
+  SpeedSourceDiagnosticsRenderModel,
+  SpeedSourceObdDeviceBadgeRenderModel,
+  SpeedSourceObdDeviceRenderModel,
+  SpeedSourcePanelRenderModel,
+} from "./speed_source_panel";
+import type { SettingsFeedbackMessage } from "./settings_feedback";
 
 export interface SettingsSpeedSourceSettingsSnapshot
   extends SpeedSourceStateSource {
@@ -40,42 +45,24 @@ export interface SettingsSpeedSourceRenderState {
 }
 
 export interface SettingsSpeedSourcePresenterDeps {
-  dom: Pick<
-    SettingsSpeedSourcePanelDom,
-    | "gpsFallbackPanel"
-    | "manualSpeedConfig"
-    | "manualSpeedFeedback"
-    | "manualSpeedInput"
-    | "obdConfiguredDevice"
-    | "obdDeviceList"
-    | "obdDeviceScanStatus"
-    | "obdSpeedConfig"
-    | "saveSpeedSourceBtn"
-    | "scanObdDevicesBtn"
-    | "speedSourceChoiceGps"
-    | "speedSourceChoiceManual"
-    | "speedSourceChoiceObd"
-    | "speedSourceCurrentSource"
-    | "speedSourceDiagnostics"
-    | "speedSourceEffectiveSpeed"
-    | "speedSourceFallbackActive"
-    | "speedSourceRadios"
-    | "speedSourceSaveFeedback"
-    | "staleTimeoutFeedback"
-    | "staleTimeoutInput"
-  >;
   fmt: (value: number, digits?: number) => string;
   getSpeedUnit: () => string;
   t: (key: string, vars?: Record<string, unknown>) => string;
 }
 
-export interface SettingsSpeedSourcePresenter {
-  focusManualSpeedInput(): void;
-  focusScanObdDevices(): void;
-  focusStaleTimeoutInput(): void;
-  isObdConfigVisible(): boolean;
-  render(state: SettingsSpeedSourceRenderState): void;
-}
+const CONNECTION_STATE_I18N: Record<string, string> = {
+  connected: "settings.speed.state_connected",
+  disabled: "settings.speed.state_disabled",
+  disconnected: "settings.speed.state_disconnected",
+  stale: "settings.speed.state_stale",
+};
+
+const OBD_POLL_MODE_I18N: Record<string, string> = {
+  rpm_only: "settings.speed.obd_mode_rpm_only",
+  rpm_only_backoff: "settings.speed.obd_mode_rpm_only_backoff",
+  rpm_priority: "settings.speed.obd_mode_rpm_priority",
+  rpm_priority_backoff: "settings.speed.obd_mode_rpm_priority_backoff",
+};
 
 function selectedSpeedUnitLabel(
   deps: Pick<SettingsSpeedSourcePresenterDeps, "getSpeedUnit" | "t">,
@@ -150,42 +137,23 @@ function activeEffectiveSpeedKph(
     : settings.gpsEffectiveSpeedKph;
 }
 
-function syncChoiceState(
-  element: HTMLElement | null,
+function buildChoiceState(
   t: SettingsSpeedSourcePresenterDeps["t"],
   {
     active,
     pending,
     error,
   }: { active: boolean; pending: boolean; error: boolean },
-): void {
-  setChoiceCardState(element, {
-    selected: active,
-    state: error ? "error" : pending ? "draft" : active ? "active" : null,
+): SpeedSourceChoiceCardRenderModel {
+  return {
     badgeText: pending
       ? t("settings.speed.choice_pending")
       : active
         ? t("settings.speed.choice_active")
         : null,
-  });
-}
-
-function applyInputFeedback(
-  input: HTMLInputElement | null,
-  feedback: HTMLElement | null,
-  message: SettingsFeedbackMessage | null,
-): void {
-  if (!message) {
-    input?.removeAttribute("aria-invalid");
-    input?.removeAttribute("aria-describedby");
-    setSettingsFeedback(feedback, null);
-    return;
-  }
-  if (feedback?.id) {
-    input?.setAttribute("aria-describedby", feedback.id);
-  }
-  input?.setAttribute("aria-invalid", "true");
-  setSettingsFeedback(feedback, message);
+    selected: active,
+    state: error ? "error" : pending ? "draft" : active ? "active" : null,
+  };
 }
 
 function looksLikeMacAlias(rawValue: string | null | undefined): boolean {
@@ -206,22 +174,22 @@ function obdDeviceSecondaryLabel(device: ObdDevicePayload): string | null {
   return hasHumanReadableDeviceName(device) ? device.mac_address : null;
 }
 
-function createBadge(label: string, active = false): HTMLSpanElement {
-  return createElementNode("span", {
-    className: "speed-source-device__badge",
-    data: {
-      active: active ? "true" : null,
-    },
-    text: label,
-  });
+function createBadge(
+  labelText: string,
+  active = false,
+): SpeedSourceObdDeviceBadgeRenderModel {
+  return {
+    active,
+    labelText,
+  };
 }
 
-function createObdDeviceRow(
+function buildObdDeviceModel(
   device: ObdDevicePayload,
   state: SettingsSpeedSourceRenderState,
   t: SettingsSpeedSourcePresenterDeps["t"],
-): HTMLDivElement {
-  const badges = [];
+): SpeedSourceObdDeviceRenderModel {
+  const badges: SpeedSourceObdDeviceBadgeRenderModel[] = [];
   if (device.mac_address === state.settings.obdDeviceMac) {
     badges.push(createBadge(t("settings.speed.obd_configured_badge"), true));
   }
@@ -243,205 +211,214 @@ function createObdDeviceRow(
         : t("settings.speed.obd_pair_and_use");
   const secondaryLabel = obdDeviceSecondaryLabel(device);
 
-  return createElementNode("div", {
-    className: "speed-source-device",
-    children: [
-      createElementNode("div", {
-        className: "speed-source-device__header",
-        children: [
-          createElementNode("div", {
-            className: "speed-source-device__identity",
-            children: [
-              createElementNode("div", {
-                className: "speed-source-device__name",
-                text: obdDevicePrimaryLabel(device),
-              }),
-              secondaryLabel
-                ? createElementNode("div", {
-                    className: "speed-source-device__mac",
-                    text: secondaryLabel,
-                  })
-                : null,
-            ],
-          }),
-          createElementNode("div", {
-            className: "speed-source-device__badges",
-            children: badges,
-          }),
-        ],
-      }),
-      createElementNode("div", {
-        className: "speed-source-device__actions",
-        children: [
-          createElementNode("button", {
-            className: "btn btn--secondary",
-            attrs: {
-              disabled: state.scanInFlight || state.pairInFlightMac !== null,
-              type: "button",
-            },
-            data: {
-              obdPairMac: device.mac_address,
-            },
-            text: actionLabel,
-          }),
-        ],
-      }),
-    ],
-  });
+  return {
+    actionDisabled: state.scanInFlight || state.pairInFlightMac !== null,
+    actionLabelText: actionLabel,
+    badges,
+    macAddress: device.mac_address,
+    primaryText: obdDevicePrimaryLabel(device),
+    secondaryText: secondaryLabel,
+  };
 }
 
-function renderObdDeviceList(
-  container: HTMLElement | null,
-  state: SettingsSpeedSourceRenderState,
+function connectionStateLabel(
+  connectionState: string,
   t: SettingsSpeedSourcePresenterDeps["t"],
-): void {
-  if (!container) {
-    return;
-  }
-  if (state.scannedDevices.length === 0) {
-    renderChildren(container);
-    return;
-  }
-  renderChildren(
-    container,
-    state.scannedDevices.map((device) => createObdDeviceRow(device, state, t)),
-  );
+): string {
+  const key = CONNECTION_STATE_I18N[connectionState];
+  return key ? t(key) : connectionState;
 }
 
-export function createSettingsSpeedSourcePresenter(
+function boolLabel(
+  value: boolean,
+  t: SettingsSpeedSourcePresenterDeps["t"],
+): string {
+  return value
+    ? t("settings.speed.fallback_yes")
+    : t("settings.speed.fallback_no");
+}
+
+function formatAgeSeconds(
+  ageSeconds: number | null,
+  t: SettingsSpeedSourcePresenterDeps["t"],
+): string | null {
+  return ageSeconds != null
+    ? t("settings.speed.last_update_value", {
+        value: {
+          number: ageSeconds,
+          options: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+        },
+      })
+    : null;
+}
+
+function formatCadenceFromTarget(
+  intervalMs: number | null,
   deps: SettingsSpeedSourcePresenterDeps,
-): SettingsSpeedSourcePresenter {
-  const { dom, t } = deps;
-
-  function render(state: SettingsSpeedSourceRenderState): void {
-    const displayedMode = deriveDisplayedSpeedSourceMode(state.settings);
-    const hasPendingSelection =
-      state.draftDirty && state.selectedMode !== displayedMode;
-
-    dom.speedSourceRadios.forEach((radio) => {
-      radio.checked = radio.value === state.selectedMode;
-    });
-
-    if (dom.manualSpeedInput) {
-      dom.manualSpeedInput.value = state.manualSpeedInputValue;
-    }
-    if (dom.staleTimeoutInput) {
-      dom.staleTimeoutInput.value = state.staleTimeoutInputValue;
-    }
-
-    syncChoiceState(dom.speedSourceChoiceGps, t, {
-      active: displayedMode === "gps",
-      pending: hasPendingSelection && state.selectedMode === "gps",
-      error: false,
-    });
-    syncChoiceState(dom.speedSourceChoiceObd, t, {
-      active: displayedMode === "obd2",
-      pending: hasPendingSelection && state.selectedMode === "obd2",
-      error: state.obdSelectionError,
-    });
-    syncChoiceState(dom.speedSourceChoiceManual, t, {
-      active: displayedMode === "manual",
-      pending: hasPendingSelection && state.selectedMode === "manual",
-      error: false,
-    });
-
-    if (dom.manualSpeedConfig) {
-      dom.manualSpeedConfig.hidden = state.selectedMode !== "manual";
-    }
-    if (dom.obdSpeedConfig) {
-      dom.obdSpeedConfig.hidden = state.selectedMode !== "obd2";
-    }
-    if (dom.gpsFallbackPanel) {
-      dom.gpsFallbackPanel.hidden = state.selectedMode === "manual";
-    }
-
-    if (dom.speedSourceCurrentSource) {
-      dom.speedSourceCurrentSource.textContent = activeSourceLabel(
-        state.settings,
-        t,
-      );
-    }
-    if (dom.speedSourceEffectiveSpeed) {
-      dom.speedSourceEffectiveSpeed.textContent = formatSpeedValue(
-        activeEffectiveSpeedKph(state.settings),
-        deps,
-      );
-    }
-    if (dom.speedSourceFallbackActive) {
-      dom.speedSourceFallbackActive.textContent = state.settings.gpsFallbackActive
-        ? t("settings.speed.fallback_yes")
-        : t("settings.speed.fallback_no");
-    }
-    if (dom.obdConfiguredDevice) {
-      dom.obdConfiguredDevice.textContent = formatConfiguredObdDevice(
-        state.settings,
-        t,
-      );
-    }
-    if (dom.scanObdDevicesBtn) {
-      dom.scanObdDevicesBtn.disabled =
-        state.scanInFlight || state.pairInFlightMac !== null;
-    }
-    if (dom.obdDeviceScanStatus) {
-      dom.obdDeviceScanStatus.textContent =
-        state.obdScanStatusMessage ?? t("settings.speed.obd_scan_idle");
-    }
-    renderObdDeviceList(dom.obdDeviceList, state, t);
-
-    applyInputFeedback(
-      dom.manualSpeedInput,
-      dom.manualSpeedFeedback,
-      state.manualSpeedFeedback,
-    );
-    applyInputFeedback(
-      dom.staleTimeoutInput,
-      dom.staleTimeoutFeedback,
-      state.staleTimeoutFeedback,
-    );
-    setSettingsFeedback(dom.speedSourceSaveFeedback, state.saveFeedback);
-
-    const obdRadio = dom.speedSourceRadios.find(
-      (radio) => radio.value === "obd2",
-    );
-    if (state.obdSelectionError) {
-      obdRadio?.setAttribute("aria-invalid", "true");
-    } else {
-      obdRadio?.removeAttribute("aria-invalid");
-    }
-
-    if (
-      state.diagnosticsOpen
-      || resolveEffectiveSpeedSource(state.settings) !== state.settings.speedSource
-    ) {
-      dom.speedSourceDiagnostics?.setAttribute("open", "");
-    }
+): string | null {
+  if (intervalMs == null || intervalMs <= 0) {
+    return null;
   }
+  return `${deps.fmt(1000 / intervalMs, 1)} Hz (${deps.fmt(intervalMs, 0)} ms)`;
+}
 
-  function isObdConfigVisible(): boolean {
-    if (!dom.obdSpeedConfig || dom.obdSpeedConfig.hidden) {
-      return false;
-    }
-    const activePanel = dom.obdSpeedConfig.closest<HTMLElement>(
-      ".settings-tab-panel",
-    );
-    if (!activePanel || activePanel.hidden) {
-      return false;
-    }
-    const activeView = activePanel.closest<HTMLElement>(".view");
-    return activeView == null || !activeView.hidden;
+function formatCadenceHz(
+  hz: number | null,
+  deps: SettingsSpeedSourcePresenterDeps,
+): string | null {
+  return hz != null ? `${deps.fmt(hz, 1)} Hz` : null;
+}
+
+function formatMilliseconds(
+  ms: number | null,
+  deps: SettingsSpeedSourcePresenterDeps,
+): string | null {
+  return ms != null ? `${deps.fmt(ms, 0)} ms` : null;
+}
+
+function obdPollModeLabel(
+  mode: string | null,
+  t: SettingsSpeedSourcePresenterDeps["t"],
+): string | null {
+  if (mode == null) {
+    return null;
   }
+  const key = OBD_POLL_MODE_I18N[mode];
+  return key ? t(key) : mode;
+}
+
+export function buildSettingsSpeedSourcePanelModel(
+  state: SettingsSpeedSourceRenderState,
+  deps: SettingsSpeedSourcePresenterDeps,
+): SpeedSourcePanelRenderModel {
+  const displayedMode = deriveDisplayedSpeedSourceMode(state.settings);
+  const hasPendingSelection =
+    state.draftDirty && state.selectedMode !== displayedMode;
 
   return {
-    focusManualSpeedInput(): void {
-      dom.manualSpeedInput?.focus();
+    choiceCards: {
+      gps: buildChoiceState(deps.t, {
+        active: displayedMode === "gps",
+        pending: hasPendingSelection && state.selectedMode === "gps",
+        error: false,
+      }),
+      manual: buildChoiceState(deps.t, {
+        active: displayedMode === "manual",
+        pending: hasPendingSelection && state.selectedMode === "manual",
+        error: false,
+      }),
+      obd2: buildChoiceState(deps.t, {
+        active: displayedMode === "obd2",
+        pending: hasPendingSelection && state.selectedMode === "obd2",
+        error: state.obdSelectionError,
+      }),
     },
-    focusScanObdDevices(): void {
-      dom.scanObdDevicesBtn?.focus();
+    diagnosticsShouldOpen:
+      state.diagnosticsOpen
+      || resolveEffectiveSpeedSource(state.settings) !== state.settings.speedSource,
+    manualConfigVisible: state.selectedMode === "manual",
+    manualSpeedFeedback: state.manualSpeedFeedback,
+    manualSpeedInputValue: state.manualSpeedInputValue,
+    obdConfigVisible: state.selectedMode === "obd2",
+    obdConfiguredDeviceText: formatConfiguredObdDevice(state.settings, deps.t),
+    obdDevices: state.scannedDevices.map((device) =>
+      buildObdDeviceModel(device, state, deps.t)
+    ),
+    obdScanStatusText:
+      state.obdScanStatusMessage ?? deps.t("settings.speed.obd_scan_idle"),
+    obdSelectionInvalid: state.obdSelectionError,
+    scanObdDevicesDisabled:
+      state.scanInFlight || state.pairInFlightMac !== null,
+    saveFeedback: state.saveFeedback,
+    selectedMode: state.selectedMode,
+    showGpsFallbackPanel: state.selectedMode !== "manual",
+    staleTimeoutFeedback: state.staleTimeoutFeedback,
+    staleTimeoutInputValue: state.staleTimeoutInputValue,
+    summary: {
+      currentSourceText: activeSourceLabel(state.settings, deps.t),
+      effectiveSpeedText: formatSpeedValue(
+        activeEffectiveSpeedKph(state.settings),
+        deps,
+      ),
+      fallbackActiveText: boolLabel(state.settings.gpsFallbackActive, deps.t),
     },
-    focusStaleTimeoutInput(): void {
-      dom.staleTimeoutInput?.focus();
+  };
+}
+
+export function buildSpeedSourceDiagnosticsRenderModel(
+  status: SpeedSourceStatusPayload,
+  obdStatus: ObdStatusPayload | null,
+  deps: SettingsSpeedSourcePresenterDeps,
+): SpeedSourceDiagnosticsRenderModel {
+  return {
+    gps: {
+      deviceText: status.device ?? "--",
+      effectiveSpeedText: formatSpeedValue(status.effective_speed_kmh, deps),
+      fallbackText: boolLabel(status.fallback_active, deps.t),
+      lastErrorText: status.last_error ?? "--",
+      lastUpdateText:
+        formatAgeSeconds(status.last_update_age_s, deps.t)
+        ?? deps.t("settings.speed.last_update_never"),
+      rawSpeedText: formatSpeedValue(status.raw_speed_kmh, deps),
+      reconnectText:
+        status.reconnect_delay_s != null
+          ? `${deps.fmt(status.reconnect_delay_s, 1)}s`
+          : "--",
+      stateText: connectionStateLabel(status.connection_state, deps.t),
     },
-    isObdConfigVisible,
-    render,
+    obd: obdStatus
+      ? {
+          backoffText: boolLabel(obdStatus.backoff_active, deps.t),
+          configuredDeviceText: formatConfiguredObdDevice(
+            {
+              obdDeviceMac: obdStatus.configured_device_mac ?? null,
+              obdDeviceName: obdStatus.configured_device_name ?? null,
+            },
+            deps.t,
+          ),
+          connectedText: boolLabel(obdStatus.connected, deps.t),
+          debugHintText: obdStatus.debug_hint ?? "--",
+          effectiveCadenceText:
+            formatCadenceHz(obdStatus.rpm_effective_hz, deps) ?? "--",
+          errorsText: String(obdStatus.error_count),
+          lastRpmText:
+            obdStatus.last_rpm != null ? deps.fmt(obdStatus.last_rpm, 0) : "--",
+          modeText: obdPollModeLabel(obdStatus.poll_mode, deps.t) ?? "--",
+          pairingText: boolLabel(obdStatus.paired, deps.t),
+          rawResponseText: obdStatus.last_raw_response ?? "--",
+          requestRttText:
+            formatMilliseconds(obdStatus.request_rtt_ms, deps) ?? "--",
+          rfcommChannelText:
+            obdStatus.rfcomm_channel != null
+              ? String(obdStatus.rfcomm_channel)
+              : "--",
+          rpmAgeText:
+            formatAgeSeconds(obdStatus.rpm_sample_age_s, deps.t) ?? "--",
+          targetCadenceText:
+            formatCadenceFromTarget(obdStatus.rpm_target_interval_ms, deps)
+            ?? "--",
+          timeoutsText: String(obdStatus.timeout_count),
+          trustedText: boolLabel(obdStatus.trusted, deps.t),
+          visible: true,
+        }
+      : {
+          backoffText: "--",
+          configuredDeviceText: "--",
+          connectedText: "--",
+          debugHintText: "--",
+          effectiveCadenceText: "--",
+          errorsText: "--",
+          lastRpmText: "--",
+          modeText: "--",
+          pairingText: "--",
+          rawResponseText: "--",
+          requestRttText: "--",
+          rfcommChannelText: "--",
+          rpmAgeText: "--",
+          targetCadenceText: "--",
+          timeoutsText: "--",
+          trustedText: "--",
+          visible: false,
+        },
   };
 }

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -1,62 +1,505 @@
 import { h } from "preact";
 
+import type { DisplayedSpeedSourceMode } from "../speed_source_state";
+import type { ChoiceCardState } from "../style_state";
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
+import type { SettingsFeedbackMessage } from "./settings_feedback";
 
 export interface SettingsSpeedSourcePanelDom {
-  speedSourceRadios: HTMLInputElement[];
-  speedSourceCurrentSource: HTMLElement | null;
-  speedSourceEffectiveSpeed: HTMLElement | null;
-  speedSourceFallbackActive: HTMLElement | null;
-  speedSourceChoiceGps: HTMLElement | null;
-  speedSourceChoiceObd: HTMLElement | null;
-  speedSourceChoiceManual: HTMLElement | null;
-  manualSpeedConfig: HTMLElement | null;
   manualSpeedInput: HTMLInputElement | null;
-  manualSpeedFeedback: HTMLElement | null;
-  obdSpeedConfig: HTMLElement | null;
-  obdConfiguredDevice: HTMLElement | null;
-  scanObdDevicesBtn: HTMLButtonElement | null;
-  obdDeviceScanStatus: HTMLElement | null;
   obdDeviceList: HTMLElement | null;
+  obdSpeedConfig: HTMLElement | null;
   saveSpeedSourceBtn: HTMLButtonElement | null;
-  speedSourceSaveFeedback: HTMLElement | null;
-  speedSourceDiagnostics: HTMLDetailsElement | null;
-  gpsFallbackPanel: HTMLElement | null;
+  scanObdDevicesBtn: HTMLButtonElement | null;
+  speedSourceRadios: HTMLInputElement[];
   staleTimeoutInput: HTMLInputElement | null;
-  staleTimeoutFeedback: HTMLElement | null;
-  gpsStatusPanel: HTMLElement | null;
-  gpsStatusState: HTMLElement | null;
-  gpsStatusDevice: HTMLElement | null;
-  gpsStatusLastUpdate: HTMLElement | null;
-  gpsStatusRawSpeed: HTMLElement | null;
-  gpsStatusEffectiveSpeed: HTMLElement | null;
-  gpsStatusLastError: HTMLElement | null;
-  gpsStatusReconnect: HTMLElement | null;
-  gpsStatusFallback: HTMLElement | null;
-  obdStatusPanel: HTMLElement | null;
-  obdStatusConfiguredDevice: HTMLElement | null;
-  obdStatusPairing: HTMLElement | null;
-  obdStatusTrusted: HTMLElement | null;
-  obdStatusConnected: HTMLElement | null;
-  obdStatusRfcommChannel: HTMLElement | null;
-  obdStatusLastRpm: HTMLElement | null;
-  obdStatusRpmAge: HTMLElement | null;
-  obdStatusTargetCadence: HTMLElement | null;
-  obdStatusEffectiveCadence: HTMLElement | null;
-  obdStatusRequestRtt: HTMLElement | null;
-  obdStatusTimeouts: HTMLElement | null;
-  obdStatusErrors: HTMLElement | null;
-  obdStatusMode: HTMLElement | null;
-  obdStatusBackoff: HTMLElement | null;
-  obdStatusRawResponse: HTMLElement | null;
-  obdStatusDebugHint: HTMLElement | null;
+}
+
+export interface SpeedSourceChoiceCardRenderModel {
+  badgeText: string | null;
+  selected: boolean;
+  state: ChoiceCardState | null;
+}
+
+export interface SpeedSourceSummaryRenderModel {
+  currentSourceText: string;
+  effectiveSpeedText: string;
+  fallbackActiveText: string;
+}
+
+export interface SpeedSourceObdDeviceBadgeRenderModel {
+  active: boolean;
+  labelText: string;
+}
+
+export interface SpeedSourceObdDeviceRenderModel {
+  actionDisabled: boolean;
+  actionLabelText: string;
+  badges: readonly SpeedSourceObdDeviceBadgeRenderModel[];
+  macAddress: string;
+  primaryText: string;
+  secondaryText: string | null;
+}
+
+export interface SpeedSourcePanelRenderModel {
+  choiceCards: Record<DisplayedSpeedSourceMode, SpeedSourceChoiceCardRenderModel>;
+  diagnosticsShouldOpen: boolean;
+  manualConfigVisible: boolean;
+  manualSpeedFeedback: SettingsFeedbackMessage | null;
+  manualSpeedInputValue: string;
+  obdConfigVisible: boolean;
+  obdConfiguredDeviceText: string;
+  obdDevices: readonly SpeedSourceObdDeviceRenderModel[];
+  obdScanStatusText: string;
+  obdSelectionInvalid: boolean;
+  scanObdDevicesDisabled: boolean;
+  saveFeedback: SettingsFeedbackMessage | null;
+  selectedMode: DisplayedSpeedSourceMode;
+  showGpsFallbackPanel: boolean;
+  staleTimeoutFeedback: SettingsFeedbackMessage | null;
+  staleTimeoutInputValue: string;
+  summary: SpeedSourceSummaryRenderModel;
+}
+
+export interface SpeedSourceGpsStatusRenderModel {
+  deviceText: string;
+  effectiveSpeedText: string;
+  fallbackText: string;
+  lastErrorText: string;
+  lastUpdateText: string;
+  rawSpeedText: string;
+  reconnectText: string;
+  stateText: string;
+}
+
+export interface SpeedSourceObdStatusRenderModel {
+  backoffText: string;
+  configuredDeviceText: string;
+  connectedText: string;
+  debugHintText: string;
+  effectiveCadenceText: string;
+  errorsText: string;
+  lastRpmText: string;
+  modeText: string;
+  pairingText: string;
+  rawResponseText: string;
+  requestRttText: string;
+  rfcommChannelText: string;
+  rpmAgeText: string;
+  targetCadenceText: string;
+  timeoutsText: string;
+  trustedText: string;
+  visible: boolean;
+}
+
+export interface SpeedSourceDiagnosticsRenderModel {
+  gps: SpeedSourceGpsStatusRenderModel;
+  obd: SpeedSourceObdStatusRenderModel;
 }
 
 export interface SpeedSourcePanelView {
   readonly dom: SettingsSpeedSourcePanelDom;
+  focusManualSpeedInput(): void;
+  focusScanObdDevices(): void;
+  focusStaleTimeoutInput(): void;
+  isObdConfigVisible(): boolean;
+  render(model: SpeedSourcePanelRenderModel): void;
+  renderDiagnostics(model: SpeedSourceDiagnosticsRenderModel): void;
 }
 
-function SpeedSourcePanel() {
+type SpeedSourcePanelBridgeState = {
+  diagnostics: SpeedSourceDiagnosticsRenderModel;
+  diagnosticsDisclosureOpen: boolean;
+  model: SpeedSourcePanelRenderModel;
+};
+
+const SPEED_SOURCE_CHOICES = [
+  {
+    captionKey: "settings.speed.gps_caption",
+    captionText: "Use live GPS speed when it is healthy and available.",
+    id: "speedSourceChoiceGps",
+    mode: "gps",
+    titleKey: "settings.speed.gps",
+    titleText: "GPS",
+  },
+  {
+    captionKey: "settings.speed.obd_caption",
+    captionText:
+      "Use a paired Bluetooth OBD adapter on the Pi for live vehicle speed and RPM.",
+    id: "speedSourceChoiceObd",
+    mode: "obd2",
+    titleKey: "settings.speed.obd",
+    titleText: "OBD-II",
+  },
+  {
+    captionKey: "settings.speed.manual_caption",
+    captionText: "Use a fixed speed when you need a deliberate override.",
+    id: "speedSourceChoiceManual",
+    mode: "manual",
+    titleKey: "settings.speed.manual",
+    titleText: "Manual",
+  },
+] as const satisfies readonly {
+  captionKey: string;
+  captionText: string;
+  id: string;
+  mode: DisplayedSpeedSourceMode;
+  titleKey: string;
+  titleText: string;
+}[];
+
+const GPS_STATUS_ROWS = [
+  {
+    fallbackLabel: "Connection",
+    id: "gpsStatusState",
+    labelKey: "settings.speed.connection_state",
+    valueKey: "stateText",
+  },
+  {
+    fallbackLabel: "Device",
+    id: "gpsStatusDevice",
+    labelKey: "settings.speed.device",
+    valueKey: "deviceText",
+  },
+  {
+    fallbackLabel: "Last update",
+    id: "gpsStatusLastUpdate",
+    labelKey: "settings.speed.last_update",
+    valueKey: "lastUpdateText",
+  },
+  {
+    fallbackLabel: "Raw speed",
+    id: "gpsStatusRawSpeed",
+    labelKey: "settings.speed.raw_speed",
+    valueKey: "rawSpeedText",
+  },
+  {
+    fallbackLabel: "Effective speed",
+    id: "gpsStatusEffectiveSpeed",
+    labelKey: "settings.speed.effective_speed",
+    valueKey: "effectiveSpeedText",
+  },
+  {
+    fallbackLabel: "Last error",
+    id: "gpsStatusLastError",
+    labelKey: "settings.speed.last_error",
+    valueKey: "lastErrorText",
+  },
+  {
+    fallbackLabel: "Reconnect in",
+    id: "gpsStatusReconnect",
+    labelKey: "settings.speed.reconnect_in",
+    valueKey: "reconnectText",
+  },
+  {
+    fallbackLabel: "Fallback active",
+    id: "gpsStatusFallback",
+    labelKey: "settings.speed.fallback_active",
+    valueKey: "fallbackText",
+  },
+] as const satisfies readonly {
+  fallbackLabel: string;
+  id: string;
+  labelKey: string;
+  valueKey: keyof SpeedSourceGpsStatusRenderModel;
+}[];
+
+const OBD_STATUS_ROWS = [
+  {
+    fallbackLabel: "Configured adapter",
+    id: "obdStatusConfiguredDevice",
+    labelKey: "settings.speed.obd_configured_device",
+    valueKey: "configuredDeviceText",
+  },
+  {
+    fallbackLabel: "Paired",
+    id: "obdStatusPairing",
+    labelKey: "settings.speed.obd_paired",
+    valueKey: "pairingText",
+  },
+  {
+    fallbackLabel: "Trusted",
+    id: "obdStatusTrusted",
+    labelKey: "settings.speed.obd_trusted",
+    valueKey: "trustedText",
+  },
+  {
+    fallbackLabel: "Bluetooth connected",
+    id: "obdStatusConnected",
+    labelKey: "settings.speed.obd_connected",
+    valueKey: "connectedText",
+  },
+  {
+    fallbackLabel: "RFCOMM channel",
+    id: "obdStatusRfcommChannel",
+    labelKey: "settings.speed.obd_rfcomm_channel",
+    valueKey: "rfcommChannelText",
+  },
+  {
+    fallbackLabel: "Last RPM",
+    id: "obdStatusLastRpm",
+    labelKey: "settings.speed.obd_last_rpm",
+    valueKey: "lastRpmText",
+  },
+  {
+    fallbackLabel: "RPM age",
+    id: "obdStatusRpmAge",
+    labelKey: "settings.speed.obd_rpm_age",
+    valueKey: "rpmAgeText",
+  },
+  {
+    fallbackLabel: "Target cadence",
+    id: "obdStatusTargetCadence",
+    labelKey: "settings.speed.obd_target_cadence",
+    valueKey: "targetCadenceText",
+  },
+  {
+    fallbackLabel: "Effective cadence",
+    id: "obdStatusEffectiveCadence",
+    labelKey: "settings.speed.obd_effective_cadence",
+    valueKey: "effectiveCadenceText",
+  },
+  {
+    fallbackLabel: "Avg request RTT",
+    id: "obdStatusRequestRtt",
+    labelKey: "settings.speed.obd_request_rtt",
+    valueKey: "requestRttText",
+  },
+  {
+    fallbackLabel: "Timeouts",
+    id: "obdStatusTimeouts",
+    labelKey: "settings.speed.obd_timeouts",
+    valueKey: "timeoutsText",
+  },
+  {
+    fallbackLabel: "Errors",
+    id: "obdStatusErrors",
+    labelKey: "settings.speed.obd_errors",
+    valueKey: "errorsText",
+  },
+  {
+    fallbackLabel: "Monitor mode",
+    id: "obdStatusMode",
+    labelKey: "settings.speed.obd_mode",
+    valueKey: "modeText",
+  },
+  {
+    fallbackLabel: "Backoff active",
+    id: "obdStatusBackoff",
+    labelKey: "settings.speed.obd_backoff_active",
+    valueKey: "backoffText",
+  },
+  {
+    fallbackLabel: "Last raw response",
+    id: "obdStatusRawResponse",
+    labelKey: "settings.speed.obd_raw_response",
+    valueKey: "rawResponseText",
+  },
+  {
+    fallbackLabel: "Debug hint",
+    id: "obdStatusDebugHint",
+    labelKey: "settings.speed.obd_debug_hint",
+    valueKey: "debugHintText",
+  },
+] as const satisfies readonly {
+  fallbackLabel: string;
+  id: string;
+  labelKey: string;
+  valueKey: Exclude<keyof SpeedSourceObdStatusRenderModel, "visible">;
+}[];
+
+const DEFAULT_SPEED_SOURCE_PANEL_MODEL: SpeedSourcePanelRenderModel = {
+  choiceCards: {
+    gps: { badgeText: null, selected: false, state: null },
+    manual: { badgeText: null, selected: false, state: null },
+    obd2: { badgeText: null, selected: false, state: null },
+  },
+  diagnosticsShouldOpen: false,
+  manualConfigVisible: false,
+  manualSpeedFeedback: null,
+  manualSpeedInputValue: "",
+  obdConfigVisible: false,
+  obdConfiguredDeviceText: "--",
+  obdDevices: [],
+  obdScanStatusText: "Scan to discover nearby Bluetooth OBD adapters.",
+  obdSelectionInvalid: false,
+  scanObdDevicesDisabled: false,
+  saveFeedback: null,
+  selectedMode: "gps",
+  showGpsFallbackPanel: false,
+  staleTimeoutFeedback: null,
+  staleTimeoutInputValue: "10",
+  summary: {
+    currentSourceText: "--",
+    effectiveSpeedText: "--",
+    fallbackActiveText: "--",
+  },
+};
+
+const DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL: SpeedSourceDiagnosticsRenderModel = {
+  gps: {
+    deviceText: "--",
+    effectiveSpeedText: "--",
+    fallbackText: "--",
+    lastErrorText: "--",
+    lastUpdateText: "--",
+    rawSpeedText: "--",
+    reconnectText: "--",
+    stateText: "--",
+  },
+  obd: {
+    backoffText: "--",
+    configuredDeviceText: "--",
+    connectedText: "--",
+    debugHintText: "--",
+    effectiveCadenceText: "--",
+    errorsText: "--",
+    lastRpmText: "--",
+    modeText: "--",
+    pairingText: "--",
+    rawResponseText: "--",
+    requestRttText: "--",
+    rfcommChannelText: "--",
+    rpmAgeText: "--",
+    targetCadenceText: "--",
+    timeoutsText: "--",
+    trustedText: "--",
+    visible: false,
+  },
+};
+
+function feedbackClassName(message: SettingsFeedbackMessage): string {
+  const tone = message.tone ?? "info";
+  const classNames = ["settings-feedback", `settings-feedback--${tone}`];
+  if (message.compact) {
+    classNames.push("settings-feedback--compact");
+  }
+  return classNames.join(" ");
+}
+
+function SettingsFeedbackBlock(props: {
+  message: SettingsFeedbackMessage;
+}) {
+  const { message } = props;
+  return (
+    <div
+      class={feedbackClassName(message)}
+      aria-live={message.tone === "error" ? "assertive" : "polite"}
+    >
+      {message.title ? (
+        <strong class="settings-feedback__title">{message.title}</strong>
+      ) : null}
+      <span class="settings-feedback__body">{message.body}</span>
+      {message.detail ? (
+        <span class="settings-feedback__detail">{message.detail}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function SettingsFeedbackSlot(props: {
+  className: string;
+  id: string;
+  message: SettingsFeedbackMessage | null;
+}) {
+  const { className, id, message } = props;
+  return (
+    <div id={id} class={className} hidden={message === null}>
+      {message ? <SettingsFeedbackBlock message={message} /> : null}
+    </div>
+  );
+}
+
+function SpeedSourceChoiceCard(props: {
+  choice: (typeof SPEED_SOURCE_CHOICES)[number];
+  model: SpeedSourcePanelRenderModel;
+}) {
+  const { choice, model } = props;
+  const choiceState = model.choiceCards[choice.mode];
+  return (
+    <label
+      id={choice.id}
+      class="speed-source-choice"
+      data-speed-source-choice={choice.mode}
+      data-selected={choiceState.selected ? "true" : undefined}
+      data-choice-state={choiceState.state ?? undefined}
+      data-choice-badge={choiceState.badgeText ?? undefined}
+    >
+      <input
+        class="speed-source-choice__radio"
+        type="radio"
+        name="speedSourceRadio"
+        value={choice.mode}
+        checked={model.selectedMode === choice.mode}
+        aria-invalid={
+          choice.mode === "obd2" && model.obdSelectionInvalid ? "true" : undefined
+        }
+      />
+      <span class="speed-source-choice__title" data-i18n={choice.titleKey}>
+        {choice.titleText}
+      </span>
+      <span class="speed-source-choice__caption" data-i18n={choice.captionKey}>
+        {choice.captionText}
+      </span>
+    </label>
+  );
+}
+
+function SpeedSourceObdDeviceRow(props: {
+  device: SpeedSourceObdDeviceRenderModel;
+}) {
+  const { device } = props;
+  return (
+    <div class="speed-source-device">
+      <div class="speed-source-device__header">
+        <div class="speed-source-device__identity">
+          <div class="speed-source-device__name">{device.primaryText}</div>
+          {device.secondaryText ? (
+            <div class="speed-source-device__mac">{device.secondaryText}</div>
+          ) : null}
+        </div>
+        <div class="speed-source-device__badges">
+          {device.badges.map((badge) => (
+            <span
+              key={`${device.macAddress}-${badge.labelText}`}
+              class="speed-source-device__badge"
+              data-active={badge.active ? "true" : undefined}
+            >
+              {badge.labelText}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div class="speed-source-device__actions">
+        <button
+          class="btn btn--secondary"
+          type="button"
+          disabled={device.actionDisabled}
+          data-obd-pair-mac={device.macAddress}
+        >
+          {device.actionLabelText}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SpeedSourcePanel(props: {
+  manualInputRef: (element: HTMLInputElement | null) => void;
+  obdConfigRef: (element: HTMLElement | null) => void;
+  onDiagnosticsToggle: (event: Event) => void;
+  scanButtonRef: (element: HTMLButtonElement | null) => void;
+  staleTimeoutInputRef: (element: HTMLInputElement | null) => void;
+  state: SpeedSourcePanelBridgeState;
+}) {
+  const {
+    manualInputRef,
+    obdConfigRef,
+    onDiagnosticsToggle,
+    scanButtonRef,
+    staleTimeoutInputRef,
+    state,
+  } = props;
   return (
     <>
       <div class="panel card">
@@ -87,7 +530,7 @@ function SpeedSourcePanel() {
                 id="speedSourceCurrentSource"
                 class="speed-source-summary__value"
               >
-                --
+                {state.model.summary.currentSourceText}
               </div>
             </div>
             <div class="speed-source-summary__stat">
@@ -101,7 +544,7 @@ function SpeedSourcePanel() {
                 id="speedSourceEffectiveSpeed"
                 class="speed-source-summary__value"
               >
-                --
+                {state.model.summary.effectiveSpeedText}
               </div>
             </div>
             <div class="speed-source-summary__stat">
@@ -115,88 +558,25 @@ function SpeedSourcePanel() {
                 id="speedSourceFallbackActive"
                 class="speed-source-summary__value"
               >
-                --
+                {state.model.summary.fallbackActiveText}
               </div>
             </div>
           </div>
         </div>
         <div class="speed-source-choice-grid">
-          <label
-            id="speedSourceChoiceGps"
-            class="speed-source-choice"
-            data-speed-source-choice="gps"
-          >
-            <input
-              class="speed-source-choice__radio"
-              type="radio"
-              name="speedSourceRadio"
-              value="gps"
-              checked
+          {SPEED_SOURCE_CHOICES.map((choice) => (
+            <SpeedSourceChoiceCard
+              key={choice.mode}
+              choice={choice}
+              model={state.model}
             />
-            <span
-              class="speed-source-choice__title"
-              data-i18n="settings.speed.gps"
-            >
-              GPS
-            </span>
-            <span
-              class="speed-source-choice__caption"
-              data-i18n="settings.speed.gps_caption"
-            >
-              Use live GPS speed when it is healthy and available.
-            </span>
-          </label>
-          <label
-            id="speedSourceChoiceObd"
-            class="speed-source-choice"
-            data-speed-source-choice="obd2"
-          >
-            <input
-              class="speed-source-choice__radio"
-              type="radio"
-              name="speedSourceRadio"
-              value="obd2"
-            />
-            <span
-              class="speed-source-choice__title"
-              data-i18n="settings.speed.obd"
-            >
-              OBD-II
-            </span>
-            <span
-              class="speed-source-choice__caption"
-              data-i18n="settings.speed.obd_caption"
-            >
-              Use a paired Bluetooth OBD adapter on the Pi for live vehicle
-              speed and RPM.
-            </span>
-          </label>
-          <label
-            id="speedSourceChoiceManual"
-            class="speed-source-choice"
-            data-speed-source-choice="manual"
-          >
-            <input
-              class="speed-source-choice__radio"
-              type="radio"
-              name="speedSourceRadio"
-              value="manual"
-            />
-            <span
-              class="speed-source-choice__title"
-              data-i18n="settings.speed.manual"
-            >
-              Manual
-            </span>
-            <span
-              class="speed-source-choice__caption"
-              data-i18n="settings.speed.manual_caption"
-            >
-              Use a fixed speed when you need a deliberate override.
-            </span>
-          </label>
+          ))}
         </div>
-        <div id="manualSpeedConfig" class="speed-source-config" hidden>
+        <div
+          id="manualSpeedConfig"
+          class="speed-source-config"
+          hidden={!state.model.manualConfigVisible}
+        >
           <div class="subtle" data-i18n="settings.speed.manual_intro">
             Set a fixed speed for manual mode and as the live-source fallback
             when GPS or OBD-II data goes stale.
@@ -208,15 +588,33 @@ function SpeedSourcePanel() {
             >
               Manual Speed (km/h)
             </label>
-            <input id="manualSpeedInput" type="number" step="0.1" min="0" />
+            <input
+              id="manualSpeedInput"
+              ref={manualInputRef}
+              type="number"
+              step="0.1"
+              min="0"
+              value={state.model.manualSpeedInputValue}
+              aria-invalid={
+                state.model.manualSpeedFeedback ? "true" : undefined
+              }
+              aria-describedby={
+                state.model.manualSpeedFeedback ? "manualSpeedFeedback" : undefined
+              }
+            />
           </div>
-          <div
+          <SettingsFeedbackSlot
             id="manualSpeedFeedback"
-            class="settings-feedback-slot settings-feedback-slot--compact"
-            hidden
-          ></div>
+            className="settings-feedback-slot settings-feedback-slot--compact"
+            message={state.model.manualSpeedFeedback}
+          />
         </div>
-        <div id="obdSpeedConfig" class="speed-source-config" hidden>
+        <div
+          id="obdSpeedConfig"
+          ref={obdConfigRef}
+          class="speed-source-config"
+          hidden={!state.model.obdConfigVisible}
+        >
           <div class="subtle" data-i18n="settings.speed.obd_intro">
             Pair a Bluetooth OBD adapter with the Pi, then save OBD-II as the
             selected live source.
@@ -230,28 +628,37 @@ function SpeedSourcePanel() {
                 Configured adapter
               </div>
               <div id="obdConfiguredDevice" class="speed-source-summary__value">
-                --
+                {state.model.obdConfiguredDeviceText}
               </div>
             </div>
             <button
               id="scanObdDevicesBtn"
+              ref={scanButtonRef}
               class="btn btn--secondary"
               type="button"
+              disabled={state.model.scanObdDevicesDisabled}
               data-i18n="settings.speed.obd_scan"
             >
               Scan for adapters
             </button>
           </div>
-          <div
-            id="obdDeviceScanStatus"
-            class="subtle"
-            data-i18n="settings.speed.obd_scan_idle"
-          >
-            Scan to discover nearby Bluetooth OBD adapters.
+          <div id="obdDeviceScanStatus" class="subtle">
+            {state.model.obdScanStatusText}
           </div>
-          <div id="obdDeviceList" class="speed-source-device-list"></div>
+          <div id="obdDeviceList" class="speed-source-device-list">
+            {state.model.obdDevices.map((device) => (
+              <SpeedSourceObdDeviceRow
+                key={device.macAddress}
+                device={device}
+              />
+            ))}
+          </div>
         </div>
-        <div id="gpsFallbackPanel" class="speed-source-config" hidden>
+        <div
+          id="gpsFallbackPanel"
+          class="speed-source-config"
+          hidden={!state.model.showGpsFallbackPanel}
+        >
           <div class="subtle" data-i18n="settings.speed.gps_intro">
             Choose how long stale live-source data can remain usable before the
             manual fallback takes over.
@@ -265,24 +672,38 @@ function SpeedSourcePanel() {
             </label>
             <input
               id="staleTimeoutInput"
+              ref={staleTimeoutInputRef}
               type="number"
               step="1"
               min="3"
               max="120"
-              value="10"
+              value={state.model.staleTimeoutInputValue}
+              aria-invalid={
+                state.model.staleTimeoutFeedback ? "true" : undefined
+              }
+              aria-describedby={
+                state.model.staleTimeoutFeedback
+                  ? "staleTimeoutFeedback"
+                  : undefined
+              }
             />
           </div>
-          <div
+          <SettingsFeedbackSlot
             id="staleTimeoutFeedback"
-            class="settings-feedback-slot settings-feedback-slot--compact"
-            hidden
-          ></div>
+            className="settings-feedback-slot settings-feedback-slot--compact"
+            message={state.model.staleTimeoutFeedback}
+          />
         </div>
-        <div id="speedSourceSaveFeedback" class="settings-feedback-slot" hidden></div>
+        <SettingsFeedbackSlot
+          id="speedSourceSaveFeedback"
+          className="settings-feedback-slot"
+          message={state.model.saveFeedback}
+        />
         <div class="settings-actions settings-actions--sticky">
           <button
             id="saveSpeedSourceBtn"
             class="btn btn--primary"
+            type="button"
             data-i18n="settings.speed.save"
           >
             Save Speed Source
@@ -293,6 +714,8 @@ function SpeedSourcePanel() {
       <details
         id="speedSourceDiagnostics"
         class="settings-help-disclosure speed-source-diagnostics"
+        open={state.diagnosticsDisclosureOpen}
+        onToggle={onDiagnosticsToggle}
       >
         <summary class="settings-help-disclosure__summary">
           <span class="settings-help-disclosure__heading">
@@ -314,122 +737,26 @@ function SpeedSourcePanel() {
         <div class="settings-help-disclosure__body">
           <table class="kv-table" id="gpsStatusPanel">
             <tbody>
-              <tr>
-                <td data-i18n="settings.speed.connection_state">Connection</td>
-                <td id="gpsStatusState">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.device">Device</td>
-                <td id="gpsStatusDevice">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.last_update">Last update</td>
-                <td id="gpsStatusLastUpdate">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.raw_speed">Raw speed</td>
-                <td id="gpsStatusRawSpeed">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.effective_speed">
-                  Effective speed
-                </td>
-                <td id="gpsStatusEffectiveSpeed">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.last_error">Last error</td>
-                <td id="gpsStatusLastError">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.reconnect_in">Reconnect in</td>
-                <td id="gpsStatusReconnect">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.fallback_active">Fallback active</td>
-                <td id="gpsStatusFallback">--</td>
-              </tr>
+              {GPS_STATUS_ROWS.map((row) => (
+                <tr key={row.id}>
+                  <td data-i18n={row.labelKey}>{row.fallbackLabel}</td>
+                  <td id={row.id}>{state.diagnostics.gps[row.valueKey]}</td>
+                </tr>
+              ))}
             </tbody>
           </table>
-          <table class="kv-table" id="obdStatusPanel" hidden>
+          <table
+            class="kv-table"
+            id="obdStatusPanel"
+            hidden={!state.diagnostics.obd.visible}
+          >
             <tbody>
-              <tr>
-                <td data-i18n="settings.speed.obd_configured_device">
-                  Configured adapter
-                </td>
-                <td id="obdStatusConfiguredDevice">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_paired">Paired</td>
-                <td id="obdStatusPairing">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_trusted">Trusted</td>
-                <td id="obdStatusTrusted">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_connected">
-                  Bluetooth connected
-                </td>
-                <td id="obdStatusConnected">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_rfcomm_channel">
-                  RFCOMM channel
-                </td>
-                <td id="obdStatusRfcommChannel">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_last_rpm">Last RPM</td>
-                <td id="obdStatusLastRpm">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_rpm_age">RPM age</td>
-                <td id="obdStatusRpmAge">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_target_cadence">
-                  Target cadence
-                </td>
-                <td id="obdStatusTargetCadence">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_effective_cadence">
-                  Effective cadence
-                </td>
-                <td id="obdStatusEffectiveCadence">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_request_rtt">Avg request RTT</td>
-                <td id="obdStatusRequestRtt">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_timeouts">Timeouts</td>
-                <td id="obdStatusTimeouts">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_errors">Errors</td>
-                <td id="obdStatusErrors">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_mode">Monitor mode</td>
-                <td id="obdStatusMode">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_backoff_active">
-                  Backoff active
-                </td>
-                <td id="obdStatusBackoff">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_raw_response">
-                  Last raw response
-                </td>
-                <td id="obdStatusRawResponse">--</td>
-              </tr>
-              <tr>
-                <td data-i18n="settings.speed.obd_debug_hint">Debug hint</td>
-                <td id="obdStatusDebugHint">--</td>
-              </tr>
+              {OBD_STATUS_ROWS.map((row) => (
+                <tr key={row.id}>
+                  <td data-i18n={row.labelKey}>{row.fallbackLabel}</td>
+                  <td id={row.id}>{state.diagnostics.obd[row.valueKey]}</td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>
@@ -443,61 +770,89 @@ function createSpeedSourcePanelDom(host: HTMLElement): SettingsSpeedSourcePanelD
     host.querySelector<T>(`#${id}`);
 
   return {
+    manualSpeedInput: queryById<HTMLInputElement>("manualSpeedInput"),
+    obdDeviceList: queryById<HTMLElement>("obdDeviceList"),
+    obdSpeedConfig: queryById<HTMLElement>("obdSpeedConfig"),
+    saveSpeedSourceBtn: queryById<HTMLButtonElement>("saveSpeedSourceBtn"),
+    scanObdDevicesBtn: queryById<HTMLButtonElement>("scanObdDevicesBtn"),
     speedSourceRadios: Array.from(
       host.querySelectorAll<HTMLInputElement>('input[name="speedSourceRadio"]'),
     ),
-    speedSourceCurrentSource: queryById<HTMLElement>("speedSourceCurrentSource"),
-    speedSourceEffectiveSpeed: queryById<HTMLElement>("speedSourceEffectiveSpeed"),
-    speedSourceFallbackActive: queryById<HTMLElement>("speedSourceFallbackActive"),
-    speedSourceChoiceGps: queryById<HTMLElement>("speedSourceChoiceGps"),
-    speedSourceChoiceObd: queryById<HTMLElement>("speedSourceChoiceObd"),
-    speedSourceChoiceManual: queryById<HTMLElement>("speedSourceChoiceManual"),
-    manualSpeedConfig: queryById<HTMLElement>("manualSpeedConfig"),
-    manualSpeedInput: queryById<HTMLInputElement>("manualSpeedInput"),
-    manualSpeedFeedback: queryById<HTMLElement>("manualSpeedFeedback"),
-    obdSpeedConfig: queryById<HTMLElement>("obdSpeedConfig"),
-    obdConfiguredDevice: queryById<HTMLElement>("obdConfiguredDevice"),
-    scanObdDevicesBtn: queryById<HTMLButtonElement>("scanObdDevicesBtn"),
-    obdDeviceScanStatus: queryById<HTMLElement>("obdDeviceScanStatus"),
-    obdDeviceList: queryById<HTMLElement>("obdDeviceList"),
-    saveSpeedSourceBtn: queryById<HTMLButtonElement>("saveSpeedSourceBtn"),
-    speedSourceSaveFeedback: queryById<HTMLElement>("speedSourceSaveFeedback"),
-    speedSourceDiagnostics: queryById<HTMLDetailsElement>("speedSourceDiagnostics"),
-    gpsFallbackPanel: queryById<HTMLElement>("gpsFallbackPanel"),
     staleTimeoutInput: queryById<HTMLInputElement>("staleTimeoutInput"),
-    staleTimeoutFeedback: queryById<HTMLElement>("staleTimeoutFeedback"),
-    gpsStatusPanel: queryById<HTMLElement>("gpsStatusPanel"),
-    gpsStatusState: queryById<HTMLElement>("gpsStatusState"),
-    gpsStatusDevice: queryById<HTMLElement>("gpsStatusDevice"),
-    gpsStatusLastUpdate: queryById<HTMLElement>("gpsStatusLastUpdate"),
-    gpsStatusRawSpeed: queryById<HTMLElement>("gpsStatusRawSpeed"),
-    gpsStatusEffectiveSpeed: queryById<HTMLElement>("gpsStatusEffectiveSpeed"),
-    gpsStatusLastError: queryById<HTMLElement>("gpsStatusLastError"),
-    gpsStatusReconnect: queryById<HTMLElement>("gpsStatusReconnect"),
-    gpsStatusFallback: queryById<HTMLElement>("gpsStatusFallback"),
-    obdStatusPanel: queryById<HTMLElement>("obdStatusPanel"),
-    obdStatusConfiguredDevice: queryById<HTMLElement>("obdStatusConfiguredDevice"),
-    obdStatusPairing: queryById<HTMLElement>("obdStatusPairing"),
-    obdStatusTrusted: queryById<HTMLElement>("obdStatusTrusted"),
-    obdStatusConnected: queryById<HTMLElement>("obdStatusConnected"),
-    obdStatusRfcommChannel: queryById<HTMLElement>("obdStatusRfcommChannel"),
-    obdStatusLastRpm: queryById<HTMLElement>("obdStatusLastRpm"),
-    obdStatusRpmAge: queryById<HTMLElement>("obdStatusRpmAge"),
-    obdStatusTargetCadence: queryById<HTMLElement>("obdStatusTargetCadence"),
-    obdStatusEffectiveCadence: queryById<HTMLElement>("obdStatusEffectiveCadence"),
-    obdStatusRequestRtt: queryById<HTMLElement>("obdStatusRequestRtt"),
-    obdStatusTimeouts: queryById<HTMLElement>("obdStatusTimeouts"),
-    obdStatusErrors: queryById<HTMLElement>("obdStatusErrors"),
-    obdStatusMode: queryById<HTMLElement>("obdStatusMode"),
-    obdStatusBackoff: queryById<HTMLElement>("obdStatusBackoff"),
-    obdStatusRawResponse: queryById<HTMLElement>("obdStatusRawResponse"),
-    obdStatusDebugHint: queryById<HTMLElement>("obdStatusDebugHint"),
   };
 }
 
 export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
-  createUiPreactMount(host).render(<SpeedSourcePanel />);
+  const bridgeState: SpeedSourcePanelBridgeState = {
+    diagnostics: DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
+    diagnosticsDisclosureOpen: false,
+    model: DEFAULT_SPEED_SOURCE_PANEL_MODEL,
+  };
+  let manualSpeedInput: HTMLInputElement | null = null;
+  let obdConfig: HTMLElement | null = null;
+  let scanObdDevicesBtn: HTMLButtonElement | null = null;
+  let staleTimeoutInput: HTMLInputElement | null = null;
+  const mount = createUiPreactMount(host);
+
+  function render(): void {
+    if (bridgeState.model.diagnosticsShouldOpen) {
+      bridgeState.diagnosticsDisclosureOpen = true;
+    }
+    mount.render(
+      <SpeedSourcePanel
+        manualInputRef={(element) => {
+          manualSpeedInput = element;
+        }}
+        obdConfigRef={(element) => {
+          obdConfig = element;
+        }}
+        onDiagnosticsToggle={(event) => {
+          bridgeState.diagnosticsDisclosureOpen =
+            (event.currentTarget as HTMLDetailsElement | null)?.open ?? false;
+        }}
+        scanButtonRef={(element) => {
+          scanObdDevicesBtn = element;
+        }}
+        staleTimeoutInputRef={(element) => {
+          staleTimeoutInput = element;
+        }}
+        state={bridgeState}
+      />,
+    );
+  }
+
+  render();
+  const dom = createSpeedSourcePanelDom(host);
+
   return {
-    dom: createSpeedSourcePanelDom(host),
+    dom,
+    focusManualSpeedInput(): void {
+      manualSpeedInput?.focus();
+    },
+    focusScanObdDevices(): void {
+      scanObdDevicesBtn?.focus();
+    },
+    focusStaleTimeoutInput(): void {
+      staleTimeoutInput?.focus();
+    },
+    isObdConfigVisible(): boolean {
+      if (!obdConfig || obdConfig.hidden) {
+        return false;
+      }
+      const activePanel = obdConfig.closest<HTMLElement>(".settings-tab-panel");
+      if (!activePanel || activePanel.hidden) {
+        return false;
+      }
+      const activeView = activePanel.closest<HTMLElement>(".view");
+      return activeView == null || !activeView.hidden;
+    },
+    render(model): void {
+      bridgeState.model = model;
+      render();
+    },
+    renderDiagnostics(model): void {
+      bridgeState.diagnostics = model;
+      render();
+    },
   };
 }

--- a/apps/ui/tests/settings_speed_source_presenter.spec.ts
+++ b/apps/ui/tests/settings_speed_source_presenter.spec.ts
@@ -1,0 +1,276 @@
+import { expect, test } from "@playwright/test";
+
+import type {
+  ObdDevicePayload,
+  ObdStatusPayload,
+  SpeedSourceStatusPayload,
+} from "../src/transport/http_models";
+import {
+  buildSettingsSpeedSourcePanelModel,
+  buildSpeedSourceDiagnosticsRenderModel,
+  type SettingsSpeedSourcePresenterDeps,
+  type SettingsSpeedSourceRenderState,
+} from "../src/app/views/settings_speed_source_presenter";
+
+function createPresenterDeps(
+  speedUnit: "kmh" | "mps" = "kmh",
+): SettingsSpeedSourcePresenterDeps {
+  return {
+    fmt(value, digits = 0) {
+      return Number(value).toFixed(digits);
+    },
+    getSpeedUnit() {
+      return speedUnit;
+    },
+    t(key, vars) {
+      switch (key) {
+        case "dashboard.rotational.source.obd2":
+          return "OBD2";
+        case "settings.speed.choice_active":
+          return "Active";
+        case "settings.speed.choice_pending":
+          return "Pending save";
+        case "settings.speed.current_source_fallback_manual":
+          return "Manual fallback";
+        case "settings.speed.current_source_manual_override":
+          return "Manual override";
+        case "settings.speed.fallback_no":
+          return "No";
+        case "settings.speed.fallback_yes":
+          return "Yes";
+        case "settings.speed.gps":
+          return "GPS";
+        case "settings.speed.last_update_never":
+          return "Never";
+        case "settings.speed.last_update_value":
+          return `${Number(
+            (vars?.value as { number: number } | undefined)?.number ?? 0,
+          ).toFixed(1)}s ago`;
+        case "settings.speed.obd_configured_badge":
+          return "Configured";
+        case "settings.speed.obd_connected_badge":
+          return "Connected";
+        case "settings.speed.obd_not_configured":
+          return "Not configured";
+        case "settings.speed.obd_pair_and_use":
+          return "Pair and use";
+        case "settings.speed.obd_pairing":
+          return "Pairing adapter...";
+        case "settings.speed.obd_paired_badge":
+          return "Paired";
+        case "settings.speed.obd_scan_idle":
+          return "Scan to discover nearby Bluetooth OBD adapters.";
+        case "settings.speed.obd_trusted_badge":
+          return "Trusted";
+        case "settings.speed.obd_use":
+          return "Use adapter";
+        case "settings.speed.obd_mode_rpm_only_backoff":
+          return "RPM priority only (backed off)";
+        case "settings.speed.state_connected":
+          return "Connected";
+        case "speed.unit.kmh":
+          return "km/h";
+        case "speed.unit.mps":
+          return "m/s";
+        default:
+          return key;
+      }
+    },
+  };
+}
+
+function makeObdDevice(
+  overrides: Partial<ObdDevicePayload> = {},
+): ObdDevicePayload {
+  return {
+    connected: false,
+    mac_address: "00:22:d9:00:1b:b1",
+    name: "OBDLink CX",
+    paired: false,
+    rfcomm_channel: null,
+    trusted: false,
+    ...overrides,
+  };
+}
+
+function makeRenderState(
+  overrides: Partial<SettingsSpeedSourceRenderState> = {},
+): SettingsSpeedSourceRenderState {
+  return {
+    diagnosticsOpen: false,
+    draftDirty: false,
+    manualSpeedFeedback: null,
+    manualSpeedInputValue: "",
+    obdScanStatusMessage: null,
+    obdSelectionError: false,
+    pairInFlightMac: null,
+    saveFeedback: null,
+    scannedDevices: [],
+    scanInFlight: false,
+    selectedMode: "gps",
+    settings: {
+      gpsFallbackActive: false,
+      gpsEffectiveSpeedKph: 72,
+      manualSpeedKph: null,
+      obdDeviceMac: null,
+      obdDeviceName: null,
+      resolvedSpeedSource: "gps",
+      speedSource: "gps",
+    },
+    staleTimeoutFeedback: null,
+    staleTimeoutInputValue: "5",
+    ...overrides,
+  };
+}
+
+test("speed-source panel model keeps the active GPS card while a manual draft is pending save", () => {
+  const state = makeRenderState({
+    diagnosticsOpen: true,
+    draftDirty: true,
+    manualSpeedFeedback: {
+      body: "Enter a manual speed between 0.1 and 500 km/h.",
+      compact: true,
+      tone: "error",
+    },
+    manualSpeedInputValue: "45",
+    saveFeedback: {
+      body: "GPS remains active right now. No changes were saved.",
+      title: "Save failed",
+      tone: "error",
+    },
+    selectedMode: "manual",
+  });
+
+  const model = buildSettingsSpeedSourcePanelModel(
+    state,
+    createPresenterDeps(),
+  );
+
+  expect(model.selectedMode).toBe("manual");
+  expect(model.choiceCards.gps).toEqual({
+    badgeText: "Active",
+    selected: true,
+    state: "active",
+  });
+  expect(model.choiceCards.manual).toEqual({
+    badgeText: "Pending save",
+    selected: false,
+    state: "draft",
+  });
+  expect(model.manualConfigVisible).toBe(true);
+  expect(model.showGpsFallbackPanel).toBe(false);
+  expect(model.diagnosticsShouldOpen).toBe(true);
+  expect(model.summary).toEqual({
+    currentSourceText: "GPS",
+    effectiveSpeedText: "72.0 km/h",
+    fallbackActiveText: "No",
+  });
+  expect(model.manualSpeedFeedback?.body).toBe(
+    "Enter a manual speed between 0.1 and 500 km/h.",
+  );
+});
+
+test("speed-source presenter builds OBD device rows and diagnostics render models", () => {
+  const configuredDevice = makeObdDevice({
+    connected: true,
+    paired: true,
+    trusted: true,
+  });
+  const aliasOnlyDevice = makeObdDevice({
+    mac_address: "53:40:ac:57:11:77",
+    name: "53-40-AC-57-11-77",
+  });
+
+  const panelModel = buildSettingsSpeedSourcePanelModel(
+    makeRenderState({
+      obdScanStatusMessage: "2 adapter(s) found.",
+      scannedDevices: [configuredDevice, aliasOnlyDevice],
+      selectedMode: "obd2",
+      settings: {
+        gpsFallbackActive: false,
+        gpsEffectiveSpeedKph: 81,
+        manualSpeedKph: null,
+        obdDeviceMac: configuredDevice.mac_address,
+        obdDeviceName: configuredDevice.name,
+        resolvedSpeedSource: "obd2",
+        speedSource: "obd2",
+      },
+    }),
+    createPresenterDeps(),
+  );
+
+  expect(panelModel.obdConfiguredDeviceText).toBe(
+    "OBDLink CX (00:22:d9:00:1b:b1)",
+  );
+  expect(panelModel.obdDevices[0]).toEqual({
+    actionDisabled: false,
+    actionLabelText: "Use adapter",
+    badges: [
+      { active: true, labelText: "Configured" },
+      { active: false, labelText: "Paired" },
+      { active: false, labelText: "Trusted" },
+      { active: true, labelText: "Connected" },
+    ],
+    macAddress: "00:22:d9:00:1b:b1",
+    primaryText: "OBDLink CX",
+    secondaryText: "00:22:d9:00:1b:b1",
+  });
+  expect(panelModel.obdDevices[1].secondaryText).toBeNull();
+
+  const speedStatus: SpeedSourceStatusPayload = {
+    connection_state: "connected",
+    device: "gpsd",
+    effective_speed_kmh: 45,
+    fallback_active: true,
+    gps_enabled: true,
+    last_error: null,
+    last_update_age_s: 0.3,
+    raw_speed_kmh: 36,
+    reconnect_delay_s: 1.5,
+    speed_source: "obd2",
+  };
+  const obdStatus: ObdStatusPayload = {
+    backoff_active: true,
+    configured_device_mac: configuredDevice.mac_address,
+    configured_device_name: configuredDevice.name,
+    connected: true,
+    debug_hint: "Check power",
+    error_count: 2,
+    last_raw_response: "41 0C 1B 58",
+    last_rpm: 2200,
+    paired: true,
+    poll_mode: "rpm_only_backoff",
+    request_rtt_ms: 61.4,
+    rfcomm_channel: 1,
+    rpm_effective_hz: 13.3,
+    rpm_sample_age_s: 0.1,
+    rpm_target_interval_ms: 75,
+    timeout_count: 1,
+    trusted: true,
+  };
+
+  const diagnostics = buildSpeedSourceDiagnosticsRenderModel(
+    speedStatus,
+    obdStatus,
+    createPresenterDeps("mps"),
+  );
+
+  expect(diagnostics.gps).toMatchObject({
+    deviceText: "gpsd",
+    effectiveSpeedText: "12.5 m/s",
+    fallbackText: "Yes",
+    lastUpdateText: "0.3s ago",
+    rawSpeedText: "10.0 m/s",
+    reconnectText: "1.5s",
+    stateText: "Connected",
+  });
+  expect(diagnostics.obd).toMatchObject({
+    backoffText: "Yes",
+    configuredDeviceText: "OBDLink CX (00:22:d9:00:1b:b1)",
+    effectiveCadenceText: "13.3 Hz",
+    modeText: "RPM priority only (backed off)",
+    requestRttText: "61 ms",
+    targetCadenceText: "13.3 Hz (75 ms)",
+    visible: true,
+  });
+});

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -74,6 +74,35 @@ test("manual speed save uses settings endpoint only (no speed-override call)", a
   await expect.poll(() => speedOverrideCalls).toBe(0);
 });
 
+test("manual speed validation marks the field invalid while keeping the active GPS card visible", async ({ page }) => {
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "GET /api/settings/language": { language: "en" },
+      "GET /api/settings/speed-unit": { speed_unit: "kmh" },
+      "GET /api/settings/speed-source": {
+        speed_source: "gps",
+        manual_speed_kph: null,
+        stale_timeout_s: 5,
+      },
+    }),
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await page.locator('[data-speed-source-choice="manual"]').click();
+  await page.locator("#manualSpeedInput").fill("0");
+  await page.locator("#saveSpeedSourceBtn").click();
+
+  await expect(page.locator("#manualSpeedInput")).toHaveAttribute("aria-invalid", "true");
+  await expect(page.locator("#manualSpeedFeedback")).toContainText("Enter a manual speed between 0.1 and 500 km/h.");
+  await expect(page.locator("#speedSourceSaveFeedback")).toContainText("GPS remains active right now");
+  await expect(page.locator('[data-speed-source-choice="gps"]')).toHaveAttribute("data-selected", "true");
+  await expect(page.locator('[data-speed-source-choice="manual"]')).toHaveAttribute("data-choice-state", "draft");
+  await expect(page.locator("#speedSourceDiagnostics")).toHaveAttribute("open", "");
+});
+
 test("resolved fallback manual state stays coherent across header status, form, and GPS status", async ({ page }) => {
   await installCommonRoutes(page, {
     settingsHandler: createSettingsHandlerFromMap({
@@ -705,6 +734,7 @@ test("manual OBD scan sorts named devices first and background rescans progressi
   await expect(deviceNames.nth(0)).toHaveText("Audioengine HD6");
   await expect(deviceNames.nth(1)).toHaveText("53-40-AC-57-11-77");
   await expect(page.locator(".speed-source-device__mac").nth(0)).toHaveText("0022d9001bb1");
+  await expect(page.locator(".speed-source-device__actions .btn").nth(0)).toHaveText("Pair and use");
 
   await expect.poll(() => scanCalls, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
   await expect(deviceNames.nth(1)).toHaveText("Pim's iPhone");


### PR DESCRIPTION
## Summary

This PR completes issue #2286 by moving the remaining speed-source rendering seam into the existing Preact island. Before this change, `speed_source_panel.tsx` mostly mounted static shell markup while `settings_speed_source_presenter.ts` handled the UI through direct DOM mutation. It was still setting summary text, choice-card data attributes, validation state, feedback slots, diagnostics disclosure state, and the OBD device list imperatively. `settings_gps_status_module.ts` separately wrote the live GPS and OBD diagnostics tables cell by cell. The workflow in `settings_speed_source_workflow.ts` was already DOM-free, but the view side still depended on `textContent`, low-level node builders, and imperative attribute management.

The implementation keeps the good part of the current split and only replaces the remaining rendering seam. The workflow and transport boundaries stay in place. The existing typed speed-source bindings also stay in place for now, because the issue is specifically about migrating diagnostics and OBD rendering into Preact rather than rewriting event wiring at the same time. The main architectural shift is that `speed_source_panel.tsx` now owns the JSX for the full settings surface and live diagnostics section, while `settings_speed_source_presenter.ts` is reduced to pure model shaping.

## What changed

The largest change is in `apps/ui/src/app/views/speed_source_panel.tsx`. That file now renders the full speed-source UI surface through JSX rather than acting as a static shell. The panel owns the active-source summary, the three choice cards with their active and pending-save data attributes, the manual configuration block, the OBD configuration block, the inline feedback slots, the sticky save action, the OBD device rows and buttons, and the GPS/OBD diagnostics tables. I kept the existing ids, classes, and `data-*` attributes stable, because the speed-source workflow, delegated bindings, and browser smoke tests already rely on that contract. The bridge now exposes render methods for both the settings state and the diagnostics state, plus the same focus and visibility helpers the workflow already needs for validation and background rescan behavior.

`apps/ui/src/app/views/settings_speed_source_presenter.ts` is no longer a presenter in the old imperative sense. It now contains pure helpers that take typed workflow state or typed diagnostics payloads and return render models for the panel. That includes the summary text, choice-card state, OBD scan status text, OBD device row badges and button labels, and the formatted GPS/OBD diagnostics values. This removes the previous dependence on direct `textContent` writes, imperative `aria-*` writes, `createElementNode()`, and manual `renderChildren()` calls for the normal speed-source surface. It also consolidates the status formatting logic so the panel and the polling module are using one render-model path instead of separate DOM-writing codepaths.

On the feature side, `apps/ui/src/app/features/settings_speed_source_module.ts` now adapts the existing DOM-free workflow into the shared Preact panel bridge instead of constructing an imperative presenter object. The workflow still owns validation, draft state, save/load orchestration, OBD scan/pair flows, and background rescans. The module now simply converts workflow render state into a panel render model and sends that to the island. This keeps the business logic unchanged while replacing the rendering seam beneath it. `apps/ui/src/app/features/settings_gps_status_module.ts` received the same treatment: instead of mutating every diagnostics table cell directly, it now polls the server, updates the shared settings state, and sends a typed diagnostics model into the same panel bridge.

I also updated `apps/ui/src/app/features/settings_feature.ts` to wire the shared speed-source panel into both modules, so the settings workflow and the live diagnostics polling module render through one owner instead of competing DOM writers. The docs in `apps/ui/README.md` now describe the speed-source presenter as a pure render-model builder and the panel as the JSX owner for the full surface.

## Tests and validation

I added `apps/ui/tests/settings_speed_source_presenter.spec.ts` as focused coverage for the new render-model seam. The new spec exercises two cases that matter for this migration. First, it verifies that the panel model preserves the active GPS card while a manual draft is pending save, including the active/pending choice-card state and the summary text. Second, it verifies that configured OBD devices and the live diagnostics payload format correctly into typed render models, including badge state, action labels, unit conversion, cadence formatting, and OBD monitor-mode text.

I also extended `apps/ui/tests/smoke.settings.spec.ts` with a validation case for manual-speed validation. That case confirms the migrated panel still marks the manual input as invalid, still surfaces the inline feedback copy, keeps the active GPS card visible, and still forces the diagnostics disclosure open when validation fails. I also tightened the OBD scan smoke path so it checks the rendered OBD device action button label, which now comes from JSX rather than the old DOM builder path.

The local validation run for this branch was:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/settings_speed_source_presenter.spec.ts tests/settings_speed_source_workflow.spec.ts tests/speed_source_state.spec.ts tests/ui_action_bindings.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/settings_obd_scan_timeout.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --grep "gps status uses selected speed unit in settings panel|manual speed save uses settings endpoint only \\(no speed-override call\\)|manual speed validation marks the field invalid while keeping the active GPS card visible|resolved fallback manual state stays coherent across header status, form, and GPS status|resolved OBD2 state stays coherent across header status, form, and device summary|failed speed-source save keeps the draft and explains which source remains active|manual OBD scan sorts named devices first and background rescans progressively improve the list|background OBD rescans stop when the Speed Source OBD panel is no longer visible" --workers=1`

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that I intentionally kept `settings_speed_source_bindings.ts` in place. It is still the thin delegated event layer that turns raw radio, input, save, scan, navigation, and OBD pair interactions into typed workflow actions. That means this PR is not the final “delete every DOM-adjacent helper” step for speed source. I made that choice on purpose to keep the scope aligned with issue #2286: rendering diagnostics and OBD devices in Preact without rewriting the already-stable workflow and input contract at the same time. The existing bindings tests are still valuable, and the remaining cleanup can happen in a later pass if the repo still wants that seam gone.

The other key risk area was preserving browser behavior while changing the render owner. The speed-source UI has several subtle contracts: pending-save choice-card state versus active source state, unit conversion for diagnostics, save failures that keep the draft visible, background OBD rescans that should stop when the OBD panel is no longer visible, and OBD device rows that should sort and label correctly even when a Bluetooth name is really just a MAC alias. The new panel bridge keeps the existing ids, classes, and data attributes specifically so those interactions continue to flow through the same workflow and test surface.

Closes #2286
