### PR TITLE
refactor(ui): replace ui_i18n listeners

### DIFF
--- a/apps/ui/src/app/ui_i18n.ts
+++ b/apps/ui/src/app/ui_i18n.ts
@@ -1,51 +1,30 @@
-import { useEffect, useState } from "preact/hooks";
-
 import { get as translate, normalizeLang } from "../i18n";
+import { signal } from "./ui_signals";
 
-type TranslationListener = () => void;
-
-let currentLanguage = "en";
-const listeners = new Set<TranslationListener>();
-
-function notifyLanguageListeners(): void {
-  for (const listener of listeners) {
-    listener();
-  }
-}
+const currentLanguage = signal("en");
 
 export function getUiText(
   key: string,
   fallback: string,
   vars?: Record<string, unknown>,
 ): string {
-  return translate(currentLanguage, key, vars) || fallback;
+  return translate(currentLanguage.value, key, vars) || fallback;
 }
 
 export function setUiLanguage(lang: string): void {
   const normalizedLanguage = normalizeLang(lang);
-  if (normalizedLanguage === currentLanguage) {
+  if (normalizedLanguage === currentLanguage.value) {
     return;
   }
-  currentLanguage = normalizedLanguage;
-  notifyLanguageListeners();
+  currentLanguage.value = normalizedLanguage;
 }
 
 export function useUiTranslation() {
-  const [, setVersion] = useState(0);
-
-  useEffect(() => {
-    const listener = () => {
-      setVersion((version) => version + 1);
-    };
-    listeners.add(listener);
-    return () => {
-      listeners.delete(listener);
-    };
-  }, []);
+  const language = currentLanguage.value;
 
   return (
     key: string,
     fallback: string,
     vars?: Record<string, unknown>,
-  ): string => getUiText(key, fallback, vars);
+  ): string => translate(language, key, vars) || fallback;
 }

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -159,20 +159,20 @@ function SensorsPanel(props: { state: SensorsPanelBridgeState }) {
 }
 
 export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
-  const bridgeState: SensorsPanelBridgeState = {
+  let state: SensorsPanelBridgeState = {
     actions: null,
     model: { table: null },
   };
   const mount = createUiPreactMount(host);
-  const render = () => mount.render(<SensorsPanel state={bridgeState} />);
+  const render = () => mount.render(<SensorsPanel state={state} />);
   render();
   return {
     render(model) {
-      bridgeState.model = model;
+      state = { ...state, model };
       render();
     },
     bindActions(handlers) {
-      bridgeState.actions = handlers;
+      state = { ...state, actions: handlers };
       render();
     },
   };

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -96,6 +96,13 @@ export async function fulfillJson(route: Route, body: unknown): Promise<void> {
   await route.fulfill(jsonOk(body));
 }
 
+function defaultSettingsPayload(path: string): Record<string, unknown> {
+  if (path === "/api/settings/cars" || path === "/api/settings/cars/active") {
+    return { cars: [], active_car_id: null };
+  }
+  return {};
+}
+
 export type SemanticSurfaceStyles = {
   backgroundColor: string;
   borderColor: string;
@@ -273,11 +280,7 @@ export async function installCommonRoutes(page: Page, options: CommonRouteOption
       await options.settingsHandler(route);
       return;
     }
-    if (path === "/api/settings/cars" || path === "/api/settings/cars/active") {
-      await fulfillJson(route, { cars: [], active_car_id: null });
-      return;
-    }
-    await fulfillJson(route, {});
+    await fulfillJson(route, defaultSettingsPayload(path));
   });
   await page.route("**/api/esp-flash/**", async (route) => {
     if (!requestPath(route).startsWith("/api/esp-flash")) {
@@ -322,7 +325,7 @@ export function createSettingsHandlerFromMap(settingsMap: Record<string, Setting
       await fulfillJson(route, value);
       return;
     }
-    await fulfillJson(route, {});
+    await fulfillJson(route, defaultSettingsPayload(path));
   };
 }
 

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -46,8 +46,10 @@ test("spectrum title updates when switching language", async ({ page }) => {
   });
   await page.goto("/");
   await expect(page.locator("#dashboardView [data-i18n='chart.spectrum_title']")).toHaveText("Multi-Sensor Blended Spectrum");
+  await expect(page.locator("#languageSelect")).toHaveValue("en");
   await page.locator("#languageSelect").selectOption("nl");
   await expect(page.locator("#dashboardView [data-i18n='chart.spectrum_title']")).toHaveText("Gecombineerd spectrum van meerdere sensoren");
+  await expect(page.locator("#languageSelect")).toHaveValue("nl");
 });
 
 test("manual speed save uses settings endpoint only (no speed-override call)", async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR replaces the custom language listener plumbing in `apps/ui/src/app/ui_i18n.ts` with signal-backed state, keeps the existing translation helper ergonomics for JSX callers, and strengthens the language-switch smoke coverage so the issue is validated through the actual UI flow.

The production refactor is intentionally small: language state now lives in a signal, `setUiLanguage()` updates that signal directly, and `useUiTranslation()` no longer needs a local `useState`/`useEffect` rerender counter. Validation exposed two tightly coupled follow-up fixes that belong with the same change: a settings-route fixture gap in the smoke helper and a Sensors panel bridge-state update path that stopped producing DOM diffs once that panel became signal-aware through `useUiTranslation()`.

## Problem being solved

Issue #2304 called out that `ui_i18n.ts` was still maintaining its own reactive system beside Preact. The file used a module-global `currentLanguage` string, a `Set` of listeners, and a hook-level rerender bump in `useUiTranslation()` to force translated views to refresh when the language changed. The goal here was to replace that listener mechanism with signals while preserving the existing API shape and translation fallback behavior.

## Implementation approach

I kept the implementation focused on the issue body: remove the listener `Set`, remove the rerender bookkeeping inside `useUiTranslation()`, and preserve the current translation behavior and hook ergonomics. `getUiText()` still exposes the same call shape, `setUiLanguage()` still normalizes incoming values, and `useUiTranslation()` still returns the same translator signature the existing views expect.

While validating the change through the existing language smoke test, I hit a failure that looked like a regression at first: the UI text switched to Dutch, but the language picker snapped back to English and showed an error. Tracing the browser error showed that the failing code path was actually the realtime logging refresh reading `settings.cars.length` after the custom smoke settings handler had returned `{}` for `/api/settings/cars`. That behavior was not caused by the new signal code; it was a long-standing gap in the smoke helper fallback when tests override only part of the settings API. I fixed it in the same PR because it directly blocked accurate validation of the issue’s real behavior.

Once that was fixed, CI surfaced one signal-specific compatibility issue in `sensors_panel.tsx`: the panel mutates a stable bridge-state object in place, and after `useUiTranslation()` became signal-backed, those manual `render()` calls no longer produced DOM updates. Converting the mount to replace the wrapper state object on each render and action bind kept the panel compatible with the new translation path without widening the broader settings-shell architecture.

## Main code changes by area

### 1. `apps/ui/src/app/ui_i18n.ts`

The old implementation imported `useEffect` and `useState`, kept `currentLanguage` as a mutable string, and manually notified a module-global listener `Set`. The new implementation imports `signal` from the repo’s canonical `app/ui_signals.ts` entrypoint, stores the language in `currentLanguage.value`, and lets `useUiTranslation()` read that signal during render instead of subscribing and bumping local state. The translation fallback behavior stays the same.

### 2. `apps/ui/tests/smoke.settings.spec.ts`

The existing language-switch smoke test already verified that the translated spectrum title changes after selecting Dutch. I extended it with explicit assertions on `#languageSelect` before and after the switch so the test now proves both the visible text update and the persisted preference state.

### 3. `apps/ui/tests/smoke.helpers.ts` and `apps/ui/src/app/views/sensors_panel.tsx`

Validation exposed a test-fixture gap in `smoke.helpers.ts`: `installCommonRoutes()` already had a special default payload for `/api/settings/cars` and `/api/settings/cars/active`, but `createSettingsHandlerFromMap()` did not preserve that default when a test supplied a partial settings map. I extracted that behavior into `defaultSettingsPayload()` and reused it in both places so unspecified settings routes stop corrupting shared state during unrelated flows like language-save refresh.

The same validation loop also exposed a real compatibility issue in `sensors_panel.tsx`. That mount was reusing a single mutable bridge-state object across renders. After the signal-backed translation hook landed, that pattern no longer reliably produced DOM updates for the sensor table. `mountSensorsPanel()` now replaces the wrapper state object on `render()` and `bindActions()` instead of mutating it in place.

## Validation and verification

I validated the change through the same surfaces the issue called out.

First, I ran the language-switch smoke flow against an isolated local UI server because the shared default Playwright port in this environment was already serving an unrelated app. That isolated run caught the fixture problem described above, which I fixed before re-running the targeted smoke successfully. After CI exposed the Sensors tab regression, I reran the full `tests/smoke.settings.spec.ts` suite locally against the same isolated server and used that suite to confirm the follow-up panel fix.

After the smoke path passed, I ran the normal frontend validation commands:

- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Type-check and build passed. Lint completed with the same existing Biome warnings in unrelated files (`car_wizard_view.ts` and `tests/history_feature_modules.spec.ts`) that were already present before this change.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is that `useUiTranslation()` still returns a plain function rather than pushing the whole translation layer into a broader signals-first API. I kept that intentionally because the issue asks for a narrow replacement of the listener plumbing, not a public API redesign for i18n.

The helper and Sensors-panel changes are slightly broader than the issue title, but both were required to keep the real UI validation honest. Leaving either one in place would have turned the smoke failures into false negatives unrelated to the intended `ui_i18n` refactor.

## Out of scope and follow-ups

This PR does **not** migrate the rest of shared frontend state to signals, change the shell controller render fan-out, or remove all remaining `data-i18n` attributes. Those broader migration items are already tracked in the follow-up frontend audit backlog.

This PR completes the narrower #2304 step: language changes no longer propagate through a custom listener registry, and the UI’s language-switch and Sensors settings smoke paths now validate that behavior against a compatible reactive/view update path.

Closes #2304
