### PR TITLE
Move update and internet form state out of DOM-driven presenter code

### DIFF
--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -45,13 +45,18 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       },
     });
     ctx.internetPanel.bindActions({
+      onPasswordInput: (value) => {
+        presenter.setPasswordInput(value);
+      },
       onTogglePassword: () => {
         presenter.togglePassword();
       },
-      onTransportChange: () => {
+      onTransportChange: (transport) => {
+        presenter.setSelectedTransport(transport);
         workflow.renderCurrentState();
       },
-      onSsidInput: () => {
+      onSsidInput: (value) => {
+        presenter.setSsidInput(value);
         workflow.renderCurrentState();
       },
     });

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -60,6 +60,7 @@ export interface InternetPanelRenderModel {
 }
 
 export interface InternetPanelActionHandlers {
+  onPasswordInput(value: string): void;
   onSsidInput(value: string): void;
   onTogglePassword(): void;
   onTransportChange(transport: UpdateStartRequestPayload["transport"]): void;
@@ -385,6 +386,8 @@ function InternetPanel(props: {
                   style="width:100%;max-width:20rem;"
                   value={model.passwordInputValue}
                   disabled={model.controlsLocked}
+                  onInput={(event) =>
+                    state.actions?.onPasswordInput(event.currentTarget.value)}
                 />
                 <button
                   type="button"

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -67,6 +67,9 @@ export interface UpdateFeaturePresenterDeps {
 }
 
 export interface UpdateFeaturePresenter {
+  setPasswordInput(value: string): void;
+  setSelectedTransport(transport: UpdateStartRequestPayload["transport"]): void;
+  setSsidInput(value: string): void;
   render(state: UpdateFeatureRenderState): void;
   readStartIntent(state: UpdateFeatureRenderState): UpdateFeatureStartIntent;
   togglePassword(): void;
@@ -341,45 +344,38 @@ export function createUpdateFeaturePresenter(
 ): UpdateFeaturePresenter {
   const { internetPanel, panel, t } = ctx;
 
-  let passwordVisible = false;
+  let formState: UpdateFeatureFormSnapshot = {
+    passwordInputValue: "",
+    passwordVisible: false,
+    selectedTransport: "wifi",
+    ssidInputValue: "",
+  };
   let lastPanelModels: UpdateFeaturePanelModels | null = null;
   let lastRenderedState: UpdateFeatureRenderState | null = null;
   let hasHydratedPersistedWifiSettings = false;
 
-  function readSsidInputValue(state: UpdateFeatureRenderState): string {
-    const currentValue = internetPanel.dom.updateSsidInput?.value ?? "";
+  function syncHydratedWifiSettings(state: UpdateFeatureRenderState): void {
     if (hasHydratedPersistedWifiSettings || state.updateStatus == null) {
-      return currentValue;
+      return;
     }
     hasHydratedPersistedWifiSettings = true;
     if (
       state.updateStatus.transport === "wifi" &&
       state.updateStatus.ssid &&
-      currentValue.trim().length === 0
+      formState.ssidInputValue.trim().length === 0
     ) {
-      return state.updateStatus.ssid;
+      formState = { ...formState, ssidInputValue: state.updateStatus.ssid };
     }
-    return currentValue;
-  }
-
-  function readSelectedTransport(
-    state: UpdateFeatureRenderState,
-  ): UpdateStartRequestPayload["transport"] {
-    if (state.updateState === "running") {
-      return state.updateTransport;
-    }
-    return internetPanel.dom.updateTransportUsbRadio?.checked ? "usb_internet" : "wifi";
   }
 
   function readFormSnapshot(
     state: UpdateFeatureRenderState,
   ): UpdateFeatureFormSnapshot {
-    return {
-      passwordInputValue: internetPanel.dom.updatePasswordInput?.value ?? "",
-      passwordVisible,
-      selectedTransport: readSelectedTransport(state),
-      ssidInputValue: readSsidInputValue(state),
-    };
+    syncHydratedWifiSettings(state);
+    if (state.updateState === "running" && formState.selectedTransport !== state.updateTransport) {
+      formState = { ...formState, selectedTransport: state.updateTransport };
+    }
+    return formState;
   }
 
   function render(state: UpdateFeatureRenderState): void {
@@ -413,19 +409,26 @@ export function createUpdateFeaturePresenter(
   }
 
   return {
+    setPasswordInput(value) {
+      formState = { ...formState, passwordInputValue: value };
+    },
+    setSelectedTransport(transport) {
+      formState = { ...formState, selectedTransport: transport };
+    },
+    setSsidInput(value) {
+      formState = { ...formState, ssidInputValue: value };
+    },
     render,
     readStartIntent,
     togglePassword() {
-      passwordVisible = !passwordVisible;
+      formState = { ...formState, passwordVisible: !formState.passwordVisible };
       rerenderLastState();
     },
     focusSsidInput() {
       internetPanel.dom.updateSsidInput?.focus();
     },
     clearPassword() {
-      if (internetPanel.dom.updatePasswordInput) {
-        internetPanel.dom.updatePasswordInput.value = "";
-      }
+      formState = { ...formState, passwordInputValue: "" };
       rerenderLastState();
     },
   };

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -720,6 +720,9 @@ function createUpdateDeps() {
     internetPanel: {
       dom: internetDom,
       bindActions(handlers: InternetPanelActionHandlers) {
+        internetDom.updatePasswordInput?.addEventListener("input", () => {
+          handlers.onPasswordInput(internetDom.updatePasswordInput?.value ?? "");
+        });
         internetDom.updateTogglePasswordBtn?.addEventListener("click", () => {
           handlers.onTogglePassword();
         });
@@ -749,6 +752,7 @@ function createUpdateDeps() {
     updateTransportWifiRadio,
     updateTransportUsbRadio,
     updateUsbTransportSummary,
+    updateSsidInput,
     updatePasswordInput,
     updateStartBtn,
     updateCancelBtn,
@@ -1251,6 +1255,9 @@ test.describe("createUpdateFeature polling", () => {
       const deps = createUpdateDeps();
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
+      deps.updateSsidInput.value = "MyWiFi";
+      deps.updateSsidInput.dispatchEvent(new Event("input"));
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1454,9 +1461,11 @@ test.describe("createUpdateFeature polling", () => {
 
     try {
       const deps = createUpdateDeps();
-      deps.internetPanel.dom.updateSsidInput.value = "Driver-entered Wi-Fi";
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
+      deps.updateSsidInput.value = "Driver-entered Wi-Fi";
+      deps.updateSsidInput.dispatchEvent(new Event("input"));
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1498,6 +1507,9 @@ test.describe("createUpdateFeature polling", () => {
       const deps = createUpdateDeps();
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
+      deps.updateSsidInput.value = "MyWiFi";
+      deps.updateSsidInput.dispatchEvent(new Event("input"));
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1558,6 +1570,10 @@ test.describe("createUpdateFeature polling", () => {
       feature.bindUpdateHandlers();
       feature.startPolling();
       await expectTimerDelays(timers, [10_000]);
+      deps.updatePasswordInput.value = "secret";
+      deps.updatePasswordInput.dispatchEvent(new Event("input"));
+      deps.updateSsidInput.value = "MyWiFi";
+      deps.updateSsidInput.dispatchEvent(new Event("input"));
 
       deps.updateStartBtn.click();
       await expectTimerDelays(timers, [10_000]);
@@ -1617,6 +1633,8 @@ test.describe("createUpdateFeature polling", () => {
       feature.bindUpdateHandlers();
       feature.startPolling();
       await flushAsyncWork();
+      deps.updatePasswordInput.value = "secret";
+      deps.updatePasswordInput.dispatchEvent(new Event("input"));
       deps.updateTransportWifiRadio.checked = false;
       deps.updateTransportUsbRadio.checked = true;
       deps.updateTransportUsbRadio.dispatchEvent(new Event("change"));

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -68,4 +68,5 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
   expect(() => feature.bindUpdateHandlers()).not.toThrow();
   expect(updateHandlers).not.toBeNull();
   expect(internetHandlers).not.toBeNull();
+  expect(typeof internetHandlers?.onPasswordInput).toBe("function");
 });

--- a/apps/ui/tests/update_feature_presenter.spec.ts
+++ b/apps/ui/tests/update_feature_presenter.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-import { buildUpdateFeaturePanelModels } from "../src/app/views/update_feature_presenter";
+import type { InternetPanelRenderModel } from "../src/app/views/internet_panel";
+import type { UpdatePanelRenderModel } from "../src/app/views/update_panel";
+import {
+  buildUpdateFeaturePanelModels,
+  createUpdateFeaturePresenter,
+} from "../src/app/views/update_feature_presenter";
 import type {
   HealthStatusPayload,
   UpdateStatusPayload,
@@ -235,5 +240,93 @@ test.describe("buildUpdateFeaturePanelModels", () => {
     expect(models.internetPanel.togglePasswordLabelText).toBe(
       "settings.update.hide_password",
     );
+  });
+});
+
+test.describe("createUpdateFeaturePresenter", () => {
+  test("reads and clears presenter-owned form state instead of DOM values", () => {
+    let latestInternetPanel: InternetPanelRenderModel | null = null;
+    let latestUpdatePanel: UpdatePanelRenderModel | null = null;
+    let focusCalls = 0;
+    const presenter = createUpdateFeaturePresenter({
+      internetPanel: {
+        dom: {
+          internetStatusPanel: null,
+          updateTransportOptions: null,
+          updateTransportChoiceWifi: null,
+          updateTransportChoiceUsb: null,
+          updateWifiFields: null,
+          updateReadinessSummary: null,
+          updateDetailsCaption: null,
+          updateTransportNote: null,
+          updateTransportWifiRadio: { checked: false } as HTMLInputElement,
+          updateTransportUsbRadio: { checked: true } as HTMLInputElement,
+          updateUsbTransportSummary: null,
+          updateSsidInput: {
+            focus() {
+              focusCalls += 1;
+            },
+            value: "dom-ssid",
+          } as HTMLInputElement,
+          updatePasswordInput: {
+            value: "dom-password",
+          } as HTMLInputElement,
+          updateTogglePasswordBtn: null,
+        },
+        bindActions() {},
+        render(model) {
+          latestInternetPanel = model;
+        },
+      },
+      panel: {
+        dom: {
+          updateOverviewPanel: null,
+          updateStartBtn: {} as HTMLButtonElement,
+          updateCancelBtn: {} as HTMLButtonElement,
+          updateStatusPanel: {} as HTMLElement,
+        },
+        bindActions() {},
+        render(model) {
+          latestUpdatePanel = model;
+        },
+      },
+      t,
+    });
+    const state = {
+      internetStatus: makeInternet({
+        detected: true,
+        usable: true,
+        interface_name: "usb0",
+      }),
+      healthStatus: makeHealth(),
+      updateStatus: makeStatus(),
+      updateState: "idle" as const,
+      updateTransport: "wifi" as const,
+    };
+
+    presenter.setSelectedTransport("wifi");
+    presenter.setSsidInput("presenter-ssid");
+    presenter.setPasswordInput("presenter-password");
+    presenter.render(state);
+
+    expect(latestInternetPanel?.ssidInputValue).toBe("presenter-ssid");
+    expect(latestInternetPanel?.passwordInputValue).toBe("presenter-password");
+    expect(latestUpdatePanel?.startButtonDisabled).toBe(false);
+    expect(presenter.readStartIntent(state)).toMatchObject({
+      password: "presenter-password",
+      ssid: "presenter-ssid",
+      transport: "wifi",
+    });
+
+    presenter.clearPassword();
+    expect(latestInternetPanel?.passwordInputValue).toBe("");
+    expect(presenter.readStartIntent(state)).toMatchObject({
+      password: "",
+      ssid: "presenter-ssid",
+      transport: "wifi",
+    });
+
+    presenter.focusSsidInput();
+    expect(focusCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes #2308 by moving the update and internet form state out of DOM-driven presenter reads and writes and into presenter-owned typed state. Before this change, `apps/ui/src/app/views/update_feature_presenter.ts` treated DOM fields as the source of truth for SSID, password, and selected transport. It also kept password visibility as local presenter-only mutable state and cleared the password by mutating the input element directly. That arrangement made the update flow harder to reason about, harder to test without a live DOM subtree, and inconsistent with the direction of the recent Preact migration.

The new shape keeps the presenter responsible for a typed form snapshot instead of reading `value` and `checked` from `InternetPanelDom`. The mounted Preact island now reports user edits through typed action callbacks, and the feature layer feeds those changes into explicit presenter setters. That keeps the intent-building and readiness logic in one place while removing the DOM as the canonical backing store for form data.

Closes #2308.

## Problem

The issue description called out four specific problems in the old presenter:

1. `readStartIntent()` and related rendering logic pulled SSID and password directly from DOM inputs.
2. Selected transport came from inspecting the USB radio’s checked state.
3. Password visibility lived as standalone local mutable state instead of being part of the same typed form snapshot as the other fields.
4. Clearing the password was implemented by mutating `updatePasswordInput.value`.

That meant the presenter could only be fully exercised with live DOM fixtures, because the most important state transitions were implicit DOM mutations rather than explicit application state. It also meant the presenter was still carrying migration residue from the pre-Preact implementation even after #2307 had already moved the event binding seam into typed view actions.

## Implementation approach

I kept the scope narrow and followed directly from the seam introduced in #2307. That earlier issue already moved update and internet event registration into typed `bindActions()` surfaces on the view side. This PR builds on that by making those actions carry the canonical form values back into the presenter, instead of leaving the presenter to read DOM state later.

The presenter now initializes a typed `formState` snapshot with:

- `ssidInputValue`
- `passwordInputValue`
- `selectedTransport`
- `passwordVisible`

`createUpdateFeaturePresenter()` exposes explicit setter methods for the fields that can change through user interaction. The feature layer wires `onSsidInput`, `onPasswordInput`, and `onTransportChange` into those setters, then rerenders only where the UI needs to react immediately to the new state. Password visibility remains controlled through the existing toggle action, but it is now stored inside the same typed form state instead of separate mutable presenter state.

I kept the existing persisted-SSID hydration behavior, because the issue explicitly required preserving current intent-building and validation behavior. The presenter still hydrates a stored Wi-Fi SSID from update status once, but it now does that by updating typed presenter state rather than by reading and reusing DOM state. It also still avoids overwriting a user edit that is already in progress.

## Main code changes

### `apps/ui/src/app/views/update_feature_presenter.ts`

- Added presenter-owned `formState` as the single typed snapshot for update form values.
- Removed DOM-driven reads of `updateSsidInput.value`, `updatePasswordInput.value`, and `updateTransportUsbRadio.checked`.
- Replaced the standalone `passwordVisible` mutable variable with `formState.passwordVisible`.
- Reworked the persisted Wi-Fi hydration helper so it updates typed presenter state instead of returning a derived DOM-backed value.
- Updated `clearPassword()` to clear the presenter state and rerender, rather than mutating the DOM input directly.
- Added explicit setter methods so the feature can update presenter state from typed view callbacks.

This keeps `readStartIntent()` and render-model building fully representable from typed state plus the fetched backend status payloads.

### `apps/ui/src/app/features/update_feature.ts`

The feature wiring now treats the typed view actions as the input path for canonical form state:

- `onPasswordInput` writes the new password into presenter state.
- `onSsidInput` writes the SSID into presenter state and rerenders to refresh readiness.
- `onTransportChange` writes the selected transport into presenter state and rerenders to refresh readiness.

This keeps the feature responsible for wiring view events into workflow state, while the presenter stays responsible for deriving render models and start intent.

### `apps/ui/src/app/views/internet_panel.tsx`

The internet panel view contract now includes a typed `onPasswordInput` action and forwards password field edits through that action. This was the missing piece that let the presenter stop consulting the input element later.

## Test changes and validation

The issue explicitly called for presenter coverage updates, so the tests were part of the main implementation, not cleanup.

### `apps/ui/tests/update_feature_presenter.spec.ts`

I added a focused regression that creates the presenter with conflicting DOM field values and presenter-owned values, then proves:

- render models use the presenter-owned SSID and password,
- `readStartIntent()` uses presenter-owned state instead of DOM fields,
- `clearPassword()` clears typed state without needing DOM mutation,
- `focusSsidInput()` still works through the imperative focus bridge.

This is the strongest proof that the presenter is no longer DOM-driven for form state.

### `apps/ui/tests/esp_flash_feature.spec.ts`

Despite the filename, this file is the main update-feature integration-style regression surface. I updated its internet panel fixture so password input changes flow through the new typed action. I also updated the tests that previously depended on prefilled stub DOM values being treated as source-of-truth. Those cases now drive SSID and password state through the action surface the way the real feature does.

That change matters because it keeps the tests aligned with the new architecture instead of preserving an obsolete fixture assumption.

### `apps/ui/tests/update_feature_bindings.spec.ts`

I extended the existing binding regression to assert that the internet handlers now include the password input action. This helps guard the seam added in this PR.

### Commands run

- `cd apps/ui && npx playwright test tests/update_feature_presenter.spec.ts tests/update_feature_bindings.spec.ts tests/esp_flash_feature.spec.ts tests/update_feature_workflow.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks, tradeoffs, and out of scope

The main tradeoff here is that the presenter now owns more explicit state, which is slightly more code than lazily reading values from DOM fields. That is intentional: the state is now testable, serializable in concept, and aligned with the repo’s Preact migration direction.

I kept the existing imperative focus bridge in place. The issue targeted canonical form ownership, not complete removal of all DOM-facing methods from the presenter. Focus management is still a reasonable imperative boundary here.

I also kept this change scoped away from the larger AppState and runtime ownership issues already tracked elsewhere in the audit backlog. This PR does not attempt to merge the presenter into the island, restructure the update workflow, or broaden the migration beyond the form-state problem described in #2308.
