### PR TITLE
feat(ui): add signals state contract

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -7,6 +7,7 @@ server over HTTP (REST) and WebSocket (live data).
 ## Tech Stack
 
 - **TypeScript** — application logic
+- **Preact + @preact/signals** — UI rendering plus shared reactive state
 - **Vite** — build tool and dev server
 - **uPlot** — high-performance spectrum charts
 - **Playwright** — visual regression testing
@@ -86,6 +87,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/start_ui_app.ts` | CSS-aware startup entry that mounts the Preact shell/page/settings islands, then constructs and starts the app runtime |
 | `app/dom/` | Island-host lookup modules plus focused runtime DOM locators such as the spectrum chart surface |
 | `app/ui_app_runtime.ts` | UI composition root that wires state, feature-scoped DOM locators, focused runtime controllers, and explicit feature port bundles |
+| `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_preact_mount.ts` | Canonical helper for mounting and disposing incremental Preact islands inside existing DOM hosts |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, and app-level error banner plus the typed shell chrome bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, connection pill/banner, and other chrome state |
@@ -183,8 +185,10 @@ panel islands own their local chrome plus typed bridges. The remaining
 imperative paths are deliberate runtime integrations rather than alternate UI
 renderers: the shell controller still owns app-level status/preference state,
 the spectrum controller still owns the uPlot/canvas lifecycle through
-island-owned chart refs, and a few feature-local presenters still materialize
-typed wizard or status models behind island-owned hosts.
+island-owned chart refs, and a few follow-up migration issues still materialize
+typed wizard or status models behind island-owned hosts. Those transitional
+bridge patterns should not be copied into new work now that the signals
+contract below is available.
 
 Realtime follows that same split explicitly: `realtime_feature.ts` is the thin
 facade, `realtime_feature_workflow.ts` owns the controller-style polling and
@@ -205,6 +209,19 @@ and `shell.css`, `components.css`, `maintenance.css`, `realtime.css`,
 Shared visual state conventions prefer stable data/ARIA selectors such as
 `data-variant`, `data-choice-state`, `data-selected`, and `data-step-state`
 instead of controller-side variant class interpolation.
+
+## Shared reactive state contract
+
+- Import shared reactive primitives from `app/ui_signals.ts` so runtime,
+  feature, presenter, and view code shares one documented signals entrypoint.
+- Use `signal()` for shared state that spans modules or needs to outlive a
+  single component render. Keep component-local transient state in hooks.
+- Use `computed()` for derived state instead of mirroring derived fields onto
+  mutable state bags or manual render-model caches.
+- Use `effect()` only for narrow imperative integrations such as timers,
+  persistence, canvas/uPlot bridges, or other external-library coordination.
+- Existing mutable app-state objects and manual bridge rerenders are follow-up
+  migration residue, not the default pattern for new frontend work.
 
 ## Architecture guardrails
 

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vibesensor-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@preact/signals": "^2.9.0",
         "ajv": "^8.18.0",
         "preact": "^10.29.1",
         "uplot": "^1.6.31"
@@ -649,6 +650,32 @@
       "peerDependencies": {
         "@babel/core": "7.x",
         "vite": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.0.tgz",
+      "integrity": "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@prefresh/babel-plugin": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -25,6 +25,7 @@
     "snapshot:update": "node update-snapshots.mjs"
   },
   "dependencies": {
+    "@preact/signals": "^2.9.0",
     "ajv": "^8.18.0",
     "preact": "^10.29.1",
     "uplot": "^1.6.31"

--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -1,0 +1,19 @@
+import {
+  batch,
+  computed,
+  effect,
+  signal,
+  type ReadonlySignal,
+  type Signal,
+} from "@preact/signals";
+
+/**
+ * Canonical import surface for shared frontend reactive state.
+ *
+ * Keep component-local ephemeral UI state in hooks. Reach for these exports when
+ * state must be shared across runtime, feature, presenter, or view boundaries,
+ * and keep effect() limited to narrow imperative integrations such as timers,
+ * storage, or external library bridges.
+ */
+export { batch, computed, effect, signal };
+export type { ReadonlySignal, Signal };


### PR DESCRIPTION
## Summary

This PR completes the foundational setup for the post-migration frontend cleanup by adding `@preact/signals` to the UI package, introducing a single canonical import surface for shared reactive state, and updating the frontend README so new work has a clear signals-first contract.

It deliberately does **not** migrate `AppState`, replace the existing bridge render loops, or fold the current controller and presenter seams into signals in one pass. Those are already tracked as follow-up issues in the new frontend audit backlog. The goal here is simply to give those later issues one stable starting point.

## Problem being solved

The frontend was recently migrated so that the visible UI surfaces are Preact-owned, but the audit that produced issue #2303 showed that the repo still had no actual signals dependency and no canonical shared reactive-state entrypoint. In practice that meant the UI had Preact islands, but shared state still relied on plain mutable objects, manual `render()` fan-out, and ad hoc listener sets. The clearest example is `ui_i18n.ts`, which currently implements language updates with a module-global value, a listener `Set`, and a hook-level rerender counter instead of native reactive primitives.

That absence creates two concrete risks for the remaining migration backlog. First, every follow-up issue would otherwise have to decide on its own whether to import directly from `@preact/signals`, create a local wrapper, or continue using mutable bridge state. Second, the README could still be read as if the current bridge and mutable state patterns were acceptable for new work. This PR fixes both by making signals available in the package and by documenting one explicit contract for how shared reactive frontend state should be introduced from here on out.

## Implementation approach

I kept this PR intentionally narrow because the issue itself is explicitly foundational. The implementation has three parts:

1. Add the missing runtime dependency so frontend code can actually import signals.
2. Add one canonical `app/ui_signals.ts` module that re-exports the approved primitives for shared state work.
3. Update `apps/ui/README.md` so contributors have a documented signals-first rule and do not copy legacy mutable bridge patterns into new code.

I did **not** convert any live feature or runtime path to signals in this PR. That would have broadened the scope into the follow-up issues, made review noisier, and increased the risk of subtle behavior changes in code that the audit intentionally split into separate tickets.

## Main code changes by area

### 1. UI dependency setup

`apps/ui/package.json` now includes `@preact/signals` in the main UI dependencies, and `apps/ui/package-lock.json` was updated through `npm install` so the checked-in lockfile matches the intended dependency graph.

This is the minimum package-level change required to satisfy the issue’s “frontend code can import and type-check signal primitives” requirement. I used the existing UI package workflow rather than editing the lockfile manually so the dependency update stays consistent with the repo’s documented npm usage.

### 2. Canonical signals entrypoint

The new file `apps/ui/src/app/ui_signals.ts` is the canonical import surface for shared frontend reactive state. It re-exports:

- `signal`
- `computed`
- `effect`
- `batch`
- `Signal`
- `ReadonlySignal`

The file-level documentation makes the intended usage boundary explicit:

- component-local ephemeral UI state should stay in hooks
- shared state across runtime, feature, presenter, or view boundaries should use signals
- `effect()` should stay reserved for narrow imperative integrations such as timers, storage, or external library bridges

That gives the remaining migration work one stable place to import from and one place to evolve later if the repo wants additional conventions.

### 3. README contract and architecture guidance

`apps/ui/README.md` now reflects the new state contract in three ways.

First, the tech stack section explicitly calls out **Preact + `@preact/signals`** instead of describing the UI only in terms of TypeScript and Vite.

Second, the source module table now includes `app/ui_signals.ts` so future contributors can find the canonical import path without hunting through the codebase.

Third, and most importantly, the README now has a dedicated **Shared reactive state contract** section. It documents the rules this issue is establishing:

- import shared reactive primitives from `app/ui_signals.ts`
- use `signal()` for shared state that spans modules or outlives a single render
- use `computed()` for derived state instead of mirrored mutable caches
- use `effect()` only for narrow imperative integrations
- treat existing mutable app-state objects and manual bridge rerenders as migration residue rather than the default pattern

I also adjusted the nearby architecture prose so it explicitly frames the remaining bridge-style presenter and runtime seams as transitional follow-up migration work, not as the recommended model for new code.

## Validation and verification

Before making changes, I re-ran the relevant frontend baseline checks on the issue branch:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

After the dependency, helper module, and README changes, I ran:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Type-check and build passed cleanly. Lint completed successfully but reported pre-existing warnings in untouched files such as `car_wizard_view.ts` and `tests/history_feature_modules.spec.ts`. I did not fold those unrelated warnings into this PR because they are outside the issue scope and not caused by the signals setup work.

## Risks, tradeoffs, and edge cases considered

The main tradeoff in this PR is that it introduces the contract without yet demonstrating it through a live runtime migration. I chose that deliberately. The issue description explicitly says this change should stay foundational and should not try to migrate every feature in the same PR.

I also chose to centralize imports through `app/ui_signals.ts` instead of telling contributors to import directly from `@preact/signals`. That gives the repo one documented seam for shared reactive state and keeps future cleanup simpler if the project later wants helper types, conventions, or a narrowed public surface.

Finally, I kept the README update honest about the current architecture. The UI surfaces remain fully Preact-owned, but some shared state and bridge patterns are still transitional residue. The new wording makes that distinction clearer without claiming this PR completed the rest of the migration.

## Out of scope and follow-ups

This PR does **not**:

- migrate `ui_i18n.ts` to signals
- replace `AppState` with signal-backed state
- remove shell render fan-out
- convert bridge-based views to reactive island state
- change live transport scheduling or runtime behavior

Those are already represented by the follow-up issues created from the frontend audit, starting with #2304. This PR is meant to make those follow-ups consistent by ensuring they all build on the same dependency setup and the same documented shared-state contract.

Closes #2303
