### PR TITLE
Render ESP flash settings in Preact

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -111,7 +111,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
 | `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
 | `app/views/settings_shell.tsx` | Preact owner for the shared settings tab chrome and tab-panel wrappers that mount the per-tab panel hosts and expose the settings navigation bridge |
-| `app/views/esp_flash_panel.tsx` | Preact owner for the ESP flash settings shell that mounts the controls, readiness, status, history, and log surface while exposing the bridge consumed by the ESP flash feature |
+| `app/views/esp_flash_panel.tsx` | Preact owner for the ESP flash settings shell and its typed render bridge for port selection, readiness, journey, history, and log surfaces |
 | `app/views/internet_panel.tsx` | Preact owner for the full internet settings surface that renders USB status, transport choices, Wi-Fi credentials, and readiness guidance through a typed bridge |
 | `app/views/update_panel.tsx` | Preact owner for the full update settings surface that renders the action row plus current status, health, journey, issues, latest attempt, and log cards through a typed bridge |
 | `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that renders the full sensor table and exposes typed identify/remove/location callbacks to the realtime feature |
@@ -124,7 +124,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/update_feature_workflow.ts` | DOM-free update workflow/controller for update polling, internet-status normalization, and start/cancel command orchestration |
 | `app/views/dom_render.ts` | Shared low-level DOM render helper for fragments, element creation, text updates, and class-state toggles |
 | `app/views/esp_flash_feature_bindings.ts` | Feature-local ESP flash bindings for start/cancel/refresh/select actions without leaving raw DOM event parsing in the feature |
-| `app/views/esp_flash_feature_presenter.ts` | ESP flash presenter that owns readiness/banner/journey/history/log/select rendering through the island-owned ESP flash panel bridge |
+| `app/views/esp_flash_feature_presenter.ts` | ESP flash presenter that derives typed panel models for the island-owned ESP flash bridge while leaving workflow state in the feature workflow |
 | `app/views/history_table_models.ts` | Typed row/detail/finding/heatmap view models that describe history table rendering without HTML fragments |
 | `app/views/history_table_presenters.ts` | Presenter builders that turn runs plus loaded insights/preview detail into typed history row and details models |
 | `app/views/history_panel.tsx` | Preact owner for the history panel shell that renders summary/toolbar chrome and binds typed row actions through a bridge |
@@ -138,7 +138,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/update_feature_presenter.ts` | Update presenter that derives typed update/internet panel models from workflow state plus draft form inputs and toggles |
 | `app/views/internet_status_view.ts` | Pure USB-internet status model builder reused by the Preact internet panel |
 | `app/views/update_status_view_models.ts` | Typed update-status section builders for current status, journey, issues, attempt history, health, and log cards |
-| `app/views/maintenance_readiness_view.ts` | Shared maintenance-readiness model contract still reused by update and ESP flash readiness flows |
+| `app/views/maintenance_readiness_view.ts` | Shared maintenance-readiness model and Preact component contract reused by update and ESP flash readiness flows |
 | `app/views/` | Focused render-model builders, event-target decoding, and disposable delegated event binders for settings, cars wizard, realtime, history, and updater surfaces |
 | `app/views/realtime_feature_presenter.ts` | Realtime presenter that owns derived live/logging panel state, elapsed-timer sync, and cross-view navigation clicks |
 | `transport/` | UI-local HTTP / WS DTOs plus adapter helpers that isolate generated contract files from app state and feature code |

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -18,9 +18,8 @@ export function createEspFlashFeature(
   ctx: EspFlashFeatureDeps,
 ): EspFlashFeature {
   const presenter = createEspFlashFeaturePresenter({
-    dom: ctx.panel.dom,
+    panel: ctx.panel,
     t: ctx.t,
-    escapeHtml: ctx.escapeHtml,
   });
   const workflow = createEspFlashFeatureWorkflow({
     t: ctx.t,

--- a/apps/ui/src/app/views/dom_helpers.ts
+++ b/apps/ui/src/app/views/dom_helpers.ts
@@ -163,13 +163,6 @@ export function formatEpochTimestamp(epoch: number | null | undefined): string {
   return new Date(epoch * 1000).toLocaleString();
 }
 
-export function renderStatusGridRow(
-  labelHtml: string,
-  valueHtml: string,
-): string {
-  return `<div class="status-grid__row"><span class="status-grid__label">${labelHtml}</span><span>${valueHtml}</span></div>`;
-}
-
 export function createStatusGridRowElement(
   labelText: string,
   valueText: string,

--- a/apps/ui/src/app/views/esp_flash_feature_presenter.ts
+++ b/apps/ui/src/app/views/esp_flash_feature_presenter.ts
@@ -3,23 +3,28 @@ import type {
   EspFlashStatusPayload,
   EspSerialPortPayload,
 } from "../../transport/http_models";
-import type { EspFlashPanelDom } from "./esp_flash_panel";
-import { formatEpochTimestamp, renderStatusGridRow } from "./dom_helpers";
-import {
-  renderMaintenanceReadinessPanel,
-  type MaintenanceReadinessPanelModel,
-} from "./maintenance_readiness_view";
-import { setVariantState, type VisualVariant } from "../style_state";
-
-const LOG_PANEL_BASE_CLASS = "maintenance-log-slot";
+import type { VisualVariant } from "../style_state";
+import { formatEpochTimestamp } from "./dom_helpers";
+import type { MaintenanceReadinessPanelModel } from "./maintenance_readiness_view";
+import type {
+  EspFlashHistoryAttemptModel,
+  EspFlashHistoryPanelModel,
+  EspFlashJourneyPanelModel,
+  EspFlashJourneyStageModel,
+  EspFlashJourneyStageState,
+  EspFlashLogPanelModel,
+  EspFlashPanelRenderModel,
+  EspFlashPanelView,
+  EspFlashReadinessPanelModel,
+  EspFlashStatusBadgeModel,
+  EspFlashStatusGridRowModel,
+} from "./esp_flash_panel";
 
 const STATE_TO_VARIANT: Readonly<Record<string, VisualVariant>> = {
-  success: "ok",
-  running: "warn",
   failed: "bad",
+  running: "warn",
+  success: "ok",
 };
-
-type JourneyStageState = "upcoming" | "active" | "done" | "attention";
 
 interface FlashAttemptSummary {
   autoDetect: boolean;
@@ -33,29 +38,29 @@ interface FlashAttemptSummary {
 
 const ESP_FLASH_JOURNEY_STAGES = [
   {
+    detailKey: "settings.esp_flash.journey.detail.validating",
     phase: "validating",
     titleKey: "settings.esp_flash.phase.validating",
-    detailKey: "settings.esp_flash.journey.detail.validating",
   },
   {
+    detailKey: "settings.esp_flash.journey.detail.preparing",
     phase: "preparing",
     titleKey: "settings.esp_flash.phase.preparing",
-    detailKey: "settings.esp_flash.journey.detail.preparing",
   },
   {
+    detailKey: "settings.esp_flash.journey.detail.erasing",
     phase: "erasing",
     titleKey: "settings.esp_flash.phase.erasing",
-    detailKey: "settings.esp_flash.journey.detail.erasing",
   },
   {
+    detailKey: "settings.esp_flash.journey.detail.flashing",
     phase: "flashing",
     titleKey: "settings.esp_flash.phase.flashing",
-    detailKey: "settings.esp_flash.journey.detail.flashing",
   },
   {
+    detailKey: "settings.esp_flash.journey.detail.done",
     phase: "done",
     titleKey: "settings.esp_flash.phase.done",
-    detailKey: "settings.esp_flash.journey.detail.done",
   },
 ] as const;
 
@@ -69,9 +74,8 @@ export interface EspFlashFeatureRenderState {
 }
 
 export interface EspFlashFeaturePresenterDeps {
-  dom: EspFlashPanelDom;
+  panel: EspFlashPanelView;
   t: (key: string, vars?: Record<string, unknown>) => string;
-  escapeHtml: (value: unknown) => string;
 }
 
 export interface EspFlashFeaturePresenter {
@@ -82,418 +86,393 @@ function safeEspFlashState(state: string | null | undefined): string {
   return state || "idle";
 }
 
-export function createEspFlashFeaturePresenter(
-  ctx: EspFlashFeaturePresenterDeps,
-): EspFlashFeaturePresenter {
-  const { dom: els, t, escapeHtml } = ctx;
+function translateKeyOrFallback(
+  t: (key: string, vars?: Record<string, unknown>) => string,
+  key: string,
+  fallback: string,
+): string {
+  const translated = t(key);
+  return translated === key ? fallback : translated;
+}
 
-  function translateKeyOrFallback(key: string, fallback: string): string {
-    const translated = t(key);
-    return translated === key ? fallback : translated;
+function formatEspFlashPhase(
+  t: (key: string, vars?: Record<string, unknown>) => string,
+  phase: string | null | undefined,
+): string {
+  const safePhase = phase || "idle";
+  return translateKeyOrFallback(
+    t,
+    `settings.esp_flash.phase.${safePhase}`,
+    safePhase,
+  );
+}
+
+function stageStateLabel(
+  t: (key: string, vars?: Record<string, unknown>) => string,
+  state: EspFlashJourneyStageState,
+): string {
+  return t(`maintenance.stage_state.${state}`);
+}
+
+function journeyStageIndex(phase: string | null | undefined): number {
+  return ESP_FLASH_JOURNEY_STAGES.findIndex(
+    (stage) => stage.phase === (phase || "idle"),
+  );
+}
+
+function resolvedJourneyPhase(state: EspFlashFeatureRenderState): string | null {
+  if (journeyStageIndex(state.status.phase) !== -1) {
+    return state.status.phase || null;
   }
-
-  function formatEspFlashPhase(phase: string | null | undefined): string {
-    const safePhase = phase || "idle";
-    return translateKeyOrFallback(
-      `settings.esp_flash.phase.${safePhase}`,
-      safePhase,
-    );
+  const safeState = safeEspFlashState(state.status.state);
+  if (safeState === "failed" || safeState === "cancelled") {
+    return state.lastJourneyPhase;
   }
+  return null;
+}
 
-  function stageStateLabel(state: JourneyStageState): string {
-    return t(`maintenance.stage_state.${state}`);
+function resolveJourneyStageState(
+  state: EspFlashFeatureRenderState,
+  stageIndex: number,
+): EspFlashJourneyStageState {
+  const safeState = safeEspFlashState(state.status.state);
+  if (safeState === "success") {
+    return "done";
   }
-
-  function journeyStageIndex(phase: string | null | undefined): number {
-    return ESP_FLASH_JOURNEY_STAGES.findIndex(
-      (stage) => stage.phase === (phase || "idle"),
-    );
-  }
-
-  function resolvedJourneyPhase(
-    state: EspFlashFeatureRenderState,
-  ): string | null {
-    if (journeyStageIndex(state.status.phase) !== -1) {
-      return state.status.phase || null;
-    }
-    const safeState = safeEspFlashState(state.status.state);
-    if (safeState === "failed" || safeState === "cancelled") {
-      return state.lastJourneyPhase;
-    }
-    return null;
-  }
-
-  function resolveJourneyStageState(
-    state: EspFlashFeatureRenderState,
-    stageIndex: number,
-  ): JourneyStageState {
-    const safeState = safeEspFlashState(state.status.state);
-    if (safeState === "success") {
-      return "done";
-    }
-    if (safeState === "idle") {
-      return "upcoming";
-    }
-    const currentIndex = journeyStageIndex(resolvedJourneyPhase(state));
-    if (currentIndex === -1) {
-      return "upcoming";
-    }
-    if (stageIndex < currentIndex) {
-      return "done";
-    }
-    if (stageIndex === currentIndex) {
-      return safeState === "failed" || safeState === "cancelled"
-        ? "attention"
-        : "active";
-    }
+  if (safeState === "idle") {
     return "upcoming";
   }
+  const currentIndex = journeyStageIndex(resolvedJourneyPhase(state));
+  if (currentIndex === -1) {
+    return "upcoming";
+  }
+  if (stageIndex < currentIndex) {
+    return "done";
+  }
+  if (stageIndex === currentIndex) {
+    return safeState === "failed" || safeState === "cancelled"
+      ? "attention"
+      : "active";
+  }
+  return "upcoming";
+}
 
-  function renderJourney(state: EspFlashFeatureRenderState): string {
-    const items = ESP_FLASH_JOURNEY_STAGES.map((stage, index) => {
+function buildJourneyPanelModel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): EspFlashJourneyPanelModel {
+  const stages: EspFlashJourneyStageModel[] = ESP_FLASH_JOURNEY_STAGES.map(
+    (stage, index) => {
       const stageState = resolveJourneyStageState(state, index);
-      const markerLabel = stageState === "done" ? "✓" : `${index + 1}`;
-      const currentStepAttr =
-        stageState === "active" ? ' aria-current="step"' : "";
-      return `<li class="maintenance-stage" data-stage-phase="${stage.phase}" data-stage-state="${stageState}"${currentStepAttr}>
-        <span class="maintenance-stage__marker">${markerLabel}</span>
-        <div class="maintenance-stage__body">
-          <div class="maintenance-stage__title">${escapeHtml(t(stage.titleKey))}</div>
-          <div class="maintenance-stage__detail">${escapeHtml(t(stage.detailKey))}</div>
-        </div>
-        <span class="maintenance-stage__state">${escapeHtml(stageStateLabel(stageState))}</span>
-      </li>`;
-    }).join("");
-    const terminalState = safeEspFlashState(state.status.state);
-    const terminalNote =
-      terminalState === "failed" || terminalState === "cancelled"
-        ? `<div class="maintenance-note maintenance-note--bad">${escapeHtml(t(`settings.esp_flash.journey_terminal.${terminalState}`))}</div>`
-        : "";
-    return `<div class="maintenance-journey">
-      ${terminalNote}
-      <ol class="maintenance-stage-list">${items}</ol>
-    </div>`;
-  }
-
-  function selectedTargetLabel(state: EspFlashFeatureRenderState): string {
-    const selectedValue = state.selectedPortValue;
-    const raw =
-      state.status.selected_port ||
-      (selectedValue !== "__auto__" ? selectedValue : null);
-    return raw || t("settings.esp_flash.auto_detect");
-  }
-
-  function detectedPortsLabel(state: EspFlashFeatureRenderState): string {
-    if (state.availablePorts.length === 0) {
-      return t("settings.esp_flash.readiness.no_ports");
-    }
-    if (state.availablePorts.length === 1) {
-      const port = state.availablePorts[0];
-      const label = port.description
-        ? `${port.port} — ${port.description}`
-        : port.port;
-      return t("settings.esp_flash.readiness.one_port", { port: label });
-    }
-    return t("settings.esp_flash.readiness.multiple_ports", {
-      count: state.availablePorts.length,
-    });
-  }
-
-  function readinessSummary(state: EspFlashFeatureRenderState): string {
-    const safeState = safeEspFlashState(state.status.state);
-    switch (safeState) {
-      case "running":
-        return t("settings.esp_flash.readiness.summary.running");
-      case "success":
-        return t("settings.esp_flash.readiness.summary.success");
-      case "failed":
-        return t("settings.esp_flash.readiness.summary.failed");
-      case "cancelled":
-        return t("settings.esp_flash.readiness.summary.cancelled");
-      default:
-        return state.availablePorts.length > 0
-          ? t("settings.esp_flash.readiness.summary.ready_ports")
-          : t("settings.esp_flash.readiness.summary.ready_no_ports");
-    }
-  }
-
-  function latestAttemptSummary(attempt: FlashAttemptSummary): string {
-    const stateLabel = t(
-      `settings.esp_flash.state.${safeEspFlashState(attempt.state)}`,
-    );
-    const when = formatEpochTimestamp(attempt.finishedAt ?? attempt.startedAt);
-    return t("settings.esp_flash.last_result_value", {
-      state: stateLabel,
-      when,
-    });
-  }
-
-  function currentAttemptSummaries(
-    state: EspFlashFeatureRenderState,
-  ): FlashAttemptSummary[] {
-    if (state.attempts.length > 0) {
-      return state.attempts.map((attempt) => ({
-        autoDetect: attempt.auto_detect,
-        error: attempt.error ?? null,
-        exitCode: attempt.exit_code ?? null,
-        finishedAt: attempt.finished_at ?? null,
-        selectedPort: attempt.selected_port ?? null,
-        startedAt: attempt.started_at ?? null,
-        state: safeEspFlashState(attempt.state),
-      }));
-    }
-    const safeState = safeEspFlashState(state.status.state);
-    if (safeState === "idle" || safeState === "running") {
-      return [];
-    }
-    return [
-      {
-        autoDetect: state.status.auto_detect,
-        error: state.status.error ?? null,
-        exitCode: state.status.exit_code ?? null,
-        finishedAt: state.status.finished_at ?? null,
-        selectedPort: state.status.selected_port ?? null,
-        startedAt: state.status.started_at ?? null,
-        state: safeState,
-      },
-    ];
-  }
-
-  function recoverySummary(state: EspFlashFeatureRenderState): {
-    message: string;
-    phaseLabel: string;
-    recoveryDetail: string;
-    recoveryTitle: string;
-  } | null {
-    const safeState = safeEspFlashState(state.status.state);
-    if (safeState !== "failed" && safeState !== "cancelled") {
-      return null;
-    }
-    const phase = resolvedJourneyPhase(state) ?? state.status.phase ?? "idle";
-    const keyBase =
-      safeState === "cancelled"
-        ? "settings.esp_flash.recovery.cancelled"
-        : phase === "preparing"
-          ? "settings.esp_flash.recovery.preparing"
-          : phase === "erasing"
-            ? "settings.esp_flash.recovery.erasing"
-            : phase === "flashing"
-              ? "settings.esp_flash.recovery.flashing"
-              : phase === "validating"
-                ? "settings.esp_flash.recovery.validating"
-                : "settings.esp_flash.recovery.generic";
-    return {
-      message:
-        state.status.error || t("settings.esp_flash.recovery.fallback_error"),
-      phaseLabel: formatEspFlashPhase(phase),
-      recoveryTitle: t(`${keyBase}.title`),
-      recoveryDetail: t(`${keyBase}.detail`),
-    };
-  }
-
-  function buildActionSummary(state: EspFlashFeatureRenderState): {
-    canStart: boolean;
-    panelModel: MaintenanceReadinessPanelModel;
-    startLabel: string;
-  } {
-    const safeState = safeEspFlashState(state.status.state);
-    const portsDetected = state.availablePorts.length > 0;
-    const selectedTarget = selectedTargetLabel(state);
-    const readinessItems = [
-      {
-        label: t("settings.esp_flash.start_readiness.item.connection"),
-        detail: portsDetected
-          ? t("settings.esp_flash.start_readiness.item.connection_ready", {
-              ports: detectedPortsLabel(state),
-            })
-          : t("settings.esp_flash.start_readiness.item.connection_blocked"),
-        state: portsDetected ? ("ready" as const) : ("blocked" as const),
-      },
-      {
-        label: t("settings.esp_flash.start_readiness.item.target"),
-        detail: portsDetected
-          ? t("settings.esp_flash.start_readiness.item.target_ready", {
-              target: selectedTarget,
-            })
-          : t("settings.esp_flash.start_readiness.item.target_blocked"),
-        state: portsDetected ? ("ready" as const) : ("blocked" as const),
-      },
-    ];
-    const recovery = recoverySummary(state);
-    const isRecoveryState = recovery !== null;
-    const stateLabel = isRecoveryState
-      ? portsDetected
-        ? t(`settings.esp_flash.state.${safeState}`)
-        : t("maintenance.readiness.blocked")
-      : safeState === "running"
-        ? t("maintenance.readiness.running")
-        : portsDetected
-          ? t("maintenance.readiness.ready")
-          : t("maintenance.readiness.blocked");
-    return {
-      canStart: safeState !== "running" && portsDetected,
-      startLabel: t(
-        isRecoveryState
-          ? "settings.esp_flash.retry"
-          : "settings.esp_flash.start",
-      ),
-      panelModel: {
-        title: t(
-          isRecoveryState
-            ? "settings.esp_flash.recovery.title"
-            : "settings.esp_flash.start_readiness.title",
-        ),
-        summary: t(
-          isRecoveryState
-            ? portsDetected
-              ? "settings.esp_flash.recovery.summary_retry"
-              : "settings.esp_flash.recovery.summary_blocked"
-            : safeState === "running"
-              ? "settings.esp_flash.start_readiness.summary_running"
-              : portsDetected
-                ? "settings.esp_flash.start_readiness.summary_ready"
-                : "settings.esp_flash.start_readiness.summary_blocked",
-        ),
-        stateLabel,
-        stateVariant: isRecoveryState
-          ? "bad"
-          : safeState === "running"
-            ? "warn"
-            : portsDetected
-              ? "ok"
-              : "bad",
-        items: recovery
-          ? [
-              {
-                label: t("settings.esp_flash.recovery.item.failed_step"),
-                detail: recovery.phaseLabel,
-                state: "attention" as const,
-              },
-              {
-                label: t("settings.esp_flash.recovery.item.captured_detail"),
-                detail: recovery.message,
-                state: "attention" as const,
-              },
-              {
-                label: t("settings.esp_flash.recovery.item.next_step"),
-                detail: portsDetected
-                  ? `${recovery.recoveryTitle} — ${recovery.recoveryDetail}`
-                  : t("settings.esp_flash.recovery.item.next_step_blocked"),
-                state: portsDetected
-                  ? ("attention" as const)
-                  : ("blocked" as const),
-              },
-            ]
-          : readinessItems,
-      },
-    };
-  }
-
-  function renderPortOptions(state: EspFlashFeatureRenderState): void {
-    if (!els.espFlashPortSelect) {
-      return;
-    }
-    const options = [
-      `<option value="__auto__">${escapeHtml(t("settings.esp_flash.auto_detect"))}</option>`,
-    ];
-    for (const port of state.availablePorts) {
-      const label = `${port.port}${port.description ? ` — ${port.description}` : ""}`;
-      options.push(
-        `<option value="${escapeHtml(port.port)}">${escapeHtml(label)}</option>`,
-      );
-    }
-    els.espFlashPortSelect.innerHTML = options.join("");
-    els.espFlashPortSelect.value = state.selectedPortValue;
-  }
-
-  function syncFlashControls(
-    state: EspFlashFeatureRenderState,
-    actionSummary: {
-      canStart: boolean;
-      panelModel: MaintenanceReadinessPanelModel;
-      startLabel: string;
+      return {
+        current: stageState === "active",
+        detailText: t(stage.detailKey),
+        markerText: stageState === "done" ? "\u2713" : `${index + 1}`,
+        phase: stage.phase,
+        state: stageState,
+        stateText: stageStateLabel(t, stageState),
+        titleText: t(stage.titleKey),
+      };
     },
-  ): void {
-    const safeState = safeEspFlashState(state.status.state);
-    if (els.espFlashStartSummary) {
-      els.espFlashStartSummary.innerHTML = renderMaintenanceReadinessPanel(
-        actionSummary.panelModel,
-        escapeHtml,
-      );
-    }
-    if (els.espFlashStartBtn) {
-      els.espFlashStartBtn.textContent = actionSummary.startLabel;
-      els.espFlashStartBtn.hidden = safeState === "running";
-      els.espFlashStartBtn.disabled =
-        safeState === "running" || !actionSummary.canStart;
-    }
-    if (els.espFlashCancelBtn) {
-      els.espFlashCancelBtn.hidden = safeState !== "running";
-      els.espFlashCancelBtn.disabled = safeState !== "running";
-    }
-    if (els.espFlashPortSelect) {
-      els.espFlashPortSelect.disabled = safeState === "running";
-    }
-    if (els.espFlashRefreshPortsBtn) {
-      els.espFlashRefreshPortsBtn.disabled = safeState === "running";
-    }
-  }
+  );
+  const terminalState = safeEspFlashState(state.status.state);
+  return {
+    stages,
+    terminalNoteText:
+      terminalState === "failed" || terminalState === "cancelled"
+        ? t(`settings.esp_flash.journey_terminal.${terminalState}`)
+        : null,
+  };
+}
 
-  function renderReadinessPanel(state: EspFlashFeatureRenderState): void {
-    if (!els.espFlashReadinessPanel) {
-      return;
-    }
-    const safeState = safeEspFlashState(state.status.state);
-    const rows = [
-      renderStatusGridRow(
-        escapeHtml(t("settings.esp_flash.readiness.detected_ports")),
-        escapeHtml(detectedPortsLabel(state)),
+function selectedTargetLabel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): string {
+  const selectedValue = state.selectedPortValue;
+  const raw =
+    state.status.selected_port ||
+    (selectedValue !== "__auto__" ? selectedValue : null);
+  return raw || t("settings.esp_flash.auto_detect");
+}
+
+function detectedPortsLabel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): string {
+  if (state.availablePorts.length === 0) {
+    return t("settings.esp_flash.readiness.no_ports");
+  }
+  if (state.availablePorts.length === 1) {
+    const port = state.availablePorts[0];
+    const label = port.description
+      ? `${port.port} — ${port.description}`
+      : port.port;
+    return t("settings.esp_flash.readiness.one_port", { port: label });
+  }
+  return t("settings.esp_flash.readiness.multiple_ports", {
+    count: state.availablePorts.length,
+  });
+}
+
+function readinessSummary(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): string {
+  const safeState = safeEspFlashState(state.status.state);
+  switch (safeState) {
+    case "running":
+      return t("settings.esp_flash.readiness.summary.running");
+    case "success":
+      return t("settings.esp_flash.readiness.summary.success");
+    case "failed":
+      return t("settings.esp_flash.readiness.summary.failed");
+    case "cancelled":
+      return t("settings.esp_flash.readiness.summary.cancelled");
+    default:
+      return state.availablePorts.length > 0
+        ? t("settings.esp_flash.readiness.summary.ready_ports")
+        : t("settings.esp_flash.readiness.summary.ready_no_ports");
+  }
+}
+
+function latestAttemptSummary(
+  attempt: FlashAttemptSummary,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): string {
+  const stateLabel = t(
+    `settings.esp_flash.state.${safeEspFlashState(attempt.state)}`,
+  );
+  const when = formatEpochTimestamp(attempt.finishedAt ?? attempt.startedAt);
+  return t("settings.esp_flash.last_result_value", {
+    state: stateLabel,
+    when,
+  });
+}
+
+function currentAttemptSummaries(
+  state: EspFlashFeatureRenderState,
+): FlashAttemptSummary[] {
+  if (state.attempts.length > 0) {
+    return state.attempts.map((attempt) => ({
+      autoDetect: attempt.auto_detect,
+      error: attempt.error ?? null,
+      exitCode: attempt.exit_code ?? null,
+      finishedAt: attempt.finished_at ?? null,
+      selectedPort: attempt.selected_port ?? null,
+      startedAt: attempt.started_at ?? null,
+      state: safeEspFlashState(attempt.state),
+    }));
+  }
+  const safeState = safeEspFlashState(state.status.state);
+  if (safeState === "idle" || safeState === "running") {
+    return [];
+  }
+  return [
+    {
+      autoDetect: state.status.auto_detect,
+      error: state.status.error ?? null,
+      exitCode: state.status.exit_code ?? null,
+      finishedAt: state.status.finished_at ?? null,
+      selectedPort: state.status.selected_port ?? null,
+      startedAt: state.status.started_at ?? null,
+      state: safeState,
+    },
+  ];
+}
+
+function recoverySummary(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): {
+  message: string;
+  phaseLabel: string;
+  recoveryDetail: string;
+  recoveryTitle: string;
+} | null {
+  const safeState = safeEspFlashState(state.status.state);
+  if (safeState !== "failed" && safeState !== "cancelled") {
+    return null;
+  }
+  const phase = resolvedJourneyPhase(state) ?? state.status.phase ?? "idle";
+  const keyBase =
+    safeState === "cancelled"
+      ? "settings.esp_flash.recovery.cancelled"
+      : phase === "preparing"
+        ? "settings.esp_flash.recovery.preparing"
+        : phase === "erasing"
+          ? "settings.esp_flash.recovery.erasing"
+          : phase === "flashing"
+            ? "settings.esp_flash.recovery.flashing"
+            : phase === "validating"
+              ? "settings.esp_flash.recovery.validating"
+              : "settings.esp_flash.recovery.generic";
+  return {
+    message: state.status.error || t("settings.esp_flash.recovery.fallback_error"),
+    phaseLabel: formatEspFlashPhase(t, phase),
+    recoveryDetail: t(`${keyBase}.detail`),
+    recoveryTitle: t(`${keyBase}.title`),
+  };
+}
+
+function buildActionSummary(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): {
+  canStart: boolean;
+  panelModel: MaintenanceReadinessPanelModel;
+  startLabel: string;
+} {
+  const safeState = safeEspFlashState(state.status.state);
+  const portsDetected = state.availablePorts.length > 0;
+  const selectedTarget = selectedTargetLabel(state, t);
+  const readinessItems = [
+    {
+      detail: portsDetected
+        ? t("settings.esp_flash.start_readiness.item.connection_ready", {
+            ports: detectedPortsLabel(state, t),
+          })
+        : t("settings.esp_flash.start_readiness.item.connection_blocked"),
+      label: t("settings.esp_flash.start_readiness.item.connection"),
+      state: portsDetected ? ("ready" as const) : ("blocked" as const),
+    },
+    {
+      detail: portsDetected
+        ? t("settings.esp_flash.start_readiness.item.target_ready", {
+            target: selectedTarget,
+          })
+        : t("settings.esp_flash.start_readiness.item.target_blocked"),
+      label: t("settings.esp_flash.start_readiness.item.target"),
+      state: portsDetected ? ("ready" as const) : ("blocked" as const),
+    },
+  ];
+  const recovery = recoverySummary(state, t);
+  const isRecoveryState = recovery !== null;
+  const stateLabel = isRecoveryState
+    ? portsDetected
+      ? t(`settings.esp_flash.state.${safeState}`)
+      : t("maintenance.readiness.blocked")
+    : safeState === "running"
+      ? t("maintenance.readiness.running")
+      : portsDetected
+        ? t("maintenance.readiness.ready")
+        : t("maintenance.readiness.blocked");
+  return {
+    canStart: safeState !== "running" && portsDetected,
+    panelModel: {
+      items: recovery
+        ? [
+            {
+              detail: recovery.phaseLabel,
+              label: t("settings.esp_flash.recovery.item.failed_step"),
+              state: "attention" as const,
+            },
+            {
+              detail: recovery.message,
+              label: t("settings.esp_flash.recovery.item.captured_detail"),
+              state: "attention" as const,
+            },
+            {
+              detail: portsDetected
+                ? `${recovery.recoveryTitle} — ${recovery.recoveryDetail}`
+                : t("settings.esp_flash.recovery.item.next_step_blocked"),
+              label: t("settings.esp_flash.recovery.item.next_step"),
+              state: portsDetected
+                ? ("attention" as const)
+                : ("blocked" as const),
+            },
+          ]
+        : readinessItems,
+      stateLabel,
+      stateVariant: isRecoveryState
+        ? "bad"
+        : safeState === "running"
+          ? "warn"
+          : portsDetected
+            ? "ok"
+            : "bad",
+      summary: t(
+        isRecoveryState
+          ? portsDetected
+            ? "settings.esp_flash.recovery.summary_retry"
+            : "settings.esp_flash.recovery.summary_blocked"
+          : safeState === "running"
+            ? "settings.esp_flash.start_readiness.summary_running"
+            : portsDetected
+              ? "settings.esp_flash.start_readiness.summary_ready"
+              : "settings.esp_flash.start_readiness.summary_blocked",
       ),
-      renderStatusGridRow(
-        escapeHtml(t("settings.esp_flash.readiness.selected_target")),
-        escapeHtml(selectedTargetLabel(state)),
+      title: t(
+        isRecoveryState
+          ? "settings.esp_flash.recovery.title"
+          : "settings.esp_flash.start_readiness.title",
       ),
-    ];
-    if (safeState === "running") {
-      rows.push(
-        renderStatusGridRow(
-          escapeHtml(t("settings.esp_flash.readiness.current_step")),
-          escapeHtml(formatEspFlashPhase(state.status.phase)),
-        ),
-      );
-    }
-    if (state.status.last_success_at != null) {
-      rows.push(
-        renderStatusGridRow(
-          escapeHtml(t("settings.esp_flash.readiness.last_success")),
-          escapeHtml(formatEpochTimestamp(state.status.last_success_at)),
-        ),
-      );
-    }
-    const attempts = currentAttemptSummaries(state);
-    if (attempts.length > 0) {
-      rows.push(
-        renderStatusGridRow(
-          escapeHtml(t("settings.esp_flash.readiness.last_result")),
-          escapeHtml(latestAttemptSummary(attempts[0])),
-        ),
-      );
-    }
-    const errorHtml = state.status.error
-      ? `<div class="maintenance-note maintenance-note--bad">${escapeHtml(state.status.error)}</div>`
-      : "";
-    els.espFlashReadinessPanel.innerHTML = `<div class="subtle">${escapeHtml(readinessSummary(state))}</div><div class="status-grid">${rows.join("")}</div>${errorHtml}`;
-  }
+    },
+    startLabel: t(
+      isRecoveryState ? "settings.esp_flash.retry" : "settings.esp_flash.start",
+    ),
+  };
+}
 
-  function renderJourneyPanel(state: EspFlashFeatureRenderState): void {
-    if (!els.espFlashJourneyPanel) {
-      return;
-    }
-    els.espFlashJourneyPanel.innerHTML = renderJourney(state);
+function buildReadinessPanelModel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): EspFlashReadinessPanelModel {
+  const safeState = safeEspFlashState(state.status.state);
+  const rows: EspFlashStatusGridRowModel[] = [
+    {
+      labelText: t("settings.esp_flash.readiness.detected_ports"),
+      valueText: detectedPortsLabel(state, t),
+    },
+    {
+      labelText: t("settings.esp_flash.readiness.selected_target"),
+      valueText: selectedTargetLabel(state, t),
+    },
+  ];
+  if (safeState === "running") {
+    rows.push({
+      labelText: t("settings.esp_flash.readiness.current_step"),
+      valueText: formatEspFlashPhase(t, state.status.phase),
+    });
   }
+  if (state.status.last_success_at != null) {
+    rows.push({
+      labelText: t("settings.esp_flash.readiness.last_success"),
+      valueText: formatEpochTimestamp(state.status.last_success_at),
+    });
+  }
+  const attempts = currentAttemptSummaries(state);
+  if (attempts.length > 0) {
+    rows.push({
+      labelText: t("settings.esp_flash.readiness.last_result"),
+      valueText: latestAttemptSummary(attempts[0], t),
+    });
+  }
+  return {
+    errorText: state.status.error ?? null,
+    rows,
+    summaryText: readinessSummary(state, t),
+  };
+}
 
-  function renderLogsEmptyState(status: EspFlashStatusPayload): string {
-    const safeState = safeEspFlashState(status.state);
+function buildStatusBannerModel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): EspFlashStatusBadgeModel {
+  const safeState = safeEspFlashState(state.status.state);
+  const stateLabel = t(`settings.esp_flash.state.${safeState}`);
+  return {
+    text: state.status.error ? `${stateLabel} — ${state.status.error}` : stateLabel,
+    variant: STATE_TO_VARIANT[safeState] ?? "muted",
+  };
+}
+
+function buildLogPanelModel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): EspFlashLogPanelModel {
+  if (state.status.log_count === 0 && state.logText.length === 0) {
+    const safeState = safeEspFlashState(state.status.state);
     const titleKey =
       safeState === "running"
         ? "settings.esp_flash.logs_running_title"
@@ -506,88 +485,125 @@ export function createEspFlashFeaturePresenter(
         : safeState === "failed" || safeState === "cancelled"
           ? "settings.esp_flash.logs_failed_body"
           : "settings.esp_flash.logs_idle_body";
-    return `<div class="empty-state empty-state--inline"><strong>${escapeHtml(t(titleKey))}</strong><span>${escapeHtml(t(bodyKey))}</span></div>`;
+    return {
+      emptyState: {
+        bodyText: t(bodyKey),
+        titleText: t(titleKey),
+      },
+      text: "",
+    };
   }
-
-  function renderHistoryPanel(state: EspFlashFeatureRenderState): void {
-    if (!els.espFlashHistoryPanel) {
-      return;
-    }
-    const attempts = currentAttemptSummaries(state);
-    if (!attempts.length) {
-      els.espFlashHistoryPanel.innerHTML = `<div class="empty-state empty-state--inline"><strong>${escapeHtml(t("settings.esp_flash.history_empty_title"))}</strong><span>${escapeHtml(t("settings.esp_flash.history_empty_body"))}</span></div>`;
-      return;
-    }
-    const rows = attempts.slice(0, 5).map((attempt) => {
-      const safeState = safeEspFlashState(attempt.state);
-      const stateLabel = t(`settings.esp_flash.state.${safeState}`);
-      const variant = STATE_TO_VARIANT[safeState] || "muted";
-      const port = attempt.selectedPort || t("settings.esp_flash.auto_detect");
-      const meta = [
-        attempt.finishedAt != null
-          ? t("settings.esp_flash.history_finished_at", {
-              value: formatEpochTimestamp(attempt.finishedAt),
-            })
-          : t("settings.esp_flash.history_started_at", {
-              value: formatEpochTimestamp(attempt.startedAt),
-            }),
-        attempt.autoDetect
-          ? t("settings.esp_flash.history_auto_detect_used")
-          : t("settings.esp_flash.history_manual_target_used"),
-      ];
-      if (attempt.exitCode != null) {
-        meta.push(
-          t("settings.esp_flash.history_exit_code", { code: attempt.exitCode }),
-        );
-      }
-      const errorHtml = attempt.error
-        ? `<div class="maintenance-note maintenance-note--bad">${escapeHtml(attempt.error)}</div>`
-        : "";
-      return `<li class="maintenance-attempt"><div class="maintenance-attempt__header"><span class="pill" data-variant="${variant}">${escapeHtml(stateLabel)}</span><strong>${escapeHtml(port)}</strong></div><div class="maintenance-attempt__meta subtle">${escapeHtml(meta.join(" · "))}</div>${errorHtml}</li>`;
-    });
-    els.espFlashHistoryPanel.innerHTML = `<ul class="maintenance-attempt-list">${rows.join("")}</ul>`;
-  }
-
-  function renderStatusBanner(state: EspFlashFeatureRenderState): void {
-    if (!els.espFlashStatusBanner) {
-      return;
-    }
-    const safeState = safeEspFlashState(state.status.state);
-    const stateLabel = t(`settings.esp_flash.state.${safeState}`);
-    const extra = state.status.error ? ` — ${state.status.error}` : "";
-    els.espFlashStatusBanner.textContent = `${stateLabel}${extra}`;
-    const variant = STATE_TO_VARIANT[safeState] || "muted";
-    els.espFlashStatusBanner.className = "pill";
-    setVariantState(els.espFlashStatusBanner, variant);
-  }
-
-  function renderLogPanel(state: EspFlashFeatureRenderState): void {
-    if (!els.espFlashLogPanel) {
-      return;
-    }
-    const panel = els.espFlashLogPanel;
-    if (state.status.log_count === 0 && state.logText.length === 0) {
-      panel.className = LOG_PANEL_BASE_CLASS;
-      panel.innerHTML = renderLogsEmptyState(state.status);
-      return;
-    }
-    panel.className = `${LOG_PANEL_BASE_CLASS} maintenance-log-panel`;
-    panel.textContent = state.logText;
-    panel.scrollTop = panel.scrollHeight;
-  }
-
-  function render(state: EspFlashFeatureRenderState): void {
-    renderPortOptions(state);
-    renderStatusBanner(state);
-    const actionSummary = buildActionSummary(state);
-    syncFlashControls(state, actionSummary);
-    renderReadinessPanel(state);
-    renderJourneyPanel(state);
-    renderHistoryPanel(state);
-    renderLogPanel(state);
-  }
-
   return {
-    render,
+    emptyState: null,
+    text: state.logText,
+  };
+}
+
+function buildHistoryPanelModel(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): EspFlashHistoryPanelModel {
+  const attempts = currentAttemptSummaries(state);
+  if (attempts.length === 0) {
+    return {
+      attempts: [],
+      emptyState: {
+        bodyText: t("settings.esp_flash.history_empty_body"),
+        titleText: t("settings.esp_flash.history_empty_title"),
+      },
+    };
+  }
+  const items: EspFlashHistoryAttemptModel[] = attempts.slice(0, 5).map((attempt) => {
+    const safeState = safeEspFlashState(attempt.state);
+    const portText = attempt.selectedPort || t("settings.esp_flash.auto_detect");
+    const meta = [
+      attempt.finishedAt != null
+        ? t("settings.esp_flash.history_finished_at", {
+            value: formatEpochTimestamp(attempt.finishedAt),
+          })
+        : t("settings.esp_flash.history_started_at", {
+            value: formatEpochTimestamp(attempt.startedAt),
+          }),
+      attempt.autoDetect
+        ? t("settings.esp_flash.history_auto_detect_used")
+        : t("settings.esp_flash.history_manual_target_used"),
+    ];
+    if (attempt.exitCode != null) {
+      meta.push(
+        t("settings.esp_flash.history_exit_code", { code: attempt.exitCode }),
+      );
+    }
+    return {
+      badge: {
+        text: t(`settings.esp_flash.state.${safeState}`),
+        variant: STATE_TO_VARIANT[safeState] ?? "muted",
+      },
+      errorText: attempt.error,
+      metaText: meta.join(" · "),
+      portText,
+    };
+  });
+  return {
+    attempts: items,
+    emptyState: null,
+  };
+}
+
+function buildPortOptions(
+  state: EspFlashFeatureRenderState,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): EspFlashPanelRenderModel["portOptions"] {
+  return [
+    {
+      labelText: t("settings.esp_flash.auto_detect"),
+      value: "__auto__",
+    },
+    ...state.availablePorts.map((port) => ({
+      labelText: `${port.port}${port.description ? ` — ${port.description}` : ""}`,
+      value: port.port,
+    })),
+  ];
+}
+
+export function buildEspFlashPanelRenderModel(
+  state: EspFlashFeatureRenderState,
+  deps: {
+    t: (key: string, vars?: Record<string, unknown>) => string;
+  },
+): EspFlashPanelRenderModel {
+  const actionSummary = buildActionSummary(state, deps.t);
+  const safeState = safeEspFlashState(state.status.state);
+  const running = safeState === "running";
+  return {
+    cancelButtonDisabled: !running,
+    cancelButtonHidden: !running,
+    history: buildHistoryPanelModel(state, deps.t),
+    journey: buildJourneyPanelModel(state, deps.t),
+    log: buildLogPanelModel(state, deps.t),
+    portOptions: buildPortOptions(state, deps.t),
+    portSelectDisabled: running,
+    readiness: buildReadinessPanelModel(state, deps.t),
+    refreshPortsDisabled: running,
+    selectedPortValue: state.selectedPortValue,
+    startButtonDisabled: running || !actionSummary.canStart,
+    startButtonHidden: running,
+    startButtonLabelText: actionSummary.startLabel,
+    startSummary: actionSummary.panelModel,
+    statusBanner: buildStatusBannerModel(state, deps.t),
+  };
+}
+
+export function createEspFlashFeaturePresenter(
+  ctx: EspFlashFeaturePresenterDeps,
+): EspFlashFeaturePresenter {
+  return {
+    render(state) {
+      const model = buildEspFlashPanelRenderModel(state, { t: ctx.t });
+      ctx.panel.render(model);
+      if (ctx.panel.dom.espFlashLogPanel && model.log.emptyState === null) {
+        ctx.panel.dom.espFlashLogPanel.scrollTop =
+          ctx.panel.dom.espFlashLogPanel.scrollHeight;
+      }
+    },
   };
 }

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -1,6 +1,75 @@
 import { h } from "preact";
 
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
+import type { VisualVariant } from "../style_state";
+import {
+  MaintenanceReadinessPanel,
+  type MaintenanceReadinessPanelModel,
+} from "./maintenance_readiness_view";
+
+export interface EspFlashStatusBadgeModel {
+  text: string;
+  variant: VisualVariant;
+}
+
+export interface EspFlashStatusGridRowModel {
+  labelText: string;
+  valueText: string;
+}
+
+export interface EspFlashPortOptionModel {
+  labelText: string;
+  value: string;
+}
+
+export type EspFlashJourneyStageState =
+  | "active"
+  | "attention"
+  | "done"
+  | "upcoming";
+
+export interface EspFlashJourneyStageModel {
+  current: boolean;
+  detailText: string;
+  markerText: string;
+  phase: string;
+  state: EspFlashJourneyStageState;
+  stateText: string;
+  titleText: string;
+}
+
+export interface EspFlashJourneyPanelModel {
+  stages: readonly EspFlashJourneyStageModel[];
+  terminalNoteText: string | null;
+}
+
+export interface EspFlashEmptyStateModel {
+  bodyText: string;
+  titleText: string;
+}
+
+export interface EspFlashHistoryAttemptModel {
+  badge: EspFlashStatusBadgeModel;
+  errorText: string | null;
+  metaText: string;
+  portText: string;
+}
+
+export interface EspFlashHistoryPanelModel {
+  attempts: readonly EspFlashHistoryAttemptModel[];
+  emptyState: EspFlashEmptyStateModel | null;
+}
+
+export interface EspFlashLogPanelModel {
+  emptyState: EspFlashEmptyStateModel | null;
+  text: string;
+}
+
+export interface EspFlashReadinessPanelModel {
+  errorText: string | null;
+  rows: readonly EspFlashStatusGridRowModel[];
+  summaryText: string;
+}
 
 export interface EspFlashPanelDom {
   espFlashPortSelect: HTMLSelectElement | null;
@@ -15,11 +84,220 @@ export interface EspFlashPanelDom {
   espFlashHistoryPanel: HTMLElement | null;
 }
 
-export interface EspFlashPanelView {
-  readonly dom: EspFlashPanelDom;
+export interface EspFlashPanelRenderModel {
+  cancelButtonDisabled: boolean;
+  cancelButtonHidden: boolean;
+  history: EspFlashHistoryPanelModel;
+  journey: EspFlashJourneyPanelModel;
+  log: EspFlashLogPanelModel;
+  portOptions: readonly EspFlashPortOptionModel[];
+  portSelectDisabled: boolean;
+  readiness: EspFlashReadinessPanelModel;
+  refreshPortsDisabled: boolean;
+  selectedPortValue: string;
+  startButtonDisabled: boolean;
+  startButtonHidden: boolean;
+  startButtonLabelText: string;
+  startSummary: MaintenanceReadinessPanelModel;
+  statusBanner: EspFlashStatusBadgeModel;
 }
 
-function EspFlashPanel() {
+export interface EspFlashPanelView {
+  readonly dom: EspFlashPanelDom;
+  render(model: EspFlashPanelRenderModel): void;
+}
+
+type EspFlashPanelBridgeState = {
+  model: EspFlashPanelRenderModel;
+};
+
+const DEFAULT_ESP_FLASH_PANEL_MODEL: EspFlashPanelRenderModel = {
+  cancelButtonDisabled: true,
+  cancelButtonHidden: true,
+  history: {
+    attempts: [],
+    emptyState: null,
+  },
+  journey: {
+    stages: [],
+    terminalNoteText: null,
+  },
+  log: {
+    emptyState: null,
+    text: "",
+  },
+  portOptions: [
+    {
+      labelText: "Auto-detect",
+      value: "__auto__",
+    },
+  ],
+  portSelectDisabled: false,
+  readiness: {
+    errorText: null,
+    rows: [],
+    summaryText: "",
+  },
+  refreshPortsDisabled: false,
+  selectedPortValue: "__auto__",
+  startButtonDisabled: true,
+  startButtonHidden: false,
+  startButtonLabelText: "Flash latest",
+  startSummary: {
+    items: [],
+    stateLabel: "",
+    stateVariant: "muted",
+    summary: "",
+    title: "",
+  },
+  statusBanner: {
+    text: "Idle",
+    variant: "muted",
+  },
+};
+
+function StatusBadge(props: {
+  badge: EspFlashStatusBadgeModel;
+}) {
+  const { badge } = props;
+  return (
+    <span class="pill" data-variant={badge.variant}>
+      {badge.text}
+    </span>
+  );
+}
+
+function StatusGrid(props: {
+  rows: readonly EspFlashStatusGridRowModel[];
+}) {
+  const { rows } = props;
+  return (
+    <div class="status-grid">
+      {rows.map((row) => (
+        <div class="status-grid__row" key={`${row.labelText}:${row.valueText}`}>
+          <span class="status-grid__label">{row.labelText}</span>
+          <span>{row.valueText}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MaintenanceNote(props: {
+  text: string;
+  variant?: "bad";
+}) {
+  const className = props.variant
+    ? `maintenance-note maintenance-note--${props.variant}`
+    : "maintenance-note";
+  return <div class={className}>{props.text}</div>;
+}
+
+function InlineEmptyState(props: {
+  model: EspFlashEmptyStateModel;
+}) {
+  const { model } = props;
+  return (
+    <div class="empty-state empty-state--inline">
+      <strong class="empty-state__title">{model.titleText}</strong>
+      <span class="empty-state__body">{model.bodyText}</span>
+    </div>
+  );
+}
+
+function EspFlashReadinessSection(props: {
+  model: EspFlashReadinessPanelModel;
+}) {
+  const { model } = props;
+  return (
+    <div class="maintenance-stack maintenance-stack--tight">
+      <div class="subtle">{model.summaryText}</div>
+      {model.rows.length > 0 ? <StatusGrid rows={model.rows} /> : null}
+      {model.errorText ? (
+        <MaintenanceNote text={model.errorText} variant="bad" />
+      ) : null}
+    </div>
+  );
+}
+
+function JourneyStageItem(props: {
+  stage: EspFlashJourneyStageModel;
+}) {
+  const { stage } = props;
+  return (
+    <li
+      class="maintenance-stage"
+      data-stage-phase={stage.phase}
+      data-stage-state={stage.state}
+      aria-current={stage.current ? "step" : undefined}
+    >
+      <span class="maintenance-stage__marker">{stage.markerText}</span>
+      <div class="maintenance-stage__body">
+        <div class="maintenance-stage__title">{stage.titleText}</div>
+        <div class="maintenance-stage__detail">{stage.detailText}</div>
+      </div>
+      <span class="maintenance-stage__state">{stage.stateText}</span>
+    </li>
+  );
+}
+
+function EspFlashJourneySection(props: {
+  model: EspFlashJourneyPanelModel;
+}) {
+  const { model } = props;
+  return (
+    <div class="maintenance-journey">
+      {model.terminalNoteText ? (
+        <MaintenanceNote text={model.terminalNoteText} variant="bad" />
+      ) : null}
+      <ol class="maintenance-stage-list">
+        {model.stages.map((stage) => (
+          <JourneyStageItem key={stage.phase} stage={stage} />
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function EspFlashLogContent(props: {
+  model: EspFlashLogPanelModel;
+}) {
+  const { model } = props;
+  if (model.emptyState) {
+    return <InlineEmptyState model={model.emptyState} />;
+  }
+  return <pre class="log-pre">{model.text}</pre>;
+}
+
+function EspFlashHistoryContent(props: {
+  model: EspFlashHistoryPanelModel;
+}) {
+  const { model } = props;
+  if (model.emptyState) {
+    return <InlineEmptyState model={model.emptyState} />;
+  }
+  return (
+    <ul class="maintenance-attempt-list">
+      {model.attempts.map((attempt, index) => (
+        <li class="maintenance-attempt" key={`${attempt.portText}:${index}`}>
+          <div class="maintenance-attempt__header">
+            <StatusBadge badge={attempt.badge} />
+            <strong>{attempt.portText}</strong>
+          </div>
+          <div class="maintenance-attempt__meta subtle">{attempt.metaText}</div>
+          {attempt.errorText ? (
+            <MaintenanceNote text={attempt.errorText} variant="bad" />
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EspFlashPanel(props: {
+  model: EspFlashPanelRenderModel;
+}) {
+  const { model } = props;
   return (
     <div class="panel card">
       <div class="maintenance-layout maintenance-layout--compact">
@@ -42,10 +320,10 @@ function EspFlashPanel() {
               </div>
               <span
                 id="espFlashStatusBanner"
-                class="pill pill--muted"
-                data-i18n="settings.esp_flash.state.idle"
+                class="pill"
+                data-variant={model.statusBanner.variant}
               >
-                Idle
+                {model.statusBanner.text}
               </span>
             </div>
             <div class="maintenance-card__body maintenance-card__body--hero">
@@ -56,19 +334,23 @@ function EspFlashPanel() {
                 >
                   Serial Port
                 </label>
-                <select id="espFlashPortSelect">
-                  <option
-                    value="__auto__"
-                    data-i18n="settings.esp_flash.auto_detect"
-                  >
-                    Auto-detect
-                  </option>
+                <select
+                  id="espFlashPortSelect"
+                  disabled={model.portSelectDisabled}
+                  value={model.selectedPortValue}
+                >
+                  {model.portOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.labelText}
+                    </option>
+                  ))}
                 </select>
                 <button
                   type="button"
                   id="espFlashRefreshPortsBtn"
                   class="btn btn--muted"
                   data-i18n="settings.esp_flash.refresh_ports"
+                  disabled={model.refreshPortsDisabled}
                 >
                   Refresh
                 </button>
@@ -77,12 +359,16 @@ function EspFlashPanel() {
                 id="espFlashStartSummary"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
-              ></div>
+              >
+                <MaintenanceReadinessPanel model={model.startSummary} />
+              </div>
               <div
                 id="espFlashReadinessPanel"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
-              ></div>
+              >
+                <EspFlashReadinessSection model={model.readiness} />
+              </div>
               <details class="settings-help-disclosure settings-help-disclosure--inline">
                 <summary class="settings-help-disclosure__summary">
                   <span class="settings-help-disclosure__heading">
@@ -116,17 +402,18 @@ function EspFlashPanel() {
                   type="button"
                   id="espFlashStartBtn"
                   class="btn btn--success"
-                  data-i18n="settings.esp_flash.start"
+                  hidden={model.startButtonHidden}
+                  disabled={model.startButtonDisabled}
                 >
-                  Flash latest
+                  {model.startButtonLabelText}
                 </button>
                 <button
                   type="button"
                   id="espFlashCancelBtn"
                   class="btn btn--danger"
                   data-i18n="settings.esp_flash.cancel"
-                  hidden
-                  disabled
+                  hidden={model.cancelButtonHidden}
+                  disabled={model.cancelButtonDisabled}
                 >
                   Cancel
                 </button>
@@ -150,7 +437,9 @@ function EspFlashPanel() {
                 id="espFlashJourneyPanel"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
-              ></div>
+              >
+                <EspFlashJourneySection model={model.journey} />
+              </div>
             </section>
             <section class="maintenance-card">
               <div class="maintenance-card__header">
@@ -172,9 +461,15 @@ function EspFlashPanel() {
               </div>
               <div
                 id="espFlashLogPanel"
-                class="maintenance-log-slot"
+                class={
+                  model.log.emptyState
+                    ? "maintenance-log-slot"
+                    : "maintenance-log-slot maintenance-log-panel"
+                }
                 aria-live="polite"
-              ></div>
+              >
+                <EspFlashLogContent model={model.log} />
+              </div>
             </section>
           </div>
 
@@ -199,7 +494,9 @@ function EspFlashPanel() {
             <div
               id="espFlashHistoryPanel"
               class="maintenance-stack maintenance-stack--tight"
-            ></div>
+            >
+              <EspFlashHistoryContent model={model.history} />
+            </div>
           </section>
         </div>
       </div>
@@ -238,8 +535,22 @@ function createEspFlashPanelDom(host: HTMLElement): EspFlashPanelDom {
 }
 
 export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
-  createUiPreactMount(host).render(<EspFlashPanel />);
+  const bridgeState: EspFlashPanelBridgeState = {
+    model: DEFAULT_ESP_FLASH_PANEL_MODEL,
+  };
+  const mount = createUiPreactMount(host);
+
+  function render(): void {
+    mount.render(<EspFlashPanel model={bridgeState.model} />);
+  }
+
+  render();
+
   return {
     dom: createEspFlashPanelDom(host),
+    render(model) {
+      bridgeState.model = model;
+      render();
+    },
   };
 }

--- a/apps/ui/src/app/views/maintenance_readiness_view.ts
+++ b/apps/ui/src/app/views/maintenance_readiness_view.ts
@@ -1,3 +1,5 @@
+import { h } from "preact";
+
 export type MaintenanceReadinessItemState = "attention" | "blocked" | "ready";
 
 export interface MaintenanceReadinessItem {
@@ -14,33 +16,67 @@ export interface MaintenanceReadinessPanelModel {
   items: readonly MaintenanceReadinessItem[];
 }
 
-function renderItem(
-  item: MaintenanceReadinessItem,
-  escapeHtml: (value: unknown) => string,
-): string {
-  const marker = item.state === "ready" ? "✓" : "!";
-  return `<li class="maintenance-readiness__item" data-readiness-state="${item.state}">
-    <span class="maintenance-readiness__marker" aria-hidden="true">${marker}</span>
-    <div class="maintenance-readiness__body">
-      <div class="maintenance-readiness__label">${escapeHtml(item.label)}</div>
-      <div class="maintenance-readiness__detail">${escapeHtml(item.detail)}</div>
-    </div>
-  </li>`;
+function MaintenanceReadinessItemRow(props: {
+  item: MaintenanceReadinessItem;
+}) {
+  const { item } = props;
+  const marker = item.state === "ready" ? "\u2713" : "!";
+  return h(
+    "li",
+    {
+      class: "maintenance-readiness__item",
+      "data-readiness-state": item.state,
+    },
+    h(
+      "span",
+      {
+        "aria-hidden": "true",
+        class: "maintenance-readiness__marker",
+      },
+      marker,
+    ),
+    h(
+      "div",
+      { class: "maintenance-readiness__body" },
+      h("div", { class: "maintenance-readiness__label" }, item.label),
+      h("div", { class: "maintenance-readiness__detail" }, item.detail),
+    ),
+  );
 }
 
-export function renderMaintenanceReadinessPanel(
-  model: MaintenanceReadinessPanelModel,
-  escapeHtml: (value: unknown) => string,
-): string {
-  const items = model.items.map((item) => renderItem(item, escapeHtml)).join("");
-  return `<section class="maintenance-readiness">
-    <div class="maintenance-readiness__header">
-      <div class="maintenance-readiness__heading">
-        <div class="maintenance-readiness__title">${escapeHtml(model.title)}</div>
-        <div class="maintenance-readiness__summary">${escapeHtml(model.summary)}</div>
-      </div>
-      <span class="pill" data-variant="${model.stateVariant}">${escapeHtml(model.stateLabel)}</span>
-    </div>
-    <ul class="maintenance-readiness__list">${items}</ul>
-  </section>`;
+export function MaintenanceReadinessPanel(props: {
+  model: MaintenanceReadinessPanelModel;
+}) {
+  const { model } = props;
+  return h(
+    "section",
+    { class: "maintenance-readiness" },
+    h(
+      "div",
+      { class: "maintenance-readiness__header" },
+      h(
+        "div",
+        { class: "maintenance-readiness__heading" },
+        h("div", { class: "maintenance-readiness__title" }, model.title),
+        h("div", { class: "maintenance-readiness__summary" }, model.summary),
+      ),
+      model.stateLabel
+        ? h(
+            "span",
+            { class: "pill", "data-variant": model.stateVariant },
+            model.stateLabel,
+          )
+        : null,
+    ),
+    h(
+      "ul",
+      { class: "maintenance-readiness__list" },
+      model.items.map((item, index) =>
+        h(MaintenanceReadinessItemRow, {
+          item,
+          key: `${item.label}:${index}`,
+        }),
+      ),
+    ),
+  );
 }

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -2,7 +2,10 @@ import { expect, test } from "@playwright/test";
 
 import { createEspFlashFeature } from "../src/app/features/esp_flash_feature";
 import { createUpdateFeature } from "../src/app/features/update_feature";
-import type { EspFlashPanelDom } from "../src/app/views/esp_flash_panel";
+import type {
+  EspFlashPanelDom,
+  EspFlashPanelRenderModel,
+} from "../src/app/views/esp_flash_panel";
 import type {
   InternetPanelDom,
   InternetPanelRenderModel,
@@ -418,6 +421,94 @@ function renderInternetPanelDom(
   }
 }
 
+function serializeEspFlashReadinessPanel(
+  model: EspFlashPanelRenderModel["readiness"],
+): string {
+  return `<div class="maintenance-stack maintenance-stack--tight"><div class="subtle">${model.summaryText}</div>${model.rows.length > 0 ? serializeStatusGrid(model.rows) : ""}${model.errorText ? `<div class="maintenance-note maintenance-note--bad">${model.errorText}</div>` : ""}</div>`;
+}
+
+function serializeEspFlashJourney(
+  model: EspFlashPanelRenderModel["journey"],
+): string {
+  const noteHtml = model.terminalNoteText
+    ? `<div class="maintenance-note maintenance-note--bad">${model.terminalNoteText}</div>`
+    : "";
+  const stagesHtml = model.stages.map((stage) => `<li class="maintenance-stage" data-stage-phase="${stage.phase}" data-stage-state="${stage.state}"${stage.current ? ' aria-current="step"' : ""}><span class="maintenance-stage__marker">${stage.markerText}</span><div class="maintenance-stage__body"><div class="maintenance-stage__title">${stage.titleText}</div><div class="maintenance-stage__detail">${stage.detailText}</div></div><span class="maintenance-stage__state">${stage.stateText}</span></li>`).join("");
+  return `<div class="maintenance-journey">${noteHtml}<ol class="maintenance-stage-list">${stagesHtml}</ol></div>`;
+}
+
+function serializeInlineEmptyState(model: {
+  bodyText: string;
+  titleText: string;
+}): string {
+  return `<div class="empty-state empty-state--inline"><strong class="empty-state__title">${model.titleText}</strong><span class="empty-state__body">${model.bodyText}</span></div>`;
+}
+
+function serializeEspFlashLog(
+  model: EspFlashPanelRenderModel["log"],
+): string {
+  return model.emptyState
+    ? serializeInlineEmptyState(model.emptyState)
+    : `<pre class="log-pre">${model.text}</pre>`;
+}
+
+function serializeEspFlashHistory(
+  model: EspFlashPanelRenderModel["history"],
+): string {
+  if (model.emptyState) {
+    return serializeInlineEmptyState(model.emptyState);
+  }
+  return `<ul class="maintenance-attempt-list">${model.attempts.map((attempt) => `<li class="maintenance-attempt"><div class="maintenance-attempt__header"><span class="pill" data-variant="${attempt.badge.variant}">${attempt.badge.text}</span><strong>${attempt.portText}</strong></div><div class="maintenance-attempt__meta subtle">${attempt.metaText}</div>${attempt.errorText ? `<div class="maintenance-note maintenance-note--bad">${attempt.errorText}</div>` : ""}</li>`).join("")}</ul>`;
+}
+
+function renderEspFlashPanelDom(
+  dom: EspFlashPanelDom,
+  model: EspFlashPanelRenderModel,
+): void {
+  if (dom.espFlashPortSelect) {
+    dom.espFlashPortSelect.innerHTML = model.portOptions.map((option) => `<option value="${option.value}">${option.labelText}</option>`).join("");
+    dom.espFlashPortSelect.value = model.selectedPortValue;
+    dom.espFlashPortSelect.disabled = model.portSelectDisabled;
+  }
+  if (dom.espFlashRefreshPortsBtn) {
+    dom.espFlashRefreshPortsBtn.disabled = model.refreshPortsDisabled;
+  }
+  dom.espFlashStartBtn.textContent = model.startButtonLabelText;
+  dom.espFlashStartBtn.disabled = model.startButtonDisabled;
+  dom.espFlashStartBtn.hidden = model.startButtonHidden;
+  if (dom.espFlashCancelBtn) {
+    dom.espFlashCancelBtn.disabled = model.cancelButtonDisabled;
+    dom.espFlashCancelBtn.hidden = model.cancelButtonHidden;
+  }
+  if (dom.espFlashStartSummary) {
+    dom.espFlashStartSummary.innerHTML = serializeReadinessPanel(model.startSummary);
+  }
+  if (dom.espFlashStatusBanner) {
+    dom.espFlashStatusBanner.className = "pill";
+    setOptionalAttribute(
+      dom.espFlashStatusBanner,
+      "data-variant",
+      model.statusBanner.variant,
+    );
+    dom.espFlashStatusBanner.textContent = model.statusBanner.text;
+  }
+  if (dom.espFlashReadinessPanel) {
+    dom.espFlashReadinessPanel.innerHTML = serializeEspFlashReadinessPanel(model.readiness);
+  }
+  if (dom.espFlashJourneyPanel) {
+    dom.espFlashJourneyPanel.innerHTML = serializeEspFlashJourney(model.journey);
+  }
+  if (dom.espFlashLogPanel) {
+    dom.espFlashLogPanel.className = model.log.emptyState
+      ? "maintenance-log-slot"
+      : "maintenance-log-slot maintenance-log-panel";
+    dom.espFlashLogPanel.innerHTML = serializeEspFlashLog(model.log);
+  }
+  if (dom.espFlashHistoryPanel) {
+    dom.espFlashHistoryPanel.innerHTML = serializeEspFlashHistory(model.history);
+  }
+}
+
 function createDeps() {
   const espFlashPortSelect = createSelect("__auto__");
   const espFlashRefreshPortsBtn = createButton();
@@ -450,6 +541,9 @@ function createDeps() {
   return {
     panel: {
       dom,
+      render(model: EspFlashPanelRenderModel) {
+        renderEspFlashPanelDom(dom, model);
+      },
     },
     els: dom,
     espFlashStartBtn,
@@ -975,6 +1069,67 @@ test.describe("createEspFlashFeature polling", () => {
     } finally {
       restoreFetch();
       timers.restore();
+    }
+  });
+
+  test("manual port selection is reflected in the flash start payload", async () => {
+    let startBody: Record<string, unknown> | null = null;
+    const restoreFetch = installFetchMock(async (url, method, body) => {
+      if (url.pathname === "/api/esp-flash/ports") {
+        return jsonResponse({
+          ports: [
+            {
+              port: "/dev/ttyUSB0",
+              description: "USB UART",
+              vid: 1,
+              pid: 2,
+              serial_number: "abc",
+            },
+            {
+              port: "/dev/ttyUSB1",
+              description: "ESP32 Bootloader",
+              vid: 3,
+              pid: 4,
+              serial_number: "def",
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/api/esp-flash/start" && method === "POST") {
+        startBody = JSON.parse(body) as Record<string, unknown>;
+        return jsonResponse({ status: "started", job_id: 1 });
+      }
+      if (url.pathname === "/api/esp-flash/status") {
+        return jsonResponse({ state: "idle", log_count: 0, error: null });
+      }
+      if (url.pathname === "/api/esp-flash/logs") {
+        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
+      }
+      if (url.pathname === "/api/esp-flash/history") {
+        return jsonResponse({ attempts: [] });
+      }
+      return jsonResponse({});
+    });
+
+    try {
+      const deps = createDeps();
+      const feature = createEspFlashFeature(deps);
+
+      feature.bindHandlers();
+      feature.startPolling();
+      await flushAsyncWork();
+
+      deps.els.espFlashPortSelect.value = "/dev/ttyUSB1";
+      deps.els.espFlashPortSelect.dispatchEvent(new Event("change"));
+      deps.espFlashStartBtn.click();
+      await flushAsyncWork();
+
+      expect(startBody).toEqual({
+        auto_detect: false,
+        port: "/dev/ttyUSB1",
+      });
+    } finally {
+      restoreFetch();
     }
   });
 

--- a/apps/ui/tests/esp_flash_feature_presenter.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_presenter.spec.ts
@@ -1,0 +1,224 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  buildEspFlashPanelRenderModel,
+  type EspFlashFeatureRenderState,
+} from "../src/app/views/esp_flash_feature_presenter";
+import type {
+  EspFlashHistoryAttemptPayload,
+  EspFlashStatusPayload,
+  EspSerialPortPayload,
+} from "../src/transport/http_models";
+
+function makeStatus(
+  overrides: Partial<EspFlashStatusPayload> = {},
+): EspFlashStatusPayload {
+  return {
+    auto_detect: true,
+    error: null,
+    exit_code: null,
+    finished_at: null,
+    job_id: 1,
+    last_success_at: null,
+    log_count: 0,
+    phase: "idle",
+    selected_port: null,
+    started_at: null,
+    state: "idle",
+    ...overrides,
+  };
+}
+
+function makeAttempt(
+  overrides: Partial<EspFlashHistoryAttemptPayload> = {},
+): EspFlashHistoryAttemptPayload {
+  return {
+    auto_detect: false,
+    error: null,
+    exit_code: 0,
+    finished_at: 2,
+    job_id: 1,
+    selected_port: "/dev/ttyUSB0",
+    started_at: 1,
+    state: "success",
+    ...overrides,
+  };
+}
+
+function makePort(
+  overrides: Partial<EspSerialPortPayload> = {},
+): EspSerialPortPayload {
+  return {
+    description: "USB UART",
+    pid: 2,
+    port: "/dev/ttyUSB0",
+    serial_number: "abc",
+    vid: 1,
+    ...overrides,
+  };
+}
+
+function makeState(
+  overrides: Partial<EspFlashFeatureRenderState> = {},
+): EspFlashFeatureRenderState {
+  return {
+    attempts: [],
+    availablePorts: [],
+    lastJourneyPhase: null,
+    logText: "",
+    selectedPortValue: "__auto__",
+    status: makeStatus(),
+    ...overrides,
+  };
+}
+
+test.describe("buildEspFlashPanelRenderModel", () => {
+  test("builds ready idle models with rendered port options and empty states", () => {
+    const model = buildEspFlashPanelRenderModel(
+      makeState({
+        availablePorts: [makePort()],
+      }),
+      { t: (key) => key },
+    );
+
+    expect(model.portOptions).toEqual([
+      { labelText: "settings.esp_flash.auto_detect", value: "__auto__" },
+      {
+        labelText: "/dev/ttyUSB0 — USB UART",
+        value: "/dev/ttyUSB0",
+      },
+    ]);
+    expect(model.startButtonDisabled).toBe(false);
+    expect(model.startSummary.summary).toBe(
+      "settings.esp_flash.start_readiness.summary_ready",
+    );
+    expect(model.startSummary.items[0]).toMatchObject({
+      detail: "settings.esp_flash.start_readiness.item.connection_ready",
+      state: "ready",
+    });
+    expect(model.readiness.summaryText).toBe(
+      "settings.esp_flash.readiness.summary.ready_ports",
+    );
+    expect(model.history.emptyState?.titleText).toBe(
+      "settings.esp_flash.history_empty_title",
+    );
+    expect(model.log.emptyState?.titleText).toBe(
+      "settings.esp_flash.logs_idle_title",
+    );
+    expect(model.statusBanner).toEqual({
+      text: "settings.esp_flash.state.idle",
+      variant: "muted",
+    });
+  });
+
+  test("builds running models with disabled controls and an active journey stage", () => {
+    const model = buildEspFlashPanelRenderModel(
+      makeState({
+        availablePorts: [makePort()],
+        selectedPortValue: "/dev/ttyUSB0",
+        status: makeStatus({
+          auto_detect: false,
+          phase: "flashing",
+          selected_port: "/dev/ttyUSB0",
+          state: "running",
+        }),
+      }),
+      { t: (key) => key },
+    );
+
+    expect(model.startButtonHidden).toBe(true);
+    expect(model.cancelButtonHidden).toBe(false);
+    expect(model.portSelectDisabled).toBe(true);
+    expect(model.refreshPortsDisabled).toBe(true);
+    expect(model.readiness.rows).toContainEqual({
+      labelText: "settings.esp_flash.readiness.current_step",
+      valueText: "flashing",
+    });
+    expect(
+      model.journey.stages.find((stage) => stage.phase === "flashing"),
+    ).toMatchObject({
+      current: true,
+      state: "active",
+    });
+    expect(
+      model.journey.stages.filter((stage) => stage.state === "done"),
+    ).toHaveLength(3);
+    expect(model.log.emptyState?.titleText).toBe(
+      "settings.esp_flash.logs_running_title",
+    );
+  });
+
+  test("builds failed recovery models with fallback history and failed log state", () => {
+    const model = buildEspFlashPanelRenderModel(
+      makeState({
+        availablePorts: [makePort()],
+        lastJourneyPhase: "flashing",
+        selectedPortValue: "/dev/ttyUSB0",
+        status: makeStatus({
+          auto_detect: false,
+          error: "serial port disconnected",
+          exit_code: 2,
+          finished_at: 2,
+          phase: "failed",
+          selected_port: "/dev/ttyUSB0",
+          started_at: 1,
+          state: "failed",
+        }),
+      }),
+      { t: (key) => key },
+    );
+
+    expect(model.startButtonLabelText).toBe("settings.esp_flash.retry");
+    expect(model.startSummary.title).toBe("settings.esp_flash.recovery.title");
+    expect(model.startSummary.items).toContainEqual({
+      detail: "flashing",
+      label: "settings.esp_flash.recovery.item.failed_step",
+      state: "attention",
+    });
+    expect(model.readiness.errorText).toBe("serial port disconnected");
+    expect(model.journey.terminalNoteText).toBe(
+      "settings.esp_flash.journey_terminal.failed",
+    );
+    expect(
+      model.journey.stages.find((stage) => stage.phase === "flashing"),
+    ).toMatchObject({
+      current: false,
+      state: "attention",
+    });
+    expect(model.log.emptyState?.titleText).toBe(
+      "settings.esp_flash.logs_failed_title",
+    );
+    expect(model.history.emptyState).toBeNull();
+    expect(model.history.attempts[0]).toMatchObject({
+      errorText: "serial port disconnected",
+      portText: "/dev/ttyUSB0",
+    });
+  });
+
+  test("prefers API history entries over fallback attempt synthesis", () => {
+    const model = buildEspFlashPanelRenderModel(
+      makeState({
+        attempts: [
+          makeAttempt({
+            error: "upload failed",
+            selected_port: "/dev/ttyUSB1",
+            state: "failed",
+          }),
+        ],
+        availablePorts: [makePort()],
+        status: makeStatus({
+          error: "ignored status error",
+          selected_port: "/dev/ttyUSB0",
+          state: "failed",
+        }),
+      }),
+      { t: (key) => key },
+    );
+
+    expect(model.history.attempts).toHaveLength(1);
+    expect(model.history.attempts[0]).toMatchObject({
+      errorText: "upload failed",
+      portText: "/dev/ttyUSB1",
+    });
+  });
+});

--- a/apps/ui/tests/smoke.esp-flash.spec.ts
+++ b/apps/ui/tests/smoke.esp-flash.spec.ts
@@ -42,6 +42,13 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({ pa
   await page.goto("/");
   await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="espFlashTab"]').click();
+  await expect(page.locator("#espFlashPortSelect option")).toHaveCount(2);
+  await expect(page.locator("#espFlashPortSelect option").first()).toHaveText(
+    "Auto-detect",
+  );
+  await expect(page.locator("#espFlashPortSelect option").nth(1)).toHaveText(
+    "/dev/ttyUSB0 — USB UART",
+  );
   await expect(page.locator("#espFlashStartBtn")).toBeEnabled();
   await expect(page.locator("#espFlashCancelBtn")).toBeHidden();
   await expect(page.locator("#espFlashStartSummary")).toContainText(


### PR DESCRIPTION
## Summary

This PR completes the remaining ESP flash Preact migration by moving the flash
settings surface out of imperative DOM/string rendering and into the existing
ESP flash island. The shell for this feature already existed in Preact, but the
real UI still depended on `esp_flash_feature_presenter.ts` writing large HTML
fragments for the start-readiness summary, current-readiness grid, journey
stages, attempt history, empty log states, status badge text, and serial-port
option elements.

The change here mirrors the update/internet migration pattern from the previous
issue. `esp_flash_panel.tsx` is now the render owner for the full ESP flash
surface, while `esp_flash_feature_presenter.ts` is reduced to deriving typed
render models from workflow state. The workflow/controller split in
`esp_flash_feature_workflow.ts` remains intact, and the explicit DOM bindings in
`esp_flash_feature_bindings.ts` still own user interaction wiring for start,
cancel, refresh, and port selection.

## Problem being solved

Before this PR, the ESP flash presenter mixed two responsibilities:

1. interpreting workflow state, and
2. constructing feature HTML with `innerHTML`, string builders, and direct DOM
   mutation.

That left a number of migration problems in place:

- the port selector options were still built as HTML strings instead of JSX;
- the journey and history cards still depended on handcrafted markup;
- readiness and recovery summaries still came from imperative DOM rendering;
- empty log states still depended on presenter-owned HTML fragments; and
- button, banner, and control state lived partly in DOM mutation instead of in a
  typed panel contract.

## Implementation approach

The approach in this PR was to keep the existing workflow logic and interaction
bindings unchanged, and only replace the rendering seam. That keeps the change
reviewable while still finishing the feature-level migration.

Concretely:

- `esp_flash_panel.tsx` now exposes a typed `render(model)` bridge and renders
  the serial-port options, status banner, readiness card, current-readiness
  section, journey stages, log panel, and history panel in JSX.
- `esp_flash_feature_presenter.ts` now builds render models for those sections
  from `EspFlashFeatureRenderState` instead of writing `innerHTML`.
- `esp_flash_feature.ts` now passes the full panel bridge into the presenter,
  while the workflow still produces the same render state and polling behavior.

I kept one tiny imperative behavior: log autoscroll after render. That is still
appropriate as a post-render effect on the island DOM node and does not re-open
the old string-render path.

## Main code changes by area

### 1. ESP flash panel bridge

`app/views/esp_flash_panel.tsx` is the main feature change. It previously
mounted mostly static markup with empty host containers that the presenter later
filled imperatively. It now defines render-model types for:

- status badges,
- status-grid rows,
- port options,
- journey stages,
- readiness state,
- log state, and
- history attempts.

The panel now renders those models directly through JSX and preserves the
existing IDs used by the rest of the feature, so the explicit binding layer did
not need to change. The start/cancel button visibility, disabled state, and
labeling now come from the model rather than the presenter mutating the
elements after the fact.

### 2. Presenter simplification

`app/views/esp_flash_feature_presenter.ts` was rewritten around model-building.
It still contains the feature rules for:

- safe status normalization,
- journey stage resolution,
- readiness summary derivation,
- recovery-mode messaging,
- fallback history synthesis when the API has no explicit attempt entries, and
- button/banner state selection.

What changed is the output: instead of building HTML strings for each section,
the presenter now emits typed objects consumed by the panel. That keeps the
business/UI interpretation in one place without leaving rendering ownership in
imperative string builders.

### 3. Shared readiness contract and dead helper cleanup

Because the ESP flash hero card still used the shared readiness contract, I
updated `app/views/maintenance_readiness_view.ts` to export a Preact readiness
component alongside the shared model types. That lets the ESP flash island
reuse the same readiness structure without keeping the previous string-render
helper alive for this feature.

With the presenter string path removed, the old `renderStatusGridRow` helper in
`app/views/dom_helpers.ts` became dead and was removed. I left broader
cross-feature DOM-helper cleanup for the later final cleanup issue instead of
expanding scope here.

### 4. Feature wiring, docs, and tests

`app/features/esp_flash_feature.ts` only needed a small wiring change so the
presenter receives the full panel view instead of raw DOM references.

`apps/ui/README.md` was updated so the architecture notes match the new
ownership split: the panel owns the render bridge, and the presenter derives
panel models rather than rendering strings directly.

Test updates were focused on preserving behavior:

- new `tests/esp_flash_feature_presenter.spec.ts` covers idle, running, and
  failed/recovery model derivation, history fallback behavior, empty-log state
  handling, and port-option rendering;
- `tests/esp_flash_feature.spec.ts` now drives the ESP flash fake panel through
  `panel.render(model)` and adds a regression that verifies manual port
  selection flows into the `/api/esp-flash/start` payload; and
- `tests/smoke.esp-flash.spec.ts` adds a browser assertion for rendered port
  options while keeping the existing lifecycle/journey/log/history checks.

## Validation

I ran the issue-scoped frontend validation called out in the issue and the
relevant focused tests for the changed seam:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/esp_flash_feature_presenter.spec.ts tests/esp_flash_feature.spec.ts tests/esp_flash_feature_workflow.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.esp-flash.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

## Risks, tradeoffs, and edge cases

The main tradeoff here is that I intentionally kept the workflow and bindings
unchanged and limited the migration to the rendering seam. That avoids a larger
controller refactor in the middle of the backlog while still satisfying the
issue definition of done.

I also left the log autoscroll as a post-render DOM effect. That is a deliberate
small exception because it is tied to scroll position, not to declarative UI
structure. The rest of the feature’s visible state is now model-driven.

Edge cases explicitly preserved in the model layer include:

- no detected serial ports blocking the start action;
- running jobs disabling port/refresh controls and surfacing the active stage;
- failed/cancelled states retaining the last meaningful journey phase for
  recovery messaging;
- fallback attempt history when the API has not yet persisted an explicit
  history row; and
- empty log messaging that changes between idle, running, and failed states.

## Follow-up / out of scope

This PR does not attempt the broader final cleanup for all remaining generic DOM
helpers. That still belongs in the final Preact cleanup issue after the
remaining shell/spectrum follow-ups land.

Closes #2288