### PR TITLE
refactor(ui): move update bindings into views

### DIFF
--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -33,35 +33,27 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       return;
     }
     handlersBound = true;
-    ctx.panel.dom.updateStartBtn.addEventListener("click", () => {
-      workflow.renderCurrentState();
-      void workflow.startUpdate(
-        presenter.readStartIntent(workflow.getRenderState()),
-      );
+    ctx.panel.bindActions({
+      onStart: () => {
+        workflow.renderCurrentState();
+        void workflow.startUpdate(
+          presenter.readStartIntent(workflow.getRenderState()),
+        );
+      },
+      onCancel: () => {
+        void workflow.cancelUpdate();
+      },
     });
-    ctx.panel.dom.updateCancelBtn.addEventListener("click", () => {
-      void workflow.cancelUpdate();
-    });
-    ctx.internetPanel.dom.updateTogglePasswordBtn?.addEventListener(
-      "click",
-      () => {
+    ctx.internetPanel.bindActions({
+      onTogglePassword: () => {
         presenter.togglePassword();
       },
-    );
-    ctx.internetPanel.dom.updateTransportWifiRadio?.addEventListener(
-      "change",
-      () => {
+      onTransportChange: () => {
         workflow.renderCurrentState();
       },
-    );
-    ctx.internetPanel.dom.updateTransportUsbRadio?.addEventListener(
-      "change",
-      () => {
+      onSsidInput: () => {
         workflow.renderCurrentState();
       },
-    );
-    ctx.internetPanel.dom.updateSsidInput?.addEventListener("input", () => {
-      workflow.renderCurrentState();
     });
     workflow.renderCurrentState();
   }

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -59,12 +59,20 @@ export interface InternetPanelRenderModel {
   wifiFieldsHidden: boolean;
 }
 
+export interface InternetPanelActionHandlers {
+  onSsidInput(value: string): void;
+  onTogglePassword(): void;
+  onTransportChange(transport: UpdateStartRequestPayload["transport"]): void;
+}
+
 export interface InternetPanelView {
   readonly dom: InternetPanelDom;
+  bindActions(handlers: InternetPanelActionHandlers): void;
   render(model: InternetPanelRenderModel): void;
 }
 
 type InternetPanelBridgeState = {
+  actions: InternetPanelActionHandlers | null;
   model: InternetPanelRenderModel;
 };
 
@@ -221,12 +229,13 @@ function UpdateTransportChoiceCard(props: {
   captionId?: string;
   choiceId: string;
   model: UpdateTransportChoiceCardRenderModel;
+  onSelect: ((transport: UpdateStartRequestPayload["transport"]) => void) | null;
   radioId: string;
   titleKey: string;
   titleText: string;
   value: UpdateStartRequestPayload["transport"];
 }) {
-  const { captionId, choiceId, model, radioId, titleKey, titleText, value } = props;
+  const { captionId, choiceId, model, onSelect, radioId, titleKey, titleText, value } = props;
   return (
     <label
       id={choiceId}
@@ -245,6 +254,7 @@ function UpdateTransportChoiceCard(props: {
         value={value}
         checked={model.selected}
         disabled={model.inputDisabled}
+        onChange={() => onSelect?.(value)}
       />
       <span class="speed-source-choice__title" data-i18n={titleKey}>
         {titleText}
@@ -257,9 +267,10 @@ function UpdateTransportChoiceCard(props: {
 }
 
 function InternetPanel(props: {
-  model: InternetPanelRenderModel;
+  state: InternetPanelBridgeState;
 }) {
-  const { model } = props;
+  const { state } = props;
+  const { model } = state;
   const t = useUiTranslation();
   return (
     <div class="maintenance-stack">
@@ -320,6 +331,7 @@ function InternetPanel(props: {
               <UpdateTransportChoiceCard
                 choiceId="updateTransportChoiceWifi"
                 model={model.transportChoices.wifi}
+                onSelect={state.actions?.onTransportChange ?? null}
                 radioId="updateTransportWifiRadio"
                 titleKey="settings.update.transport.wifi_title"
                 titleText={t("settings.update.transport.wifi_title", "Temporary Wi-Fi")}
@@ -329,6 +341,7 @@ function InternetPanel(props: {
                 captionId="updateUsbTransportSummary"
                 choiceId="updateTransportChoiceUsb"
                 model={model.transportChoices.usb_internet}
+                onSelect={state.actions?.onTransportChange ?? null}
                 radioId="updateTransportUsbRadio"
                 titleKey="settings.update.transport.usb_title"
                 titleText={t(
@@ -352,6 +365,8 @@ function InternetPanel(props: {
                 style="width:100%;max-width:20rem;"
                 value={model.ssidInputValue}
                 disabled={model.controlsLocked}
+                onInput={(event) =>
+                  state.actions?.onSsidInput(event.currentTarget.value)}
               />
             </div>
             <div class="form-group">
@@ -376,6 +391,7 @@ function InternetPanel(props: {
                   id="updateTogglePasswordBtn"
                   class="btn btn--small"
                   disabled={model.togglePasswordDisabled}
+                  onClick={() => state.actions?.onTogglePassword()}
                 >
                   <span>{model.togglePasswordLabelText}</span>
                 </button>
@@ -456,21 +472,26 @@ function createInternetPanelDom(host: HTMLElement): InternetPanelDom {
 }
 
 export function mountInternetPanel(host: HTMLElement): InternetPanelView {
-  const bridgeState: InternetPanelBridgeState = {
+  let state: InternetPanelBridgeState = {
+    actions: null,
     model: DEFAULT_INTERNET_PANEL_MODEL,
   };
   const mount = createUiPreactMount(host);
 
   function render(): void {
-    mount.render(<InternetPanel model={bridgeState.model} />);
+    mount.render(<InternetPanel state={state} />);
   }
 
   render();
 
   return {
     dom: createInternetPanelDom(host),
+    bindActions(handlers) {
+      state = { ...state, actions: handlers };
+      render();
+    },
     render(model) {
-      bridgeState.model = model;
+      state = { ...state, model };
       render();
     },
   };

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -33,12 +33,19 @@ export interface UpdatePanelRenderModel {
   status: UpdateStatusPanelViewModel | null;
 }
 
+export interface UpdatePanelActionHandlers {
+  onCancel(): void;
+  onStart(): void;
+}
+
 export interface UpdatePanelView {
   readonly dom: UpdatePanelDom;
+  bindActions(handlers: UpdatePanelActionHandlers): void;
   render(model: UpdatePanelRenderModel): void;
 }
 
 type UpdatePanelBridgeState = {
+  actions: UpdatePanelActionHandlers | null;
   model: UpdatePanelRenderModel;
 };
 
@@ -323,9 +330,10 @@ function UpdateStatusContent(props: {
 }
 
 function UpdatePanel(props: {
-  model: UpdatePanelRenderModel;
+  state: UpdatePanelBridgeState;
 }) {
-  const { model } = props;
+  const { state } = props;
+  const { model } = state;
   const t = useUiTranslation();
   return (
     <div class="panel card">
@@ -365,6 +373,7 @@ function UpdatePanel(props: {
                 class="btn btn--success"
                 hidden={model.startButtonHidden}
                 disabled={model.startButtonDisabled}
+                onClick={() => state.actions?.onStart()}
               >
                 {model.startButtonLabelText}
               </button>
@@ -374,6 +383,7 @@ function UpdatePanel(props: {
                 class="btn btn--danger"
                 hidden={model.cancelButtonHidden}
                 disabled={model.cancelButtonDisabled}
+                onClick={() => state.actions?.onCancel()}
               >
                 {t("settings.update.cancel", "Cancel Update")}
               </button>
@@ -414,21 +424,26 @@ function createUpdatePanelDom(host: HTMLElement): UpdatePanelDom {
 }
 
 export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
-  const bridgeState: UpdatePanelBridgeState = {
+  let state: UpdatePanelBridgeState = {
+    actions: null,
     model: DEFAULT_UPDATE_PANEL_MODEL,
   };
   const mount = createUiPreactMount(host);
 
   function render(): void {
-    mount.render(<UpdatePanel model={bridgeState.model} />);
+    mount.render(<UpdatePanel state={state} />);
   }
 
   render();
 
   return {
     dom: createUpdatePanelDom(host),
+    bindActions(handlers) {
+      state = { ...state, actions: handlers };
+      render();
+    },
     render(model) {
-      bridgeState.model = model;
+      state = { ...state, model };
       render();
     },
   };

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -7,10 +7,12 @@ import type {
   EspFlashPanelRenderModel,
 } from "../src/app/views/esp_flash_panel";
 import type {
+  InternetPanelActionHandlers,
   InternetPanelDom,
   InternetPanelRenderModel,
 } from "../src/app/views/internet_panel";
 import type {
+  UpdatePanelActionHandlers,
   UpdatePanelDom,
   UpdatePanelRenderModel,
 } from "../src/app/views/update_panel";
@@ -703,12 +705,34 @@ function createUpdateDeps() {
   return {
     panel: {
       dom,
+      bindActions(handlers: UpdatePanelActionHandlers) {
+        dom.updateStartBtn.addEventListener("click", () => {
+          handlers.onStart();
+        });
+        dom.updateCancelBtn.addEventListener("click", () => {
+          handlers.onCancel();
+        });
+      },
       render(model: UpdatePanelRenderModel) {
         renderUpdatePanelDom(dom, model);
       },
     },
     internetPanel: {
       dom: internetDom,
+      bindActions(handlers: InternetPanelActionHandlers) {
+        internetDom.updateTogglePasswordBtn?.addEventListener("click", () => {
+          handlers.onTogglePassword();
+        });
+        internetDom.updateTransportWifiRadio?.addEventListener("change", () => {
+          handlers.onTransportChange("wifi");
+        });
+        internetDom.updateTransportUsbRadio?.addEventListener("change", () => {
+          handlers.onTransportChange("usb_internet");
+        });
+        internetDom.updateSsidInput?.addEventListener("input", () => {
+          handlers.onSsidInput(internetDom.updateSsidInput?.value ?? "");
+        });
+      },
       render(model: InternetPanelRenderModel) {
         renderInternetPanelDom(internetDom, model);
       },

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+import { createUpdateFeature } from "../src/app/features/update_feature";
+import type {
+  InternetPanelActionHandlers,
+  InternetPanelDom,
+  InternetPanelRenderModel,
+} from "../src/app/views/internet_panel";
+import type {
+  UpdatePanelActionHandlers,
+  UpdatePanelDom,
+  UpdatePanelRenderModel,
+} from "../src/app/views/update_panel";
+
+function createInputStub(value = "", type = "text") {
+  return {
+    checked: false,
+    disabled: false,
+    type,
+    value,
+  } as HTMLInputElement;
+}
+
+test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners", () => {
+  let updateHandlers: UpdatePanelActionHandlers | null = null;
+  let internetHandlers: InternetPanelActionHandlers | null = null;
+
+  const feature = createUpdateFeature({
+    t: (key) => key,
+    escapeHtml: (value) => String(value ?? ""),
+    showError: () => undefined,
+    panel: {
+      dom: {
+        updateOverviewPanel: null,
+        updateStartBtn: {} as HTMLButtonElement,
+        updateCancelBtn: {} as HTMLButtonElement,
+        updateStatusPanel: {} as HTMLElement,
+      } as UpdatePanelDom,
+      bindActions(handlers: UpdatePanelActionHandlers) {
+        updateHandlers = handlers;
+      },
+      render(_model: UpdatePanelRenderModel) {},
+    },
+    internetPanel: {
+      dom: {
+        internetStatusPanel: null,
+        updateTransportOptions: null,
+        updateTransportChoiceWifi: null,
+        updateTransportChoiceUsb: null,
+        updateWifiFields: null,
+        updateReadinessSummary: null,
+        updateDetailsCaption: null,
+        updateTransportNote: null,
+        updateTransportWifiRadio: createInputStub("", "radio"),
+        updateTransportUsbRadio: createInputStub("", "radio"),
+        updateUsbTransportSummary: null,
+        updateSsidInput: createInputStub("MyWiFi"),
+        updatePasswordInput: createInputStub("secret", "password"),
+        updateTogglePasswordBtn: {} as HTMLButtonElement,
+      } as InternetPanelDom,
+      bindActions(handlers: InternetPanelActionHandlers) {
+        internetHandlers = handlers;
+      },
+      render(_model: InternetPanelRenderModel) {},
+    },
+  });
+
+  expect(() => feature.bindUpdateHandlers()).not.toThrow();
+  expect(updateHandlers).not.toBeNull();
+  expect(internetHandlers).not.toBeNull();
+});


### PR DESCRIPTION
## Summary

This PR removes the raw `addEventListener()` wiring that `createUpdateFeature()` still applied directly to the update and internet panel DOM handles, and replaces that seam with typed action surfaces owned by the mounted Preact views. The user-visible update flow stays the same: start/cancel still work, transport and SSID changes still rerender readiness, and the password toggle still rerenders presenter state.

The scope is intentionally limited to issue #2307. I moved the event binding into the island views, but I did **not** rewrite the presenter’s DOM-backed form reads in `update_feature_presenter.ts`. That broader “form state should stop living in the DOM” cleanup is tracked separately in #2308, and keeping that boundary intact makes this PR smaller, easier to review, and more faithful to the issue ordering in the audit backlog.

## Problem being solved

Before this change, `apps/ui/src/app/features/update_feature.ts` treated the update and internet panels as raw DOM surfaces. `bindUpdateHandlers()` reached into `panel.dom` and `internetPanel.dom`, then registered click, change, and input listeners directly on individual buttons, radio inputs, and fields. Even though the update and internet settings UIs are already rendered through Preact islands, the feature layer still owned the event binding seam.

That was migration residue. The feature module should coordinate the workflow and presenter, not know which concrete button ID or input element receives each interaction.

Issue #2307 asked for that seam to move into the Preact-owned view layer while preserving the existing interactions. The right fix was to give the update and internet views typed action surfaces and have the feature bind to those, rather than binding listeners on raw DOM nodes itself.

## Implementation approach

I kept the implementation centered on the existing feature/view split.

`createUpdateFeature()` still owns the workflow orchestration. It still asks the presenter for the current start intent, still calls `workflow.startUpdate()` and `workflow.cancelUpdate()`, still toggles the presenter password state, and still rerenders the workflow when transport or SSID changes should affect readiness. The difference is that it now binds those behaviors through view contracts instead of through DOM listeners.

To support that, `update_panel.tsx` and `internet_panel.tsx` now expose typed `bindActions()` methods in their view contracts. The mounted Preact views own the actual `onClick`, `onChange`, and `onInput` handlers inside the JSX tree. The feature hands those views callbacks, and the components invoke them when the relevant controls are used.

That gives the code a cleaner ownership boundary:

- the feature coordinates workflow behavior,
- the presenter still translates between workflow state and render models,
- the mounted views own DOM interaction binding for their own controls.

I deliberately stopped there. The presenter still reads current SSID, password, and transport state from `internetPanel.dom`, because that is the next issue in the queue and changing it here would have broadened the PR beyond the requested binding-only migration.

## Main code changes by area

### 1. `apps/ui/src/app/features/update_feature.ts`

The raw listener registration block is gone. `bindUpdateHandlers()` now calls `ctx.panel.bindActions()` and `ctx.internetPanel.bindActions()` with typed callbacks for:

- start update
- cancel update
- toggle password visibility
- transport change rerender
- SSID input rerender

This keeps the feature focused on behavior instead of DOM wiring.

### 2. `apps/ui/src/app/views/update_panel.tsx`

The update panel view now exports `UpdatePanelActionHandlers` and adds `bindActions()` to `UpdatePanelView`. The mounted view keeps its existing DOM handles for the presenter and surrounding feature code, but the start and cancel buttons now invoke typed action callbacks from the rendered component instead of waiting for the feature to register DOM listeners after mount.

The bridge state for the panel now carries both the render model and the current action handlers, following the same broad pattern already used by other migrated views in the UI.

### 3. `apps/ui/src/app/views/internet_panel.tsx`

The internet panel now exports `InternetPanelActionHandlers` and also supports `bindActions()`. The mounted island owns:

- password-toggle button clicks
- transport radio changes
- SSID input changes

The handlers remain intentionally narrow. Transport and SSID callbacks provide typed values, but the feature still chooses how much of that data to use today. That keeps the view contract explicit without forcing the presenter-state migration into the same change.

### 4. `apps/ui/tests/esp_flash_feature.spec.ts`

This file already carried the update-feature regression coverage, so I updated its update/internet view stubs to implement the new `bindActions()` contracts. The test behavior stays the same: the update-feature tests still drive the workflow through clicks, radio changes, and SSID input changes, but those interactions now pass through the view action surfaces first.

### 5. `apps/ui/tests/update_feature_bindings.spec.ts`

I added one focused regression test specifically for the migration seam. It constructs stub update and internet views whose DOM fields do **not** provide listener methods, then verifies that `feature.bindUpdateHandlers()` succeeds by binding through `bindActions()` instead. This would fail immediately if `createUpdateFeature()` regressed back to raw `addEventListener()` usage.

## Validation and verification

I validated the change through the tests that actually exercise the affected flow.

First, I ran the focused binding regression and the existing update-feature coverage together:

- `cd apps/ui && npx playwright test tests/update_feature_bindings.spec.ts tests/esp_flash_feature.spec.ts --workers=1`

After those tests passed, I reran the normal frontend validation gates:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Both passed on the final branch state.

## Risks, tradeoffs, and edge cases considered

The main tradeoff here is that the presenter still reads current form state from `internetPanel.dom`. That is an intentional staging point, not an oversight. Collapsing both the binding migration and the presenter-state migration into one PR would have made the review noisier and would have skipped over the separate backlog issue created for that next step.

I also kept the DOM handles in the view contracts because existing presenter logic still depends on them. Removing those handles in this PR would have forced the #2308 state migration early and increased the blast radius well beyond the event-binding seam.

## Out of scope and follow-ups

This PR does **not** move update/internet form state into component-owned or presenter-owned state, and it does **not** remove the presenter’s remaining reads and writes against `internetPanel.dom`. That work is still tracked in #2308.

What this PR does complete is the narrower #2307 goal: `createUpdateFeature()` no longer owns raw DOM listener registration for the update and internet islands, and those interactions now flow through typed view actions owned by the mounted Preact surfaces.

Closes #2307
