### PR TITLE
refactor(ui): move shell nav to signals

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -319,7 +319,7 @@ function UiShellChrome(props: UiShellChromeProps) {
             </label>
           </div>
         </div>
-        <div class="site-header__status">
+        <div class="site-header__status" hidden={model.activeViewId === "dashboardView"}>
           <div class="site-header__status-pills">
             <div
               id="linkState"

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -15,6 +15,7 @@ import {
   createUiShellNavigationModule,
   type UiShellNavigationModule,
 } from "./ui_shell_navigation_module";
+import { createUiShellViewVisibilityModule } from "./ui_shell_view_visibility_module";
 import {
   createUiShellNotificationModule,
   type UiShellNotificationModule,
@@ -86,15 +87,17 @@ export class UiShellController {
     setUiLanguage(this.state.shell.lang);
     this.chrome = deps.chrome;
     const appShellWrap = queryOne<HTMLElement>(".wrap");
+    const views = queryRequiredAll<HTMLElement>(".view", "UI shell views");
     this.navigation = createUiShellNavigationModule({
       shell: this.state.shell,
-      dom: {
-        appShellWrap,
-        views: queryRequiredAll<HTMLElement>(".view", "UI shell views"),
-      },
+      viewIds: views.map((view) => view.id),
       onDashboardViewActivated: () => {
         this.state.spectrum.spectrumPlot?.resize();
       },
+    });
+    createUiShellViewVisibilityModule({
+      activeViewId: this.navigation.activeViewId,
+      views,
     });
     this.notifications = createUiShellNotificationModule({
       onChanged: () => this.renderChrome(),

--- a/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
@@ -1,36 +1,36 @@
 import type { ShellState } from "../ui_app_state";
+import { signal, type ReadonlySignal } from "../ui_signals";
 
 export const DEFAULT_SHELL_VIEW_ID = "dashboardView";
 
-type UiShellNavigationDom = {
-  appShellWrap: HTMLElement | null;
-  views: HTMLElement[];
-};
-
 type UiShellNavigationDeps = {
-  dom: UiShellNavigationDom;
   onDashboardViewActivated?: () => void;
   shell: ShellState;
+  viewIds: readonly string[];
 };
 
 export interface UiShellNavigationModule {
+  readonly activeViewId: ReadonlySignal<string>;
   setActiveView(viewId: string): void;
+}
+
+function normalizeActiveViewId(viewId: string, viewIds: readonly string[]): string {
+  return viewIds.some((candidate) => candidate === viewId) ? viewId : DEFAULT_SHELL_VIEW_ID;
 }
 
 export function createUiShellNavigationModule(
   deps: UiShellNavigationDeps,
 ): UiShellNavigationModule {
+  const activeViewId = signal(normalizeActiveViewId(deps.shell.activeViewId, deps.viewIds));
+  deps.shell.activeViewId = activeViewId.value;
+
   return {
+    activeViewId,
     setActiveView(viewId) {
-      const valid = deps.dom.views.some((view) => view.id === viewId);
-      deps.shell.activeViewId = valid ? viewId : DEFAULT_SHELL_VIEW_ID;
-      for (const view of deps.dom.views) {
-        view.hidden = view.id !== deps.shell.activeViewId;
-      }
-      if (deps.dom.appShellWrap) {
-        deps.dom.appShellWrap.dataset.activeView = deps.shell.activeViewId;
-      }
-      if (deps.shell.activeViewId === DEFAULT_SHELL_VIEW_ID) {
+      const nextViewId = normalizeActiveViewId(viewId, deps.viewIds);
+      activeViewId.value = nextViewId;
+      deps.shell.activeViewId = nextViewId;
+      if (nextViewId === DEFAULT_SHELL_VIEW_ID) {
         deps.onDashboardViewActivated?.();
       }
     },

--- a/apps/ui/src/app/runtime/ui_shell_view_visibility_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_view_visibility_module.ts
@@ -1,0 +1,23 @@
+import { effect, type ReadonlySignal } from "../ui_signals";
+
+type UiShellViewVisibilityDeps = {
+  activeViewId: ReadonlySignal<string>;
+  views: HTMLElement[];
+};
+
+export interface UiShellViewVisibilityModule {
+  dispose(): void;
+}
+
+export function createUiShellViewVisibilityModule(
+  deps: UiShellViewVisibilityDeps,
+): UiShellViewVisibilityModule {
+  const dispose = effect(() => {
+    const activeViewId = deps.activeViewId.value;
+    for (const view of deps.views) {
+      view.hidden = view.id !== activeViewId;
+    }
+  });
+
+  return { dispose };
+}

--- a/apps/ui/src/styles/shell.css
+++ b/apps/ui/src/styles/shell.css
@@ -113,9 +113,7 @@
   padding: 0;
 }
 
-.wrap[data-active-view="dashboardView"] .site-header__status {
-  display: none;
-}
+.site-header__status[hidden] { display: none; }
 
 .site-header__status-pills {
   display: flex;

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -16,6 +16,7 @@ import {
 import { createUiShellNotificationModule } from "../src/app/runtime/ui_shell_notification_module";
 import { createUiShellPreferencesModule } from "../src/app/runtime/ui_shell_preferences_module";
 import { createUiShellStatusModule } from "../src/app/runtime/ui_shell_status_module";
+import { createUiShellViewVisibilityModule } from "../src/app/runtime/ui_shell_view_visibility_module";
 
 function createView(id: string): HTMLElement {
   return {
@@ -79,19 +80,13 @@ function installShellDocument() {
 }
 
 test.describe("createUiShellNavigationModule", () => {
-  test("setActiveView toggles views and falls back to dashboard", () => {
+  test("setActiveView updates signal-backed state and falls back to dashboard", () => {
     const state = createAppState();
-    const dashboardView = createView(DEFAULT_SHELL_VIEW_ID);
-    const historyView = createView("historyView");
-    const appShellWrap = createWrap();
     let resizeCalls = 0;
 
     const module = createUiShellNavigationModule({
       shell: state.shell,
-      dom: {
-        appShellWrap,
-        views: [dashboardView, historyView],
-      },
+      viewIds: [DEFAULT_SHELL_VIEW_ID, "historyView"],
       onDashboardViewActivated: () => {
         resizeCalls += 1;
       },
@@ -99,17 +94,38 @@ test.describe("createUiShellNavigationModule", () => {
 
     module.setActiveView("historyView");
     expect(state.shell.activeViewId).toBe("historyView");
-    expect(historyView.hidden).toBe(false);
-    expect(dashboardView.hidden).toBe(true);
-    expect(appShellWrap.dataset.activeView).toBe("historyView");
+    expect(module.activeViewId.value).toBe("historyView");
     expect(resizeCalls).toBe(0);
 
     module.setActiveView("missingView");
     expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(resizeCalls).toBe(1);
+  });
+});
+
+test.describe("createUiShellViewVisibilityModule", () => {
+  test("syncs section visibility from the active view signal", () => {
+    const state = createAppState();
+    const dashboardView = createView(DEFAULT_SHELL_VIEW_ID);
+    const historyView = createView("historyView");
+    const navigation = createUiShellNavigationModule({
+      shell: state.shell,
+      viewIds: [DEFAULT_SHELL_VIEW_ID, "historyView"],
+    });
+    const visibility = createUiShellViewVisibilityModule({
+      activeViewId: navigation.activeViewId,
+      views: [dashboardView, historyView],
+    });
+
     expect(dashboardView.hidden).toBe(false);
     expect(historyView.hidden).toBe(true);
-    expect(appShellWrap.dataset.activeView).toBe(DEFAULT_SHELL_VIEW_ID);
-    expect(resizeCalls).toBe(1);
+
+    navigation.setActiveView("historyView");
+    expect(dashboardView.hidden).toBe(true);
+    expect(historyView.hidden).toBe(false);
+
+    visibility.dispose();
   });
 });
 


### PR DESCRIPTION
## Summary

This PR replaces the shell’s imperative hidden-toggle navigation seam with signal-backed navigation state while keeping the existing top-level shell layout, menu structure, and visible behavior intact. `UiShellNavigationModule` now owns the active primary view as reactive state, a dedicated visibility module syncs that state into the still-static top-level shell sections, and the header status area no longer depends on `.wrap[data-active-view]` styling side effects.

The change stays within issue #2306 instead of pulling in later shell refactors. The top-level `section` containers still live in `index.html`, and `UiShellController` still owns broader shell orchestration.

## Problem being solved

Before this change, `apps/ui/src/app/runtime/ui_shell_navigation_module.ts` handled a view change by mutating `state.shell.activeViewId`, looping over every `.view` DOM node to toggle `hidden`, and mutating `appShellWrap.dataset.activeView` so CSS could decide whether the shell status pills should be visible. That left the shell in an awkward in-between state: the menu lived in Preact, but primary view visibility still behaved like an old DOM widget.

Issue #2306 asked for that seam to move to reactive shell state without broadening into the later “move everything into the shell component tree” work. The right target here was to separate state ownership from DOM syncing: the navigation module should own which view is active, while a dedicated sync owner should map that state onto the still-static top-level sections until the later shell-container migration lands.

## Implementation approach

I kept the implementation scoped around three boundaries.

First, `UiShellNavigationModule` now owns `activeViewId` as signal-backed state instead of using the DOM list as its source of truth. It still validates requested view IDs and falls back to `dashboardView` for unknown targets, but it no longer directly mutates view visibility or shell wrapper dataset state. It mirrors the normalized value back into `state.shell.activeViewId` so existing callers that still read the plain app state continue to behave correctly.

Second, I extracted the view visibility mutation into a dedicated runtime module: `ui_shell_view_visibility_module.ts`. That module is a narrow imperative bridge, driven by `effect()`, whose only job is to read the reactive active-view signal and synchronize the `hidden` attribute on the static top-level `section.view` containers. The sections still come from `index.html`, so some DOM synchronization is still required until the later container migration issue is done.

Third, I removed the header status panel’s dependence on `.wrap[data-active-view]`. The shell chrome component already receives `activeViewId` in its render model, so it can hide or show `.site-header__status` directly from that state.

## Main code changes by area

### 1. `ui_shell_navigation_module.ts`

The navigation module now imports the canonical frontend signals surface and exposes `activeViewId` as a `ReadonlySignal<string>`. The module’s dependencies were simplified from DOM nodes plus shell state to shell state plus a list of valid view IDs. The normalization logic moved into a helper so the current view can be sanitized both at initialization time and on each navigation request.

### 2. `ui_shell_view_visibility_module.ts`

This new runtime module owns the temporary bridge between reactive navigation state and the static shell sections that still come from `index.html`. It reads the active-view signal in an `effect()` and applies `hidden` to the matching `section.view` nodes.

### 3. `ui_shell_controller.ts`

`UiShellController` now creates the shell view list once, passes just the view IDs into the navigation module, and wires the new visibility module to the navigation signal. The controller still renders the shell chrome model and still notifies active-view listeners.

### 4. `ui_shell_chrome.tsx` and `shell.css`

The shell chrome status row now uses the actual active-view state to decide when it should be hidden instead of relying on wrapper dataset styling. While validating that change in a real browser, the smoke suite exposed a subtle regression: the `hidden` attribute was present, but `.site-header__status { display: flex; }` overrode the browser’s default hidden styling. I fixed that by adding `.site-header__status[hidden] { display: none; }`, which makes the component-level visibility control authoritative.

### 5. `ui_shell_runtime_modules.spec.ts`

The runtime spec coverage now matches the new architecture. The navigation test asserts signal-backed state normalization rather than DOM toggling, and a new focused test covers the dedicated visibility module by asserting that it synchronizes `hidden` state from the active-view signal.

## Validation and verification

I validated the change in layers.

First, I ran the focused shell runtime test file directly:

- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`

That verified the new signal-backed navigation behavior and the extracted visibility module alongside the pre-existing shell runtime tests in the same file.

Second, because this issue changes real primary-view navigation behavior, I ran an isolated browser-level bootstrap smoke flow against a dedicated Vite server on `127.0.0.1:4174` instead of the shared default smoke port used elsewhere in this environment. That smoke pass initially caught the `hidden`-attribute CSS regression described above. After fixing the CSS rule, I reran the isolated bootstrap smoke successfully:

- `cd apps/ui && npx playwright test --config=playwright.smoke.local-4174.config.ts`

Third, I reran the normal frontend build gate:

- `cd apps/ui && npm run build`

The build passed after the navigation and CSS changes, so the final state is covered both at the runtime-module level and at the browser smoke level.

## Risks, tradeoffs, and edge cases considered

The biggest tradeoff here is that the top-level shell sections are still static HTML containers, so the final view-visibility sync still uses an imperative bridge. That is intentional. Replacing those containers outright belongs to the later shell-container migration issue, and this PR avoids collapsing those scopes together.

I also left the broader `UiShellController.renderChrome()` fan-out intact. That work is tracked separately, and in practice it is coupled to the later signal-backed AppState issue. Trying to remove that fan-out here would have mixed two separately-scoped shell issues and pushed this PR past the narrow navigation seam it is supposed to address.

## Out of scope and follow-ups

This PR does **not** move the top-level `dashboardView`, `historyView`, and `settingsView` containers out of `index.html`, and it does **not** collapse the rest of the shell chrome render model into direct signal consumption. Those are follow-up issues already in the backlog.

What this PR does complete is the narrower #2306 goal: active primary-view ownership is reactive, the navigation module no longer owns the hidden-toggle DOM loop, and shell active-view styling no longer depends on imperative wrapper dataset mutation.

Closes #2306
